### PR TITLE
spike: validate arm64 CUDA libtorch packaging

### DIFF
--- a/.github/workflows/arm-gpu-spike.yml
+++ b/.github/workflows/arm-gpu-spike.yml
@@ -35,7 +35,7 @@ jobs:
             -e CARGO_INCREMENTAL=0 \
             hyprstream-cuda130-arm64-spike:ci \
             bash -euo pipefail -c '
-              file /opt/libtorch/lib/libtorch_cuda.so
+              test -s /opt/libtorch/lib/libtorch_cuda.so
               python3 -c "import torch; print(torch.__version__, torch.version.cuda, torch.cuda.is_available())"
               cargo build -p hyprstream --release --features otel
               ldd target/release/hyprstream | grep -E "libtorch|not found" || true

--- a/.github/workflows/arm-gpu-spike.yml
+++ b/.github/workflows/arm-gpu-spike.yml
@@ -1,0 +1,66 @@
+name: ARM GPU packaging spike
+
+# Dispatch-only reconnaissance. This is intentionally not a PR or merge gate:
+# it downloads a large aarch64 CUDA wheel and exercises an experimental ABI.
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  cuda130-aarch64:
+    name: CUDA 13.0 aarch64 libtorch compatibility
+    runs-on: [self-hosted, linux, arm64, graviton, hyprstream-merge-gate]
+    timeout-minutes: 150
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Build the arm64 CUDA libtorch spike image
+        run: |
+          podman build \
+            --target builder-cuda130-arm64-spike \
+            -t hyprstream-cuda130-arm64-spike:ci \
+            -f Dockerfile \
+            .
+
+      - name: Verify native CUDA wheel and compile Hyprstream
+        run: |
+          podman run --rm \
+            -v "$PWD":/build:Z -w /build \
+            -e OPENSSL_NO_VENDOR=1 \
+            -e LIBTORCH=/opt/libtorch \
+            -e LD_LIBRARY_PATH=/opt/libtorch/lib \
+            -e LIBTORCH_BYPASS_VERSION_CHECK=1 \
+            -e CARGO_INCREMENTAL=0 \
+            hyprstream-cuda130-arm64-spike:ci \
+            bash -euo pipefail -c '
+              file /opt/libtorch/lib/libtorch_cuda.so
+              python3 -c "import torch; print(torch.__version__, torch.version.cuda, torch.cuda.is_available())"
+              cargo build -p hyprstream --release --features otel
+              ldd target/release/hyprstream | grep -E "libtorch|not found" || true
+            '
+
+      - name: Record GPU availability
+        run: |
+          if command -v nvidia-smi >/dev/null; then
+            nvidia-smi
+          else
+            echo '::notice::No NVIDIA device is attached to this Graviton build runner; this spike validates packaging and linking only.'
+          fi
+
+  rocm-aarch64-inventory:
+    name: ROCm aarch64 wheel inventory
+    runs-on: ubuntu-latest
+    steps:
+      - name: Record current ROCm aarch64 availability
+        run: |
+          set -euo pipefail
+          curl -fsSL https://download.pytorch.org/whl/rocm7.1/torch/ > /tmp/rocm71-torch-index.html
+          matches=$(grep -oE 'torch-[^" ]+aarch64\.whl' /tmp/rocm71-torch-index.html | sort -u || true)
+          printf '%s\n' "$matches"
+          if printf '%s\n' "$matches" | grep -Eq 'torch-(2\.[89]|[3-9]\.)'; then
+            echo '::notice::Modern ROCm aarch64 wheels detected; reassess the ROCm packaging path.'
+          else
+            echo '::notice::No modern ROCm aarch64 wheel is currently available; keep ROCm AppImages x86_64-only.'
+          fi

--- a/.github/workflows/arm-gpu-spike.yml
+++ b/.github/workflows/arm-gpu-spike.yml
@@ -44,7 +44,7 @@ jobs:
       - name: Record GPU availability
         run: |
           if command -v nvidia-smi >/dev/null; then
-            nvidia-smi
+            nvidia-smi || echo "::notice::nvidia-smi is installed but no usable NVIDIA driver/device is attached"
           else
             echo '::notice::No NVIDIA device is attached to this Graviton build runner; this spike validates packaging and linking only.'
           fi
@@ -59,7 +59,7 @@ jobs:
           curl -fsSL https://download.pytorch.org/whl/rocm7.1/torch/ > /tmp/rocm71-torch-index.html
           matches=$(grep -oE 'torch-[^" ]+aarch64\.whl' /tmp/rocm71-torch-index.html | sort -u || true)
           printf '%s\n' "$matches"
-          if printf '%s\n' "$matches" | grep -Eq 'torch-(2\.[89]|[3-9]\.)'; then
+          if printf '%s\n' "$matches" | grep -Eq 'torch-(2\.(8|9|[1-9][0-9]+)|[3-9][0-9]*\.)'; then
             echo '::notice::Modern ROCm aarch64 wheels detected; reassess the ROCm packaging path.'
           else
             echo '::notice::No modern ROCm aarch64 wheel is currently available; keep ROCm AppImages x86_64-only.'

