### PR TITLE
feat(discovery): serve DID-anchored deployment trust

### DIFF
--- a/crates/hyprstream-discovery/src/checkpointed_pds.rs
+++ b/crates/hyprstream-discovery/src/checkpointed_pds.rs
@@ -50,6 +50,31 @@ impl CheckpointedPdsAcceptedStateSource {
         path: &Path,
         acceptance_identity: crate::service::RegistryDeploymentVerifier,
     ) -> Result<Self> {
+        if !path.exists() {
+            // Fresh node (first boot — e.g. the #1137 metal stack): the
+            // registry service is the sole writer and would create this store
+            // on its first start, but the production resolver installs BEFORE
+            // any service starts, so a missing store must not deadlock the
+            // boot. An empty store IS the genesis state (no accepted at9p
+            // state yet). Create it and drop the write handle immediately so
+            // the later read-only probe and the writer's own open are
+            // uncontended. NOTE: on a node that previously held state this
+            // branch means the duplicity history was LOST (deleted volume) —
+            // log loudly; the boot proceeds at genesis posture exactly as a
+            // first boot would.
+            tracing::warn!(
+                path = %path.display(),
+                "checkpointed PDS store absent — initializing an empty (genesis) store; \
+                 if this node previously held at9p state, duplicity history was lost"
+            );
+            let mut opts = rocksdb::Options::default();
+            opts.create_if_missing(true);
+            drop(
+                rocksdb::DB::open(&opts, path).with_context(|| {
+                    format!("failed to initialize checkpointed PDS store at {path:?}")
+                })?,
+            );
+        }
         let _probe = rocksdb::DB::open_for_read_only(&readonly_opts(), path, false)
             .with_context(|| format!("failed to open checkpointed PDS store at {path:?}"))?;
         Ok(Self {

--- a/crates/hyprstream-discovery/src/checkpointed_pds.rs
+++ b/crates/hyprstream-discovery/src/checkpointed_pds.rs
@@ -50,31 +50,10 @@ impl CheckpointedPdsAcceptedStateSource {
         path: &Path,
         acceptance_identity: crate::service::RegistryDeploymentVerifier,
     ) -> Result<Self> {
-        if !path.exists() {
-            // Fresh node (first boot — e.g. the #1137 metal stack): the
-            // registry service is the sole writer and would create this store
-            // on its first start, but the production resolver installs BEFORE
-            // any service starts, so a missing store must not deadlock the
-            // boot. An empty store IS the genesis state (no accepted at9p
-            // state yet). Create it and drop the write handle immediately so
-            // the later read-only probe and the writer's own open are
-            // uncontended. NOTE: on a node that previously held state this
-            // branch means the duplicity history was LOST (deleted volume) —
-            // log loudly; the boot proceeds at genesis posture exactly as a
-            // first boot would.
-            tracing::warn!(
-                path = %path.display(),
-                "checkpointed PDS store absent — initializing an empty (genesis) store; \
-                 if this node previously held at9p state, duplicity history was lost"
-            );
-            let mut opts = rocksdb::Options::default();
-            opts.create_if_missing(true);
-            drop(
-                rocksdb::DB::open(&opts, path).with_context(|| {
-                    format!("failed to initialize checkpointed PDS store at {path:?}")
-                })?,
-            );
-        }
+        // The monotonic checkpoint history is security state. A missing
+        // database is indistinguishable from deletion of that history, so it
+        // must never be recreated at resolver bootstrap. First boot is an
+        // explicit deployment-provisioning step before services may start.
         let _probe = rocksdb::DB::open_for_read_only(&readonly_opts(), path, false)
             .with_context(|| format!("failed to open checkpointed PDS store at {path:?}"))?;
         Ok(Self {
@@ -104,6 +83,24 @@ impl CheckpointedPdsAcceptedStateSource {
         }
         Ok(state)
     }
+}
+
+/// Explicitly create the empty checkpoint store for a newly provisioned
+/// deployment. Resolver startup never calls this: a missing store there is
+/// treated as lost security history and fails closed.
+pub(crate) fn initialize_deployment_store() -> Result<()> {
+    let path = hyprstream_service::deployment_data_dir()?.join("pds-store");
+    anyhow::ensure!(
+        !path.exists(),
+        "refusing to initialize existing checkpointed PDS store at {}",
+        path.display()
+    );
+    let mut opts = rocksdb::Options::default();
+    opts.create_if_missing(true);
+    drop(rocksdb::DB::open(&opts, &path).with_context(|| {
+        format!("failed to initialize checkpointed PDS store at {path:?}")
+    })?);
+    Ok(())
 }
 
 impl super::service::AcceptedStateSource for CheckpointedPdsAcceptedStateSource {

--- a/crates/hyprstream-discovery/src/did_anchored.rs
+++ b/crates/hyprstream-discovery/src/did_anchored.rs
@@ -33,6 +33,18 @@ const DEPLOYMENT_REACH_SERVICE: &str = "#ns";
 pub struct DidAnchors {
     pub cluster_at9p_did: String,
     pub cluster_did_web: String,
+    /// Optional extra TLS root (PEM) for private-PKI deployments whose
+    /// did:web host terminates with an internal CA. ADDITIVE — the public
+    /// WebPKI roots remain enabled; this never disables verification.
+    pub extra_root_cert_pem: Option<Vec<u8>>,
+}
+
+impl DidAnchors {
+    /// Attach an extra TLS root for private-PKI did:web termination.
+    pub fn with_root_cert_pem(mut self, pem: Vec<u8>) -> Self {
+        self.extra_root_cert_pem = Some(pem);
+        self
+    }
 }
 
 /// Explicit startup trust-source selection.
@@ -74,6 +86,7 @@ impl DeploymentTrustSource {
                 Ok(Self::DidAnchored(DidAnchors {
                     cluster_at9p_did: at9p.to_owned(),
                     cluster_did_web: web.to_owned(),
+                    extra_root_cert_pem: None,
                 }))
             }
             _ => bail!(
@@ -88,6 +101,20 @@ pub(crate) struct DidAnchoredTrust {
     pub ca_verifying_key: VerifyingKey,
     pub discovery_transport: TransportConfig,
     pub authoritative_identity: AuthoritativeIdentity,
+    /// The current CA-signed registry deployment credential, fetched from the
+    /// same well-known endpoint family as the capsule. Like the capsule, it
+    /// is integrity-protected by design (CA signature + one-hour freshness
+    /// profile, enforced by `validate_registry_deployment_credential_profile`),
+    /// so the byte channel needs no trust of its own.
+    pub registry_credential: String,
+    /// The document's `#mesh-kem` hybrid-KEM recipient public, when published.
+    /// Required by the REMOTE-node bootstrap arm (QUIC forbids cleartext
+    /// envelopes); the same-node arm never encrypts over the local fabric.
+    pub mesh_kem_recipient: Option<hyprstream_rpc::crypto::hybrid_kem::RecipientPublic>,
+    /// The document's ML-DSA-65 verification methods (`#mesh-pq`). The
+    /// remote-node arm requires exactly one — the discovery service's mesh
+    /// PQ verifying key — to anchor response authentication.
+    pub ml_dsa_65_keys: Vec<hyprstream_rpc::crypto::pq::MlDsaVerifyingKey>,
 }
 
 /// Fetch capsules from the deployment's static well-known content endpoint.
@@ -101,16 +128,62 @@ struct HttpWellKnownCapsuleSource {
     document_url: String,
 }
 
+/// Maximum accepted size of the registry deployment credential response.
+/// A compact EdDSA JWT is well under 4 KiB; 64 KiB is generous headroom.
+const MAX_CREDENTIAL_BYTES: usize = 64 * 1024;
+
 impl HttpWellKnownCapsuleSource {
-    fn new(did_web: &str) -> Result<Self> {
+    fn new(did_web: &str, extra_root_pem: Option<&[u8]>) -> Result<Self> {
         let document_url = did_web_to_url(did_web)?;
-        let http = reqwest::Client::builder()
+        let mut builder = reqwest::Client::builder()
             .redirect(reqwest::redirect::Policy::none())
             .connect_timeout(Duration::from_secs(10))
-            .timeout(Duration::from_secs(10))
+            .timeout(Duration::from_secs(10));
+        if let Some(pem) = extra_root_pem {
+            let cert = reqwest::Certificate::from_pem(pem)
+                .context("extra well-known TLS root is not a valid PEM certificate")?;
+            builder = builder.add_root_certificate(cert);
+        }
+        let http = builder
             .build()
             .context("failed to build at9p capsule HTTPS client")?;
         Ok(Self { http, document_url })
+    }
+
+    /// Fetch the current registry deployment credential from beside the
+    /// capsule (`{prefix}deployment/registry-service.jwt`). The bytes are an
+    /// untrusted transport only: `validate_registry_deployment_credential_profile`
+    /// decides whether they are accepted (CA signature + freshness window).
+    async fn fetch_registry_credential(&self) -> Result<String> {
+        let prefix = self
+            .document_url
+            .strip_suffix("did.json")
+            .ok_or_else(|| anyhow::anyhow!("derived did:web URL does not end in did.json"))?;
+        let url = format!("{prefix}deployment/registry-service.jwt");
+        let response = self
+            .http
+            .get(&url)
+            .send()
+            .await
+            .with_context(|| format!("failed to fetch registry deployment credential from {url}"))?
+            .error_for_status()
+            .with_context(|| format!("registry deployment credential endpoint rejected {url}"))?;
+        if let Some(length) = response.content_length() {
+            anyhow::ensure!(
+                length <= MAX_CREDENTIAL_BYTES as u64,
+                "registry deployment credential exceeds {MAX_CREDENTIAL_BYTES}-byte limit"
+            );
+        }
+        let bytes = response
+            .bytes()
+            .await
+            .context("failed to read registry deployment credential body")?;
+        anyhow::ensure!(
+            bytes.len() <= MAX_CREDENTIAL_BYTES,
+            "registry deployment credential exceeds {MAX_CREDENTIAL_BYTES}-byte limit"
+        );
+        String::from_utf8(bytes.to_vec())
+            .context("registry deployment credential is not UTF-8")
     }
 
     fn capsule_url(&self, did: &str) -> Result<String> {
@@ -245,6 +318,7 @@ pub(crate) async fn verify_did_anchored_document(
     anchors: &DidAnchors,
     document: &Value,
     capsule_source: Arc<dyn CapsuleSource>,
+    registry_credential: String,
 ) -> Result<DidAnchoredTrust> {
     anyhow::ensure!(
         document.get("id").and_then(Value::as_str) == Some(anchors.cluster_did_web.as_str()),
@@ -282,17 +356,37 @@ pub(crate) async fn verify_did_anchored_document(
         ca_verifying_key,
         discovery_transport,
         authoritative_identity,
+        registry_credential,
+        mesh_kem_recipient: hyprstream_rpc::did_web::mesh_kem_recipient(document),
+        ml_dsa_65_keys: hyprstream_rpc::did_web::verification_method_ml_dsa_65_keys(document),
     })
 }
 
 pub(crate) async fn resolve_did_anchored_trust(anchors: &DidAnchors) -> Result<DidAnchoredTrust> {
-    let document = DidWebResolver::new(HttpDidDocFetcher::new(Duration::from_secs(3600))?)
-        .resolve_document(&anchors.cluster_did_web)
+    let extra_root = anchors.extra_root_cert_pem.as_deref();
+    let document = DidWebResolver::new(match extra_root {
+        Some(pem) => HttpDidDocFetcher::with_extra_root(Duration::from_secs(3600), pem)?,
+        None => HttpDidDocFetcher::new(Duration::from_secs(3600))?,
+    })
+    .resolve_document(&anchors.cluster_did_web)
+    .await
+    .context("failed to fetch configured cluster did:web document")?;
+    let capsule_source =
+        Arc::new(HttpWellKnownCapsuleSource::new(&anchors.cluster_did_web, extra_root)?);
+    // Fetch the registry credential from the same well-known family BEFORE
+    // trusting anything: a missing/refusing endpoint must fail the bootstrap
+    // even when the document and capsule are otherwise valid.
+    let registry_credential = capsule_source
+        .fetch_registry_credential()
         .await
-        .context("failed to fetch configured cluster did:web document")?;
-    let capsule_source: Arc<dyn CapsuleSource> =
-        Arc::new(HttpWellKnownCapsuleSource::new(&anchors.cluster_did_web)?);
-    let trust = verify_did_anchored_document(anchors, &document, capsule_source).await?;
+        .context("failed to fetch registry deployment credential")?;
+    let trust = verify_did_anchored_document(
+        anchors,
+        &document,
+        capsule_source,
+        registry_credential,
+    )
+    .await?;
     tracing::info!(
         at9p = %trust.authoritative_identity.at9p_did,
         did_web = %trust.authoritative_identity.classical_did,
@@ -430,11 +524,13 @@ mod tests {
         let anchors = DidAnchors {
             cluster_at9p_did: configured_did.clone(),
             cluster_did_web: web.to_owned(),
+            extra_root_cert_pem: None,
         };
         let error = verify_did_anchored_document(
             &anchors,
             &document(web, Some(&configured_did)),
             Arc::new(FixedCapsuleSource(served_bytes)),
+            "unused-test-credential".to_owned(),
         )
         .await
         .err()
@@ -450,11 +546,13 @@ mod tests {
         let anchors = DidAnchors {
             cluster_at9p_did: at9p.clone(),
             cluster_did_web: web.to_owned(),
+            extra_root_cert_pem: None,
         };
         let error = verify_did_anchored_document(
             &anchors,
             &document(web, Some(&at9p)),
             Arc::new(FixedCapsuleSource(bytes)),
+            "unused-test-credential".to_owned(),
         )
         .await
         .err()
@@ -469,11 +567,13 @@ mod tests {
         let anchors = DidAnchors {
             cluster_at9p_did: at9p.clone(),
             cluster_did_web: web.to_owned(),
+            extra_root_cert_pem: None,
         };
         let trust = verify_did_anchored_document(
             &anchors,
             &document(web, Some(&at9p)),
             Arc::new(FixedCapsuleSource(bytes)),
+            "unused-test-credential".to_owned(),
         )
         .await
         .unwrap();

--- a/crates/hyprstream-discovery/src/did_anchored.rs
+++ b/crates/hyprstream-discovery/src/did_anchored.rs
@@ -182,8 +182,7 @@ impl HttpWellKnownCapsuleSource {
             bytes.len() <= MAX_CREDENTIAL_BYTES,
             "registry deployment credential exceeds {MAX_CREDENTIAL_BYTES}-byte limit"
         );
-        String::from_utf8(bytes.to_vec())
-            .context("registry deployment credential is not UTF-8")
+        String::from_utf8(bytes.to_vec()).context("registry deployment credential is not UTF-8")
     }
 
     fn capsule_url(&self, did: &str) -> Result<String> {
@@ -371,8 +370,10 @@ pub(crate) async fn resolve_did_anchored_trust(anchors: &DidAnchors) -> Result<D
     .resolve_document(&anchors.cluster_did_web)
     .await
     .context("failed to fetch configured cluster did:web document")?;
-    let capsule_source =
-        Arc::new(HttpWellKnownCapsuleSource::new(&anchors.cluster_did_web, extra_root)?);
+    let capsule_source = Arc::new(HttpWellKnownCapsuleSource::new(
+        &anchors.cluster_did_web,
+        extra_root,
+    )?);
     // Fetch the registry credential from the same well-known family BEFORE
     // trusting anything: a missing/refusing endpoint must fail the bootstrap
     // even when the document and capsule are otherwise valid.
@@ -380,13 +381,9 @@ pub(crate) async fn resolve_did_anchored_trust(anchors: &DidAnchors) -> Result<D
         .fetch_registry_credential()
         .await
         .context("failed to fetch registry deployment credential")?;
-    let trust = verify_did_anchored_document(
-        anchors,
-        &document,
-        capsule_source,
-        registry_credential,
-    )
-    .await?;
+    let trust =
+        verify_did_anchored_document(anchors, &document, capsule_source, registry_credential)
+            .await?;
     tracing::info!(
         at9p = %trust.authoritative_identity.at9p_did,
         did_web = %trust.authoritative_identity.classical_did,

--- a/crates/hyprstream-discovery/src/did_anchored.rs
+++ b/crates/hyprstream-discovery/src/did_anchored.rs
@@ -160,7 +160,7 @@ impl HttpWellKnownCapsuleSource {
             .strip_suffix("did.json")
             .ok_or_else(|| anyhow::anyhow!("derived did:web URL does not end in did.json"))?;
         let url = format!("{prefix}deployment/registry-service.jwt");
-        let response = self
+        let mut response = self
             .http
             .get(&url)
             .send()
@@ -174,15 +174,19 @@ impl HttpWellKnownCapsuleSource {
                 "registry deployment credential exceeds {MAX_CREDENTIAL_BYTES}-byte limit"
             );
         }
-        let bytes = response
-            .bytes()
+        let mut bytes = Vec::new();
+        while let Some(chunk) = response
+            .chunk()
             .await
-            .context("failed to read registry deployment credential body")?;
-        anyhow::ensure!(
-            bytes.len() <= MAX_CREDENTIAL_BYTES,
-            "registry deployment credential exceeds {MAX_CREDENTIAL_BYTES}-byte limit"
-        );
-        String::from_utf8(bytes.to_vec()).context("registry deployment credential is not UTF-8")
+            .context("failed to read registry deployment credential body")?
+        {
+            anyhow::ensure!(
+                bytes.len().saturating_add(chunk.len()) <= MAX_CREDENTIAL_BYTES,
+                "registry deployment credential exceeds {MAX_CREDENTIAL_BYTES}-byte limit"
+            );
+            bytes.extend_from_slice(&chunk);
+        }
+        String::from_utf8(bytes).context("registry deployment credential is not UTF-8")
     }
 
     fn capsule_url(&self, did: &str) -> Result<String> {
@@ -590,12 +594,14 @@ mod tests {
         let anchors = DidAnchors {
             cluster_at9p_did: at9p.clone(),
             cluster_did_web: web.to_owned(),
+            extra_root_cert_pem: None,
         };
 
         let honest = verify_did_anchored_document(
             &anchors,
             &document_with_ca_and_reach(web, Some(&at9p), [0x07; 32], [0x45; 32]),
             Arc::new(FixedCapsuleSource(bytes.clone())),
+            "unused-test-credential".to_owned(),
         )
         .await
         .unwrap();
@@ -603,6 +609,7 @@ mod tests {
             &anchors,
             &document_with_ca_and_reach(web, Some(&at9p), [0x66; 32], [0xEE; 32]),
             Arc::new(FixedCapsuleSource(bytes)),
+            "unused-test-credential".to_owned(),
         )
         .await
         .unwrap();
@@ -623,11 +630,13 @@ mod tests {
         let anchors = DidAnchors {
             cluster_at9p_did: at9p.clone(),
             cluster_did_web: web.to_owned(),
+            extra_root_cert_pem: None,
         };
         let error = verify_did_anchored_document(
             &anchors,
             &document(web, Some(&at9p)),
             Arc::new(FixedCapsuleSource(bytes)),
+            "unused-test-credential".to_owned(),
         )
         .await
         .err()
@@ -649,12 +658,14 @@ mod tests {
         let anchors = DidAnchors {
             cluster_at9p_did: at9p.clone(),
             cluster_did_web: web.to_owned(),
+            extra_root_cert_pem: None,
         };
 
         let trust = verify_did_anchored_document(
             &anchors,
             &document(web, Some(&at9p)),
             Arc::new(FixedCapsuleSource(bytes)),
+            "unused-test-credential".to_owned(),
         )
         .await
         .unwrap();

--- a/crates/hyprstream-discovery/src/did_anchored.rs
+++ b/crates/hyprstream-discovery/src/did_anchored.rs
@@ -268,7 +268,7 @@ fn ca_key_from_capsule(verified: &VerifiedCapsule) -> Result<VerifyingKey> {
 /// Extract Discovery reach from the capsule's typed `#ns` service. The
 /// independent nodeId is transport reach only; the signed ping remains pinned
 /// to the separately authenticated Discovery application key.
-fn reach_from_capsule(verified: &VerifiedCapsule) -> Result<TransportConfig> {
+fn reach_from_capsule(verified: &VerifiedCapsule, document: &Value) -> Result<TransportConfig> {
     let entry = verified
         .capsule()
         .body
@@ -309,7 +309,23 @@ fn reach_from_capsule(verified: &VerifiedCapsule) -> Result<TransportConfig> {
             let address = carrier
                 .parse()
                 .context("capsule QUIC reach is not an IP socket address")?;
-            Ok(TransportConfig::quic(address, address.ip().to_string()).with_connect_mode())
+            // The capsule remains authoritative for WHERE to dial. The
+            // did:web service may only contribute channel mechanics (SNI,
+            // WebPKI policy, and certificate hashes) for that exact
+            // capsule-bound socket. Those mechanics cannot select application
+            // identity: the signed ping is still pinned independently.
+            let document_transport = hyprstream_rpc::did_web::transport_entries(document)
+                .into_iter()
+                .map(|decoded| decoded.config)
+                .find(|config| {
+                    matches!(
+                        &config.endpoint,
+                        EndpointType::Quic { addr, .. } if *addr == address
+                    )
+                });
+            Ok(document_transport.unwrap_or_else(|| {
+                TransportConfig::quic(address, address.ip().to_string()).with_connect_mode()
+            }))
         }
         ref other => bail!(
             "capsule deployment reach {DEPLOYMENT_REACH_SERVICE:?} is not an iroh or QUIC endpoint (got {other:?})"
@@ -346,7 +362,7 @@ pub(crate) async fn verify_did_anchored_document(
     // The document contributes only the reciprocal identifier vouch above.
     // Everything installed is content-bound to the configured did:at9p pin.
     let ca_verifying_key = ca_key_from_capsule(&verified)?;
-    let discovery_transport = reach_from_capsule(&verified)?;
+    let discovery_transport = reach_from_capsule(&verified, document)?;
     anyhow::ensure!(
         matches!(
             discovery_transport.endpoint,
@@ -660,18 +676,32 @@ mod tests {
             cluster_did_web: web.to_owned(),
             extra_root_cert_pem: None,
         };
+        let channel_auth =
+            hyprstream_rpc::transport::QuicServerAuth::pinned(vec![[0xA5; 32]]).unwrap();
+        let mut document = document(web, Some(&at9p));
+        document["service"] = json!([{
+            "id": format!("{web}#quic"),
+            "type": "QuicTransport",
+            "serviceEndpoint": hyprstream_rpc::service_entry::encode_quic(
+                "https://127.0.0.1:7443",
+                &channel_auth,
+                &["hyprstream-rpc/1"],
+            ),
+        }]);
 
         let trust = verify_did_anchored_document(
             &anchors,
-            &document(web, Some(&at9p)),
+            &document,
             Arc::new(FixedCapsuleSource(bytes)),
             "unused-test-credential".to_owned(),
         )
         .await
         .unwrap();
         match trust.discovery_transport.endpoint {
-            EndpointType::Quic { addr, .. } => {
+            EndpointType::Quic { addr, auth, .. } => {
                 assert_eq!(addr, "127.0.0.1:7443".parse().unwrap());
+                assert!(!auth.require_web_pki());
+                assert_eq!(auth.accept_cert_hashes(), &[[0xA5; 32]]);
             }
             other => panic!("expected capsule-bound QUIC reach, got {other:?}"),
         }

--- a/crates/hyprstream-discovery/src/lib.rs
+++ b/crates/hyprstream-discovery/src/lib.rs
@@ -109,8 +109,8 @@ pub use hyprstream_rpc::resolver::Resolver;
 #[cfg(not(target_arch = "wasm32"))]
 pub use did_anchored::{DeploymentTrustSource, DidAnchors};
 pub use service::{
-    bootstrap_deployment_process, deployment_registry_verifier, AuthorizationProvider,
-    DiscoveryService, RecordCarData, RecordResolver, RegistryDeploymentVerifier,
+    bootstrap_deployment_process, deployment_registry_verifier, resolve_and_authenticate_did_anchors,
+    AuthorizationProvider, DiscoveryService, RecordCarData, RecordResolver, RegistryDeploymentVerifier,
     production_browser_currentness_verifier, production_browser_provisioning,
     production_rpc_client,
 };

--- a/crates/hyprstream-discovery/src/lib.rs
+++ b/crates/hyprstream-discovery/src/lib.rs
@@ -56,6 +56,13 @@ mod service;
 #[cfg(not(target_arch = "wasm32"))]
 mod checkpointed_pds;
 
+/// Create the empty checkpoint store for an explicitly provisioned fresh node.
+/// Ordinary resolver startup never calls this, so missing history fails closed.
+#[cfg(not(target_arch = "wasm32"))]
+pub fn initialize_deployment_checkpoint_store() -> anyhow::Result<()> {
+    checkpointed_pds::initialize_deployment_store()
+}
+
 /// #893 (at9p D1) — `did:at9p` capsule resolver: turns a GATE-verified capsule
 /// into a dialable `TransportConfig::iroh` (sibling to
 /// `hyprstream_rpc::service_entry::decode_iroh`). Injectable at the

--- a/crates/hyprstream-discovery/src/scheduling.rs
+++ b/crates/hyprstream-discovery/src/scheduling.rs
@@ -31,7 +31,10 @@ pub struct Resource {
 
 impl Resource {
     pub fn new(name: impl Into<String>, quantity: impl Into<String>) -> Self {
-        Self { name: name.into(), quantity: quantity.into() }
+        Self {
+            name: name.into(),
+            quantity: quantity.into(),
+        }
     }
 }
 
@@ -45,13 +48,19 @@ pub struct ResourceRequest {
 
 impl ResourceRequest {
     pub fn new(name: impl Into<String>, min_quantity: impl Into<String>) -> Self {
-        Self { name: name.into(), min_quantity: min_quantity.into() }
+        Self {
+            name: name.into(),
+            min_quantity: min_quantity.into(),
+        }
     }
 
     /// Satisfied iff `available` parses and is `>= min_quantity`. A missing/
     /// unparseable available value is *not* satisfiable (fail-closed).
     pub fn satisfied_by(&self, available: &str) -> bool {
-        match (parse_k8s_quantity(available), parse_k8s_quantity(&self.min_quantity)) {
+        match (
+            parse_k8s_quantity(available),
+            parse_k8s_quantity(&self.min_quantity),
+        ) {
             (Some(have), Some(need)) => have >= need,
             _ => false,
         }
@@ -80,7 +89,11 @@ pub struct LabelSelector {
 
 impl LabelSelector {
     pub fn new(key: impl Into<String>, op: SelectorOp, values: Vec<String>) -> Self {
-        Self { key: key.into(), op, values }
+        Self {
+            key: key.into(),
+            op,
+            values,
+        }
     }
 
     /// Evaluate this selector against a label set `(key, value)`.
@@ -93,8 +106,12 @@ impl LabelSelector {
             SelectorOp::NotIn => entry.is_none_or(|(_, v)| !self.values.iter().any(|w| w == v)),
             // Gt/Lt compare numerically over the k8s-quantity value (k8s restricts
             // these to integer resources; we extend to any parseable quantity).
-            SelectorOp::Gt => self.cmp_numeric(entry.map(|(_, v)| v.as_str()), |o| o == Ordering::Greater),
-            SelectorOp::Lt => self.cmp_numeric(entry.map(|(_, v)| v.as_str()), |o| o == Ordering::Less),
+            SelectorOp::Gt => {
+                self.cmp_numeric(entry.map(|(_, v)| v.as_str()), |o| o == Ordering::Greater)
+            }
+            SelectorOp::Lt => {
+                self.cmp_numeric(entry.map(|(_, v)| v.as_str()), |o| o == Ordering::Less)
+            }
         }
     }
 
@@ -160,8 +177,8 @@ pub fn parse_k8s_quantity(s: &str) -> Option<i128> {
     // Sub-unit suffixes (`m`, `u`) divide instead of multiply.
     let milli: i128 = match suffix {
         "" => (v * 1_000.0) as i128,
-        "m" => v as i128,                       // already milli
-        "u" | "µ" => (v / 1_000.0) as i128,     // micro → milli
+        "m" => v as i128,                   // already milli
+        "u" | "µ" => (v / 1_000.0) as i128, // micro → milli
         "k" => (v * 1_000.0 * 1_000.0) as i128,
         "M" => (v * 1_000_000.0 * 1_000.0) as i128,
         "G" => (v * 1_000_000_000.0 * 1_000.0) as i128,
@@ -211,7 +228,10 @@ pub fn filter<'c, C>(candidates: &'c [C], predicates: &[Predicate<C>]) -> Vec<Ou
         .iter()
         .map(|c| {
             let rejected = predicates.iter().find_map(|p| p(c));
-            Outcome { candidate: c, rejected }
+            Outcome {
+                candidate: c,
+                rejected,
+            }
         })
         .collect()
 }
@@ -257,7 +277,11 @@ where
     C: Clone,
 {
     let outcomes = filter(candidates, predicates);
-    let mut survivors: Vec<&C> = outcomes.iter().filter(|o| o.passed()).map(|o| o.candidate).collect();
+    let mut survivors: Vec<&C> = outcomes
+        .iter()
+        .filter(|o| o.passed())
+        .map(|o| o.candidate)
+        .collect();
     survivors = rank(survivors, rank_by);
     let bound: Vec<&C> = survivors.into_iter().take(max).collect();
     let chosen: Vec<&C> = bound.clone();
@@ -275,13 +299,24 @@ where
                 .iter()
                 .find(|o| std::ptr::eq(o.candidate, c))
                 .and_then(|o| o.rejected.as_ref().map(|r| r.0.clone()));
-            CandidateOutcome { candidate: c.clone(), selected: is_selected, rejection_reason: rejection }
+            CandidateOutcome {
+                candidate: c.clone(),
+                selected: is_selected,
+                rejection_reason: rejection,
+            }
         })
         .collect();
     let selected_idx = bound.first().and_then(|b| {
-        candidates.iter().position(|c| std::ptr::eq(c as *const _, *b as *const _))
+        candidates
+            .iter()
+            .position(|c| std::ptr::eq(c as *const _, *b as *const _))
     });
-    SelectionReport { requested: String::new(), candidates: candidate_reports, selected: selected_idx, summary }
+    SelectionReport {
+        requested: String::new(),
+        candidates: candidate_reports,
+        selected: selected_idx,
+        summary,
+    }
 }
 
 // ─── Capability-source contract ────────────────────────────────────────────
@@ -366,15 +401,24 @@ mod tests {
     #[test]
     fn filter_rank_select_pipeline() {
         // candidates: (name, priority). predicate: keep priority >= 2.
-        let cands = vec![("a".to_owned(), 1), ("b".to_owned(), 3), ("c".to_owned(), 2), ("d".to_owned(), 2)];
+        let cands = vec![
+            ("a".to_owned(), 1),
+            ("b".to_owned(), 3),
+            ("c".to_owned(), 2),
+            ("d".to_owned(), 2),
+        ];
         let preds: Vec<Predicate<(String, i32)>> = vec![Box::new(|c| {
-            if c.1 >= 2 { None } else { Some(RejectionReason("priority < 2".into())) }
+            if c.1 >= 2 {
+                None
+            } else {
+                Some(RejectionReason("priority < 2".into()))
+            }
         })];
         let report = select(
             &cands,
             &preds,
             |a, b| b.1.cmp(&a.1).then(a.0.cmp(&b.0)), // priority desc, name asc
-            2, // bound
+            2,                                        // bound
         );
         // survivors after filter: b(3), c(2), d(2) → ranked b, c, d → bound 2 → [b, c]
         let selected: Vec<&String> = report
@@ -385,7 +429,11 @@ mod tests {
             .collect();
         assert_eq!(selected, vec![&"b".to_owned(), &"c".to_owned()]);
         // rejected candidate carries its reason
-        let a = report.candidates.iter().find(|o| o.candidate.0 == "a").unwrap();
+        let a = report
+            .candidates
+            .iter()
+            .find(|o| o.candidate.0 == "a")
+            .unwrap();
         assert_eq!(a.rejection_reason.as_deref(), Some("priority < 2"));
         assert!(report.summary.contains("4 considered") && report.summary.contains("3 survived"));
     }
@@ -394,8 +442,20 @@ mod tests {
     fn filter_records_first_rejection_only() {
         let cands = vec![1, 2, 3];
         let preds: Vec<Predicate<i32>> = vec![
-            Box::new(|c| if c % 2 == 0 { Some(RejectionReason("even".into())) } else { None }),
-            Box::new(|c| if *c == 1 { Some(RejectionReason("is-one".into())) } else { None }),
+            Box::new(|c| {
+                if c % 2 == 0 {
+                    Some(RejectionReason("even".into()))
+                } else {
+                    None
+                }
+            }),
+            Box::new(|c| {
+                if *c == 1 {
+                    Some(RejectionReason("is-one".into()))
+                } else {
+                    None
+                }
+            }),
         ];
         let out = filter(&cands, &preds);
         // 1 rejected by FIRST predicate? no — 1 is odd, passes pred 0, rejected by pred 1 ("is-one")
@@ -418,7 +478,10 @@ mod tests {
             }
         }
         let g = Gpu;
-        assert_eq!(g.capability_labels(), vec![("gpu.arch".into(), "hopper".into())]);
+        assert_eq!(
+            g.capability_labels(),
+            vec![("gpu.arch".into(), "hopper".into())]
+        );
         assert_eq!(g.capability_resources().len(), 1);
     }
 }

--- a/crates/hyprstream-discovery/src/service.rs
+++ b/crates/hyprstream-discovery/src/service.rs
@@ -1978,10 +1978,22 @@ static PROCESS_BOOTSTRAP_AUTHORITY: parking_lot::Mutex<ProcessBootstrapAuthority
 /// Atomically consume the explicitly selected deployment witness and install
 /// the process Discovery resolver. Selection never falls back between the
 /// OS-owned and DID-anchored providers.
+///
+/// `remote_node` selects how the DID-anchored provider reaches Discovery:
+/// - `false` (same-node fabric, e.g. the metal stack's `service start --ipc`
+///   containers sharing the IPC volume): a lazy local discovery client —
+///   identical posture to the OS-owned path, which also never pings. This is
+///   required on nodes that HOST Discovery (possibly as an in-process
+///   dependency started after this install), where a pre-install network
+///   liveness check would self-deadlock.
+/// - `true` (remote worker): dial the DID-advertised network transport and
+///   REQUIRE a successful signed liveness ping before installing — a dead or
+///   wrong-key endpoint refuses the boot.
 #[cfg(not(target_arch = "wasm32"))]
 pub async fn bootstrap_deployment_process(
     signing_key: SigningKey,
     trust_source: crate::DeploymentTrustSource,
+    remote_node: bool,
 ) -> Result<()> {
     let discovery_vk = hyprstream_service::global_trust_store()
         .resolve_one("discovery")
@@ -1994,20 +2006,74 @@ pub async fn bootstrap_deployment_process(
             (authority, client)
         }
         crate::DeploymentTrustSource::DidAnchored(anchors) => {
-            let (authority, transport) = authenticate_did_anchored_bootstrap(&anchors).await?;
+            let (authority, discovery_transport, mesh_kem_recipient, ml_dsa_65_keys) =
+                authenticate_did_anchored_bootstrap(&anchors).await?;
             let signer = hyprstream_rpc::signer::LocalSigner::new(signing_key);
-            let rpc = hyprstream_rpc::dial::dial(&transport, signer, Some(discovery_vk), None)?;
-            let client = crate::DiscoveryClient::new(rpc);
-            let health = client
-                .ping()
-                .await
-                .context("DID-anchored Discovery reach failed liveness check")?;
-            anyhow::ensure!(
-                health.status == "ok",
-                "DID-anchored Discovery liveness returned status {:?}",
-                health.status
-            );
-            (authority, client)
+            if remote_node {
+                // Remote worker: the DID-advertised transport is the only
+                // reach. QUIC forbids cleartext envelopes, so the document's
+                // #mesh-kem recipient (anchored by the mutual-alias + CA-bound
+                // trust decision above) is REQUIRED — no recipient, no boot.
+                let recipient = mesh_kem_recipient.ok_or_else(|| {
+                    anyhow::anyhow!(
+                        "did:web deployment document publishes no #mesh-kem keyAgreement; \
+                         refusing cleartext downgrade for the remote-node bootstrap"
+                    )
+                })?;
+                // Response authentication likewise requires the document's
+                // single #mesh-pq (ML-DSA-65) anchor for the discovery key.
+                let pq_key = match ml_dsa_65_keys.as_slice() {
+                    [key] => key.clone(),
+                    keys => anyhow::bail!(
+                        "did:web deployment document must publish exactly one ML-DSA-65 \
+                         verification method for the remote-node bootstrap (found {})",
+                        keys.len()
+                    ),
+                };
+                let mut kem_store =
+                    hyprstream_rpc::crypto::hybrid_kem::KeyedKemTrustStore::new();
+                kem_store.bind(discovery_vk.to_bytes(), recipient);
+                let mut pq_store = hyprstream_rpc::envelope::KeyedPqTrustStore::new();
+                pq_store.bind(discovery_vk.to_bytes(), &pq_key);
+                // Dial it and require liveness — a reachable-but-wrong
+                // endpoint (no discovery key) or a dead one fails closed here.
+                let rpc = hyprstream_rpc::dial::dial_with_crypto_stores(
+                    &discovery_transport,
+                    signer,
+                    Some(discovery_vk),
+                    None,
+                    Some(Arc::new(kem_store)),
+                    Some(Arc::new(pq_store)),
+                )?;
+                let client = crate::DiscoveryClient::new(rpc);
+                let health = client
+                    .ping()
+                    .await
+                    .context("DID-anchored Discovery reach failed liveness check")?;
+                anyhow::ensure!(
+                    health.status == "ok",
+                    "DID-anchored Discovery liveness returned status {:?}",
+                    health.status
+                );
+                (authority, client)
+            } else {
+                // Same-node fabric: the local default discovery endpoint is a
+                // lazy client (connects on first use), so Discovery may start
+                // after this install inside the same process. Trust decisions
+                // were already made above (GATE + mutual alias + CA-bound
+                // credential) — no liveness check is meaningful or required
+                // for a lazy local client, matching the OS-owned path.
+                let transport = hyprstream_rpc::registry::try_global()
+                    .ok_or_else(|| anyhow::anyhow!(
+                        "EndpointRegistry not initialized — same-node discovery fabric unavailable"
+                    ))?
+                    .try_endpoint(
+                        "discovery",
+                        hyprstream_rpc::registry::SocketKind::Rep,
+                    )?;
+                let rpc = hyprstream_rpc::dial::dial(&transport, signer, Some(discovery_vk), None)?;
+                (authority, crate::DiscoveryClient::new(rpc))
+            }
         }
     };
     DiscoveryService::bootstrap_authenticated_process(authority, discovery_client)
@@ -2040,19 +2106,51 @@ fn authenticate_deployment_bootstrap() -> Result<ProcessBootstrapAuthority> {
 #[cfg(not(target_arch = "wasm32"))]
 async fn authenticate_did_anchored_bootstrap(
     anchors: &crate::DidAnchors,
-) -> Result<(ProcessBootstrapAuthority, TransportConfig)> {
+) -> Result<(
+    ProcessBootstrapAuthority,
+    TransportConfig,
+    Option<hyprstream_rpc::crypto::hybrid_kem::RecipientPublic>,
+    Vec<hyprstream_rpc::crypto::pq::MlDsaVerifyingKey>,
+)> {
     seal_process_bootstrap_authority()?;
     let trust = crate::did_anchored::resolve_did_anchored_trust(anchors).await?;
     let witness =
         authenticate_registry_deployment_credentials(TrustedRegistryDeploymentCredentials {
             ca_verifying_key: trust.ca_verifying_key,
-            registry_credential: load_registry_deployment_credential()?,
+            registry_credential: trust.registry_credential,
         })?;
     let authority = ProcessBootstrapAuthority {
         store_path: hyprstream_service::deployment_data_dir()?.join("pds-store"),
         acceptance_identity: ProcessAcceptanceIdentity::Deployment(witness.verifier),
     };
-    Ok((authority, trust.discovery_transport))
+    Ok((
+        authority,
+        trust.discovery_transport,
+        trust.mesh_kem_recipient,
+        trust.ml_dsa_65_keys,
+    ))
+}
+
+/// Resolve the configured DID anchors and authenticate the fetched registry
+/// deployment credential against the DID-derived deployment CA. This is the
+/// full DID-anchored trust decision — GATE (canon → hash → sig), mutual
+/// alsoKnownAs attestation, credential fetch, and the exact credential profile
+/// (CA-bound kid/iss/domain, one-hour freshness) — WITHOUT the process-global
+/// one-shot seal and resolver install performed by
+/// [`bootstrap_deployment_process`]. Exposed so integration tests can exercise
+/// the trust decision (and its failure modes) more than once per process.
+/// Any failure is terminal for the caller; nothing here retries or downgrades.
+#[cfg(not(target_arch = "wasm32"))]
+pub async fn resolve_and_authenticate_did_anchors(
+    anchors: &crate::DidAnchors,
+) -> Result<(RegistryDeploymentVerifier, TransportConfig)> {
+    let trust = crate::did_anchored::resolve_did_anchored_trust(anchors).await?;
+    let witness =
+        authenticate_registry_deployment_credentials(TrustedRegistryDeploymentCredentials {
+            ca_verifying_key: trust.ca_verifying_key,
+            registry_credential: trust.registry_credential,
+        })?;
+    Ok((witness.verifier, trust.discovery_transport))
 }
 
 #[cfg(test)]

--- a/crates/hyprstream-discovery/src/service.rs
+++ b/crates/hyprstream-discovery/src/service.rs
@@ -2030,8 +2030,7 @@ pub async fn bootstrap_deployment_process(
                         keys.len()
                     ),
                 };
-                let mut kem_store =
-                    hyprstream_rpc::crypto::hybrid_kem::KeyedKemTrustStore::new();
+                let mut kem_store = hyprstream_rpc::crypto::hybrid_kem::KeyedKemTrustStore::new();
                 kem_store.bind(discovery_vk.to_bytes(), recipient);
                 let mut pq_store = hyprstream_rpc::envelope::KeyedPqTrustStore::new();
                 pq_store.bind(discovery_vk.to_bytes(), &pq_key);
@@ -2064,13 +2063,12 @@ pub async fn bootstrap_deployment_process(
                 // credential) — no liveness check is meaningful or required
                 // for a lazy local client, matching the OS-owned path.
                 let transport = hyprstream_rpc::registry::try_global()
-                    .ok_or_else(|| anyhow::anyhow!(
+                    .ok_or_else(|| {
+                        anyhow::anyhow!(
                         "EndpointRegistry not initialized — same-node discovery fabric unavailable"
-                    ))?
-                    .try_endpoint(
-                        "discovery",
-                        hyprstream_rpc::registry::SocketKind::Rep,
-                    )?;
+                    )
+                    })?
+                    .try_endpoint("discovery", hyprstream_rpc::registry::SocketKind::Rep)?;
                 let rpc = hyprstream_rpc::dial::dial(&transport, signer, Some(discovery_vk), None)?;
                 (authority, crate::DiscoveryClient::new(rpc))
             }

--- a/crates/hyprstream-rpc/src/did_web.rs
+++ b/crates/hyprstream-rpc/src/did_web.rs
@@ -361,6 +361,53 @@ pub fn verification_method_ed25519_keys(doc: &Value) -> Vec<[u8; 32]> {
     keys
 }
 
+/// multicodec `x25519-pub` unsigned-varint prefix (matches the publisher in
+/// `hyprstream::services::oauth::did_document`).
+const MULTICODEC_X25519_PUB: [u8; 2] = [0xec, 0x01];
+/// multicodec `mlkem-768-pub` unsigned-varint prefix.
+const MULTICODEC_ML_KEM_768_PUB: [u8; 2] = [0x8c, 0x24];
+
+/// Extract the `#mesh-kem` hybrid-KEM recipient public from a DID document's
+/// `keyAgreement` relationship (#1137 remote-node bootstrap).
+///
+/// The publisher emits one `Multikey` VM per suite leg (X25519, then
+/// ML-KEM-768, multicodec-prefixed base58btc). The extractor requires EXACTLY
+/// one of each, reassembles them in the pinned suite's component order, and
+/// runs [`RecipientPublic::validate`] — a partial, duplicated, reordered, or
+/// malformed relationship is `None` (caller fails closed), never a partial
+/// recipient.
+pub fn mesh_kem_recipient(
+    doc: &Value,
+) -> Option<crate::crypto::hybrid_kem::RecipientPublic> {
+    let kas = doc.get("keyAgreement")?.as_array()?;
+    let mut x25519: Option<Vec<u8>> = None;
+    let mut mlkem768: Option<Vec<u8>> = None;
+    for vm in kas {
+        let mb = vm.get("publicKeyMultibase").and_then(Value::as_str)?;
+        let payload = bs58::decode(mb.strip_prefix('z')?).into_vec().ok()?;
+        let (codec, key) = payload.split_at_checked(2)?;
+        match codec {
+            c if c == MULTICODEC_X25519_PUB => {
+                if x25519.replace(key.to_vec()).is_some() {
+                    return None; // duplicated leg — ambiguous, fail closed
+                }
+            }
+            c if c == MULTICODEC_ML_KEM_768_PUB => {
+                if mlkem768.replace(key.to_vec()).is_some() {
+                    return None;
+                }
+            }
+            _ => return None, // unexpected keyAgreement leg — fail closed
+        }
+    }
+    let recipient = crate::crypto::hybrid_kem::RecipientPublic {
+        suite_id: crate::crypto::hybrid_kem::SuiteId::HyKemX25519MlKem768,
+        eks: vec![x25519?, mlkem768?],
+    };
+    recipient.validate().ok()?;
+    Some(recipient)
+}
+
 /// Extract every ML-DSA-65 verifying key published in a DID document's
 /// `verificationMethod` array (#579 multi-alg VM extraction).
 ///
@@ -623,13 +670,33 @@ impl HttpDidDocFetcher {
     /// than swallowed (a `unwrap_or_default()` would yield a client WITHOUT the
     /// configured timeout/redirect policy, defeating the SSRF/DoS hardening).
     pub fn new(ttl: std::time::Duration) -> Result<Self> {
-        let http = reqwest::Client::builder()
+        Self::build(ttl, None)
+    }
+
+    /// Construct a fetcher that additionally trusts an extra root certificate
+    /// (PEM), for private-PKI deployments whose did:web host terminates TLS
+    /// with an internal CA. This ADDS a trust anchor — the public WebPKI roots
+    /// remain enabled, and all other hardening (https-only, no redirects,
+    /// timeouts, size cap) is unchanged. Returns `Err` on an unreadable or
+    /// malformed PEM rather than silently degrading.
+    pub fn with_extra_root(ttl: std::time::Duration, extra_root_pem: &[u8]) -> Result<Self> {
+        Self::build(ttl, Some(extra_root_pem))
+    }
+
+    fn build(ttl: std::time::Duration, extra_root_pem: Option<&[u8]>) -> Result<Self> {
+        let mut builder = reqwest::Client::builder()
             // SSRF: do NOT follow redirects. did:web is a direct HTTPS GET; a
             // redirect to http://127.0.0.1 / link-local would bypass https-only.
             .redirect(reqwest::redirect::Policy::none())
             // Bound how long a connect/request can hang.
             .connect_timeout(std::time::Duration::from_secs(10))
-            .timeout(std::time::Duration::from_secs(10))
+            .timeout(std::time::Duration::from_secs(10));
+        if let Some(pem) = extra_root_pem {
+            let cert = reqwest::Certificate::from_pem(pem)
+                .map_err(|e| anyhow!("extra did:web TLS root is not a valid PEM certificate: {e}"))?;
+            builder = builder.add_root_certificate(cert);
+        }
+        let http = builder
             .build()
             .map_err(|e| anyhow!("failed to build did:web HTTPS client: {e}"))?;
         Ok(Self {

--- a/crates/hyprstream-rpc/src/paths.rs
+++ b/crates/hyprstream-rpc/src/paths.rs
@@ -7,15 +7,36 @@
 
 use std::path::PathBuf;
 
+use anyhow::{bail, Result};
+
+fn validate_instance_name(instance: &str) -> Result<()> {
+    if matches!(instance, "." | "..")
+        || !instance
+            .bytes()
+            .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'.' | b'_' | b'-'))
+    {
+        bail!(
+            "HYPRSTREAM_INSTANCE must contain only ASCII letters, digits, '.', '_', or '-' and must not be '.' or '..'"
+        );
+    }
+    Ok(())
+}
+
 /// Apply HYPRSTREAM_INSTANCE namespacing to a base path.
 ///
 /// When `HYPRSTREAM_INSTANCE` is set and non-empty, appends `instances/{value}`
 /// to the base path.  This allows multiple hyprstream instances to coexist on
 /// the same host without IPC socket or data directory collisions.
-fn apply_instance_namespace(base: PathBuf) -> PathBuf {
+fn apply_instance_namespace(base: PathBuf) -> Result<PathBuf> {
     match std::env::var("HYPRSTREAM_INSTANCE") {
-        Ok(inst) if !inst.is_empty() => base.join("instances").join(inst),
-        _ => base,
+        Ok(inst) if !inst.is_empty() => {
+            validate_instance_name(&inst)?;
+            Ok(base.join("instances").join(inst))
+        }
+        Ok(_) | Err(std::env::VarError::NotPresent) => Ok(base),
+        Err(std::env::VarError::NotUnicode(_)) => {
+            bail!("HYPRSTREAM_INSTANCE must be valid Unicode")
+        }
     }
 }
 
@@ -43,6 +64,7 @@ pub fn runtime_dir() -> PathBuf {
         }
     };
     apply_instance_namespace(base)
+        .unwrap_or_else(|error| panic!("invalid HYPRSTREAM_INSTANCE: {error}"))
 }
 
 /// Socket directory for EventService
@@ -194,7 +216,17 @@ pub fn bin_dir() -> Option<PathBuf> {
 /// When `HYPRSTREAM_INSTANCE` is set, returns
 /// `~/.local/share/hyprstream/instances/{instance}`.
 pub fn data_dir() -> Option<PathBuf> {
-    dirs::data_local_dir().map(|d| apply_instance_namespace(d.join("hyprstream")))
+    try_data_dir().ok().flatten()
+}
+
+/// Resolve the data directory while reporting an invalid instance namespace.
+///
+/// Deployment-owned storage must use this checked variant so a malformed
+/// `HYPRSTREAM_INSTANCE` cannot be mistaken for an unavailable data directory.
+pub fn try_data_dir() -> Result<Option<PathBuf>> {
+    dirs::data_local_dir()
+        .map(|dir| apply_instance_namespace(dir.join("hyprstream")))
+        .transpose()
 }
 
 /// Versions directory (`~/.local/share/hyprstream/versions`)
@@ -272,7 +304,8 @@ mod tests {
         // When HYPRSTREAM_INSTANCE is unset, paths should not contain "instances"
         std::env::remove_var("HYPRSTREAM_INSTANCE");
         let base = PathBuf::from("/tmp/test-hyprstream");
-        let result = apply_instance_namespace(base.clone());
+        let result = apply_instance_namespace(base.clone())
+            .unwrap_or_else(|error| panic!("unset instance must be accepted: {error}"));
         assert_eq!(result, base);
     }
 
@@ -280,7 +313,8 @@ mod tests {
     fn test_instance_namespace_set() {
         std::env::set_var("HYPRSTREAM_INSTANCE", "foo");
         let base = PathBuf::from("/tmp/test-hyprstream");
-        let result = apply_instance_namespace(base);
+        let result = apply_instance_namespace(base)
+            .unwrap_or_else(|error| panic!("safe instance must be accepted: {error}"));
         assert_eq!(result, PathBuf::from("/tmp/test-hyprstream/instances/foo"));
         std::env::remove_var("HYPRSTREAM_INSTANCE");
     }
@@ -289,8 +323,37 @@ mod tests {
     fn test_instance_namespace_empty_string() {
         std::env::set_var("HYPRSTREAM_INSTANCE", "");
         let base = PathBuf::from("/tmp/test-hyprstream");
-        let result = apply_instance_namespace(base.clone());
-        assert_eq!(result, base, "empty HYPRSTREAM_INSTANCE should be treated as unset");
+        let result = apply_instance_namespace(base.clone())
+            .unwrap_or_else(|error| panic!("empty instance must be accepted: {error}"));
+        assert_eq!(
+            result, base,
+            "empty HYPRSTREAM_INSTANCE should be treated as unset"
+        );
         std::env::remove_var("HYPRSTREAM_INSTANCE");
+    }
+
+    #[test]
+    fn test_instance_namespace_rejects_non_names() {
+        for instance in [
+            ".",
+            "..",
+            "../escape",
+            "nested/path",
+            r"nested\path",
+            "bad name",
+        ] {
+            assert!(
+                validate_instance_name(instance).is_err(),
+                "{instance:?} must be rejected"
+            );
+        }
+    }
+
+    #[test]
+    fn test_instance_namespace_accepts_safe_names() {
+        for instance in ["foo", "did-trust-123", "node_1", "node.example"] {
+            validate_instance_name(instance)
+                .unwrap_or_else(|error| panic!("{instance:?} must be accepted: {error}"));
+        }
     }
 }

--- a/crates/hyprstream-service/src/service/factory.rs
+++ b/crates/hyprstream-service/src/service/factory.rs
@@ -858,9 +858,12 @@ impl ServiceContext {
 /// authenticated process bootstrap. No caller-provided context or path can
 /// influence this value.
 pub fn deployment_data_dir() -> anyhow::Result<std::path::PathBuf> {
-    let data_dir = hyprstream_rpc::paths::data_dir()
+    let data_dir = hyprstream_rpc::paths::try_data_dir()?
         .ok_or_else(|| anyhow::anyhow!("deployment data directory is unavailable"))?;
-    anyhow::ensure!(data_dir.is_absolute(), "deployment data directory must be absolute");
+    anyhow::ensure!(
+        data_dir.is_absolute(),
+        "deployment data directory must be absolute"
+    );
     Ok(data_dir.join("models/.registry"))
 }
 
@@ -1149,5 +1152,4 @@ mod tests {
             .expect("authority mutation subprocess");
         assert!(status.success(), "authority mutation subprocess failed");
     }
-
 }

--- a/crates/hyprstream/examples/did-trust-local-deploy.rs
+++ b/crates/hyprstream/examples/did-trust-local-deploy.rs
@@ -1,0 +1,116 @@
+//! #1137 local boot-repro fixture: stand up a REAL local deployment — the
+//! same material the e2e tests use — and serve it over REAL HTTPS, then
+//! print the exact environment a same-node `service start … --ipc`
+//! invocation needs to DID-anchor against it.
+//!
+//! Usage:
+//!   cargo run -p hyprstream --example did-trust-local-deploy -- <workdir>
+//!
+//! Then, in another shell:
+//!   export HYPRSTREAM__CLUSTER_AT9P_DID=...   (printed)
+//!   export HYPRSTREAM__CLUSTER_DID_WEB=...    (printed)
+//!   export HYPRSTREAM__CLUSTER_ANCHOR_ROOT_CERT=...  (printed)
+//!   export HYPRSTREAM_INSTANCE=...            (printed)
+//!   hyprstream service start registry --foreground --ipc
+
+#![allow(clippy::expect_used, clippy::print_stdout, clippy::unwrap_used)]
+
+#[path = "../tests/fixtures/did_trust.rs"]
+mod did_trust;
+use did_trust::*;
+
+use ed25519_dalek::SigningKey;
+use hyprstream_rpc::did_key::ed25519_to_did_key;
+use hyprstream_rpc::service_entry::encode_quic;
+use hyprstream_rpc::transport::QuicServerAuth;
+use serde_json::json;
+
+#[tokio::main(flavor = "multi_thread", worker_threads = 2)]
+async fn main() -> anyhow::Result<()> {
+    // rustls needs an explicit process default (both aws-lc-rs and ring are
+    // linked in this workspace); use the repo's declared interop provider.
+    hyprstream_rpc::transport::pq_provider::install_pq_crypto_provider()
+        .map_err(|e| anyhow::anyhow!("crypto provider: {e}"))?;
+    let workdir = std::env::args()
+        .nth(1)
+        .map(std::path::PathBuf::from)
+        .unwrap_or_else(|| std::path::PathBuf::from("/tmp/did-trust-local-deploy"));
+    std::fs::create_dir_all(&workdir)?;
+
+    // Reserve the listener before emitting the DID so callers can connect as
+    // soon as this process reports the deployment ready.
+    let https_listener = std::net::TcpListener::bind("127.0.0.1:0")?;
+    let https_port = https_listener.local_addr()?.port();
+    let did_web = format!("did:web:localhost%3A{https_port}");
+    let capsule = make_capsule(&did_web, 0x71);
+    let ca = SigningKey::from_bytes(&[0x72; 32]);
+    let registry = SigningKey::from_bytes(&[0x73; 32]);
+    let tls = make_tls();
+
+    // Deployment well-known directory layout.
+    let well_known = workdir.join("well-known");
+    std::fs::create_dir_all(well_known.join("at9p"))?;
+    std::fs::create_dir_all(well_known.join("deployment"))?;
+
+    let ca_vk = ca.verifying_key();
+    let multikey = ed25519_to_did_key(ca_vk.as_bytes())
+        .strip_prefix("did:key:")
+        .unwrap()
+        .to_owned();
+    let auth = QuicServerAuth::pinned(vec![[9u8; 32]]).unwrap();
+    let document = json!({
+        "id": did_web,
+        "alsoKnownAs": [capsule.at9p_did],
+        "verificationMethod": [{
+            "id": format!("{did_web}#deployment-ca"),
+            "type": "Multikey",
+            "controller": did_web,
+            "publicKeyMultibase": multikey,
+        }],
+        "service": [{
+            "id": format!("{did_web}#quic"),
+            "type": "QuicTransport",
+            "serviceEndpoint": encode_quic("https://127.0.0.1:4433", &auth, &["hyprstream-rpc/1"]),
+        }],
+    });
+    std::fs::write(well_known.join("did.json"), document.to_string())?;
+    let cid = capsule.at9p_did.strip_prefix("did:at9p:").unwrap();
+    std::fs::write(
+        well_known.join("at9p").join(format!("{cid}.cbor")),
+        &capsule.bytes,
+    )?;
+    std::fs::write(
+        well_known.join("deployment").join("registry-service.jwt"),
+        mint_credential(&ca, &registry),
+    )?;
+    let root_cert_path = workdir.join("test-root.pem");
+    std::fs::write(&root_cert_path, &tls.root_pem)?;
+
+    // Real HTTPS serving side (the REAL deployment well-known router).
+    let rustls =
+        axum_server::tls_rustls::RustlsConfig::from_der(tls.chain_der, tls.key_der).await?;
+    let app = hyprstream_core::services::oauth::deployment_well_known::router::<()>(Some(
+        well_known.clone(),
+    ));
+    tokio::spawn(async move {
+        axum_server::from_tcp_rustls(https_listener, rustls)
+            .serve(app.into_make_service())
+            .await
+            .expect("deployment well-known HTTPS server failed");
+    });
+
+    let instance = format!("did-trust-boot-{}", std::process::id());
+    println!("deployment ready at {}", workdir.display());
+    println!("export HYPRSTREAM__CLUSTER_AT9P_DID={}", capsule.at9p_did);
+    println!("export HYPRSTREAM__CLUSTER_DID_WEB={did_web}");
+    println!(
+        "export HYPRSTREAM__CLUSTER_ANCHOR_ROOT_CERT={}",
+        root_cert_path.display()
+    );
+    println!("export HYPRSTREAM_INSTANCE={instance}");
+    println!("serving https://localhost:{https_port}/.well-known/ — Ctrl-C to stop");
+
+    // Park forever.
+    tokio::signal::ctrl_c().await?;
+    Ok(())
+}

--- a/crates/hyprstream/src/bin/main.rs
+++ b/crates/hyprstream/src/bin/main.rs
@@ -164,6 +164,10 @@ fn build_cli() -> ClapCommand {
         ClapCommand::new("pds")
             .about("Attach this host to its home personal data server")
             .subcommand(
+                ClapCommand::new("init-deployment-store")
+                    .about("Initialize the checkpoint store for an explicitly provisioned fresh deployment"),
+            )
+            .subcommand(
                 ClapCommand::new("join")
                     .visible_alias("attach")
                     .about("Authorize and attach this host to one home PDS")
@@ -1911,6 +1915,11 @@ fn main() -> Result<()> {
     // newly provisioned host before local services are running.
     if let Some(("pds", sub_m)) = matches.subcommand() {
         match sub_m.subcommand() {
+            Some(("init-deployment-store", _)) => {
+                hyprstream_discovery::initialize_deployment_checkpoint_store()?;
+                println!("initialized empty deployment checkpoint store");
+                return Ok(());
+            }
             Some(("join", join_m)) => {
                 let pds_url = join_m
                     .get_one::<String>("url")
@@ -1921,7 +1930,7 @@ fn main() -> Result<()> {
                     || hyprstream_core::cli::pds_handlers::handle_pds_join(&config, pds_url, scope),
                 );
             }
-            _ => anyhow::bail!("usage: hyprstream pds join <PDS_URL> [--scope <SCOPE>]"),
+            _ => anyhow::bail!("usage: hyprstream pds init-deployment-store | pds join <PDS_URL> [--scope <SCOPE>]"),
         }
     }
 

--- a/crates/hyprstream/src/bin/main.rs
+++ b/crates/hyprstream/src/bin/main.rs
@@ -1468,11 +1468,41 @@ async fn install_process_production_resolver(
     signing_key: &SigningKey,
     config: &HyprConfig,
 ) -> Result<()> {
+    // The bootstrap pins the discovery service key from the process trust
+    // store; in CLI/service-start mode nothing has seeded it yet. Seed from
+    // the node's own bootstrap-pubkeys (the same source resolve_service_vk
+    // uses on first use) — a no-op when already populated or unprovisioned.
+    let _ = resolve_service_vk("discovery");
     let trust_source = hyprstream_discovery::DeploymentTrustSource::from_anchors(
         config.cluster_at9p_did.as_deref(),
         config.cluster_did_web.as_deref(),
     )?;
-    hyprstream_discovery::bootstrap_deployment_process(signing_key.clone(), trust_source).await?;
+    // Private-PKI deployments may terminate the did:web host with an internal
+    // CA; the extra root is additive (never disables verification), and an
+    // unreadable file is a hard configuration error, not a silent skip.
+    let trust_source = match (&trust_source, &config.cluster_anchor_root_cert) {
+        (hyprstream_discovery::DeploymentTrustSource::DidAnchored(anchors), Some(path)) => {
+            let pem = std::fs::read(path).with_context(|| {
+                format!("cluster_anchor_root_cert is not readable: {}", path.display())
+            })?;
+            hyprstream_discovery::DeploymentTrustSource::DidAnchored(
+                anchors.clone().with_root_cert_pem(pem),
+            )
+        }
+        (hyprstream_discovery::DeploymentTrustSource::OsOwnedFiles, Some(path)) => {
+            anyhow::bail!(
+                "cluster_anchor_root_cert ({}) is set but no DID anchors are configured",
+                path.display()
+            )
+        }
+        _ => trust_source,
+    };
+    hyprstream_discovery::bootstrap_deployment_process(
+        signing_key.clone(),
+        trust_source,
+        config.cluster_remote_node,
+    )
+    .await?;
     hyprstream_rpc::envelope::install_browser_currentness_verifier(
         hyprstream_discovery::production_browser_currentness_verifier()?,
     )

--- a/crates/hyprstream/src/config/mod.rs
+++ b/crates/hyprstream/src/config/mod.rs
@@ -175,6 +175,22 @@ pub struct HyprConfig {
     #[serde(default)]
     pub cluster_did_web: Option<String>,
 
+    /// Optional extra TLS root certificate (PEM file) for private-PKI
+    /// deployments whose did:web host terminates TLS with an internal CA
+    /// (#1137). ADDITIVE — public WebPKI roots remain enabled; an unreadable
+    /// or malformed file fails the bootstrap rather than degrading.
+    #[serde(default)]
+    pub cluster_anchor_root_cert: Option<PathBuf>,
+
+    /// When `true`, this node is REMOTE from the cluster's Discovery service:
+    /// the DID-anchored bootstrap dials the did:web-advertised network
+    /// transport and requires a signed liveness ping before installing the
+    /// resolver (#1137). When `false` (default — same-node fabric, e.g. the
+    /// metal stack's containers sharing the IPC volume), a lazy local
+    /// discovery client is used, matching the OS-owned path's posture.
+    #[serde(default)]
+    pub cluster_remote_node: bool,
+
     /// Phase-1 cellular-ledger local-enforcer configuration (epic #922, #925).
     ///
     /// Only present when the `ledger` cargo feature is enabled; `enabled`
@@ -1147,6 +1163,17 @@ pub struct OAuthConfig {
     #[serde(default)]
     pub quic_port: Option<u16>,
 
+    /// Deployment static well-known directory (#1137 / #1136 serving half).
+    /// When set, this OAuth instance terminates the deployment's did:web host:
+    /// `/.well-known/did.json` serves `<dir>/did.json` (replacing the dynamic
+    /// node document), `/.well-known/at9p/<cid>.cbor` serves the cluster at9p
+    /// capsule, and `/.well-known/deployment/registry-service.jwt` serves the
+    /// current CA-signed registry deployment credential. All are public,
+    /// integrity-anchored bytes re-read on every request so an external
+    /// credential-refresh agent needs no restart.
+    #[serde(default)]
+    pub deployment_well_known_dir: Option<PathBuf>,
+
     /// CORS configuration for the OAuth HTTP server
     #[serde(default = "default_oauth_cors")]
     pub cors: server::CorsConfig,
@@ -1288,6 +1315,7 @@ impl Default for OAuthConfig {
             // atproto profile at the authorize handler level.
             require_pushed_authorization_requests: false,
             xrpc_read_slice: false,
+            deployment_well_known_dir: None,
         }
     }
 }
@@ -2091,6 +2119,8 @@ pub struct HyprConfigBuilder {
     metrics: MetricsConfig,
     cluster_at9p_did: Option<String>,
     cluster_did_web: Option<String>,
+    cluster_anchor_root_cert: Option<PathBuf>,
+    cluster_remote_node: bool,
 }
 
 impl HyprConfigBuilder {
@@ -2122,6 +2152,8 @@ impl HyprConfigBuilder {
             metrics: MetricsConfig::default(),
             cluster_at9p_did: None,
             cluster_did_web: None,
+            cluster_anchor_root_cert: None,
+            cluster_remote_node: false,
         }
     }
 
@@ -2153,6 +2185,8 @@ impl HyprConfigBuilder {
             metrics: config.metrics,
             cluster_at9p_did: config.cluster_at9p_did,
             cluster_did_web: config.cluster_did_web,
+            cluster_anchor_root_cert: config.cluster_anchor_root_cert,
+            cluster_remote_node: config.cluster_remote_node,
         }
     }
 
@@ -2202,6 +2236,8 @@ impl HyprConfigBuilder {
             secrets: Default::default(),
             cluster_at9p_did: self.cluster_at9p_did,
             cluster_did_web: self.cluster_did_web,
+            cluster_anchor_root_cert: self.cluster_anchor_root_cert,
+            cluster_remote_node: self.cluster_remote_node,
             #[cfg(feature = "ledger")]
             ledger: Default::default(),
         }

--- a/crates/hyprstream/src/services/oauth/deployment_well_known.rs
+++ b/crates/hyprstream/src/services/oauth/deployment_well_known.rs
@@ -1,0 +1,162 @@
+//! Deployment static well-known endpoints (#1137 / #1136 serving half).
+//!
+//! The DID-anchored trust bootstrap (#1143) fetches three public,
+//! integrity-anchored documents from the deployment's did:web host:
+//!
+//! - `/.well-known/did.json` — the deployment DID document (alsoKnownAs →
+//!   cluster `did:at9p`, exactly one Ed25519 Multikey deployment CA,
+//!   Iroh/QUIC transport reach);
+//! - `/.well-known/at9p/<cid>.cbor` — the cluster at9p genesis capsule
+//!   (self-certifying: BLAKE3-512 over its canonical bytes IS the DID);
+//! - `/.well-known/deployment/registry-service.jwt` — the current CA-signed
+//!   registry deployment credential (one-hour freshness profile).
+//!
+//! None of these are secret: every one is verified by the fetcher (GATE
+//! canon → hash → sig for the capsule; mutual alsoKnownAs attestation for
+//! the document; CA signature + numeric-date profile for the credential).
+//! Serving them is therefore plain static-file work — but it must happen
+//! SOMEWHERE, and the OAuth service is the deliberate choice: it already
+//! terminates the did:web document surface (`/.well-known/did.json`), and it
+//! is the only genuinely dual-stack (HTTP + RPC) service in the mesh, so the
+//! deployment's `did:web` host can terminate here directly (e.g. via the
+//! stack's Caddy reverse proxy).
+//!
+//! The operator provisions a deployment well-known directory:
+//!
+//! ```text
+//! <dir>/did.json
+//! <dir>/at9p/<cid>.cbor
+//! <dir>/deployment/registry-service.jwt   (refreshed hourly by the CA holder)
+//! ```
+//!
+//! Files are re-read on EVERY request so the external credential-refresh
+//! agent needs no service restart. Missing/unreadable files are 404 — the
+//! bootstrap fails closed, never on stale in-memory copies.
+
+use std::path::{Path, PathBuf};
+
+use axum::{
+    extract::{Path as AxumPath, State},
+    http::{header, StatusCode},
+    response::{IntoResponse, Response},
+    routing::get,
+    Router,
+};
+use tokio::io::AsyncReadExt;
+
+/// Capsule cap, matching the client's `MAX_CAPSULE_BYTES`.
+const MAX_CAPSULE_BYTES: u64 = 4 * 1024 * 1024;
+/// Registry credential cap, matching the client's `MAX_CREDENTIAL_BYTES`.
+const MAX_CREDENTIAL_BYTES: u64 = 64 * 1024;
+/// DID document cap (a deployment document is a few KiB of JSON).
+const MAX_DID_DOC_BYTES: u64 = 1024 * 1024;
+
+/// Mount the deployment well-known routes. Always registered; each handler
+/// 404s when no deployment directory is configured, so an OAuth instance
+/// that is not the deployment terminator answers exactly like one where the
+/// material is absent — no information about configuration leaks.
+pub fn router<S>(deployment_dir: Option<PathBuf>) -> Router<S>
+where
+    S: Clone + Send + Sync + 'static,
+{
+    Router::new()
+        .route("/.well-known/did.json", get(serve_did_document))
+        .route("/.well-known/at9p/:cid.cbor", get(serve_capsule))
+        .route(
+            "/.well-known/deployment/registry-service.jwt",
+            get(serve_registry_credential),
+        )
+        .with_state(deployment_dir)
+}
+
+/// Serve the deployment directory's `did.json`. Mounted only in deployment
+/// mode (see `create_app`): a missing document 404s — deployment mode was
+/// explicitly selected, so a missing document is an operator error, never a
+/// reason to silently serve the dynamic node document the bootstrap would
+/// rightly reject.
+async fn serve_did_document(State(deployment_dir): State<Option<PathBuf>>) -> Response {
+    let Some(ref dir) = deployment_dir else {
+        return StatusCode::NOT_FOUND.into_response();
+    };
+    serve_file(
+        &dir.join("did.json"),
+        "application/did+json",
+        MAX_DID_DOC_BYTES,
+    )
+    .await
+}
+
+async fn serve_capsule(
+    State(deployment_dir): State<Option<PathBuf>>,
+    AxumPath(cid): AxumPath<String>,
+) -> Response {
+    let cid = match cid.strip_suffix(".cbor") {
+        Some(cid) => cid,
+        None => return StatusCode::NOT_FOUND.into_response(),
+    };
+    // The client constrains the CID to lowercase alphanumerics before it ever
+    // builds this URL; mirror that here so the parameter can never become a
+    // path-traversal primitive.
+    if cid.is_empty()
+        || !cid
+            .bytes()
+            .all(|b| b.is_ascii_lowercase() || b.is_ascii_digit())
+    {
+        return StatusCode::NOT_FOUND.into_response();
+    }
+    let Some(ref dir) = deployment_dir else {
+        return StatusCode::NOT_FOUND.into_response();
+    };
+    serve_file(
+        &dir.join("at9p").join(format!("{cid}.cbor")),
+        "application/cbor",
+        MAX_CAPSULE_BYTES,
+    )
+    .await
+}
+
+async fn serve_registry_credential(State(deployment_dir): State<Option<PathBuf>>) -> Response {
+    let Some(ref dir) = deployment_dir else {
+        return StatusCode::NOT_FOUND.into_response();
+    };
+    serve_file(
+        &dir.join("deployment").join("registry-service.jwt"),
+        "application/jwt",
+        MAX_CREDENTIAL_BYTES,
+    )
+    .await
+}
+
+/// Read and serve one file with a hard size cap. Any failure — missing,
+/// unreadable, oversize — is a plain 404: these endpoints reveal nothing
+/// about filesystem state beyond existence, and the bootstrap treats every
+/// one of them as "no deployment material served."
+async fn serve_file(path: &Path, content_type: &'static str, max_bytes: u64) -> Response {
+    match read_capped(path, max_bytes).await {
+        Ok(bytes) => (
+            StatusCode::OK,
+            [
+                (header::CONTENT_TYPE, content_type),
+                (header::CACHE_CONTROL, "no-store"),
+            ],
+            bytes,
+        )
+            .into_response(),
+        Err(error) => {
+            tracing::warn!(path = %path.display(), %error, "deployment well-known read failed");
+            StatusCode::NOT_FOUND.into_response()
+        }
+    }
+}
+
+async fn read_capped(path: &Path, max_bytes: u64) -> anyhow::Result<Vec<u8>> {
+    let file = tokio::fs::File::open(path).await?;
+    let mut limited = file.take(max_bytes + 1);
+    let mut bytes = Vec::new();
+    limited.read_to_end(&mut bytes).await?;
+    anyhow::ensure!(
+        bytes.len() <= max_bytes as usize,
+        "file exceeds {max_bytes}-byte limit"
+    );
+    Ok(bytes)
+}

--- a/crates/hyprstream/src/services/oauth/mod.rs
+++ b/crates/hyprstream/src/services/oauth/mod.rs
@@ -31,6 +31,7 @@ pub mod authorize;
 pub mod challenge;
 pub mod cimd_cache;
 pub mod client_auth;
+pub mod deployment_well_known;
 pub mod device;
 pub mod device_enrollment;
 pub mod did_document;
@@ -213,16 +214,26 @@ pub fn create_app(state: Arc<OAuthState>, cors_config: &crate::config::CorsConfi
     // permissive-header CORS layer (CorsConfig::did_document) — kept separate from
     // the broad public router so the relaxation never reaches secret-bearing
     // endpoints like /oauth/token (closes #472).
-    let mut did_router = Router::new()
-        // Phase 0c — did:web document endpoints
-        .route(
+    let mut did_router = Router::new();
+    if state.deployment_well_known_dir.is_some() {
+        // #1137 serving half — deployment mode: this host terminates the
+        // deployment's did:web. The static router owns `/.well-known/did.json`
+        // plus the at9p capsule and registry credential endpoints (each 404s
+        // when its file is absent — never a silent fall-through).
+        did_router = did_router.merge(deployment_well_known::router(
+            state.deployment_well_known_dir.clone(),
+        ));
+    } else {
+        did_router = did_router.route(
             "/.well-known/did.json",
             get(did_document::root_did_document),
         )
         .route(
             "/.well-known/at9p/:cid.cbor",
             get(did_document::at9p_capsule),
-        )
+        );
+    }
+    let mut did_router = did_router
         // atproto handle→DID HTTP resolution (#500) — plaintext bare DID
         .route("/.well-known/atproto-did", get(did_document::atproto_did))
         .route(

--- a/crates/hyprstream/src/services/oauth/state.rs
+++ b/crates/hyprstream/src/services/oauth/state.rs
@@ -929,6 +929,14 @@ pub struct OAuthState {
     /// When `true`, the XRPC read-slice routes (`/xrpc/…`) are mounted on the
     /// OAuth router (#1112). Copied from `OAuthConfig::xrpc_read_slice`.
     pub xrpc_read_slice: bool,
+    /// Deployment static well-known directory (#1137 serving half). When set,
+    /// this OAuth instance terminates the deployment's did:web host: it serves
+    /// `<dir>/did.json` in place of the dynamic node document, plus
+    /// `<dir>/at9p/<cid>.cbor` and `<dir>/deployment/registry-service.jwt`.
+    /// All three are public, integrity-anchored bytes — see
+    /// `deployment_well_known.rs`. Copied from
+    /// `OAuthConfig::deployment_well_known_dir`.
+    pub deployment_well_known_dir: Option<std::path::PathBuf>,
     /// RSA encoding key for RS256 id_token signing (optional, loaded from secrets).
     pub rsa_encoding_key: Option<jsonwebtoken::EncodingKey>,
     /// RSA public key as JWK JSON (for the JWKS endpoint).
@@ -1097,6 +1105,7 @@ impl OAuthState {
             sessions: super::session::SessionStore::default(),
             xrpc_repos: Arc::new(super::xrpc::XrpcRepoStore::new()),
             xrpc_read_slice: config.xrpc_read_slice,
+            deployment_well_known_dir: config.deployment_well_known_dir.clone(),
             rsa_encoding_key: None,
             rsa_jwk: None,
             rsa_kid: None,

--- a/crates/hyprstream/tests/did_trust_e2e.rs
+++ b/crates/hyprstream/tests/did_trust_e2e.rs
@@ -1,0 +1,368 @@
+//! #1137 end-to-end: the DID-anchored trust bootstrap against the REAL
+//! serving side.
+//!
+//! This boots the production `bootstrap_deployment_process` against:
+//! - a REAL HTTPS server (rustls, test-CA-signed `localhost` certificate)
+//!   mounting the REAL `deployment_well_known` router from a real
+//!   operator-laid-out directory (`did.json`, `at9p/<cid>.cbor`,
+//!   `deployment/registry-service.jwt`), and
+//! - a REAL DiscoveryService served over REAL QUIC (self-signed cert, pinned
+//!   by SHA-256 in the DID document's `QuicTransport` entry).
+//!
+//! The positive test exercises resolve → mutual-alias verify → GATE →
+//! credential fetch + validation → dial → signed liveness ping → resolver
+//! install. Every negative test removes or corrupts one leg and asserts the
+//! bootstrap REFUSES — a reachable-but-wrong endpoint must never downgrade
+//! trust.
+//!
+//! Process-global note: `bootstrap_deployment_process` seals a one-shot
+//! authority per process, so exactly one test drives the full boot; the
+//! negatives drive `resolve_and_authenticate_did_anchors` (the identical
+//! trust decision minus the seal/install). The same-node (local) arm has its
+//! own test file (`did_trust_e2e_local.rs`) for the same reason.
+
+#![allow(clippy::expect_used, clippy::unwrap_used)]
+
+#[path = "fixtures/did_trust.rs"]
+mod did_trust;
+use did_trust::*;
+
+use ed25519_dalek::SigningKey;
+use hyprstream_discovery::{DeploymentTrustSource, DidAnchors};
+use hyprstream_rpc::did_key::ed25519_to_did_key;
+use hyprstream_rpc::service_entry::encode_quic;
+use hyprstream_rpc::transport::{QuicServerAuth, TransportConfig};
+use hyprstream_service::{InprocManager, ServiceManager as _};
+use serde_json::json;
+use std::net::SocketAddr;
+use std::sync::Arc;
+use tempfile::TempDir;
+
+struct Fixture {
+    _dir: TempDir,
+    _discovery: hyprstream_service::SpawnedService,
+    well_known: std::path::PathBuf,
+    did_web: String,
+    capsule: CapsuleMaterial,
+    ca: SigningKey,
+    registry: SigningKey,
+    tls: TlsMaterial,
+    discovery_sk: SigningKey,
+    quic_addr: SocketAddr,
+    quic_cert_der: Vec<u8>,
+}
+
+impl Fixture {
+    fn anchors(&self) -> DidAnchors {
+        DidAnchors {
+            cluster_at9p_did: self.capsule.at9p_did.clone(),
+            cluster_did_web: self.did_web.clone(),
+            extra_root_cert_pem: None,
+        }
+        .with_root_cert_pem(self.tls.root_pem.clone())
+    }
+
+    fn trust_source(&self) -> DeploymentTrustSource {
+        DeploymentTrustSource::DidAnchored(self.anchors())
+    }
+
+    fn did_document(&self) -> serde_json::Value {
+        let ca_vk = self.ca.verifying_key();
+        let multikey = ed25519_to_did_key(ca_vk.as_bytes())
+            .strip_prefix("did:key:")
+            .unwrap()
+            .to_owned();
+        let pin = hyprstream_rpc::transport::quinn_transport::cert_sha256(&self.quic_cert_der);
+        let auth = QuicServerAuth::pinned(vec![pin]).unwrap();
+        // The discovery service's #mesh-kem hybrid-KEM recipient, derived
+        // from its signing key exactly as the QUIC loop derives it — the
+        // remote bootstrap arm binds the pinned discovery key to this.
+        let kem = hyprstream_rpc::node_identity::derive_mesh_kem_recipient(&self.discovery_sk)
+            .unwrap()
+            .public();
+        let multibase = |codec: [u8; 2], key: &[u8]| {
+            let mut payload = Vec::with_capacity(2 + key.len());
+            payload.extend_from_slice(&codec);
+            payload.extend_from_slice(key);
+            format!("z{}", bs58::encode(payload).into_string())
+        };
+        // The discovery service's mesh ML-DSA-65 verifying key — the remote
+        // bootstrap arm anchors response authentication to it.
+        let pq_sk = hyprstream_rpc::node_identity::derive_mesh_mldsa_key(&self.discovery_sk);
+        let pq_vk_bytes = hyprstream_rpc::crypto::pq::ml_dsa_sk_to_vk_bytes(&pq_sk);
+        json!({
+            "id": self.did_web,
+            "alsoKnownAs": [self.capsule.at9p_did],
+            "verificationMethod": [
+                {
+                    "id": format!("{}#deployment-ca", self.did_web),
+                    "type": "Multikey",
+                    "controller": self.did_web,
+                    "publicKeyMultibase": multikey,
+                },
+                {
+                    "id": format!("{}#mesh-pq", self.did_web),
+                    "type": "Multikey",
+                    "controller": self.did_web,
+                    "publicKeyMultibase": multibase([0x91, 0x24], &pq_vk_bytes),
+                },
+            ],
+            "keyAgreement": [
+                {
+                    "id": format!("{}#mesh-kem-x25519", self.did_web),
+                    "type": "Multikey",
+                    "controller": self.did_web,
+                    "publicKeyMultibase": multibase([0xec, 0x01], &kem.eks[0]),
+                },
+                {
+                    "id": format!("{}#mesh-kem-mlkem768", self.did_web),
+                    "type": "Multikey",
+                    "controller": self.did_web,
+                    "publicKeyMultibase": multibase([0x8c, 0x24], &kem.eks[1]),
+                },
+            ],
+            "service": [{
+                "id": format!("{}#quic", self.did_web),
+                "type": "QuicTransport",
+                "serviceEndpoint": encode_quic(
+                    &format!("https://{}", self.quic_addr),
+                    &auth,
+                    &["hyprstream-rpc/1"],
+                ),
+            }],
+        })
+    }
+
+    /// Lay out (or refresh) the deployment well-known directory contents.
+    fn write_material(&self, capsule_bytes: &[u8], credential: &str, document: &serde_json::Value) {
+        let at9p_dir = self.well_known.join("at9p");
+        let deployment_dir = self.well_known.join("deployment");
+        std::fs::create_dir_all(&at9p_dir).unwrap();
+        std::fs::create_dir_all(&deployment_dir).unwrap();
+        std::fs::write(self.well_known.join("did.json"), document.to_string()).unwrap();
+        let cid = self
+            .capsule
+            .at9p_did
+            .strip_prefix("did:at9p:")
+            .unwrap()
+            .to_owned();
+        std::fs::write(at9p_dir.join(format!("{cid}.cbor")), capsule_bytes).unwrap();
+        std::fs::write(deployment_dir.join("registry-service.jwt"), credential).unwrap();
+    }
+
+    fn write_valid(&self) {
+        let credential = mint_credential(&self.ca, &self.registry);
+        self.write_material(&self.capsule.bytes, &credential, &self.did_document());
+    }
+}
+
+async fn build_fixture() -> Fixture {
+    ensure_process_globals();
+
+    // Bind before publishing the DID so the first bootstrap fetch cannot race
+    // the spawned HTTPS task for an otherwise-free port.
+    let https_listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+    let https_addr = https_listener.local_addr().unwrap();
+    let https_port = https_addr.port();
+    let did_web = format!("did:web:localhost%3A{https_port}");
+    let capsule = make_capsule(&did_web, 0x51);
+
+    // Real DiscoveryService over real QUIC (WebTransport, h3 — the same
+    // service loop production uses; self-signed cert, SHA-256 pinned).
+    let discovery_sk = SigningKey::from_bytes(&[0x52; 32]);
+    register_discovery_key(discovery_sk.verifying_key());
+    let quic_cert =
+        rcgen::generate_simple_self_signed(vec!["hyprstream.local".to_owned()]).unwrap();
+    let quic_cert_der = quic_cert.cert.der().to_vec();
+    let quic_key_der = quic_cert.key_pair.serialize_der();
+    let jwt_vk = SigningKey::from_bytes(&[0x53; 32]).verifying_key();
+    let discovery_service = hyprstream_discovery::DiscoveryService::new(
+        Arc::new(discovery_sk.clone()),
+        jwt_vk,
+        TransportConfig::inproc("did-trust-e2e-discovery"),
+    );
+    let (addr_tx, addr_rx) = tokio::sync::oneshot::channel::<SocketAddr>();
+    let quic_config = hyprstream_rpc::service::QuicLoopConfig {
+        cert_chain: vec![quic_cert_der.clone()],
+        key_der: zeroize::Zeroizing::new(quic_key_der),
+        bind_addr: "127.0.0.1:0".parse().unwrap(),
+        server_name: "hyprstream.local".to_owned(),
+        protected_resource_json: None,
+        on_quic_bound: Some(Box::new(move |_name, addr, _server| {
+            let _ = addr_tx.send(addr);
+        })),
+        iroh_enabled: false,
+        on_iroh_bound: None,
+        moq_relay: None,
+    };
+    let service =
+        hyprstream_service::UnifiedServiceConfig::new(discovery_service, Some(quic_config));
+    let manager = InprocManager::new();
+    let spawned = manager
+        .spawn(Box::new(service))
+        .await
+        .expect("discovery QUIC loop must bind");
+    let quic_addr = addr_rx.await.expect("QUIC loop must report its bound addr");
+
+    let dir = TempDir::new().unwrap();
+    let well_known = dir.path().join("well-known");
+    std::fs::create_dir_all(&well_known).unwrap();
+
+    let fixture = Fixture {
+        well_known,
+        _discovery: spawned,
+        did_web,
+        capsule,
+        ca: SigningKey::from_bytes(&[0x54; 32]),
+        registry: SigningKey::from_bytes(&[0x55; 32]),
+        tls: make_tls(),
+        discovery_sk,
+        quic_addr,
+        quic_cert_der,
+        _dir: dir,
+    };
+    fixture.write_valid();
+
+    // Real HTTPS serving side: the REAL deployment well-known router.
+    let rustls = axum_server::tls_rustls::RustlsConfig::from_der(
+        fixture.tls.chain_der.clone(),
+        fixture.tls.key_der.clone(),
+    )
+    .await
+    .expect("test RustlsConfig must build");
+    let app = hyprstream_core::services::oauth::deployment_well_known::router::<()>(Some(
+        fixture.well_known.clone(),
+    ));
+    tokio::spawn(async move {
+        axum_server::from_tcp_rustls(https_listener, rustls)
+            .serve(app.into_make_service())
+            .await
+            .expect("deployment well-known HTTPS server failed");
+    });
+
+    fixture
+}
+
+/// THE end-to-end boot: real serving side, real GATE, real credential, real
+/// QUIC discovery, real liveness ping, real resolver install.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn did_anchored_bootstrap_boots_end_to_end() {
+    let fixture = build_fixture().await;
+    let node_key = SigningKey::from_bytes(&[0x56; 32]);
+    hyprstream_discovery::bootstrap_deployment_process(node_key, fixture.trust_source(), true)
+        .await
+        .expect("DID-anchored bootstrap must boot against the real serving side");
+}
+
+/// A reachable serving side that does NOT serve the capsule must refuse.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn missing_capsule_refuses() {
+    let fixture = build_fixture().await;
+    let cid = fixture.capsule.at9p_did.strip_prefix("did:at9p:").unwrap();
+    std::fs::remove_file(fixture.well_known.join("at9p").join(format!("{cid}.cbor"))).unwrap();
+    let error = hyprstream_discovery::resolve_and_authenticate_did_anchors(&fixture.anchors())
+        .await
+        .err()
+        .expect("bootstrap must refuse when the capsule endpoint 404s");
+    assert!(format!("{error:#}").contains("capsule"), "{error:#}");
+}
+
+/// A DIFFERENT (validly-signed, wrong-hash) capsule must refuse at the
+/// hash-gate — a reachable-but-hostile capsule endpoint cannot downgrade.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn foreign_capsule_refuses_at_hash_gate() {
+    let fixture = build_fixture().await;
+    let foreign = make_capsule(&fixture.did_web, 0x77);
+    let credential = mint_credential(&fixture.ca, &fixture.registry);
+    fixture.write_material(&foreign.bytes, &credential, &fixture.did_document());
+    let error = hyprstream_discovery::resolve_and_authenticate_did_anchors(&fixture.anchors())
+        .await
+        .err()
+        .expect("a capsule that does not hash to the configured DID must refuse");
+    assert!(format!("{error:#}").contains("hash-gate"), "{error:#}");
+}
+
+/// A capsule that does not reciprocate the did:web alias must refuse.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn one_sided_alias_refuses() {
+    let fixture = build_fixture().await;
+    // Doc-side one-sided claim: the capsule reciprocates the did:web, but the
+    // served document does not name the configured at9p DID. Mutual
+    // attestation is bidirectional at this layer too — refuse.
+    let mut document = fixture.did_document();
+    document.as_object_mut().unwrap().remove("alsoKnownAs");
+    let credential = mint_credential(&fixture.ca, &fixture.registry);
+    fixture.write_material(&fixture.capsule.bytes, &credential, &document);
+    let error = hyprstream_discovery::resolve_and_authenticate_did_anchors(&fixture.anchors())
+        .await
+        .err()
+        .expect("a document that does not name the at9p DID must refuse");
+    assert!(format!("{error:#}").contains("alsoKnownAs"), "{error:#}");
+}
+
+/// No registry credential at the endpoint → refuse (never degrade to a
+/// weaker or stale credential source).
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn missing_credential_refuses() {
+    let fixture = build_fixture().await;
+    std::fs::remove_file(
+        fixture
+            .well_known
+            .join("deployment")
+            .join("registry-service.jwt"),
+    )
+    .unwrap();
+    let error = hyprstream_discovery::resolve_and_authenticate_did_anchors(&fixture.anchors())
+        .await
+        .err()
+        .expect("bootstrap must refuse when the credential endpoint 404s");
+    assert!(format!("{error:#}").contains("credential"), "{error:#}");
+}
+
+/// A credential minted under a DIFFERENT CA must refuse — the DID-derived CA
+/// is the only authority, exactly the attack my #1143 review repro exercised.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn foreign_ca_credential_refuses() {
+    let fixture = build_fixture().await;
+    let attacker_ca = SigningKey::from_bytes(&[0xAA; 32]);
+    let credential = mint_credential(&attacker_ca, &fixture.registry);
+    fixture.write_material(&fixture.capsule.bytes, &credential, &fixture.did_document());
+    let error = hyprstream_discovery::resolve_and_authenticate_did_anchors(&fixture.anchors())
+        .await
+        .err()
+        .expect("a credential under a foreign CA must refuse");
+    assert!(format!("{error:#}").contains("credential"), "{error:#}");
+}
+
+/// The liveness leg: a DID-advertised transport whose endpoint does not hold
+/// the pinned discovery key (or is dead) must fail the signed ping.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn dead_or_wrong_key_discovery_fails_liveness() {
+    let fixture = build_fixture().await;
+
+    // Dead endpoint — nothing listening.
+    let dead: SocketAddr = "127.0.0.1:9".parse().unwrap();
+    let pin = hyprstream_rpc::transport::quinn_transport::cert_sha256(&fixture.quic_cert_der);
+    let dead_transport = TransportConfig::quic_pinned(dead, "hyprstream.local", pin);
+    let signer = hyprstream_rpc::signer::LocalSigner::new(SigningKey::from_bytes(&[0x57; 32]));
+    let discovery_vk = fixture.discovery_sk.verifying_key();
+    let rpc =
+        hyprstream_rpc::dial::dial(&dead_transport, signer, Some(discovery_vk), None).unwrap();
+    let client = hyprstream_discovery::DiscoveryClient::new(rpc);
+    assert!(
+        client.ping().await.is_err(),
+        "ping against a dead endpoint must fail"
+    );
+
+    // Wrong key at a LIVE endpoint: dial the real discovery but pin a key it
+    // does not hold — response verification must fail.
+    let wrong_vk = SigningKey::from_bytes(&[0x58; 32]).verifying_key();
+    let live_transport = TransportConfig::quic_pinned(fixture.quic_addr, "hyprstream.local", pin);
+    let signer = hyprstream_rpc::signer::LocalSigner::new(SigningKey::from_bytes(&[0x59; 32]));
+    let rpc = hyprstream_rpc::dial::dial(&live_transport, signer, Some(wrong_vk), None).unwrap();
+    let client = hyprstream_discovery::DiscoveryClient::new(rpc);
+    assert!(
+        client.ping().await.is_err(),
+        "ping pinned to a key the endpoint does not hold must fail"
+    );
+}

--- a/crates/hyprstream/tests/did_trust_e2e.rs
+++ b/crates/hyprstream/tests/did_trust_e2e.rs
@@ -165,8 +165,6 @@ async fn build_fixture() -> Fixture {
     let https_addr = https_listener.local_addr().unwrap();
     let https_port = https_addr.port();
     let did_web = format!("did:web:localhost%3A{https_port}");
-    let capsule = make_capsule(&did_web, 0x51);
-
     // Real DiscoveryService over real QUIC (WebTransport, h3 — the same
     // service loop production uses; self-signed cert, SHA-256 pinned).
     let discovery_sk = SigningKey::from_bytes(&[0x52; 32]);
@@ -203,6 +201,7 @@ async fn build_fixture() -> Fixture {
         .await
         .expect("discovery QUIC loop must bind");
     let quic_addr = addr_rx.await.expect("QUIC loop must report its bound addr");
+    let capsule = make_quic_capsule(&did_web, 0x51, quic_addr);
 
     let dir = TempDir::new().unwrap();
     let well_known = dir.path().join("well-known");
@@ -213,7 +212,9 @@ async fn build_fixture() -> Fixture {
         _discovery: spawned,
         did_web,
         capsule,
-        ca: SigningKey::from_bytes(&[0x54; 32]),
+        // The GATE-verified capsule's primary subject key is the deployment
+        // CA; credentials and the document projection must use that same key.
+        ca: SigningKey::from_bytes(&[0x51; 32]),
         registry: SigningKey::from_bytes(&[0x55; 32]),
         tls: make_tls(),
         discovery_sk,
@@ -248,6 +249,8 @@ async fn build_fixture() -> Fixture {
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn did_anchored_bootstrap_boots_end_to_end() {
     let fixture = build_fixture().await;
+    hyprstream_discovery::initialize_deployment_checkpoint_store()
+        .expect("fresh test deployment must provision its checkpoint store");
     let node_key = SigningKey::from_bytes(&[0x56; 32]);
     hyprstream_discovery::bootstrap_deployment_process(node_key, fixture.trust_source(), true)
         .await

--- a/crates/hyprstream/tests/did_trust_e2e_local.rs
+++ b/crates/hyprstream/tests/did_trust_e2e_local.rs
@@ -1,0 +1,155 @@
+//! #1137 end-to-end, same-node arm: the DID-anchored bootstrap with a lazy
+//! local discovery client (the metal stack's `service start --ipc` shape —
+//! containers sharing the IPC fabric, Discovery hosted in-process).
+//!
+//! Separate test FILE from `did_trust_e2e.rs` because
+//! `bootstrap_deployment_process` seals a one-shot process-global authority;
+//! each arm gets its own process.
+
+#![allow(clippy::expect_used, clippy::unwrap_used)]
+
+#[path = "fixtures/did_trust.rs"]
+mod did_trust;
+use did_trust::*;
+
+use ed25519_dalek::SigningKey;
+use hyprstream_discovery::{DeploymentTrustSource, DidAnchors};
+use hyprstream_rpc::did_key::ed25519_to_did_key;
+use hyprstream_rpc::service_entry::encode_quic;
+use hyprstream_rpc::transport::QuicServerAuth;
+use serde_json::json;
+use tempfile::TempDir;
+
+struct LocalFixture {
+    _dir: TempDir,
+    well_known: std::path::PathBuf,
+    did_web: String,
+    capsule: CapsuleMaterial,
+    ca: SigningKey,
+    registry: SigningKey,
+    tls: TlsMaterial,
+}
+
+impl LocalFixture {
+    fn anchors(&self) -> DidAnchors {
+        DidAnchors {
+            cluster_at9p_did: self.capsule.at9p_did.clone(),
+            cluster_did_web: self.did_web.clone(),
+            extra_root_cert_pem: None,
+        }
+        .with_root_cert_pem(self.tls.root_pem.clone())
+    }
+
+    fn did_document(&self) -> serde_json::Value {
+        let ca_vk = self.ca.verifying_key();
+        let multikey = ed25519_to_did_key(ca_vk.as_bytes())
+            .strip_prefix("did:key:")
+            .unwrap()
+            .to_owned();
+        // The local arm never dials the advertised transport; a pinned
+        // loopback entry stands in for reach.
+        let auth = QuicServerAuth::pinned(vec![[7u8; 32]]).unwrap();
+        json!({
+            "id": self.did_web,
+            "alsoKnownAs": [self.capsule.at9p_did],
+            "verificationMethod": [{
+                "id": format!("{}#deployment-ca", self.did_web),
+                "type": "Multikey",
+                "controller": self.did_web,
+                "publicKeyMultibase": multikey,
+            }],
+            "service": [{
+                "id": format!("{}#quic", self.did_web),
+                "type": "QuicTransport",
+                "serviceEndpoint": encode_quic(
+                    "https://127.0.0.1:4433",
+                    &auth,
+                    &["hyprstream-rpc/1"],
+                ),
+            }],
+        })
+    }
+}
+
+/// The same-node boot: full resolve → verify → credential validation against
+/// the real serving side, then a LAZY local discovery client and resolver
+/// install — no network liveness required (the metal stack shape, where
+/// Discovery starts later in the same process).
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn did_anchored_bootstrap_boots_same_node() {
+    ensure_process_globals();
+
+    // Bind before publishing the DID so the first bootstrap fetch cannot race
+    // the spawned HTTPS task for an otherwise-free port.
+    let https_listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+    let https_port = https_listener.local_addr().unwrap().port();
+    let did_web = format!("did:web:localhost%3A{https_port}");
+    let capsule = make_capsule(&did_web, 0x61);
+
+    let dir = TempDir::new().unwrap();
+    let well_known = dir.path().join("well-known");
+    std::fs::create_dir_all(well_known.join("at9p")).unwrap();
+    std::fs::create_dir_all(well_known.join("deployment")).unwrap();
+
+    let fixture = LocalFixture {
+        well_known,
+        did_web,
+        capsule,
+        ca: SigningKey::from_bytes(&[0x62; 32]),
+        registry: SigningKey::from_bytes(&[0x63; 32]),
+        tls: make_tls(),
+        _dir: dir,
+    };
+
+    // Lay out the deployment material.
+    let cid = fixture.capsule.at9p_did.strip_prefix("did:at9p:").unwrap();
+    std::fs::write(
+        fixture.well_known.join("did.json"),
+        fixture.did_document().to_string(),
+    )
+    .unwrap();
+    std::fs::write(
+        fixture.well_known.join("at9p").join(format!("{cid}.cbor")),
+        &fixture.capsule.bytes,
+    )
+    .unwrap();
+    std::fs::write(
+        fixture
+            .well_known
+            .join("deployment")
+            .join("registry-service.jwt"),
+        mint_credential(&fixture.ca, &fixture.registry),
+    )
+    .unwrap();
+
+    // Real HTTPS serving side (the REAL deployment well-known router).
+    let rustls = axum_server::tls_rustls::RustlsConfig::from_der(
+        fixture.tls.chain_der.clone(),
+        fixture.tls.key_der.clone(),
+    )
+    .await
+    .expect("test RustlsConfig must build");
+    let app = hyprstream_core::services::oauth::deployment_well_known::router::<()>(Some(
+        fixture.well_known.clone(),
+    ));
+    tokio::spawn(async move {
+        axum_server::from_tcp_rustls(https_listener, rustls)
+            .serve(app.into_make_service())
+            .await
+            .expect("deployment well-known HTTPS server failed");
+    });
+
+    // The discovery key the local trust store pins (the local client is lazy;
+    // no live discovery needed for this arm).
+    let discovery_sk = SigningKey::from_bytes(&[0x64; 32]);
+    register_discovery_key(discovery_sk.verifying_key());
+
+    let node_key = SigningKey::from_bytes(&[0x65; 32]);
+    hyprstream_discovery::bootstrap_deployment_process(
+        node_key,
+        DeploymentTrustSource::DidAnchored(fixture.anchors()),
+        false,
+    )
+    .await
+    .expect("same-node DID-anchored bootstrap must boot without network liveness");
+}

--- a/crates/hyprstream/tests/did_trust_e2e_local.rs
+++ b/crates/hyprstream/tests/did_trust_e2e_local.rs
@@ -78,6 +78,8 @@ impl LocalFixture {
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn did_anchored_bootstrap_boots_same_node() {
     ensure_process_globals();
+    hyprstream_discovery::initialize_deployment_checkpoint_store()
+        .expect("fresh test deployment must provision its checkpoint store");
 
     // Bind before publishing the DID so the first bootstrap fetch cannot race
     // the spawned HTTPS task for an otherwise-free port.
@@ -95,7 +97,9 @@ async fn did_anchored_bootstrap_boots_same_node() {
         well_known,
         did_web,
         capsule,
-        ca: SigningKey::from_bytes(&[0x62; 32]),
+        // The GATE-verified capsule's primary subject key is the deployment
+        // CA; credentials and the document projection must use that same key.
+        ca: SigningKey::from_bytes(&[0x61; 32]),
         registry: SigningKey::from_bytes(&[0x63; 32]),
         tls: make_tls(),
         _dir: dir,

--- a/crates/hyprstream/tests/fixtures/did_trust.rs
+++ b/crates/hyprstream/tests/fixtures/did_trust.rs
@@ -1,0 +1,171 @@
+//! Shared fixture helpers for the DID-anchored trust e2e tests (#1137).
+//! Included via `#[path]` from the per-process test files.
+
+#![allow(clippy::expect_used, clippy::unwrap_used, dead_code, unused_imports)]
+
+use std::net::SocketAddr;
+use std::sync::Arc;
+
+use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine as _};
+use ed25519_dalek::{Signer as _, SigningKey};
+use hyprstream_discovery::{DeploymentTrustSource, DidAnchors};
+use hyprstream_pds::at9p::{
+    CapsuleBody, HybridKeyPair, ServiceEndpoint, ServiceEntry, ServiceType, Transport,
+};
+use hyprstream_pds::at9p_sign::sign_capsule;
+use hyprstream_rpc::did_key::ed25519_to_did_key;
+use hyprstream_rpc::service_entry::encode_quic;
+use hyprstream_rpc::transport::{QuicServerAuth, TransportConfig};
+use hyprstream_service::{InprocManager, ServiceManager as _};
+use serde_json::json;
+use tempfile::TempDir;
+
+pub const AUD: &str = "urn:hyprstream:service:registry";
+pub const PROFILE: &str = "hyprstream.registry-deployment.v1";
+
+/// Reserve a loopback port (bind + release). Tiny race, acceptable in tests.
+pub fn free_port() -> u16 {
+    std::net::TcpListener::bind("127.0.0.1:0")
+        .unwrap()
+        .local_addr()
+        .unwrap()
+        .port()
+}
+
+pub fn ensure_process_globals() {
+    use hyprstream_rpc::crypto::CryptoPolicy;
+    use hyprstream_rpc::registry::{init as init_registry, EndpointMode};
+    let _ = tracing_subscriber::fmt()
+        .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
+        .try_init();
+    // Isolate the deployment data dir (the bootstrap opens the checkpointed
+    // PDS store under it) from any real node state.
+    std::env::set_var(
+        "HYPRSTREAM_INSTANCE",
+        format!("did-trust-e2e-{}", std::process::id()),
+    );
+    // Idempotent: registry init and verify-config installs are first-write-wins.
+    init_registry(EndpointMode::Ipc, Some(std::env::temp_dir()));
+    // rustls needs an explicit process default when both aws-lc-rs and ring
+    // features are linked; use the repo's declared interop provider.
+    hyprstream_rpc::transport::pq_provider::install_pq_crypto_provider()
+        .expect("process crypto provider must install");
+    let _ = hyprstream_rpc::envelope::install_verify_config(
+        hyprstream_rpc::envelope::EnvelopeVerifyConfig {
+            policy: CryptoPolicy::Classical,
+            pq_store: None,
+        },
+    );
+    let _ = hyprstream_rpc::envelope::install_response_verify_config(
+        hyprstream_rpc::envelope::ResponseVerifyConfig {
+            policy: CryptoPolicy::Classical,
+            pq_store: None,
+        },
+    );
+}
+
+pub fn register_discovery_key(vk: ed25519_dalek::VerifyingKey) {
+    hyprstream_service::global_trust_store().insert(
+        vk,
+        hyprstream_service::Attestation {
+            scopes: std::iter::once("discovery".to_owned()).collect(),
+            subject: None,
+            jwt: None,
+            expires_at: chrono::Utc::now().timestamp() + 86_400,
+            attested_by: None,
+        },
+    );
+}
+
+pub fn deployment_domain(ca_vk: &ed25519_dalek::VerifyingKey) -> String {
+    hyprstream_rpc::auth::jwk_thumbprint(&hyprstream_rpc::auth::JwkThumbprintInput::Ed25519 {
+        x: ca_vk.as_bytes(),
+    })
+}
+
+/// Mint a registry deployment credential with the exact production profile.
+pub fn mint_credential(ca: &SigningKey, registry: &SigningKey) -> String {
+    let domain = deployment_domain(&ca.verifying_key());
+    let now = chrono::Utc::now().timestamp();
+    let protected = json!({"alg": "EdDSA", "typ": "wit+jwt", "kid": domain});
+    let claims = json!({
+        "iss": format!("urn:hyprstream:deployment:{domain}"),
+        "sub": "service:registry",
+        "aud": AUD,
+        "exp": now + 3600,
+        "nbf": now,
+        "iat": now,
+        "deployment_domain": domain,
+        "profile": PROFILE,
+        "cnf": {"jwk": {
+            "kty": "OKP",
+            "crv": "Ed25519",
+            "x": URL_SAFE_NO_PAD.encode(registry.verifying_key().as_bytes()),
+        }},
+    });
+    let protected = URL_SAFE_NO_PAD.encode(protected.to_string().as_bytes());
+    let claims = URL_SAFE_NO_PAD.encode(claims.to_string().as_bytes());
+    let input = format!("{protected}.{claims}");
+    let sig = ca.sign(input.as_bytes());
+    format!("{input}.{}", URL_SAFE_NO_PAD.encode(sig.to_bytes()))
+}
+
+pub struct CapsuleMaterial {
+    pub bytes: Vec<u8>,
+    pub at9p_did: String,
+}
+
+pub fn make_capsule(did_web: &str, tag: u8) -> CapsuleMaterial {
+    let ed = SigningKey::from_bytes(&[tag; 32]);
+    let (pq, pq_vk) = hyprstream_crypto::pq::ml_dsa_generate_keypair();
+    let pair = HybridKeyPair::new(
+        ed.verifying_key().to_bytes().to_vec(),
+        hyprstream_crypto::pq::ml_dsa_vk_bytes(&pq_vk),
+    )
+    .unwrap();
+    let endpoint = ServiceEndpoint::new(Transport::Iroh, format!("iroh://node{tag}")).unwrap();
+    let service = ServiceEntry::new("#ns", ServiceType::NinePExport, endpoint).unwrap();
+    let mut body = CapsuleBody::new(vec![pair], vec![service]).unwrap();
+    body.also_known_as = Some(vec![did_web.to_owned()]);
+    let capsule = sign_capsule(body, &ed, &pq).unwrap();
+    let bytes = capsule.to_dag_cbor().unwrap();
+    let did = format!("did:at9p:{}", capsule.cid512().unwrap());
+    CapsuleMaterial {
+        bytes,
+        at9p_did: did,
+    }
+}
+
+pub struct TlsMaterial {
+    /// PEM of the test root CA — the client's extra trust anchor.
+    pub root_pem: Vec<u8>,
+    /// DER chain (leaf, CA) + DER key for the HTTPS server.
+    pub chain_der: Vec<Vec<u8>>,
+    pub key_der: Vec<u8>,
+}
+
+pub fn make_tls() -> TlsMaterial {
+    let ca_key = rcgen::KeyPair::generate_for(&rcgen::PKCS_ECDSA_P256_SHA256).unwrap();
+    let mut ca_params = rcgen::CertificateParams::default();
+    ca_params.is_ca = rcgen::IsCa::Ca(rcgen::BasicConstraints::Unconstrained);
+    // Distinct issuer/subject DNs are load-bearing: with empty DNs OpenSSL
+    // (reqwest's native-tls here) classifies the leaf as self-signed
+    // (issuer == subject) and chain building to the extra root fails.
+    ca_params
+        .distinguished_name
+        .push(rcgen::DnType::CommonName, "hyprstream-test-root");
+    let ca = ca_params.self_signed(&ca_key).unwrap();
+
+    let leaf_key = rcgen::KeyPair::generate_for(&rcgen::PKCS_ECDSA_P256_SHA256).unwrap();
+    let mut leaf_params = rcgen::CertificateParams::new(vec!["localhost".to_owned()]).unwrap();
+    leaf_params
+        .distinguished_name
+        .push(rcgen::DnType::CommonName, "localhost");
+    let leaf = leaf_params.signed_by(&leaf_key, &ca, &ca_key).unwrap();
+
+    TlsMaterial {
+        root_pem: ca.pem().into_bytes(),
+        chain_der: vec![leaf.der().to_vec(), ca.der().to_vec()],
+        key_der: leaf_key.serialize_der(),
+    }
+}

--- a/crates/hyprstream/tests/fixtures/did_trust.rs
+++ b/crates/hyprstream/tests/fixtures/did_trust.rs
@@ -115,7 +115,11 @@ pub struct CapsuleMaterial {
     pub at9p_did: String,
 }
 
-pub fn make_capsule(did_web: &str, tag: u8) -> CapsuleMaterial {
+fn make_capsule_with_endpoint(
+    did_web: &str,
+    tag: u8,
+    endpoint: ServiceEndpoint,
+) -> CapsuleMaterial {
     let ed = SigningKey::from_bytes(&[tag; 32]);
     let (pq, pq_vk) = hyprstream_crypto::pq::ml_dsa_generate_keypair();
     let pair = HybridKeyPair::new(
@@ -123,7 +127,6 @@ pub fn make_capsule(did_web: &str, tag: u8) -> CapsuleMaterial {
         hyprstream_crypto::pq::ml_dsa_vk_bytes(&pq_vk),
     )
     .unwrap();
-    let endpoint = ServiceEndpoint::new(Transport::Iroh, format!("iroh://node{tag}")).unwrap();
     let service = ServiceEntry::new("#ns", ServiceType::NinePExport, endpoint).unwrap();
     let mut body = CapsuleBody::new(vec![pair], vec![service]).unwrap();
     body.also_known_as = Some(vec![did_web.to_owned()]);
@@ -134,6 +137,23 @@ pub fn make_capsule(did_web: &str, tag: u8) -> CapsuleMaterial {
         bytes,
         at9p_did: did,
     }
+}
+
+pub fn make_capsule(did_web: &str, tag: u8) -> CapsuleMaterial {
+    let mut endpoint = ServiceEndpoint::new(Transport::Iroh, format!("iroh://node{tag}")).unwrap();
+    let carrier = SigningKey::from_bytes(&[tag.wrapping_add(1); 32]);
+    endpoint.node_id = Some(
+        ed25519_to_did_key(carrier.verifying_key().as_bytes())
+            .strip_prefix("did:key:")
+            .unwrap()
+            .to_owned(),
+    );
+    make_capsule_with_endpoint(did_web, tag, endpoint)
+}
+
+pub fn make_quic_capsule(did_web: &str, tag: u8, address: SocketAddr) -> CapsuleMaterial {
+    let endpoint = ServiceEndpoint::new(Transport::Quic, format!("quic://{address}")).unwrap();
+    make_capsule_with_endpoint(did_web, tag, endpoint)
 }
 
 pub struct TlsMaterial {

--- a/docs/deployment-registry-trust.md
+++ b/docs/deployment-registry-trust.md
@@ -74,12 +74,65 @@ not become trust decisions: identity remains pinned by the configured at9p
 hash and mutual alias rule, while application responses remain pinned to the
 separately authenticated Discovery service key.
 
-This first increment changes server trust and reach only. The existing
-OS-owned `registry-service.jwt` is still required to bind the deployment CA to
-the registry verification key. Enrollment (including operator-approved device
-flow and unattended machine attestation) and final `SecretsProfile` integration
-remain separate work; no client-authentication authority is inferred from the
-two public anchors.
+The registry deployment credential is fetched from beside the capsule —
+`/.well-known/deployment/registry-service.jwt` — and validated with the exact
+same profile as the OS-owned file (CA-bound `kid`/`iss`/`deployment_domain`,
+one-hour freshness). The credential is CA-signed and short-lived, so the
+channel is untrusted by design; the OS-owned JWT file is required only when
+the OS-owned source is selected. Enrollment (operator-approved device flow,
+unattended machine attestation) and final `SecretsProfile` integration remain
+separate work; no client-authentication authority is inferred from the two
+public anchors.
+
+### Serving the deployment well-known documents
+
+The OAuth service terminates the deployment's did:web host when configured
+with a static well-known directory (it is the only dual-stack HTTP+RPC
+service, and it already owns `/.well-known/did.json`):
+
+```toml
+[oauth]
+deployment_well_known_dir = "/var/lib/hyprstream/deployment-well-known"
+```
+
+The operator provisions three public, integrity-anchored documents, re-read
+on every request (so the hourly credential refresh needs no restart):
+
+```text
+<dir>/did.json                              the deployment DID document
+<dir>/at9p/<cid512>.cbor                    the cluster at9p genesis capsule
+<dir>/deployment/registry-service.jwt       the current CA-signed credential
+```
+
+When the directory is configured, `/.well-known/did.json` serves the static
+deployment document IN PLACE OF the dynamic node document; a missing file is
+a 404, never a silent fall-through.
+
+### Same-node vs remote-node discovery reach
+
+A DID-anchored node that hosts Discovery on its local IPC fabric (the metal
+stack's `service start … --ipc` containers; the default) uses a lazy local
+discovery client — identical posture to the OS-owned path, which also never
+pings. A node REMOTE from the cluster's Discovery sets
+`cluster_remote_node = true`: startup then dials the document-advertised
+transport and requires a successful signed liveness `ping` before installing
+the resolver. The remote arm additionally requires the document's `#mesh-kem`
+`keyAgreement` (request confidentiality — QUIC forbids cleartext envelopes)
+and exactly one ML-DSA-65 `#mesh-pq` verification method (response
+authentication); either absent fails the boot.
+
+Private-PKI deployments whose did:web host terminates TLS with an internal CA
+may add `cluster_anchor_root_cert = "/path/to/root.pem"` — an ADDITIVE trust
+anchor (public roots remain enabled); an unreadable or malformed file fails
+startup.
+
+### Fresh nodes
+
+A first boot has no checkpointed PDS store. The bootstrap initializes an
+empty (genesis) store rather than deadlock — the registry service is the
+sole writer and would otherwise be unstartable. If a node that previously
+held at9p state boots with a missing store, that means the duplicity history
+was lost; startup logs a loud warning and proceeds at genesis posture.
 
 ## Registry credential profile
 


### PR DESCRIPTION
Refs #1137, #1136, #1143, and #1157.

## Current status

This PR remains blocked pending the dedicated #1157 Option C lane. I will not claim that a DID document is harmless until its CA, reach, KEM, and PQ material are capsule/accepted-state sourced and the coordinated document-plus-credential substitution test refuses.

## Changes pushed

- eb4981a98: checkpoint-loss now fails closed. An empty checkpoint store can only be created by the explicit hyprstream pds init-deployment-store first-provision command; normal resolver startup never recreates missing history.
- Metal stack dependency f212ed9: provisions DID anchors, discovery bootstrap-pubkeys, static public deployment artifacts, and explicit first-boot store initialization. Caddy owns discovery.hyprstream.com and serves /.well-known/* before any Hyprstream service starts, breaking the OAuth cold-start cycle. OAuth is no longer the trust terminator.

## Stack acceptance

I did not claim the actual stack boots. The current stack intentionally has no verified arm64 image digest, and no real did.json, capsule, short-lived credential, or bootstrap discovery-key inputs have been supplied. Therefore no safe cloud apply or real service start event --foreground --ipc acceptance run is possible yet. Once those operator inputs exist and Option C lands, the command must be run against the rendered stack and report service readiness.

## Remaining review work

- F1: owned by fix/1157-capsule-sourced-trust; currently uncommitted/incomplete.
- F5: replace the direct-RPC liveness test with a production-bootstrap causal test.
- F6: stream credential reads under the 64 KiB cap.

## Validation

- Metal: tofu fmt --check, tofu validate with structurally valid placeholder inputs.
- Hyprstream: repository pre-commit release Clippy completed before eb4981a98.
- git diff --check.

cargo fmt --check remains known-broken on clean main (#1140).