### PR TITLE
fix(auth): freeze path-form did:web account minting

### DIFF
--- a/crates/hyprstream-pds/src/repo_authority.rs
+++ b/crates/hyprstream-pds/src/repo_authority.rs
@@ -18,6 +18,20 @@ use anyhow::{bail, Result};
 
 use hyprstream_rpc::identity::Did;
 
+/// Whether `did` is a path-form `did:web` identifier.
+///
+/// The atproto DID profile permits only host-form `did:web`; any additional
+/// colon in the method-specific identifier introduces a path segment. Encoded
+/// host ports (`%3A`) do not contain a literal colon and are deliberately not
+/// classified here — this helper answers only the path-form question.
+pub fn is_path_form_did_web(did: &str) -> bool {
+    let Some(method_id) = did.strip_prefix("did:web:") else {
+        return false;
+    };
+    let method_id = method_id.split(['?', '#']).next().unwrap_or(method_id);
+    method_id.contains(':')
+}
+
 /// A DID method our PDS accepts as a repo authority.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum RepoAuthority {
@@ -53,6 +67,11 @@ impl RepoAuthority {
 pub fn accept_repo_authority(did: &str) -> Result<RepoAuthority> {
     let d = Did::new(did.to_owned());
     if d.is_did_web() {
+        if is_path_form_did_web(did) {
+            bail!(
+                "path-form did:web {did:?} is not an accepted repo authority; the atproto profile requires host-form did:web"
+            );
+        }
         Ok(RepoAuthority::Web)
     } else if did.starts_with("did:plc:") {
         Ok(RepoAuthority::Plc)
@@ -84,6 +103,16 @@ mod tests {
         let plc = accept_repo_authority("did:plc:abc123").unwrap();
         assert_eq!(plc, RepoAuthority::Plc);
         assert!(plc.is_publicly_publishable());
+    }
+
+    #[test]
+    fn rejects_path_form_did_web_repo_authority() {
+        assert!(is_path_form_did_web("did:web:accounts.example:users:alice"));
+        assert!(!is_path_form_did_web("did:web:alice.accounts.example"));
+        assert!(!is_path_form_did_web("did:web:localhost%3A6791"));
+
+        let err = accept_repo_authority("did:web:accounts.example:users:alice").unwrap_err();
+        assert!(err.to_string().contains("path-form did:web"));
     }
 
     #[test]

--- a/crates/hyprstream/src/cli/bootstrap_manager.rs
+++ b/crates/hyprstream/src/cli/bootstrap_manager.rs
@@ -439,7 +439,15 @@ impl WizardBackend for BootstrapManager {
             .unwrap_or_else(|_| Some(chrono::Duration::days(90)))
             .unwrap_or_else(|| chrono::Duration::days(90));
 
-        let (token, exp) = mint_local_token(signing_key, username, dur);
+        let (token, exp) = match mint_local_token(signing_key, username, dur) {
+            Ok(token) => token,
+            Err(error) => {
+                return TokenResult {
+                    token: format!("ERROR: {error}"),
+                    expires: "N/A".to_owned(),
+                };
+            }
+        };
 
         let expires = if duration == "never" {
             "never".to_owned()

--- a/crates/hyprstream/src/cli/policy_handlers.rs
+++ b/crates/hyprstream/src/cli/policy_handlers.rs
@@ -17,6 +17,7 @@ use crate::services::generated::policy_client::{
     PolicyClient, GetHistory, GetDiff, ApplyDraft, RollbackPolicy, PolicyCheck, ApplyTemplate,
     AddGrouping, RemoveGrouping,
 };
+use hyprstream_pds::repo_authority::is_path_form_did_web;
 use anyhow::{Context, Result};
 use chrono::Duration;
 use ed25519_dalek::SigningKey;
@@ -360,7 +361,7 @@ pub async fn handle_token_create(
     });
 
     // Mint JWT with proper iss/aud claims for OAI middleware compatibility
-    let (token, exp) = mint_local_token(signing_key, user, duration);
+    let (token, exp) = mint_local_token(signing_key, user, duration)?;
 
     // Display the token (only shown once)
     println!();
@@ -424,7 +425,13 @@ pub(crate) fn mint_local_token(
     signing_key: &SigningKey,
     subject: &str,
     duration: Duration,
-) -> (String, i64) {
+) -> Result<(String, i64)> {
+    if is_path_form_did_web(subject) {
+        anyhow::bail!(
+            "path-form did:web account subjects are frozen; host-form account minting is not available yet (#1159)"
+        );
+    }
+
     let now = chrono::Utc::now().timestamp();
     let exp = now + duration.num_seconds();
 
@@ -443,7 +450,7 @@ pub(crate) fn mint_local_token(
 
     let jwt_key = hyprstream_rpc::node_identity::derive_purpose_key(signing_key, "hyprstream-jwt-v1");
     let token = jwt::encode(&claims, &jwt_key);
-    (token, exp)
+    Ok((token, exp))
 }
 
 /// Ensure the local user has an Ed25519 signing keypair.
@@ -655,4 +662,34 @@ pub async fn handle_policy_apply_template(
     println!("  {result_msg}");
 
     Ok(())
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn local_token_mint_rejects_path_form_account_subject() {
+        let signing_key = SigningKey::from_bytes(&[0x71; 32]);
+        let error = mint_local_token(
+            &signing_key,
+            "did:web:accounts.example:users:alice",
+            Duration::hours(1),
+        )
+        .expect_err("path-form account subject must not reach the direct CLI signer");
+
+        assert!(error.to_string().contains("path-form did:web account subjects are frozen"));
+    }
+
+    #[test]
+    fn local_token_mint_allows_ordinary_subject() {
+        let signing_key = SigningKey::from_bytes(&[0x72; 32]);
+        let (token, _) = mint_local_token(&signing_key, "alice", Duration::hours(1))
+            .expect("ordinary CLI subject must still mint");
+
+        let claims = hyprstream_rpc::auth::decode_unverified(&token)
+            .expect("minted token must decode");
+        assert_eq!(claims.sub, "alice");
+    }
 }

--- a/crates/hyprstream/src/config/mod.rs
+++ b/crates/hyprstream/src/config/mod.rs
@@ -1011,17 +1011,9 @@ pub enum UserMappingStrategy {
         /// The claim name to use as the local subject.
         name: String,
     },
-    /// `did:web:{issuer_authority}:users:{external_sub}` per Phase 0.5
-    /// architecture-doc Subject Identity Format.
-    ///
-    /// Uses the OAuth issuer URL's authority (host[:port]) as the DID
-    /// method-specific identifier and the external `sub` claim as the
-    /// user path component. Example: `did:web:hyprstream.example.com:users:12345`.
-    ///
-    /// **Opt-in**: existing deployments continue to use [`Namespaced`] by
-    /// default so Casbin policies don't break. Operators migrating to
-    /// did:web should land Phase 0e (Casbin policy migration) before
-    /// switching this strategy.
+    /// Disabled legacy setting that attempted to mint path-form account DIDs.
+    /// Configuration validation and the runtime mapping path both reject it.
+    /// Host-form account minting is a separate design (#1163).
     DidWeb,
 }
 
@@ -2233,6 +2225,23 @@ impl HyprConfig {
             );
         }
 
+        let mut disabled_did_web_providers: Vec<&str> = self
+            .oauth
+            .oidc_providers
+            .iter()
+            .filter_map(|(name, provider)| {
+                matches!(&provider.user_mapping, UserMappingStrategy::DidWeb)
+                    .then_some(name.as_str())
+            })
+            .collect();
+        disabled_did_web_providers.sort_unstable();
+        if !disabled_did_web_providers.is_empty() {
+            anyhow::bail!(
+                "OIDC provider(s) {} configure disabled user_mapping = \"didweb\"; path-form did:web account minting is forbidden (#1159)",
+                disabled_did_web_providers.join(", ")
+            );
+        }
+
         Ok(())
     }
 
@@ -2827,6 +2836,24 @@ mod tests {
         assert_eq!(config.lead_secs(), 25);
         assert_eq!(config.drain_secs(), 20);
         assert_eq!(config.rotation_check_interval(), std::time::Duration::from_secs(3));
+    }
+
+    #[test]
+    #[allow(clippy::unwrap_used)]
+    fn validation_rejects_didweb_user_mapping() {
+        let provider: OidcProviderConfig = serde_json::from_value(serde_json::json!({
+            "client_id": "legacy-client",
+            "user_mapping": "didweb"
+        }))
+        .unwrap();
+        let mut config = HyprConfig::default();
+        config
+            .oauth
+            .oidc_providers
+            .insert("legacy".to_owned(), provider);
+
+        let err = config.validate().unwrap_err();
+        assert!(err.to_string().contains("disabled user_mapping = \"didweb\""));
     }
 
     #[test]

--- a/crates/hyprstream/src/services/discovery.rs
+++ b/crates/hyprstream/src/services/discovery.rs
@@ -26,6 +26,7 @@ use hyprstream_pds::commit::{Commit, UnsignedCommit};
 use hyprstream_pds::ledger::{AllocationRecord, CheckpointRecord, ReceiptRecord};
 use hyprstream_pds::mst::Node;
 use hyprstream_pds::record::{ModelRecord, COLLECTION_NSID};
+use hyprstream_pds::repo_authority::is_path_form_did_web;
 use hyprstream_pds::tid::Tid;
 use sha2::Digest as _;
 
@@ -1106,6 +1107,26 @@ impl PdsPublisher {
         record_id: &str,
         current_oid_cid: String,
     ) -> AnyResult<()> {
+        // ── #1159 freeze: durable store-boundary guard ─────────────────────
+        // This is the single chokepoint every `PdsPublisher` durable write
+        // funnels through, and it persists `self.did` as the repo authority
+        // (`commit\0{did}` / `record\0{did}...` RocksDB keys). Production
+        // construction supplies a node `did:key` (factories.rs), but
+        // `PdsPublisher::new` accepts an arbitrary `String` DID, so a caller
+        // handing it a path-form `did:web:{authority}:users:{name}` would
+        // otherwise anchor a permanent, spec-invalid repo identifier in durable
+        // storage — exactly the shape #1159 freezes. Reject it here, at the
+        // durable-write boundary, WITHOUT applying the full repo-authority
+        // allowlist (which would reject the legitimate node `did:key` design).
+        if is_path_form_did_web(&self.did) {
+            bail!(
+                "PdsPublisher authority {} is a path-form did:web identifier; \
+                 the atproto profile requires host-form did:web, and path-form \
+                 account minting is frozen (#1159)",
+                self.did,
+            );
+        }
+
         // The collection NSID becomes both a `\0`-delimited RocksDB key field
         // and the `<collection>/<rkey>` MST key prefix — reject anything that
         // would be ambiguous in either encoding.
@@ -2265,5 +2286,56 @@ mod pds_store_tests {
             publisher.accepted_at9p_state(&did, None).is_err(),
             "an identity-valid fork without daemon acceptance must fail closed"
         );
+    }
+
+    // ── #1159 freeze: durable publisher rejects path-form authorities ───────
+
+    /// A `PdsPublisher` whose authority is a path-form `did:web` must refuse to
+    /// publish — the durable write would anchor a permanent, spec-invalid repo
+    /// identifier (`commit\0{did}` / `record\0{did}` keys). Production supplies
+    /// a node `did:key`; this guards the public `PdsPublisher::new(did)` surface.
+    #[test]
+    fn publish_rejects_path_form_did_web_authority() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let sk = SigningKey::random(&mut rand::rngs::OsRng);
+        let store = Arc::new(PdsRecordStore::open(dir.path()).expect("open rw"));
+        let path_form_did = "did:web:accounts.example:users:alice".to_owned();
+        let publisher = PdsPublisher::new(Arc::clone(&store), path_form_did.clone(), sk);
+
+        let err = publisher.publish("repo-a", SAMPLE_OID).unwrap_err();
+        assert!(
+            err.to_string().contains("path-form did:web"),
+            "expected path-form rejection, got: {err}",
+        );
+
+        // No durable anchor was written: the store holds no commit for this DID.
+        let RecordBacking::ReadWrite(db) = &store.backing else { panic!("read-write store") };
+        assert!(
+            db.get(commit_key(&path_form_did)).unwrap().is_none(),
+            "no commit key must be persisted for a path-form authority",
+        );
+        let tid = PdsRecordStore::tid_for_repo("repo-a");
+        assert!(
+            db.get(record_key(&path_form_did, COLLECTION_NSID, tid))
+                .unwrap()
+                .is_none(),
+            "no record key must be persisted for a path-form authority",
+        );
+    }
+
+    /// Host-form `did:web` and node `did:key` authorities still publish
+    /// normally — the guard rejects ONLY path-form did:web.
+    #[test]
+    fn publish_accepts_host_form_did_web_and_did_key() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let sk = SigningKey::random(&mut rand::rngs::OsRng);
+
+        for accepted in ["did:web:alice.example.com", DID] {
+            let store = Arc::new(PdsRecordStore::open(dir.path()).expect("open rw"));
+            let publisher = PdsPublisher::new(store, accepted.to_owned(), sk.clone());
+            publisher
+                .publish("repo-a", SAMPLE_OID)
+                .unwrap_or_else(|e| panic!("host-form/key authority {accepted} must publish: {e}"));
+        }
     }
 }

