### PR TITLE
ci: build AppImages nightly on x86_64 and arm64

### DIFF
--- a/.github/workflows/appimage.yml
+++ b/.github/workflows/appimage.yml
@@ -1,8 +1,11 @@
 name: Build AppImage
 
 on:
+  schedule:
+    # Full distributable builds are deliberately off the merge path.
+    - cron: '30 3 * * *'
+  workflow_dispatch:
   push:
-    branches: [ "main" ]
     tags:
       - 'v*'
 
@@ -24,10 +27,10 @@ env:
   CARGO_INCREMENTAL: 0
 
 jobs:
-  # Build all backend variants sequentially on a single runner
-  # This maximizes sccache hits and minimizes disk usage
-  build-all-variants:
-    name: Build all variants (sequential)
+  # Build all supported x86_64 variants sequentially on a single runner. This
+  # keeps the large libtorch payloads and Cargo target on one disk.
+  build-x86_64:
+    name: Build x86_64 AppImages (sequential)
     runs-on: ubuntu-latest
 
     steps:
@@ -97,18 +100,13 @@ jobs:
           path: appimage/output/*-cpu-*.AppImage
           retention-days: 5
 
-      # Heavy GPU variants + universal build only on release tags. On push-to-main
-      # we ship just the CPU AppImage — building all 5 every push cost ~70min and
-      # produced ~11GB of artifacts that only matter at release.
       - name: Build CUDA 12.8 AppImage
-        if: startsWith(github.ref, 'refs/tags/')
         run: |
           ./appimage/build-appimage.sh build cuda128 --version ${{ steps.version.outputs.version }}
           ./appimage/build-appimage.sh stage cuda128
           ./appimage/build-appimage.sh clean cuda128
 
       - name: Upload CUDA 12.8 AppImage
-        if: startsWith(github.ref, 'refs/tags/')
         uses: actions/upload-artifact@v4
         with:
           name: appimage-cuda128
@@ -116,14 +114,12 @@ jobs:
           retention-days: 5
 
       - name: Build CUDA 13.0 AppImage
-        if: startsWith(github.ref, 'refs/tags/')
         run: |
           ./appimage/build-appimage.sh build cuda130 --version ${{ steps.version.outputs.version }}
           ./appimage/build-appimage.sh stage cuda130
           ./appimage/build-appimage.sh clean cuda130
 
       - name: Upload CUDA 13.0 AppImage
-        if: startsWith(github.ref, 'refs/tags/')
         uses: actions/upload-artifact@v4
         with:
           name: appimage-cuda130
@@ -131,14 +127,12 @@ jobs:
           retention-days: 5
 
       - name: Build ROCm 7.1 AppImage
-        if: startsWith(github.ref, 'refs/tags/')
         run: |
           ./appimage/build-appimage.sh build rocm71 --version ${{ steps.version.outputs.version }}
           ./appimage/build-appimage.sh stage rocm71
           ./appimage/build-appimage.sh clean rocm71
 
       - name: Upload ROCm 7.1 AppImage
-        if: startsWith(github.ref, 'refs/tags/')
         uses: actions/upload-artifact@v4
         with:
           name: appimage-rocm71
@@ -146,12 +140,10 @@ jobs:
           retention-days: 5
 
       - name: Build Universal AppImage
-        if: startsWith(github.ref, 'refs/tags/')
         run: |
           ./appimage/build-appimage.sh build universal --version ${{ steps.version.outputs.version }}
 
       - name: Upload Universal AppImage
-        if: startsWith(github.ref, 'refs/tags/')
         uses: actions/upload-artifact@v4
         with:
           name: appimage-universal
@@ -161,11 +153,57 @@ jobs:
       - name: Show sccache stats
         run: sccache --show-stats
 
+  # Native arm64 packaging. Upstream publishes arm64 CPU libtorch through the
+  # PyTorch wheel, but not CUDA/ROCm archives; build the supported CPU image in
+  # the prebuilt Graviton builder so Rust and libtorch stay architecture-native.
+  build-arm64-cpu:
+    name: Build arm64 CPU AppImage
+    runs-on: [self-hosted, linux, arm64, graviton, hyprstream-merge-gate]
+    timeout-minutes: 150
+    env:
+      BUILDER_IMAGE: ghcr.io/hyprstream/rust-builder-arm64@sha256:aa9feb1c8432ebf4583fcfc9c8236c371cb050f489c4d0882a7f2d8c8589120e
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - name: Pull arm64 builder image
+        run: podman pull "$BUILDER_IMAGE"
+
+      - name: Build arm64 CPU AppImage in the native builder
+        run: |
+          podman run --rm \
+            -v "$PWD":/build:Z -w /build \
+            -e HYPRSTREAM_APPIMAGE_ARCH=aarch64 \
+            -e HYPRSTREAM_LIBTORCH_DIR=/opt/libtorch \
+            -e GITHUB_REF_NAME \
+            -e APPIMAGE_EXTRACT_AND_RUN=1 \
+            -e OPENSSL_NO_VENDOR=1 \
+            -e LIBTORCH=/opt/libtorch -e LD_LIBRARY_PATH=/opt/libtorch/lib \
+            -e LIBTORCH_BYPASS_VERSION_CHECK=1 \
+            -e CARGO_INCREMENTAL=0 -e CARGO_TERM_COLOR=always \
+            "$BUILDER_IMAGE" \
+            bash -euo pipefail -c '
+              apt-get update
+              apt-get install -y --no-install-recommends squashfs-tools
+              version="${GITHUB_REF_NAME#v}"
+              [[ "$version" == "$GITHUB_REF_NAME" ]] && version=dev
+              ./appimage/build-appimage.sh build cpu --version "$version"
+            '
+
+      - name: Upload arm64 CPU AppImage
+        uses: actions/upload-artifact@v4
+        with:
+          name: appimage-arm64-cpu
+          path: appimage/output/*-cpu-aarch64.AppImage
+          retention-days: 5
+
   # Create GitHub Release with all AppImages (tags only)
   release:
     name: Create Release
     if: startsWith(github.ref, 'refs/tags/')
-    needs: build-all-variants
+    needs: [build-x86_64, build-arm64-cpu]
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -230,6 +268,7 @@ jobs:
             | `hyprstream-${{ steps.version.outputs.version }}-cuda128-x86_64.AppImage` | NVIDIA CUDA 12.8 |
             | `hyprstream-${{ steps.version.outputs.version }}-cuda130-x86_64.AppImage` | NVIDIA CUDA 13.0 |
             | `hyprstream-${{ steps.version.outputs.version }}-rocm71-x86_64.AppImage` | AMD ROCm 7.1 |
+            | `hyprstream-${{ steps.version.outputs.version }}-cpu-aarch64.AppImage` | ARM64 CPU only |
 
             ### Manual Install
 

--- a/appimage/build-appimage.sh
+++ b/appimage/build-appimage.sh
@@ -37,8 +37,22 @@ LIBTORCH_CACHE_DIR="${LIBTORCH_CACHE_DIR:-$SCRIPT_DIR/libtorch-cache}"
 BUILD_DIR="$SCRIPT_DIR/build"
 OUTPUT_DIR="$SCRIPT_DIR/output"
 
-# All variants
-ALL_VARIANTS=(cpu cuda128 cuda130 rocm71)
+# AppImage tooling and the upstream GPU libtorch archives are architecture
+# specific. aarch64 currently has a CPU libtorch only (from the PyTorch wheel).
+case "${HYPRSTREAM_APPIMAGE_ARCH:-$(uname -m)}" in
+    x86_64|amd64) APPIMAGE_ARCH=x86_64 ;;
+    aarch64|arm64) APPIMAGE_ARCH=aarch64 ;;
+    *) echo "[ERROR] Unsupported AppImage architecture: $(uname -m)" >&2; exit 1 ;;
+esac
+
+# GPU AppImages are currently x86_64-only because upstream does not publish
+# aarch64 CUDA/ROCm libtorch archives. The arm64 CI job supplies the CPU
+# libtorch directory from the official PyTorch aarch64 wheel.
+if [[ "$APPIMAGE_ARCH" == "aarch64" ]]; then
+    ALL_VARIANTS=(cpu)
+else
+    ALL_VARIANTS=(cpu cuda128 cuda130 rocm71)
+fi
 
 # libtorch download URLs
 declare -A LIBTORCH_URLS=(
@@ -71,6 +85,10 @@ validate_variant() {
     if [[ "$variant" == "all" ]] || [[ "$variant" == "universal" ]]; then
         return 0
     fi
+    if [[ "$APPIMAGE_ARCH" == "aarch64" && "$variant" != "cpu" ]]; then
+        log_error "AppImage variant $variant is unavailable on aarch64 (CPU only)"
+        exit 1
+    fi
     if [[ ! "${LIBTORCH_URLS[$variant]+isset}" ]]; then
         log_error "Invalid variant: $variant"
         log_error "Valid variants: ${ALL_VARIANTS[*]} universal all"
@@ -92,13 +110,16 @@ ensure_appimagetool() {
 
     log_info "Downloading appimagetool..."
     curl -sSL -o "$APPIMAGETOOL" \
-        "https://github.com/AppImage/appimagetool/releases/download/continuous/appimagetool-x86_64.AppImage"
+        "https://github.com/AppImage/appimagetool/releases/download/continuous/appimagetool-${APPIMAGE_ARCH}.AppImage"
     chmod +x "$APPIMAGETOOL"
 }
 
 # Download libtorch for a variant
 download_libtorch() {
     local variant="$1"
+    # The aarch64 PyTorch wheel is already installed by the arm64 builder image.
+    # It supplies both headers and shared libraries at HYPRSTREAM_LIBTORCH_DIR.
+    [[ -n "${HYPRSTREAM_LIBTORCH_DIR:-}" ]] && return 0
     local url="${LIBTORCH_URLS[$variant]}"
     local cache_file="$LIBTORCH_CACHE_DIR/libtorch-${LIBTORCH_VERSION}-${variant}.zip"
     local extract_dir="$LIBTORCH_CACHE_DIR/$variant"
@@ -120,7 +141,7 @@ download_libtorch() {
 # Build hyprstream binary for a variant
 build_binary() {
     local variant="$1"
-    local libtorch_dir="$LIBTORCH_CACHE_DIR/$variant/libtorch"
+    local libtorch_dir="${HYPRSTREAM_LIBTORCH_DIR:-$LIBTORCH_CACHE_DIR/$variant/libtorch}"
 
     log_info "Building hyprstream for $variant..."
 
@@ -159,7 +180,8 @@ strip_libtorch_libs() {
 create_appimage() {
     local variant="$1"
     local appdir="$BUILD_DIR/hyprstream-$variant.AppDir"
-    local output="$OUTPUT_DIR/hyprstream-${VERSION}-${variant}-x86_64.AppImage"
+    local output="$OUTPUT_DIR/hyprstream-${VERSION}-${variant}-${APPIMAGE_ARCH}.AppImage"
+    local libtorch_dir="${HYPRSTREAM_LIBTORCH_DIR:-$LIBTORCH_CACHE_DIR/$variant/libtorch}"
 
     log_info "Creating AppImage for $variant..."
 
@@ -168,7 +190,7 @@ create_appimage() {
 
     cp "$BUILD_DIR/bin/hyprstream-$variant" "$appdir/usr/bin/hyprstream"
     # Copy entire lib directory (includes subdirs with Tensile libraries for ROCm)
-    cp -r "$LIBTORCH_CACHE_DIR/$variant/libtorch/lib/"* "$appdir/usr/lib/libtorch/lib/"
+    cp -r "$libtorch_dir/lib/"* "$appdir/usr/lib/libtorch/lib/"
     strip_libtorch_libs "$appdir/usr/lib/libtorch/lib"
 
     sed "s/HYPRSTREAM_VARIANT:-cpu/HYPRSTREAM_VARIANT:-$variant/" \
@@ -179,14 +201,14 @@ create_appimage() {
     cp "$SCRIPT_DIR/hyprstream.svg" "$appdir/"
 
     mkdir -p "$OUTPUT_DIR"
-    ARCH=x86_64 "$APPIMAGETOOL" "$appdir" "$output"
+    ARCH="$APPIMAGE_ARCH" "$APPIMAGETOOL" "$appdir" "$output"
     log_success "Created: $output"
 }
 
 # Create universal AppImage with all backends
 create_universal_appimage() {
     local appdir="$BUILD_DIR/hyprstream-universal.AppDir"
-    local output="$OUTPUT_DIR/hyprstream-${VERSION}-x86_64.AppImage"
+    local output="$OUTPUT_DIR/hyprstream-${VERSION}-${APPIMAGE_ARCH}.AppImage"
     local staging="$BUILD_DIR/universal-staging"
 
     log_info "Creating universal AppImage..."
@@ -203,7 +225,8 @@ create_universal_appimage() {
         else
             cp "$BUILD_DIR/bin/hyprstream-$variant" "$appdir/usr/bin/"
             mkdir -p "$appdir/usr/lib/$variant/libtorch/lib"
-            cp -r "$LIBTORCH_CACHE_DIR/$variant/libtorch/lib/"* "$appdir/usr/lib/$variant/libtorch/lib/"
+            local libtorch_dir="${HYPRSTREAM_LIBTORCH_DIR:-$LIBTORCH_CACHE_DIR/$variant/libtorch}"
+            cp -r "$libtorch_dir/lib/"* "$appdir/usr/lib/$variant/libtorch/lib/"
         fi
     done
 
@@ -215,7 +238,7 @@ create_universal_appimage() {
     cp "$SCRIPT_DIR/hyprstream.svg" "$appdir/"
 
     mkdir -p "$OUTPUT_DIR"
-    ARCH=x86_64 "$APPIMAGETOOL" "$appdir" "$output"
+    ARCH="$APPIMAGE_ARCH" "$APPIMAGETOOL" "$appdir" "$output"
     log_success "Created: $output"
 }
 


### PR DESCRIPTION
## Summary
- remove the `push`-to-`main` AppImage trigger
- build the full CPU/CUDA/ROCm/universal x86_64 set nightly at 03:30 UTC (and on release tags)
- build the supported native arm64 CPU AppImage nightly/tagged on the self-hosted Graviton fleet
- attach the arm64 CPU artifact to tag releases

## Architecture
CUDA and ROCm AppImages remain x86_64-only: upstream publishes those libtorch archives only for x86_64. The arm64 build uses the official PyTorch aarch64 wheel already present in the arm64 builder image, and downloads the aarch64 `appimagetool`.

## Validation
- `git diff --check`
- `bash -n appimage/build-appimage.sh`
- verified an arm64 GPU variant is rejected as unsupported

A full manual workflow dispatch is intentionally not included in this PR: it is the expensive release-style build this change moves off every merge.