--- a/.github/workflows/graviton-build-validate.yml
+++ b/.github/workflows/graviton-build-validate.yml
@@ -37,6 +37,9 @@ permissions:
 
 jobs:
   build-arm64:
+    # A CUDA-spike dispatch runs its dedicated job below; avoid consuming a
+    # second Graviton runner with the normal CPU validation at the same time.
+    if: ${{ !inputs.cuda_spike }}
     runs-on: [self-hosted, linux, arm64, graviton, hyprstream-merge-gate]
     timeout-minutes: 150
     steps:

--- a/.github/workflows/graviton-build-validate.yml
+++ b/.github/workflows/graviton-build-validate.yml
@@ -123,7 +123,7 @@ jobs:
             -e CARGO_INCREMENTAL=0 \
             hyprstream-cuda130-arm64-spike:ci \
             bash -euo pipefail -c '
-              file /opt/libtorch/lib/libtorch_cuda.so
+              test -s /opt/libtorch/lib/libtorch_cuda.so
               python3 -c "import torch; print(torch.__version__, torch.version.cuda, torch.cuda.is_available())"
               cargo build -p hyprstream --release --features otel
               ldd target/release/hyprstream | grep -E "libtorch|not found" || true

--- a/.github/workflows/graviton-build-validate.yml
+++ b/.github/workflows/graviton-build-validate.yml
@@ -132,7 +132,7 @@ jobs:
       - name: Record GPU availability
         run: |
           if command -v nvidia-smi >/dev/null; then
-            nvidia-smi
+            nvidia-smi || echo "::notice::nvidia-smi is installed but no usable NVIDIA driver/device is attached"
           else
             echo '::notice::No NVIDIA device is attached to this Graviton build runner; this spike validates packaging and linking only.'
           fi

--- a/.github/workflows/graviton-build-validate.yml
+++ b/.github/workflows/graviton-build-validate.yml
@@ -15,6 +15,12 @@ name: Graviton Build Validation
 # reaches the default branch).
 on:
   workflow_dispatch:
+    inputs:
+      cuda_spike:
+        description: 'Run the experimental arm64 CUDA 13.0 wheel compatibility spike'
+        required: false
+        type: boolean
+        default: false
   # Re-run on changes that can affect the arm64 build — the Dockerfile
   # (toolchain), workspace source (arch-specific fixes), or this workflow.
   push:
@@ -84,3 +90,46 @@ jobs:
             -e CARGO_TERM_COLOR=always \
             hyprstream-builder-arm64:ci \
             cargo build --release --no-default-features --features otel,gittorrent,xet
+
+  cuda130-arm64-spike:
+    # The Dockerfile target and normal dispatch-only workflow live on this
+    # branch. This mirror exists solely because GitHub permits dispatching only
+    # workflows already present on the default branch.
+    if: inputs.cuda_spike
+    runs-on: [self-hosted, linux, arm64, graviton, hyprstream-merge-gate]
+    timeout-minutes: 150
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Build the arm64 CUDA libtorch spike image
+        run: |
+          podman build \
+            --target builder-cuda130-arm64-spike \
+            -t hyprstream-cuda130-arm64-spike:ci \
+            -f Dockerfile \
+            .
+
+      - name: Verify native CUDA wheel and compile Hyprstream
+        run: |
+          podman run --rm \
+            -v "$PWD":/build:Z -w /build \
+            -e OPENSSL_NO_VENDOR=1 \
+            -e LIBTORCH=/opt/libtorch \
+            -e LD_LIBRARY_PATH=/opt/libtorch/lib \
+            -e LIBTORCH_BYPASS_VERSION_CHECK=1 \
+            -e CARGO_INCREMENTAL=0 \
+            hyprstream-cuda130-arm64-spike:ci \
+            bash -euo pipefail -c '
+              file /opt/libtorch/lib/libtorch_cuda.so
+              python3 -c "import torch; print(torch.__version__, torch.version.cuda, torch.cuda.is_available())"
+              cargo build -p hyprstream --release --features otel
+              ldd target/release/hyprstream | grep -E "libtorch|not found" || true
+            '
+
+      - name: Record GPU availability
+        run: |
+          if command -v nvidia-smi >/dev/null; then
+            nvidia-smi
+          else
+            echo '::notice::No NVIDIA device is attached to this Graviton build runner; this spike validates packaging and linking only.'
+          fi

--- a/Dockerfile
+++ b/Dockerfile
@@ -242,8 +242,8 @@ RUN --mount=type=cache,target=/root/.cache/pip \
     && TORCH_DIR="$(python3 -c 'import torch, os; print(os.path.dirname(torch.__file__))')" \
     && ln -s "$TORCH_DIR" /opt/libtorch \
     && python3 -c 'import torch; assert torch.version.cuda == "13.0"; print(torch.__version__, torch.version.cuda)' \