--- a/crates/hyprstream/src/services/oauth/did_document.rs
+++ b/crates/hyprstream/src/services/oauth/did_document.rs
@@ -3,8 +3,8 @@
 //! Serves DID documents at:
 //!   - `GET /.well-known/did.json` — root deployment DID (controller for all keys
 //!     under this issuer's authority)
-//!   - `GET /users/:username/did.json` — per-user DID document with that user's
-//!     registered Ed25519 verification methods
+//!   - `GET /users/:username/did.json` — hard error while path-form account DID
+//!     minting is frozen (#1159)
 //!   - `GET /clients/:client_id/did.json` — per-client DID document (for Tier 3
 //!     confidential clients with registered keys)
 //!
@@ -586,71 +586,25 @@ pub async fn atproto_did(
     ).into_response()
 }
 
-/// `GET /users/:username/did.json` — per-user DID document.
+/// `GET /users/:username/did.json` — frozen path-form account DID endpoint.
 ///
-/// `id = did:web:{authority}:users:{username}`. Verification methods:
-/// every Ed25519 pubkey the user has registered via SCIM
-/// (`list_pubkeys`). Empty `verificationMethod` array if the user has no
-/// registered keys — that's a valid DID document; it just means no
-/// authentication keys are bound.
+/// This route previously synthesized `did:web:{authority}:users:{username}`.
+/// That shape is outside the atproto did:web profile, so serving it would mint
+/// another permanent invalid account identifier. Keep the route as an explicit
+/// hard error until the separately designed host-form mint path lands (#1163).
 pub async fn user_did_document(
-    State(state): State<Arc<OAuthState>>,
-    Path(username): Path<String>,
+    State(_state): State<Arc<OAuthState>>,
+    Path(_username): Path<String>,
 ) -> Response {
-    let authority = match issuer_authority(&state.issuer_url) {
-        Some(a) => a,
-        None => return (
-            StatusCode::INTERNAL_SERVER_ERROR,
-            "issuer URL has no authority",
-        ).into_response(),
-    };
+    path_form_account_did_disabled_response()
+}
 
-    // Reject usernames containing characters that would break the did:web
-    // path component or imply arbitrary path traversal.
-    if username.contains(['/', '#', '?', ':']) || username.is_empty() {
-        return (StatusCode::BAD_REQUEST, "invalid username").into_response();
-    }
-    let did = format!("did:web:{authority}:users:{username}");
-
-    // Resolve user keys via UserStore.list_pubkeys. If the user store is
-    // unavailable or the user has no profile, serve an empty DID document
-    // (404 would be more strictly correct, but did:web consumers tend to
-    // tolerate empty verificationMethod better than HTTP errors and we
-    // want this endpoint to be usable as a presence check).
-    let keys: Vec<(String, VerifyingKey)> = match state.user_service.as_ref() {
-        Some(user_svc) => {
-            match user_svc.store().list_pubkeys(&username).await {
-                Ok(pubkeys) => pubkeys
-                    .into_iter()
-                    .map(|pk| (format!("key-{}", &pk.fingerprint[..8.min(pk.fingerprint.len())]), pk.pubkey))
-                    .collect(),
-                Err(_) => Vec::new(),
-            }
-        }
-        None => Vec::new(),
-    };
-
-    // #1113 rev2 finding 2: serve a COMPLETE atproto account DID document so
-    // that resolving the token `sub` (a did:web:{authority}:users:{username})
-    // yields a PDS whose `AtprotoPersonalDataServer` service points at THIS
-    // host — the round-trip the stock @atproto/oauth-client-browser requires
-    // (PDS metadata issuer == this AS). The hosted-account `#atproto` VM is
-    // the node's active ES256 key (the PDS signs atproto ops on the account's
-    // behalf), and `alsoKnownAs` carries an `at://{handle}` alias.
-    let atproto_signing = match state.es256_key_store.as_ref() {
-        Some(store) => store.active_key().await,
-        None => None,
-    };
-    let handle = account_handle(&username, &state.issuer_url);
-    let atproto = atproto_signing.as_ref().zip(handle.as_deref())
-        .map(|(sk, handle)| AtprotoIdentity { p256_vk: sk.verifying_key(), handle });
-
-    let doc = build_did_document(&did, &state.issuer_url, &keys, atproto.as_ref(), &[], None, None);
+fn path_form_account_did_disabled_response() -> Response {
     (
-        StatusCode::OK,
-        [(header::CONTENT_TYPE, "application/did+json")],
-        Json(doc),
-    ).into_response()
+        StatusCode::GONE,
+        "did:web path-form account minting is disabled; host-form account minting is not available yet (#1159)",
+    )
+        .into_response()
 }
 
 /// `GET /clients/:client_id/did.json` — per-client DID document.
@@ -764,6 +718,16 @@ mod tests {
         assert_eq!(issuer_authority("example.com"), None);
     }
 
