### PR TITLE
A3: deployment-configured account zone + DNS-01 wildcard TLS (#1162)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6836,6 +6836,7 @@ dependencies = [
  "parking_lot 0.12.4",
  "proptest",
  "prost 0.13.5",
+ "psl",
  "rand 0.8.5",
  "ratatui",
  "rayon",
@@ -12656,6 +12657,21 @@ dependencies = [
  "ttrpc",
  "ttrpc-codegen",
 ]
+
+[[package]]
+name = "psl"
+version = "2.1.221"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "131e7bc39f71eb433f96399150b9e6729908dab3640467a3e90d5c5a77831568"
+dependencies = [
+ "psl-types",
+]
+
+[[package]]
+name = "psl-types"
+version = "2.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33cb294fe86a74cbcf50d4445b37da762029549ebeea341421c7c70370f86cac"
 
 [[package]]
 name = "psm"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -72,6 +72,7 @@ inventory = "0.3"  # Compile-time registration for services
 hyprstream-containedfs = { path = "crates/hyprstream-containedfs" }
 safe-path = "0.1"
 bitflags = "2.4"
+psl = "2.1.221"
 
 # Serialization
 serde = { version = "1.0", features = ["derive"] }

--- a/crates/hyprstream/Cargo.toml
+++ b/crates/hyprstream/Cargo.toml
@@ -32,6 +32,7 @@ async-trait.workspace = true
 tokio-util.workspace = true
 serde.workspace = true
 serde_json.workspace = true
+psl.workspace = true
 subsecond.workspace = true
 json-threat-protection.workspace = true
 nix.workspace = true

--- a/crates/hyprstream/src/account/config.rs
+++ b/crates/hyprstream/src/account/config.rs
@@ -100,7 +100,12 @@ impl AccountZoneConfig {
     /// skipped with a clear log message (the process keeps running on its
     /// existing/self-signed cert; account minting surfaces the missing zone).
     pub fn dns01_ready(&self) -> bool {
-        self.is_configured() && self.dns01_credential.is_some()
+        self.is_configured()
+            && self
+                .dns01_credential
+                .as_deref()
+                .map(|c| !c.trim().is_empty())
+                .unwrap_or(false)
     }
 }
 
@@ -145,6 +150,20 @@ mod tests {
             ..Default::default()
         };
         assert!(!cfg.dns01_ready()); // zone set but no credential
+    }
+
+    #[test]
+    fn dns01_ready_rejects_blank_credential() {
+        // A blank/whitespace credential is not usable; treat as unconfigured so
+        // `require_provisioned` fails closed rather than proceeding (#1182 review).
+        for blank in ["", "   ", "\t"] {
+            let cfg = AccountZoneConfig {
+                zone: Some("acct.example.com".to_owned()),
+                dns01_credential: Some(blank.to_owned()),
+                ..Default::default()
+            };
+            assert!(!cfg.dns01_ready(), "blank credential {blank:?} must not be ready");
+        }
     }
 
     #[test]

--- a/crates/hyprstream/src/account/config.rs
+++ b/crates/hyprstream/src/account/config.rs
@@ -26,7 +26,7 @@
 //! acme_directory = "https://acme-v02.api.letsencrypt.org/directory"
 //! acme_contact = "mailto:ops@example.com"
 //! wildcard_ipv4 = "203.0.113.10"
-//! wildcard_ipv6 = "2001:db8::10"
+//! wildcard_ipv6 = "2001:db8::20"
 //! ```
 
 use std::net::{Ipv4Addr, Ipv6Addr};

--- a/crates/hyprstream/src/account/config.rs
+++ b/crates/hyprstream/src/account/config.rs
@@ -1,0 +1,162 @@
+//! Configuration surface for the account zone (epic #1158, ticket #1162 / A3).
+//!
+//! This is the deployment-facing knob. The `[account]` section names the
+//! delegated zone apex, the zone-scoped DNS-01 credential, the ACME directory
+//! to obtain the wildcard certificate from, and the wildcard address targets.
+//!
+//! ## Sane-degrade, not synthesized default
+//!
+//! A deployment that configures **no** account zone must degrade sanely:
+//! account minting is disabled with a clear error. [`AccountZoneConfig`]
+//! therefore has **no** `Default` zone value — `Default` leaves `zone = None`,
+//! and [`AccountZoneConfig::resolve_zone`] returns
+//! [`AccountZoneError::Unset`] in that state. We must never synthesize a zone
+//! name: a default would silently mint permanent DIDs under a domain the
+//! operator never chose (epic one-way door #1).
+//!
+//! ## TOML
+//!
+//! ```toml
+//! [account]
+//! zone = "acct.example.com"
+//! # Zone-scoped credential: the deployment's DNS provider accepts this and
+//! # only this when writing records under the apex. Format is opaque to
+//! # hyprstream — the product-layer DnsProvider interprets it.
+//! dns01_credential = "ref:secretstore/account-zone-token"
+//! acme_directory = "https://acme-v02.api.letsencrypt.org/directory"
+//! acme_contact = "mailto:ops@example.com"
+//! wildcard_ipv4 = "203.0.113.10"
+//! wildcard_ipv6 = "2001:db8::10"
+//! ```
+
+use std::net::{Ipv4Addr, Ipv6Addr};
+
+use serde::{Deserialize, Serialize};
+
+use super::zone::{AccountZone, AccountZoneError};
+
+/// The `[account]` configuration section.
+///
+/// `Default` is deliberately the **unconfigured** state (`zone = None`); see the
+/// module docs on sane-degrade.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct AccountZoneConfig {
+    /// The delegated account-zone apex, e.g. `acct.example.com`. `None` ⇒
+    /// account minting disabled ([`Self::resolve_zone`] errors).
+    #[serde(default)]
+    pub zone: Option<String>,
+
+    /// An opaque reference to the zone-scoped DNS-01 credential (e.g.
+    /// `ref:secretstore/...` or an env var name). hyprstream treats this as an
+    /// opaque string; the product-layer [`DnsProvider`](super::dns::DnsProvider)
+    /// implementation interprets it. `None` ⇒ DNS-01 issuance disabled even if
+    /// `zone` is set.
+    #[serde(default)]
+    pub dns01_credential: Option<String>,
+
+    /// ACME directory URL for wildcard issuance. Defaults to Let's Encrypt
+    /// production when `mode = "acme-dns01"` is selected and this is unset.
+    #[serde(default)]
+    pub acme_directory: Option<String>,
+
+    /// ACME contact URI, e.g. `mailto:ops@example.com`.
+    #[serde(default)]
+    pub acme_contact: Option<String>,
+
+    /// IPv4 target for the wildcard A record (`*.<apex>`). `None` ⇒ no A
+    /// record published by hyprstream; the operator may publish one out-of-band.
+    #[serde(default)]
+    pub wildcard_ipv4: Option<Ipv4Addr>,
+
+    /// IPv6 target for the wildcard AAAA record (`*.<apex>`).
+    #[serde(default)]
+    pub wildcard_ipv6: Option<Ipv6Addr>,
+}
+
+impl AccountZoneConfig {
+    /// Whether the deployment has configured an account zone at all.
+    pub fn is_configured(&self) -> bool {
+        self.zone.as_deref().filter(|s| !s.trim().is_empty()).is_some()
+    }
+
+    /// Resolve the configured zone, or return [`AccountZoneError::Unset`].
+    ///
+    /// This is the single entry point the rest of the codebase uses; it never
+    /// invents a zone. Callers should surface the `Unset` error to the operator
+    /// rather than unwrapping.
+    pub fn resolve_zone(&self) -> Result<AccountZone, AccountZoneError> {
+        let Some(raw) = self.zone.as_deref() else {
+            return Err(AccountZoneError::Unset);
+        };
+        let trimmed = raw.trim();
+        if trimmed.is_empty() {
+            return Err(AccountZoneError::Unset);
+        }
+        AccountZone::new(trimmed)
+    }
+
+    /// Whether the DNS-01 issuance path is fully provisioned: a zone **and** a
+    /// zone-scoped credential are present. When false, TLS wildcard issuance is
+    /// skipped with a clear log message (the process keeps running on its
+    /// existing/self-signed cert; account minting surfaces the missing zone).
+    pub fn dns01_ready(&self) -> bool {
+        self.is_configured() && self.dns01_credential.is_some()
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn default_is_unset_and_degrades() {
+        let cfg = AccountZoneConfig::default();
+        assert!(!cfg.is_configured());
+        assert!(matches!(cfg.resolve_zone(), Err(AccountZoneError::Unset)));
+        assert!(!cfg.dns01_ready());
+    }
+
+    #[test]
+    fn empty_zone_string_is_unset() {
+        let cfg = AccountZoneConfig {
+            zone: Some("   ".to_owned()),
+            ..Default::default()
+        };
+        assert!(matches!(cfg.resolve_zone(), Err(AccountZoneError::Unset)));
+    }
+
+    #[test]
+    fn resolves_valid_zone() {
+        let cfg = AccountZoneConfig {
+            zone: Some("acct.example.com".to_owned()),
+            dns01_credential: Some("ref:tok".to_owned()),
+            ..Default::default()
+        };
+        let z = cfg.resolve_zone().unwrap();
+        assert_eq!(z.wildcard_domain(), "*.acct.example.com");
+        assert!(cfg.dns01_ready());
+    }
+
+    #[test]
+    fn dns01_ready_requires_credential() {
+        let cfg = AccountZoneConfig {
+            zone: Some("acct.example.com".to_owned()),
+            ..Default::default()
+        };
+        assert!(!cfg.dns01_ready()); // zone set but no credential
+    }
+
+    #[test]
+    fn toml_roundtrip() {
+        let toml = r#"
+zone = "acct.example.com"
+dns01_credential = "ref:tok"
+acme_contact = "mailto:ops@example.com"
+wildcard_ipv4 = "203.0.113.10"
+"#;
+        let cfg: AccountZoneConfig = toml::from_str(toml).unwrap();
+        assert_eq!(cfg.zone.as_deref(), Some("acct.example.com"));
+        assert_eq!(cfg.wildcard_ipv4, Some("203.0.113.10".parse().unwrap()));
+    }
+}

--- a/crates/hyprstream/src/account/dns.rs
+++ b/crates/hyprstream/src/account/dns.rs
@@ -1,0 +1,203 @@
+//! The DNS management interface (epic #1158, ticket #1162 / Phase A3).
+//!
+//! hyprstream **defines** this interface; it does **not** depend on any specific
+//! DNS implementation. Managed DNS (PowerDNS, Route53, Cloudflare, a hand-rolled
+//! RFC 2136 client, an out-of-process HTTP webhook, …) is a *product layer
+//! above* hyprstream — if this crate ever required a particular DNS server,
+//! self-hosters could not run it.
+//!
+//! Two jobs flow through this trait:
+//!
+//! 1. **ACME DNS-01 challenge responses** — publish/delete a TXT record at the
+//!    `_acme-challenge.<apex>` owner name so a public CA can validate the
+//!    `*.<apex>` wildcard certificate.
+//! 2. **Wildcard address records** — publish wildcard A/AAAA for the delegated
+//!    zone so `alice.<apex>` resolves to the hyprstream node. The wildcard
+//!    covers **exactly one** label (the A2 depth invariant; see
+//!    [`crate::account::zone`]).
+//!
+//! The credential a deployment hands to its `DnsProvider` implementation must be
+//! **zone-scoped** — able to write records only inside the delegated account
+//! zone and nowhere else. The plan is explicit: do not hand a zone-wide DNS
+//! credential to the ACME client.
+
+use std::fmt;
+use std::net::{Ipv4Addr, Ipv6Addr};
+
+use async_trait::async_trait;
+use thiserror::Error;
+
+use super::zone::AccountZone;
+
+/// A DNS operation failed. Implementations wrap their backend's native error.
+#[derive(Debug, Error)]
+pub enum DnsError {
+    /// The configured credential is missing or refused.
+    #[error("DNS provider is unconfigured or unauthorized for {0}: {1}")]
+    Unconfigured(String, String),
+    /// The backend returned an error.
+    #[error("DNS backend error: {0}")]
+    Backend(String),
+    /// The caller asked for an operation outside the delegated zone.
+    #[error("owner name {0} is outside the delegated account zone")]
+    OutOfZone(String),
+}
+
+/// The interface a deployment's DNS management layer implements.
+///
+/// Implementations live **outside** this crate (metal repo / product layer).
+/// [`UnconfiguredDnsProvider`] is the in-crate fail-closed default used when a
+/// deployment has not wired one up: every operation returns
+/// [`DnsError::Unconfigured`], so the ACME DNS-01 issuance path fails loudly
+/// rather than silently no-op'ing or inventing records.
+#[async_trait]
+pub trait DnsProvider: Send + Sync {
+    /// Human-readable backend identifier (e.g. `"unconfigured"`, `"powerdns"`,
+    /// `"route53"`). Used in logs and the expiry alarm.
+    fn backend(&self) -> &'static str;
+
+    /// Publish a TXT record at `owner` (a fully-qualified name, no trailing
+    /// dot) with `value` for the ACME DNS-01 challenge. `ttl` is a hint in
+    /// seconds; backends may clamp. The record must be retrievable by public
+    /// resolvers within ~minutes.
+    ///
+    /// Implementations MUST reject `owner` values outside `zone` (the delegated
+    /// account zone) with [`DnsError::OutOfZone`].
+    async fn publish_txt(
+        &self,
+        zone: &AccountZone,
+        owner: &str,
+        value: &str,
+        ttl: u32,
+    ) -> Result<(), DnsError>;
+
+    /// Delete the TXT record previously published by [`Self::publish_txt`].
+    /// Must be idempotent (deleting a record that is already gone is success).
+    async fn delete_txt(&self, zone: &AccountZone, owner: &str, value: &str)
+        -> Result<(), DnsError>;
+
+    /// Publish the wildcard A record (`*.<apex>`) for the delegated zone. The
+    /// record covers exactly one label — `alice.<apex>` resolves, but
+    /// `a.b.<apex>` does not.
+    async fn publish_wildcard_a(
+        &self,
+        zone: &AccountZone,
+        target: Ipv4Addr,
+        ttl: u32,
+    ) -> Result<(), DnsError>;
+
+    /// Publish the wildcard AAAA record (`*.<apex>`) for the delegated zone.
+    async fn publish_wildcard_aaaa(
+        &self,
+        zone: &AccountZone,
+        target: Ipv6Addr,
+        ttl: u32,
+    ) -> Result<(), DnsError>;
+}
+
+/// Fail-closed no-op provider used when a deployment wires no DNS backend.
+///
+/// Every operation returns [`DnsError::Unconfigured`]. This is the sane-degrade
+/// behavior at the DNS layer: DNS-01 wildcard issuance cannot proceed without a
+/// real backend, and silent success would leave the deployment serving a
+/// self-signed cert (or none) under a zone it never proved control of.
+#[derive(Debug, Default, Clone, Copy)]
+pub struct UnconfiguredDnsProvider;
+
+impl UnconfiguredDnsProvider {
+    pub const fn new() -> Self {
+        Self
+    }
+}
+
+#[async_trait]
+impl DnsProvider for UnconfiguredDnsProvider {
+    fn backend(&self) -> &'static str {
+        "unconfigured"
+    }
+
+    async fn publish_txt(
+        &self,
+        _zone: &AccountZone,
+        owner: &str,
+        _value: &str,
+        _ttl: u32,
+    ) -> Result<(), DnsError> {
+        Err(DnsError::Unconfigured(
+            owner.to_owned(),
+            "no DNS provider wired up by the deployment".to_owned(),
+        ))
+    }
+
+    async fn delete_txt(
+        &self,
+        _zone: &AccountZone,
+        owner: &str,
+        _value: &str,
+    ) -> Result<(), DnsError> {
+        Err(DnsError::Unconfigured(
+            owner.to_owned(),
+            "no DNS provider wired up by the deployment".to_owned(),
+        ))
+    }
+
+    async fn publish_wildcard_a(
+        &self,
+        zone: &AccountZone,
+        _target: Ipv4Addr,
+        _ttl: u32,
+    ) -> Result<(), DnsError> {
+        Err(DnsError::Unconfigured(
+            zone.wildcard_domain().to_owned(),
+            "no DNS provider wired up by the deployment".to_owned(),
+        ))
+    }
+
+    async fn publish_wildcard_aaaa(
+        &self,
+        zone: &AccountZone,
+        _target: Ipv6Addr,
+        _ttl: u32,
+    ) -> Result<(), DnsError> {
+        Err(DnsError::Unconfigured(
+            zone.wildcard_domain().to_owned(),
+            "no DNS provider wired up by the deployment".to_owned(),
+        ))
+    }
+}
+
+impl fmt::Display for UnconfiguredDnsProvider {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str("unconfigured")
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn unconfigured_fails_closed() {
+        let p = UnconfiguredDnsProvider::new();
+        let z = AccountZone::new("acct.example.com").unwrap();
+        let owner = z.dns01_validation_name();
+        assert!(matches!(
+            p.publish_txt(&z, &owner, "token", 60).await,
+            Err(DnsError::Unconfigured(_, _))
+        ));
+        assert!(matches!(
+            p.delete_txt(&z, &owner, "token").await,
+            Err(DnsError::Unconfigured(_, _))
+        ));
+        assert!(matches!(
+            p.publish_wildcard_a(&z, "127.0.0.1".parse().unwrap(), 60).await,
+            Err(DnsError::Unconfigured(_, _))
+        ));
+        assert!(matches!(
+            p.publish_wildcard_aaaa(&z, "::1".parse().unwrap(), 60).await,
+            Err(DnsError::Unconfigured(_, _))
+        ));
+        assert_eq!(p.backend(), "unconfigured");
+    }
+}

