### PR TITLE
fix(oauth): bind and validate minted authority (#1146 Lane B)

### DIFF
--- a/crates/hyprstream-rpc/schema/common.capnp
+++ b/crates/hyprstream-rpc/schema/common.capnp
@@ -164,6 +164,7 @@ struct Claims {
   token @6 :Text;        # Original JWT for e2e verification by downstream services
   iss @7 :Text;          # Issuer URL (RFC 7519); hyprstream node that minted this token
   pubKey @8 :Text;       # Ed25519 public key (base64url) for service identity tokens
+  oauthScope @9 :Text;   # Signed OAuth grant ceiling (space-delimited scope claim)
 }
 
 # UTC timestamp with nanosecond precision

--- a/crates/hyprstream-rpc/src/auth/claims.rs
+++ b/crates/hyprstream-rpc/src/auth/claims.rs
@@ -2,7 +2,8 @@
 //!
 //! Two claim types:
 //! - [`Claims`] — access token claims used throughout the RPC layer.
-//!   Authorization is enforced server-side via Casbin policies, not JWT scopes.
+//!   OAuth grants carry their granted scope set in the signed JWT so consumers
+//!   can attenuate authority without falling back to subject-wide policy.
 //! - [`IdTokenClaims`] — OIDC ID Token claims (Section 2 of OpenID Connect
 //!   Core 1.0). Only used by the OAuth token endpoint when `scope=openid`.
 
@@ -109,8 +110,9 @@ pub struct ActClaim {
 
 /// JWT claims for authentication.
 ///
-/// Note: Authorization is enforced via Casbin policies server-side.
-/// Scopes are NOT embedded in JWTs.
+/// Casbin remains the server-side policy authority. OAuth access tokens also
+/// carry the grant's scope ceiling so a verifier can enforce the intersection
+/// of subject policy and the authority delegated by that specific grant.
 #[derive(Clone, Serialize, Deserialize)]
 pub struct Claims {
     /// Issuer URL — the hyprstream node that minted this token.
@@ -128,6 +130,13 @@ pub struct Claims {
     /// RFC 8707 audience claim for resource indicator binding.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub aud: Option<String>,
+    /// OAuth 2.0 granted scope set, serialized as a space-delimited string.
+    ///
+    /// This is optional because non-OAuth service tokens do not originate from
+    /// an OAuth grant. Consumers that derive authority from OAuth scopes MUST
+    /// use [`Self::has_scope`] and fail closed when this claim is absent.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub scope: Option<String>,
     /// RFC 8705 / WIMSE proof-of-possession confirmation claim.
     ///
     /// Binds the Ed25519 signing key to the JWT-attested identity via a standard
@@ -202,6 +211,7 @@ impl std::fmt::Debug for Claims {
             .field("iat", &self.iat)
             .field("jti", &self.jti)
             .field("aud", &self.aud)
+            .field("scope", &self.scope)
             .field("cnf", &self.cnf)
             .field("token", &self.token.as_ref().map(|_| "[REDACTED]"))
             .field("clearance", &self.clearance)
@@ -285,6 +295,9 @@ impl FromCapnp for Claims {
             iat: reader.get_iat(),
             jti: None,
             aud,
+            // OAuth scopes are JWT-carried authority and deliberately are not
+            // reconstructed from the legacy Cap'n Proto scope list.
+            scope: None,
             cnf,
             token,
             // MAC clearance (S8/#574) is not carried on the Cap'n Proto envelope
@@ -311,6 +324,7 @@ impl Claims {
             iat,
             jti: None,
             aud: None,
+            scope: None,
             cnf: None,
             token: None,
             clearance: None,
@@ -340,6 +354,25 @@ impl Claims {
     pub fn with_audience(mut self, audience: Option<String>) -> Self {
         self.aud = audience;
         self
+    }
+
+    /// Set the OAuth 2.0 granted scope claim.
+    pub fn with_scope(mut self, scope: Option<String>) -> Self {
+        self.scope = scope.filter(|value| !value.trim().is_empty());
+        self
+    }
+
+    /// Iterate over the exact scopes granted to this token.
+    ///
+    /// An absent claim yields an empty iterator, keeping scope-based consumers
+    /// fail closed for legacy and non-OAuth tokens.
+    pub fn granted_scopes(&self) -> impl Iterator<Item = &str> {
+        self.scope.as_deref().into_iter().flat_map(str::split_whitespace)
+    }
+
+    /// Return whether this token's signed grant contains `required` exactly.
+    pub fn has_scope(&self, required: &str) -> bool {
+        self.granted_scopes().any(|granted| granted == required)
     }
 
     /// Attach original JWT token for e2e verification by downstream services.
@@ -510,6 +543,22 @@ impl crate::auth::mac::SubjectContextClaims for Claims {
 #[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn oauth_scope_claim_is_exact_and_absence_fails_closed() {
+        let plain = Claims::new("alice".to_owned(), 1000, 2000);
+        assert!(!plain.has_scope("atproto"));
+        assert!(!serde_json::to_string(&plain).unwrap().contains("\"scope\""));
+
+        let scoped = plain.with_scope(Some("atproto transition:generic".to_owned()));
+        assert!(scoped.has_scope("atproto"));
+        assert!(scoped.has_scope("transition:generic"));
+        assert!(!scoped.has_scope("transition"));
+        assert_eq!(
+            scoped.granted_scopes().collect::<Vec<_>>(),
+            vec!["atproto", "transition:generic"]
+        );
+    }
 
     #[test]
     fn test_act_claim_serde_roundtrip_and_default_none() {

--- a/crates/hyprstream-rpc/src/auth/claims.rs
+++ b/crates/hyprstream-rpc/src/auth/claims.rs
@@ -243,6 +243,9 @@ impl ToCapnp for Claims {
                 builder.set_pub_key(&jwk.x);
             }
         }
+        if let Some(ref scope) = self.scope {
+            builder.set_oauth_scope(scope);
+        }
         // Write empty scopes list for wire compatibility
         builder.reborrow().init_scopes(0);
     }
@@ -252,9 +255,15 @@ impl FromCapnp for Claims {
     type Reader<'a> = common_capnp::claims::Reader<'a>;
 
     fn read_from(reader: Self::Reader<'_>) -> Result<Self> {
-        // Scopes on the wire are ignored - authorization is via Casbin
         let aud = reader
             .get_aud()
+            .ok()
+            .and_then(|s| s.to_str().ok())
+            .map(std::borrow::ToOwned::to_owned)
+            .filter(|s| !s.is_empty());
+
+        let scope = reader
+            .get_oauth_scope()
             .ok()
             .and_then(|s| s.to_str().ok())
             .map(std::borrow::ToOwned::to_owned)
@@ -295,9 +304,9 @@ impl FromCapnp for Claims {
             iat: reader.get_iat(),
             jti: None,
             aud,
-            // OAuth scopes are JWT-carried authority and deliberately are not
-            // reconstructed from the legacy Cap'n Proto scope list.
-            scope: None,
+            // The dedicated OAuth field preserves the signed grant ceiling;
+            // the legacy structured scope list remains unused by Claims.
+            scope,
             cnf,
             token,
             // MAC clearance (S8/#574) is not carried on the Cap'n Proto envelope
@@ -558,6 +567,21 @@ mod tests {
             scoped.granted_scopes().collect::<Vec<_>>(),
             vec!["atproto", "transition:generic"]
         );
+    }
+
+    #[test]
+    fn oauth_scope_survives_capnp_envelope_roundtrip() -> anyhow::Result<()> {
+        let claims = Claims::new("alice".to_owned(), 1000, 2000)
+            .with_scope(Some("atproto transition:generic".to_owned()));
+        let mut message = capnp::message::Builder::new_default();
+        let mut builder = message.init_root::<common_capnp::claims::Builder>();
+        claims.write_to(&mut builder);
+
+        let decoded = Claims::read_from(builder.into_reader())?;
+        assert_eq!(decoded.scope, claims.scope);
+        assert!(decoded.has_scope("atproto"));
+        assert!(decoded.has_scope("transition:generic"));
+        Ok(())
     }
 
     #[test]

--- a/crates/hyprstream-rpc/src/auth/key_source.rs
+++ b/crates/hyprstream-rpc/src/auth/key_source.rs
@@ -117,10 +117,27 @@ pub trait JwtKeySource: Send + Sync + 'static {
 #[derive(Clone)]
 pub struct ClusterKeySource {
     ca_verifying_key: VerifyingKey,
-    local_issuer_url: String,
     local_issuers_vec: Vec<String>,
     ml_dsa_vks: Arc<std::sync::RwLock<Vec<crate::crypto::pq::MlDsaVerifyingKey>>>,
     composite_keys: Arc<super::CompositeKeySet>,
+}
+
+fn local_issuer_aliases(local_issuer_url: &str) -> Vec<String> {
+    if local_issuer_url.is_empty() {
+        return Vec::new();
+    }
+    let mut issuers = vec![local_issuer_url.to_owned()];
+    // Keep this byte-for-byte aligned with OAuthState::canonical_issuer_origin:
+    // the atproto issuer is the configured scheme + authority with its path
+    // removed, without URL-library normalization of ports or casing.
+    if let Some((scheme, rest)) = local_issuer_url.split_once("://") {
+        let authority = rest.split('/').next().unwrap_or_default();
+        let origin = format!("{scheme}://{authority}");
+        if !scheme.is_empty() && !authority.is_empty() && origin != local_issuer_url {
+            issuers.push(origin);
+        }
+    }
+    issuers
 }
 
 impl ClusterKeySource {
@@ -131,14 +148,9 @@ impl ClusterKeySource {
     /// * `ca_verifying_key` - The cluster's CA verifying key (from PolicyService)
     /// * `local_issuer_url` - The OAuth issuer URL (e.g., "http://127.0.0.1:9080")
     pub fn new(ca_verifying_key: VerifyingKey, local_issuer_url: String) -> Self {
-        let local_issuers_vec = if local_issuer_url.is_empty() {
-            vec![]
-        } else {
-            vec![local_issuer_url.clone()]
-        };
+        let local_issuers_vec = local_issuer_aliases(&local_issuer_url);
         Self {
             ca_verifying_key,
-            local_issuer_url,
             local_issuers_vec,
             ml_dsa_vks: Arc::new(std::sync::RwLock::new(Vec::new())),
             composite_keys: super::global_composite_key_set(),
@@ -184,8 +196,10 @@ impl JwtKeySource for ClusterKeySource {
         if issuer.is_empty() {
             return true;
         }
-        // Match against local issuer URL
-        issuer == self.local_issuer_url
+        // The atproto profile emits the canonical origin while generic OAuth
+        // retains the configured issuer (which may carry a path). Both are
+        // exact local aliases; sibling paths and foreign origins remain denied.
+        self.local_issuers_vec.iter().any(|local| local == issuer)
     }
 
     fn local_issuers(&self) -> &[String] {
@@ -306,7 +320,6 @@ struct CachedKey {
 /// - Semaphore bounds concurrent JWKS fetches
 pub struct JwksKeySource {
     mode: JwksMode,
-    local_issuer_url: String,
     local_issuers_vec: Vec<String>,
     fetcher: JwksFetcher,
     cache: RwLock<HashMap<String, CachedKey>>,
@@ -339,14 +352,9 @@ pub struct JwksKeySource {
 
 impl JwksKeySource {
     pub fn new(mode: JwksMode, local_issuer_url: String, fetcher: JwksFetcher) -> Self {
-        let local_issuers_vec = if local_issuer_url.is_empty() {
-            vec![]
-        } else {
-            vec![local_issuer_url.clone()]
-        };
+        let local_issuers_vec = local_issuer_aliases(&local_issuer_url);
         Self {
             mode,
-            local_issuer_url,
             local_issuers_vec,
             fetcher,
             cache: RwLock::new(HashMap::new()),
@@ -397,7 +405,7 @@ impl JwksKeySource {
     }
 
     fn is_local(&self, issuer: &str) -> bool {
-        issuer.is_empty() || issuer == self.local_issuer_url
+        issuer.is_empty() || self.local_issuers_vec.iter().any(|local| local == issuer)
     }
 
     async fn resolve_jwks_url(&self, issuer: &str) -> Result<String> {
@@ -594,6 +602,31 @@ mod tests {
 
         let key = ks.get_key("http://localhost:9080", None).await?;
         assert_eq!(key, test_ca_key());
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn local_key_sources_trust_canonical_origin_for_path_issuer() -> anyhow::Result<()> {
+        let configured = "https://pds.example.test/configured/path";
+        let origin = "https://pds.example.test";
+        let ks = ClusterKeySource::new(test_ca_key(), configured.to_owned());
+        assert!(ks.is_trusted(configured));
+        assert!(ks.is_trusted(origin));
+        assert!(!ks.is_trusted("https://pds.example.test/other"));
+        assert_eq!(ks.get_key(origin, None).await?, test_ca_key());
+        assert_eq!(ks.local_issuers(), &[configured, origin]);
+
+        let fetcher: JwksFetcher = std::sync::Arc::new(|_url: String| {
+            Box::pin(async move { anyhow::bail!("network must not be used") })
+        });
+        let jwks = JwksKeySource::new(
+            JwksMode::Isolated { jwks_url: "https://pds.example.test/oauth/jwks".to_owned() },
+            configured.to_owned(),
+            fetcher,
+        )
+        .with_local_ca_key(test_ca_key());
+        assert!(jwks.is_trusted(origin));
+        assert_eq!(jwks.local_issuers(), &[configured, origin]);
         Ok(())
     }
 

--- a/crates/hyprstream/src/services/oauth/auth.rs
+++ b/crates/hyprstream/src/services/oauth/auth.rs
@@ -9,6 +9,7 @@
 
 use std::sync::Arc;
 
+use hyprstream_rpc::auth::JtiBlocklist as _;
 use subtle::ConstantTimeEq;
 use axum::{
     extract::{Request, State},
@@ -22,7 +23,8 @@ pub use crate::server::middleware::AuthenticatedUser;
 
 /// Require a valid Bearer or DPoP token on the request.
 ///
-/// Validates the Ed25519-signed JWT against the server's verifying key.
+/// Routes JWT verification by the protected `alg` header, then validates the
+/// exact OAuth-self audience and one of this node's exact profile issuers.
 /// When `Authorization: DPoP` is used, also verifies the `DPoP` proof header and
 /// checks that `cnf.jkt` in the token matches the proof key's thumbprint.
 /// Inserts `AuthenticatedUser` into request extensions on success.
@@ -71,15 +73,7 @@ pub async fn require_bearer_token(
         None
     };
 
-    let vk = match ed25519_dalek::VerifyingKey::from_bytes(&state.verifying_key_bytes) {
-        Ok(k) => k,
-        Err(_) => {
-            return (StatusCode::INTERNAL_SERVER_ERROR, "server configuration error")
-                .into_response();
-        }
-    };
-
-    let claims = match hyprstream_rpc::auth::jwt::decode(&token, &vk, None) {
+    let claims = match validate_oauth_access_token(&state, &token).await {
         Ok(c) => c,
         Err(_) => {
             return (
@@ -194,4 +188,68 @@ pub async fn require_bearer_token(
     });
 
     next.run(request).await
+}
+
+/// Verify a JWT access token against the OAuth server's complete local signing
+/// surface. PolicyService mints composite tokens, while classical EdDSA remains
+/// accepted for explicitly classical deployments and legacy rotation slots.
+///
+/// Audience and issuer are mandatory here: the OAuth server is its own RFC 9728
+/// protected resource, whose canonical resource identifier is the origin-only
+/// atproto issuer. A configured issuer carrying a path remains a valid issuer
+/// for generic-profile tokens minted by this same server, but never an audience.
+pub(super) async fn validate_oauth_access_token(
+    state: &OAuthState,
+    token: &str,
+) -> Result<hyprstream_rpc::auth::Claims, &'static str> {
+    let header = hyprstream_rpc::auth::parse_protected_header(token)
+        .map_err(|_| "JWT header invalid")?;
+    if !hyprstream_rpc::auth::is_rfc9068_access_token_type(&header.typ) {
+        return Err("JWT type invalid");
+    }
+
+    let expected_audience = state.atproto_issuer_url();
+    let claims = match header.alg.as_str() {
+        "ML-DSA-65-Ed25519" => {
+            let dispatch = hyprstream_rpc::auth::parse_composite_dispatch(
+                token,
+                hyprstream_rpc::auth::RFC9068_ACCESS_TOKEN_TYPES,
+            )
+            .map_err(|_| "composite JWT dispatch invalid")?;
+            let snapshot = hyprstream_rpc::auth::global_composite_key_set().snapshot();
+            let pair = snapshot
+                .pair(dispatch.kid())
+                .ok_or("composite JWT kid unknown")?;
+            hyprstream_rpc::auth::jwt::decode_composite(
+                token,
+                pair.ml_dsa(),
+                pair.ed25519(),
+                Some(&expected_audience),
+                &dispatch,
+            )
+            .map_err(|_| "composite JWT validation failed")?
+        }
+        "EdDSA" => {
+            let key = state
+                .jwt_bearer_verifying_key()
+                .await
+                .ok_or("EdDSA verification key unavailable")?;
+            hyprstream_rpc::auth::jwt::decode(token, &key, Some(&expected_audience))
+                .map_err(|_| "EdDSA JWT validation failed")?
+        }
+        _ => return Err("JWT algorithm unsupported"),
+    };
+
+    let issuer_is_local = claims.iss == expected_audience || claims.iss == state.issuer_url;
+    if !issuer_is_local {
+        return Err("JWT issuer invalid");
+    }
+    if claims
+        .jti
+        .as_deref()
+        .is_some_and(|jti| state.jti_blocklist.as_ref().is_some_and(|list| list.is_revoked(jti)))
+    {
+        return Err("JWT revoked");
+    }
+    Ok(claims)
 }

--- a/crates/hyprstream/src/services/oauth/auth.rs
+++ b/crates/hyprstream/src/services/oauth/auth.rs
@@ -194,10 +194,10 @@ pub async fn require_bearer_token(
 /// surface. PolicyService mints composite tokens, while classical EdDSA remains
 /// accepted for explicitly classical deployments and legacy rotation slots.
 ///
-/// Audience and issuer are mandatory here: the OAuth server is its own RFC 9728
-/// protected resource, whose canonical resource identifier is the origin-only
-/// atproto issuer. A configured issuer carrying a path remains a valid issuer
-/// for generic-profile tokens minted by this same server, but never an audience.
+/// Audience and issuer are mandatory here. The canonical origin is the OAuth
+/// server's RFC 9728 resource identifier, while the configured issuer remains
+/// an accepted local audience alias for default-audience tokens minted before
+/// the resource indicator is known. No other audience is accepted.
 pub(super) async fn validate_oauth_access_token(
     state: &OAuthState,
     token: &str,
@@ -208,7 +208,17 @@ pub(super) async fn validate_oauth_access_token(
         return Err("JWT type invalid");
     }
 
-    let expected_audience = state.atproto_issuer_url();
+    let canonical_audience = state.atproto_issuer_url();
+    let unverified = hyprstream_rpc::auth::decode_unverified(token)
+        .map_err(|_| "JWT claims invalid")?;
+    let expected_audience = match unverified.aud.as_deref() {
+        Some(audience)
+            if audience == canonical_audience || audience == state.issuer_url.as_str() =>
+        {
+            audience.to_owned()
+        }
+        _ => return Err("JWT audience invalid"),
+    };
     let claims = match header.alg.as_str() {
         "ML-DSA-65-Ed25519" => {
             let dispatch = hyprstream_rpc::auth::parse_composite_dispatch(
@@ -240,7 +250,7 @@ pub(super) async fn validate_oauth_access_token(
         _ => return Err("JWT algorithm unsupported"),
     };
 
-    let issuer_is_local = claims.iss == expected_audience || claims.iss == state.issuer_url;
+    let issuer_is_local = claims.iss == canonical_audience || claims.iss == state.issuer_url;
     if !issuer_is_local {
         return Err("JWT issuer invalid");
     }

--- a/crates/hyprstream/src/services/oauth/introspection.rs
+++ b/crates/hyprstream/src/services/oauth/introspection.rs
@@ -3,7 +3,8 @@
 //! `POST /oauth/introspect` — validates a token and returns its metadata.
 //! Caller must authenticate with a Bearer token.
 //!
-//! - JWT access tokens: verified against the server's Ed25519 key.
+//! - JWT access tokens: routed by algorithm and verified against the server's
+//!   exact published composite pair or Ed25519 key.
 //! - Opaque refresh tokens: looked up from RocksDB with lazy expiry.
 //! - Any failure → `{"active": false}` per RFC 7662 § 2.2.
 
@@ -33,19 +34,14 @@ pub async fn introspect_token(
 ) -> Response {
     // JWT tokens contain dots; opaque tokens do not.
     if params.token.contains('.') {
-        introspect_jwt(&state, &params.token)
+        introspect_jwt(&state, &params.token).await
     } else {
         introspect_refresh(&state, &params.token).await
     }
 }
 
-fn introspect_jwt(state: &Arc<OAuthState>, token: &str) -> Response {
-    let vk = match ed25519_dalek::VerifyingKey::from_bytes(&state.verifying_key_bytes) {
-        Ok(k) => k,
-        Err(_) => return inactive_response(),
-    };
-
-    let claims = match hyprstream_rpc::auth::jwt::decode(token, &vk, None) {
+async fn introspect_jwt(state: &Arc<OAuthState>, token: &str) -> Response {
+    let claims = match super::auth::validate_oauth_access_token(state, token).await {
         Ok(c) => c,
         Err(_) => return inactive_response(),
     };
@@ -66,6 +62,7 @@ fn introspect_jwt(state: &Arc<OAuthState>, token: &str) -> Response {
             "exp": claims.exp,
             "iat": claims.iat,
             "aud": claims.aud,
+            "scope": claims.scope,
         })),
     )
         .into_response()

--- a/crates/hyprstream/src/services/oauth/mod.rs
+++ b/crates/hyprstream/src/services/oauth/mod.rs
@@ -1547,6 +1547,7 @@ mod tests {
         assert_eq!(claims["iss"], ISSUER);
         assert_eq!(claims["sub"], MAPPED_DID);
         assert_eq!(claims["aud"], ISSUER);
+        assert_eq!(claims["scope"], "atproto");
 
         // A confidential atproto client signs private_key_jwt for the
         // canonical token endpoint advertised by the atproto metadata, even
@@ -1738,6 +1739,7 @@ mod tests {
         assert!(state.get_refresh_token(&refresh_token).await?.is_none());
         let refreshed_claims = jwt_claims(refreshed_json["access_token"].as_str().unwrap());
         assert_eq!(refreshed_claims["sub"], MAPPED_DID);
+        assert_eq!(refreshed_claims["scope"], "atproto");
 
         // A non-atproto PAR consent cannot be upgraded to the atproto profile
         // by mutating hidden fields on the callback POST.
@@ -1858,22 +1860,74 @@ mod tests {
         assert_eq!(generic_claims["sub"], "alice");
         assert_eq!(generic_claims["iss"], GENERIC_ISSUER);
         assert_eq!(generic_claims["aud"], ISSUER);
-        let now = chrono::Utc::now().timestamp();
-        let introspection_caller = hyprstream_rpc::auth::jwt::encode(
-            &hyprstream_rpc::auth::Claims::new("introspection-test".to_owned(), now, now + 300),
-            &service_key,
-        );
+        assert_eq!(generic_claims["scope"], "read:*:*");
+
+        // The real composite token minted above authenticates to a protected
+        // OAuth route. This failed when middleware routed every JWT through
+        // the fixed EdDSA key.
         let generic_introspection = post_form_bearer(
             &app,
             "/oauth/introspect",
             &[("token", &generic_refresh_token)],
-            &introspection_caller,
+            &generic_access_token,
         ).await;
         let generic_introspection_status = generic_introspection.status();
         let generic_introspection_json = response_json(generic_introspection).await;
         assert_eq!(generic_introspection_status, axum::http::StatusCode::OK, "{generic_introspection_json}");
         assert_eq!(generic_introspection_json["active"], true);
         assert_eq!(generic_introspection_json["sub"], "alice");
+
+        // JWT introspection uses the same composite/audience/issuer validator
+        // and returns the signed grant scope rather than subject-wide policy.
+        let access_introspection = post_form_bearer(
+            &app,
+            "/oauth/introspect",
+            &[("token", &generic_access_token)],
+            &generic_access_token,
+        ).await;
+        assert_eq!(access_introspection.status(), axum::http::StatusCode::OK);
+        let access_introspection_json = response_json(access_introspection).await;
+        assert_eq!(access_introspection_json["active"], true);
+        assert_eq!(access_introspection_json["scope"], "read:*:*");
+
+        let snapshot = hyprstream_rpc::auth::global_composite_key_set().snapshot();
+        let signing_pair = snapshot
+            .active_signing_pair(hyprstream_rpc::auth::CompositePairRole::Policy)
+            .unwrap();
+        let (ml_signing, ed_signing) = signing_pair.signing_keys().unwrap();
+        let now = chrono::Utc::now().timestamp();
+        let wrong_audience = crate::auth::jwt::encode_composite_ml_dsa_65_ed25519(
+            &hyprstream_rpc::auth::Claims::new("alice".to_owned(), now, now + 300)
+                .with_issuer(GENERIC_ISSUER.to_owned())
+                .with_audience(Some("https://other-resource.example.test".to_owned()))
+                .with_scope(Some("read:*:*".to_owned())),
+            &ml_signing,
+            &ed_signing,
+        );
+        let rejected_audience = post_form_bearer(
+            &app,
+            "/oauth/introspect",
+            &[("token", &generic_refresh_token)],
+            &wrong_audience,
+        ).await;
+        assert_eq!(rejected_audience.status(), axum::http::StatusCode::UNAUTHORIZED);
+
+        let wrong_issuer = crate::auth::jwt::encode_composite_ml_dsa_65_ed25519(
+            &hyprstream_rpc::auth::Claims::new("alice".to_owned(), now, now + 300)
+                .with_issuer("https://other-issuer.example.test".to_owned())
+                .with_audience(Some(ISSUER.to_owned()))
+                .with_scope(Some("read:*:*".to_owned())),
+            &ml_signing,
+            &ed_signing,
+        );
+        let rejected_issuer = post_form_bearer(
+            &app,
+            "/oauth/introspect",
+            &[("token", &wrong_issuer)],
+            &generic_access_token,
+        ).await;
+        assert_eq!(rejected_issuer.status(), axum::http::StatusCode::OK);
+        assert_eq!(response_json(rejected_issuer).await["active"], false);
 
         // A real generic device flow retains the local username byte-for-byte
         // and the legacy Bearer response shape.
@@ -1938,6 +1992,7 @@ mod tests {
         assert_eq!(device_claims["sub"], "alice");
         assert_eq!(device_claims["iss"], GENERIC_ISSUER);
         assert_eq!(device_claims["aud"], ISSUER);
+        assert_eq!(device_claims["scope"], "read:*:*");
 
         policy_handle.stop().await?;
         Ok(())

--- a/crates/hyprstream/src/services/oauth/mod.rs
+++ b/crates/hyprstream/src/services/oauth/mod.rs
@@ -1256,6 +1256,7 @@ mod tests {
         use super::token_store::RocksDbTokenStore;
         use crate::auth::rocksdb_store::RocksDbUserStore;
         use crate::auth::{PolicyManager, UserProfile, UserStore};
+        use crate::services::generated::policy_client::IssueToken;
         use crate::services::{DiscoveryClient, PolicyClient, PolicyService};
 
         const ISSUER: &str = "https://pds.example.test";
@@ -1370,6 +1371,7 @@ mod tests {
                     "authorization_code".to_owned(),
                     "refresh_token".to_owned(),
                     "urn:ietf:params:oauth:grant-type:device_code".to_owned(),
+                    "urn:ietf:params:oauth:grant-type:token-exchange".to_owned(),
                 ],
                 response_types: vec!["code".to_owned()],
                 token_endpoint_auth_method: Some("none".to_owned()),
@@ -1861,6 +1863,126 @@ mod tests {
         assert_eq!(generic_claims["iss"], GENERIC_ISSUER);
         assert_eq!(generic_claims["aud"], ISSUER);
         assert_eq!(generic_claims["scope"], "read:*:*");
+
+        // A token minted without an explicit resource uses PolicyService's
+        // configured path-bearing default audience. The AS must accept that
+        // exact local alias on its own protected routes.
+        let default_audience_token = state
+            .policy_client
+            .issue_token(&IssueToken {
+                requested_scopes: Some(vec!["read:*:*".to_owned()]),
+                ttl: Some(300),
+                audience: None,
+                subject: Some("default-audience-user".to_owned()),
+                user_pub_key: None,
+                dpop_jkt: None,
+                issuer: None,
+            })
+            .await?
+            .token;
+        assert_eq!(jwt_claims(&default_audience_token)["aud"], GENERIC_ISSUER);
+        let default_audience_auth = post_form_bearer(
+            &app,
+            "/oauth/introspect",
+            &[("token", &generic_access_token)],
+            &default_audience_token,
+        )
+        .await;
+        assert_eq!(
+            default_audience_auth.status(),
+            axum::http::StatusCode::OK,
+            "the AS must accept its path-bearing default audience alias"
+        );
+
+        // Token exchange may only attenuate the verified subject token's signed
+        // grant. A caller holding read:*:* cannot write transition:generic into
+        // a newly signed scope claim.
+        let inflation_subject = state
+            .policy_client
+            .issue_token(&IssueToken {
+                requested_scopes: Some(vec!["read:*:*".to_owned()]),
+                ttl: Some(300),
+                audience: Some(ISSUER.to_owned()),
+                subject: Some("scope-inflation-user".to_owned()),
+                user_pub_key: None,
+                dpop_jkt: None,
+                issuer: None,
+            })
+            .await?
+            .token;
+        let inflated_exchange = post_form(
+            &app,
+            "/oauth/token",
+            &[
+                (
+                    "grant_type",
+                    "urn:ietf:params:oauth:grant-type:token-exchange",
+                ),
+                ("client_id", CLIENT_ID),
+                ("subject_token", &inflation_subject),
+                (
+                    "subject_token_type",
+                    "urn:ietf:params:oauth:token-type:access_token",
+                ),
+                ("scope", "transition:generic"),
+                ("audience", ISSUER),
+            ],
+            None,
+            false,
+        )
+        .await;
+        assert_eq!(
+            inflated_exchange.status(),
+            axum::http::StatusCode::BAD_REQUEST
+        );
+        assert_eq!(response_json(inflated_exchange).await["error"], "invalid_scope");
+
+        // The same endpoint accepts a production composite access token and
+        // preserves a requested subset of its signed grant. This exercises the
+        // shared algorithm/audience/issuer validator on the subject-token path.
+        let valid_exchange_subject = state
+            .policy_client
+            .issue_token(&IssueToken {
+                requested_scopes: Some(vec![
+                    "read:*:*".to_owned(),
+                    "transition:generic".to_owned(),
+                ]),
+                ttl: Some(300),
+                audience: Some(ISSUER.to_owned()),
+                subject: Some("scope-valid-user".to_owned()),
+                user_pub_key: None,
+                dpop_jkt: None,
+                issuer: None,
+            })
+            .await?
+            .token;
+        let valid_exchange = post_form(
+            &app,
+            "/oauth/token",
+            &[
+                (
+                    "grant_type",
+                    "urn:ietf:params:oauth:grant-type:token-exchange",
+                ),
+                ("client_id", CLIENT_ID),
+                ("subject_token", &valid_exchange_subject),
+                (
+                    "subject_token_type",
+                    "urn:ietf:params:oauth:token-type:access_token",
+                ),
+                ("scope", "read:*:*"),
+                ("audience", ISSUER),
+            ],
+            None,
+            false,
+        )
+        .await;
+        assert_eq!(valid_exchange.status(), axum::http::StatusCode::OK);
+        let valid_exchange_json = response_json(valid_exchange).await;
+        let valid_exchange_claims =
+            jwt_claims(valid_exchange_json["access_token"].as_str().unwrap());
+        assert_eq!(valid_exchange_claims["sub"], "scope-valid-user");
+        assert_eq!(valid_exchange_claims["scope"], "read:*:*");
 
         // The real composite token minted above authenticates to a protected
         // OAuth route. This failed when middleware routed every JWT through

--- a/crates/hyprstream/src/services/oauth/token_exchange.rs
+++ b/crates/hyprstream/src/services/oauth/token_exchange.rs
@@ -29,6 +29,9 @@ struct VerifiedSubject {
     sub: String,
     cnf_key_bytes: Option<[u8; 32]>,
     iat: i64,
+    /// Authority from a locally validated OAuth access-token grant. Identity
+    /// tokens and generic JWTs do not carry a server-authorized OAuth grant.
+    granted_scopes: Option<Vec<String>>,
 }
 
 /// POST /oauth/token — token-exchange grant (RFC 8693).
@@ -63,7 +66,7 @@ pub async fn exchange_token_exchange(
 
     let verified = match subject_token_type {
         TOKEN_TYPE_ID_TOKEN => verify_id_token(state, subject_token).await,
-        TOKEN_TYPE_ACCESS_TOKEN => verify_access_token(state, subject_token),
+        TOKEN_TYPE_ACCESS_TOKEN => verify_access_token(state, subject_token).await,
         TOKEN_TYPE_JWT => verify_jwt(state, subject_token).await,
         _ => return tx_error(
             StatusCode::BAD_REQUEST,
@@ -77,6 +80,17 @@ pub async fn exchange_token_exchange(
         Err(e) => return tx_error(StatusCode::UNAUTHORIZED, "invalid_grant", &e),
     };
 
+    let requested_scopes = match attenuate_exchange_scopes(&verified, scope) {
+        Ok(scopes) => scopes,
+        Err(description) => {
+            return tx_error(
+                StatusCode::BAD_REQUEST,
+                "invalid_scope",
+                description,
+            );
+        }
+    };
+
     // Replay prevention: SHA-256 of the subject token as the replay key.
     // Covers all token types, regardless of whether they carry a jti claim.
     let token_hash = URL_SAFE_NO_PAD.encode(Sha256::digest(subject_token.as_bytes()));
@@ -87,9 +101,6 @@ pub async fn exchange_token_exchange(
             "subject_token already used (replay)",
         );
     }
-
-    let requested_scopes: Option<Vec<String>> =
-        scope.map(|s| s.split_whitespace().map(str::to_owned).collect());
 
     // Encode cnf key bytes for PolicyService (same path as user_pub_key in other flows).
     let user_pub_key = verified.cnf_key_bytes.map(|b| URL_SAFE_NO_PAD.encode(b));
@@ -176,22 +187,27 @@ async fn verify_id_token(state: &Arc<OAuthState>, token: &str) -> Result<Verifie
         sub: claims.sub,
         cnf_key_bytes: None, // ID tokens carry no key binding
         iat: claims.iat,
+        granted_scopes: None,
     })
 }
 
-/// Verify an existing hyprstream at+jwt (downscoping / audience narrowing).
-fn verify_access_token(state: &OAuthState, token: &str) -> Result<VerifiedSubject, String> {
-    let vk = ed25519_dalek::VerifyingKey::from_bytes(&state.verifying_key_bytes)
-        .map_err(|_| "server configuration error: invalid verifying key".to_owned())?;
-
-    let claims = hyprstream_rpc::auth::jwt::decode(token, &vk, None)
+/// Verify an existing hyprstream at+jwt through the same algorithm, audience,
+/// issuer, and revocation checks used by protected OAuth routes.
+async fn verify_access_token(state: &OAuthState, token: &str) -> Result<VerifiedSubject, String> {
+    let claims = super::auth::validate_oauth_access_token(state, token)
+        .await
         .map_err(|e| format!("access_token verification failed: {e}"))?;
 
+    let granted_scopes = claims
+        .scope
+        .as_ref()
+        .map(|_| claims.granted_scopes().map(str::to_owned).collect());
     let cnf_key_bytes = claims.cnf_key_bytes();
     Ok(VerifiedSubject {
         sub: claims.sub,
         cnf_key_bytes,
         iat: claims.iat,
+        granted_scopes,
     })
 }
 
@@ -240,7 +256,53 @@ async fn verify_jwt(state: &Arc<OAuthState>, token: &str) -> Result<VerifiedSubj
         sub: claims.sub,
         cnf_key_bytes,
         iat: claims.iat,
+        granted_scopes: None,
     })
+}
+
+/// Bound an RFC 8693 scope request to authority already present on the verified
+/// subject access token. The signed subject-token grant is the ceiling: callers
+/// may retain or narrow it, never add authority. Subject types without a local
+/// OAuth grant cannot mint a scope claim through token exchange.
+fn attenuate_exchange_scopes(
+    subject: &VerifiedSubject,
+    requested: Option<&str>,
+) -> Result<Option<Vec<String>>, &'static str> {
+    let Some(granted) = subject.granted_scopes.as_ref() else {
+        return if requested.is_some() {
+            Err("subject token carries no OAuth grant to authorize requested scope")
+        } else {
+            Ok(None)
+        };
+    };
+
+    let Some(requested) = requested else {
+        return Ok(Some(granted.clone()));
+    };
+    let requested: Vec<&str> = requested
+        .split_whitespace()
+        .map(|scope| {
+            super::state::normalize_scope_token(scope)
+                .ok_or("requested scope contains an invalid token")
+        })
+        .collect::<Result<_, _>>()?;
+    if requested.is_empty() {
+        return Err("requested scope must not be empty");
+    }
+    if requested
+        .iter()
+        .any(|scope| !granted.iter().any(|allowed| allowed == scope))
+    {
+        return Err("requested scope exceeds the subject token grant");
+    }
+
+    Ok(Some(
+        granted
+            .iter()
+            .filter(|allowed| requested.contains(&allowed.as_str()))
+            .cloned()
+            .collect(),
+    ))
 }
 
 /// Decode `nbf` from JWT payload and reject if in the future (±5s clock skew).

--- a/crates/hyprstream/src/services/policy.rs
+++ b/crates/hyprstream/src/services/policy.rs
@@ -358,11 +358,19 @@ impl PolicyHandler for PolicyService {
             }));
         }
 
-        // Create and sign JWT with audience binding (RFC 8707)
-        // Scopes are not embedded in JWT - Casbin enforces authorization server-side
+        // Create and sign JWT with audience (RFC 8707) and the OAuth grant's
+        // scope ceiling. Casbin still supplies subject policy; verifiers must
+        // intersect it with this signed per-grant authority (#1146 T2.1).
         let now = chrono::Utc::now().timestamp();
         let audience = data.audience.as_ref().filter(|s| !s.is_empty()).cloned()
             .or_else(|| self.default_audience.clone());
+        let granted_scope = data.requested_scopes.as_ref().map(|scopes| {
+            scopes.iter()
+                .map(String::as_str)
+                .filter(|scope| !scope.is_empty())
+                .collect::<Vec<_>>()
+                .join(" ")
+        });
 
         // Service tokens: cnf.jwk must be the service's REGISTERED key, never a
         // CA-derived guess (#441/#806) — bootstrap generates independent random
@@ -396,7 +404,8 @@ impl PolicyHandler for PolicyService {
             now,
             now + requested_ttl as i64,
         ).with_issuer(issuer)
-         .with_audience(audience);
+         .with_audience(audience)
+         .with_scope(granted_scope);
 
         // DPoP jkt takes priority over userPubKey (RFC 9449 § 6).
         if let Some(ref jkt) = data.dpop_jkt {


### PR DESCRIPTION
## Summary

- choose T2.1 shape (a): embed the granted OAuth scope set as an optional signed `scope` claim, with fail-closed exact-scope helpers for downstream consumers such as #1119
- route OAuth bearer authentication and JWT introspection by the protected JWT algorithm so PolicyService composite tokens verify against their exact published pair
- require the OAuth-self audience and an exact profile-valid local issuer on both acceptance paths
- treat both a configured path-bearing issuer and its canonical origin as local key-routing aliases

Shape (a) is intentional: #1119 needs to attenuate authority from the grant presented by the caller without a subject-wide lookup. A signed optional claim gives the bridge that verifiable ceiling directly, while remaining backward-compatible with non-OAuth service tokens.

## Regression coverage

- minted atproto, refresh, generic, and device tokens carry their granted scope
- a composite token minted by the production PolicyService path authenticates to a protected OAuth route and can be introspected
- a token for another audience is rejected by bearer middleware
- a token from another issuer is inactive under JWT introspection
- path-bearing configured issuers route their canonical-origin atproto tokens as local, while sibling paths remain rejected

## Validation

- `cargo test -p hyprstream-rpc --lib --no-fail-fast` — 774 passed, 3 ignored
- `cargo build -p hyprstream` — passed
- `cargo test -p hyprstream --lib --no-fail-fast` — 1,135 passed, 1 ignored
- `cargo clippy -p hyprstream --all-targets -- -D warnings` — passed
- `cargo clippy -p hyprstream-rpc --all-targets -- -D warnings` — passed
- repository pre-commit release workspace Clippy — passed
- `git diff --check` — passed

`cargo fmt --check` was not run because the clean-base failure is tracked in #1140.

Refs #1146 (Lane B), #1121, #1119, #1145.