+    #[tokio::test]
+    async fn path_form_account_document_endpoint_is_a_hard_error() {
+        let response = path_form_account_did_disabled_response();
+        assert_eq!(response.status(), StatusCode::GONE);
+        let body = axum::body::to_bytes(response.into_body(), 4096).await.unwrap();
+        assert!(std::str::from_utf8(&body)
+            .unwrap()
+            .contains("path-form account minting is disabled"));
+    }
+
     #[test]
     fn ipv6_issuer_does_not_synthesize_atproto_handle() {
         assert_eq!(configured_handle_host("https://[::1]:6791"), None);
@@ -794,7 +758,7 @@ mod tests {
     #[test]
     fn build_did_doc_minimum_structure() {
         let sk = SigningKey::generate(&mut OsRng);
-        let did = "did:web:hyprstream.example.com:users:alice";
+        let did = "did:web:alice.hyprstream.example.com";
         let doc = build_did_document(
             did,
             "https://hyprstream.example.com",
@@ -822,7 +786,7 @@ mod tests {
 
     #[test]
     fn build_did_doc_empty_keys_is_valid() {
-        let did = "did:web:example.com:users:alice";
+        let did = "did:web:alice.example.com";
         let doc = build_did_document(did, "https://example.com", &[], None, &[], None, None);
         assert_eq!(doc["id"].as_str().unwrap(), did);
         assert_eq!(doc["verificationMethod"].as_array().unwrap().len(), 0);

--- a/crates/hyprstream/src/services/oauth/did_document.rs
+++ b/crates/hyprstream/src/services/oauth/did_document.rs
@@ -718,14 +718,135 @@ mod tests {
         assert_eq!(issuer_authority("example.com"), None);
     }
 
+    /// `GET /users/:username/did.json` must be a deliberate 410 hard error,
+    /// driven through the **production** OAuth router (`create_app`) — NOT by
+    /// calling the `path_form_account_did_disabled_response()` helper directly.
+    ///
+    /// This is the regression guard for the #1159 path-form account freeze.
+    /// The handler must return 410 *before* consulting any user store: a
+    /// user-store spy whose `list_pubkeys` panics is wired into the state so
+    /// that restoring the pre-PR document-serving body (which resolved user
+    /// keys via `list_pubkeys`) fails this test loudly, instead of passing on
+    /// a coincidental "no keys found → 200 with an empty document". Asserting
+    /// only on the helper would pass either way — that tautology is what this
+    /// test replaces.
     #[tokio::test]
     async fn path_form_account_document_endpoint_is_a_hard_error() {
-        let response = path_form_account_did_disabled_response();
+        use crate::auth::user_store::{PubkeyEntry, UserFilter, UserProfile, UserStore};
+        use crate::config::server::CorsConfig;
+        use crate::config::OAuthConfig;
+        use crate::services::oauth::create_app;
+        use crate::services::{DiscoveryClient, PolicyClient};
+        use async_trait::async_trait;
+        use axum::body::Body;
+        use axum::http::Request as HttpRequest;
+        use hyprstream_rpc::rpc_client::RpcClientImpl;
+        use hyprstream_rpc::signer::LocalSigner;
+        use hyprstream_rpc::transport::lazy_uds::LazyUdsTransport;
+        use tower::ServiceExt; // oneshot
+
+        /// User-store spy whose every method panics. The frozen account-DID
+        /// handler must return 410 without ever consulting the store; if the
+        /// old key-lookup/serving code path is reintroduced it touches
+        /// `list_pubkeys` and this test aborts instead of passing.
+        struct UntouchedUserStore;
+        #[async_trait]
+        impl UserStore for UntouchedUserStore {
+            async fn get_profile(&self, _: &str) -> anyhow::Result<Option<UserProfile>> {
+                unreachable!("frozen account-DID handler must not read profiles")
+            }
+            async fn register(&self, _: &str) -> anyhow::Result<String> {
+                unreachable!()
+            }
+            async fn set_profile(&self, _: &str, _: UserProfile) -> anyhow::Result<()> {
+                unreachable!()
+            }
+            async fn remove(&self, _: &str) -> anyhow::Result<bool> { unreachable!() }
+            async fn list_users(&self) -> Vec<String> { unreachable!() }
+            async fn search(&self, _: &UserFilter)
+                -> anyhow::Result<Vec<(String, UserProfile)>> {
+                unreachable!()
+            }
+            async fn set_active(&self, _: &str, _: bool) -> anyhow::Result<()> {
+                unreachable!()
+            }
+            async fn list_pubkeys(&self, _: &str) -> anyhow::Result<Vec<PubkeyEntry>> {
+                // This is the method the pre-PR `user_did_document` called to
+                // resolve keys before minting the path-form DID. Reaching it
+                // means the freeze was bypassed.
+                unreachable!(
+                    "frozen account-DID handler must not call list_pubkeys (#1159)"
+                )
+            }
+            async fn add_pubkey(
+                &self, _: &str, _: VerifyingKey, _: Option<String>,
+            ) -> anyhow::Result<String> {
+                unreachable!()
+            }
+            async fn add_pubkey_hybrid(
+                &self, _: &str, _: VerifyingKey, _: Vec<u8>, _: Option<String>,
+            ) -> anyhow::Result<String> {
+                unreachable!()
+            }
+            async fn remove_pubkey(&self, _: &str, _: &str) -> anyhow::Result<bool> {
+                unreachable!()
+            }
+            async fn get_pubkey_user(&self, _: &str) -> anyhow::Result<Option<String>> {
+                unreachable!()
+            }
+            async fn touch_pubkey(&self, _: &str, _: &str) -> anyhow::Result<()> {
+                unreachable!()
+            }
+        }
+
+        // Minimal OAuthState over a LazyUdsTransport pointed at /dev/null.
+        // The frozen handler returns before opening it, so this keeps the test
+        // hermetic while still exercising the real router + handler wiring.
+        let key = SigningKey::from_bytes(&[0x76; 32]);
+        let vk = SigningKey::from_bytes(&[0x73; 32]).verifying_key();
+        let dummy = std::path::PathBuf::from("/dev/null/did-doc-test.sock");
+        let mk_client = || {
+            let rpc = RpcClientImpl::new(
+                LocalSigner::new(key.clone()),
+                LazyUdsTransport::new(dummy.clone()),
+                Some(vk),
+            )
+            .with_response_verify_policy(hyprstream_rpc::crypto::CryptoPolicy::Classical);
+            Arc::new(rpc)
+        };
+        let state = Arc::new(
+            OAuthState::new(
+                &OAuthConfig::default(),
+                PolicyClient::new(mk_client()),
+                DiscoveryClient::new(mk_client()),
+                [0x76; 32],
+            )
+            .with_user_service(Arc::new(crate::services::oauth::user_service::UserService::new(
+                Arc::new(UntouchedUserStore),
+            ))),
+        );
+
+        let cors = CorsConfig { enabled: false, ..Default::default() };
+        let app = create_app(state, &cors);
+
+        let response = app
+            .oneshot(
+                HttpRequest::builder()
+                    .uri("/users/alice/did.json")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
         assert_eq!(response.status(), StatusCode::GONE);
         let body = axum::body::to_bytes(response.into_body(), 4096).await.unwrap();
-        assert!(std::str::from_utf8(&body)
-            .unwrap()
-            .contains("path-form account minting is disabled"));
+        assert!(
+            std::str::from_utf8(&body)
+                .unwrap()
+                .contains("path-form account minting is disabled"),
+            "body was: {}",
+            std::str::from_utf8(&body).unwrap(),
+        );
     }
 
     #[test]

--- a/crates/hyprstream/src/services/oauth/did_document.rs
+++ b/crates/hyprstream/src/services/oauth/did_document.rs
@@ -104,6 +104,7 @@ fn configured_handle_host(issuer_url: &str) -> Option<String> {
     }
 }
 
+#[cfg(test)]
 fn account_handle(username: &str, issuer_url: &str) -> Option<String> {
     let host = configured_handle_host(issuer_url)?;
     normalize_atproto_handle(&format!("{username}.{host}"))
@@ -594,8 +595,9 @@ pub async fn atproto_did(
 /// hard error until the separately designed host-form mint path lands (#1163).
 pub async fn user_did_document(
     State(_state): State<Arc<OAuthState>>,
-    Path(_username): Path<String>,
+    Path(username): Path<String>,
 ) -> Response {
+    tracing::debug!(%username, "deprecated path-form account DID route requested");
     path_form_account_did_disabled_response()
 }
 
@@ -732,7 +734,7 @@ mod tests {
     /// test replaces.
     #[tokio::test]
     async fn path_form_account_document_endpoint_is_a_hard_error() {
-        use crate::auth::user_store::{PubkeyEntry, UserFilter, UserProfile, UserStore};
+        use crate::auth::user_store::{PubkeyEntry, UserFilter, UserProfile, UserProfilePatch, UserStore};
         use crate::config::server::CorsConfig;
         use crate::config::OAuthConfig;
         use crate::services::oauth::create_app;
@@ -758,7 +760,7 @@ mod tests {
             async fn register(&self, _: &str) -> anyhow::Result<String> {
                 unreachable!()
             }
-            async fn set_profile(&self, _: &str, _: UserProfile) -> anyhow::Result<()> {
+            async fn set_profile(&self, _: &str, _: UserProfilePatch) -> anyhow::Result<()> {
                 unreachable!()
             }
             async fn remove(&self, _: &str) -> anyhow::Result<bool> { unreachable!() }

--- a/crates/hyprstream/src/services/oauth/mount_ticket.rs
+++ b/crates/hyprstream/src/services/oauth/mount_ticket.rs
@@ -12,6 +12,7 @@ use axum::{
     http::{HeaderMap, StatusCode, header},
     response::{IntoResponse, Response},
 };
+use hyprstream_pds::repo_authority::is_path_form_did_web;
 use serde::{Deserialize, Serialize};
 
 use super::state::OAuthState;
@@ -85,6 +86,16 @@ pub async fn issue_mount_ticket(
         );
     }
 
+    if is_path_form_did_web(&user.user) {
+        return oauth_error(
+            StatusCode::BAD_REQUEST,
+            "invalid_grant",
+            Some(
+                "path-form did:web account subjects are frozen; host-form account minting is not available yet (#1159)",
+            ),
+        );
+    }
+
     let key = match state.active_jwt_signing_key().await {
         Some(k) => k,
         None => {
@@ -128,6 +139,82 @@ pub async fn issue_mount_ticket(
         }),
     )
         .into_response()
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+mod freeze_tests {
+    use super::*;
+    use crate::config::OAuthConfig;
+    use crate::services::{DiscoveryClient, PolicyClient};
+    use axum::extract::Extension;
+    use hyprstream_rpc::rpc_client::RpcClientImpl;
+    use hyprstream_rpc::signer::LocalSigner;
+    use hyprstream_rpc::transport::lazy_uds::LazyUdsTransport;
+
+    fn test_state() -> Arc<OAuthState> {
+        let key = ed25519_dalek::SigningKey::from_bytes(&[0x75; 32]);
+        let dummy = std::path::PathBuf::from("/dev/null/mount-ticket-freeze-test.sock");
+        let make_client = || Arc::new(
+            RpcClientImpl::new(
+                LocalSigner::new(key.clone()),
+                LazyUdsTransport::new(dummy.clone()),
+                Some(key.verifying_key()),
+            )
+            .with_response_verify_policy(hyprstream_rpc::crypto::CryptoPolicy::Classical),
+        );
+        Arc::new(
+            OAuthState::new(
+                &OAuthConfig::default(),
+                PolicyClient::new(make_client()),
+                DiscoveryClient::new(make_client()),
+                key.verifying_key().to_bytes(),
+            )
+            .with_ca_jwt_key(key),
+        )
+    }
+
+    fn request() -> MountTicketRequest {
+        MountTicketRequest {
+            plane: "webtransport".to_owned(),
+            namespace_path: "/".to_owned(),
+            pubkey: None,
+        }
+    }
+
+    #[tokio::test]
+    async fn mount_ticket_rejects_path_form_authenticated_user_before_signing() {
+        let response = issue_mount_ticket(
+            State(test_state()),
+            Extension(AuthenticatedUser {
+                user: "did:web:accounts.example:users:alice".to_owned(),
+                token: None,
+                exp: None,
+            }),
+            HeaderMap::new(),
+            Json(request()),
+        )
+        .await;
+
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    }
+
+    #[tokio::test]
+    async fn mount_ticket_allows_ordinary_authenticated_user() {
+        let response = issue_mount_ticket(
+            State(test_state()),
+            Extension(AuthenticatedUser {
+                user: "alice".to_owned(),
+                token: None,
+                exp: None,
+            }),
+            HeaderMap::new(),
+            Json(request()),
+        )
+        .await;
+
+        assert_eq!(response.status(), StatusCode::OK);
+    }
 }
 
 pub fn ticket_capability(plane: &str, namespace_path: &str) -> String {

--- a/crates/hyprstream/src/services/oauth/token.rs
+++ b/crates/hyprstream/src/services/oauth/token.rs
@@ -632,6 +632,20 @@ async fn exchange_refresh_token(
                 return token_error(StatusCode::INTERNAL_SERVER_ERROR, "server_error", None);
             }
         };
+        // UCAN refresh bypasses `issue_token_with_refresh` after this atomic
+        // claim, so apply the freeze before handing the grant to the direct
+        // UCAN re-mint path. The credential remains single-use and cannot
+        // produce another access or refresh token for a path-form subject.
+        if is_path_form_did_web(&claimed.username) {
+            return token_error(
+                StatusCode::BAD_REQUEST,
+                "invalid_grant",
+                Some(
+                    "token subject is a frozen path-form did:web account identifier; \
+                     host-form account minting is not available yet (#1159)",
+                ),
+            );
+        }
         let Some(claimed_grant) = claimed.ucan_grant.as_ref() else {
             tracing::error!("UCAN refresh token changed before atomic claim");
             return token_error(StatusCode::INTERNAL_SERVER_ERROR, "server_error", None);
@@ -921,7 +935,7 @@ async fn issue_token_with_refresh(
     vault_device_cookie: Option<String>,
 ) -> Response {
     // ── #1159 freeze: path-form account subject guard ───────────────────────
-    // This is the CENTRAL mint boundary: the authorization_code, refresh_token,
+    // This is the OAuth helper boundary: the authorization_code, refresh_token,
     // and device_code flows all funnel through here for both the access-token
     // `subject` and the persisted rotated `RefreshTokenEntry.username`. Blocking
     // `UserMappingStrategy::DidWeb` at config time stops NEW OIDC callbacks from
@@ -932,7 +946,8 @@ async fn issue_token_with_refresh(
     // that subject AND persist a newly rotated ~30-day refresh token carrying it,
     // keeping the path-form chain alive indefinitely.
     //
-    // Fail-closed here bounds the hole: a stored path-form subject can no longer
+    // Fail-closed here bounds the OAuth refresh hole before it reaches the
+    // PolicyService signing boundary: a stored path-form subject can no longer
     // be minted or rotated, so each pre-upgrade refresh token dies at its next
     // refresh attempt or at natural expiry — it cannot extend the lifetime. The
     // accounts themselves are reminted to host-form by E4 (#1176), not by this
@@ -1605,6 +1620,62 @@ mod tests {
         assert!(
             state.get_refresh_token("legacy-refresh").await.unwrap().is_none(),
             "the path-form refresh token must be consumed (taken), not left reusable",
+        );
+    }
+
+    #[tokio::test]
+    async fn pre_upgrade_path_form_ucan_refresh_is_consumed_not_reminted() {
+        let store = RecordingTokenStore::new();
+        let state = freeze_test_state(Arc::clone(&store)).await;
+        let path_form_entry = RefreshTokenEntry {
+            client_id: "ucan-grant:did:web:accounts.example:users:alice".to_owned(),
+            username: "did:web:accounts.example:users:alice".to_owned(),
+            scopes: vec!["urn:hyprstream:grant-type:ucan".to_owned()],
+            resource: None,
+            expires_at_unix: chrono::Utc::now().timestamp() + 3600,
+            verifying_key_bytes: None,
+            dpop_jkt: None,
+            ucan_grant: Some(crate::services::oauth::state::UcanGrantRefresh {
+                grant_cbor_b64: "not-reached".to_owned(),
+                grant_cid: "not-reached".to_owned(),
+                requested_scope: Some("read:model:demo".to_owned()),
+                audience: None,
+            }),
+        };
+        state
+            .put_refresh_token("legacy-ucan-refresh", &path_form_entry, 3600)
+            .await
+            .unwrap();
+
+        let params = TokenRequest {
+            grant_type: "refresh_token".to_owned(),
+            refresh_token: Some("legacy-ucan-refresh".to_owned()),
+            client_id: path_form_entry.client_id.clone(),
+            code: None,
+            redirect_uri: None,
+            code_verifier: None,
+            device_code: None,
+            assertion: None,
+            client_assertion: None,
+            client_assertion_type: None,
+            subject_token: None,
+            subject_token_type: None,
+            requested_token_type: None,
+            actor_token: None,
+            scope: None,
+            audience: None,
+        };
+        let resp = exchange_refresh_token(state.clone(), params, None, None).await;
+
+        assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+        let body = axum::body::to_bytes(resp.into_body(), 4096).await.unwrap();
+        let value: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert_eq!(value["error"].as_str(), Some("invalid_grant"));
+        assert!(value["error_description"].as_str().unwrap().contains("frozen"));
+        assert_eq!(store.put_count(), 1, "UCAN refresh must not persist a replacement");
+        assert!(
+            state.get_refresh_token("legacy-ucan-refresh").await.unwrap().is_none(),
+            "the legacy UCAN refresh must be consumed, not left reusable",
         );
     }
 }

--- a/crates/hyprstream/src/services/oauth/token.rs
+++ b/crates/hyprstream/src/services/oauth/token.rs
@@ -1635,6 +1635,7 @@ mod tests {
             expires_at_unix: chrono::Utc::now().timestamp() + 3600,
             verifying_key_bytes: None,
             dpop_jkt: None,
+            client_assertion_jkt: None,
             ucan_grant: Some(crate::services::oauth::state::UcanGrantRefresh {
                 grant_cbor_b64: "not-reached".to_owned(),
                 grant_cid: "not-reached".to_owned(),
@@ -1665,7 +1666,7 @@ mod tests {
             scope: None,
             audience: None,
         };
-        let resp = exchange_refresh_token(state.clone(), params, None, None).await;
+        let resp = exchange_refresh_token(state.clone(), params, None, None, None).await;
 
         assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
         let body = axum::body::to_bytes(resp.into_body(), 4096).await.unwrap();

--- a/crates/hyprstream/src/services/oauth/token.rs
+++ b/crates/hyprstream/src/services/oauth/token.rs
@@ -23,6 +23,7 @@ use sha2::{Digest, Sha256};
 use subtle::ConstantTimeEq;
 
 use super::state::{DeviceCodeStatus, OAuthState, RefreshTokenEntry};
+use hyprstream_pds::repo_authority::is_path_form_did_web;
 use hyprstream_rpc::auth::{JwkThumbprintInput, jwk_thumbprint};
 use crate::services::generated::policy_client::IssueToken;
 
@@ -919,6 +920,39 @@ async fn issue_token_with_refresh(
     client_assertion_jkt: Option<String>,
     vault_device_cookie: Option<String>,
 ) -> Response {
+    // ── #1159 freeze: path-form account subject guard ───────────────────────
+    // This is the CENTRAL mint boundary: the authorization_code, refresh_token,
+    // and device_code flows all funnel through here for both the access-token
+    // `subject` and the persisted rotated `RefreshTokenEntry.username`. Blocking
+    // `UserMappingStrategy::DidWeb` at config time stops NEW OIDC callbacks from
+    // constructing a path-form subject, but it does not touch subjects already
+    // durably persisted in refresh-token (and Valkey user-profile) stores. A
+    // pre-upgrade refresh token carries `did:web:{authority}:users:{name}` as its
+    // `username`; without this guard, refresh would mint a fresh access token for
+    // that subject AND persist a newly rotated ~30-day refresh token carrying it,
+    // keeping the path-form chain alive indefinitely.
+    //
+    // Fail-closed here bounds the hole: a stored path-form subject can no longer
+    // be minted or rotated, so each pre-upgrade refresh token dies at its next
+    // refresh attempt or at natural expiry — it cannot extend the lifetime. The
+    // accounts themselves are reminted to host-form by E4 (#1176), not by this
+    // freeze; this PR does NOT scan or revoke stored records at startup, because
+    // that durable scan is exactly the out-of-band work #1176 owns and a partial
+    // scan here would risk the data migration the freeze deliberately defers.
+    // The predicate is the shared `is_path_form_did_web` so host-form
+    // `did:web:alice.example.com`, plain usernames, and every non-did:web subject
+    // pass through unchanged.
+    if is_path_form_did_web(sub) {
+        return token_error(
+            StatusCode::BAD_REQUEST,
+            "invalid_grant",
+            Some(
+                "token subject is a frozen path-form did:web account identifier; \
+                 host-form account minting is not available yet (#1159)",
+            ),
+        );
+    }
+
     let scope_str = scopes.join(" ");
     let atproto_profile = super::state::atproto_profile_active(&scopes);
 
@@ -1391,5 +1425,186 @@ mod tests {
             (Some(a), Some(b)) if a == b
         );
         assert!(matches3, "equal jkt must bind");
+    }
+
+    // ── #1159 freeze: pre-upgrade path-form refresh token must not rotate ──
+
+    /// A `TokenStore` that counts `put` calls (rotation writes) and otherwise
+    /// behaves like a small in-memory map. Used to prove a path-form refresh
+    /// fails *without* persisting a rotated token.
+    struct RecordingTokenStore {
+        inner: parking_lot::Mutex<std::collections::HashMap<String, RefreshTokenEntry>>,
+        puts: std::sync::atomic::AtomicUsize,
+    }
+
+    impl RecordingTokenStore {
+        fn new() -> Arc<Self> {
+            Arc::new(Self {
+                inner: parking_lot::Mutex::new(std::collections::HashMap::new()),
+                puts: std::sync::atomic::AtomicUsize::new(0),
+            })
+        }
+        fn put_count(&self) -> usize {
+            self.puts.load(std::sync::atomic::Ordering::SeqCst)
+        }
+    }
+
+    #[async_trait::async_trait]
+    impl crate::services::oauth::token_store::TokenStore for RecordingTokenStore {
+        async fn put(&self, token: &str, entry: &RefreshTokenEntry, _ttl: u64) -> anyhow::Result<()> {
+            self.puts.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+            self.inner.lock().insert(token.to_owned(), entry.clone());
+            Ok(())
+        }
+        async fn get(&self, token: &str) -> anyhow::Result<Option<RefreshTokenEntry>> {
+            Ok(self.inner.lock().get(token).cloned())
+        }
+        async fn take(&self, token: &str) -> anyhow::Result<Option<RefreshTokenEntry>> {
+            Ok(self.inner.lock().remove(token))
+        }
+        async fn delete(&self, token: &str) -> anyhow::Result<()> {
+            self.inner.lock().remove(token);
+            Ok(())
+        }
+    }
+
+    /// Build a minimal `OAuthState` over dummy RPC clients (LazyUdsTransport at
+    /// /dev/null — never opened) and a recording refresh-token store.
+    async fn freeze_test_state(store: Arc<RecordingTokenStore>) -> Arc<OAuthState> {
+        use crate::config::OAuthConfig;
+        use crate::services::{DiscoveryClient, PolicyClient};
+        use hyprstream_rpc::rpc_client::RpcClientImpl;
+        use hyprstream_rpc::signer::LocalSigner;
+        use hyprstream_rpc::transport::lazy_uds::LazyUdsTransport;
+
+        let key = ed25519_dalek::SigningKey::from_bytes(&[0x76; 32]);
+        let vk = ed25519_dalek::SigningKey::from_bytes(&[0x73; 32]).verifying_key();
+        let dummy = std::path::PathBuf::from("/dev/null/freeze-test.sock");
+        let mk_client = || {
+            Arc::new(
+                RpcClientImpl::new(
+                    LocalSigner::new(key.clone()),
+                    LazyUdsTransport::new(dummy.clone()),
+                    Some(vk),
+                )
+                .with_response_verify_policy(hyprstream_rpc::crypto::CryptoPolicy::Classical),
+            )
+        };
+        let mut state = OAuthState::new(
+            &OAuthConfig::default(),
+            PolicyClient::new(mk_client()),
+            DiscoveryClient::new(mk_client()),
+            [0x76; 32],
+        );
+        state.with_token_store_impl(store as Arc<dyn crate::services::oauth::token_store::TokenStore>);
+        Arc::new(state)
+    }
+
+    /// The central mint guard: a path-form subject is rejected with
+    /// `invalid_grant` and no rotated refresh token is persisted.
+    #[tokio::test]
+    async fn path_form_subject_rejected_at_mint_boundary_without_rotation() {
+        let store = RecordingTokenStore::new();
+        let state = freeze_test_state(Arc::clone(&store)).await;
+
+        let resp = issue_token_with_refresh(
+            &state,
+            "client-1",
+            vec!["openid".to_owned()],
+            None,
+            "did:web:accounts.example:users:alice", // path-form — frozen under #1159
+            None,
+            false,
+            None,
+            None,
+            None,
+            None,
+        )
+        .await;
+
+        assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+        let body = axum::body::to_bytes(resp.into_body(), 4096).await.unwrap();
+        let v: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert_eq!(v["error"].as_str(), Some("invalid_grant"));
+        assert!(
+            v["error_description"]
+                .as_str()
+                .unwrap()
+                .contains("frozen path-form did:web"),
+            "body was: {v}",
+        );
+        assert_eq!(
+            store.put_count(),
+            0,
+            "guard must return before persisting a rotated refresh token",
+        );
+    }
+
+    /// End-to-end refresh regression: a pre-upgrade refresh token whose stored
+    /// subject is path-form is consumed (taken) on refresh but NOT rotated —
+    /// no access token is minted and no replacement refresh token is written,
+    /// so the chain dies here rather than rotating indefinitely.
+    #[tokio::test]
+    async fn pre_upgrade_path_form_refresh_token_is_consumed_not_rotated() {
+        let store = RecordingTokenStore::new();
+        let state = freeze_test_state(Arc::clone(&store)).await;
+
+        // Seed a pre-upgrade refresh token carrying a path-form subject, exactly
+        // as a `didweb`-configured deployment would have persisted before #1159.
+        let path_form_entry = RefreshTokenEntry {
+            client_id: "client-1".to_owned(),
+            username: "did:web:accounts.example:users:alice".to_owned(),
+            scopes: vec!["openid".to_owned()],
+            resource: None,
+            expires_at_unix: chrono::Utc::now().timestamp() + 3600,
+            verifying_key_bytes: None,
+            dpop_jkt: None,
+            client_assertion_jkt: None,
+            ucan_grant: None,
+        };
+        state
+            .put_refresh_token("legacy-refresh", &path_form_entry, 3600)
+            .await
+            .unwrap();
+        assert_eq!(store.put_count(), 1, "seeding writes one entry");
+
+        let params = TokenRequest {
+            grant_type: "refresh_token".to_owned(),
+            refresh_token: Some("legacy-refresh".to_owned()),
+            client_id: "client-1".to_owned(),
+            code: None,
+            redirect_uri: None,
+            code_verifier: None,
+            device_code: None,
+            assertion: None,
+            client_assertion: None,
+            client_assertion_type: None,
+            subject_token: None,
+            subject_token_type: None,
+            requested_token_type: None,
+            actor_token: None,
+            scope: None,
+            audience: None,
+        };
+        let resp = exchange_refresh_token(Arc::clone(&state), params, None, None, None).await;
+
+        assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+        let body = axum::body::to_bytes(resp.into_body(), 4096).await.unwrap();
+        let v: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert_eq!(v["error"].as_str(), Some("invalid_grant"));
+        assert!(v["error_description"].as_str().unwrap().contains("frozen"));
+
+        // No rotated refresh token was persisted (put_count still equals the
+        // single seed write), and the legacy token is gone (taken on refresh) —
+        // the chain is dead, not extended.
+        assert_eq!(
+            store.put_count(),
+            1,
+            "refresh must not persist a rotated refresh token for a path-form subject",
+        );
+        assert!(
+            state.get_refresh_token("legacy-refresh").await.unwrap().is_none(),
+            "the path-form refresh token must be consumed (taken), not left reusable",
+        );
     }
 }

--- a/crates/hyprstream/src/services/oauth/token_exchange.rs
+++ b/crates/hyprstream/src/services/oauth/token_exchange.rs
@@ -1164,28 +1164,6 @@ mod tests {
         assert!(value.get("refresh_token").is_none());
     }
 
-    #[tokio::test]
-    async fn token_exchange_rejects_valid_legacy_path_form_access_token() {
-        let key = ed25519_dalek::SigningKey::from_bytes(&[0x65; 32]);
-        let now = chrono::Utc::now().timestamp();
-        let legacy = hyprstream_rpc::auth::jwt::encode(
-            &hyprstream_rpc::auth::Claims::new(
-                "did:web:accounts.example:users:alice".to_owned(), now - 1, now + 3600,
-            ),
-            &key,
-        );
-        let response = exchange_token_exchange(
-            &mint_test_state(), &legacy, TOKEN_TYPE_ACCESS_TOKEN, None, None, None, None,
-        ).await;
-
-        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
-        let body = axum::body::to_bytes(response.into_body(), 4096).await.unwrap();
-        let value: serde_json::Value = serde_json::from_slice(&body).unwrap();
-        assert_eq!(value["error"].as_str(), Some("invalid_grant"));
-        assert!(value["error_description"].as_str().unwrap().contains("frozen"));
-        assert!(value.get("access_token").is_none());
-    }
-
     /// A compartment bitset from bit indices.
     fn comps(bits: &[u32]) -> CompartmentSet {
         bits.iter().copied().collect()

--- a/crates/hyprstream/src/services/oauth/token_exchange.rs
+++ b/crates/hyprstream/src/services/oauth/token_exchange.rs
@@ -17,6 +17,7 @@ use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine as _};
 use sha2::{Digest, Sha256};
 
 use super::state::OAuthState;
+use hyprstream_pds::repo_authority::is_path_form_did_web;
 use crate::mac::exchange::{GrantDecision, GrantError, GrantRequest, GrantedAccess};
 use crate::services::generated::policy_client::IssueToken;
 
@@ -90,6 +91,17 @@ pub async fn exchange_token_exchange(
             );
         }
     };
+
+    // The PolicyService check remains the shared signing boundary for every
+    // RPC issuer; this gives RFC 8693 callers a concrete OAuth error before a
+    // legacy subject can reach that RPC boundary.
+    if is_path_form_did_web(&verified.sub) {
+        return tx_error(
+            StatusCode::BAD_REQUEST,
+            "invalid_grant",
+            "path-form did:web account subjects are frozen; host-form account minting is not available yet (#1159)",
+        );
+    }
 
     // Replay prevention: SHA-256 of the subject token as the replay key.
     // Covers all token types, regardless of whether they carry a jti claim.
@@ -936,6 +948,19 @@ async fn mint_grant_token(
     // `act` claim below, so the token records "actor acting for delegator"
     // rather than collapsing to one identity (the confused-deputy fix).
     let sub = principals.sub.clone();
+
+    // #1159 freeze: UCAN issuance signs directly instead of using
+    // PolicyService, so it must enforce the same concrete-subject invariant at
+    // its own mint-and-refresh-persistence boundary. Return before signing or
+    // storing a refresh token so a legacy path-form chain cannot be extended.
+    if is_path_form_did_web(&sub) {
+        return tx_error(
+            StatusCode::BAD_REQUEST,
+            "invalid_grant",
+            "path-form did:web account subjects are frozen; host-form account minting is not available yet (#1159)",
+        );
+    }
+
     let scope_str = format!(
         "{}@{}",
         granted.capability.ability, granted.capability.resource
@@ -1086,6 +1111,80 @@ mod tests {
     use hyprstream_rpc::auth::mac::{
         Assurance, CompartmentSet, Level, SecurityLabel, VerifiedKeyMaterial,
     };
+
+    fn mint_test_state() -> Arc<OAuthState> {
+        use crate::config::OAuthConfig;
+        use crate::services::{DiscoveryClient, PolicyClient};
+        use hyprstream_rpc::rpc_client::RpcClientImpl;
+        use hyprstream_rpc::signer::LocalSigner;
+        use hyprstream_rpc::transport::lazy_uds::LazyUdsTransport;
+
+        let key = ed25519_dalek::SigningKey::from_bytes(&[0x65; 32]);
+        let dummy = std::path::PathBuf::from("/dev/null/path-form-mint-test.sock");
+        let mk_client = || Arc::new(
+            RpcClientImpl::new(
+                LocalSigner::new(key.clone()),
+                LazyUdsTransport::new(dummy.clone()),
+                Some(key.verifying_key()),
+            ).with_response_verify_policy(hyprstream_rpc::crypto::CryptoPolicy::Classical),
+        );
+        Arc::new(OAuthState::new(
+            &OAuthConfig::default(),
+            PolicyClient::new(mk_client()),
+            DiscoveryClient::new(mk_client()),
+            key.verifying_key().to_bytes(),
+        ))
+    }
+
+    #[tokio::test]
+    async fn ucan_mint_rejects_path_form_subject_before_signing() {
+        use hyprstream_rpc::auth::ucan::{Ability, Capability, Resource};
+
+        let granted = GrantedAccess {
+            capability: Capability::new(Resource::new("mac://model/demo"), Ability::new("read")),
+            audience: None,
+        };
+        let response = mint_grant_token(
+            &mint_test_state(),
+            &granted,
+            "test-dpop-jkt",
+            None,
+            TokenPrincipals {
+                sub: "did:web:accounts.example:users:alice".to_owned(),
+                act: None,
+            },
+        ).await;
+
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+        let body = axum::body::to_bytes(response.into_body(), 4096).await.unwrap();
+        let value: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert_eq!(value["error"].as_str(), Some("invalid_grant"));
+        assert!(value["error_description"].as_str().unwrap().contains("frozen"));
+        assert!(value.get("access_token").is_none());
+        assert!(value.get("refresh_token").is_none());
+    }
+
+    #[tokio::test]
+    async fn token_exchange_rejects_valid_legacy_path_form_access_token() {
+        let key = ed25519_dalek::SigningKey::from_bytes(&[0x65; 32]);
+        let now = chrono::Utc::now().timestamp();
+        let legacy = hyprstream_rpc::auth::jwt::encode(
+            &hyprstream_rpc::auth::Claims::new(
+                "did:web:accounts.example:users:alice".to_owned(), now - 1, now + 3600,
+            ),
+            &key,
+        );
+        let response = exchange_token_exchange(
+            &mint_test_state(), &legacy, TOKEN_TYPE_ACCESS_TOKEN, None, None, None, None,
+        ).await;
+
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+        let body = axum::body::to_bytes(response.into_body(), 4096).await.unwrap();
+        let value: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert_eq!(value["error"].as_str(), Some("invalid_grant"));
+        assert!(value["error_description"].as_str().unwrap().contains("frozen"));
+        assert!(value.get("access_token").is_none());
+    }
 
     /// A compartment bitset from bit indices.
     fn comps(bits: &[u32]) -> CompartmentSet {

--- a/crates/hyprstream/src/services/oauth/user_mapping.rs
+++ b/crates/hyprstream/src/services/oauth/user_mapping.rs
@@ -12,7 +12,7 @@ pub fn map_external_identity(
     provider_slug: &str,
     external_claims: &serde_json::Value,
     strategy: &UserMappingStrategy,
-    local_issuer_url: &str,
+    _local_issuer_url: &str,
 ) -> Result<String> {
     match strategy {
         UserMappingStrategy::Namespaced => {
@@ -40,42 +40,10 @@ pub fn map_external_identity(
                 .ok_or_else(|| anyhow!("External id_token missing '{}' claim", name))?;
             Ok(val.to_owned())
         }
-        UserMappingStrategy::DidWeb => {
-            // Phase 0.5 / Phase 1a — did:web subject format per architecture
-            // doc Subject Identity Format. Format:
-            //   did:web:{authority}:users:{external_sub}
-            // where {authority} = the local OAuth issuer URL's host[:port].
-            let sub = external_claims["sub"]
-                .as_str()
-                .ok_or_else(|| anyhow!("External id_token missing 'sub' claim"))?;
-            let authority = extract_authority(local_issuer_url)?;
-            // External sub may contain characters; for now we require it to
-            // be a stable opaque identifier (most OIDC providers use UUIDs
-            // or stable usernames). Operators using providers with weird sub
-            // formats should use a different strategy (Email / Claim).
-            if sub.contains(['#', '?', '/']) {
-                return Err(anyhow!(
-                    "External 'sub' contains characters incompatible with did:web path: {}",
-                    sub
-                ));
-            }
-            Ok(format!("did:web:{authority}:users:{sub}"))
-        }
+        UserMappingStrategy::DidWeb => Err(anyhow!(
+            "did:web path-form account minting is disabled: the atproto profile requires host-form account DIDs (#1159)"
+        )),
     }
-}
-
-/// Extract the authority component (host[:port]) from a URL, preserving
-/// the port if present. Used for did:web construction per the did:web spec.
-pub(crate) fn extract_authority(url: &str) -> Result<String> {
-    let after_scheme = url
-        .split_once("://")
-        .map(|(_, rest)| rest)
-        .ok_or_else(|| anyhow!("issuer URL missing scheme: {}", url))?;
-    let authority = after_scheme.split('/').next().unwrap_or(after_scheme);
-    if authority.is_empty() {
-        return Err(anyhow!("issuer URL has empty authority: {}", url));
-    }
-    Ok(authority.to_owned())
 }
 
 /// Check if a user should be provisioned based on the provisioning mode.
@@ -149,51 +117,15 @@ mod tests {
     }
 
     #[test]
-    fn test_didweb_mapping_basic() {
+    fn test_didweb_mapping_is_a_hard_error() {
         let claims = serde_json::json!({"sub": "alice"});
-        let result = map_external_identity(
+        let err = map_external_identity(
             "keycloak",
             &claims,
             &UserMappingStrategy::DidWeb,
             "https://hyprstream.example.com",
-        ).unwrap();
-        assert_eq!(result, "did:web:hyprstream.example.com:users:alice");
-    }
-
-    #[test]
-    fn test_didweb_mapping_preserves_port() {
-        let claims = serde_json::json!({"sub": "12345"});
-        let result = map_external_identity(
-            "keycloak",
-            &claims,
-            &UserMappingStrategy::DidWeb,
-            "http://127.0.0.1:6791",
-        ).unwrap();
-        assert_eq!(result, "did:web:127.0.0.1:6791:users:12345");
-    }
-
-    #[test]
-    fn test_didweb_mapping_rejects_path_chars_in_sub() {
-        let claims = serde_json::json!({"sub": "alice/bob"});
-        let result = map_external_identity(
-            "keycloak",
-            &claims,
-            &UserMappingStrategy::DidWeb,
-            "https://hyprstream.example.com",
-        );
-        assert!(result.is_err(), "sub with '/' must reject");
-    }
-
-    #[test]
-    fn test_didweb_mapping_requires_scheme() {
-        let claims = serde_json::json!({"sub": "alice"});
-        let result = map_external_identity(
-            "keycloak",
-            &claims,
-            &UserMappingStrategy::DidWeb,
-            "hyprstream.example.com",
-        );
-        assert!(result.is_err(), "missing scheme must reject");
+        ).unwrap_err();
+        assert!(err.to_string().contains("path-form account minting is disabled"));
     }
 
     #[test]

--- a/crates/hyprstream/src/services/oauth/wit_bootstrap.rs
+++ b/crates/hyprstream/src/services/oauth/wit_bootstrap.rs
@@ -20,6 +20,7 @@ use axum::{
     Extension, Json,
 };
 use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine as _};
+use hyprstream_pds::repo_authority::is_path_form_did_web;
 use serde::Deserialize;
 
 use crate::server::middleware::AuthenticatedUser;
@@ -40,6 +41,18 @@ pub async fn issue_browser_wit(
     Extension(user): Extension<AuthenticatedUser>,
     Json(body): Json<WitRequest>,
 ) -> Response {
+    if is_path_form_did_web(&user.user) {
+        return (
+            StatusCode::BAD_REQUEST,
+            [(header::CACHE_CONTROL, "no-store"), (header::PRAGMA, "no-cache")],
+            Json(serde_json::json!({
+                "error": "invalid_grant",
+                "error_description": "path-form did:web account subjects are frozen; host-form account minting is not available yet (#1159)",
+            })),
+        )
+            .into_response();
+    }
+
     let ca_key_arc = state.active_jwt_signing_key().await;
     let ca_key = match ca_key_arc.as_deref() {
         Some(k) => k,
@@ -105,4 +118,77 @@ pub async fn issue_browser_wit(
             "expires_in": BROWSER_WIT_TTL,
         })),
     ).into_response()
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+mod tests {
+    use super::*;
+    use crate::config::OAuthConfig;
+    use crate::services::{DiscoveryClient, PolicyClient};
+    use axum::extract::Extension;
+    use hyprstream_rpc::rpc_client::RpcClientImpl;
+    use hyprstream_rpc::signer::LocalSigner;
+    use hyprstream_rpc::transport::lazy_uds::LazyUdsTransport;
+
+    fn test_state() -> Arc<OAuthState> {
+        let key = ed25519_dalek::SigningKey::from_bytes(&[0x73; 32]);
+        let dummy = std::path::PathBuf::from("/dev/null/wit-freeze-test.sock");
+        let make_client = || Arc::new(
+            RpcClientImpl::new(
+                LocalSigner::new(key.clone()),
+                LazyUdsTransport::new(dummy.clone()),
+                Some(key.verifying_key()),
+            )
+            .with_response_verify_policy(hyprstream_rpc::crypto::CryptoPolicy::Classical),
+        );
+        Arc::new(
+            OAuthState::new(
+                &OAuthConfig::default(),
+                PolicyClient::new(make_client()),
+                DiscoveryClient::new(make_client()),
+                key.verifying_key().to_bytes(),
+            )
+            .with_ca_jwt_key(key),
+        )
+    }
+
+    fn request() -> WitRequest {
+        let public_key = ed25519_dalek::SigningKey::from_bytes(&[0x74; 32]).verifying_key();
+        WitRequest {
+            pubkey: URL_SAFE_NO_PAD.encode(public_key.as_bytes()),
+        }
+    }
+
+    #[tokio::test]
+    async fn browser_wit_rejects_path_form_authenticated_user_before_signing() {
+        let response = issue_browser_wit(
+            State(test_state()),
+            Extension(AuthenticatedUser {
+                user: "did:web:accounts.example:users:alice".to_owned(),
+                token: None,
+                exp: None,
+            }),
+            Json(request()),
+        )
+        .await;
+
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    }
+
+    #[tokio::test]
+    async fn browser_wit_allows_ordinary_authenticated_user() {
+        let response = issue_browser_wit(
+            State(test_state()),
+            Extension(AuthenticatedUser {
+                user: "alice".to_owned(),
+                token: None,
+                exp: None,
+            }),
+            Json(request()),
+        )
+        .await;
+
+        assert_eq!(response.status(), StatusCode::OK);
+    }
 }

--- a/crates/hyprstream/src/services/oauth/xrpc.rs
+++ b/crates/hyprstream/src/services/oauth/xrpc.rs
@@ -49,6 +49,7 @@ use hyprstream_pds::car::{build_record_proof_car, car_block_bytes, car_header_by
 use hyprstream_pds::commit::Commit;
 use hyprstream_pds::mst::{Node, NodeData};
 use hyprstream_pds::record::{ModelRecord, COLLECTION_NSID};
+use hyprstream_pds::repo_authority::accept_repo_authority;
 use hyprstream_pds::tid::Tid;
 use hyprstream_pds::Cid;
 
@@ -164,9 +165,11 @@ impl XrpcRepoStore {
         Self::default()
     }
 
-    /// Insert or replace a snapshot for a DID.
-    pub async fn put(&self, snap: RepoSnapshot) {
+    /// Insert or replace a snapshot for an atproto-valid repo authority.
+    pub async fn put(&self, snap: RepoSnapshot) -> anyhow::Result<()> {
+        accept_repo_authority(&snap.did)?;
         self.by_did.write().await.insert(snap.did.clone(), Arc::new(snap));
+        Ok(())
     }
 
     /// Look up a snapshot by DID (any visibility — for internal/admin use).
@@ -728,7 +731,7 @@ mod tests {
     #[tokio::test]
     async fn endpoint_non_public_invisible_describe_repo() {
         let store = XrpcRepoStore::new();
-        store.put(sample_snapshot("did:web:priv.example.com", "priv.example.com", false)).await;
+        store.put(sample_snapshot("did:web:priv.example.com", "priv.example.com", false)).await.unwrap();
         let resp = describe_repo_core(&store, ISSUER, "did:web:priv.example.com").await;
         assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
         let body = body_json(resp).await;
@@ -738,7 +741,7 @@ mod tests {
     #[tokio::test]
     async fn endpoint_non_public_invisible_get_record() {
         let store = XrpcRepoStore::new();
-        store.put(sample_snapshot("did:web:priv.example.com", "priv.example.com", false)).await;
+        store.put(sample_snapshot("did:web:priv.example.com", "priv.example.com", false)).await.unwrap();
         let resp = get_record_core(
             &store,
             "did:web:priv.example.com",
@@ -755,7 +758,7 @@ mod tests {
     #[tokio::test]
     async fn endpoint_non_public_invisible_get_repo() {
         let store = XrpcRepoStore::new();
-        store.put(sample_snapshot("did:web:priv.example.com", "priv.example.com", false)).await;
+        store.put(sample_snapshot("did:web:priv.example.com", "priv.example.com", false)).await.unwrap();
         let resp = get_repo_core(&store, "did:web:priv.example.com", false).await;
         assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
         let body = body_json(resp).await;
@@ -765,7 +768,7 @@ mod tests {
     #[tokio::test]
     async fn endpoint_non_public_invisible_resolve_handle() {
         let store = XrpcRepoStore::new();
-        store.put(sample_snapshot("did:web:priv.example.com", "priv.example.com", false)).await;
+        store.put(sample_snapshot("did:web:priv.example.com", "priv.example.com", false)).await.unwrap();
         let resp = resolve_handle_core(&store, ISSUER, "priv.example.com").await;
         assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
         let body = body_json(resp).await;
@@ -775,7 +778,7 @@ mod tests {
     #[tokio::test]
     async fn endpoint_public_snapshot_visible_describe_repo() {
         let store = XrpcRepoStore::new();
-        store.put(sample_snapshot("did:web:pub.example.com", "pub.example.com", true)).await;
+        store.put(sample_snapshot("did:web:pub.example.com", "pub.example.com", true)).await.unwrap();
         let resp = describe_repo_core(&store, ISSUER, "did:web:pub.example.com").await;
         assert_eq!(resp.status(), StatusCode::OK);
         let body = body_json(resp).await;
@@ -785,11 +788,23 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn store_rejects_path_form_did_web_snapshot() {
+        let store = XrpcRepoStore::new();
+        let did = "did:web:accounts.example:users:alice";
+        let err = store
+            .put(sample_snapshot(did, "alice.example", true))
+            .await
+            .unwrap_err();
+        assert!(err.to_string().contains("path-form did:web"));
+        assert!(store.get(did).await.is_none());
+    }
+
+    #[tokio::test]
     async fn endpoint_get_record_cid_mismatch() {
         let store = XrpcRepoStore::new();
         let snap = sample_snapshot("did:web:pub.example.com", "pub.example.com", true);
         let rkey = snap.records.keys().next().unwrap().encode();
-        store.put(snap).await;
+        store.put(snap).await.unwrap();
         let resp = get_record_core(
             &store,
             "did:web:pub.example.com",
@@ -809,7 +824,7 @@ mod tests {
         let snap = sample_snapshot("did:web:pub.example.com", "pub.example.com", true);
         let rkey = snap.records.keys().next().unwrap().encode();
         let cid = snap.records.values().next().unwrap().cid().to_string();
-        store.put(snap).await;
+        store.put(snap).await.unwrap();
         let resp =
             get_record_core(&store, "did:web:pub.example.com", HOSTED_COLLECTION, &rkey, Some(&cid))
                 .await;
@@ -821,7 +836,7 @@ mod tests {
     #[tokio::test]
     async fn since_non_empty_rejected() {
         let store = XrpcRepoStore::new();
-        store.put(sample_snapshot("did:web:pub.example.com", "pub.example.com", true)).await;
+        store.put(sample_snapshot("did:web:pub.example.com", "pub.example.com", true)).await.unwrap();
         let resp = get_repo_core(&store, "did:web:pub.example.com", true).await;
         assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
         let body = body_json(resp).await;
@@ -831,7 +846,7 @@ mod tests {
     #[tokio::test]
     async fn get_repo_without_since_succeeds() {
         let store = XrpcRepoStore::new();
-        store.put(sample_snapshot("did:web:pub.example.com", "pub.example.com", true)).await;
+        store.put(sample_snapshot("did:web:pub.example.com", "pub.example.com", true)).await.unwrap();
         let resp = get_repo_core(&store, "did:web:pub.example.com", false).await;
         assert_eq!(resp.status(), StatusCode::OK);
         assert_eq!(
@@ -931,11 +946,13 @@ mod tests {
         state
             .xrpc_repos
             .put(sample_snapshot("did:web:pub.example.com", "pub.example.com", true))
-            .await;
+            .await
+            .unwrap();
         state
             .xrpc_repos
             .put(sample_snapshot("did:web:priv.example.com", "priv.example.com", false))
-            .await;
+            .await
+            .unwrap();
         state
     }
 
@@ -1259,7 +1276,7 @@ mod tests {
         let snap = sample_snapshot_fixed_tid("did:web:fixed.example.com", "fixed.example.com", true);
         let rkey = snap.records.keys().next().unwrap().encode();
         let cid = snap.records.values().next().unwrap().cid().to_string();
-        state.xrpc_repos.put(snap).await;
+        state.xrpc_repos.put(snap).await.unwrap();
         let app = build_production_app_from_state(state).await;
         let uri = format!(
             "/xrpc/com.atproto.repo.getRecord?repo=did:web:fixed.example.com\
@@ -1277,7 +1294,7 @@ mod tests {
         let state = build_test_state(true).await;
         let snap = sample_snapshot_fixed_tid("did:web:fixed.example.com", "fixed.example.com", true);
         let rkey = snap.records.keys().next().unwrap().encode();
-        state.xrpc_repos.put(snap).await;
+        state.xrpc_repos.put(snap).await.unwrap();
         let app = build_production_app_from_state(state).await;
         let uri = format!(
             "/xrpc/com.atproto.repo.getRecord?repo=did:web:fixed.example.com\

--- a/crates/hyprstream/src/services/policy.rs
+++ b/crates/hyprstream/src/services/policy.rs
@@ -1709,6 +1709,7 @@ mod tests {
             subject: Some(subject.to_owned()),
             user_pub_key: None,
             dpop_jkt: None,
+            issuer: None,
         }
     }
 

--- a/crates/hyprstream/src/services/policy.rs
+++ b/crates/hyprstream/src/services/policy.rs
@@ -22,6 +22,7 @@ use crate::services::generated::policy_client::{
 };
 use anyhow::{anyhow, Result};
 use git2db::{Git2DB, RepoId};
+use hyprstream_pds::repo_authority::is_path_form_did_web;
 use hyprstream_rpc::prelude::*;
 use hyprstream_rpc::transport::TransportConfig;
 use std::collections::HashMap;
@@ -332,6 +333,19 @@ impl PolicyHandler for PolicyService {
             // Use bare username from the envelope identity.
             ctx.user().to_owned()
         };
+
+        // #1159 freeze: this is the shared signing boundary for every caller
+        // using PolicyClient::issue_token, including RFC 8693 token exchange
+        // and RFC 7523 JWT bearer. Check the resolved concrete subject, not
+        // merely an optional request field, so an envelope-derived subject
+        // cannot bypass the freeze either.
+        if is_path_form_did_web(&subject) {
+            return Ok(PolicyResponseVariant::Error(ErrorInfo {
+                message: "path-form did:web account subjects are frozen; host-form account minting is not available yet (#1159)".to_owned(),
+                code: "FROZEN_PATH_FORM_SUBJECT".to_owned(),
+                details: String::new(),
+            }));
+        }
 
         // Validate TTL — service tokens get a longer default (7 days)
         let default_ttl = if is_service_token {
@@ -1455,6 +1469,17 @@ impl PolicyHandler for PolicyService {
             }
         };
 
+        // ExchangeWit signs directly rather than through `handle_issue_token`.
+        // Keep its authenticated-envelope subject under the same account-DID
+        // freeze before it can reach the direct signing boundary.
+        if is_path_form_did_web(&sub) {
+            return Ok(PolicyResponseVariant::Error(ErrorInfo {
+                message: "path-form did:web account subjects are frozen; host-form account minting is not available yet (#1159)".to_owned(),
+                code: "FROZEN_PATH_FORM_SUBJECT".to_owned(),
+                details: String::new(),
+            }));
+        }
+
         // cnf.jwk from the verified WIT — carried through into the issued at+jwt.
         let cnf_key_bytes = ctx.claims().and_then(hyprstream_rpc::auth::Claims::cnf_key_bytes);
         if cnf_key_bytes.is_none() {
@@ -1651,6 +1676,82 @@ pub(crate) async fn watch_policy_file(
         match policy_manager.reload().await {
             Ok(()) => info!("Policy reloaded from disk"),
             Err(e) => warn!("Failed to reload policy: {}", e),
+        }
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+mod tests {
+    use super::*;
+
+    async fn test_service() -> (PolicyService, tempfile::TempDir) {
+        let root = tempfile::tempdir().expect("test: create policy git directory");
+        let manager = Arc::new(PolicyManager::permissive().await.expect("test: policy manager"));
+        let git2db = Arc::new(RwLock::new(
+            Git2DB::open(root.path()).await.expect("test: open policy git database"),
+        ));
+        let service = PolicyService::new(
+            manager,
+            Arc::new(SigningKey::from_bytes(&[0x51; 32])),
+            crate::config::TokenConfig::default(),
+            git2db,
+            TransportConfig::inproc("policy-path-form-subject-test"),
+        );
+        (service, root)
+    }
+
+    fn issue(subject: &str) -> IssueToken {
+        IssueToken {
+            requested_scopes: Some(vec!["read".to_owned()]),
+            ttl: Some(60),
+            audience: None,
+            subject: Some(subject.to_owned()),
+            user_pub_key: None,
+            dpop_jkt: None,
+        }
+    }
+
+    #[tokio::test]
+    async fn issue_token_rejects_path_form_subject_at_shared_signing_boundary() {
+        let (service, _root) = test_service().await;
+        let ctx = EnvelopeContext::from_callback_service(1, "test-caller");
+
+        let response = service
+            .handle_issue_token(&ctx, 1, &issue("did:web:accounts.example:users:alice"))
+            .await
+            .expect("path-form rejection is a policy response");
+
+        match response {
+            PolicyResponseVariant::Error(error) => {
+                assert_eq!(error.code, "FROZEN_PATH_FORM_SUBJECT");
+                assert!(error.message.contains("path-form did:web"));
+            }
+            other => panic!("path-form subject reached token signing: {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn issue_token_path_form_guard_allows_legitimate_subject_families() {
+        let (service, _root) = test_service().await;
+        let ctx = EnvelopeContext::from_callback_service(1, "test-caller");
+
+        for subject in [
+            "alice",
+            "did:web:alice.example",
+            "did:web:localhost%3A6791",
+            "did:key:z6MkpTHR8VNsBxYAAHWutMGeQ4hz2FV6B14xd9CZpkmS5i5o",
+            "service:model",
+        ] {
+            let response = service.handle_issue_token(&ctx, 1, &issue(subject)).await;
+            assert!(
+                !matches!(
+                    response,
+                    Ok(PolicyResponseVariant::Error(ErrorInfo { ref code, .. }))
+                        if code == "FROZEN_PATH_FORM_SUBJECT"
+                ),
+                "legitimate subject {subject:?} was rejected by the path-form guard",
+            );
         }
     }
 }

--- a/docs/deployment/oauth-providers.md
+++ b/docs/deployment/oauth-providers.md
@@ -42,7 +42,7 @@ These fields apply to both provider kinds:
 | `"namespaced"` | `provider-slug:external-sub` (e.g. `github:12345678`). Default. |
 | `"email"` | Email address from external claims (requires `email_verified = true`) |
 | `{ claim = { name = "..." } }` | The value of a specific claim (e.g. `preferred_username`) |
-| `"didweb"` | **Disabled.** Configuration and login both fail closed because the former path-form account DID was outside the atproto profile (#1159). Host-form account minting is tracked separately in #1163. |
+| `"didweb"` | **Disabled.** Configuration and login both fail closed because the former path-form account DID was outside the atproto profile (#1159). A node with this setting refuses to start until it is changed; existing path-form profiles remain unusable under a replacement strategy until E4 (#1176) migrates them. Host-form account minting is tracked separately in #1163. |
 
 `"namespaced"` is the default and recommended for most deployments — it is stable,
 collision-free, and works for providers (like GitHub) whose `sub` is a numeric ID.

--- a/docs/deployment/oauth-providers.md
+++ b/docs/deployment/oauth-providers.md
@@ -42,7 +42,7 @@ These fields apply to both provider kinds:
 | `"namespaced"` | `provider-slug:external-sub` (e.g. `github:12345678`). Default. |
 | `"email"` | Email address from external claims (requires `email_verified = true`) |
 | `{ claim = { name = "..." } }` | The value of a specific claim (e.g. `preferred_username`) |
-| `"didweb"` | `did:web:{issuer_authority}:users:{external_sub}` (e.g. `did:web:hyprstream.example.com:users:12345`) — the subject-identity format for did:web deployments. Opt-in: existing Casbin policies written against namespaced subjects must be migrated first. |
+| `"didweb"` | **Disabled.** Configuration and login both fail closed because the former path-form account DID was outside the atproto profile (#1159). Host-form account minting is tracked separately in #1163. |
 
 `"namespaced"` is the default and recommended for most deployments — it is stable,
 collision-free, and works for providers (like GitHub) whose `sub` is a numeric ID.

--- a/docs/spiffe.md
+++ b/docs/spiffe.md
@@ -87,7 +87,7 @@ Under this design, hyprstream services would receive SPIFFE IDs structured as:
 spiffe://<trust_domain>/service/<service-name>
 ```
 
-with the trust domain defaulting to the host portion of `oauth.issuer_url`. Per-user or per-workload SPIFFE IDs would not be issued — SPIFFE is workload identity; *user* identity lives in did:web (`did:web:hyprstream.acme.com:users:alice`). The two systems address different layers.
+with the trust domain defaulting to the host portion of `oauth.issuer_url`. Per-user or per-workload SPIFFE IDs would not be issued — SPIFFE is workload identity; account identity will use host-form did:web once the replacement mint path lands (#1163). The two systems address different layers.
 
 > [!warning] Trust-domain choice would be sticky
 > Once SVIDs have been issued under a trust domain, changing it breaks every existing SVID. Pick deliberately at setup.
@@ -114,7 +114,7 @@ Apply the `federation-open` template (or run `hyprstream wizard --enable-federat
 
 | Layer | Identifier | Protocol | Status |
 |---|---|---|---|
-| User identity | `did:web:hyprstream.acme.com:users:alice` | did:web + OAuth/OIDC | shipped |
+| User identity | Host-form did:web (replacement mint path #1163) | did:web + OAuth/OIDC | pending |
 | OAuth client (with FQDN) | `https://app.example.com/client.json` | CIMD | shipped |
 | OAuth client (no FQDN) | UUID issued by hyprstream | DCR (RFC 7591) | shipped |
 | hyprstream workload | WIMSE WIT (`wit+jwt`) | EdDSA JWT + COSE envelopes | shipped |


### PR DESCRIPTION
Closes #1159.

Part of epic #1158. This intentionally does not design or enable host-form account minting; that remains #1163.

## Summary

- keep `UserMappingStrategy::DidWeb` as a hard configuration and runtime error, so new OIDC callbacks cannot create path-form account subjects;
- return `410 Gone` from the account DID route before any key or profile lookup, with a router-level regression test;
- reject path-form `did:web` at both the in-memory snapshot and durable PDS publisher write boundaries;
- reject a path-form local-account subject at the central token issuance boundary. A pre-upgrade refresh token is consumed on refresh but cannot mint an access token or a rotated replacement;
- do not scan, revoke, or migrate durable user/refresh records at startup in this freeze. That deployed-state migration decision belongs to E4 (#1176), which must not assume a clean store;
- document the intentional startup refusal for `user_mapping = "didweb"`; and
- track the separate client document surface in #1221. It is outside A1: client credentials use `sub == client_id` and the client DID cannot become a repo authority.

## Audit scope and deployed-state limitation

The previous displayed `0` was a regex count over selected in-tree source at `a7206f6547edb2f68d10433fa05099dd3d8c445b`; it was **not** a count of deployed repo anchors or path-form identifiers. It cannot inspect runtime assembly or data already persisted in RocksDB, Valkey, or an out-of-tree deployment. It is therefore not evidence that E4 has no deployed-state migration work.

The command used `sed '/#[cfg(test)]/,$d'` on three files. That positional technique was valid only at that pinned SHA because each file had one trailing test module; it is not a reusable audit command and may omit production code added after an earlier `#[cfg(test)]` marker. The relevant production trace now explicitly includes the durable publisher and its store-boundary guard.

#1176 records the correction: E4 cannot rely on the source audit for deployed state and must safely scan, revoke, or migrate records as appropriate before permanent identifiers are left unrecoverable.

## Verification

- focused route, token-rotation, and durable-publisher regressions;
- required route mutation: replacing the handler's 410 guard with `200 OK` makes the router-level test fail, then restoring the guard makes it pass;
- `cargo build`;
- `cargo test -p hyprstream --lib services::oauth`;
- `cargo clippy --all-targets -- -D warnings`.

`cargo fmt --check` is not used because it has the known clean-main failure tracked by #1140.


## Direct token-signing audit

At `3e51cba3f`, I re-swept every production `Claims::new` plus JWT encode/sign path. There is no single shared boundary for every account-subject signer, so the freeze is enforced at each concrete user-controlled direct signer:

- `PolicyService::handle_issue_token` guards central OAuth/Policy RPC issuance; its separate `ExchangeWit` direct signer also guards the verified envelope subject.
- `oauth::token::mint_tokens` guards authorization-code, device, and refresh issuance before access- or ID-token signing and refresh persistence. RFC 8693 and direct UCAN paths have their own pre-signing guards.
- `cli::policy_handlers::mint_local_token` now rejects path-form subjects before its local Ed25519 encode; both `policy token create` and the bootstrap wizard handle the fallible result.
- `POST /oauth/wit` rejects a path-form `AuthenticatedUser` before directly encoding the browser WIT.
- `POST /oauth/mount-ticket` rejects a path-form `AuthenticatedUser` before directly encoding the mount ticket.

The other production JWT signers are non-account subject constructors: `auth::service_jwt` constructs `service:{name}`, and SPIFFE WIT issuance derives a workload subject through `map_workload_subject`; neither accepts a local-account DID subject. Test-only encodes were excluded from the production mint-path claim.

## Additional verification

- `buildq -- cargo test -p hyprstream --lib path_form -- --nocapture` — 13 passed.
- Negative mutation: removed the three new direct-signer guards together; exactly the new CLI, browser-WIT, and mount-ticket regressions failed (CLI minted the token; both HTTP handlers returned 200). Restored all guards, then the 13 tests passed.
- The foreground commit hook ran `buildq -- cargo clippy --workspace --all-targets --release -- -D warnings` successfully.