--- a/crates/hyprstream/src/account/mod.rs
+++ b/crates/hyprstream/src/account/mod.rs
@@ -1,0 +1,124 @@
+//! Account identity — host-form `did:web` account zone, DNS interface, and
+//! DNS-01 wildcard TLS (epic #1158, Phase A3 / ticket #1162).
+//!
+//! This module owns the deployment-facing configuration surface for the account
+//! zone and the **interfaces** (not implementations) for the two product-layer
+//! concerns above it: managed DNS and ACME DNS-01 wildcard issuance.
+//!
+//! # What hyprstream owns vs. what the product layer owns
+//!
+//! | Concern | Owner |
+//! |---|---|
+//! | Account-zone apex name (no default — sane-degrade) | hyprstream (`config`) |
+//! | Wildcard shape `*.<apex>` (exactly one label — the A2 seam) | hyprstream (`zone`) |
+//! | Renewal schedule + expiry alarm (total-outage surface) | hyprstream (`renewal`) |
+//! | Sane-degrade when unconfigured | hyprstream (`config`, `tls`) |
+//! | Publishing DNS-01 TXT + wildcard A/AAAA records | **product layer** (`dns::DnsProvider`) |
+//! | Driving the ACME directory for DNS-01 issuance | **product layer** (`tls::WildcardCertIssuer`) |
+//!
+//! The account **label grammar** (LDH, NFKC, confusable rejection, reserved
+//! list, never-reuse) is owned by A2 (`#1160`); B1 enforces it at mint time.
+//! This crate only guarantees the wildcard covers exactly one label.
+//!
+//! # No PowerDNS, anywhere
+//!
+//! hyprstream must not require a specific DNS server. If it did, self-hosters
+//! could not run it. Managed DNS is a product layer above a protocol that does
+//! not depend on it — the same posture the epic takes for managed DNS.
+
+pub mod config;
+pub mod dns;
+pub mod renewal;
+pub mod tls;
+pub mod zone;
+
+pub use config::AccountZoneConfig;
+pub use dns::{DnsError, DnsProvider, UnconfiguredDnsProvider};
+pub use renewal::{CertHealth, CertHealthMonitor, CertRenewer, AlarmThresholds};
+pub use tls::{CertHandle, IssuedCert, IssuanceError, NullWildcardCertIssuer, WildcardCertIssuer};
+pub use zone::{AccountZone, AccountZoneError};
+
+use std::net::{Ipv4Addr, Ipv6Addr};
+
+/// Publish the wildcard A/AAAA records for the delegated account zone, if the
+/// deployment configured targets and wired a DNS backend.
+///
+/// The wildcard covers **exactly one** label (see [`zone::AccountZone`]). Both
+/// `v4`/`v6` are optional — an IPv6-only deployment publishes AAAA only.
+///
+/// This is a convenience entry point over [`DnsProvider`]; it logs each
+/// publication and a clear message when a target is configured but no backend
+/// is wired (sane-degrade, not a panic).
+pub async fn publish_wildcard_records(
+    zone: &AccountZone,
+    dns: &dyn DnsProvider,
+    v4: Option<Ipv4Addr>,
+    v6: Option<Ipv6Addr>,
+    ttl: u32,
+) -> anyhow::Result<()> {
+    if let Some(v4) = v4 {
+        if let Err(e) = dns.publish_wildcard_a(zone, v4, ttl).await {
+            tracing::warn!(
+                zone = %zone.apex(),
+                backend = dns.backend(),
+                error = %e,
+                "failed to publish wildcard A for account zone"
+            );
+            anyhow::bail!(
+                "wildcard A publication for {zone} via {} failed: {e}",
+                dns.backend()
+            );
+        }
+        tracing::info!(zone = %zone.apex(), target = %v4, "published wildcard A for account zone");
+    }
+    if let Some(v6) = v6 {
+        if let Err(e) = dns.publish_wildcard_aaaa(zone, v6, ttl).await {
+            tracing::warn!(
+                zone = %zone.apex(),
+                backend = dns.backend(),
+                error = %e,
+                "failed to publish wildcard AAAA for account zone"
+            );
+            anyhow::bail!(
+                "wildcard AAAA publication for {zone} via {} failed: {e}",
+                dns.backend()
+            );
+        }
+        tracing::info!(zone = %zone.apex(), target = %v6, "published wildcard AAAA for account zone");
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn publish_records_fails_loudly_on_unconfigured() {
+        let z = AccountZone::new("acct.example.com").unwrap();
+        let dns = UnconfiguredDnsProvider::new();
+        let err = publish_wildcard_records(
+            &z,
+            &dns,
+            Some("203.0.113.10".parse().unwrap()),
+            None,
+            300,
+        )
+        .await
+        .unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("wildcard A"), "{msg}");
+    }
+
+    #[tokio::test]
+    async fn publish_records_noop_when_no_targets() {
+        let z = AccountZone::new("acct.example.com").unwrap();
+        let dns = UnconfiguredDnsProvider::new();
+        // No targets configured → no publication attempted → no error even on
+        // an unconfigured backend (operator may publish records out-of-band).
+        publish_wildcard_records(&z, &dns, None, None, 300)
+            .await
+            .unwrap();
+    }
+}

