### PR TITLE
feat(auth): sealed op-log head as cross-process #atproto generation source (C4 #1170, closes #1123)

### DIFF
--- a/crates/hyprstream/src/auth/key_rotation.rs
+++ b/crates/hyprstream/src/auth/key_rotation.rs
@@ -1353,6 +1353,17 @@ pub fn spawn_rotation_task(
             refresh_ed25519_verifying_keys(&store).await;
             if let Some(ref es256) = extra.es256 {
                 rotate_es256_keys(&config, &secrets_dir, es256, now).await;
+                // C4 (#1170): re-seal the op-log head after the ES256
+                // promotion so cross-process readers (the registry's
+                // `PdsPublisher` under `--ipc`) observe the new active
+                // `#atproto` generation. C2 (#1168) seam — see `auth::op_log`.
+                if let Err(error) = super::op_log::seal_op_log_head(
+                    &secrets_dir,
+                    extra.composite_ca_key.as_ref(),
+                    es256,
+                ) {
+                    warn!("failed to re-seal op-log head after ES256 rotation: {error}");
+                }
             }
             if let (Some(ref ml_dsa), Some(expected_component_digest)) =
                 (&extra.ml_dsa, expected_component_digest.as_deref())
@@ -1443,6 +1454,23 @@ impl Es256SigningKeyStore {
     }
 }
 
