### PR TITLE
feat(discovery): add DID-anchored trust bootstrap

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6979,6 +6979,7 @@ dependencies = [
  "parking_lot 0.12.4",
  "proptest",
  "rand 0.8.5",
+ "reqwest 0.11.27",
  "rocksdb",
  "serde",
  "serde_json",

--- a/crates/hyprstream-discovery/Cargo.toml
+++ b/crates/hyprstream-discovery/Cargo.toml
@@ -46,6 +46,7 @@ parking_lot = { workspace = true }
 # Logging
 tracing = { workspace = true }
 chrono = { workspace = true }
+reqwest = { workspace = true }
 
 # Crypto (for signing keys)
 ed25519-dalek = { workspace = true }

--- a/crates/hyprstream-discovery/src/at9p_alias.rs
+++ b/crates/hyprstream-discovery/src/at9p_alias.rs
@@ -28,7 +28,7 @@ use std::sync::Arc;
 use anyhow::Result;
 
 use hyprstream_pds::at9p_alias::{resolve_authoritative_alias, AuthoritativeIdentity};
-use hyprstream_pds::at9p_gate::verify_did_at9p;
+use hyprstream_pds::at9p_gate::{verify_did_at9p, VerifiedCapsule};
 use hyprstream_rpc::identity::Did;
 
 use crate::at9p_resolver::CapsuleSource;
@@ -64,6 +64,22 @@ impl At9pAliasResolver {
         classical_did: &Did,
         classical_aka_at9p: &Did,
     ) -> Result<AuthoritativeIdentity> {
+        Ok(self
+            .resolve_authoritative_with_capsule(classical_did, classical_aka_at9p)
+            .await?
+            .0)
+    }
+
+    /// Resolve a mutually-attested identity and retain the exact GATE witness.
+    ///
+    /// Consumers that install trust material must source it from this verified
+    /// capsule, not from the classical DID document that only supplies the
+    /// reciprocal identifier vouch.
+    pub async fn resolve_authoritative_with_capsule(
+        &self,
+        classical_did: &Did,
+        classical_aka_at9p: &Did,
+    ) -> Result<(AuthoritativeIdentity, VerifiedCapsule)> {
         let did_str = classical_aka_at9p.as_str();
         // The locator derives zero authority — GATE is what makes the bytes
         // trustworthy, not the source.
@@ -71,7 +87,8 @@ impl At9pAliasResolver {
         // GATE — canon → hash → sig. The only place capsule authority is granted.
         let verified = verify_did_at9p(did_str, &bytes)?;
         // Authoritative-direction rule — mutual attestation or fail closed.
-        resolve_authoritative_alias(classical_did, classical_aka_at9p, &verified)
+        let identity = resolve_authoritative_alias(classical_did, classical_aka_at9p, &verified)?;
+        Ok((identity, verified))
     }
 }
 

--- a/crates/hyprstream-discovery/src/did_anchored.rs
+++ b/crates/hyprstream-discovery/src/did_anchored.rs
@@ -4,7 +4,9 @@
 //! deployment material. Network responses are never authority by themselves:
 //! the fetched capsule must pass the canon -> hash -> signature GATE for the
 //! configured `did:at9p`, and the fetched `did:web` document must reciprocally
-//! name that exact identity before its CA key or transport reach is used.
+//! name that exact identity before the pair is trusted. The deployment CA and
+//! Discovery reach come exclusively from the GATE-verified capsule; document
+//! keys and services remain advisory.
 
 use std::sync::Arc;
 use std::time::Duration;
@@ -12,11 +14,10 @@ use std::time::Duration;
 use anyhow::{bail, Context, Result};
 use async_trait::async_trait;
 use ed25519_dalek::VerifyingKey;
+use hyprstream_pds::at9p::{ServiceType, Transport as At9pTransport};
 use hyprstream_pds::at9p_alias::AuthoritativeIdentity;
-use hyprstream_rpc::did_web::{
-    did_web_to_url, preferred_transport, verification_method_ed25519_keys, DidWebResolver,
-    HttpDidDocFetcher,
-};
+use hyprstream_pds::at9p_gate::VerifiedCapsule;
+use hyprstream_rpc::did_web::{did_web_to_url, DidWebResolver, HttpDidDocFetcher};
 use hyprstream_rpc::identity::Did;
 use hyprstream_rpc::transport::{EndpointType, TransportConfig};
 use serde_json::Value;
@@ -25,6 +26,7 @@ use crate::at9p_alias::At9pAliasResolver;
 use crate::at9p_resolver::CapsuleSource;
 
 const MAX_CAPSULE_BYTES: usize = 4 * 1024 * 1024;
+const DEPLOYMENT_REACH_SERVICE: &str = "#ns";
 
 /// The two public, non-secret anchors for DID-backed deployment trust.
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -170,6 +172,75 @@ fn document_names_at9p(document: &Value, at9p_did: &str) -> bool {
         .is_some_and(|aliases| aliases.iter().any(|alias| alias.as_str() == Some(at9p_did)))
 }
 
+/// Extract the deployment CA from the primary hybrid subject key that signed
+/// the GATE-verified capsule.
+fn ca_key_from_capsule(verified: &VerifiedCapsule) -> Result<VerifyingKey> {
+    let primary = verified
+        .capsule()
+        .body
+        .subject_keys
+        .first()
+        .ok_or_else(|| anyhow::anyhow!("GATE-verified capsule has no subject key"))?;
+    let ed: [u8; 32] = primary
+        .ed25519_pub
+        .as_slice()
+        .try_into()
+        .map_err(|_| anyhow::anyhow!("capsule subject Ed25519 key is not 32 bytes"))?;
+    VerifyingKey::from_bytes(&ed).context("capsule subject Ed25519 key is malformed")
+}
+
+/// Extract Discovery reach from the capsule's typed `#ns` service. The
+/// independent nodeId is transport reach only; the signed ping remains pinned
+/// to the separately authenticated Discovery application key.
+fn reach_from_capsule(verified: &VerifiedCapsule) -> Result<TransportConfig> {
+    let entry = verified
+        .capsule()
+        .body
+        .services
+        .iter()
+        .find(|service| {
+            service.id == DEPLOYMENT_REACH_SERVICE
+                && service.service_type == ServiceType::NinePExport
+        })
+        .ok_or_else(|| {
+            anyhow::anyhow!(
+                "capsule has no NinePExport service entry {DEPLOYMENT_REACH_SERVICE:?} for deployment reach"
+            )
+        })?;
+    match entry.endpoint.transport {
+        At9pTransport::Iroh => {
+            let node_id_multibase = entry.endpoint.node_id.as_deref().ok_or_else(|| {
+                anyhow::anyhow!(
+                    "capsule deployment reach {DEPLOYMENT_REACH_SERVICE:?} carries no independent iroh nodeId"
+                )
+            })?;
+            let node_id = hyprstream_rpc::did_key::decode_ed25519_multikey(node_id_multibase)
+                .context("capsule deployment reach nodeId is not a valid Ed25519 Multikey")?;
+            Ok(TransportConfig::iroh(
+                node_id,
+                Vec::new(),
+                entry.endpoint.relay.clone(),
+            ))
+        }
+        At9pTransport::Quic => {
+            let carrier = entry
+                .endpoint
+                .address
+                .strip_prefix("quic://")
+                .ok_or_else(|| {
+                    anyhow::anyhow!("capsule QUIC reach must use a quic:// socket carrier")
+                })?;
+            let address = carrier
+                .parse()
+                .context("capsule QUIC reach is not an IP socket address")?;
+            Ok(TransportConfig::quic(address, address.ip().to_string()).with_connect_mode())
+        }
+        ref other => bail!(
+            "capsule deployment reach {DEPLOYMENT_REACH_SERVICE:?} is not an iroh or QUIC endpoint (got {other:?})"
+        ),
+    }
+}
+
 pub(crate) async fn verify_did_anchored_document(
     anchors: &DidAnchors,
     document: &Value,
@@ -186,8 +257,8 @@ pub(crate) async fn verify_did_anchored_document(
 
     let classical = Did::new(anchors.cluster_did_web.clone());
     let at9p = Did::new(anchors.cluster_at9p_did.clone());
-    let authoritative_identity = At9pAliasResolver::new(capsule_source)
-        .resolve_authoritative(&classical, &at9p)
+    let (authoritative_identity, verified) = At9pAliasResolver::new(capsule_source)
+        .resolve_authoritative_with_capsule(&classical, &at9p)
         .await
         .context("DID deployment anchors failed mutual-alias verification")?;
     anyhow::ensure!(
@@ -195,23 +266,16 @@ pub(crate) async fn verify_did_anchored_document(
         "mutual-alias resolver did not preserve configured at9p authority"
     );
 
-    let ca_keys = verification_method_ed25519_keys(document);
-    anyhow::ensure!(
-        ca_keys.len() == 1,
-        "did:web deployment document must publish exactly one Ed25519 Multikey CA (found {})",
-        ca_keys.len()
-    );
-    let ca_verifying_key =
-        VerifyingKey::from_bytes(&ca_keys[0]).context("did:web deployment CA key is malformed")?;
-
-    let discovery_transport = preferred_transport(document, None)
-        .ok_or_else(|| anyhow::anyhow!("did:web document has no dialable transport service"))?;
+    // The document contributes only the reciprocal identifier vouch above.
+    // Everything installed is content-bound to the configured did:at9p pin.
+    let ca_verifying_key = ca_key_from_capsule(&verified)?;
+    let discovery_transport = reach_from_capsule(&verified)?;
     anyhow::ensure!(
         matches!(
             discovery_transport.endpoint,
             EndpointType::Iroh { .. } | EndpointType::Quic { .. }
         ),
-        "did:web deployment reach is not a network transport"
+        "capsule deployment reach is not a network transport"
     );
 
     Ok(DidAnchoredTrust {
@@ -232,7 +296,7 @@ pub(crate) async fn resolve_did_anchored_trust(anchors: &DidAnchors) -> Result<D
     tracing::info!(
         at9p = %trust.authoritative_identity.at9p_did,
         did_web = %trust.authoritative_identity.classical_did,
-        "verified mutually-attested DID deployment trust anchors"
+        "verified mutually-attested DID deployment trust anchors from GATE-verified capsule"
     );
     Ok(trust)
 }
@@ -275,9 +339,28 @@ mod tests {
         CapsuleSigner { ed, pq, pair }
     }
 
-    fn capsule(classical_alias: &str, tag: u8) -> (Vec<u8>, String) {
+    fn multikey(key: &[u8; 32]) -> String {
+        hyprstream_rpc::did_key::ed25519_to_did_key(key)
+            .strip_prefix("did:key:")
+            .unwrap()
+            .to_owned()
+    }
+
+    fn capsule_ca(tag: u8) -> [u8; 32] {
+        SigningKey::from_bytes(&[tag; 32])
+            .verifying_key()
+            .to_bytes()
+    }
+
+    fn capsule_with_carrier(
+        classical_alias: &str,
+        tag: u8,
+        carrier: Option<[u8; 32]>,
+    ) -> (Vec<u8>, String) {
         let signer = capsule_signer(tag);
-        let endpoint = ServiceEndpoint::new(Transport::Iroh, format!("iroh://node{tag}")).unwrap();
+        let mut endpoint =
+            ServiceEndpoint::new(Transport::Iroh, format!("iroh://node{tag}")).unwrap();
+        endpoint.node_id = carrier.map(|key| multikey(&key));
         let service = ServiceEntry::new("#ns", ServiceType::NinePExport, endpoint).unwrap();
         let mut body = CapsuleBody::new(vec![signer.pair], vec![service]).unwrap();
         body.also_known_as = Some(vec![classical_alias.to_owned()]);
@@ -287,22 +370,37 @@ mod tests {
         (bytes, did)
     }
 
-    fn document(web: &str, at9p: Option<&str>, ca: [u8; 32]) -> Value {
-        let did_key = hyprstream_rpc::did_key::ed25519_to_did_key(&ca);
-        let multikey = did_key.strip_prefix("did:key:").unwrap();
+    fn capsule(classical_alias: &str, tag: u8) -> (Vec<u8>, String) {
+        capsule_with_carrier(classical_alias, tag, Some([0xC0; 32]))
+    }
+
+    fn document(web: &str, at9p: Option<&str>) -> Value {
+        let mut document = json!({ "id": web });
+        if let Some(at9p) = at9p {
+            document["alsoKnownAs"] = json!([at9p]);
+        }
+        document
+    }
+
+    fn document_with_ca_and_reach(
+        web: &str,
+        at9p: Option<&str>,
+        ca: [u8; 32],
+        iroh_node: [u8; 32],
+    ) -> Value {
         let mut document = json!({
             "id": web,
             "verificationMethod": [{
                 "id": format!("{web}#deployment-ca"),
                 "type": "Multikey",
                 "controller": web,
-                "publicKeyMultibase": multikey,
+                "publicKeyMultibase": multikey(&ca),
             }],
             "service": [{
                 "id": format!("{web}#iroh"),
                 "type": "IrohTransport",
                 "serviceEndpoint": hyprstream_rpc::service_entry::encode_iroh(
-                    &[0x45; 32],
+                    &iroh_node,
                     &[],
                     &["hyprstream-rpc/1"],
                 ),
@@ -335,7 +433,7 @@ mod tests {
         };
         let error = verify_did_anchored_document(
             &anchors,
-            &document(web, Some(&configured_did), [9; 32]),
+            &document(web, Some(&configured_did)),
             Arc::new(FixedCapsuleSource(served_bytes)),
         )
         .await
@@ -355,7 +453,7 @@ mod tests {
         };
         let error = verify_did_anchored_document(
             &anchors,
-            &document(web, Some(&at9p), [8; 32]),
+            &document(web, Some(&at9p)),
             Arc::new(FixedCapsuleSource(bytes)),
         )
         .await
@@ -368,24 +466,106 @@ mod tests {
     async fn mutual_alias_accepts_at9p_as_authoritative() {
         let web = "did:web:cluster.example";
         let (bytes, at9p) = capsule(web, 4);
-        let ca = SigningKey::from_bytes(&[7; 32]).verifying_key().to_bytes();
         let anchors = DidAnchors {
             cluster_at9p_did: at9p.clone(),
             cluster_did_web: web.to_owned(),
         };
         let trust = verify_did_anchored_document(
             &anchors,
-            &document(web, Some(&at9p), ca),
+            &document(web, Some(&at9p)),
             Arc::new(FixedCapsuleSource(bytes)),
         )
         .await
         .unwrap();
         assert_eq!(trust.authoritative_identity.at9p_did.as_str(), at9p);
         assert_eq!(trust.authoritative_identity.classical_did.as_str(), web);
-        assert_eq!(trust.ca_verifying_key.to_bytes(), ca);
-        assert!(matches!(
-            trust.discovery_transport.endpoint,
-            EndpointType::Iroh { .. }
-        ));
+        assert_eq!(trust.ca_verifying_key.to_bytes(), capsule_ca(4));
+        match trust.discovery_transport.endpoint {
+            EndpointType::Iroh { node_id, .. } => assert_eq!(node_id, [0xC0; 32]),
+            other => panic!("expected iroh reach from capsule, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn substituted_document_ca_and_reach_are_ignored() {
+        let web = "did:web:cluster.example";
+        let (bytes, at9p) = capsule(web, 4);
+        let anchors = DidAnchors {
+            cluster_at9p_did: at9p.clone(),
+            cluster_did_web: web.to_owned(),
+        };
+
+        let honest = verify_did_anchored_document(
+            &anchors,
+            &document_with_ca_and_reach(web, Some(&at9p), [0x07; 32], [0x45; 32]),
+            Arc::new(FixedCapsuleSource(bytes.clone())),
+        )
+        .await
+        .unwrap();
+        let substituted = verify_did_anchored_document(
+            &anchors,
+            &document_with_ca_and_reach(web, Some(&at9p), [0x66; 32], [0xEE; 32]),
+            Arc::new(FixedCapsuleSource(bytes)),
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(honest.ca_verifying_key, substituted.ca_verifying_key);
+        assert_eq!(honest.discovery_transport, substituted.discovery_transport);
+        assert_eq!(honest.ca_verifying_key.to_bytes(), capsule_ca(4));
+        match honest.discovery_transport.endpoint {
+            EndpointType::Iroh { node_id, .. } => assert_eq!(node_id, [0xC0; 32]),
+            other => panic!("expected capsule-bound iroh reach, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn reach_without_carrier_node_id_fails_closed() {
+        let web = "did:web:cluster.example";
+        let (bytes, at9p) = capsule_with_carrier(web, 4, None);
+        let anchors = DidAnchors {
+            cluster_at9p_did: at9p.clone(),
+            cluster_did_web: web.to_owned(),
+        };
+        let error = verify_did_anchored_document(
+            &anchors,
+            &document(web, Some(&at9p)),
+            Arc::new(FixedCapsuleSource(bytes)),
+        )
+        .await
+        .err()
+        .expect("carrier-less reach unexpectedly accepted");
+        assert!(format!("{error:#}").contains("no independent iroh nodeId"));
+    }
+
+    #[tokio::test]
+    async fn capsule_bound_quic_reach_is_accepted() {
+        let web = "did:web:cluster.example";
+        let signer = capsule_signer(5);
+        let endpoint = ServiceEndpoint::new(Transport::Quic, "quic://127.0.0.1:7443").unwrap();
+        let service = ServiceEntry::new("#ns", ServiceType::NinePExport, endpoint).unwrap();
+        let mut body = CapsuleBody::new(vec![signer.pair], vec![service]).unwrap();
+        body.also_known_as = Some(vec![web.to_owned()]);
+        let capsule = sign_capsule(body, &signer.ed, &signer.pq).unwrap();
+        let bytes = capsule.to_dag_cbor().unwrap();
+        let at9p = format!("did:at9p:{}", capsule.cid512().unwrap());
+        let anchors = DidAnchors {
+            cluster_at9p_did: at9p.clone(),
+            cluster_did_web: web.to_owned(),
+        };
+
+        let trust = verify_did_anchored_document(
+            &anchors,
+            &document(web, Some(&at9p)),
+            Arc::new(FixedCapsuleSource(bytes)),
+        )
+        .await
+        .unwrap();
+        match trust.discovery_transport.endpoint {
+            EndpointType::Quic { addr, .. } => {
+                assert_eq!(addr, "127.0.0.1:7443".parse().unwrap());
+            }
+            other => panic!("expected capsule-bound QUIC reach, got {other:?}"),
+        }
     }
 }

--- a/crates/hyprstream-discovery/src/did_anchored.rs
+++ b/crates/hyprstream-discovery/src/did_anchored.rs
@@ -1,0 +1,391 @@
+//! DID-anchored deployment trust bootstrap (#1136).
+//!
+//! This module resolves two public operator pins into verification-only
+//! deployment material. Network responses are never authority by themselves:
+//! the fetched capsule must pass the canon -> hash -> signature GATE for the
+//! configured `did:at9p`, and the fetched `did:web` document must reciprocally
+//! name that exact identity before its CA key or transport reach is used.
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use anyhow::{bail, Context, Result};
+use async_trait::async_trait;
+use ed25519_dalek::VerifyingKey;
+use hyprstream_pds::at9p_alias::AuthoritativeIdentity;
+use hyprstream_rpc::did_web::{
+    did_web_to_url, preferred_transport, verification_method_ed25519_keys, DidWebResolver,
+    HttpDidDocFetcher,
+};
+use hyprstream_rpc::identity::Did;
+use hyprstream_rpc::transport::{EndpointType, TransportConfig};
+use serde_json::Value;
+
+use crate::at9p_alias::At9pAliasResolver;
+use crate::at9p_resolver::CapsuleSource;
+
+const MAX_CAPSULE_BYTES: usize = 4 * 1024 * 1024;
+
+/// The two public, non-secret anchors for DID-backed deployment trust.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct DidAnchors {
+    pub cluster_at9p_did: String,
+    pub cluster_did_web: String,
+}
+
+/// Explicit startup trust-source selection.
+///
+/// There is deliberately no fallback between variants: once `DidAnchored` is
+/// selected, any fetch, verification, or liveness failure is terminal.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum DeploymentTrustSource {
+    OsOwnedFiles,
+    DidAnchored(DidAnchors),
+}
+
+impl DeploymentTrustSource {
+    /// Select a trust source from the public anchor pair.
+    ///
+    /// Both unset preserves the historical OS-owned-file behavior exactly.
+    /// Supplying only one anchor is rejected rather than silently downgrading.
+    pub fn from_anchors(
+        cluster_at9p_did: Option<&str>,
+        cluster_did_web: Option<&str>,
+    ) -> Result<Self> {
+        match (cluster_at9p_did, cluster_did_web) {
+            (None, None) => Ok(Self::OsOwnedFiles),
+            (Some(at9p), Some(web)) => {
+                anyhow::ensure!(
+                    at9p.starts_with(hyprstream_pds::at9p_gate::DID_AT9P_PREFIX),
+                    "cluster_at9p_did must be a did:at9p identifier"
+                );
+                anyhow::ensure!(
+                    web.starts_with("did:web:"),
+                    "cluster_did_web must be a did:web identifier"
+                );
+                anyhow::ensure!(
+                    at9p.trim() == at9p && web.trim() == web,
+                    "DID deployment anchors must not contain surrounding whitespace"
+                );
+                // Validate the did:web method-specific identifier before any I/O.
+                did_web_to_url(web).context("cluster_did_web is malformed")?;
+                Ok(Self::DidAnchored(DidAnchors {
+                    cluster_at9p_did: at9p.to_owned(),
+                    cluster_did_web: web.to_owned(),
+                }))
+            }
+            _ => bail!(
+                "cluster_at9p_did and cluster_did_web must be configured together; partial DID trust configuration is forbidden"
+            ),
+        }
+    }
+}
+
+/// Verified public material extracted from a mutually-attested identity pair.
+pub(crate) struct DidAnchoredTrust {
+    pub ca_verifying_key: VerifyingKey,
+    pub discovery_transport: TransportConfig,
+    pub authoritative_identity: AuthoritativeIdentity,
+}
+
+/// Fetch capsules from the deployment's static well-known content endpoint.
+///
+/// A root `did:web:host` document at `/.well-known/did.json` maps capsule CIDs
+/// to `/.well-known/at9p/<cid>.cbor`; a path-form DID maps them beside its
+/// `did.json`. This endpoint is an untrusted byte transport only: the configured
+/// CID and GATE pipeline decide whether the bytes are accepted.
+struct HttpWellKnownCapsuleSource {
+    http: reqwest::Client,
+    document_url: String,
+}
+
+impl HttpWellKnownCapsuleSource {
+    fn new(did_web: &str) -> Result<Self> {
+        let document_url = did_web_to_url(did_web)?;
+        let http = reqwest::Client::builder()
+            .redirect(reqwest::redirect::Policy::none())
+            .connect_timeout(Duration::from_secs(10))
+            .timeout(Duration::from_secs(10))
+            .build()
+            .context("failed to build at9p capsule HTTPS client")?;
+        Ok(Self { http, document_url })
+    }
+
+    fn capsule_url(&self, did: &str) -> Result<String> {
+        let cid = did
+            .strip_prefix(hyprstream_pds::at9p_gate::DID_AT9P_PREFIX)
+            .ok_or_else(|| anyhow::anyhow!("capsule fetch requested for a non-at9p DID"))?;
+        // The full CID parser runs in GATE after fetch. Constrain the URL path
+        // before I/O so a malformed configured identifier cannot inject path,
+        // query, or authority syntax.
+        anyhow::ensure!(
+            !cid.is_empty()
+                && cid
+                    .bytes()
+                    .all(|byte| byte.is_ascii_lowercase() || byte.is_ascii_digit()),
+            "did:at9p CID contains URL-unsafe characters"
+        );
+        let prefix = self
+            .document_url
+            .strip_suffix("did.json")
+            .ok_or_else(|| anyhow::anyhow!("derived did:web URL does not end in did.json"))?;
+        Ok(format!("{prefix}at9p/{cid}.cbor"))
+    }
+}
+
+#[async_trait]
+impl CapsuleSource for HttpWellKnownCapsuleSource {
+    async fn fetch_capsule(&self, did: &str) -> Result<Vec<u8>> {
+        let url = self.capsule_url(did)?;
+        let mut response = self
+            .http
+            .get(&url)
+            .send()
+            .await
+            .with_context(|| format!("failed to fetch at9p capsule from {url}"))?
+            .error_for_status()
+            .with_context(|| format!("at9p capsule endpoint rejected {url}"))?;
+        if let Some(length) = response.content_length() {
+            anyhow::ensure!(
+                length <= MAX_CAPSULE_BYTES as u64,
+                "at9p capsule exceeds {MAX_CAPSULE_BYTES}-byte limit"
+            );
+        }
+        let mut bytes = Vec::new();
+        while let Some(chunk) = response.chunk().await? {
+            anyhow::ensure!(
+                bytes.len().saturating_add(chunk.len()) <= MAX_CAPSULE_BYTES,
+                "at9p capsule exceeds {MAX_CAPSULE_BYTES}-byte limit"
+            );
+            bytes.extend_from_slice(&chunk);
+        }
+        Ok(bytes)
+    }
+}
+
+fn document_names_at9p(document: &Value, at9p_did: &str) -> bool {
+    document
+        .get("alsoKnownAs")
+        .and_then(Value::as_array)
+        .is_some_and(|aliases| aliases.iter().any(|alias| alias.as_str() == Some(at9p_did)))
+}
+
+pub(crate) async fn verify_did_anchored_document(
+    anchors: &DidAnchors,
+    document: &Value,
+    capsule_source: Arc<dyn CapsuleSource>,
+) -> Result<DidAnchoredTrust> {
+    anyhow::ensure!(
+        document.get("id").and_then(Value::as_str) == Some(anchors.cluster_did_web.as_str()),
+        "did:web document id does not match configured cluster_did_web"
+    );
+    anyhow::ensure!(
+        document_names_at9p(document, &anchors.cluster_at9p_did),
+        "did:web document does not name the configured did:at9p in alsoKnownAs"
+    );
+
+    let classical = Did::new(anchors.cluster_did_web.clone());
+    let at9p = Did::new(anchors.cluster_at9p_did.clone());
+    let authoritative_identity = At9pAliasResolver::new(capsule_source)
+        .resolve_authoritative(&classical, &at9p)
+        .await
+        .context("DID deployment anchors failed mutual-alias verification")?;
+    anyhow::ensure!(
+        authoritative_identity.at9p_did == at9p,
+        "mutual-alias resolver did not preserve configured at9p authority"
+    );
+
+    let ca_keys = verification_method_ed25519_keys(document);
+    anyhow::ensure!(
+        ca_keys.len() == 1,
+        "did:web deployment document must publish exactly one Ed25519 Multikey CA (found {})",
+        ca_keys.len()
+    );
+    let ca_verifying_key =
+        VerifyingKey::from_bytes(&ca_keys[0]).context("did:web deployment CA key is malformed")?;
+
+    let discovery_transport = preferred_transport(document, None)
+        .ok_or_else(|| anyhow::anyhow!("did:web document has no dialable transport service"))?;
+    anyhow::ensure!(
+        matches!(
+            discovery_transport.endpoint,
+            EndpointType::Iroh { .. } | EndpointType::Quic { .. }
+        ),
+        "did:web deployment reach is not a network transport"
+    );
+
+    Ok(DidAnchoredTrust {
+        ca_verifying_key,
+        discovery_transport,
+        authoritative_identity,
+    })
+}
+
+pub(crate) async fn resolve_did_anchored_trust(anchors: &DidAnchors) -> Result<DidAnchoredTrust> {
+    let document = DidWebResolver::new(HttpDidDocFetcher::new(Duration::from_secs(3600))?)
+        .resolve_document(&anchors.cluster_did_web)
+        .await
+        .context("failed to fetch configured cluster did:web document")?;
+    let capsule_source: Arc<dyn CapsuleSource> =
+        Arc::new(HttpWellKnownCapsuleSource::new(&anchors.cluster_did_web)?);
+    let trust = verify_did_anchored_document(anchors, &document, capsule_source).await?;
+    tracing::info!(
+        at9p = %trust.authoritative_identity.at9p_did,
+        did_web = %trust.authoritative_identity.classical_did,
+        "verified mutually-attested DID deployment trust anchors"
+    );
+    Ok(trust)
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+mod tests {
+    use super::*;
+    use ed25519_dalek::SigningKey;
+    use hyprstream_crypto::pq::{ml_dsa_generate_keypair, ml_dsa_vk_bytes, MlDsaSigningKey};
+    use hyprstream_pds::at9p::{
+        CapsuleBody, HybridKeyPair, ServiceEndpoint, ServiceEntry, ServiceType, Transport,
+    };
+    use hyprstream_pds::at9p_sign::sign_capsule;
+    use serde_json::json;
+
+    struct FixedCapsuleSource(Vec<u8>);
+
+    #[async_trait]
+    impl CapsuleSource for FixedCapsuleSource {
+        async fn fetch_capsule(&self, _did: &str) -> Result<Vec<u8>> {
+            Ok(self.0.clone())
+        }
+    }
+
+    struct CapsuleSigner {
+        ed: SigningKey,
+        pq: MlDsaSigningKey,
+        pair: HybridKeyPair,
+    }
+
+    fn capsule_signer(tag: u8) -> CapsuleSigner {
+        let ed = SigningKey::from_bytes(&[tag; 32]);
+        let (pq, pq_vk) = ml_dsa_generate_keypair();
+        let pair = HybridKeyPair::new(
+            ed.verifying_key().to_bytes().to_vec(),
+            ml_dsa_vk_bytes(&pq_vk),
+        )
+        .unwrap();
+        CapsuleSigner { ed, pq, pair }
+    }
+
+    fn capsule(classical_alias: &str, tag: u8) -> (Vec<u8>, String) {
+        let signer = capsule_signer(tag);
+        let endpoint = ServiceEndpoint::new(Transport::Iroh, format!("iroh://node{tag}")).unwrap();
+        let service = ServiceEntry::new("#ns", ServiceType::NinePExport, endpoint).unwrap();
+        let mut body = CapsuleBody::new(vec![signer.pair], vec![service]).unwrap();
+        body.also_known_as = Some(vec![classical_alias.to_owned()]);
+        let capsule = sign_capsule(body, &signer.ed, &signer.pq).unwrap();
+        let bytes = capsule.to_dag_cbor().unwrap();
+        let did = format!("did:at9p:{}", capsule.cid512().unwrap());
+        (bytes, did)
+    }
+
+    fn document(web: &str, at9p: Option<&str>, ca: [u8; 32]) -> Value {
+        let did_key = hyprstream_rpc::did_key::ed25519_to_did_key(&ca);
+        let multikey = did_key.strip_prefix("did:key:").unwrap();
+        let mut document = json!({
+            "id": web,
+            "verificationMethod": [{
+                "id": format!("{web}#deployment-ca"),
+                "type": "Multikey",
+                "controller": web,
+                "publicKeyMultibase": multikey,
+            }],
+            "service": [{
+                "id": format!("{web}#iroh"),
+                "type": "IrohTransport",
+                "serviceEndpoint": hyprstream_rpc::service_entry::encode_iroh(
+                    &[0x45; 32],
+                    &[],
+                    &["hyprstream-rpc/1"],
+                ),
+            }],
+        });
+        if let Some(at9p) = at9p {
+            document["alsoKnownAs"] = json!([at9p]);
+        }
+        document
+    }
+
+    #[test]
+    fn unset_anchors_preserve_os_owned_files_selection() {
+        assert_eq!(
+            DeploymentTrustSource::from_anchors(None, None).unwrap(),
+            DeploymentTrustSource::OsOwnedFiles
+        );
+        assert!(DeploymentTrustSource::from_anchors(Some("did:at9p:x"), None).is_err());
+        assert!(DeploymentTrustSource::from_anchors(None, Some("did:web:example.com")).is_err());
+    }
+
+    #[tokio::test]
+    async fn capsule_hash_mismatch_is_rejected() {
+        let web = "did:web:cluster.example";
+        let (served_bytes, _served_did) = capsule(web, 1);
+        let (_other_bytes, configured_did) = capsule(web, 2);
+        let anchors = DidAnchors {
+            cluster_at9p_did: configured_did.clone(),
+            cluster_did_web: web.to_owned(),
+        };
+        let error = verify_did_anchored_document(
+            &anchors,
+            &document(web, Some(&configured_did), [9; 32]),
+            Arc::new(FixedCapsuleSource(served_bytes)),
+        )
+        .await
+        .err()
+        .expect("mismatched capsule unexpectedly accepted");
+        assert!(error.to_string().contains("mutual-alias"), "{error:#}");
+        assert!(format!("{error:#}").contains("hash-gate"), "{error:#}");
+    }
+
+    #[tokio::test]
+    async fn one_way_alias_is_rejected() {
+        let web = "did:web:cluster.example";
+        let (bytes, at9p) = capsule("did:web:someone-else.example", 3);
+        let anchors = DidAnchors {
+            cluster_at9p_did: at9p.clone(),
+            cluster_did_web: web.to_owned(),
+        };
+        let error = verify_did_anchored_document(
+            &anchors,
+            &document(web, Some(&at9p), [8; 32]),
+            Arc::new(FixedCapsuleSource(bytes)),
+        )
+        .await
+        .err()
+        .expect("one-way alias unexpectedly accepted");
+        assert!(format!("{error:#}").contains("does not name"), "{error:#}");
+    }
+
+    #[tokio::test]
+    async fn mutual_alias_accepts_at9p_as_authoritative() {
+        let web = "did:web:cluster.example";
+        let (bytes, at9p) = capsule(web, 4);
+        let ca = SigningKey::from_bytes(&[7; 32]).verifying_key().to_bytes();
+        let anchors = DidAnchors {
+            cluster_at9p_did: at9p.clone(),
+            cluster_did_web: web.to_owned(),
+        };
+        let trust = verify_did_anchored_document(
+            &anchors,
+            &document(web, Some(&at9p), ca),
+            Arc::new(FixedCapsuleSource(bytes)),
+        )
+        .await
+        .unwrap();
+        assert_eq!(trust.authoritative_identity.at9p_did.as_str(), at9p);
+        assert_eq!(trust.authoritative_identity.classical_did.as_str(), web);
+        assert_eq!(trust.ca_verifying_key.to_bytes(), ca);
+        assert!(matches!(
+            trust.discovery_transport.endpoint,
+            EndpointType::Iroh { .. }
+        ));
+    }
+}

--- a/crates/hyprstream-discovery/src/lib.rs
+++ b/crates/hyprstream-discovery/src/lib.rs
@@ -67,6 +67,11 @@ pub mod at9p_resolver;
 /// `alsoKnownAs` attestation + the GATE pipeline. Sibling to `at9p_resolver`.
 pub mod at9p_alias;
 
+/// #1136 — explicit DID-anchored deployment trust source. Resolves the public
+/// `(did:at9p, did:web)` pin pair without weakening the OS-owned-file source.
+#[cfg(not(target_arch = "wasm32"))]
+pub mod did_anchored;
+
 /// #524 P1 — placement directory record ingestion + in-process index.
 ///
 /// Polls `RecordResolver::resolve_repo` for a bootstrap set of node DIDs,
@@ -101,6 +106,8 @@ pub mod podspec;
 // Re-export key types
 pub use hyprstream_rpc::registry::SocketKind;
 pub use hyprstream_rpc::resolver::Resolver;
+#[cfg(not(target_arch = "wasm32"))]
+pub use did_anchored::{DeploymentTrustSource, DidAnchors};
 pub use service::{
     bootstrap_deployment_process, deployment_registry_verifier, AuthorizationProvider,
     DiscoveryService, RecordCarData, RecordResolver, RegistryDeploymentVerifier,

--- a/crates/hyprstream-discovery/src/service.rs
+++ b/crates/hyprstream-discovery/src/service.rs
@@ -1903,6 +1903,14 @@ fn read_os_owned_file(_path: &std::path::Path, description: &str) -> Result<Vec<
     anyhow::bail!("{description} requires the OS-owned Unix deployment seam")
 }
 
+fn load_registry_deployment_credential() -> Result<String> {
+    String::from_utf8(read_os_owned_file(
+        std::path::Path::new(REGISTRY_DEPLOYMENT_CREDENTIAL_PATH),
+        "registry deployment credential",
+    )?)
+    .map_err(|error| anyhow::anyhow!("registry deployment credential is not UTF-8: {error}"))
+}
+
 fn load_trusted_registry_deployment_credentials() -> Result<TrustedRegistryDeploymentCredentials> {
     let ca_bytes = read_os_owned_file(
         std::path::Path::new(DEPLOYMENT_CA_ROOT_PATH),
@@ -1914,11 +1922,7 @@ fn load_trusted_registry_deployment_credentials() -> Result<TrustedRegistryDeplo
         .map_err(|_| anyhow::anyhow!("deployment CA root must be 32 bytes"))?;
     let ca_verifying_key = VerifyingKey::from_bytes(&ca_bytes)
         .map_err(|error| anyhow::anyhow!("deployment CA root is malformed: {error}"))?;
-    let registry_credential = String::from_utf8(read_os_owned_file(
-        std::path::Path::new(REGISTRY_DEPLOYMENT_CREDENTIAL_PATH),
-        "registry deployment credential",
-    )?)
-    .map_err(|error| anyhow::anyhow!("registry deployment credential is not UTF-8: {error}"))?;
+    let registry_credential = load_registry_deployment_credential()?;
     Ok(TrustedRegistryDeploymentCredentials {
         ca_verifying_key,
         registry_credential,
@@ -1960,29 +1964,58 @@ enum ProcessBootstrapAuthorityState {
 static PROCESS_BOOTSTRAP_AUTHORITY: parking_lot::Mutex<ProcessBootstrapAuthorityState> =
     parking_lot::Mutex::new(ProcessBootstrapAuthorityState::Unsealed);
 
-/// Atomically consume the fixed OS-owned deployment witness and install the
-/// process Discovery resolver. No credential path, CA, JWT, key, witness, or
-/// extraction callback crosses this boundary.
+/// Atomically consume the explicitly selected deployment witness and install
+/// the process Discovery resolver. Selection never falls back between the
+/// OS-owned and DID-anchored providers.
 #[cfg(not(target_arch = "wasm32"))]
-pub fn bootstrap_deployment_process(signing_key: SigningKey) -> Result<()> {
-    let authority = authenticate_deployment_bootstrap()?;
+pub async fn bootstrap_deployment_process(
+    signing_key: SigningKey,
+    trust_source: crate::DeploymentTrustSource,
+) -> Result<()> {
     let discovery_vk = hyprstream_service::global_trust_store()
         .resolve_one("discovery")
         .ok_or_else(|| anyhow::anyhow!("trust store has no authenticated discovery key"))?;
-    let discovery_client =
-        crate::DiscoveryClient::for_local_bootstrap(signing_key, discovery_vk, None)?;
+    let (authority, discovery_client) = match trust_source {
+        crate::DeploymentTrustSource::OsOwnedFiles => {
+            let authority = authenticate_deployment_bootstrap()?;
+            let client =
+                crate::DiscoveryClient::for_local_bootstrap(signing_key, discovery_vk, None)?;
+            (authority, client)
+        }
+        crate::DeploymentTrustSource::DidAnchored(anchors) => {
+            let (authority, transport) = authenticate_did_anchored_bootstrap(&anchors).await?;
+            let signer = hyprstream_rpc::signer::LocalSigner::new(signing_key);
+            let rpc = hyprstream_rpc::dial::dial(&transport, signer, Some(discovery_vk), None)?;
+            let client = crate::DiscoveryClient::new(rpc);
+            let health = client
+                .ping()
+                .await
+                .context("DID-anchored Discovery reach failed liveness check")?;
+            anyhow::ensure!(
+                health.status == "ok",
+                "DID-anchored Discovery liveness returned status {:?}",
+                health.status
+            );
+            (authority, client)
+        }
+    };
     DiscoveryService::bootstrap_authenticated_process(authority, discovery_client)
 }
 
 #[cfg(not(target_arch = "wasm32"))]
-fn authenticate_deployment_bootstrap() -> Result<ProcessBootstrapAuthority> {
+fn seal_process_bootstrap_authority() -> Result<()> {
     let mut state = PROCESS_BOOTSTRAP_AUTHORITY.lock();
     anyhow::ensure!(
         matches!(*state, ProcessBootstrapAuthorityState::Unsealed),
         "Discovery bootstrap authority is already sealed or consumed"
     );
     *state = ProcessBootstrapAuthorityState::Sealed;
-    drop(state);
+    Ok(())
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+fn authenticate_deployment_bootstrap() -> Result<ProcessBootstrapAuthority> {
+    seal_process_bootstrap_authority()?;
     let witness = authenticate_registry_deployment_credentials(
         load_trusted_registry_deployment_credentials()?,
     )?;
@@ -1991,6 +2024,24 @@ fn authenticate_deployment_bootstrap() -> Result<ProcessBootstrapAuthority> {
         store_path,
         acceptance_identity: ProcessAcceptanceIdentity::Deployment(witness.verifier),
     })
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+async fn authenticate_did_anchored_bootstrap(
+    anchors: &crate::DidAnchors,
+) -> Result<(ProcessBootstrapAuthority, TransportConfig)> {
+    seal_process_bootstrap_authority()?;
+    let trust = crate::did_anchored::resolve_did_anchored_trust(anchors).await?;
+    let witness =
+        authenticate_registry_deployment_credentials(TrustedRegistryDeploymentCredentials {
+            ca_verifying_key: trust.ca_verifying_key,
+            registry_credential: load_registry_deployment_credential()?,
+        })?;
+    let authority = ProcessBootstrapAuthority {
+        store_path: hyprstream_service::deployment_data_dir()?.join("pds-store"),
+        acceptance_identity: ProcessAcceptanceIdentity::Deployment(witness.verifier),
+    };
+    Ok((authority, trust.discovery_transport))
 }
 
 #[cfg(test)]

--- a/crates/hyprstream/src/bin/main.rs
+++ b/crates/hyprstream/src/bin/main.rs
@@ -1455,8 +1455,15 @@ fn resolve_service_vk(service_name: &str) -> Option<VerifyingKey> {
     trust.resolve_one(service_name)
 }
 
-fn install_process_production_resolver(signing_key: &SigningKey) -> Result<()> {
-    hyprstream_discovery::bootstrap_deployment_process(signing_key.clone())?;
+async fn install_process_production_resolver(
+    signing_key: &SigningKey,
+    config: &HyprConfig,
+) -> Result<()> {
+    let trust_source = hyprstream_discovery::DeploymentTrustSource::from_anchors(
+        config.cluster_at9p_did.as_deref(),
+        config.cluster_did_web.as_deref(),
+    )?;
+    hyprstream_discovery::bootstrap_deployment_process(signing_key.clone(), trust_source).await?;
     hyprstream_rpc::envelope::install_browser_currentness_verifier(
         hyprstream_discovery::production_browser_currentness_verifier()?,
     )
@@ -1896,7 +1903,7 @@ fn main() -> Result<()> {
             let signing_key = load_or_generate_signing_key(&keys_dir).await?;
             let verifying_key = signing_key.verifying_key();
 
-            install_process_production_resolver(&signing_key)
+            install_process_production_resolver(&signing_key, &config).await
                 .context("Failed to install checkpoint-backed production resolver")?;
             let client = hyprstream_core::services::RegistryClient::from_resolver(
                 signing_key.clone(),
@@ -2865,10 +2872,10 @@ mod resolver_startup_controls {
             .next()
             .expect("production binary source");
         let startup = production
-            .find("install_process_production_resolver(&signing_key)")
+            .find("install_process_production_resolver(&signing_key, &config).await")
             .expect("trusted startup boundary");
         let install = production[startup..]
-            .find("install_process_production_resolver(&signing_key)")
+            .find("install_process_production_resolver(&signing_key, &config).await")
             .expect("process resolver install");
         let first_generated = production[startup..]
             .find("RegistryClient::from_resolver(")
@@ -2880,7 +2887,7 @@ mod resolver_startup_controls {
         assert!(first_generated < command_dispatch);
         assert_eq!(
             production
-                .matches("install_process_production_resolver(&signing_key)")
+                .matches("install_process_production_resolver(&signing_key, &config).await")
                 .count(),
             1
         );

--- a/crates/hyprstream/src/config/mod.rs
+++ b/crates/hyprstream/src/config/mod.rs
@@ -161,6 +161,16 @@ pub struct HyprConfig {
     #[serde(default)]
     pub secrets: SecretsConfig,
 
+    /// Public self-certifying cluster identity pin used by the explicit
+    /// DID-anchored deployment trust source (#1136).
+    /// Must be configured together with `cluster_did_web`.
+    #[serde(default)]
+    pub cluster_at9p_did: Option<String>,
+
+    /// Public did:web alias/discovery anchor paired with `cluster_at9p_did`.
+    #[serde(default)]
+    pub cluster_did_web: Option<String>,
+
     /// Phase-1 cellular-ledger local-enforcer configuration (epic #922, #925).
     ///
     /// Only present when the `ledger` cargo feature is enabled; `enabled`
@@ -2016,6 +2026,8 @@ pub struct HyprConfigBuilder {
     discovery: DiscoveryServiceConfig,
     tui: TuiServiceConfig,
     metrics: MetricsConfig,
+    cluster_at9p_did: Option<String>,
+    cluster_did_web: Option<String>,
 }
 
 impl HyprConfigBuilder {
@@ -2045,6 +2057,8 @@ impl HyprConfigBuilder {
             discovery: DiscoveryServiceConfig::default(),
             tui: TuiServiceConfig::default(),
             metrics: MetricsConfig::default(),
+            cluster_at9p_did: None,
+            cluster_did_web: None,
         }
     }
 
@@ -2074,6 +2088,8 @@ impl HyprConfigBuilder {
             discovery: config.discovery,
             tui: config.tui,
             metrics: config.metrics,
+            cluster_at9p_did: config.cluster_at9p_did,
+            cluster_did_web: config.cluster_did_web,
         }
     }
 
@@ -2120,6 +2136,8 @@ impl HyprConfigBuilder {
             metrics: self.metrics,
             signing_key: None,
             secrets: Default::default(),
+            cluster_at9p_did: self.cluster_at9p_did,
+            cluster_did_web: self.cluster_did_web,
             #[cfg(feature = "ledger")]
             ledger: Default::default(),
         }
@@ -2632,6 +2650,26 @@ mod tests {
 
     /// Serialize process-env mutations for secrets-dir resolver tests.
     static SECRETS_DIR_ENV_LOCK: parking_lot::Mutex<()> = parking_lot::Mutex::new(());
+
+    #[test]
+    #[allow(clippy::unwrap_used)]
+    fn public_cluster_did_anchors_deserialize_from_root_config() {
+        let config: HyprConfig = toml::from_str(
+            r#"
+cluster_at9p_did = "did:at9p:bafyclusterpin"
+cluster_did_web = "did:web:discovery.hyprstream.com"
+"#,
+        )
+        .unwrap();
+        assert_eq!(
+            config.cluster_at9p_did.as_deref(),
+            Some("did:at9p:bafyclusterpin")
+        );
+        assert_eq!(
+            config.cluster_did_web.as_deref(),
+            Some("did:web:discovery.hyprstream.com")
+        );
+    }
 
     #[test]
     #[allow(clippy::unwrap_used)]

--- a/crates/hyprstream/src/config/mod.rs
+++ b/crates/hyprstream/src/config/mod.rs
@@ -2260,6 +2260,28 @@ impl HyprConfig {
             );
         }
 
+        // #1136 DID-anchored trust: the two anchors are a PAIR, not two
+        // independent settings. #905 §2/§6 is bidirectional-or-not-believed —
+        // a did:web claim is credited only when the at9p side names it back —
+        // so a one-sided anchor configuration can never establish trust. It
+        // must be rejected here rather than loading cleanly and failing later
+        // in `install_process_production_resolver()`: a config that parses and
+        // then dies at resolver install is an outage discovered at startup
+        // instead of at validation.
+        match (&self.cluster_at9p_did, &self.cluster_did_web) {
+            (Some(_), None) => anyhow::bail!(
+                "cluster_at9p_did is set without cluster_did_web; the DID-anchored trust \
+                 source requires BOTH anchors (#1136, #905 §2/§6 mutual aliasing)"
+            ),
+            (None, Some(_)) => anyhow::bail!(
+                "cluster_did_web is set without cluster_at9p_did; the DID-anchored trust \
+                 source requires BOTH anchors (#1136, #905 §2/§6 mutual aliasing)"
+            ),
+            // Both absent = anchors not configured, the OS-owned path applies.
+            // Both present = the pairing the resolver expects.
+            (None, None) | (Some(_), Some(_)) => {}
+        }
+
         Ok(())
     }
 
@@ -2646,6 +2668,32 @@ impl From<&crate::config::server::SamplingParamDefaults> for SamplingParams {
 
 #[cfg(test)]
 mod tests {
+    /// #1136 anchors are a PAIR. #905 §2/§6 is bidirectional-or-not-believed, so a
+    /// one-sided anchor config can never establish trust and must fail at validation
+    /// rather than at `install_process_production_resolver()`.
+    #[test]
+    fn validate_rejects_one_sided_did_anchor_config() {
+        let mut c = HyprConfig::default();
+        c.model.path = std::path::PathBuf::new();
+
+        c.cluster_at9p_did = Some("did:at9p:example".to_owned());
+        c.cluster_did_web = None;
+        assert!(c.validate().is_err(), "at9p without did:web must be rejected");
+
+        c.cluster_at9p_did = None;
+        c.cluster_did_web = Some("did:web:example.com".to_owned());
+        assert!(c.validate().is_err(), "did:web without at9p must be rejected");
+
+        // Both absent: anchors simply not configured — the OS-owned path applies.
+        c.cluster_did_web = None;
+        assert!(c.validate().is_ok(), "no anchors configured must remain valid");
+
+        // Both present: the pairing the resolver expects.
+        c.cluster_at9p_did = Some("did:at9p:example".to_owned());
+        c.cluster_did_web = Some("did:web:example.com".to_owned());
+        assert!(c.validate().is_ok(), "paired anchors must be accepted");
+    }
+
     use super::*;
 
     /// Serialize process-env mutations for secrets-dir resolver tests.

--- a/docs/deployment-registry-trust.md
+++ b/docs/deployment-registry-trust.md
@@ -56,11 +56,18 @@ canonical-encoding, BLAKE3-512 hash-to-configured-DID, and hybrid-signature
 GATE. The DID document must have the configured `id` and name that exact
 `did:at9p` in `alsoKnownAs`; the verified capsule must reciprocally name the
 configured `did:web`. Only after both directions verify does startup accept the
-at9p identity as authoritative and extract the document's single Ed25519
-Multikey as the deployment CA plus its preferred typed Iroh/QUIC transport.
+at9p identity as authoritative.
+
+The deployment CA and Discovery reach are taken from the GATE-verified capsule,
+never from the `did:web` document. The CA is the capsule's primary hybrid
+subject key's Ed25519 half (`body.subject_keys[0]`), and reach is the capsule's
+`#ns` `NinePExport` service, dialed by its independent iroh `nodeId` or signed
+QUIC socket carrier. The document contributes only the reciprocal identifier
+vouch; any keys or services it publishes are advisory and are never installed
+as trust material.
 
 Capsule content only proves a content-bound reach claim, not that the endpoint
-is currently live. Startup therefore dials the document-derived Discovery
+is currently live. Startup therefore dials the capsule-derived Discovery
 transport and requires a successful signed `ping` before installing the
 process resolver. Fetched bytes, DNS, TLS, relays, and transport endpoints do
 not become trust decisions: identity remains pinned by the configured at9p
@@ -79,7 +86,7 @@ two public anchors.
 `registry-service.jwt` is a closed, one-hour-maximum deployment credential, not
 a generic JWT or access token. Let `D` be the RFC 7638 Ed25519 JWK thumbprint of
 the exact public key selected as the deployment CA (from
-`deployment-ca.ed25519` or the mutually verified DID document). Provisioning
+`deployment-ca.ed25519` or the GATE-verified capsule). Provisioning
 must use the following profile exactly:
 
 - The protected header contains only `alg`, `typ`, and `kid`, with values

--- a/docs/deployment-registry-trust.md
+++ b/docs/deployment-registry-trust.md
@@ -5,7 +5,7 @@ or generated clients run. The executable does not consult
 `CREDENTIALS_DIRECTORY`, XDG/user configuration, `HYPRSTREAM__SECRETS__PATH`, a
 public setter, or a caller-provided path for this authority.
 
-The current deployment seam is deliberately small and fail-closed:
+The OS-owned deployment seam is deliberately small and fail-closed:
 
 - `/etc/hyprstream/trust/deployment-ca.ed25519` is the independently provisioned
   32-byte Ed25519 deployment CA public key.
@@ -19,14 +19,13 @@ startup fail closed. The JWT is verified against the `/etc` pin before its key i
 represented by an opaque verification-only capability. The raw key and one-shot
 witness are not exposed through the public service or Discovery APIs.
 
-The repository does not yet contain an operator enrollment protocol that can
-derive this deployment-specific CA from a universally embedded cid512 capsule.
-Deployments must therefore provision the `/etc` pin through their OS image,
-configuration manager, measured-boot policy, or equivalent root-owned mechanism,
-and project the registry JWT into the fixed `/run` location before starting
-hyprstream. User-mode service-manager installations that cannot provide these
-fixed OS-owned files are intentionally not production-authoritative and fail
-closed; ambient credential-directory fallback is not supported.
+The repository does not yet contain an operator enrollment protocol. Deployments
+using this OS-owned source must therefore provision the `/etc` pin through their
+OS image, configuration manager, measured-boot policy, or equivalent root-owned
+mechanism, and project the registry JWT into the fixed `/run` location before
+starting hyprstream. User-mode service-manager installations that cannot provide
+these fixed OS-owned files are intentionally not production-authoritative and
+fail closed; ambient credential-directory fallback is not supported.
 
 The CA authenticates the registry credential. The registry key in that credential
 then certifies the purpose-derived audit key used by accepted-state envelopes and
@@ -35,12 +34,53 @@ monotonic checkpoints. The accepted state remains self-addressed as
 checkpoint/currentness validation described in
 [`at9p-accepted-state.md`](at9p-accepted-state.md).
 
+## DID-anchored trust source
+
+Deployments may explicitly select the first increment of the DID-anchored
+source with two public root configuration values:
+
+```toml
+cluster_at9p_did = "did:at9p:<cid512>"
+cluster_did_web = "did:web:discovery.hyprstream.com"
+```
+
+Both values must be set together. When both are absent, startup uses the
+OS-owned source exactly as before. A partial pair is an error, and a failure in
+the selected DID source never falls back to the OS-owned source.
+
+The bootstrap fetches the `did:web` document and the at9p genesis capsule over
+untrusted HTTPS. A root DID document's capsule is served at
+`/.well-known/at9p/<cid512>.cbor`; for a path-form DID it is served in the
+corresponding directory beside `did.json`. The capsule must pass the existing
+canonical-encoding, BLAKE3-512 hash-to-configured-DID, and hybrid-signature
+GATE. The DID document must have the configured `id` and name that exact
+`did:at9p` in `alsoKnownAs`; the verified capsule must reciprocally name the
+configured `did:web`. Only after both directions verify does startup accept the
+at9p identity as authoritative and extract the document's single Ed25519
+Multikey as the deployment CA plus its preferred typed Iroh/QUIC transport.
+
+Capsule content only proves a content-bound reach claim, not that the endpoint
+is currently live. Startup therefore dials the document-derived Discovery
+transport and requires a successful signed `ping` before installing the
+process resolver. Fetched bytes, DNS, TLS, relays, and transport endpoints do
+not become trust decisions: identity remains pinned by the configured at9p
+hash and mutual alias rule, while application responses remain pinned to the
+separately authenticated Discovery service key.
+
+This first increment changes server trust and reach only. The existing
+OS-owned `registry-service.jwt` is still required to bind the deployment CA to
+the registry verification key. Enrollment (including operator-approved device
+flow and unattended machine attestation) and final `SecretsProfile` integration
+remain separate work; no client-authentication authority is inferred from the
+two public anchors.
+
 ## Registry credential profile
 
 `registry-service.jwt` is a closed, one-hour-maximum deployment credential, not
 a generic JWT or access token. Let `D` be the RFC 7638 Ed25519 JWK thumbprint of
-the exact public key installed as `deployment-ca.ed25519`. Provisioning must use
-the following profile exactly:
+the exact public key selected as the deployment CA (from
+`deployment-ca.ed25519` or the mutually verified DID document). Provisioning
+must use the following profile exactly:
 
 - The protected header contains only `alg`, `typ`, and `kid`, with values
   `EdDSA`, `wit+jwt`, and `D`, respectively.


### PR DESCRIPTION
Refs #1136 and #1137.

## Summary

- add explicit `OsOwnedFiles` and `DidAnchored` deployment trust providers
- select DID-anchored trust only when both `cluster_at9p_did` and `cluster_did_web` are configured, with no fallback on partial or failed configuration
- verify the `did:web` document and hybrid-signed `did:at9p` capsule as mutual aliases through the existing GATE path, keeping `did:at9p` authoritative
- extract exactly one Ed25519 registry CA and preferred Iroh/QUIC reachability from the verified DID document
- require a signed discovery ping over the DID-derived transport before installing the production resolver
- document the static well-known capsule transport and trust boundary

This is the first server-authentication/reachability increment requested in #1136. The existing root-owned registry JWT is still used. Enrollment/operator-device flow, machine attestation, and the final #805 `SecretsProfile` integration remain deferred, so #1137 is referenced rather than closed.

## Validation

- `cargo test -p hyprstream-discovery --lib` (83 passed)
- focused DID-anchor mismatch, one-way alias, mutual-alias, and unset-provider tests
- `cargo check -p hyprstream`
- `cargo build -p hyprstream-discovery -p hyprstream-pds -p hyprstream`
- `cargo clippy -p hyprstream-discovery -p hyprstream --all-targets -- -D warnings`
- repository pre-commit: `cargo clippy --workspace --all-targets --release -- -D warnings`
- `git diff --check` and targeted rustfmt check pass

`cargo fmt --check` remains blocked by existing formatting drift in untouched workspace crates; this change introduces no rustfmt diff in its new module.