-    && file /opt/libtorch/lib/libtorch_cuda.so \
-    && ls /opt/libtorch/include/torch >/dev/null
+    && test -s /opt/libtorch/lib/libtorch_cuda.so \
+    && test -d /opt/libtorch/include/torch
 
 ENV LIBTORCH=/opt/libtorch
 ENV LD_LIBRARY_PATH=/opt/libtorch/lib

--- a/Dockerfile
+++ b/Dockerfile
@@ -237,7 +237,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 
 RUN --mount=type=cache,target=/root/.cache/pip \
     pip3 install --break-system-packages \
-        --index-url https://download.pytorch.org/whl/cu130 \
+        --extra-index-url https://download.pytorch.org/whl/cu130 \
         'torch==2.9.1+cu130' \
     && TORCH_DIR="$(python3 -c 'import torch, os; print(os.path.dirname(torch.__file__))')" \
     && ln -s "$TORCH_DIR" /opt/libtorch \

--- a/Dockerfile
+++ b/Dockerfile
@@ -220,6 +220,36 @@ RUN cd /tmp/tc \
     && rm -rf /tmp/tc
 
 #############################################
+# CUDA 13.0 Builder (aarch64 / arm64) — reconnaissance only
+#############################################
+#
+# NVIDIA CUDA supports arm64-sbsa, and PyTorch publishes aarch64 CUDA wheels.
+# Unlike the CPU wheel, the CUDA wheel is currently not aligned to the project's
+# pinned 2.10.0 libtorch release; this image pins the available 2.9.1+cu130
+# wheel solely for the dispatch-only compatibility spike. Do not use this stage
+# for release packaging until the pinned tch/libtorch ABI is resolved.
+FROM builder-base AS builder-cuda130-arm64-spike
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        python3 python3-pip \
+    && rm -rf /var/lib/apt/lists/* \
+    && apt-get clean
+
+RUN --mount=type=cache,target=/root/.cache/pip \
+    pip3 install --break-system-packages \
+        --index-url https://download.pytorch.org/whl/cu130 \
+        'torch==2.9.1+cu130' \
+    && TORCH_DIR="$(python3 -c 'import torch, os; print(os.path.dirname(torch.__file__))')" \
+    && ln -s "$TORCH_DIR" /opt/libtorch \
+    && python3 -c 'import torch; assert torch.version.cuda == "13.0"; print(torch.__version__, torch.version.cuda)' \
+    && file /opt/libtorch/lib/libtorch_cuda.so \
+    && ls /opt/libtorch/include/torch >/dev/null
+
+ENV LIBTORCH=/opt/libtorch
+ENV LD_LIBRARY_PATH=/opt/libtorch/lib
+ENV LIBTORCH_BYPASS_VERSION_CHECK=1
+
+#############################################
 # Select Builder Based on Variant
 #############################################
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -224,10 +224,9 @@ RUN cd /tmp/tc \
 #############################################
 #
 # NVIDIA CUDA supports arm64-sbsa, and PyTorch publishes aarch64 CUDA wheels.
-# Unlike the CPU wheel, the CUDA wheel is currently not aligned to the project's
-# pinned 2.10.0 libtorch release; this image pins the available 2.9.1+cu130
-# wheel solely for the dispatch-only compatibility spike. Do not use this stage
-# for release packaging until the pinned tch/libtorch ABI is resolved.
+# This uses the project's pinned 2.10.0 libtorch release with the CUDA 13.0
+# aarch64 wheel. It remains dispatch-only until a GPU-equipped ARM runner
+# validates runtime execution.
 FROM builder-base AS builder-cuda130-arm64-spike
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
@@ -238,7 +237,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 RUN --mount=type=cache,target=/root/.cache/pip \
     pip3 install --break-system-packages \
         --extra-index-url https://download.pytorch.org/whl/cu130 \
-        'torch==2.9.1+cu130' \
+        'torch==2.10.0+cu130' \
     && TORCH_DIR="$(python3 -c 'import torch, os; print(os.path.dirname(torch.__file__))')" \
     && ln -s "$TORCH_DIR" /opt/libtorch \
     && python3 -c 'import torch; assert torch.version.cuda == "13.0"; print(torch.__version__, torch.version.cuda)' \


### PR DESCRIPTION
## Scope
Dispatch-only investigation of native ARM64 GPU packaging. It is not a release workflow or a required check.

## CUDA
- adds an arm64 CUDA 13.0 builder stage using the available PyTorch `2.9.1+cu130` aarch64 wheel
- verifies the native CUDA library and attempts a release Hyprstream build on a Graviton runner
- records whether a physical NVIDIA device is attached (none is expected on the current runner fleet)

The project pins libtorch 2.10.0, while the available arm64 CUDA wheel tested here is 2.9.1. This is deliberately an ABI-compatibility spike, not production packaging.

## ROCm
A second job inventories the official ROCm 7.1 wheel index. Current evidence shows no modern ROCm aarch64 wheel, so it remains x86_64-only.

## Validation
- `git diff --check`
- full native build is exercised by the manually dispatched spike workflow.