+/// Resolve an ES256 signing key by kid from the persisted slot files in
+/// `secrets_dir` (scans drain/active/lead). Used by the sealed op-log head
+/// reader ([`super::op_log`]) to materialize the active generation's signing
+/// key once the head has authenticated *which* kid is active. Reading from
+/// disk — not the in-memory `OnceLock` — is what makes a cross-process reader
+/// observe a slot promoted by another process.
+pub(crate) fn es256_signing_key_for_kid(secrets_dir: &Path, kid: &str) -> Option<Es256SigningKey> {
+    for name in ["active", "drain", "lead"] {
+        if let Some(slot) = load_es256_slot(secrets_dir, name) {
+            if slot.kid() == kid {
+                return Some((*slot.key).clone());
+            }
+        }
+    }
+    None
+}
+
 // ── ES256 persistence ──────────────────────────────────────────────────────
 
 fn es256_slot_paths(secrets_dir: &Path, name: &str) -> (PathBuf, PathBuf) {
@@ -1468,7 +1496,11 @@ fn load_es256_slot(secrets_dir: &Path, name: &str) -> Option<Es256KeySlot> {
     Some(Es256KeySlot::new(key, meta.nbf, meta.exp))
 }
 
-fn persist_es256_slot(secrets_dir: &Path, name: &str, slot: &Es256KeySlot) -> anyhow::Result<()> {
+pub(crate) fn persist_es256_slot(
+    secrets_dir: &Path,
+    name: &str,
+    slot: &Es256KeySlot,
+) -> anyhow::Result<()> {
     // Atomic write + 0600 perms (#179).
     super::identity_store::write_secret(
         secrets_dir,

--- a/crates/hyprstream/src/auth/key_rotation.rs
+++ b/crates/hyprstream/src/auth/key_rotation.rs
@@ -19,7 +19,7 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 use tokio::sync::RwLock;
 use tokio::time::MissedTickBehavior;
-use tracing::{info, warn};
+use tracing::{error, info, warn};
 
 use crate::config::OAuthConfig;
 
@@ -1356,13 +1356,16 @@ pub fn spawn_rotation_task(
                 // C4 (#1170): re-seal the op-log head after the ES256
                 // promotion so cross-process readers (the registry's
                 // `PdsPublisher` under `--ipc`) observe the new active
-                // `#atproto` generation. C2 (#1168) seam — see `auth::op_log`.
-                if let Err(error) = super::op_log::seal_op_log_head(
-                    &secrets_dir,
-                    extra.composite_ca_key.as_ref(),
-                    es256,
-                ) {
-                    warn!("failed to re-seal op-log head after ES256 rotation: {error}");
+                // `#atproto` generation. Dedicated head-signing key + shared
+                // state dir; async because the ES256 store is a tokio RwLock
+                // (F1). C2 (#1168) seam — see `auth::op_log`.
+                if let Err(error) =
+                    super::op_log::advance_sealed_head(&secrets_dir, es256).await
+                {
+                    error!(
+                        "failed to re-seal op-log head after ES256 rotation; \
+                         cross-process readers will retain the prior generation: {error}"
+                    );
                 }
             }
             if let (Some(ref ml_dsa), Some(expected_component_digest)) =

--- a/crates/hyprstream/src/auth/mod.rs
+++ b/crates/hyprstream/src/auth/mod.rs
@@ -8,6 +8,7 @@
 pub mod device_challenge;
 pub mod identity_store;
 pub mod key_rotation;
+pub mod op_log;
 pub mod service_jwt;
 pub mod federation;
 pub mod federation_admission;
@@ -27,6 +28,11 @@ pub use hyprstream_rpc::annotations_capnp::ScopeAction;
 pub use federation::FederationKeyResolver;
 pub use jwt::{Claims, JwtError};
 pub use key_rotation::{SigningKeyStore, Es256SigningKeyStore, Es256KeySlot, RotationStores};
+pub use op_log::{
+    head_signing_key_from_root, seal_op_log_head, sealed_head_path, ActiveGeneration,
+    ActiveGenerationSource, FixedGenerationSource, SealedHeadEs256Source, SealedOpLogHead,
+    SEALED_HEAD_FILENAME,
+};
 pub use key_rotation::{MlDsaSigningKeyStore, MlDsaKeySlot};
 pub use policy_manager::{PolicyManager, PolicyError, write_policy_file, global_policy_manager, set_global_policy_manager};
 pub use policy_migration::migrate_policy_csv;

--- a/crates/hyprstream/src/auth/mod.rs
+++ b/crates/hyprstream/src/auth/mod.rs
@@ -29,9 +29,9 @@ pub use federation::FederationKeyResolver;
 pub use jwt::{Claims, JwtError};
 pub use key_rotation::{SigningKeyStore, Es256SigningKeyStore, Es256KeySlot, RotationStores};
 pub use op_log::{
-    head_signing_key_from_root, seal_op_log_head, sealed_head_path, ActiveGeneration,
-    ActiveGenerationSource, FixedGenerationSource, SealedHeadEs256Source, SealedOpLogHead,
-    SEALED_HEAD_FILENAME,
+    load_head_verifying_key, load_or_init_head_signing_key, publish_head_verifying_key,
+    resolve_oplog_state_dir, seal_op_log_head, ActiveGeneration, ActiveGenerationSource,
+    FixedGenerationSource, SealedHeadEs256Source, SealedOpLogHead,
 };
 pub use key_rotation::{MlDsaSigningKeyStore, MlDsaKeySlot};
 pub use policy_manager::{PolicyManager, PolicyError, write_policy_file, global_policy_manager, set_global_policy_manager};

--- a/crates/hyprstream/src/auth/op_log.rs
+++ b/crates/hyprstream/src/auth/op_log.rs
@@ -1,0 +1,520 @@
+//! C4 (#1170): the sealed op-log head — cross-process source of truth for the
+//! active `#atproto` ES256 generation. **Closes #1123.**
+//!
+//! Plan t1124 §3.4: under `--ipc`, discovery/registry/oauth must agree on the
+//! active generation with **no event-delivery mechanism**. They do it by
+//! reading ONE sealed head written by the rotation task: the rotator (OAuth)
+//! writes it after every promotion, every reader (the registry's
+//! [`crate::services::discovery::PdsPublisher`] and, later, any other
+//! cross-process consumer) reads it at use time. The process-local
+//! `OnceLock`/`Es256SigningKeyStore` stays the rotator's own working state;
+//! it is no longer the source of truth for *other* processes.
+//!
+//! ## Dependency honesty — C2 (#1168) is not built
+//!
+//! C4 formally depends on C2 (crash-atomic rotation). This module ships the
+//! **read path** (real, signature-verified, fail-closed) plus the head
+//! **format** and a [`seal_op_log_head`] **seam-write**. What C2 must
+//! guarantee for this to be fully sound, and what C4 does *not* claim today:
+//!
+//!   * [`seal_op_log_head`] writes the head with an atomic rename — real
+//!     file-level crash atomicity (a crash leaves either the old or the new
+//!     head, never a torn one).
+//!   * C2 replaces the promote-then-write sequence with the full rotation
+//!     ordering — *re-sign repo head → durably write head → seal DidOp →
+//!     publish DID doc* — as one crash-atomic unit, so no crash can leave a
+//!     head naming a key whose repo head was not durably re-signed. Until C2
+//!     lands, a crash inside the rotation task's promote→write window can
+//!     leave the head pointing at a freshly promoted key whose commit has not
+//!     yet been re-published; the reader trusts the head anyway (it is
+//!     node-signed), so the next publish signs with that key. That is the
+//!     window C2 closes.
+//!
+//! See the PR body for the full C2 contract.
+//!
+//! ## What this is NOT
+//!
+//! Not the federated `DidOp` witness chain (C1 #1167 / C5 #1171). The head is
+//! a **node-attested projection** for cross-process readers on ONE node,
+//! signed by a purpose-key derived from the node's CA root. It deliberately
+//! does not encode rotation-key custody (epic #1158 Q2 / one-way door #4), so
+//! it does not touch that one-way door. The projection carries its own
+//! `version` so it can evolve independently of the DidOp format C1 finalizes.
+
+use anyhow::{anyhow, Context as _, Result};
+use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine as _};
+use ed25519_dalek::{Signature, Signer, SigningKey as Ed25519SigningKey, Verifier};
+use p256::ecdsa::{SigningKey as Es256SigningKey, VerifyingKey as Es256VerifyingKey};
+use serde::{Deserialize, Serialize};
+use sha2::{Digest as _, Sha256};
+use std::path::{Path, PathBuf};
+
+use super::jwt::es256_kid;
+use super::key_rotation::Es256SigningKeyStore;
+
+/// Purpose label for the Ed25519 key that signs the sealed head. Derived from
+/// the node's CA root, so every process that can load the root can verify.
+pub const HEAD_SIGNING_PURPOSE: &str = "hyprstream-oplog-head-v1";
+
+/// Derive the head-signing key from the node root. Deterministic, so the
+/// rotator (signs) and any cross-process reader (verifies) compute the same
+/// keypair without key distribution. The CA derivation step keeps this key
+/// distinct from the JWT CA key itself.
+pub fn head_signing_key_from_root(root: &Ed25519SigningKey) -> Ed25519SigningKey {
+    let ca = hyprstream_rpc::node_identity::derive_purpose_key(root, "hyprstream-jwt-v1");
+    hyprstream_rpc::node_identity::derive_purpose_key(&ca, HEAD_SIGNING_PURPOSE)
+}
+
+/// Projection format version. Versions THIS PROJECTION only — NOT the DidOp
+/// format (C1 #1167 owns that, gated on epic #1158 Q2 / one-way door #4).
+pub const PROJECTION_VERSION: u16 = 1;
+
+/// Filename of the sealed head inside the shared secrets dir.
+pub const SEALED_HEAD_FILENAME: &str = "atproto-oplog-head.json";
+
+/// Path of the sealed head inside a secrets dir.
+pub fn sealed_head_path(secrets_dir: &Path) -> PathBuf {
+    secrets_dir.join(SEALED_HEAD_FILENAME)
+}
+
+/// The on-disk sealed head: an authenticated, ordered projection of "which
+/// `#atproto` ES256 generation is active right now."
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct SealedOpLogHead {
+    pub version: u16,
+    /// Monotonic generation counter; strictly advances. Readers reject a
+    /// regression so a stale head file can never shadow a newer one.
+    pub seq: u64,
+    /// `kid` of the active `#atproto` ES256 key.
+    pub active_kid: String,
+    /// Active P-256 verifying key, SEC1 compressed, base64url (33 raw bytes).
+    pub active_vk_sec1: String,
+    /// Repo head CID re-signed by the active key (`head_at_op` in plan §3.1).
+    /// `None` until the first publish after this promotion. Forward-looking:
+    /// C3 (#1169) consumes this for historical key validity.
+    pub head_at_op: Option<String>,
+    /// `sha256` of the canonical payload of the previous head (`None` at
+    /// genesis). Forward-looking: C3 walks this chain. C4's reader checks the
+    /// node signature + `seq` monotonicity, not the full chain.
+    pub prev: Option<[u8; 32]>,
+    /// Ed25519 signature by [`head_signing_key_from_root`] over
+    /// [`SealedOpLogHead::signing_payload`].
+    pub sig: Vec<u8>,
+}
+
+impl SealedOpLogHead {
+    /// The bytes the head signature covers: canonical JSON of every field
+    /// except `sig`. Field declaration order is stable, so `serde_json` output
+    /// is deterministic across builds.
+    pub fn signing_payload(&self) -> Result<Vec<u8>> {
+        #[derive(Serialize)]
+        struct Payload<'a> {
+            version: u16,
+            seq: u64,
+            active_kid: &'a str,
+            active_vk_sec1: &'a str,
+            head_at_op: &'a Option<String>,
+            prev: &'a Option<[u8; 32]>,
+        }
+        serde_json::to_vec(&Payload {
+            version: self.version,
+            seq: self.seq,
+            active_kid: &self.active_kid,
+            active_vk_sec1: &self.active_vk_sec1,
+            head_at_op: &self.head_at_op,
+            prev: &self.prev,
+        })
+        .context("serializing sealed-head payload")
+    }
+
+    /// Verify the node signature and return the active P-256 verifying key.
+    pub fn verify(&self, head_vk: &ed25519_dalek::VerifyingKey) -> Result<Es256VerifyingKey> {
+        let sig =
+            Signature::from_slice(&self.sig).context("sealed head signature is malformed")?;
+        head_vk
+            .verify(&self.signing_payload()?, &sig)
+            .context("sealed head signature does not verify under the node head key")?;
+        if self.version != PROJECTION_VERSION {
+            return Err(anyhow!(
+                "sealed head projection version {}: reader supports {}",
+                self.version,
+                PROJECTION_VERSION
+            ));
+        }
+        let vk_bytes = URL_SAFE_NO_PAD
+            .decode(&self.active_vk_sec1)
+            .context("active_vk_sec1 is not valid base64url")?;
+        Es256VerifyingKey::from_sec1_bytes(&vk_bytes)
+            .map_err(|e| anyhow!("invalid active_vk_sec1 in sealed head: {e}"))
+    }
+}
+
+/// The active `#atproto` generation, as resolved by a reader. Carries the
+/// signing key (the publisher signs commits with it) and the verifying key.
+/// The signing key is resolved **by kid** from the shared secrets dir — the
+/// sealed head AUTHENTICATES which kid is active, so a stale in-memory slot
+/// cannot present a retired key as live.
+#[derive(Clone, Debug)]
+pub struct ActiveGeneration {
+    pub seq: u64,
+    pub kid: String,
+    pub verifying_key: Es256VerifyingKey,
+    pub signing_key: Es256SigningKey,
+    /// `None` until C3 (#1169) records the re-signed repo head.
+    pub head_at_op: Option<String>,
+}
+
+/// Source of truth for the active `#atproto` generation.
+///
+/// **Consistency guarantee (stated explicitly).** A reader is NOT guaranteed
+/// to observe a completed rotation instantaneously: the head is rewritten
+/// after the rotation task promotes a slot, so there is a bounded propagation
+/// delay (one rotation tick plus filesystem visibility). The fail-closed
+/// contract that makes "eventual" safe:
+///
+///   * the reader verifies the head's node signature and rejects a `seq`
+///     regression, so it can never accept a forged or rolled-back head;
+///   * the reader resolves the signing key **by kid** from the shared secrets
+///     dir — a kid absent from the projection is never loaded, so a retired
+///     key is never presented as active;
+///   * if the head is absent, corrupt, or unsigned-by-this-node, the reader
+///     returns `Ok(None)` and the publisher **declines to sign** rather than
+///     fall back to an untrusted local slot.
+///
+/// The worst observable case is a brief window in which the reader still
+/// presents the *previous* generation (which remains valid as drain) until
+/// the new head becomes visible — never a retired key presented as active.
+pub trait ActiveGenerationSource: Send + Sync {
+    /// The active generation, or `Ok(None)` when no sealed generation is
+    /// observable yet. `Err` is fail-closed: a corrupt/stale/unverifiable
+    /// head that a reader must not trust.
+    fn active_generation(&self) -> Result<Option<ActiveGeneration>>;
+}
+
+/// A single immutable generation — used to preserve the old
+/// `PdsPublisher::new(store, did, signing_key)` call sites (tests, simple
+/// embedders) behind the source abstraction.
+pub struct FixedGenerationSource {
+    kid: String,
+    signing_key: Es256SigningKey,
+}
+
+impl FixedGenerationSource {
+    pub fn new(signing_key: Es256SigningKey) -> Self {
+        let kid = es256_kid(&signing_key);
+        Self { kid, signing_key }
+    }
+}
+
+impl ActiveGenerationSource for FixedGenerationSource {
+    fn active_generation(&self) -> Result<Option<ActiveGeneration>> {
+        Ok(Some(ActiveGeneration {
+            seq: 0,
+            kid: self.kid.clone(),
+            verifying_key: *self.signing_key.verifying_key(),
+            signing_key: self.signing_key.clone(),
+            head_at_op: None,
+        }))
+    }
+}
+
+/// Cross-process reader: reads the sealed op-log head, verifies the node
+/// signature, and resolves the signing key by kid from the shared secrets
+/// dir. This is the source that closes #1123 — the registry process observes
+/// OAuth's rotations through the head file, not an in-memory `OnceLock`.
+pub struct SealedHeadEs256Source {
+    head_path: PathBuf,
+    head_verifying_key: ed25519_dalek::VerifyingKey,
+    secrets_dir: PathBuf,
+}
+
+impl SealedHeadEs256Source {
+    /// Construct from the node root: derives the head verifying key so the
+    /// reader and the rotator agree without key distribution.
+    pub fn from_root(secrets_dir: &Path, node_root: &Ed25519SigningKey) -> Self {
+        Self {
+            head_path: sealed_head_path(secrets_dir),
+            head_verifying_key: head_signing_key_from_root(node_root).verifying_key(),
+            secrets_dir: secrets_dir.to_path_buf(),
+        }
+    }
+
+    /// Construct from a known head verifying key (tests).
+    pub fn with_head_verifying_key(
+        secrets_dir: &Path,
+        head_verifying_key: ed25519_dalek::VerifyingKey,
+    ) -> Self {
+        Self {
+            head_path: sealed_head_path(secrets_dir),
+            head_verifying_key,
+            secrets_dir: secrets_dir.to_path_buf(),
+        }
+    }
+
+    /// Read and verify the head without resolving signing material.
+    fn read_head(&self) -> Result<Option<SealedOpLogHead>> {
+        let bytes = match std::fs::read(&self.head_path) {
+            Ok(b) => b,
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+            Err(e) => return Err(e).context("reading sealed op-log head"),
+        };
+        let head: SealedOpLogHead =
+            serde_json::from_slice(&bytes).context("sealed op-log head is corrupt")?;
+        head.verify(&self.head_verifying_key)?;
+        Ok(Some(head))
+    }
+}
+
+impl ActiveGenerationSource for SealedHeadEs256Source {
+    fn active_generation(&self) -> Result<Option<ActiveGeneration>> {
+        let head = match self.read_head()? {
+            Some(h) => h,
+            None => return Ok(None),
+        };
+        // Resolve the signing key BY KID from the shared secrets dir. The head
+        // authenticates *which* kid is active; the secrets dir provides the
+        // material. A kid missing from the projection is never loaded, so a
+        // retired key cannot be presented as the active generation.
+        let signing_key = super::key_rotation::es256_signing_key_for_kid(
+            &self.secrets_dir,
+            &head.active_kid,
+        )
+        .ok_or_else(|| {
+            anyhow!(
+                "sealed head names active kid {} but its signing key is not \
+                 materialized in the secrets dir",
+                head.active_kid
+            )
+        })?;
+        Ok(Some(ActiveGeneration {
+            seq: head.seq,
+            kid: head.active_kid,
+            verifying_key: *signing_key.verifying_key(),
+            signing_key,
+            head_at_op: head.head_at_op,
+        }))
+    }
+}
+
+/// Write the sealed op-log head after a promotion (or at boot). This is the
+/// **C2 (#1168) seam**: the write is rename-atomic at the file level, but the
+/// full crash-atomic rotation ordering (re-sign repo head → write head → seal
+/// DidOp → publish) is C2's guarantee — see the module docs.
+///
+/// `composite_ca_key` is the node's CA Ed25519 key (the same one
+/// [`super::key_rotation::RotationStores`] carries); the head is signed by a
+/// dedicated purpose-key derived from it.
+pub fn seal_op_log_head(
+    secrets_dir: &Path,
+    composite_ca_key: &Ed25519SigningKey,
+    es256_store: &Es256SigningKeyStore,
+) -> Result<()> {
+    let active = es256_store
+        .0
+        .blocking_read()
+        .active
+        .clone()
+        .ok_or_else(|| anyhow!("cannot seal op-log head: ES256 store has no active slot"))?;
+    let signing_key = (*active.key).clone();
+    let verifying_key = signing_key.verifying_key();
+    let kid = active.kid();
+    let vk_sec1 = URL_SAFE_NO_PAD.encode(verifying_key.to_sec1_bytes());
+
+    // Carry forward the chain + monotonic seq from the prior head so a reader
+    // can reject a regression. The prior head's signature was already verified
+    // when it was written; we re-verify on read, not on carry-forward.
+    let (seq, prev) = match std::fs::read(sealed_head_path(secrets_dir)) {
+        Ok(prior_bytes) => match serde_json::from_slice::<SealedOpLogHead>(&prior_bytes) {
+            Ok(prior) => {
+                let prev_hash = sha256_fixed(&prior.signing_payload()?);
+                (prior.seq.saturating_add(1), Some(prev_hash))
+            }
+            // A corrupt prior head: do not carry forward a junk chain; start
+            // fresh. The new head is node-signed, so a reader still verifies.
+            Err(_) => (1, None),
+        },
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => (1, None),
+        Err(e) => return Err(e).context("reading prior sealed op-log head"),
+    };
+
+    let mut head = SealedOpLogHead {
+        version: PROJECTION_VERSION,
+        seq,
+        active_kid: kid,
+        active_vk_sec1: vk_sec1,
+        // head_at_op is recorded when the repo head is re-signed (C2's full
+        // sequence). C4's projection carries forward the prior value.
+        head_at_op: None,
+        prev,
+        sig: Vec::new(),
+    };
+    head.head_at_op = prior_head_at_op(secrets_dir);
+
+    let head_sk = hyprstream_rpc::node_identity::derive_purpose_key(
+        composite_ca_key,
+        HEAD_SIGNING_PURPOSE,
+    );
+    let sig = head_sk.sign(&head.signing_payload()?);
+    head.sig = sig.to_bytes().to_vec();
+
+    super::identity_store::write_secret(
+        secrets_dir,
+        SEALED_HEAD_FILENAME,
+        &serde_json::to_vec(&head)?,
+    )?;
+    Ok(())
+}
+
+fn prior_head_at_op(secrets_dir: &Path) -> Option<String> {
+    let bytes = std::fs::read(sealed_head_path(secrets_dir)).ok()?;
+    serde_json::from_slice::<SealedOpLogHead>(&bytes)
+        .ok()
+        .and_then(|h| h.head_at_op)
+}
+
+fn sha256_fixed(bytes: &[u8]) -> [u8; 32] {
+    let mut h = Sha256::new();
+    h.update(bytes);
+    h.finalize().into()
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    fn ca_key() -> Ed25519SigningKey {
+        Ed25519SigningKey::from_bytes(&[0x5a; 32])
+    }
+
+    /// The CA key — what `seal_op_log_head` receives in production (the
+    /// rotation task's `composite_ca_key`). The reader derives the matching
+    /// head verifying key from the root via [`head_signing_key_from_root`].
+    fn derived_ca() -> Ed25519SigningKey {
+        hyprstream_rpc::node_identity::derive_purpose_key(&ca_key(), "hyprstream-jwt-v1")
+    }
+
+    #[test]
+    fn sealed_head_round_trips_and_verifies() {
+        let dir = TempDir::new().unwrap();
+        let sk = Es256SigningKey::random(&mut rand::rngs::OsRng);
+        let store = Es256SigningKeyStore::new(super::super::key_rotation::Es256KeySlots {
+            active: Some(super::super::key_rotation::Es256KeySlot::new(sk, 0, 0)),
+            drain: None,
+            lead: None,
+        });
+        seal_op_log_head(dir.path(), &derived_ca(), &store).unwrap();
+
+        let head: SealedOpLogHead =
+            serde_json::from_slice(&std::fs::read(sealed_head_path(dir.path())).unwrap()).unwrap();
+        let head_vk = head_signing_key_from_root(&ca_key()).verifying_key();
+        assert_eq!(head.seq, 1);
+        assert!(head.verify(&head_vk).is_ok());
+        assert!(!head.sig.is_empty());
+    }
+
+    #[test]
+    fn reader_fails_closed_on_tampered_head() {
+        let dir = TempDir::new().unwrap();
+        let sk = Es256SigningKey::random(&mut rand::rngs::OsRng);
+        let store = Es256SigningKeyStore::new(super::super::key_rotation::Es256KeySlots {
+            active: Some(super::super::key_rotation::Es256KeySlot::new(sk, 0, 0)),
+            drain: None,
+            lead: None,
+        });
+        seal_op_log_head(dir.path(), &derived_ca(), &store).unwrap();
+
+        // Tamper with the on-disk head: flip a byte in the signature.
+        let path = sealed_head_path(dir.path());
+        let mut head: SealedOpLogHead =
+            serde_json::from_slice(&std::fs::read(&path).unwrap()).unwrap();
+        head.sig[0] ^= 0xff;
+        std::fs::write(&path, serde_json::to_vec(&head).unwrap()).unwrap();
+
+        let source = SealedHeadEs256Source::from_root(dir.path(), &ca_key());
+        let err = source.active_generation().unwrap_err();
+        assert!(
+            err.to_string().contains("signature"),
+            "tampered head must fail closed on signature: {err}"
+        );
+    }
+
+    #[test]
+    fn reader_returns_none_when_head_absent() {
+        let dir = TempDir::new().unwrap();
+        let source = SealedHeadEs256Source::from_root(dir.path(), &ca_key());
+        assert!(source.active_generation().unwrap().is_none());
+    }
+
+    /// The #1123/#1170 acceptance test. Two "processes" share a secrets dir
+    /// (the `--ipc` topology): process A is the rotator (holds the in-memory
+    /// store, persists slots, seals the head); process B is the cross-process
+    /// reader (reads the head + slot files only — no shared OnceLock, no
+    /// event-delivery). B must observe A's rotation, and once it does it MUST
+    /// NOT present the retired pre-rotation key.
+    #[test]
+    fn cross_process_rotation_observed_via_sealed_head() {
+        use super::super::key_rotation::{
+            persist_es256_slot, Es256KeySlot, Es256KeySlots, Es256SigningKeyStore,
+        };
+        let dir = TempDir::new().unwrap();
+        let secrets = dir.path();
+        let root = Ed25519SigningKey::from_bytes(&[0x5a; 32]);
+        super::super::identity_store::write_ca_signing_key(secrets, &root).unwrap();
+        // `seal_op_log_head` signs with a purpose key derived from the CA key
+        // (the same key the rotation task carries as `composite_ca_key`); the
+        // reader derives the matching verifying key from the root.
+        let ca = hyprstream_rpc::node_identity::derive_purpose_key(&root, "hyprstream-jwt-v1");
+
+        // ── Process A: active K1, persisted + head sealed ──────────────────
+        let k1 = Es256SigningKey::random(&mut rand::rngs::OsRng);
+        let k1_vk = *k1.verifying_key();
+        let k1_slot = Es256KeySlot::new(k1.clone(), 0, 0);
+        let store = Es256SigningKeyStore::new(Es256KeySlots {
+            active: Some(k1_slot.clone()),
+            drain: None,
+            lead: None,
+        });
+        persist_es256_slot(secrets, "active", &k1_slot).unwrap();
+        seal_op_log_head(secrets, &ca, &store).unwrap();
+
+        // ── Process B: reads the sealed head ONLY ──────────────────────────
+        let source = SealedHeadEs256Source::from_root(secrets, &root);
+        let gen_b = source
+            .active_generation()
+            .unwrap()
+            .expect("process B observes the initial generation K1");
+        assert_eq!(gen_b.verifying_key, k1_vk);
+        assert_eq!(gen_b.seq, 1);
+
+        // ── Process A rotates: K1 → drain, K2 → active ────────────────────
+        let k2 = Es256SigningKey::random(&mut rand::rngs::OsRng);
+        let k2_vk = *k2.verifying_key();
+        persist_es256_slot(secrets, "drain", &k1_slot).unwrap();
+        let k2_slot = Es256KeySlot::new(k2.clone(), 0, 0);
+        persist_es256_slot(secrets, "active", &k2_slot).unwrap();
+        store.0.blocking_write().drain = Some(k1_slot);
+        store.0.blocking_write().active = Some(k2_slot);
+        seal_op_log_head(secrets, &ca, &store).unwrap();
+
+        // ── Process B observes the rotation via a fresh head read ──────────
+        let gen_b2 = source
+            .active_generation()
+            .unwrap()
+            .expect("process B observes the rotated generation K2");
+        assert_eq!(
+            gen_b2.verifying_key,
+            k2_vk,
+            "B must observe the rotated key K2 — no propagation mechanism"
+        );
+        assert_eq!(gen_b2.seq, 2);
+
+        // ── Negative case: once K2 is visible, B MUST NOT present K1 ───────
+        assert_ne!(
+            gen_b2.verifying_key, k1_vk,
+            "a retired key must never be presented as the active generation"
+        );
+        assert_ne!(gen_b2.kid, gen_b.kid);
+    }
+}

--- a/crates/hyprstream/src/auth/op_log.rs
+++ b/crates/hyprstream/src/auth/op_log.rs
@@ -1,80 +1,149 @@
 //! C4 (#1170): the sealed op-log head — cross-process source of truth for the
 //! active `#atproto` ES256 generation. **Closes #1123.**
 //!
-//! Plan t1124 §3.4: under `--ipc`, discovery/registry/oauth must agree on the
-//! active generation with **no event-delivery mechanism**. They do it by
-//! reading ONE sealed head written by the rotation task: the rotator (OAuth)
-//! writes it after every promotion, every reader (the registry's
-//! [`crate::services::discovery::PdsPublisher`] and, later, any other
-//! cross-process consumer) reads it at use time. The process-local
-//! `OnceLock`/`Es256SigningKeyStore` stays the rotator's own working state;
-//! it is no longer the source of truth for *other* processes.
+//! Plan t1124 §3.4: under `--ipc`, discovery/registry/oauth agree on the active
+//! generation with **no event-delivery mechanism** — every process reads ONE
+//! sealed head that the rotator (OAuth) writes after each promotion. The
+//! process-local `OnceLock` stays the rotator's own working state; it is no
+//! longer the source of truth for *other* processes.
+//!
+//! ## Credentials (split, least-privilege)
+//!
+//! The head is signed by a **dedicated** Ed25519 keypair — NOT a key derived
+//! from the CA root. The private key (`oplog-head-key`) is a secret held only
+//! by the rotator; the public verifying key (`atproto-oplog-head-pubkey`) is
+//! published to the shared state dir and loaded by readers. A process that can
+//! *verify* a head therefore **cannot forge** one (F3). Readers never touch
+//! `ca-key` (which is PolicyService-only under systemd IPC).
+//!
+//! ## Head state directory (F4)
+//!
+//! The head is a signed, public artifact — it carries no secrecy, so it does
+//! NOT live in the read-only per-unit credentials directory. It lives in a
+//! dedicated **shared writable state dir** ([`resolve_oplog_state_dir`]),
+//! env-overridable so a systemd `--ipc` deployment can point it at a shared
+//! `StateDirectory=`. Where that shared storage is provisioned is deployment
+//! plumbing (#808); this module takes the path, never assumes `secrets_dir`.
+//!
+//! ## Consistency guarantee (implemented)
+//!
+//! A reader is NOT guaranteed to observe a rotation instantaneously (bounded
+//! by one rotation tick + filesystem visibility). The fail-closed contract:
+//! the reader verifies the head's node signature, **rejects a `seq`
+//! regression** against the highest generation it has already observed
+//! ([`SealedHeadEs256Source`] holds a monotonic `AtomicU64`), and resolves
+//! the signing key **by kid** from the key-material store. A retired key is
+//! never presented as active; a replayed older-but-valid head is rejected.
 //!
 //! ## Dependency honesty — C2 (#1168) is not built
 //!
-//! C4 formally depends on C2 (crash-atomic rotation). This module ships the
-//! **read path** (real, signature-verified, fail-closed) plus the head
-//! **format** and a [`seal_op_log_head`] **seam-write**. What C2 must
-//! guarantee for this to be fully sound, and what C4 does *not* claim today:
-//!
-//!   * [`seal_op_log_head`] writes the head with an atomic rename — real
-//!     file-level crash atomicity (a crash leaves either the old or the new
-//!     head, never a torn one).
-//!   * C2 replaces the promote-then-write sequence with the full rotation
-//!     ordering — *re-sign repo head → durably write head → seal DidOp →
-//!     publish DID doc* — as one crash-atomic unit, so no crash can leave a
-//!     head naming a key whose repo head was not durably re-signed. Until C2
-//!     lands, a crash inside the rotation task's promote→write window can
-//!     leave the head pointing at a freshly promoted key whose commit has not
-//!     yet been re-published; the reader trusts the head anyway (it is
-//!     node-signed), so the next publish signs with that key. That is the
-//!     window C2 closes.
-//!
-//! See the PR body for the full C2 contract.
-//!
-//! ## What this is NOT
-//!
-//! Not the federated `DidOp` witness chain (C1 #1167 / C5 #1171). The head is
-//! a **node-attested projection** for cross-process readers on ONE node,
-//! signed by a purpose-key derived from the node's CA root. It deliberately
-//! does not encode rotation-key custody (epic #1158 Q2 / one-way door #4), so
-//! it does not touch that one-way door. The projection carries its own
-//! `version` so it can evolve independently of the DidOp format C1 finalizes.
+//! [`seal_op_log_head`] is rename-atomic at the file level. C2 must harden
+//! the full rotation ordering — *re-sign repo head → durably write head →
+//! seal DidOp → publish* — as one crash-atomic unit, so no crash leaves a
+//! head naming a key whose repo head was not durably re-signed. Full
+//! crash-injection at every boundary is C2's job; the writer verifies every
+//! prior head before carrying its `seq`/`prev` forward (F5). This is NOT the
+//! DidOp format (C1 #1167) and does not encode rotation-key custody (epic
+//! #1158 Q2 / one-way door #4); the projection carries its own `version`.
 
 use anyhow::{anyhow, Context as _, Result};
 use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine as _};
-use ed25519_dalek::{Signature, Signer, SigningKey as Ed25519SigningKey, Verifier};
+use ed25519_dalek::{
+    Signature, Signer, SigningKey as Ed25519SigningKey, Verifier, VerifyingKey as Ed25519VerifyingKey,
+};
 use p256::ecdsa::{SigningKey as Es256SigningKey, VerifyingKey as Es256VerifyingKey};
 use serde::{Deserialize, Serialize};
 use sha2::{Digest as _, Sha256};
 use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicU64, Ordering};
 
 use super::jwt::es256_kid;
 use super::key_rotation::Es256SigningKeyStore;
 
-/// Purpose label for the Ed25519 key that signs the sealed head. Derived from
-/// the node's CA root, so every process that can load the root can verify.
-pub const HEAD_SIGNING_PURPOSE: &str = "hyprstream-oplog-head-v1";
-
-/// Derive the head-signing key from the node root. Deterministic, so the
-/// rotator (signs) and any cross-process reader (verifies) compute the same
-/// keypair without key distribution. The CA derivation step keeps this key
-/// distinct from the JWT CA key itself.
-pub fn head_signing_key_from_root(root: &Ed25519SigningKey) -> Ed25519SigningKey {
-    let ca = hyprstream_rpc::node_identity::derive_purpose_key(root, "hyprstream-jwt-v1");
-    hyprstream_rpc::node_identity::derive_purpose_key(&ca, HEAD_SIGNING_PURPOSE)
-}
-
-/// Projection format version. Versions THIS PROJECTION only — NOT the DidOp
-/// format (C1 #1167 owns that, gated on epic #1158 Q2 / one-way door #4).
+/// Projection format version (NOT the DidOp format — C1 #1167 owns that).
 pub const PROJECTION_VERSION: u16 = 1;
 
-/// Filename of the sealed head inside the shared secrets dir.
+/// Secret seed for the head-signing Ed25519 key (rotator only).
+pub const HEAD_SIGNING_KEY_NAME: &str = "oplog-head-key";
+/// Public verifying key for the head signature (all readers).
+pub const HEAD_VERIFYING_KEY_FILENAME: &str = "atproto-oplog-head-pubkey";
+/// The sealed head file.
 pub const SEALED_HEAD_FILENAME: &str = "atproto-oplog-head.json";
+/// Env override for the shared head state dir (#808 systemd seam).
+pub const OPLOG_STATE_DIR_ENV: &str = "HYPRSTREAM_OPLOG_STATE_DIR";
 
-/// Path of the sealed head inside a secrets dir.
-pub fn sealed_head_path(secrets_dir: &Path) -> PathBuf {
-    secrets_dir.join(SEALED_HEAD_FILENAME)
+/// Resolve the shared, writable head state dir.
+///
+/// Default: a dedicated `oplog-state/` sibling of the secrets dir (shared and
+/// writable in the single-process daemon). A systemd `--ipc` deployment sets
+/// `HYPRSTREAM_OPLOG_STATE_DIR` to a shared `StateDirectory=` path —
+/// provisioning that shared storage is #808.
+pub fn resolve_oplog_state_dir(secrets_dir: &Path) -> Result<PathBuf> {
+    if let Some(from_env) = std::env::var_os(OPLOG_STATE_DIR_ENV) {
+        let path = PathBuf::from(from_env);
+        std::fs::create_dir_all(&path)
+            .with_context(|| format!("creating oplog state dir {}", path.display()))?;
+        return Ok(path);
+    }
+    let parent = secrets_dir
+        .parent()
+        .ok_or_else(|| anyhow!("secrets dir has no parent for oplog state"))?;
+    let path = parent.join("oplog-state");
+    std::fs::create_dir_all(&path)
+        .with_context(|| format!("creating oplog state dir {}", path.display()))?;
+    Ok(path)
+}
+
+/// Load or initialize the dedicated head-signing Ed25519 key (rotator only).
+pub fn load_or_init_head_signing_key(secrets_dir: &Path) -> Result<Ed25519SigningKey> {
+    if let Some(bytes) = super::identity_store::read_secret(secrets_dir, HEAD_SIGNING_KEY_NAME)? {
+        let mut seed = [0u8; 32];
+        let v: Vec<u8> = bytes;
+        seed.copy_from_slice(&v);
+        return Ok(Ed25519SigningKey::from_bytes(&seed));
+    }
+    let key = Ed25519SigningKey::generate(&mut rand::rngs::OsRng);
+    super::identity_store::write_secret(secrets_dir, HEAD_SIGNING_KEY_NAME, &key.to_bytes())?;
+    Ok(key)
+}
+
+/// Publish the head-signing *verifying* key to the shared state dir (public).
+pub fn publish_head_verifying_key(state_dir: &Path, head_sk: &Ed25519SigningKey) -> Result<()> {
+    let vk = head_sk.verifying_key();
+    atomic_write_public(&state_dir.join(HEAD_VERIFYING_KEY_FILENAME), &vk.to_bytes())
+}
+
+/// Atomic (rename) write with world-readable perms (0644). The head and its
+/// verifying key are signed/public artifacts shared across services, which may
+/// run as distinct users under systemd `--ipc` — so unlike secrets (0600)
+/// they must be readable by every reader process.
+fn atomic_write_public(path: &Path, bytes: &[u8]) -> Result<()> {
+    use std::io::Write as _;
+    let dir = path
+        .parent()
+        .ok_or_else(|| anyhow!("head path has no parent directory"))?;
+    let mut tmp = tempfile::NamedTempFile::new_in(dir)
+        .with_context(|| format!("creating temp file in {}", dir.display()))?;
+    tmp.write_all(bytes)?;
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        std::fs::set_permissions(tmp.path(), std::fs::Permissions::from_mode(0o644))?;
+    }
+    tmp.persist(path)
+        .with_context(|| format!("persisting {}", path.display()))?;
+    Ok(())
+}
+
+/// Load the head-signing verifying key from the shared state dir (readers).
+pub fn load_head_verifying_key(state_dir: &Path) -> Result<Ed25519VerifyingKey> {
+    let bytes = std::fs::read(state_dir.join(HEAD_VERIFYING_KEY_FILENAME))
+        .context("head verifying key is not published (rotator has not run)")?;
+    let arr: [u8; 32] = bytes
+        .as_slice()
+        .try_into()
+        .map_err(|_| anyhow!("head verifying key must be 32 bytes"))?;
+    Ed25519VerifyingKey::from_bytes(&arr).map_err(|e| anyhow!("invalid head verifying key: {e}"))
 }
 
 /// The on-disk sealed head: an authenticated, ordered projection of "which
@@ -82,30 +151,22 @@ pub fn sealed_head_path(secrets_dir: &Path) -> PathBuf {
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct SealedOpLogHead {
     pub version: u16,
-    /// Monotonic generation counter; strictly advances. Readers reject a
-    /// regression so a stale head file can never shadow a newer one.
+    /// Monotonic generation; strictly advances. Readers reject a regression.
     pub seq: u64,
-    /// `kid` of the active `#atproto` ES256 key.
     pub active_kid: String,
     /// Active P-256 verifying key, SEC1 compressed, base64url (33 raw bytes).
     pub active_vk_sec1: String,
-    /// Repo head CID re-signed by the active key (`head_at_op` in plan §3.1).
-    /// `None` until the first publish after this promotion. Forward-looking:
-    /// C3 (#1169) consumes this for historical key validity.
+    /// Repo head CID re-signed by the active key. `None` until C3 (#1169).
     pub head_at_op: Option<String>,
-    /// `sha256` of the canonical payload of the previous head (`None` at
-    /// genesis). Forward-looking: C3 walks this chain. C4's reader checks the
-    /// node signature + `seq` monotonicity, not the full chain.
+    /// sha256 of the canonical payload of the previous *verified* head.
     pub prev: Option<[u8; 32]>,
-    /// Ed25519 signature by [`head_signing_key_from_root`] over
-    /// [`SealedOpLogHead::signing_payload`].
+    /// Ed25519 signature by the head-signing key over [`Self::signing_payload`].
     pub sig: Vec<u8>,
 }
 
 impl SealedOpLogHead {
-    /// The bytes the head signature covers: canonical JSON of every field
-    /// except `sig`. Field declaration order is stable, so `serde_json` output
-    /// is deterministic across builds.
+    /// Bytes the signature covers (every field except `sig`). Field order is
+    /// stable, so `serde_json` output is deterministic.
     pub fn signing_payload(&self) -> Result<Vec<u8>> {
         #[derive(Serialize)]
         struct Payload<'a> {
@@ -127,13 +188,13 @@ impl SealedOpLogHead {
         .context("serializing sealed-head payload")
     }
 
-    /// Verify the node signature and return the active P-256 verifying key.
-    pub fn verify(&self, head_vk: &ed25519_dalek::VerifyingKey) -> Result<Es256VerifyingKey> {
+    /// Verify the head signature under `head_vk` and return the active vk.
+    pub fn verify(&self, head_vk: &Ed25519VerifyingKey) -> Result<Es256VerifyingKey> {
         let sig =
             Signature::from_slice(&self.sig).context("sealed head signature is malformed")?;
         head_vk
             .verify(&self.signing_payload()?, &sig)
-            .context("sealed head signature does not verify under the node head key")?;
+            .context("sealed head signature does not verify under the head verifying key")?;
         if self.version != PROJECTION_VERSION {
             return Err(anyhow!(
                 "sealed head projection version {}: reader supports {}",
@@ -149,51 +210,25 @@ impl SealedOpLogHead {
     }
 }
 
-/// The active `#atproto` generation, as resolved by a reader. Carries the
-/// signing key (the publisher signs commits with it) and the verifying key.
-/// The signing key is resolved **by kid** from the shared secrets dir — the
-/// sealed head AUTHENTICATES which kid is active, so a stale in-memory slot
-/// cannot present a retired key as live.
+/// The active `#atproto` generation, as resolved by a reader.
 #[derive(Clone, Debug)]
 pub struct ActiveGeneration {
     pub seq: u64,
     pub kid: String,
     pub verifying_key: Es256VerifyingKey,
     pub signing_key: Es256SigningKey,
-    /// `None` until C3 (#1169) records the re-signed repo head.
     pub head_at_op: Option<String>,
 }
 
 /// Source of truth for the active `#atproto` generation.
-///
-/// **Consistency guarantee (stated explicitly).** A reader is NOT guaranteed
-/// to observe a completed rotation instantaneously: the head is rewritten
-/// after the rotation task promotes a slot, so there is a bounded propagation
-/// delay (one rotation tick plus filesystem visibility). The fail-closed
-/// contract that makes "eventual" safe:
-///
-///   * the reader verifies the head's node signature and rejects a `seq`
-///     regression, so it can never accept a forged or rolled-back head;
-///   * the reader resolves the signing key **by kid** from the shared secrets
-///     dir — a kid absent from the projection is never loaded, so a retired
-///     key is never presented as active;
-///   * if the head is absent, corrupt, or unsigned-by-this-node, the reader
-///     returns `Ok(None)` and the publisher **declines to sign** rather than
-///     fall back to an untrusted local slot.
-///
-/// The worst observable case is a brief window in which the reader still
-/// presents the *previous* generation (which remains valid as drain) until
-/// the new head becomes visible — never a retired key presented as active.
 pub trait ActiveGenerationSource: Send + Sync {
-    /// The active generation, or `Ok(None)` when no sealed generation is
-    /// observable yet. `Err` is fail-closed: a corrupt/stale/unverifiable
-    /// head that a reader must not trust.
+    /// `Ok(None)` when no sealed generation is observable yet; `Err` is
+    /// fail-closed (corrupt/stale/rolled-back/unverifiable head).
     fn active_generation(&self) -> Result<Option<ActiveGeneration>>;
 }
 
-/// A single immutable generation — used to preserve the old
-/// `PdsPublisher::new(store, did, signing_key)` call sites (tests, simple
-/// embedders) behind the source abstraction.
+/// A single immutable generation — preserves the old `PdsPublisher::new(store,
+/// did, signing_key)` call sites behind the source abstraction.
 pub struct FixedGenerationSource {
     kid: String,
     signing_key: Es256SigningKey,
@@ -202,7 +237,10 @@ pub struct FixedGenerationSource {
 impl FixedGenerationSource {
     pub fn new(signing_key: Es256SigningKey) -> Self {
         let kid = es256_kid(&signing_key);
-        Self { kid, signing_key }
+        Self {
+            kid,
+            signing_key,
+        }
     }
 }
 
@@ -218,74 +256,83 @@ impl ActiveGenerationSource for FixedGenerationSource {
     }
 }
 
-/// Cross-process reader: reads the sealed op-log head, verifies the node
-/// signature, and resolves the signing key by kid from the shared secrets
-/// dir. This is the source that closes #1123 — the registry process observes
-/// OAuth's rotations through the head file, not an in-memory `OnceLock`.
+/// Cross-process reader of the sealed op-log head. Holds NO private key
+/// material — it loads the head-signing *verifying* key from the shared state
+/// dir, so a process that can verify a head cannot forge one (F3). It tracks
+/// the highest `seq` it has accepted and rejects any regression (F2).
 pub struct SealedHeadEs256Source {
-    head_path: PathBuf,
-    head_verifying_key: ed25519_dalek::VerifyingKey,
-    secrets_dir: PathBuf,
+    state_dir: PathBuf,
+    key_material_dir: PathBuf,
+    /// Highest `seq` ever accepted by this reader. A head with `seq <= max` is
+    /// rejected as a rollback. `0` means "no generation observed yet".
+    max_seq: AtomicU64,
 }
 
 impl SealedHeadEs256Source {
-    /// Construct from the node root: derives the head verifying key so the
-    /// reader and the rotator agree without key distribution.
-    pub fn from_root(secrets_dir: &Path, node_root: &Ed25519SigningKey) -> Self {
+    /// Construct from the shared head state dir + the ES256 key-material dir.
+    /// Holds no credentials; the verifying key is loaded from the state dir at
+    /// read time.
+    pub fn new(state_dir: &Path, key_material_dir: &Path) -> Self {
         Self {
-            head_path: sealed_head_path(secrets_dir),
-            head_verifying_key: head_signing_key_from_root(node_root).verifying_key(),
-            secrets_dir: secrets_dir.to_path_buf(),
+            state_dir: state_dir.to_path_buf(),
+            key_material_dir: key_material_dir.to_path_buf(),
+            max_seq: AtomicU64::new(0),
         }
     }
 
-    /// Construct from a known head verifying key (tests).
-    pub fn with_head_verifying_key(
-        secrets_dir: &Path,
-        head_verifying_key: ed25519_dalek::VerifyingKey,
-    ) -> Self {
-        Self {
-            head_path: sealed_head_path(secrets_dir),
-            head_verifying_key,
-            secrets_dir: secrets_dir.to_path_buf(),
-        }
+    fn head_path(&self) -> PathBuf {
+        self.state_dir.join(SEALED_HEAD_FILENAME)
     }
 
-    /// Read and verify the head without resolving signing material.
-    fn read_head(&self) -> Result<Option<SealedOpLogHead>> {
-        let bytes = match std::fs::read(&self.head_path) {
+    /// Read + verify the head (no signing-material resolution).
+    fn read_head(&self) -> Result<Option<(SealedOpLogHead, Es256VerifyingKey)>> {
+        let bytes = match std::fs::read(self.head_path()) {
             Ok(b) => b,
             Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(None),
             Err(e) => return Err(e).context("reading sealed op-log head"),
         };
         let head: SealedOpLogHead =
             serde_json::from_slice(&bytes).context("sealed op-log head is corrupt")?;
-        head.verify(&self.head_verifying_key)?;
-        Ok(Some(head))
+        let head_vk = load_head_verifying_key(&self.state_dir)?;
+        let active_vk = head.verify(&head_vk)?;
+        Ok(Some((head, active_vk)))
     }
 }
 
 impl ActiveGenerationSource for SealedHeadEs256Source {
     fn active_generation(&self) -> Result<Option<ActiveGeneration>> {
-        let head = match self.read_head()? {
+        let (head, _active_vk) = match self.read_head()? {
             Some(h) => h,
             None => return Ok(None),
         };
-        // Resolve the signing key BY KID from the shared secrets dir. The head
-        // authenticates *which* kid is active; the secrets dir provides the
-        // material. A kid missing from the projection is never loaded, so a
-        // retired key cannot be presented as the active generation.
+        // F2: reject a rolled-back head. `seq` must strictly advance past the
+        // highest generation this reader has already accepted.
+        let prev_max = self.max_seq.load(Ordering::Acquire);
+        if head.seq <= prev_max {
+            return Err(anyhow!(
+                "sealed head seq {} is not newer than the last accepted {} \
+                 (rollback or replay rejected)",
+                head.seq,
+                prev_max
+            ));
+        }
+        // Resolve the signing key BY KID from the key-material store. The head
+        // authenticates *which* kid is active; a kid it does not name is never
+        // loaded, so a retired key cannot be presented as active.
         let signing_key = super::key_rotation::es256_signing_key_for_kid(
-            &self.secrets_dir,
+            &self.key_material_dir,
             &head.active_kid,
         )
         .ok_or_else(|| {
             anyhow!(
                 "sealed head names active kid {} but its signing key is not \
-                 materialized in the secrets dir",
+                 materialized in the key-material dir",
                 head.active_kid
             )
         })?;
+        // Publish the new high-water mark only after the key resolves, so a
+        // head whose kid is missing does not poison the monotonic anchor.
+        self.max_seq.store(head.seq, Ordering::Release);
         Ok(Some(ActiveGeneration {
             seq: head.seq,
             kid: head.active_kid,
@@ -296,80 +343,91 @@ impl ActiveGenerationSource for SealedHeadEs256Source {
     }
 }
 
-/// Write the sealed op-log head after a promotion (or at boot). This is the
-/// **C2 (#1168) seam**: the write is rename-atomic at the file level, but the
-/// full crash-atomic rotation ordering (re-sign repo head → write head → seal
-/// DidOp → publish) is C2's guarantee — see the module docs.
-///
-/// `composite_ca_key` is the node's CA Ed25519 key (the same one
-/// [`super::key_rotation::RotationStores`] carries); the head is signed by a
-/// dedicated purpose-key derived from it.
-pub fn seal_op_log_head(
+/// Resolve the head state dir + dedicated head key, publish the verifying key,
+/// and seal the current ES256 active generation in one call. This is the
+/// rotator's full "advance the sealed head" step (boot + each rotation tick).
+pub async fn advance_sealed_head(
     secrets_dir: &Path,
-    composite_ca_key: &Ed25519SigningKey,
+    es256_store: &Es256SigningKeyStore,
+) -> Result<()> {
+    let state_dir = resolve_oplog_state_dir(secrets_dir)?;
+    let head_sk = load_or_init_head_signing_key(secrets_dir)?;
+    publish_head_verifying_key(&state_dir, &head_sk)?;
+    seal_op_log_head(&state_dir, &head_sk, es256_store).await
+}
+
+/// Write the sealed op-log head after a promotion (or at boot). **Async** — it
+/// reads the ES256 store via `.read().await` (the store is a tokio RwLock);
+/// the rotator calls it from its async context (F1). This is the **C2 (#1168)
+/// seam**: rename-atomic at the file level; the full crash-atomic rotation
+/// ordering is C2's guarantee (see module docs).
+///
+/// Prior state is carried forward only from a *signature-verified* prior head
+/// (F5): an unverified/tampered prior does not inject `seq`/`prev`.
+pub async fn seal_op_log_head(
+    state_dir: &Path,
+    head_signing_key: &Ed25519SigningKey,
     es256_store: &Es256SigningKeyStore,
 ) -> Result<()> {
     let active = es256_store
         .0
-        .blocking_read()
+        .read()
+        .await
         .active
         .clone()
         .ok_or_else(|| anyhow!("cannot seal op-log head: ES256 store has no active slot"))?;
     let signing_key = (*active.key).clone();
-    let verifying_key = signing_key.verifying_key();
     let kid = active.kid();
-    let vk_sec1 = URL_SAFE_NO_PAD.encode(verifying_key.to_sec1_bytes());
+    let vk_sec1 = URL_SAFE_NO_PAD.encode(signing_key.verifying_key().to_sec1_bytes());
 
-    // Carry forward the chain + monotonic seq from the prior head so a reader
-    // can reject a regression. The prior head's signature was already verified
-    // when it was written; we re-verify on read, not on carry-forward.
-    let (seq, prev) = match std::fs::read(sealed_head_path(secrets_dir)) {
-        Ok(prior_bytes) => match serde_json::from_slice::<SealedOpLogHead>(&prior_bytes) {
-            Ok(prior) => {
-                let prev_hash = sha256_fixed(&prior.signing_payload()?);
-                (prior.seq.saturating_add(1), Some(prev_hash))
-            }
-            // A corrupt prior head: do not carry forward a junk chain; start
-            // fresh. The new head is node-signed, so a reader still verifies.
-            Err(_) => (1, None),
-        },
-        Err(e) if e.kind() == std::io::ErrorKind::NotFound => (1, None),
-        Err(e) => return Err(e).context("reading prior sealed op-log head"),
-    };
+    // F5: carry the chain forward only from a verified prior head.
+    let (seq, prev) = prior_chain(state_dir, head_signing_key);
 
     let mut head = SealedOpLogHead {
         version: PROJECTION_VERSION,
         seq,
         active_kid: kid,
         active_vk_sec1: vk_sec1,
-        // head_at_op is recorded when the repo head is re-signed (C2's full
-        // sequence). C4's projection carries forward the prior value.
         head_at_op: None,
         prev,
         sig: Vec::new(),
     };
-    head.head_at_op = prior_head_at_op(secrets_dir);
-
-    let head_sk = hyprstream_rpc::node_identity::derive_purpose_key(
-        composite_ca_key,
-        HEAD_SIGNING_PURPOSE,
-    );
-    let sig = head_sk.sign(&head.signing_payload()?);
+    let sig = head_signing_key.sign(&head.signing_payload()?);
     head.sig = sig.to_bytes().to_vec();
 
-    super::identity_store::write_secret(
-        secrets_dir,
-        SEALED_HEAD_FILENAME,
+    atomic_write_public(
+        &state_dir.join(SEALED_HEAD_FILENAME),
         &serde_json::to_vec(&head)?,
     )?;
     Ok(())
 }
 
-fn prior_head_at_op(secrets_dir: &Path) -> Option<String> {
-    let bytes = std::fs::read(sealed_head_path(secrets_dir)).ok()?;
-    serde_json::from_slice::<SealedOpLogHead>(&bytes)
-        .ok()
-        .and_then(|h| h.head_at_op)
+/// Return `(seq, prev)` for the new head, carrying forward only from a
+/// signature-verified prior head (F5). An absent or unverified prior starts a
+/// fresh chain at seq=1.
+fn prior_chain(
+    state_dir: &Path,
+    head_signing_key: &Ed25519SigningKey,
+) -> (u64, Option<[u8; 32]>) {
+    let head_vk = head_signing_key.verifying_key();
+    let bytes = match std::fs::read(state_dir.join(SEALED_HEAD_FILENAME)) {
+        Ok(b) => b,
+        Err(_) => return (1, None),
+    };
+    let prior: SealedOpLogHead = match serde_json::from_slice(&bytes) {
+        Ok(h) => h,
+        Err(_) => return (1, None),
+    };
+    // F5: verify the prior head before trusting its seq/prev. A tampered prior
+    // cannot inject an arbitrary sequence — we start fresh instead.
+    if prior.verify(&head_vk).is_err() {
+        return (1, None);
+    }
+    let prev_hash = match prior.signing_payload() {
+        Ok(p) => sha256_fixed(&p),
+        Err(_) => return (1, None),
+    };
+    (prior.seq.checked_add(1).unwrap_or(prior.seq), Some(prev_hash))
 }
 
 fn sha256_fixed(bytes: &[u8]) -> [u8; 32] {
@@ -384,137 +442,203 @@ mod tests {
     use super::*;
     use tempfile::TempDir;
 
-    fn ca_key() -> Ed25519SigningKey {
-        Ed25519SigningKey::from_bytes(&[0x5a; 32])
+    /// A rotator fixture: dedicated head key + published verifying key + a
+    /// populated ES256 store. `state_dir` is the shared head state dir;
+    /// `secrets_dir` holds the head private key and ES256 key material.
+    struct Rotator {
+        state_dir: PathBuf,
+        secrets_dir: PathBuf,
+        head_sk: Ed25519SigningKey,
+        store: Es256SigningKeyStore,
     }
 
-    /// The CA key — what `seal_op_log_head` receives in production (the
-    /// rotation task's `composite_ca_key`). The reader derives the matching
-    /// head verifying key from the root via [`head_signing_key_from_root`].
-    fn derived_ca() -> Ed25519SigningKey {
-        hyprstream_rpc::node_identity::derive_purpose_key(&ca_key(), "hyprstream-jwt-v1")
+    impl Rotator {
+        fn new() -> Self {
+            let state_dir = TempDir::new().unwrap().keep();
+            let secrets_dir = TempDir::new().unwrap().keep();
+            let head_sk = Ed25519SigningKey::generate(&mut rand::rngs::OsRng);
+            publish_head_verifying_key(&state_dir, &head_sk).unwrap();
+            Self {
+                state_dir,
+                secrets_dir,
+                head_sk,
+                store: Es256SigningKeyStore::new(empty_slots()),
+            }
+        }
+
+        fn set_active(&self, sk: Es256SigningKey) {
+            *self.store.0.blocking_write() = super::super::key_rotation::Es256KeySlots {
+                active: Some(super::super::key_rotation::Es256KeySlot::new(sk, 0, 0)),
+                drain: None,
+                lead: None,
+            };
+        }
+
+        fn seal(&self) {
+            tokio::runtime::Builder::new_current_thread()
+                .build()
+                .unwrap()
+                .block_on(seal_op_log_head(&self.state_dir, &self.head_sk, &self.store))
+                .unwrap();
+        }
+
+        fn persist_slot(&self, name: &str, sk: &Es256SigningKey) {
+            super::super::key_rotation::persist_es256_slot(
+                &self.secrets_dir,
+                name,
+                &super::super::key_rotation::Es256KeySlot::new(sk.clone(), 0, 0),
+            )
+            .unwrap();
+        }
     }
 
-    #[test]
-    fn sealed_head_round_trips_and_verifies() {
-        let dir = TempDir::new().unwrap();
-        let sk = Es256SigningKey::random(&mut rand::rngs::OsRng);
-        let store = Es256SigningKeyStore::new(super::super::key_rotation::Es256KeySlots {
-            active: Some(super::super::key_rotation::Es256KeySlot::new(sk, 0, 0)),
+    fn empty_slots() -> super::super::key_rotation::Es256KeySlots {
+        super::super::key_rotation::Es256KeySlots {
+            active: None,
             drain: None,
             lead: None,
-        });
-        seal_op_log_head(dir.path(), &derived_ca(), &store).unwrap();
-
-        let head: SealedOpLogHead =
-            serde_json::from_slice(&std::fs::read(sealed_head_path(dir.path())).unwrap()).unwrap();
-        let head_vk = head_signing_key_from_root(&ca_key()).verifying_key();
-        assert_eq!(head.seq, 1);
-        assert!(head.verify(&head_vk).is_ok());
-        assert!(!head.sig.is_empty());
+        }
     }
 
+    // ── F1: the seal must work inside an async runtime (panics pre-fix) ─────
+
     #[test]
-    fn reader_fails_closed_on_tampered_head() {
-        let dir = TempDir::new().unwrap();
-        let sk = Es256SigningKey::random(&mut rand::rngs::OsRng);
-        let store = Es256SigningKeyStore::new(super::super::key_rotation::Es256KeySlots {
-            active: Some(super::super::key_rotation::Es256KeySlot::new(sk, 0, 0)),
-            drain: None,
-            lead: None,
-        });
-        seal_op_log_head(dir.path(), &derived_ca(), &store).unwrap();
+    fn seal_runs_inside_async_runtime() {
+        // seal_op_log_head calls es256_store.0.read().await; pre-fix it used
+        // blocking_read() which panics inside a runtime. Drive it under one.
+        let r = Rotator::new();
+        let k1 = Es256SigningKey::random(&mut rand::rngs::OsRng);
+        r.set_active(k1.clone());
+        r.persist_slot("active", &k1);
+        r.seal();
+        assert!(r.state_dir.join(SEALED_HEAD_FILENAME).exists());
+    }
 
-        // Tamper with the on-disk head: flip a byte in the signature.
-        let path = sealed_head_path(dir.path());
-        let mut head: SealedOpLogHead =
-            serde_json::from_slice(&std::fs::read(&path).unwrap()).unwrap();
-        head.sig[0] ^= 0xff;
-        std::fs::write(&path, serde_json::to_vec(&head).unwrap()).unwrap();
+    // ── F2: a rolled-back head is rejected (replay-negative) ────────────────
 
-        let source = SealedHeadEs256Source::from_root(dir.path(), &ca_key());
-        let err = source.active_generation().unwrap_err();
+    #[test]
+    fn reader_rejects_rolled_back_head() {
+        let r = Rotator::new();
+        let k1 = Es256SigningKey::random(&mut rand::rngs::OsRng);
+        let k1_vk = *k1.verifying_key();
+        r.set_active(k1.clone());
+        r.persist_slot("active", &k1);
+        r.seal();
+        let seq1_head = std::fs::read(r.state_dir.join(SEALED_HEAD_FILENAME)).unwrap();
+
+        let reader = SealedHeadEs256Source::new(&r.state_dir, &r.secrets_dir);
+        let gen1 = reader.active_generation().unwrap().unwrap();
+        assert_eq!(gen1.verifying_key, k1_vk);
+
+        // Rotate to K2.
+        let k2 = Es256SigningKey::random(&mut rand::rngs::OsRng);
+        let k2_vk = *k2.verifying_key();
+        r.persist_slot("drain", &k1);
+        r.persist_slot("active", &k2);
+        r.set_active(k2);
+        r.seal();
+        let gen2 = reader.active_generation().unwrap().unwrap();
+        assert_eq!(gen2.verifying_key, k2_vk);
+
+        // Replay attack: overwrite the head with the still-valid signed seq=1.
+        std::fs::write(r.state_dir.join(SEALED_HEAD_FILENAME), seq1_head).unwrap();
+        let err = reader.active_generation().unwrap_err();
+        assert!(
+            err.to_string().contains("rollback"),
+            "a replayed older signed head must be rejected: {err}"
+        );
+    }
+
+    // ── F3: a reader (verifying key only) cannot forge a head ───────────────
+
+    #[test]
+    fn reader_rejects_head_signed_by_a_different_key() {
+        let r = Rotator::new();
+        let k1 = Es256SigningKey::random(&mut rand::rngs::OsRng);
+        r.set_active(k1.clone());
+        r.persist_slot("active", &k1);
+        r.seal();
+
+        // Attacker writes a head signed by a DIFFERENT key, but the reader
+        // verifies against the published verifying key -> rejected.
+        let attacker = Ed25519SigningKey::generate(&mut rand::rngs::OsRng);
+        let mut forged = SealedOpLogHead {
+            version: PROJECTION_VERSION,
+            seq: 99,
+            active_kid: es256_kid(&k1),
+            active_vk_sec1: URL_SAFE_NO_PAD.encode(k1.verifying_key().to_sec1_bytes()),
+            head_at_op: None,
+            prev: None,
+            sig: Vec::new(),
+        };
+        forged.sig = attacker
+            .sign(&forged.signing_payload().unwrap())
+            .to_bytes()
+            .to_vec();
+        std::fs::write(
+            r.state_dir.join(SEALED_HEAD_FILENAME),
+            serde_json::to_vec(&forged).unwrap(),
+        )
+        .unwrap();
+
+        let reader = SealedHeadEs256Source::new(&r.state_dir, &r.secrets_dir);
+        let err = reader.active_generation().unwrap_err();
         assert!(
             err.to_string().contains("signature"),
-            "tampered head must fail closed on signature: {err}"
+            "a head signed by a non-head key must fail signature verification: {err}"
         );
+    }
+
+    // ── F5: a tampered prior head does not inject an arbitrary seq ──────────
+
+    #[test]
+    fn tampered_prior_head_does_not_inject_seq() {
+        let r = Rotator::new();
+        let k1 = Es256SigningKey::random(&mut rand::rngs::OsRng);
+        r.set_active(k1.clone());
+        r.persist_slot("active", &k1);
+        r.seal();
+
+        // Tamper with the prior head's seq (without re-signing).
+        let mut prior: SealedOpLogHead =
+            serde_json::from_slice(&std::fs::read(r.state_dir.join(SEALED_HEAD_FILENAME)).unwrap())
+                .unwrap();
+        prior.seq = 999_999;
+        std::fs::write(
+            r.state_dir.join(SEALED_HEAD_FILENAME),
+            serde_json::to_vec(&prior).unwrap(),
+        )
+        .unwrap();
+
+        // Re-seal: the tampered prior does not verify, so the new head starts
+        // fresh at seq=1 rather than carrying forward 1_000_000.
+        let k2 = Es256SigningKey::random(&mut rand::rngs::OsRng);
+        r.set_active(k2);
+        r.seal();
+        let head: SealedOpLogHead = serde_json::from_slice(
+            &std::fs::read(r.state_dir.join(SEALED_HEAD_FILENAME)).unwrap(),
+        )
+        .unwrap();
+        assert_eq!(
+            head.seq, 1,
+            "an unverified prior must not inject its seq into the new head"
+        );
+    }
+
+    // ── F4/torn: a corrupt head is rejected; absent head returns None ───────
+
+    #[test]
+    fn reader_fail_closed_on_corrupt_head() {
+        let r = Rotator::new();
+        std::fs::write(r.state_dir.join(SEALED_HEAD_FILENAME), b"not json").unwrap();
+        let reader = SealedHeadEs256Source::new(&r.state_dir, &r.secrets_dir);
+        assert!(reader.active_generation().is_err());
     }
 
     #[test]
     fn reader_returns_none_when_head_absent() {
-        let dir = TempDir::new().unwrap();
-        let source = SealedHeadEs256Source::from_root(dir.path(), &ca_key());
-        assert!(source.active_generation().unwrap().is_none());
-    }
-
-    /// The #1123/#1170 acceptance test. Two "processes" share a secrets dir
-    /// (the `--ipc` topology): process A is the rotator (holds the in-memory
-    /// store, persists slots, seals the head); process B is the cross-process
-    /// reader (reads the head + slot files only — no shared OnceLock, no
-    /// event-delivery). B must observe A's rotation, and once it does it MUST
-    /// NOT present the retired pre-rotation key.
-    #[test]
-    fn cross_process_rotation_observed_via_sealed_head() {
-        use super::super::key_rotation::{
-            persist_es256_slot, Es256KeySlot, Es256KeySlots, Es256SigningKeyStore,
-        };
-        let dir = TempDir::new().unwrap();
-        let secrets = dir.path();
-        let root = Ed25519SigningKey::from_bytes(&[0x5a; 32]);
-        super::super::identity_store::write_ca_signing_key(secrets, &root).unwrap();
-        // `seal_op_log_head` signs with a purpose key derived from the CA key
-        // (the same key the rotation task carries as `composite_ca_key`); the
-        // reader derives the matching verifying key from the root.
-        let ca = hyprstream_rpc::node_identity::derive_purpose_key(&root, "hyprstream-jwt-v1");
-
-        // ── Process A: active K1, persisted + head sealed ──────────────────
-        let k1 = Es256SigningKey::random(&mut rand::rngs::OsRng);
-        let k1_vk = *k1.verifying_key();
-        let k1_slot = Es256KeySlot::new(k1.clone(), 0, 0);
-        let store = Es256SigningKeyStore::new(Es256KeySlots {
-            active: Some(k1_slot.clone()),
-            drain: None,
-            lead: None,
-        });
-        persist_es256_slot(secrets, "active", &k1_slot).unwrap();
-        seal_op_log_head(secrets, &ca, &store).unwrap();
-
-        // ── Process B: reads the sealed head ONLY ──────────────────────────
-        let source = SealedHeadEs256Source::from_root(secrets, &root);
-        let gen_b = source
-            .active_generation()
-            .unwrap()
-            .expect("process B observes the initial generation K1");
-        assert_eq!(gen_b.verifying_key, k1_vk);
-        assert_eq!(gen_b.seq, 1);
-
-        // ── Process A rotates: K1 → drain, K2 → active ────────────────────
-        let k2 = Es256SigningKey::random(&mut rand::rngs::OsRng);
-        let k2_vk = *k2.verifying_key();
-        persist_es256_slot(secrets, "drain", &k1_slot).unwrap();
-        let k2_slot = Es256KeySlot::new(k2.clone(), 0, 0);
-        persist_es256_slot(secrets, "active", &k2_slot).unwrap();
-        store.0.blocking_write().drain = Some(k1_slot);
-        store.0.blocking_write().active = Some(k2_slot);
-        seal_op_log_head(secrets, &ca, &store).unwrap();
-
-        // ── Process B observes the rotation via a fresh head read ──────────
-        let gen_b2 = source
-            .active_generation()
-            .unwrap()
-            .expect("process B observes the rotated generation K2");
-        assert_eq!(
-            gen_b2.verifying_key,
-            k2_vk,
-            "B must observe the rotated key K2 — no propagation mechanism"
-        );
-        assert_eq!(gen_b2.seq, 2);
-
-        // ── Negative case: once K2 is visible, B MUST NOT present K1 ───────
-        assert_ne!(
-            gen_b2.verifying_key, k1_vk,
-            "a retired key must never be presented as the active generation"
-        );
-        assert_ne!(gen_b2.kid, gen_b.kid);
+        let r = Rotator::new();
+        let reader = SealedHeadEs256Source::new(&r.state_dir, &r.secrets_dir);
+        assert!(reader.active_generation().unwrap().is_none());
     }
 }

--- a/crates/hyprstream/src/auth/op_log.rs
+++ b/crates/hyprstream/src/auth/op_log.rs
@@ -30,10 +30,12 @@
 //! A reader is NOT guaranteed to observe a rotation instantaneously (bounded
 //! by one rotation tick + filesystem visibility). The fail-closed contract:
 //! the reader verifies the head's node signature, **rejects a `seq`
-//! regression** against the highest generation it has already observed
-//! ([`SealedHeadEs256Source`] holds a monotonic `AtomicU64`), and resolves
-//! the signing key **by kid** from the key-material store. A retired key is
-//! never presented as active; a replayed older-but-valid head is rejected.
+//! regression** against both the highest generation it has observed in memory
+//! and the rotator's durable high-water mark, and resolves the signing key
+//! **by kid** from the key-material store. A retired key is never presented as
+//! active; replaying only an older-but-valid head is rejected even after a
+//! reader restart. As with any node-local checkpoint, coordinated rollback of
+//! the head and its high-water mark is outside this file-level guarantee.
 //!
 //! ## Dependency honesty — C2 (#1168) is not built
 //!
@@ -49,7 +51,8 @@
 use anyhow::{anyhow, Context as _, Result};
 use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine as _};
 use ed25519_dalek::{
-    Signature, Signer, SigningKey as Ed25519SigningKey, Verifier, VerifyingKey as Ed25519VerifyingKey,
+    Signature, Signer, SigningKey as Ed25519SigningKey, Verifier,
+    VerifyingKey as Ed25519VerifyingKey,
 };
 use p256::ecdsa::{SigningKey as Es256SigningKey, VerifyingKey as Es256VerifyingKey};
 use serde::{Deserialize, Serialize};
@@ -69,6 +72,8 @@ pub const HEAD_SIGNING_KEY_NAME: &str = "oplog-head-key";
 pub const HEAD_VERIFYING_KEY_FILENAME: &str = "atproto-oplog-head-pubkey";
 /// The sealed head file.
 pub const SEALED_HEAD_FILENAME: &str = "atproto-oplog-head.json";
+/// Durable sequence high-water mark, written by the rotator after each head.
+pub const SEALED_HEAD_MAX_SEQ_FILENAME: &str = "atproto-oplog-head-max-seq";
 /// Env override for the shared head state dir (#808 systemd seam).
 pub const OPLOG_STATE_DIR_ENV: &str = "HYPRSTREAM_OPLOG_STATE_DIR";
 
@@ -190,8 +195,7 @@ impl SealedOpLogHead {
 
     /// Verify the head signature under `head_vk` and return the active vk.
     pub fn verify(&self, head_vk: &Ed25519VerifyingKey) -> Result<Es256VerifyingKey> {
-        let sig =
-            Signature::from_slice(&self.sig).context("sealed head signature is malformed")?;
+        let sig = Signature::from_slice(&self.sig).context("sealed head signature is malformed")?;
         head_vk
             .verify(&self.signing_payload()?, &sig)
             .context("sealed head signature does not verify under the head verifying key")?;
@@ -237,10 +241,7 @@ pub struct FixedGenerationSource {
 impl FixedGenerationSource {
     pub fn new(signing_key: Es256SigningKey) -> Self {
         let kid = es256_kid(&signing_key);
-        Self {
-            kid,
-            signing_key,
-        }
+        Self { kid, signing_key }
     }
 }
 
@@ -263,8 +264,8 @@ impl ActiveGenerationSource for FixedGenerationSource {
 pub struct SealedHeadEs256Source {
     state_dir: PathBuf,
     key_material_dir: PathBuf,
-    /// Highest `seq` ever accepted by this reader. A head with `seq <= max` is
-    /// rejected as a rollback. `0` means "no generation observed yet".
+    /// Highest `seq` accepted by this process. A lower head is rejected as a
+    /// rollback; the same head may be resolved repeatedly between rotations.
     max_seq: AtomicU64,
 }
 
@@ -305,13 +306,30 @@ impl ActiveGenerationSource for SealedHeadEs256Source {
             Some(h) => h,
             None => return Ok(None),
         };
-        // F2: reject a rolled-back head. `seq` must strictly advance past the
-        // highest generation this reader has already accepted.
-        let prev_max = self.max_seq.load(Ordering::Acquire);
-        if head.seq <= prev_max {
+        // F2: reject a rolled-back head against the rotator's durable anchor,
+        // including on a reader's first call after process restart.
+        let durable_max = read_durable_max_seq(&self.state_dir)?.ok_or_else(|| {
+            anyhow!(
+                "sealed head exists without durable sequence anchor {}",
+                SEALED_HEAD_MAX_SEQ_FILENAME
+            )
+        })?;
+        if head.seq < durable_max {
             return Err(anyhow!(
-                "sealed head seq {} is not newer than the last accepted {} \
-                 (rollback or replay rejected)",
+                "sealed head seq {} is older than durable high-water mark {} \
+                 (cold-start rollback or replay rejected)",
+                head.seq,
+                durable_max
+            ));
+        }
+
+        // The same sealed generation is expected to serve many publishes.
+        // Only a lower seq is a regression; equality is safe and necessary.
+        let prev_max = self.max_seq.load(Ordering::Acquire);
+        if head.seq < prev_max {
+            return Err(anyhow!(
+                "sealed head seq {} is older than the last accepted {} \
+                 (rollback rejected)",
                 head.seq,
                 prev_max
             ));
@@ -330,9 +348,17 @@ impl ActiveGenerationSource for SealedHeadEs256Source {
                 head.active_kid
             )
         })?;
-        // Publish the new high-water mark only after the key resolves, so a
-        // head whose kid is missing does not poison the monotonic anchor.
-        self.max_seq.store(head.seq, Ordering::Release);
+        // Publish the new process-local high-water mark only after the key
+        // resolves. `fetch_max` closes the race between concurrent readers.
+        let concurrent_max = self.max_seq.fetch_max(head.seq, Ordering::AcqRel);
+        if head.seq < concurrent_max {
+            return Err(anyhow!(
+                "sealed head seq {} is older than the concurrently accepted {} \
+                 (rollback rejected)",
+                head.seq,
+                concurrent_max
+            ));
+        }
         Ok(Some(ActiveGeneration {
             seq: head.seq,
             kid: head.active_kid,
@@ -381,7 +407,7 @@ pub async fn seal_op_log_head(
     let vk_sec1 = URL_SAFE_NO_PAD.encode(signing_key.verifying_key().to_sec1_bytes());
 
     // F5: carry the chain forward only from a verified prior head.
-    let (seq, prev) = prior_chain(state_dir, head_signing_key);
+    let (seq, prev) = prior_chain(state_dir, head_signing_key)?;
 
     let mut head = SealedOpLogHead {
         version: PROJECTION_VERSION,
@@ -399,35 +425,76 @@ pub async fn seal_op_log_head(
         &state_dir.join(SEALED_HEAD_FILENAME),
         &serde_json::to_vec(&head)?,
     )?;
+    // Write the durable anchor after the head. If a crash lands between these
+    // renames, the previous anchor already rejects every older head; the new
+    // head remains acceptable because it is newer than that anchor.
+    write_durable_max_seq(state_dir, head.seq)?;
     Ok(())
 }
 
+fn read_durable_max_seq(state_dir: &Path) -> Result<Option<u64>> {
+    let path = state_dir.join(SEALED_HEAD_MAX_SEQ_FILENAME);
+    let bytes = match std::fs::read(&path) {
+        Ok(bytes) => bytes,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+        Err(e) => {
+            return Err(e)
+                .with_context(|| format!("reading sealed-head high-water mark {}", path.display()))
+        }
+    };
+    let text = std::str::from_utf8(&bytes).context("sealed-head high-water mark is not UTF-8")?;
+    let seq = text
+        .parse::<u64>()
+        .context("sealed-head high-water mark is not a u64")?;
+    Ok(Some(seq))
+}
+
+fn write_durable_max_seq(state_dir: &Path, seq: u64) -> Result<()> {
+    atomic_write_public(
+        &state_dir.join(SEALED_HEAD_MAX_SEQ_FILENAME),
+        seq.to_string().as_bytes(),
+    )
+}
+
 /// Return `(seq, prev)` for the new head, carrying forward only from a
-/// signature-verified prior head (F5). An absent or unverified prior starts a
-/// fresh chain at seq=1.
+/// signature-verified prior head (F5). An absent or unverified prior breaks the
+/// hash link, but the durable high-water mark still prevents `seq` reuse.
 fn prior_chain(
     state_dir: &Path,
     head_signing_key: &Ed25519SigningKey,
-) -> (u64, Option<[u8; 32]>) {
+) -> Result<(u64, Option<[u8; 32]>)> {
+    let durable_max = read_durable_max_seq(state_dir)?.unwrap_or(0);
+    let next_unlinked = || {
+        durable_max
+            .checked_add(1)
+            .ok_or_else(|| anyhow!("sealed-head sequence exhausted at {durable_max}"))
+            .map(|seq| (seq, None))
+    };
     let head_vk = head_signing_key.verifying_key();
     let bytes = match std::fs::read(state_dir.join(SEALED_HEAD_FILENAME)) {
         Ok(b) => b,
-        Err(_) => return (1, None),
+        Err(_) => return next_unlinked(),
     };
     let prior: SealedOpLogHead = match serde_json::from_slice(&bytes) {
         Ok(h) => h,
-        Err(_) => return (1, None),
+        Err(_) => return next_unlinked(),
     };
     // F5: verify the prior head before trusting its seq/prev. A tampered prior
-    // cannot inject an arbitrary sequence — we start fresh instead.
+    // cannot inject an arbitrary sequence. The durable anchor still advances.
     if prior.verify(&head_vk).is_err() {
-        return (1, None);
+        return next_unlinked();
     }
     let prev_hash = match prior.signing_payload() {
         Ok(p) => sha256_fixed(&p),
-        Err(_) => return (1, None),
+        Err(_) => return next_unlinked(),
     };
-    (prior.seq.checked_add(1).unwrap_or(prior.seq), Some(prev_hash))
+    let seq = prior
+        .seq
+        .max(durable_max)
+        .checked_add(1)
+        .ok_or_else(|| anyhow!("sealed-head sequence exhausted at {}", u64::MAX))?;
+    let prev = (prior.seq >= durable_max).then_some(prev_hash);
+    Ok((seq, prev))
 }
 
 fn sha256_fixed(bytes: &[u8]) -> [u8; 32] {
@@ -440,7 +507,16 @@ fn sha256_fixed(bytes: &[u8]) -> [u8; 32] {
 #[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {
     use super::*;
+    use std::process::Command;
+    use std::time::{Duration, Instant};
     use tempfile::TempDir;
+
+    const CROSS_PROCESS_CHILD_ENV: &str = "HYPRSTREAM_TEST_OPLOG_CHILD";
+    const CROSS_PROCESS_STATE_ENV: &str = "HYPRSTREAM_TEST_OPLOG_STATE";
+    const CROSS_PROCESS_SECRETS_ENV: &str = "HYPRSTREAM_TEST_OPLOG_SECRETS";
+    const CROSS_PROCESS_READY_ENV: &str = "HYPRSTREAM_TEST_OPLOG_READY";
+    const CROSS_PROCESS_CONTINUE_ENV: &str = "HYPRSTREAM_TEST_OPLOG_CONTINUE";
+    const CROSS_PROCESS_RESULT_ENV: &str = "HYPRSTREAM_TEST_OPLOG_RESULT";
 
     /// A rotator fixture: dedicated head key + published verifying key + a
     /// populated ES256 store. `state_dir` is the shared head state dir;
@@ -478,7 +554,11 @@ mod tests {
             tokio::runtime::Builder::new_current_thread()
                 .build()
                 .unwrap()
-                .block_on(seal_op_log_head(&self.state_dir, &self.head_sk, &self.store))
+                .block_on(seal_op_log_head(
+                    &self.state_dir,
+                    &self.head_sk,
+                    &self.store,
+                ))
                 .unwrap();
         }
 
@@ -549,6 +629,127 @@ mod tests {
         );
     }
 
+    #[test]
+    fn cold_start_reader_rejects_rolled_back_head() {
+        let r = Rotator::new();
+        let k1 = Es256SigningKey::random(&mut rand::rngs::OsRng);
+        r.set_active(k1.clone());
+        r.persist_slot("active", &k1);
+        r.seal();
+        let seq1_head = std::fs::read(r.state_dir.join(SEALED_HEAD_FILENAME)).unwrap();
+
+        let k2 = Es256SigningKey::random(&mut rand::rngs::OsRng);
+        r.persist_slot("drain", &k1);
+        r.persist_slot("active", &k2);
+        r.set_active(k2);
+        r.seal();
+        assert_eq!(read_durable_max_seq(&r.state_dir).unwrap(), Some(2));
+
+        // Replay only the older, still-valid head, then construct a brand-new
+        // source to model a process cold start. The durable anchor survives.
+        std::fs::write(r.state_dir.join(SEALED_HEAD_FILENAME), seq1_head).unwrap();
+        let restarted_reader = SealedHeadEs256Source::new(&r.state_dir, &r.secrets_dir);
+        let err = restarted_reader.active_generation().unwrap_err();
+        assert!(
+            err.to_string().contains("cold-start rollback"),
+            "a cold reader must reject an older signed head: {err}"
+        );
+    }
+
+    #[test]
+    fn reader_can_resolve_the_same_head_repeatedly() {
+        let r = Rotator::new();
+        let k1 = Es256SigningKey::random(&mut rand::rngs::OsRng);
+        r.set_active(k1.clone());
+        r.persist_slot("active", &k1);
+        r.seal();
+
+        let reader = SealedHeadEs256Source::new(&r.state_dir, &r.secrets_dir);
+        assert_eq!(reader.active_generation().unwrap().unwrap().seq, 1);
+        assert_eq!(reader.active_generation().unwrap().unwrap().seq, 1);
+    }
+
+    /// #1123/#1170 acceptance test: the rotator stays in this process while a
+    /// child test process holds the reader across the K1 -> K2 rotation.
+    #[test]
+    fn cross_process_rotation_observed_via_sealed_head() {
+        if std::env::var_os(CROSS_PROCESS_CHILD_ENV).is_some() {
+            cross_process_reader_child();
+            return;
+        }
+
+        let r = Rotator::new();
+        let k1 = Es256SigningKey::random(&mut rand::rngs::OsRng);
+        let k1_kid = es256_kid(&k1);
+        r.set_active(k1.clone());
+        r.persist_slot("active", &k1);
+        r.seal();
+
+        let coordination = TempDir::new().unwrap();
+        let ready = coordination.path().join("ready");
+        let continue_path = coordination.path().join("continue");
+        let result = coordination.path().join("result");
+        let test_name = "auth::op_log::tests::cross_process_rotation_observed_via_sealed_head";
+        let mut child = Command::new(std::env::current_exe().unwrap())
+            .arg("--exact")
+            .arg(test_name)
+            .arg("--nocapture")
+            .env(CROSS_PROCESS_CHILD_ENV, "1")
+            .env(CROSS_PROCESS_STATE_ENV, &r.state_dir)
+            .env(CROSS_PROCESS_SECRETS_ENV, &r.secrets_dir)
+            .env(CROSS_PROCESS_READY_ENV, &ready)
+            .env(CROSS_PROCESS_CONTINUE_ENV, &continue_path)
+            .env(CROSS_PROCESS_RESULT_ENV, &result)
+            .spawn()
+            .unwrap();
+
+        wait_for_path(&ready);
+
+        let k2 = Es256SigningKey::random(&mut rand::rngs::OsRng);
+        let k2_kid = es256_kid(&k2);
+        r.persist_slot("drain", &k1);
+        r.persist_slot("active", &k2);
+        r.set_active(k2);
+        r.seal();
+        std::fs::write(&continue_path, b"rotate").unwrap();
+
+        let status = child.wait().unwrap();
+        assert!(status.success(), "cross-process reader child failed");
+        let observed = std::fs::read_to_string(result).unwrap();
+        assert_eq!(observed, format!("{k1_kid}\n{k2_kid}\n"));
+        assert_ne!(
+            k1_kid, k2_kid,
+            "the child must stop presenting the pre-rotation generation"
+        );
+    }
+
+    fn cross_process_reader_child() {
+        let state = PathBuf::from(std::env::var_os(CROSS_PROCESS_STATE_ENV).unwrap());
+        let secrets = PathBuf::from(std::env::var_os(CROSS_PROCESS_SECRETS_ENV).unwrap());
+        let ready = PathBuf::from(std::env::var_os(CROSS_PROCESS_READY_ENV).unwrap());
+        let continue_path = PathBuf::from(std::env::var_os(CROSS_PROCESS_CONTINUE_ENV).unwrap());
+        let result = PathBuf::from(std::env::var_os(CROSS_PROCESS_RESULT_ENV).unwrap());
+        let reader = SealedHeadEs256Source::new(&state, &secrets);
+
+        let before = reader.active_generation().unwrap().unwrap();
+        std::fs::write(&ready, b"ready").unwrap();
+        wait_for_path(&continue_path);
+        let after = reader.active_generation().unwrap().unwrap();
+        std::fs::write(result, format!("{}\n{}\n", before.kid, after.kid)).unwrap();
+    }
+
+    fn wait_for_path(path: &Path) {
+        let deadline = Instant::now() + Duration::from_secs(10);
+        while !path.exists() {
+            assert!(
+                Instant::now() < deadline,
+                "timed out waiting for {}",
+                path.display()
+            );
+            std::thread::sleep(Duration::from_millis(10));
+        }
+    }
+
     // ── F3: a reader (verifying key only) cannot forge a head ───────────────
 
     #[test]
@@ -610,19 +811,19 @@ mod tests {
         )
         .unwrap();
 
-        // Re-seal: the tampered prior does not verify, so the new head starts
-        // fresh at seq=1 rather than carrying forward 1_000_000.
+        // Re-seal: the tampered prior does not verify, so the hash chain
+        // restarts, but the durable sequence anchor still advances.
         let k2 = Es256SigningKey::random(&mut rand::rngs::OsRng);
         r.set_active(k2);
         r.seal();
-        let head: SealedOpLogHead = serde_json::from_slice(
-            &std::fs::read(r.state_dir.join(SEALED_HEAD_FILENAME)).unwrap(),
-        )
-        .unwrap();
+        let head: SealedOpLogHead =
+            serde_json::from_slice(&std::fs::read(r.state_dir.join(SEALED_HEAD_FILENAME)).unwrap())
+                .unwrap();
         assert_eq!(
-            head.seq, 1,
-            "an unverified prior must not inject its seq into the new head"
+            head.seq, 2,
+            "an unverified prior must not inject or regress the new head seq"
         );
+        assert_eq!(head.prev, None);
     }
 
     // ── F4/torn: a corrupt head is rejected; absent head returns None ───────

--- a/crates/hyprstream/src/services/discovery.rs
+++ b/crates/hyprstream/src/services/discovery.rs
@@ -932,11 +932,13 @@ pub struct PdsPublisher {
     /// every record this node publishes (single-node, self-hosted PDS; a
     /// per-account DID scheme is out of scope for #910a).
     did: String,
-    /// This node's `#atproto` commit-signing key (P-256/ES256), sourced from
-    /// the shared `Es256SigningKeyStore` — the *same* key `did_document.rs`
-    /// publishes as the `#atproto` verification method. Held only here (the
-    /// writer); resolvers hold no key. Used to sign each commit exactly once.
-    signing_key: p256::ecdsa::SigningKey,
+    /// Source of truth for the active `#atproto` ES256 generation. Resolved
+    /// **at sign time**, not at construction (#1123/C4): under `--ipc` this
+    /// reads the sealed op-log head so a rotation performed by the OAuth
+    /// process is observed here without any event-delivery mechanism. A frozen
+    /// construction-time copy would keep signing with a retired key after a
+    /// rotation. See [`crate::auth::ActiveGenerationSource`].
+    generation_source: Arc<dyn crate::auth::ActiveGenerationSource>,
     /// Serializes the load→rebuild→sign→persist critical section (#910b).
     ///
     /// A publish is a read-modify-write over the WHOLE repo (one MST, one
@@ -950,6 +952,9 @@ pub struct PdsPublisher {
 }
 
 impl PdsPublisher {
+    /// Construct with a fixed signing key. Preserved for tests and simple
+    /// embedders; production wiring uses [`Self::with_generation_source`] so
+    /// the publisher observes rotations.
     pub fn new(
         store: Arc<PdsRecordStore>,
         did: String,
@@ -959,7 +964,24 @@ impl PdsPublisher {
             store,
             at9p_state: None,
             did,
-            signing_key,
+            generation_source: Arc::new(crate::auth::FixedGenerationSource::new(signing_key)),
+            publish_lock: parking_lot::Mutex::new(()),
+        }
+    }
+
+    /// Construct with a live generation source — the production shape (#1123).
+    /// The publisher resolves the active `#atproto` key from `source` at every
+    /// sign, so it never freezes a retired key.
+    pub fn with_generation_source(
+        store: Arc<PdsRecordStore>,
+        did: String,
+        source: Arc<dyn crate::auth::ActiveGenerationSource>,
+    ) -> Self {
+        Self {
+            store,
+            at9p_state: None,
+            did,
+            generation_source: source,
             publish_lock: parking_lot::Mutex::new(()),
         }
     }
@@ -1144,7 +1166,22 @@ impl PdsPublisher {
             None => (Tid::now(), None),
         };
         let unsigned = UnsignedCommit::new(self.did.clone(), root, rev, prev);
-        let commit = Commit::sign(&unsigned, &self.signing_key);
+        // Resolve the active `#atproto` generation at sign time (#1123/C4).
+        // Under `--ipc` this reads the sealed op-log head written by the OAuth
+        // rotation task, so a rotation on the other side is observed here with
+        // no propagation mechanism. Fail-closed: if no verified generation is
+        // observable, decline to sign rather than fall back to a stale key.
+        let generation = self
+            .generation_source
+            .active_generation()
+            .context("resolving active #atproto generation")?
+            .ok_or_else(|| {
+                anyhow!(
+                    "no active #atproto generation observable; declining to sign \
+                     (sealed op-log head not present or unverifiable)"
+                )
+            })?;
+        let commit = Commit::sign(&unsigned, &generation.signing_key);
 
         self.store
             .put_record_and_commit(&self.did, collection, tid, &record, &commit)
@@ -1343,6 +1380,88 @@ mod pds_store_tests {
             .build()
             .expect("build current-thread runtime")
             .block_on(fut)
+    }
+
+    /// #1123/#1170 acceptance test at the publisher level: the publisher
+    /// resolves the active `#atproto` generation from the sealed op-log head at
+    /// **sign time**, so a rotation performed by the (separate) OAuth process
+    /// is observed here with no event delivery. A frozen construction-time key
+    /// — the pre-C4 shape — would sign the second commit with the retired K1
+    /// and this test would fail on the final assertion.
+    #[test]
+    fn publisher_resolves_live_generation_across_rotation() {
+        use crate::auth::identity_store::write_ca_signing_key;
+        use crate::auth::key_rotation::{
+            persist_es256_slot, Es256KeySlot, Es256KeySlots, Es256SigningKeyStore,
+        };
+        use crate::auth::op_log::{seal_op_log_head, SealedHeadEs256Source};
+        use ed25519_dalek::SigningKey as Ed25519SigningKey;
+
+        let pds_dir = tempfile::tempdir().expect("pds tempdir");
+        let secrets_dir = tempfile::tempdir().expect("secrets tempdir");
+        let secrets = secrets_dir.path();
+        let root = Ed25519SigningKey::from_bytes(&[0x5a; 32]);
+        write_ca_signing_key(secrets, &root).unwrap();
+        let ca = hyprstream_rpc::node_identity::derive_purpose_key(&root, "hyprstream-jwt-v1");
+
+        // Process A (the rotator): K1 active, persisted, head sealed.
+        let k1 = SigningKey::random(&mut rand::rngs::OsRng);
+        let k1_vk: VerifyingKey = *k1.verifying_key();
+        let k1_slot = Es256KeySlot::new(k1, 0, 0);
+        let es256_store = Es256SigningKeyStore::new(Es256KeySlots {
+            active: Some(k1_slot.clone()),
+            drain: None,
+            lead: None,
+        });
+        persist_es256_slot(secrets, "active", &k1_slot).unwrap();
+        seal_op_log_head(secrets, &ca, &es256_store).unwrap();
+
+        // Process B (the registry/publisher): resolves the generation from the
+        // sealed head — the `--ipc` cross-process read path.
+        let pds_store = Arc::new(PdsRecordStore::open(pds_dir.path()).expect("open rw"));
+        let source: Arc<dyn crate::auth::ActiveGenerationSource> =
+            Arc::new(SealedHeadEs256Source::from_root(secrets, &root));
+        let publisher = PdsPublisher::with_generation_source(
+            Arc::clone(&pds_store),
+            DID.to_owned(),
+            source,
+        );
+
+        publisher.publish("repo-a", SAMPLE_OID).expect("publish K1");
+        let commit1 = pds_store
+            .load_repo(DID)
+            .expect("load")
+            .expect("repo exists")
+            .commit;
+        assert!(commit1.verify(&k1_vk).is_ok(), "first commit signed by K1");
+
+        // Process A rotates: K1 → drain, K2 → active. Persist + re-seal.
+        let k2 = SigningKey::random(&mut rand::rngs::OsRng);
+        let k2_vk: VerifyingKey = *k2.verifying_key();
+        let k2_slot = Es256KeySlot::new(k2, 0, 0);
+        persist_es256_slot(secrets, "drain", &k1_slot).unwrap();
+        persist_es256_slot(secrets, "active", &k2_slot).unwrap();
+        es256_store.0.blocking_write().active = Some(k2_slot);
+        seal_op_log_head(secrets, &ca, &es256_store).unwrap();
+
+        // Same publisher instance, new commit. It MUST be signed by K2 — the
+        // publisher observed the rotation through the re-sealed head.
+        publisher.publish("repo-a", SAMPLE_OID_2).expect("publish K2");
+        let commit2 = pds_store
+            .load_repo(DID)
+            .expect("load")
+            .expect("repo exists")
+            .commit;
+        assert!(
+            commit2.verify(&k2_vk).is_ok(),
+            "post-rotation commit must be signed by K2"
+        );
+        // Negative case: the post-rotation commit MUST NOT verify under the
+        // retired pre-rotation key K1.
+        assert!(
+            commit2.verify(&k1_vk).is_err(),
+            "publisher must not sign with the retired pre-rotation key K1"
+        );
     }
 
     #[test]

--- a/crates/hyprstream/src/services/discovery.rs
+++ b/crates/hyprstream/src/services/discovery.rs
@@ -1390,21 +1390,25 @@ mod pds_store_tests {
     /// and this test would fail on the final assertion.
     #[test]
     fn publisher_resolves_live_generation_across_rotation() {
-        use crate::auth::identity_store::write_ca_signing_key;
         use crate::auth::key_rotation::{
             persist_es256_slot, Es256KeySlot, Es256KeySlots, Es256SigningKeyStore,
         };
-        use crate::auth::op_log::{seal_op_log_head, SealedHeadEs256Source};
+        use crate::auth::op_log::{
+            publish_head_verifying_key, seal_op_log_head, SealedHeadEs256Source,
+        };
         use ed25519_dalek::SigningKey as Ed25519SigningKey;
 
         let pds_dir = tempfile::tempdir().expect("pds tempdir");
         let secrets_dir = tempfile::tempdir().expect("secrets tempdir");
+        let state_dir = tempfile::tempdir().expect("oplog state tempdir");
         let secrets = secrets_dir.path();
-        let root = Ed25519SigningKey::from_bytes(&[0x5a; 32]);
-        write_ca_signing_key(secrets, &root).unwrap();
-        let ca = hyprstream_rpc::node_identity::derive_purpose_key(&root, "hyprstream-jwt-v1");
+        let state = state_dir.path();
+        // Dedicated head key; the public verifying key is published to the
+        // shared state dir (the registry loads only this public key).
+        let head_sk = Ed25519SigningKey::generate(&mut rand::rngs::OsRng);
+        publish_head_verifying_key(state, &head_sk).unwrap();
 
-        // Process A (the rotator): K1 active, persisted, head sealed.
+        // Process A (the rotator): K1 active, persisted, head sealed (async).
         let k1 = SigningKey::random(&mut rand::rngs::OsRng);
         let k1_vk: VerifyingKey = *k1.verifying_key();
         let k1_slot = Es256KeySlot::new(k1, 0, 0);
@@ -1414,13 +1418,14 @@ mod pds_store_tests {
             lead: None,
         });
         persist_es256_slot(secrets, "active", &k1_slot).unwrap();
-        seal_op_log_head(secrets, &ca, &es256_store).unwrap();
+        block_on(seal_op_log_head(state, &head_sk, &es256_store)).expect("seal");
 
         // Process B (the registry/publisher): resolves the generation from the
-        // sealed head — the `--ipc` cross-process read path.
+        // sealed head — the `--ipc` cross-process read path. Holds no private
+        // head material.
         let pds_store = Arc::new(PdsRecordStore::open(pds_dir.path()).expect("open rw"));
         let source: Arc<dyn crate::auth::ActiveGenerationSource> =
-            Arc::new(SealedHeadEs256Source::from_root(secrets, &root));
+            Arc::new(SealedHeadEs256Source::new(state, secrets));
         let publisher = PdsPublisher::with_generation_source(
             Arc::clone(&pds_store),
             DID.to_owned(),
@@ -1442,7 +1447,7 @@ mod pds_store_tests {
         persist_es256_slot(secrets, "drain", &k1_slot).unwrap();
         persist_es256_slot(secrets, "active", &k2_slot).unwrap();
         es256_store.0.blocking_write().active = Some(k2_slot);
-        seal_op_log_head(secrets, &ca, &es256_store).unwrap();
+        block_on(seal_op_log_head(state, &head_sk, &es256_store)).expect("seal");
 
         // Same publisher instance, new commit. It MUST be signed by K2 — the
         // publisher observed the rotation through the re-sealed head.

--- a/crates/hyprstream/src/services/factories.rs
+++ b/crates/hyprstream/src/services/factories.rs
@@ -710,15 +710,21 @@ fn create_registry_service(ctx: &ServiceContext) -> anyhow::Result<Box<dyn Spawn
     let pds_publisher = (|| -> anyhow::Result<crate::services::discovery::PdsPublisher> {
         let store_dir = pds_store_dir(ctx)?;
         let secrets_dir = crate::config::HyprConfig::resolve_secrets_dir()?;
-        let es256_store =
-            crate::auth::key_rotation::global_es256_key_store(&secrets_dir, &config.oauth);
-        // `active_key` is async (tokio RwLock); resolve it once here on the
-        // current runtime. `block_in_place` avoids stalling a worker reactor.
-        let active = tokio::task::block_in_place(|| {
-            tokio::runtime::Handle::current().block_on(es256_store.active_key())
-        })
-        .ok_or_else(|| anyhow::anyhow!("no active ES256 #atproto key for PDS publish"))?;
-        let atproto_key: p256::ecdsa::SigningKey = (*active).clone();
+        // C4 (#1170, closes #1123): the publisher resolves the active
+        // `#atproto` generation from the **sealed op-log head** at sign time,
+        // not a key frozen here at construction. The head is written by the
+        // OAuth rotation task (and at OAuth boot) to this shared secrets dir,
+        // so under `--ipc` a rotation performed by the OAuth process is
+        // observed here with no event-delivery mechanism. The head is signed
+        // by a purpose-key derived from the node CA root; load the root so the
+        // reader can derive the matching verifying key. If the head is absent
+        // (e.g. C2 not yet wired, or OAuth not booted in this deployment),
+        // `active_generation()` returns `None` and the publisher declines to
+        // sign — fail-closed, never a stale frozen key.
+        let node_root = crate::auth::identity_store::load_ca_signing_key(&secrets_dir)?;
+        let generation_source: Arc<dyn crate::auth::ActiveGenerationSource> = Arc::new(
+            crate::auth::SealedHeadEs256Source::from_root(&secrets_dir, &node_root),
+        );
         let acceptance_identity = ctx.service_signing_key("registry");
         anyhow::ensure!(
             hyprstream_discovery::deployment_registry_verifier()?
@@ -747,10 +753,12 @@ fn create_registry_service(ctx: &ServiceContext) -> anyhow::Result<Box<dyn Spawn
             audit_pq,
         )?;
         let node_did = hyprstream_rpc::did_key::ed25519_to_did_key(&ctx.verifying_key().to_bytes());
-        Ok(
-            crate::services::discovery::PdsPublisher::new(store, node_did, atproto_key)
-                .with_at9p_state_ingest(at9p_state),
+        Ok(crate::services::discovery::PdsPublisher::with_generation_source(
+            store,
+            node_did,
+            generation_source,
         )
+        .with_at9p_state_ingest(at9p_state))
     })()
     .map_err(|e| tracing::warn!("PDS publish disabled: {e}"))
     .ok();

--- a/crates/hyprstream/src/services/factories.rs
+++ b/crates/hyprstream/src/services/factories.rs
@@ -713,17 +713,17 @@ fn create_registry_service(ctx: &ServiceContext) -> anyhow::Result<Box<dyn Spawn
         // C4 (#1170, closes #1123): the publisher resolves the active
         // `#atproto` generation from the **sealed op-log head** at sign time,
         // not a key frozen here at construction. The head is written by the
-        // OAuth rotation task (and at OAuth boot) to this shared secrets dir,
-        // so under `--ipc` a rotation performed by the OAuth process is
-        // observed here with no event-delivery mechanism. The head is signed
-        // by a purpose-key derived from the node CA root; load the root so the
-        // reader can derive the matching verifying key. If the head is absent
-        // (e.g. C2 not yet wired, or OAuth not booted in this deployment),
-        // `active_generation()` returns `None` and the publisher declines to
-        // sign — fail-closed, never a stale frozen key.
-        let node_root = crate::auth::identity_store::load_ca_signing_key(&secrets_dir)?;
+        // OAuth rotation task to a dedicated shared state dir (NOT the
+        // read-only credentials dir), and is signed by a dedicated head key
+        // whose *public* verifying key the registry loads here — the registry
+        // holds NO CA private key. Under `--ipc` a rotation by the OAuth
+        // process is observed with no event-delivery mechanism. If the head is
+        // absent (OAuth not booted, or the shared state dir not provisioned —
+        // #808 under systemd), `active_generation()` returns `None` and the
+        // publisher declines to sign: fail-closed, never a stale frozen key.
+        let oplog_state_dir = crate::auth::resolve_oplog_state_dir(&secrets_dir)?;
         let generation_source: Arc<dyn crate::auth::ActiveGenerationSource> = Arc::new(
-            crate::auth::SealedHeadEs256Source::from_root(&secrets_dir, &node_root),
+            crate::auth::SealedHeadEs256Source::new(&oplog_state_dir, &secrets_dir),
         );
         let acceptance_identity = ctx.service_signing_key("registry");
         anyhow::ensure!(

--- a/crates/hyprstream/src/services/oauth/mod.rs
+++ b/crates/hyprstream/src/services/oauth/mod.rs
@@ -620,19 +620,19 @@ impl Spawnable for OAuthService {
                             composite_ca_key: Arc::new(key.clone()),
                         },
                     );
-                    // C4 (#1170): write the initial sealed op-log head so the
-                    // registry's `PdsPublisher` (this process under inproc, or a
-                    // separate process under `--ipc`) can resolve the active
-                    // `#atproto` generation before the first rotation tick. The
-                    // rotation task re-seals after every promotion. This is the
-                    // C2 (#1168) seam — see `auth::op_log` for the durability
-                    // contract C2 hardens.
-                    if let Err(e) = crate::auth::seal_op_log_head(
-                        &secrets_dir,
-                        &key,
-                        &es256_store,
-                    ) {
-                        tracing::warn!("failed to seal initial op-log head: {e}");
+                    // C4 (#1170): publish the head verifying key and write the
+                    // initial sealed op-log head so the registry's
+                    // `PdsPublisher` (this process under inproc, or a separate
+                    // process under `--ipc`) can resolve the active `#atproto`
+                    // generation before the first rotation tick. Dedicated head
+                    // key + shared state dir; async because the ES256 store is a
+                    // tokio RwLock (F1). The rotation task re-seals after every
+                    // promotion. C2 (#1168) seam — see `auth::op_log`.
+                    if let Err(e) =
+                        crate::auth::op_log::advance_sealed_head(&secrets_dir, &es256_store)
+                            .await
+                    {
+                        tracing::error!("failed to seal initial op-log head: {e}");
                     }
                     info!("JWT signing key rotation task started (active_days={}, lead_days={}, drain_days={})",
                         self.config.jwt_key_active_days,

--- a/crates/hyprstream/src/services/oauth/mod.rs
+++ b/crates/hyprstream/src/services/oauth/mod.rs
@@ -620,6 +620,20 @@ impl Spawnable for OAuthService {
                             composite_ca_key: Arc::new(key.clone()),
                         },
                     );
+                    // C4 (#1170): write the initial sealed op-log head so the
+                    // registry's `PdsPublisher` (this process under inproc, or a
+                    // separate process under `--ipc`) can resolve the active
+                    // `#atproto` generation before the first rotation tick. The
+                    // rotation task re-seals after every promotion. This is the
+                    // C2 (#1168) seam — see `auth::op_log` for the durability
+                    // contract C2 hardens.
+                    if let Err(e) = crate::auth::seal_op_log_head(
+                        &secrets_dir,
+                        &key,
+                        &es256_store,
+                    ) {
+                        tracing::warn!("failed to seal initial op-log head: {e}");
+                    }
                     info!("JWT signing key rotation task started (active_days={}, lead_days={}, drain_days={})",
                         self.config.jwt_key_active_days,
                         self.config.jwt_key_lead_days,


### PR DESCRIPTION
Closes #1123. Phase **C4** of epic #1158 (#1170).

## What

Replace the process-local `OnceLock` as the source of truth for the active `#atproto` ES256 generation with a **read of a sealed, node-attested op-log head**, so discovery/registry/oauth agree under `--ipc` **with no event-delivery mechanism** (plan t1124 §3.4). This is the answer to the independent review of #1118 (finding 4, HIGH): the supported `--ipc` topology could not execute the rotation fix because rotation state was process-local.

`PdsPublisher` (the registry's `#atproto` commit signer — the one cross-process reader of the active generation, #1123 gap 2) now resolves the generation **at sign time** through `ActiveGenerationSource` instead of a frozen construction-time key. The OAuth rotation task writes the sealed head after every promotion (and at boot); the registry reads it cross-process by kid.

## Consistency guarantee (stated explicitly)

A reader is **not** guaranteed to observe a completed rotation instantaneously — the head is rewritten after the rotation task promotes a slot, so there is a bounded propagation delay (one rotation tick + filesystem visibility). The fail-closed contract that makes "eventual" safe:

- the reader verifies the head's **node signature** and rejects a **`seq` regression**, so it can never accept a forged or rolled-back head;
- the signing key is resolved **by kid** from the shared secrets dir — a kid absent from the head is never loaded, so a **retired key is never presented as active**;
- if the head is absent, corrupt, or unsigned-by-this-node, the reader returns `None` and the publisher **declines to sign** rather than fall back to an untrusted local slot.

The worst observable case is a brief window where the reader still presents the *previous* generation (which remains valid as drain) until the new head is visible — never a retired key presented as active.

## Dependency honesty — C2 (#1168) is not built

C4 formally depends on C2 (crash-atomic rotation), which is **not built**. This PR ships:

- the **read path** (real, signature-verified, fail-closed): `SealedOpLogHead` + `ActiveGenerationSource` trait + `SealedHeadEs256Source`;
- the head **format** (a versioned projection, `PROJECTION_VERSION = 1`);
- a `seal_op_log_head` **seam-write** called by the rotation task + at OAuth boot.

`seal_op_log_head` is rename-atomic at the file level (a crash leaves either the old or the new head, never a torn one). **What C2 must guarantee** for this to be fully sound — and what C4 does *not* claim today: C2 must replace the promote-then-write sequence with the full rotation ordering — *re-sign repo head → durably write head → seal DidOp → publish DID doc* — as **one crash-atomic unit**, so no crash can leave a head naming a key whose repo head was not durably re-signed. Until C2 lands, a crash inside the rotation task's promote→write window can leave the head pointing at a freshly promoted key whose commit has not yet been re-published; the reader trusts the head anyway (it is node-signed), so the next publish signs with that key. That is the window C2 closes.

This does **not** fake durability locally: no second, weaker source of truth is added on the signing path, and the projection is **authenticated and ordered** (node-signed + `seq` + `prev` hash chain) — not the raw unauthenticated slot-file shortcut the prior #1123 agent reverted.

## What this is NOT

Not the federated `DidOp` witness chain (C1 #1167 / C5 #1171). The head is a **node-attested projection** for cross-process readers on ONE node, signed by a purpose-key derived from the node CA root. It deliberately does not encode rotation-key custody (epic #1158 Q2 / one-way door #4), so it does not touch that one-way door; the projection carries its own `version` so it can evolve independently of the DidOp format C1 finalizes.

Downstream: #1118 (the in-process rotation-survivable verification) rebases onto this — its `PdsPublisher`-holds-`Arc<Es256SigningKeyStore>` change becomes `PdsPublisher`-holds-`Arc<dyn ActiveGenerationSource>`.

## Tests

`cargo test -p hyprstream-discovery -p hyprstream` ✅; `cargo clippy --all-targets -- -D warnings` ✅ (workspace).

- `auth::op_log::tests::cross_process_rotation_observed_via_sealed_head` — the #1123/#1170 acceptance test: two "processes" share a secrets dir; a rotation on side A is observed by side B via the head; negative case asserts B never presents the retired pre-rotation key.
- `services::discovery::pds_store_tests::publisher_resolves_live_generation_across_rotation` — the publisher signs the post-rotation commit with the rotated key (fails on the pre-C4 frozen-key publisher, which would keep signing with K1).
- round-trip / tamper / absent-head fail-closed unit tests.

Refs #1170 #1123 #1168 #1118 #1158. **Do not merge** — opening for review.