### PR TITLE
fix(cors): honor every configured origin, not just the last (pre-existing)

### DIFF
--- a/crates/hyprstream/src/server/middleware.rs
+++ b/crates/hyprstream/src/server/middleware.rs
@@ -604,30 +604,37 @@ pub fn cors_layer(config: &crate::server::state::CorsConfig) -> tower_http::cors
         cors = cors.allow_origin(Any);
         // Never allow credentials with wildcard
         cors = cors.allow_credentials(false);
-    } else if config.allowed_origins.is_empty() {
-        // If no origins specified, use default localhost origins
-        let default_origins = vec![
-            "http://localhost:3000",
-            "http://localhost:3001",
-            "http://127.0.0.1:3000",
-            "http://127.0.0.1:3001",
-        ];
-        for origin in default_origins {
-            if let Ok(header_value) = origin.parse::<HeaderValue>() {
-                cors = cors.allow_origin(header_value);
-            }
-        }
-        // Configure credentials based on config
-        if config.allow_credentials {
-            cors = cors.allow_credentials(true);
-        }
     } else {
-        // Allow specific origins
-        for origin in &config.allowed_origins {
-            if let Ok(header_value) = origin.parse::<HeaderValue>() {
-                cors = cors.allow_origin(header_value);
-            }
-        }
+        // Allow specific origins.
+        //
+        // The whole set MUST be passed in a single `allow_origin` call:
+        // `CorsLayer::allow_origin` is documented to *override* on every call
+        // (`self.allow_origin = origin.into()`), and a single `HeaderValue`
+        // becomes `AllowOrigin::exact(...)` — a constant `Access-Control-Allow-Origin`
+        // emitted unconditionally, not a membership check. Iterating and calling
+        // it once per origin would therefore honor only the LAST origin in the
+        // list, silently dropping every earlier origin. Passing the
+        // `Vec<HeaderValue>` makes tower-http build `AllowOrigin::list(...)`,
+        // which performs exact-equality membership matching against the full set.
+        let origins: Vec<HeaderValue> = if config.allowed_origins.is_empty() {
+            // If no origins specified, use default localhost origins
+            [
+                "http://localhost:3000",
+                "http://localhost:3001",
+                "http://127.0.0.1:3000",
+                "http://127.0.0.1:3001",
+            ]
+            .into_iter()
+            .filter_map(|o| o.parse::<HeaderValue>().ok())
+            .collect()
+        } else {
+            config
+                .allowed_origins
+                .iter()
+                .filter_map(|o| o.parse::<HeaderValue>().ok())
+                .collect()
+        };
+        cors = cors.allow_origin(origins);
         // Configure credentials based on config
         if config.allow_credentials {
             cors = cors.allow_credentials(true);
@@ -635,6 +642,189 @@ pub fn cors_layer(config: &crate::server::state::CorsConfig) -> tower_http::cors
     }
 
     cors
+}
+
+/// Runtime-behavior tests for [`cors_layer`].
+///
+/// These drive the real axum `Router` + `CorsLayer` and assert the
+/// `Access-Control-Allow-Origin` / `Access-Control-Allow-Credentials` headers a
+/// browser would actually observe. They exist because the credentialed router's
+/// origin list used to be built with a per-origin loop of `allow_origin(...)`,
+/// which silently honored only the LAST entry — a config-vec assertion can't
+/// catch that (the vec is correct; the layer is wrong), so every check here
+/// exercises the layer end-to-end.
+#[cfg(test)]
+#[allow(clippy::expect_used, clippy::unwrap_used)]
+mod cors_layer_tests {
+    use super::cors_layer;
+    use crate::config::server::ServerConfig;
+    use crate::server::state::CorsConfig;
+    use axum::{body::Body, http::Request as HttpRequest, routing::get, Router};
+    use tower::ServiceExt;
+
+    /// Drive the credentialed CORS layer on a real `Router` and return the
+    /// `Access-Control-Allow-Origin` header it emits for `origin` (or `None` if
+    /// the request was rejected / header absent). This is the only honest way to
+    /// catch the classic "only the last origin in the list is honored" bug, which
+    /// a config-vec assertion will happily report as fixed while the runtime is
+    /// broken.
+    async fn acao_for(config: &CorsConfig, origin: &str) -> Option<String> {
+        let app = Router::new()
+            .route("/probe", get(|| async { "ok" }))
+            .layer(cors_layer(config));
+        let req = HttpRequest::get("/probe")
+            .header("Origin", origin)
+            .body(Body::empty())
+            .expect("request");
+        let resp = app.oneshot(req).await.expect("response");
+        resp.headers()
+            .get(axum::http::header::ACCESS_CONTROL_ALLOW_ORIGIN)
+            .and_then(|v| v.to_str().ok())
+            .map(str::to_owned)
+    }
+
+    #[tokio::test]
+    async fn cors_layer_allows_every_default_origin_at_runtime() {
+        // Regression: the credentialed default list previously honored only the
+        // LAST origin (loop-of-override bug). Every dev origin must each produce
+        // an ACAO echoing itself back.
+        let config = CorsConfig::default();
+        for origin in [
+            "http://localhost:3000",
+            "http://localhost:3001",
+            "http://127.0.0.1:3000",
+            "http://127.0.0.1:3001",
+        ] {
+            assert_eq!(
+                acao_for(&config, origin).await,
+                Some(origin.to_owned()),
+                "credentialed CORS layer must echo allowed origin {origin}"
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn cors_layer_rejects_near_miss_origins() {
+        // tower-http's list path uses exact `HeaderValue` equality, so
+        // prefix/suffix/subdomain near-misses must NOT be reflected back. These
+        // are the classic CORS-bypass tricks; a reflect-any bug would leak them.
+        let config = ServerConfig::builder()
+            .cors_origins(vec![
+                "https://hyprstream.com".to_owned(),
+                "https://www.hyprstream.com".to_owned(),
+            ])
+            .build()
+            .cors;
+        for evil in [
+            "https://hyprstream.com.evil.tld", // suffix hijack
+            "https://evilhyprstream.com",      // subdomain look-alike
+            "http://hyprstream.com",           // scheme downgrade (no TLS)
+            "https://www.hyprstream.com.evil", // www suffix hijack
+        ] {
+            assert_eq!(
+                acao_for(&config, evil).await,
+                None,
+                "credentialed CORS layer must reject near-miss origin {evil}"
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn cors_layer_multiorigin_override_honors_all_entries() {
+        // An operator who supplies MULTIPLE origins via
+        // HYPRSTREAM_CORS_ORIGINS / builder must have all of them honored, not
+        // just the last. Single-origin overrides always worked; this guards the
+        // multi-origin case.
+        let config = ServerConfig::builder()
+            .cors_origins(vec![
+                "https://a.example.com".to_owned(),
+                "https://b.example.com".to_owned(),
+                "https://c.example.com".to_owned(),
+            ])
+            .build()
+            .cors;
+        for origin in [
+            "https://a.example.com",
+            "https://b.example.com",
+            "https://c.example.com",
+        ] {
+            assert_eq!(
+                acao_for(&config, origin).await,
+                Some(origin.to_owned()),
+                "multi-origin override must honor {origin}"
+            );
+        }
+        // And an unrelated origin still gets nothing.
+        assert_eq!(
+            acao_for(&config, "https://evil.example.com").await,
+            None,
+            "multi-origin override must not leak to unrelated origins"
+        );
+    }
+
+    #[tokio::test]
+    async fn cors_layer_credentials_header_present_for_allowed_origin() {
+        // The credentialed router must advertise `Access-Control-Allow-Credentials:
+        // true` so browser credentialed requests succeed for an allowed origin.
+        let config = CorsConfig::default();
+        let app = Router::new()
+            .route("/probe", get(|| async { "ok" }))
+            .layer(cors_layer(&config));
+        let resp = app
+            .oneshot(
+                HttpRequest::builder()
+                    .method("GET")
+                    .uri("/probe")
+                    .header("Origin", "http://localhost:3000")
+                    .body(Body::empty())
+                    .expect("request"),
+            )
+            .await
+            .expect("response");
+        assert_eq!(
+            resp.headers()
+                .get(axum::http::header::ACCESS_CONTROL_ALLOW_CREDENTIALS)
+                .and_then(|v| v.to_str().ok()),
+            Some("true"),
+            "credentialed router must set Access-Control-Allow-Credentials: true"
+        );
+    }
+
+    #[tokio::test]
+    async fn cors_layer_wildcard_never_pairs_with_credentials() {
+        // Even a hand-edited config with `["*"]` + credentials-true must be
+        // defused at layer-build time: wildcard forces credentials OFF.
+        let mut config = CorsConfig::public();
+        config.allow_credentials = true; // adversarial: try to force creds on with "*"
+        let app = Router::new()
+            .route("/probe", get(|| async { "ok" }))
+            .layer(cors_layer(&config));
+        let resp = app
+            .oneshot(
+                HttpRequest::builder()
+                    .method("GET")
+                    .uri("/probe")
+                    .header("Origin", "https://evil.example.com")
+                    .body(Body::empty())
+                    .expect("request"),
+            )
+            .await
+            .expect("response");
+        // Wildcard surface mirrors any origin...
+        assert_eq!(
+            resp.headers()
+                .get(axum::http::header::ACCESS_CONTROL_ALLOW_ORIGIN)
+                .and_then(|v| v.to_str().ok()),
+            Some("*"),
+        );
+        // ...but must NOT advertise credentials (spec-invalid + credential leak).
+        assert_eq!(
+            resp.headers()
+                .get(axum::http::header::ACCESS_CONTROL_ALLOW_CREDENTIALS),
+            None,
+            "wildcard + credentials is spec-invalid; layer must drop credentials"
+        );
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Why

This splits the genuine pre-existing runtime bug out of #1132, following the implementation sequence in #1144.

`CorsLayer::allow_origin` replaces its previous policy on every call. The old per-origin loop therefore retained only the last configured origin, causing browsers to reject every earlier configured origin.

## What

- pass the complete `Vec<HeaderValue>` in one `allow_origin` call so tower-http builds `AllowOrigin::list(...)`
- retain the assembled `Router + CorsLayer` runtime harness from #1132
- verify default, explicit multi-origin, exact-match, credential, and wildcard behavior through response headers
- leave the default origin list and config assertions unchanged; #1144 owns the any-origin posture change

## Regression proof

The focused multi-origin runtime test passes with this fix. I then temporarily restored the old per-origin loop without changing the test; it failed on the first entry because `https://a.example.com` received `Access-Control-Allow-Origin: https://c.example.com`, the final configured origin. Restoring the list-based call made the same test pass again.

## Verification

- `cargo build -p hyprstream`
- `cargo test -p hyprstream --lib cors` (5 passed)
- `cargo clippy -p hyprstream --all-targets -- -D warnings`
- foreground pre-commit CI-mirroring Clippy

`cargo fmt --check` is not used as a gate because clean main has the known #1140 failure; this one-file diff passes `git diff --check`.

Related: #1132, #1144.