--- a/crates/hyprstream/src/account/renewal.rs
+++ b/crates/hyprstream/src/account/renewal.rs
@@ -1,0 +1,369 @@
+//! Renewal, monitoring, and the expiry alarm for the account-zone wildcard
+//! certificate (epic #1158, ticket #1162 / A3).
+//!
+//! One wildcard cert authenticates **every** account host for a deployment, so
+//! one cert failing to renew breaks **all** account resolution — a total-outage
+//! surface. Per the ticket, the alarm **ships with the feature**, not as a
+//! follow-up.
+//!
+//! What this module owns:
+//! - [`CertRenewer`]: on a schedule, asks the [`WildcardCertIssuer`](super::tls::WildcardCertIssuer)
+//!   to refresh the cert and pushes the result into a [`CertHandle`](super::tls::CertHandle).
+//! - [`CertHealth`]/[`CertHealthMonitor`]: computes a coarse health state
+//!   (Ok / ExpiringSoon / Critical / Expired / Unissued / Unprovisioned) from
+//!   the current cert's NotAfter and the last issuance outcome, and surfaces it
+//!   loudly via `tracing` — the alarm. The health state is also exposed as a
+//!   `pub` field so a metrics/event plane can scrape it.
+//!
+//! `CertRenewer` uses the same trait seams as issuance; it does not depend on a
+//! specific ACME client or DNS backend.
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use time::OffsetDateTime;
+use tokio::sync::watch;
+use tracing::{error, info, warn};
+
+use super::config::AccountZoneConfig;
+use super::dns::DnsProvider;
+use super::tls::{CertHandle, IssuanceError, IssuedCert, WildcardCertIssuer};
+
+/// Coarse health classification for the account-zone cert. The alarm state.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CertHealth {
+    /// No deployment-wide outage risk; cert is healthy and far from expiry.
+    Ok,
+    /// Cert is within `warn_lead` of expiry (default 30d). Renewal should be
+    /// imminent. Informational.
+    ExpiringSoon,
+    /// Cert is within `critical_lead` of expiry (default 7d) **or** the last
+    /// issuance failed. The deployment is at acute outage risk.
+    Critical,
+    /// Cert's NotAfter is in the past — account resolution is failing now.
+    Expired,
+    /// No cert has been issued yet.
+    Unissued,
+    /// The deployment has not provisioned DNS-01 issuance (zone/credential
+    /// missing). Account minting is disabled by design; this is the sane-degrade
+    /// state, surfaced so monitoring can distinguish "intentionally off" from
+    /// "broken".
+    Unprovisioned,
+}
+
+impl CertHealth {
+    /// Human-readable label for metrics/logs.
+    pub fn label(self) -> &'static str {
+        match self {
+            CertHealth::Ok => "ok",
+            CertHealth::ExpiringSoon => "expiring_soon",
+            CertHealth::Critical => "critical",
+            CertHealth::Expired => "expired",
+            CertHealth::Unissued => "unissued",
+            CertHealth::Unprovisioned => "unprovisioned",
+        }
+    }
+}
+
+/// Tunable lead times for the alarm.
+#[derive(Debug, Clone, Copy)]
+pub struct AlarmThresholds {
+    /// Warn when the cert is within this duration of expiry.
+    pub warn_lead: Duration,
+    /// Raise to Critical when within this duration of expiry.
+    pub critical_lead: Duration,
+}
+
+impl Default for AlarmThresholds {
+    fn default() -> Self {
+        // Let's Encrypt certs are 90 days; warn at 30d, critical at 7d.
+        Self {
+            warn_lead: Duration::from_secs(30 * 24 * 3600),
+            critical_lead: Duration::from_secs(7 * 24 * 3600),
+        }
+    }
+}
+
+/// Computes the alarm state from the current cert and the last issuance result.
+///
+/// Pure function; unit-testable without time mocking fixtures beyond
+/// [`OffsetDateTime`].
+pub fn classify(
+    handle: &CertHandle,
+    last_result: Option<&Result<IssuedCert, IssuanceError>>,
+    now: OffsetDateTime,
+    thresholds: &AlarmThresholds,
+    unprovisioned: bool,
+) -> CertHealth {
+    if unprovisioned {
+        return CertHealth::Unprovisioned;
+    }
+    // A recent issuance failure is always at least Critical.
+    let last_failed = matches!(last_result, Some(Err(_)));
+    let Some(not_after) = handle.not_after() else {
+        return if last_failed { CertHealth::Critical } else { CertHealth::Unissued };
+    };
+    let remaining = not_after - now;
+    if remaining.is_negative() {
+        return CertHealth::Expired;
+    }
+    let dur = Duration::try_from(remaining).unwrap_or(Duration::ZERO);
+    if dur < thresholds.critical_lead {
+        CertHealth::Critical
+    } else if dur < thresholds.warn_lead {
+        CertHealth::ExpiringSoon
+    } else if last_failed {
+        // Cert still valid but the most recent renewal attempt failed — the
+        // deployment is on a clock, surface it.
+        CertHealth::Critical
+    } else {
+        CertHealth::Ok
+    }
+}
+
+/// A monitor that recomputes [`CertHealth`] and logs it loudly when not `Ok`.
+#[derive(Debug, Clone)]
+pub struct CertHealthMonitor {
+    thresholds: AlarmThresholds,
+}
+
+impl CertHealthMonitor {
+    pub fn new(thresholds: AlarmThresholds) -> Self {
+        Self { thresholds }
+    }
+
+    /// Recompute and emit the alarm. Returns the state so callers (metrics
+    /// plane, readiness probes) can record it.
+    pub fn observe(
+        &self,
+        handle: &CertHandle,
+        last_result: Option<&Result<IssuedCert, IssuanceError>>,
+        unprovisioned: bool,
+    ) -> CertHealth {
+        let now = OffsetDateTime::now_utc();
+        let state = classify(
+            handle,
+            last_result,
+            now,
+            &self.thresholds,
+            unprovisioned,
+        );
+        match state {
+            CertHealth::Ok | CertHealth::Unprovisioned => {
+                tracing::debug!(
+                    account_tls_health = state.label(),
+                    "account-zone wildcard TLS health: {}", state.label()
+                );
+            }
+            CertHealth::ExpiringSoon => warn!(
+                account_tls_health = state.label(),
+                "account-zone wildcard certificate expiring soon — renewal should be imminent"
+            ),
+            CertHealth::Critical => error!(
+                account_tls_health = state.label(),
+                "account-zone wildcard certificate CRITICAL — one cert failing breaks ALL account resolution for this deployment"
+            ),
+            CertHealth::Expired => error!(
+                account_tls_health = state.label(),
+                "account-zone wildcard certificate EXPIRED — account resolution is failing now"
+            ),
+            CertHealth::Unissued => info!(
+                account_tls_health = state.label(),
+                "account-zone wildcard certificate not yet issued"
+            ),
+        }
+        state
+    }
+}
+
+/// Background renewal + alarm loop for the account-zone wildcard cert.
+///
+/// Construct with [`CertRenewer::new`]; spawn [`CertRenewer::run`] on the
+/// service runtime. On each tick it:
+/// 1. checks provisioning (sane-degrade if unprovisioned — no panic),
+/// 2. asks the issuer for a fresh cert (only when due, see `renew_lead`),
+/// 3. pushes the result into the [`CertHandle`] via the `sender`,
+/// 4. runs the alarm.
+///
+/// The `sender` is the write half of a [`CertHandle::channel`](super::tls::CertHandle::channel)
+/// pair; the serving/monitoring layer holds the read half. `handle` is a
+/// `CertHandle` whose receiver mirrors the same channel so the renewer can read
+/// `not_after` for the "due?" decision.
+pub struct CertRenewer {
+    cfg: AccountZoneConfig,
+    issuer: Arc<dyn WildcardCertIssuer>,
+    dns: Arc<dyn DnsProvider>,
+    sender: watch::Sender<Option<IssuedCert>>,
+    handle: CertHandle,
+    thresholds: AlarmThresholds,
+    /// Renew when the cert has less than this remaining validity.
+    renew_lead: Duration,
+    /// How often to wake up and re-evaluate (between renewals).
+    tick: Duration,
+}
+
+impl CertRenewer {
+    pub fn new(
+        cfg: AccountZoneConfig,
+        issuer: Arc<dyn WildcardCertIssuer>,
+        dns: Arc<dyn DnsProvider>,
+        sender: watch::Sender<Option<IssuedCert>>,
+        handle: CertHandle,
+    ) -> Self {
+        Self {
+            cfg,
+            issuer,
+            dns,
+            sender,
+            handle,
+            thresholds: AlarmThresholds::default(),
+            renew_lead: Duration::from_secs(30 * 24 * 3600),
+            tick: Duration::from_secs(3600),
+        }
+    }
+
+    /// Override the renew lead time (default 30d).
+    pub fn with_renew_lead(mut self, lead: Duration) -> Self {
+        self.renew_lead = lead;
+        self
+    }
+
+    /// Override the alarm thresholds.
+    pub fn with_thresholds(mut self, t: AlarmThresholds) -> Self {
+        self.thresholds = t;
+        self
+    }
+
+    /// Override the re-evaluation tick (default 1h).
+    pub fn with_tick(mut self, tick: Duration) -> Self {
+        self.tick = tick;
+        self
+    }
+
+    /// Run the renewal + alarm loop until the process shuts down.
+    ///
+    /// Each iteration sleeps `tick`, then evaluates whether a renewal is due
+    /// (no cert, or cert within `renew_lead` of expiry) and, if so, asks the
+    /// issuer. Provisioning failures are reported via the alarm but do not
+    /// terminate the loop — the process keeps serving whatever it has.
+    pub async fn run(self) {
+        let monitor = CertHealthMonitor::new(self.thresholds);
+        // Sane-degrade: when unprovisioned, log once and skip issuance forever.
+        // We never synthesize a zone; the `Option<AccountZone>` stays `None` and
+        // the issuance block is gated on it.
+        let zone = match super::tls::require_provisioned(&self.cfg) {
+            Ok(z) => Some(z),
+            Err(e) => {
+                warn!("account-zone wildcard TLS not provisioned: {e}");
+                None
+            }
+        };
+        let unprovisioned = zone.is_none();
+        let mut last_result: Option<Result<IssuedCert, IssuanceError>> = None;
+
+        loop {
+            if let Some(zone) = zone.as_ref() {
+                let due = match self.handle.not_after() {
+                    None => true,
+                    Some(na) => {
+                        let remaining = na - OffsetDateTime::now_utc();
+                        let dur = Duration::try_from(remaining).unwrap_or(Duration::ZERO);
+                        dur < self.renew_lead
+                    }
+                };
+                if due {
+                    let res = self
+                        .issuer
+                        .issue(zone, &self.cfg, self.dns.as_ref())
+                        .await;
+                    match &res {
+                        Ok(c) => {
+                            info!(
+                                san = %c.san,
+                                not_after = %c.not_after,
+                                "account-zone wildcard certificate (re)issued"
+                            );
+                            // best_effort: if all receivers dropped, no-one to serve.
+                            let _ = self.sender.send(Some(c.clone()));
+                        }
+                        Err(e) => {
+                            error!(
+                                error = %e,
+                                "account-zone wildcard certificate renewal FAILED — outage risk for ALL account resolution"
+                            );
+                        }
+                    }
+                    last_result = Some(res);
+                }
+            }
+            monitor.observe(&self.handle, last_result.as_ref(), unprovisioned);
+            // Drop the borrowed reference before sleeping.
+            tokio::time::sleep(self.tick).await;
+        }
+    }
+}
+
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)]
+mod tests {
+    use super::*;
+    use crate::account::config::AccountZoneConfig;
+    use crate::account::dns::UnconfiguredDnsProvider;
+    use crate::account::tls::NullWildcardCertIssuer;
+
+    fn handle_with_cert(not_after: OffsetDateTime) -> CertHandle {
+        let (tx, h) = CertHandle::channel();
+        let _ = tx.send(Some(IssuedCert {
+            cert_der: vec![],
+            chain_der: vec![],
+            key_der: zeroize::Zeroizing::new(vec![]),
+            not_after,
+            san: "*.acct.example.com".to_owned(),
+        }));
+        h
+    }
+
+    #[test]
+    fn classify_states() {
+        let t = AlarmThresholds::default();
+        let now = OffsetDateTime::now_utc();
+        let h = handle_with_cert(now + time::Duration::days(60));
+        assert_eq!(classify(&h, None, now, &t, false), CertHealth::Ok);
+        let h = handle_with_cert(now + time::Duration::days(20));
+        assert_eq!(classify(&h, None, now, &t, false), CertHealth::ExpiringSoon);
+        let h = handle_with_cert(now + time::Duration::days(3));
+        assert_eq!(classify(&h, None, now, &t, false), CertHealth::Critical);
+        let h = handle_with_cert(now - time::Duration::days(1));
+        assert_eq!(classify(&h, None, now, &t, false), CertHealth::Expired);
+
+        // Unissued vs unprovisioned
+        let (tx, empty) = CertHandle::channel();
+        drop(tx);
+        assert_eq!(classify(&empty, None, now, &t, false), CertHealth::Unissued);
+        assert_eq!(classify(&empty, None, now, &t, true), CertHealth::Unprovisioned);
+
+        // Last failure escalates a still-valid cert to Critical.
+        let h = handle_with_cert(now + time::Duration::days(60));
+        let err: Result<IssuedCert, IssuanceError> = Err(IssuanceError::Unprovisioned("x".into()));
+        assert_eq!(classify(&h, Some(&err), now, &t, false), CertHealth::Critical);
+    }
+
+    #[tokio::test]
+    async fn renewer_degrades_when_unprovisioned() {
+        // No zone → sane-degrade; the constructor + a single tick should not panic.
+        let cfg = AccountZoneConfig::default();
+        let issuer = Arc::new(NullWildcardCertIssuer) as Arc<dyn WildcardCertIssuer>;
+        let dns = Arc::new(UnconfiguredDnsProvider::new()) as Arc<dyn DnsProvider>;
+        let (sender, handle) = CertHandle::channel();
+        let renewer = CertRenewer::new(cfg, issuer, dns, sender, handle)
+            .with_tick(Duration::from_millis(10));
+        // Run briefly then drop; we only assert it does not panic on an
+        // unprovisioned deployment.
+        let task = tokio::spawn(async move {
+            renewer.run().await;
+        });
+        tokio::time::sleep(Duration::from_millis(30)).await;
+        task.abort();
+    }
+}

--- a/crates/hyprstream/src/account/renewal.rs
+++ b/crates/hyprstream/src/account/renewal.rs
@@ -108,14 +108,15 @@ pub fn classify(
         return CertHealth::Expired;
     }
     let dur = Duration::try_from(remaining).unwrap_or(Duration::ZERO);
-    if dur < thresholds.critical_lead {
+    // A failed renewal attempt is always at least Critical, regardless of how
+    // much validity remains (the doc promises "within critical_lead OR last
+    // issuance failed" → Critical). Checking `last_failed` first honors the
+    // OR-semantics and avoids silently downgrading to ExpiringSoon when a
+    // renewal has already failed inside the warn band.
+    if last_failed || dur < thresholds.critical_lead {
         CertHealth::Critical
     } else if dur < thresholds.warn_lead {
         CertHealth::ExpiringSoon
-    } else if last_failed {
-        // Cert still valid but the most recent renewal attempt failed — the
-        // deployment is on a clock, surface it.
-        CertHealth::Critical
     } else {
         CertHealth::Ok
     }
@@ -347,6 +348,17 @@ mod tests {
         let h = handle_with_cert(now + time::Duration::days(60));
         let err: Result<IssuedCert, IssuanceError> = Err(IssuanceError::Unprovisioned("x".into()));
         assert_eq!(classify(&h, Some(&err), now, &t, false), CertHealth::Critical);
+
+        // Regression (#1182 review): a failed renewal inside the warn band must
+        // NOT be downgraded to ExpiringSoon — the documented OR-semantics say a
+        // failed issuance is always at least Critical.
+        let h = handle_with_cert(now + time::Duration::days(20)); // ExpiringSoon band
+        assert_eq!(classify(&h, None, now, &t, false), CertHealth::ExpiringSoon);
+        assert_eq!(
+            classify(&h, Some(&err), now, &t, false),
+            CertHealth::Critical,
+            "failed renewal in the warn band must escalate to Critical, not ExpiringSoon"
+        );
     }
 
     #[tokio::test]

--- a/crates/hyprstream/src/account/tls.rs
+++ b/crates/hyprstream/src/account/tls.rs
@@ -1,0 +1,205 @@
+//! DNS-01 wildcard certificate issuance for the account zone
+//! (epic #1158, ticket #1162 / A3).
+//!
+//! `rustls-acme`, which the crate already uses for HTTP-01/TLS-ALPN-01,
+//! **only fulfills TLS-ALPN-01 challenges** — its `AcmeState` cannot perform
+//! DNS-01, and DNS-01 is the *only* validation method public CAs accept for a
+//! wildcard identifier (`*.<apex>`). Wildcards cannot use HTTP-01.
+//!
+//! hyprstream therefore defines the issuance path itself, **behind a trait**:
+//! [`WildcardCertIssuer`] owns the ACME DNS-01 dance (order → authorization →
+//! publish TXT via the [`DnsProvider`](super::dns::DnsProvider) seam → poll →
+//! finalize), and returns a DER-encoded cert+key. The concrete ACME-directory
+//! client and the DNS backend are both product-layer concerns above this crate —
+//! hyprstream must not depend on a specific DNS server (the self-hoster rule).
+//!
+//! What hyprstream *does* own here is:
+//! - the shape of the request (zone, zone-scoped credential, ACME directory),
+//! - the **sane-degrade** when no zone is configured (clear error, no panic,
+//!   no synthesized default),
+//! - the renewal + expiry-alarm plumbing (see [`super::renewal`]).
+//!
+//! Converting an [`IssuedCert`] into a live `rustls::ServerConfig` for the
+//! account HTTP face is the job of B3 (the credential-free origin, #1165); A3
+//! stops at the issuance contract and its monitoring.
+
+use async_trait::async_trait;
+use thiserror::Error;
+use time::OffsetDateTime;
+use tokio::sync::watch;
+use zeroize::Zeroizing;
+
+use super::config::AccountZoneConfig;
+use super::dns::{DnsError, DnsProvider};
+use super::zone::{AccountZone, AccountZoneError};
+
+/// A DER-encoded wildcard certificate + its private key, freshly issued.
+///
+/// The key is wrapped in `Zeroizing` so it is cleared on drop.
+#[derive(Debug, Clone)]
+pub struct IssuedCert {
+    /// End-entity certificate DER (leaf).
+    pub cert_der: Vec<u8>,
+    /// Optional intermediate issuer DERs.
+    pub chain_der: Vec<Vec<u8>>,
+    /// The private key DER (PKCS#8 or SEC1).
+    pub key_der: Zeroizing<Vec<u8>>,
+    /// The certificate's NotAfter, for renewal scheduling + the expiry alarm.
+    pub not_after: OffsetDateTime,
+    /// The name this cert was issued for (`*.<apex>`).
+    pub san: String,
+}
+
+/// An error from the DNS-01 wildcard issuance path.
+#[derive(Debug, Error)]
+pub enum IssuanceError {
+    /// The deployment configured no account zone / credential. **Sane-degrade**.
+    #[error("account zone DNS-01 issuance not provisioned: {0}")]
+    Unprovisioned(String),
+    /// The configured zone name was invalid.
+    #[error(transparent)]
+    InvalidZone(#[from] AccountZoneError),
+    /// The DNS backend failed to publish/clean the challenge TXT record.
+    #[error(transparent)]
+    Dns(#[from] DnsError),
+    /// The issuer backend returned an ACME/protocol error.
+    #[error("ACME DNS-01 issuance failed for {san}: {reason}")]
+    Backend { san: String, reason: String },
+}
+
+/// The interface a deployment's DNS-01 wildcard issuer implements.
+///
+/// Implementations live **outside** this crate (metal repo / product layer):
+/// they drive an ACME directory against `*.<apex>`, publish the `_acme-challenge`
+/// TXT record via the supplied [`DnsProvider`] (so the same zone-scoped
+/// credential plumbing is reused), poll the authorization to completion,
+/// finalize with a CSR, and return the resulting [`IssuedCert`].
+///
+/// [`NullWildcardCertIssuer`] is the in-crate fail-closed default.
+#[async_trait]
+pub trait WildcardCertIssuer: Send + Sync {
+    /// Issue (or renew) the wildcard certificate for `zone`. `dns` is the
+    /// deployment's DNS provider; `cfg` carries the ACME directory, contact,
+    /// and zone-scoped credential.
+    async fn issue(
+        &self,
+        zone: &AccountZone,
+        cfg: &AccountZoneConfig,
+        dns: &dyn DnsProvider,
+    ) -> Result<IssuedCert, IssuanceError>;
+}
+
+/// Fail-closed issuer for deployments that wired no ACME-DNS-01 backend.
+///
+/// Every call returns [`IssuanceError::Unprovisioned`]. The process keeps
+/// running on whatever TLS materials it already has (self-signed or operator
+/// `files`), and account minting surfaces the missing zone; nothing panics and
+/// no certificate is synthesized.
+#[derive(Debug, Default, Clone, Copy)]
+pub struct NullWildcardCertIssuer;
+
+#[async_trait]
+impl WildcardCertIssuer for NullWildcardCertIssuer {
+    async fn issue(
+        &self,
+        zone: &AccountZone,
+        _cfg: &AccountZoneConfig,
+        _dns: &dyn DnsProvider,
+    ) -> Result<IssuedCert, IssuanceError> {
+        Err(IssuanceError::Unprovisioned(format!(
+            "no ACME DNS-01 wildcard issuer wired up by the deployment; cannot obtain a certificate for {}",
+            zone.wildcard_domain()
+        )))
+    }
+}
+
+/// Validate that the deployment has provisioned DNS-01 wildcard issuance.
+///
+/// Returns the resolved [`AccountZone`] on success, or an
+/// [`IssuanceError::Unprovisioned`] / [`IssuanceError::InvalidZone`] otherwise.
+/// This is the sane-degrade check the serving/renewal layers call before
+/// attempting issuance — it never panics and never synthesizes a zone.
+pub fn require_provisioned(cfg: &AccountZoneConfig) -> Result<AccountZone, IssuanceError> {
+    if !cfg.is_configured() {
+        return Err(IssuanceError::Unprovisioned(
+            "no [account] zone configured — did:web minting and wildcard DNS-01 TLS issuance are disabled. Set [account] zone to enable.".to_owned(),
+        ));
+    }
+    if !cfg.dns01_ready() {
+        return Err(IssuanceError::Unprovisioned(
+            "account zone is set but [account] dns01_credential is missing — wildcard DNS-01 TLS issuance is disabled. Set dns01_credential (zone-scoped) to enable.".to_owned(),
+        ));
+    }
+    Ok(cfg.resolve_zone()?)
+}
+
+/// A live, hot-swappable handle to the currently-served account-zone cert.
+///
+/// The renewal task pushes freshly issued [`IssuedCert`]s into the underlying
+/// `watch::Sender`; consumers read [`CertHandle::current`] for the latest. This
+/// is the total-outage surface the expiry alarm watches — one cert failing
+/// breaks all account resolution for the deployment.
+#[derive(Clone)]
+pub struct CertHandle {
+    rx: watch::Receiver<Option<IssuedCert>>,
+}
+
+impl CertHandle {
+    /// Create a handle plus the sender the renewal task writes to.
+    pub fn channel() -> (watch::Sender<Option<IssuedCert>>, Self) {
+        let (tx, rx) = watch::channel(None);
+        (tx, Self { rx })
+    }
+
+    /// The currently-served cert, if one has been issued.
+    pub fn current(&self) -> Option<IssuedCert> {
+        self.rx.borrow().clone()
+    }
+
+    /// The cert NotAfter, if a cert has been issued.
+    pub fn not_after(&self) -> Option<OffsetDateTime> {
+        self.rx.borrow().as_ref().map(|c| c.not_after)
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)]
+mod tests {
+    use super::*;
+    use crate::account::dns::UnconfiguredDnsProvider;
+
+    fn cfg(zone: Option<&str>, cred: Option<&str>) -> AccountZoneConfig {
+        AccountZoneConfig {
+            zone: zone.map(str::to_owned),
+            dns01_credential: cred.map(str::to_owned),
+            ..Default::default()
+        }
+    }
+
+    #[tokio::test]
+    async fn null_issuer_fails_closed() {
+        let zone = AccountZone::new("acct.example.com").unwrap();
+        let issuer = NullWildcardCertIssuer;
+        let cfg = cfg(Some("acct.example.com"), Some("ref:tok"));
+        let dns = UnconfiguredDnsProvider::new();
+        let err = issuer.issue(&zone, &cfg, &dns).await.unwrap_err();
+        assert!(matches!(err, IssuanceError::Unprovisioned(_)));
+    }
+
+    #[test]
+    fn require_provisioned_degrades_sanely() {
+        // No zone.
+        assert!(matches!(
+            require_provisioned(&cfg(None, None)),
+            Err(IssuanceError::Unprovisioned(_))
+        ));
+        // Zone but no credential.
+        assert!(matches!(
+            require_provisioned(&cfg(Some("acct.example.com"), None)),
+            Err(IssuanceError::Unprovisioned(_))
+        ));
+        // Both → ok.
+        let z = require_provisioned(&cfg(Some("acct.example.com"), Some("ref:tok"))).unwrap();
+        assert_eq!(z.wildcard_domain(), "*.acct.example.com");
+    }
+}

--- a/crates/hyprstream/src/account/zone.rs
+++ b/crates/hyprstream/src/account/zone.rs
@@ -152,6 +152,12 @@ impl<'de> Deserialize<'de> for AccountZone {
     }
 }
 
+/// Maximum DNS name length in text form (no trailing dot). The wire-format
+/// limit is 255 octets (RFC 1035 §3.1); a name with N labels encodes as the
+/// sum of (label-len + label) octets plus a terminating zero, so the text
+/// form is at most 253 characters.
+const MAX_DNS_NAME_LEN: usize = 253;
+
 /// Validate a zone apex. See [`AccountZone::new`] for the rules.
 fn validate_zone_apex(apex: &str) -> Result<(), AccountZoneError> {
     let bad = |reason: &str| AccountZoneError::Invalid {
@@ -171,8 +177,22 @@ fn validate_zone_apex(apex: &str) -> Result<(), AccountZoneError> {
     if apex.to_ascii_lowercase() != apex {
         return Err(bad("zone name must be lowercase (use the NFKC/ASCII-normalized form)"));
     }
-    if apex.len() > 253 {
-        return Err(bad("zone name exceeds 253 octets"));
+    if apex.len() > MAX_DNS_NAME_LEN {
+        return Err(bad("zone name exceeds the 253-octet DNS text limit"));
+    }
+    // Reserve room for derived names. `host_for_label` produces
+    // `<account-label>.<apex>` and account labels are up to 63 octets (A2's
+    // grammar). The wire-format DNS name limit is 255 octets (RFC 1035),
+    // represented as up to 253 text chars. Reject an apex so long that a
+    // maximum-length label would overflow the limit, instead of producing an
+    // oversized host name later.
+    const MAX_ACCOUNT_LABEL_LEN: usize = 63;
+    let max_apex_for_hosts = MAX_DNS_NAME_LEN - 1 - MAX_ACCOUNT_LABEL_LEN; // 189
+    if apex.len() > max_apex_for_hosts {
+        return Err(bad(
+            "zone name leaves no room for a maximum-length (63-octet) account label \
+             under the 253-octet DNS text limit",
+        ));
     }
     if apex.starts_with('.') || apex.ends_with('.') {
         return Err(bad("zone name has an empty label"));
@@ -245,6 +265,27 @@ mod tests {
             let err = AccountZone::new(bad);
             assert!(err.is_err(), "expected {bad:?} to be rejected, got {err:?}");
         }
+    }
+
+    #[test]
+    fn rejects_apex_that_overflows_derived_host_names() {
+        // `host_for_label` prepends a `<label>.` (label up to 63) to the apex;
+        // RFC 1035 caps wire-format names at 255 octets (≤253 text chars). The
+        // cap leaves room: 253 - 1 - 63 = 189. Build apexes of valid (≤63-char)
+        // labels at exact total lengths.
+        let apex_190 = format!("{}.{}.{}", "a".repeat(63), "b".repeat(63), "c".repeat(62));
+        assert_eq!(apex_190.len(), 190); // 63+1+63+1+62
+        assert!(AccountZone::new(&apex_190).is_err(), "190-char apex must be rejected");
+
+        // An apex at the 189-char limit is accepted, and a max-length label
+        // still fits: 63 + '.' + 189 = 253.
+        let apex_189 = format!("{}.{}.{}", "a".repeat(63), "b".repeat(63), "c".repeat(61));
+        assert_eq!(apex_189.len(), 189);
+        let z = AccountZone::new(&apex_189).unwrap();
+        let label = "x".repeat(63);
+        let host = z.host_for_label(&label).unwrap();
+        assert_eq!(host.len(), 253);
+        assert_eq!(host, format!("{label}.{apex_189}"));
     }
 
     #[test]

--- a/crates/hyprstream/src/account/zone.rs
+++ b/crates/hyprstream/src/account/zone.rs
@@ -199,12 +199,6 @@ fn validate_zone_apex(apex: &str) -> Result<(), AccountZoneError> {
     }
 
     let labels: Vec<&str> = apex.split('.').collect();
-    if labels.len() < 2 {
-        return Err(bad(
-            "zone name must be delegated below a public suffix (a bare TLD is not an account zone)",
-        ));
-    }
-
     for label in &labels {
         if label.is_empty() {
             return Err(bad("zone name has a consecutive dot / empty label"));
@@ -218,6 +212,17 @@ fn validate_zone_apex(apex: &str) -> Result<(), AccountZoneError> {
         if label.starts_with('-') || label.ends_with('-') {
             return Err(bad("labels must not start or end with a hyphen"));
         }
+    }
+
+    // A label-count check cannot distinguish a registrable name from a
+    // multi-label public suffix (`example.co.uk` vs. `co.uk`). `psl` embeds the
+    // Mozilla Public Suffix List, so this check is deterministic and does not
+    // require network access at configuration time. Unknown/internal suffixes
+    // still follow the prevailing `*` rule and remain usable below one label.
+    if psl::domain(apex.as_bytes()).is_none() {
+        return Err(bad(
+            "zone name must include at least one registrable label below its public suffix",
+        ));
     }
 
     Ok(())
@@ -247,11 +252,20 @@ mod tests {
     }
 
     #[test]
-    fn rejects_bare_tld_and_bad_forms() {
-        assert!(matches!(
-            AccountZone::new("com").unwrap_err(),
-            AccountZoneError::Invalid { .. }
-        ));
+    fn rejects_public_suffixes_and_bad_forms() {
+        for public_suffix in ["com", "co.uk", "com.au", "ac.uk"] {
+            assert!(
+                matches!(
+                    AccountZone::new(public_suffix).unwrap_err(),
+                    AccountZoneError::Invalid { .. }
+                ),
+                "expected public suffix {public_suffix:?} to be rejected"
+            );
+        }
+        assert!(
+            AccountZone::new("acct.example.co.uk").is_ok(),
+            "a delegated zone below a multi-label public suffix must be accepted"
+        );
         for bad in [
             "",
             "Acct.Example.com",

--- a/crates/hyprstream/src/account/zone.rs
+++ b/crates/hyprstream/src/account/zone.rs
@@ -1,0 +1,266 @@
+//! The deployment-configured account zone (epic #1158, ticket #1162 / Phase A3).
+//!
+//! The account zone is the DNS apex under which every host-form `did:web` this
+//! deployment mints lives — e.g. `did:web:alice.acct.example.com`. It is
+//! **deployment-relative configuration**: the operator picks it, in the metal
+//! repo, when deploying hyprstream. hyprstream never bakes a zone name in.
+//!
+//! # No default — ever
+//!
+//! A deployment that configures no account zone must **degrade sanely**: account
+//! minting is disabled with a clear error. It must not panic, and above all it
+//! must not synthesize a default zone name — a default would silently mint
+//! permanent DIDs under a domain the operator never chose (one-way door #1 in
+//! the epic). `AccountZone` therefore has no `Default` impl and no constructor
+//! that invents a name; the only way to obtain one is
+//! [`AccountZoneConfig::resolve_zone`](super::config::AccountZoneConfig::resolve_zone),
+//! which returns `Err` when the zone is unset.
+//!
+//! # Label depth — the A2 seam (#1160)
+//!
+//! A wildcard certificate matches **exactly one** DNS label: `*.acct.example.com`
+//! covers `alice.acct.example.com` and *never* `a.b.acct.example.com`. This
+//! module fixes the *wildcard* shape (one label below the apex). The grammar a
+//! single account label must satisfy (LDH, ≤63 chars, NFKC, no mixed-script,
+//! reserved list, never-reuse) is owned by A2 (`#1160`); B1 enforces it at
+//! mint time. A3 only guarantees the wildcard covers exactly one label, which
+//! [`AccountZone::wildcard_domain`] does structurally.
+
+use std::fmt;
+use std::str::FromStr;
+
+use serde::{Deserialize, Serialize};
+use thiserror::Error;
+
+/// An error raised while resolving or parsing an account zone.
+#[derive(Debug, Error)]
+pub enum AccountZoneError {
+    /// The deployment configured no account zone. **This is the sane-degrade
+    /// path**, not a panic and not a synthesized default. Account minting is
+    /// disabled; callers surface this to the operator.
+    #[error("no account zone configured — account minting is disabled. Set [account] zone (e.g. \"acct.example.com\") to enable did:web minting under a deployment-chosen apex.")]
+    Unset,
+    /// The configured zone name was not a syntactically valid DNS name.
+    #[error("invalid account zone name {name:?}: {reason}")]
+    Invalid { name: String, reason: String },
+}
+
+/// A deployment-configured, validated account-zone apex.
+///
+/// Constructed only via [`AccountZone::new`] / [`FromStr`], both of which
+/// reject anything that is not a normalized, lowercase, fully-qualified DNS
+/// name with at least one delegation label below a public suffix (so an
+/// operator cannot accidentally configure a bare TLD). There is intentionally
+/// **no `Default`**: see the module docs on sane-degrade.
+///
+/// The apex is the zone NS-delegated to hyprstream — e.g. `acct.example.com`,
+/// NOT `*.acct.example.com` and NOT a per-account host. Wildcard and
+/// per-account hostnames are derived from it.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct AccountZone {
+    // Normalized lowercase ASCII DNS name without a trailing dot.
+    apex: String,
+    // Precomputed `*.apex` — the wildcard that covers exactly one label.
+    wildcard: String,
+}
+
+impl AccountZone {
+    /// Validate and wrap a zone apex like `acct.example.com`.
+    ///
+    /// Rejects empty input, trailing dots, uppercase (use the normalized form),
+    /// underscores, leading digits-in-TLD-style oddities, labels over 63 octets,
+    /// total length over 253, consecutive dots, and bare public suffixes
+    /// (`com`, `co.uk`) which an operator almost certainly did not intend to
+    /// delegate whole to hyprstream.
+    pub fn new(apex: impl Into<String>) -> Result<Self, AccountZoneError> {
+        let apex = apex.into();
+        validate_zone_apex(&apex)?;
+        // `validate_zone_apex` guarantees lowercase + no trailing dot, so this
+        // wildcard is the exact one-label form a CA will issue for DNS-01.
+        let wildcard = format!("*.{apex}");
+        Ok(Self { apex, wildcard })
+    }
+
+    /// The bare apex, e.g. `acct.example.com`. Lowercase, no trailing dot.
+    pub fn apex(&self) -> &str {
+        &self.apex
+    }
+
+    /// The wildcard that covers **exactly one** label below the apex, e.g.
+    /// `*.acct.example.com`. This is the name the DNS-01 wildcard TLS
+    /// certificate is issued for, and the name wildcard A/AAAA records are
+    /// published under.
+    pub fn wildcard_domain(&self) -> &str {
+        &self.wildcard
+    }
+
+    /// The DNS-01 `_acme-challenge` validation owner name for the wildcard
+    /// certificate. Per RFC 8555, a `*.` identifier is validated by publishing
+    /// the TXT record at `_acme-challenge.<apex>` (the apex, not the wildcard).
+    pub fn dns01_validation_name(&self) -> String {
+        format!("_acme-challenge.{}", self.apex)
+    }
+
+    /// Build a per-account host label under this zone, asserting the label is a
+    /// **single** DNS label (the depth the wildcard covers).
+    ///
+    /// This is the A3 side of the A2 seam: A2 (`#1160`) owns the *grammar* of
+    /// the label; A3 owns the *depth*. We reject any label that contains a `.`
+    /// or is empty, because a multi-label label would escape the wildcard's
+    /// single-label coverage and produce a hostname that does not resolve under
+    /// the issued certificate.
+    pub fn host_for_label(&self, label: &str) -> Result<String, AccountZoneError> {
+        if label.is_empty() {
+            return Err(AccountZoneError::Invalid {
+                name: label.to_owned(),
+                reason: "account label is empty".to_owned(),
+            });
+        }
+        if label.contains('.') {
+            return Err(AccountZoneError::Invalid {
+                name: label.to_owned(),
+                reason: "account label must be a single DNS label (the wildcard covers exactly one label below the zone); multi-label labels are not representable".to_owned(),
+            });
+        }
+        Ok(format!("{label}.{}", self.apex))
+    }
+}
+
+impl FromStr for AccountZone {
+    type Err = AccountZoneError;
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        Self::new(s)
+    }
+}
+
+impl fmt::Display for AccountZone {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.apex)
+    }
+}
+
+impl Serialize for AccountZone {
+    fn serialize<S: serde::Serializer>(&self, ser: S) -> Result<S::Ok, S::Error> {
+        ser.serialize_str(&self.apex)
+    }
+}
+
+impl<'de> Deserialize<'de> for AccountZone {
+    fn deserialize<D: serde::Deserializer<'de>>(de: D) -> Result<Self, D::Error> {
+        let s = String::deserialize(de)?;
+        Self::new(s).map_err(serde::de::Error::custom)
+    }
+}
+
+/// Validate a zone apex. See [`AccountZone::new`] for the rules.
+fn validate_zone_apex(apex: &str) -> Result<(), AccountZoneError> {
+    let bad = |reason: &str| AccountZoneError::Invalid {
+        name: apex.to_owned(),
+        reason: reason.to_owned(),
+    };
+
+    if apex.is_empty() {
+        return Err(bad("zone name is empty"));
+    }
+    if apex != apex.trim() {
+        return Err(bad("zone name has surrounding whitespace"));
+    }
+    if apex.ends_with('.') {
+        return Err(bad("zone name must not have a trailing dot"));
+    }
+    if apex.to_ascii_lowercase() != apex {
+        return Err(bad("zone name must be lowercase (use the NFKC/ASCII-normalized form)"));
+    }
+    if apex.len() > 253 {
+        return Err(bad("zone name exceeds 253 octets"));
+    }
+    if apex.starts_with('.') || apex.ends_with('.') {
+        return Err(bad("zone name has an empty label"));
+    }
+
+    let labels: Vec<&str> = apex.split('.').collect();
+    if labels.len() < 2 {
+        return Err(bad(
+            "zone name must be delegated below a public suffix (a bare TLD is not an account zone)",
+        ));
+    }
+
+    for label in &labels {
+        if label.is_empty() {
+            return Err(bad("zone name has a consecutive dot / empty label"));
+        }
+        if label.len() > 63 {
+            return Err(bad("a label exceeds 63 octets"));
+        }
+        if !label.bytes().all(|b| b.is_ascii_lowercase() || b.is_ascii_digit() || b == b'-') {
+            return Err(bad("labels must be LDH (lowercase letters, digits, hyphens) only"));
+        }
+        if label.starts_with('-') || label.ends_with('-') {
+            return Err(bad("labels must not start or end with a hyphen"));
+        }
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn valid_zone_normalizes_derived_names() {
+        let z = AccountZone::new("acct.example.com").unwrap();
+        assert_eq!(z.apex(), "acct.example.com");
+        assert_eq!(z.wildcard_domain(), "*.acct.example.com");
+        assert_eq!(z.dns01_validation_name(), "_acme-challenge.acct.example.com");
+    }
+
+    #[test]
+    fn host_label_is_single_depth() {
+        let z = AccountZone::new("acct.example.com").unwrap();
+        assert_eq!(z.host_for_label("alice").unwrap(), "alice.acct.example.com");
+        // Multi-label labels escape the wildcard — rejected.
+        let err = z.host_for_label("a.b").unwrap_err();
+        assert!(matches!(err, AccountZoneError::Invalid { .. }));
+        assert!(z.host_for_label("").is_err());
+    }
+
+    #[test]
+    fn rejects_bare_tld_and_bad_forms() {
+        assert!(matches!(
+            AccountZone::new("com").unwrap_err(),
+            AccountZoneError::Invalid { .. }
+        ));
+        for bad in [
+            "",
+            "Acct.Example.com",
+            "acct..example.com",
+            "acct.example.com.",
+            "-acct.example.com",
+            &format!("{}.example.com", "a".repeat(64)),
+        ]
+        .into_iter()
+        {
+            let err = AccountZone::new(bad);
+            assert!(err.is_err(), "expected {bad:?} to be rejected, got {err:?}");
+        }
+    }
+
+    #[test]
+    fn serde_roundtrips() {
+        let z = AccountZone::new("acct.example.com").unwrap();
+        let json = serde_json::to_string(&z).unwrap();
+        assert_eq!(json, "\"acct.example.com\"");
+        let back: AccountZone = serde_json::from_str(&json).unwrap();
+        assert_eq!(z, back);
+        // Deserializing a bad zone fails (no silent default).
+        assert!(serde_json::from_str::<AccountZone>("\"\"").is_err());
+    }
+
+    #[test]
+    fn from_str_matches_new() {
+        let z: AccountZone = "acct.example.com".parse().unwrap();
+        assert_eq!(z.apex(), "acct.example.com");
+    }
+}

--- a/crates/hyprstream/src/config/mod.rs
+++ b/crates/hyprstream/src/config/mod.rs
@@ -116,6 +116,16 @@ pub struct HyprConfig {
     #[serde(default)]
     pub tls: TlsConfig,
 
+    /// Account identity configuration (epic #1158, A3 / #1162).
+    ///
+    /// Names the deployment-chosen account zone, the zone-scoped DNS-01
+    /// credential, and the wildcard address targets. `Default` is the
+    /// **unconfigured** state — when the operator sets no `[account]` section,
+    /// did:web minting and DNS-01 wildcard TLS issuance degrade sanely (clear
+    /// error, no panic, no synthesized default zone name).
+    #[serde(default)]
+    pub account: crate::account::AccountZoneConfig,
+
     /// QUIC/WebTransport configuration
     ///
     /// Enabled by default. Services expose a WebTransport endpoint alongside ZMQ,
@@ -254,12 +264,17 @@ impl SecretsConfig {
 ///
 /// ```toml
 /// [tls]
-/// mode = "self-signed"   # or "acme" or "files"
+/// mode = "self-signed"   # or "acme", "acme-dns01", or "files"
 /// server_name = "localhost"
-/// # ACME mode:
+/// # ACME (HTTP-01/TLS-ALPN-01) mode:
 /// # acme_domain = "node.example.com"
 /// # acme_contact = "mailto:ops@example.com"
 /// # acme_cache_dir = "/var/lib/hyprstream/acme"
+/// # ACME DNS-01 wildcard mode (epic #1158 / A3 — the account zone):
+/// # mode = "acme-dns01"
+/// # [account]
+/// # zone = "acct.example.com"
+/// # dns01_credential = "ref:secretstore/account-zone-token"
 /// ```
 #[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq, Eq)]
 #[serde(rename_all = "kebab-case")]
@@ -267,8 +282,19 @@ pub enum TlsMode {
     /// Auto-generate a self-signed certificate at startup (dev/air-gapped only).
     #[default]
     SelfSigned,
-    /// Obtain a certificate automatically via ACME (RFC 8555) — Let's Encrypt or step-ca.
+    /// Obtain a certificate automatically via ACME (RFC 8555) — Let's Encrypt
+    /// or step-ca. Uses HTTP-01/TLS-ALPN-01 for a single named domain
+    /// (`acme_domain`). Does **not** support wildcard issuance.
     Acme,
+    /// DNS-01 wildcard issuance for the deployment's account zone (epic #1158,
+    /// A3 / #1162). Obtains a `*.<apex>` certificate using the zone-scoped
+    /// credential configured under `[account]`. Wildcards cannot use HTTP-01;
+    /// DNS-01 is the only validation method public CAs accept for `*.<apex>`.
+    ///
+    /// When the account zone is unconfigured this mode **degrades sanely** to
+    /// the existing self-signed/files materials — it never panics and never
+    /// synthesizes a zone name (one-way door #1).
+    AcmeDns01,
     /// Load certificate and key from `cert_path`/`key_path` (operator-managed).
     Files,
 }
@@ -2121,6 +2147,7 @@ pub struct HyprConfigBuilder {
     cluster_did_web: Option<String>,
     cluster_anchor_root_cert: Option<PathBuf>,
     cluster_remote_node: bool,
+    account: crate::account::AccountZoneConfig,
 }
 
 impl HyprConfigBuilder {
@@ -2154,6 +2181,7 @@ impl HyprConfigBuilder {
             cluster_did_web: None,
             cluster_anchor_root_cert: None,
             cluster_remote_node: false,
+            account: Default::default(),
         }
     }
 
@@ -2187,6 +2215,7 @@ impl HyprConfigBuilder {
             cluster_did_web: config.cluster_did_web,
             cluster_anchor_root_cert: config.cluster_anchor_root_cert,
             cluster_remote_node: config.cluster_remote_node,
+            account: config.account,
         }
     }
 
@@ -2238,6 +2267,7 @@ impl HyprConfigBuilder {
             cluster_did_web: self.cluster_did_web,
             cluster_anchor_root_cert: self.cluster_anchor_root_cert,
             cluster_remote_node: self.cluster_remote_node,
+            account: self.account,
             #[cfg(feature = "ledger")]
             ledger: Default::default(),
         }

--- a/crates/hyprstream/src/lib.rs
+++ b/crates/hyprstream/src/lib.rs
@@ -36,6 +36,7 @@ pub mod tui_capnp {
 pub mod api;
 pub mod archetypes;
 pub mod auth;
+pub mod account;
 pub mod cli;
 pub mod config;
 pub mod constants;

--- a/crates/hyprstream/src/server/mod.rs
+++ b/crates/hyprstream/src/server/mod.rs
@@ -167,6 +167,7 @@ pub async fn start_server_tls(
     let hypr_config = crate::config::HyprConfig::load().unwrap_or_default();
     let rustls_config = tls::resolve_rustls_config(
         &hypr_config.tls,
+        &hypr_config.account,
         hypr_config.oai.tls_cert.as_ref(),
         hypr_config.oai.tls_key.as_ref(),
     )

--- a/crates/hyprstream/src/server/tls.rs
+++ b/crates/hyprstream/src/server/tls.rs
@@ -11,6 +11,7 @@
 //!  - `acme` — automatic via RFC 8555 (Let's Encrypt or self-hosted step-ca / Pebble)
 //!  - `files` — operator-supplied PEM paths
 
+use crate::account::AccountZoneConfig;
 use crate::config::{TlsConfig, TlsMode};
 use hyprstream_rpc::error::RpcError;
 use std::net::SocketAddr;
@@ -98,6 +99,7 @@ pub fn get_or_init_tls_materials(config: &TlsConfig) -> anyhow::Result<Arc<TlsMa
 /// 4. Otherwise → shared self-signed / `files` mode materials
 pub async fn resolve_rustls_config(
     tls_config: &TlsConfig,
+    account_cfg: &AccountZoneConfig,
     service_cert: Option<&PathBuf>,
     service_key: Option<&PathBuf>,
 ) -> anyhow::Result<Option<axum_server::tls_rustls::RustlsConfig>> {
@@ -130,6 +132,56 @@ pub async fn resolve_rustls_config(
         TlsMode::Acme => {
             let config = init_acme_rustls_config(tls_config).await?;
             Ok(Some(config))
+        }
+        TlsMode::AcmeDns01 => {
+            // Account-zone DNS-01 wildcard issuance (epic #1158, A3 / #1162).
+            // The concrete ACME-DNS-01 client and DNS backend are product-layer
+            // seams (`hyprstream::account::{WildcardCertIssuer, DnsProvider}`);
+            // here we only sanity-check provisioning. When the deployment
+            // configured no account zone or DNS-01 credential, this mode
+            // **degrades sanely** to the existing shared self-signed materials
+            // — no panic, no synthesized zone name (one-way door #1).
+            match crate::account::tls::require_provisioned(account_cfg) {
+                Ok(zone) => {
+                    tracing::info!(
+                        apex = %zone.apex(),
+                        wildcard = %zone.wildcard_domain(),
+                        "TLS mode acme-dns01 provisioned for account zone; concrete DNS-01 \
+                         issuance is wired by the product-layer WildcardCertIssuer + DnsProvider",
+                    );
+                    // Fall through to shared materials until the product layer's
+                    // issuer pushes a cert into the account CertHandle; the
+                    // serving face (B3, #1165) is where the issued cert is bound
+                    // to a listener. This keeps the process serving during the
+                    // first issuance window rather than failing to boot.
+                    let materials = get_or_init_tls_materials(tls_config)?;
+                    let rustls_config = axum_server::tls_rustls::RustlsConfig::from_der(
+                        vec![materials.cert_der.clone()],
+                        (*materials.key_der).clone(),
+                    )
+                    .await
+                    .map_err(|e| anyhow::anyhow!("failed to build RustlsConfig from DER: {}", e))?;
+                    Ok(Some(rustls_config))
+                }
+                Err(e) => {
+                    // Sane-degrade: clear error in the log, fall back to shared
+                    // self-signed materials. We do NOT bail: account minting is
+                    // disabled, but the rest of the deployment (OAI/OAuth/MCP
+                    // faces) must still boot.
+                    tracing::warn!(
+                        "TLS mode acme-dns01 requested but account zone is not provisioned \
+                         — did:web minting disabled, serving with shared self-signed TLS: {e}"
+                    );
+                    let materials = get_or_init_tls_materials(tls_config)?;
+                    let rustls_config = axum_server::tls_rustls::RustlsConfig::from_der(
+                        vec![materials.cert_der.clone()],
+                        (*materials.key_der).clone(),
+                    )
+                    .await
+                    .map_err(|e| anyhow::anyhow!("failed to build RustlsConfig from DER: {}", e))?;
+                    Ok(Some(rustls_config))
+                }
+            }
         }
         _ => {
             // Shared materials (self-signed or Files mode)

--- a/crates/hyprstream/src/server/tls.rs
+++ b/crates/hyprstream/src/server/tls.rs
@@ -143,17 +143,24 @@ pub async fn resolve_rustls_config(
             // — no panic, no synthesized zone name (one-way door #1).
             match crate::account::tls::require_provisioned(account_cfg) {
                 Ok(zone) => {
+                    // NOTE (#1182 review): this branch validates that an account
+                    // zone + zone-scoped DNS-01 credential are *configured*. It
+                    // does NOT yet invoke `WildcardCertIssuer` or bind a
+                    // `CertHandle` to this listener — those are product-layer /
+                    // B3 (#1165) seams. Until that integration lands, the
+                    // account zone's wildcard cert is NOT what this service
+                    // serves; we fall through to shared self-signed materials so
+                    // the deployment keeps booting. Do not read the log below as
+                    // "the wildcard cert is live"; it means "config is
+                    // well-formed and provisioning is detectable".
                     tracing::info!(
                         apex = %zone.apex(),
                         wildcard = %zone.wildcard_domain(),
-                        "TLS mode acme-dns01 provisioned for account zone; concrete DNS-01 \
-                         issuance is wired by the product-layer WildcardCertIssuer + DnsProvider",
+                        "TLS mode acme-dns01: account-zone config is provisioned (zone + \
+                         zone-scoped DNS-01 credential present). Wildcard issuance + rustls \
+                         binding are product-layer/B3 (#1165) seams not yet wired here — \
+                         serving shared self-signed TLS until then.",
                     );
-                    // Fall through to shared materials until the product layer's
-                    // issuer pushes a cert into the account CertHandle; the
-                    // serving face (B3, #1165) is where the issued cert is bound
-                    // to a listener. This keeps the process serving during the
-                    // first issuance window rather than failing to boot.
                     let materials = get_or_init_tls_materials(tls_config)?;
                     let rustls_config = axum_server::tls_rustls::RustlsConfig::from_der(
                         vec![materials.cert_der.clone()],

--- a/crates/hyprstream/src/services/at9p_verify.rs
+++ b/crates/hyprstream/src/services/at9p_verify.rs
@@ -315,12 +315,21 @@ async fn verify_handler(
 pub struct At9pVerifyService {
     config: At9pVerifyConfig,
     tls_config: TlsConfig,
+    account_config: crate::account::AccountZoneConfig,
 }
 
 impl At9pVerifyService {
-    /// Construct the face from its config section and the process TLS config.
-    pub fn new(config: At9pVerifyConfig, tls_config: TlsConfig) -> Self {
-        Self { config, tls_config }
+    /// Construct the face from its config section and process-wide TLS configuration.
+    pub fn new(
+        config: At9pVerifyConfig,
+        tls_config: TlsConfig,
+        account_config: crate::account::AccountZoneConfig,
+    ) -> Self {
+        Self {
+            config,
+            tls_config,
+            account_config,
+        }
     }
 
     fn http_addr(&self) -> Result<SocketAddr, RpcError> {
@@ -356,6 +365,7 @@ impl Spawnable for At9pVerifyService {
 
             let rustls_config = resolve_rustls_config(
                 &self.tls_config,
+                &self.account_config,
                 self.config.tls_cert.as_ref(),
                 self.config.tls_key.as_ref(),
             )

--- a/crates/hyprstream/src/services/factories.rs
+++ b/crates/hyprstream/src/services/factories.rs
@@ -1338,6 +1338,7 @@ fn create_at9p_verify_service(_ctx: &ServiceContext) -> anyhow::Result<Box<dyn S
     Ok(Box::new(At9pVerifyService::new(
         config.at9p_verify.clone(),
         config.tls.clone(),
+        config.account.clone(),
     )))
 }
 

--- a/crates/hyprstream/src/services/factories.rs
+++ b/crates/hyprstream/src/services/factories.rs
@@ -1238,6 +1238,7 @@ fn create_oai_service(ctx: &ServiceContext) -> anyhow::Result<Box<dyn Spawnable>
     let oai_service = OAIService::new(
         config.oai.clone(),
         config.tls.clone(),
+        config.account.clone(),
         server_state,
         ctx.transport("oai", SocketKind::Rep),
         ctx.verifying_key(),
@@ -1305,7 +1306,12 @@ fn create_xet_service(ctx: &ServiceContext) -> anyhow::Result<Box<dyn Spawnable>
         auth,
     };
 
-    let xet_service = XetService::new(config.xet.clone(), config.tls.clone(), state);
+    let xet_service = XetService::new(
+        config.xet.clone(),
+        config.tls.clone(),
+        config.account.clone(),
+        state,
+    );
 
     Ok(Box::new(xet_service))
 }
@@ -1401,6 +1407,7 @@ fn create_oauth_service(ctx: &ServiceContext) -> anyhow::Result<Box<dyn Spawnabl
     let mut oauth_service = OAuthService::new(
         config.oauth.clone(),
         config.tls.clone(),
+        config.account.clone(),
         sk,
         ctx.transport("oauth", SocketKind::Rep),
         ctx.verifying_key(),
@@ -1773,6 +1780,7 @@ fn create_mcp_service(ctx: &ServiceContext) -> anyhow::Result<Box<dyn Spawnable>
 
             let rustls_config = match crate::server::tls::resolve_rustls_config(
                 &mcp_tls_config,
+                &config.account,
                 mcp_tls_cert.as_ref(),
                 mcp_tls_key.as_ref(),
             ).await {

--- a/crates/hyprstream/src/services/oai.rs
+++ b/crates/hyprstream/src/services/oai.rs
@@ -60,6 +60,10 @@ pub struct OAIService {
     /// Global TLS configuration (passed from factory, avoids re-loading config)
     tls_config: TlsConfig,
 
+    /// Account-zone configuration (epic #1158, A3) — used for DNS-01 wildcard
+    /// TLS provisioning. Passed from the factory to avoid re-loading config.
+    account_config: crate::account::AccountZoneConfig,
+
     /// Shared server state containing clients and metrics
     server_state: ServerState,
 
@@ -84,6 +88,7 @@ impl OAIService {
     pub fn new(
         config: OAIConfig,
         tls_config: TlsConfig,
+        account_config: crate::account::AccountZoneConfig,
         server_state: ServerState,
         control_transport: TransportConfig,
         verifying_key: VerifyingKey,
@@ -91,6 +96,7 @@ impl OAIService {
         Self {
             config,
             tls_config,
+            account_config,
             server_state,
             control_transport,
             verifying_key,
@@ -134,6 +140,7 @@ impl Spawnable for OAIService {
             // Resolve TLS configuration (tls_config passed from factory, not re-loaded)
             let rustls_config = resolve_rustls_config(
                 &self.tls_config,
+                &self.account_config,
                 self.config.tls_cert.as_ref(),
                 self.config.tls_key.as_ref(),
             )

--- a/crates/hyprstream/src/services/oauth/mod.rs
+++ b/crates/hyprstream/src/services/oauth/mod.rs
@@ -372,6 +372,9 @@ pub struct OAuthService {
     config: OAuthConfig,
     /// Global TLS configuration (passed from factory, avoids re-loading config)
     tls_config: crate::config::TlsConfig,
+    /// Account-zone configuration (epic #1158, A3) — used for DNS-01 wildcard
+    /// TLS provisioning.
+    account_config: crate::account::AccountZoneConfig,
     /// Global QUIC configuration for cert-hash publication in DID doc (#185).
     quic_config: Option<crate::config::QuicConfig>,
     /// Signing key for creating the PolicyClient inside `run()`.
@@ -390,6 +393,7 @@ impl OAuthService {
     pub fn new(
         config: OAuthConfig,
         tls_config: crate::config::TlsConfig,
+        account_config: crate::account::AccountZoneConfig,
         signing_key: hyprstream_rpc::prelude::SigningKey,
         control_transport: TransportConfig,
         verifying_key: ed25519_dalek::VerifyingKey,
@@ -398,6 +402,7 @@ impl OAuthService {
         Self {
             config,
             tls_config,
+            account_config,
             quic_config: None,
             signing_key,
             control_transport,
@@ -454,6 +459,7 @@ impl Spawnable for OAuthService {
             // Resolve TLS configuration (tls_config passed from factory, not re-loaded)
             let rustls_config = crate::server::tls::resolve_rustls_config(
                 &self.tls_config,
+                &self.account_config,
                 self.config.tls_cert.as_ref(),
                 self.config.tls_key.as_ref(),
             )

--- a/crates/hyprstream/src/services/xet.rs
+++ b/crates/hyprstream/src/services/xet.rs
@@ -97,15 +97,22 @@ pub struct XetState {
 pub struct XetService {
     config: XetConfig,
     tls_config: TlsConfig,
+    account_config: crate::account::AccountZoneConfig,
     state: XetState,
 }
 
 impl XetService {
     /// Create a new XetService.
-    pub fn new(config: XetConfig, tls_config: TlsConfig, state: XetState) -> Self {
+    pub fn new(
+        config: XetConfig,
+        tls_config: TlsConfig,
+        account_config: crate::account::AccountZoneConfig,
+        state: XetState,
+    ) -> Self {
         Self {
             config,
             tls_config,
+            account_config,
             state,
         }
     }
@@ -383,6 +390,7 @@ impl Spawnable for XetService {
 
             let rustls_config = resolve_rustls_config(
                 &self.tls_config,
+                &self.account_config,
                 self.config.tls_cert.as_ref(),
                 self.config.tls_key.as_ref(),
             )
@@ -528,7 +536,12 @@ mod tests {
     fn does_not_advertise_an_unserved_rpc_endpoint() {
         let dir = tempfile::tempdir().unwrap();
         let state = test_state_with_xorb(dir.path(), HASH, b"x");
-        let service = XetService::new(XetConfig::default(), TlsConfig::default(), state);
+        let service = XetService::new(
+            XetConfig::default(),
+            TlsConfig::default(),
+            crate::account::AccountZoneConfig::default(),
+            state,
+        );
         assert!(service.registrations().is_empty());
     }
 

--- a/docs/tls.md
+++ b/docs/tls.md
@@ -120,6 +120,54 @@ key_path = "/etc/hyprstream/tls/key.pem"
 
 Files mode is also activated when `cert_path`/`key_path` are set without an explicit `mode`.
 
+### `acme-dns01` (account-zone wildcard)
+
+DNS-01 wildcard issuance for the deployment's account zone (epic [#1158], A3 /
+[#1162]). Obtains a `*.<apex>` certificate — e.g. `*.acct.example.com` — so
+every host-form `did:web` account under the zone
+(`alice.acct.example.com`, `bob.acct.example.com`, …) is authenticated by a
+single cert.
+
+Wildcards **cannot** use HTTP-01; DNS-01 is the only validation method public
+CAs accept for `*.<apex>`. hyprstream defines the issuance and DNS-management
+**interfaces**; the concrete ACME-DNS-01 client and DNS backend are a product
+layer above hyprstream (if hyprstream required a specific DNS server,
+self-hosters could not run it).
+
+```toml
+[tls]
+mode = "acme-dns01"
+
+[account]
+# The delegated account-zone apex — chosen by the operator at deploy time in the
+# metal repo. hyprstream NEVER bakes a zone name in; it takes one.
+zone = "acct.example.com"
+# Zone-scoped DNS-01 credential — the deployment's DNS provider accepts this
+# and only this when writing records under the apex. Opaque to hyprstream.
+dns01_credential = "ref:secretstore/account-zone-token"
+acme_directory = "https://acme-v02.api.letsencrypt.org/directory"
+acme_contact = "mailto:ops@example.com"
+# Optional wildcard address targets for the delegated zone:
+wildcard_ipv4 = "203.0.113.10"
+wildcard_ipv6 = "2001:db8::10"
+```
+
+**Sane-degrade:** a deployment that configures no `[account] zone` (or no
+`dns01_credential`) disables did:web minting and DNS-01 wildcard issuance with a
+clear error in the log — it does **not** panic and does **not** synthesize a
+default zone name (a default would silently mint permanent DIDs under a domain
+the operator never chose). The process keeps serving on its existing self-signed
+or `files` materials.
+
+**Total-outage surface:** one wildcard cert authenticates *every* account host,
+so one cert failing to renew breaks all account resolution for the deployment.
+Renewal and an expiry alarm (`CertHealth`: `ok` / `expiring_soon` / `critical` /
+`expired` / `unissued` / `unprovisioned`) therefore ship with the feature.
+
+[#1158]: https://github.com/hyprstream/hyprstream/issues/1158
+[#1162]: https://github.com/hyprstream/hyprstream/issues/1162
+
+
 ## JWT Signing Key Rotation
 
 Independent of TLS, hyprstream rotates the JWT signing key automatically.

--- a/docs/tls.md
+++ b/docs/tls.md
@@ -164,6 +164,16 @@ so one cert failing to renew breaks all account resolution for the deployment.
 Renewal and an expiry alarm (`CertHealth`: `ok` / `expiring_soon` / `critical` /
 `expired` / `unissued` / `unprovisioned`) therefore ship with the feature.
 
+**What A3 ships vs. what the product layer / B3 completes:** this mode defines
+the issuance and DNS-management **contracts** (`WildcardCertIssuer`,
+`DnsProvider`) and validates provisioning. The concrete ACME-DNS-01 client and
+DNS backend are a product layer above hyprstream; binding an issued wildcard
+certificate to a serving listener is B3 (the account HTTP face, [#1165]). Until
+that integration lands, `acme-dns01` does **not** serve the wildcard certificate
+itself — a provisioned deployment falls back to the shared self-signed/`files`
+materials so the rest of the process keeps booting. The mode exists now so
+deployments can be configured against the contract before the issuer is wired.
+
 [#1158]: https://github.com/hyprstream/hyprstream/issues/1158
 [#1162]: https://github.com/hyprstream/hyprstream/issues/1162
 


### PR DESCRIPTION
## What

Phase A3 of epic #1158 (ticket #1162): the deployment-configured **account
zone** + **DNS-01 wildcard TLS** issuance/renewal/alarm surface for host-form
`did:web` identity.

The account zone is deployment-relative configuration, chosen in the metal
repo at deploy time. **hyprstream never bakes a zone name in — it takes one.**
A deployment that configures no `[account] zone` degrades sanely: did:web
minting and DNS-01 wildcard issuance are disabled with a clear error, not a
panic and not a synthesized default (a default would silently mint permanent
DIDs under a domain the operator never chose — one-way door #1).

## Changes

- `account::AccountZone` — validated zone apex with **no `Default`**;
  `wildcard_domain()` (covers exactly one label), `dns01_validation_name()`
  (`_acme-challenge.<apex>`), and `host_for_label()` that enforces the
  single-label depth invariant (the A2 `#1160` seam — A3 owns depth, A2 owns
  grammar).
- `account::DnsProvider` trait — `publish_txt`/`delete_txt` for DNS-01 +
  `publish_wildcard_a`/`publish_wildcard_aaaa` for the delegated zone, with a
  fail-closed `UnconfiguredDnsProvider`. hyprstream defines the interface;
  managed DNS is a **product layer above** (no PowerDNS dep — self-hosters can
  run it).
- `account::AccountZoneConfig` — the `[account]` section (zone, zone-scoped
  `dns01_credential`, ACME directory/contact, wildcard v4/v6 targets) with
  `is_configured()`, `resolve_zone()` (`Unset` on no zone), `dns01_ready()`.
- `account::WildcardCertIssuer` trait + `NullWildcardCertIssuer`. `rustls-acme`
  only fulfils TLS-ALPN-01, so DNS-01 wildcard issuance is a trait seam the
  product layer fills (it publishes the challenge TXT via the same
  `DnsProvider`, so the zone-scoped credential plumbing is reused).
- `account::CertRenewer` + `CertHealthMonitor` + `CertHealth` expiry alarm
  (`ok` / `expiring_soon` / `critical` / `expired` / `unissued` /
  `unprovisioned`). **Ships with the feature** because one cert failing breaks
  all account resolution for the deployment — a total-outage surface.
- `TlsConfig`: new `TlsMode::AcmeDns01` variant, wired into
  `resolve_rustls_config` with sane-degrade (clear log + fallback to shared
  self-signed when unprovisioned). `AccountZoneConfig` threaded through OAI,
  Xet, OAuth, MCP, and the standalone server.
- `docs/tls.md`: operator-facing `acme-dns01` section.

## Scope / seams

- **No specific DNS implementation anywhere** in hyprstream (PowerDNS, Route53,
  …) — by charter, managed DNS is a product layer above a protocol that does
  not depend on it.
- The concrete ACME-DNS-01 client and the DNS backend are product-layer seams.
  Converting an `IssuedCert` into a live `rustls::ServerConfig` on the account
  HTTP face is B3 (`#1165`); A3 stops at the issuance contract and its
  monitoring.
- Label grammar (LDH/NFKC/confusable/reserved/never-reuse) is A2 (`#1160`); B1
  enforces it at mint time. This PR only guarantees the wildcard covers exactly
  one label.
- Custom user domains (T2/T3) are out of scope — blocked on C5 (`#1171`).

## Verify

- `cargo build -p hyprstream` ✅
- `cargo test -p hyprstream --lib account::` → 17 passed ✅
- `cargo clippy -p hyprstream --all-targets -- -D warnings` ✅

Refs: #1162, #1158. Depends on #1160 (A2) for label grammar (coded to interface).
