### PR TITLE
feat(#1153): /moq CONNECT auth mechanism — relay-scoped, per-accept, fail-closed (NOT closing #1153)

### DIFF
--- a/crates/hyprstream-rpc/src/moq_authz.rs
+++ b/crates/hyprstream-rpc/src/moq_authz.rs
@@ -190,11 +190,14 @@ impl PeerIdentity {
 ///   `remote_id()` is carrier metadata, so the hook receives anonymous until
 ///   #1027 supplies fresh proof.
 /// - **quinn `/moq` path** ([`crate::transport::quinn_transport::QuinnRpcServer`]):
-///   the WebTransport CONNECT is *not* mutually authenticated, so no peer
-///   identity is available at accept time. The hook is still invoked with
-///   [`PeerIdentity::anonymous`]; a policy-gated authorizer will therefore deny
-///   *private* subscribes from anonymous quinn peers (fail-closed) while public
-///   broadcasts remain open. See the wiring TODO in `quinn_transport.rs`.
+///   as of #1153 the CONNECT is authenticated by
+///   [`crate::transport::moq_connect_auth::MoqConnectAuthz`] (bearer JWT,
+///   verified before the handshake completes); the tenant is resolved from the
+///   *verified* subject and a `tenant_scoped_consumer` is served. With no
+///   `MoqConnectAuthz` installed, the peer is anonymous and the hook receives
+///   [`PeerIdentity::anonymous`] (single-tenant/open model); a policy-gated
+///   authorizer will deny *private* subscribes from anonymous quinn peers
+///   (fail-closed) while public broadcasts remain open.
 pub trait SubscribeAuthorizer: Send + Sync {
     /// Decide whether `peer` may subscribe to `track_name`.
     fn authorize(&self, peer: &PeerIdentity, track_name: &str) -> SubscribeDecision;

--- a/crates/hyprstream-rpc/src/moq_authz.rs
+++ b/crates/hyprstream-rpc/src/moq_authz.rs
@@ -48,6 +48,16 @@ use moq_net::{OriginConsumer, Path};
 /// The hierarchical track-name separator (`{tenant}/{service}/{topic}/{instance}`).
 pub const TRACK_NAME_SEP: char = '/';
 
+/// Return whether `tenant` is one non-empty MoQ path segment.
+///
+/// This validation is security-sensitive: `moq_net::Path::new` normalizes an
+/// empty or slash-only string to the empty path, and an empty prefix is a
+/// wildcard matching every broadcast. Tenant-derived scopes must therefore
+/// reject empty and multi-segment values before constructing a [`Path`].
+pub fn is_valid_tenant_segment(tenant: &str) -> bool {
+    !tenant.is_empty() && !tenant.contains(TRACK_NAME_SEP)
+}
+
 /// Extract the `{tenant}` segment from a hierarchical track / broadcast name.
 ///
 /// Names are `{tenant}/{service}/{topic}/{instance}`; the tenant is the first
@@ -111,6 +121,9 @@ where
 /// than falling back to the unscoped consumer.
 #[cfg(not(target_arch = "wasm32"))]
 pub fn tenant_scoped_consumer(consumer: &OriginConsumer, tenant: &str) -> Option<OriginConsumer> {
+    if !is_valid_tenant_segment(tenant) {
+        return None;
+    }
     let prefix = tenant_prefix(tenant);
     consumer.scope(&[Path::new(&prefix)])
 }
@@ -301,6 +314,30 @@ mod tests {
     #[test]
     fn tenant_prefix_is_segment_significant() {
         assert_eq!(tenant_prefix("alice"), "alice/");
+    }
+
+    #[test]
+    fn tenant_segment_validation_rejects_root_wildcards_and_nested_scopes() {
+        assert!(is_valid_tenant_segment("alice"));
+        assert!(!is_valid_tenant_segment(""));
+        assert!(!is_valid_tenant_segment("/"));
+        assert!(!is_valid_tenant_segment("///"));
+        assert!(!is_valid_tenant_segment("/alice"));
+        assert!(!is_valid_tenant_segment("alice/"));
+        assert!(!is_valid_tenant_segment("alice/bob"));
+    }
+
+    #[test]
+    fn tenant_scoped_consumer_rejects_invalid_tenant_before_path_normalization() {
+        let producer = moq_net::Origin::random().produce();
+        let consumer = producer.consume();
+
+        for tenant in ["", "/", "///", "/alice", "alice/", "alice/bob"] {
+            assert!(
+                tenant_scoped_consumer(&consumer, tenant).is_none(),
+                "invalid tenant {tenant:?} must not become a root or nested scope"
+            );
+        }
     }
 
     #[test]

--- a/crates/hyprstream-rpc/src/transport/mod.rs
+++ b/crates/hyprstream-rpc/src/transport/mod.rs
@@ -27,6 +27,9 @@ pub mod iroh_transport;
 #[cfg(not(target_arch = "wasm32"))]
 pub mod iroh_moq;
 #[cfg(not(target_arch = "wasm32"))]
+/// CONNECT-time authentication + tenant binding for the `/moq` WebTransport
+/// plane (#1153).
+pub mod moq_connect_auth;
 #[cfg(not(target_arch = "wasm32"))]
 pub mod in_memory;
 #[cfg(not(target_arch = "wasm32"))]

--- a/crates/hyprstream-rpc/src/transport/moq_connect_auth.rs
+++ b/crates/hyprstream-rpc/src/transport/moq_connect_auth.rs
@@ -114,9 +114,13 @@ impl MoqConnectAuthz {
     }
 
     /// Require the JWT `aud` to equal `aud` (trailing-slash tolerant, matches
-    /// [`jwt::decode_with_key`]). A token with a different `aud` is rejected;
-    /// a token with no `aud` is still accepted (lenient on absence, strict on
-    /// mismatch) to interoperate with issuers that omit `aud`.
+    /// [`jwt::decode_with_key`]). A token with a different `aud` is rejected,
+    /// and — unlike the codebase-wide lenient [`jwt::decode_with_key`] — a
+    /// token with **no** `aud` is also rejected when this is set. On a
+    /// dedicated `/moq` boundary that closes the token-substitution vector
+    /// (a token minted for another service, which carries no `aud`, must not
+    /// be admitted here) per BCP 225 / RFC 8725bis. If the operator does not
+    /// set this, audience checking is off entirely (their choice).
     pub fn with_expected_aud(mut self, aud: impl Into<String>) -> Self {
         self.expected_aud = Some(aud.into());
         self
@@ -128,13 +132,23 @@ impl MoqConnectAuthz {
     /// Returns `None` — meaning the CONNECT MUST be refused — if:
     /// - no `Authorization: Bearer <jwt>` header is present,
     /// - the JWT signature, `alg`, `exp`, or `iat` check fails,
-    /// - the `aud` check fails,
+    /// - the `aud` check fails — including a **missing** `aud` when
+    ///   [`Self::with_expected_aud`] is set (token substitution is not
+    ///   admitted on a boundary that specified an audience),
     /// - or `tenant_resolver` returns `None` for the verified subject.
     ///
     /// Every branch is fail-closed; none falls back to an unscoped identity.
     pub fn verify(&self, headers: &http::HeaderMap) -> Option<VerifiedConnect> {
         let token = bearer_token(headers)?;
         let claims = jwt::decode_with_key(&token, &self.verify_key, self.expected_aud.as_deref()).ok()?;
+        // [`jwt::decode_with_key`] is lenient on a *missing* `aud` (accepts
+        // absent, rejects mismatch) to tolerate legacy federated issuers across
+        // the codebase. This dedicated `/moq` boundary is stricter: when an
+        // audience is configured, a token with no `aud` is a substitution
+        // attempt from another service and must fail closed (#1153, BCP 225).
+        if self.expected_aud.is_some() && claims.aud.is_none() {
+            return None;
+        }
         let tenant = (self.tenant_resolver)(&claims.sub)?;
         Some(VerifiedConnect {
             peer: PeerIdentity::authenticated(&claims.sub),
@@ -297,5 +311,40 @@ mod tests {
         let mut h = http::HeaderMap::new();
         h.insert("authorization", format!("Bearer {tok}").parse().unwrap());
         assert!(authz.verify(&h).is_none(), "wrong aud must fail closed");
+    }
+
+    #[test]
+    fn verify_rejects_missing_aud_when_audience_is_configured() {
+        // BCP 225 / RFC 8725bis: on a boundary that specified an audience, a
+        // token with NO aud is a substitution attempt from another service
+        // and must fail closed — not be admitted by the lenient-on-absence
+        // decode_with_key default. (`jwt::decode_with_key` accepts a missing
+        // aud; `MoqConnectAuthz` must override that here.)
+        let key = SigningKey::from_bytes(&[8u8; 32]);
+        let vk = key.verifying_key();
+        let authz =
+            MoqConnectAuthz::new(vk, resolver(&[("s", "t")])).with_expected_aud("moq.example");
+        // Token with no aud (the default from Claims::new).
+        let tok = mint(&key, "s", 60);
+        let mut h = http::HeaderMap::new();
+        h.insert("authorization", format!("Bearer {tok}").parse().unwrap());
+        assert!(
+            authz.verify(&h).is_none(),
+            "missing aud must fail closed when an audience is configured"
+        );
+    }
+
+    #[test]
+    fn verify_accepts_missing_aud_when_no_audience_configured() {
+        // If the operator did not set expected_aud, audience checking is off
+        // entirely — a token with no aud is admitted (subject to the other
+        // checks). This is the operator's explicit choice.
+        let key = SigningKey::from_bytes(&[9u8; 32]);
+        let vk = key.verifying_key();
+        let authz = MoqConnectAuthz::new(vk, resolver(&[("s", "t")]));
+        let tok = mint(&key, "s", 60); // no aud
+        let mut h = http::HeaderMap::new();
+        h.insert("authorization", format!("Bearer {tok}").parse().unwrap());
+        assert!(authz.verify(&h).is_some(), "no-aud token admitted when no audience configured");
     }
 }

--- a/crates/hyprstream-rpc/src/transport/moq_connect_auth.rs
+++ b/crates/hyprstream-rpc/src/transport/moq_connect_auth.rs
@@ -150,6 +150,12 @@ impl MoqConnectAuthz {
             return None;
         }
         let tenant = (self.tenant_resolver)(&claims.sub)?;
+        // `moq_net::Path::new` normalizes "/" to its empty wildcard path.
+        // Reject empty and multi-segment resolver output here, before it can
+        // become either a root consumer scope or unrestricted relay ingest.
+        if !crate::moq_authz::is_valid_tenant_segment(&tenant) {
+            return None;
+        }
         Some(VerifiedConnect {
             peer: PeerIdentity::authenticated(&claims.sub),
             tenant,
@@ -295,6 +301,24 @@ mod tests {
         let mut h = http::HeaderMap::new();
         h.insert("authorization", format!("Bearer {tok}").parse().unwrap());
         assert!(authz.verify(&h).is_none());
+    }
+
+    #[test]
+    fn verify_fails_when_resolver_returns_invalid_tenant_segment() {
+        let key = SigningKey::from_bytes(&[10u8; 32]);
+        let token = mint(&key, "s", 60);
+        let mut headers = http::HeaderMap::new();
+        headers.insert("authorization", format!("Bearer {token}").parse().unwrap());
+
+        for tenant in ["", "/", "///", "/alice", "alice/", "alice/bob"] {
+            let tenant = tenant.to_owned();
+            let authz =
+                MoqConnectAuthz::new(key.verifying_key(), Arc::new(move |_| Some(tenant.clone())));
+            assert!(
+                authz.verify(&headers).is_none(),
+                "invalid tenant must fail CONNECT closed"
+            );
+        }
     }
 
     #[test]

--- a/crates/hyprstream-rpc/src/transport/moq_connect_auth.rs
+++ b/crates/hyprstream-rpc/src/transport/moq_connect_auth.rs
@@ -1,0 +1,301 @@
+//! CONNECT-time authentication for the `/moq` WebTransport plane (#1153).
+//!
+//! The `/moq` WebTransport CONNECT is an entry point onto a *shared* streaming
+//! plane. This module authenticates it **before any stream is established**
+//! (the accept loop verifies the credential and refuses the CONNECT — by
+//! dropping the request, never completing the handshake — before
+//! `Request::ok()` runs), then binds the accepted session to a tenant derived
+//! from the *verified* identity.
+//!
+//! ## Credential accepted, and why
+//!
+//! The accepted credential is a **bearer JWT** carried in the HTTP/3
+//! [`Authorization`] header (`Authorization: Bearer <jwt>`). It is
+//! **verified, not merely parsed**: [`crate::auth::jwt::decode_with_key`]
+//! checks the EdDSA signature (and rejects any non-`EdDSA` `alg`, defeating
+//! algorithm-confusion), `exp`/`iat` validity, and the expected `aud`. A
+//! forged signature, a stripped claim, or an expired token fails closed.
+//!
+//! This reuses the same verified-identity primitive the RPC envelope path uses
+//! (`hyprstream_rpc::auth::jwt`/`Claims`) so the `/moq` plane and the RPC
+//! plane agree on what "verified subject" means — the derivation can be
+//! shared with the sibling Casbin-domain work (#1151) rather than invented a
+//! second time.
+//!
+//! ## Why the tenant is NOT read from the token
+//!
+//! Per the #1128 spike and #1146 (T2.1 / PR #1147), JWT scope/claim fields are
+//! not enforced at the verifier today — any tenant-shaped claim inside the
+//! token is caller-supplied data and therefore unenforceable (the existing
+//! `cap` field is the cautionary tale: present, unread). So the tenant is
+//! **never** taken from the token. It is derived, server-side, from the
+//! *verified subject* by [`MoqConnectAuthz::tenant_resolver`] — an
+//! authoritative subject→tenant provisioning map the operator controls. The
+//! token proves *who* the peer is; the resolver is the trust root for *which
+//! tenant that subject belongs to*. See `VerifiedConnect`.
+//!
+//! ## What this guarantees today (read before assuming isolation)
+//!
+//! With a `MoqConnectAuthz` installed, an unauthenticated or tenant-less
+//! `/moq` CONNECT is refused (fail-closed), and a connected peer can only
+//! enumerate/subscribe to its own tenant's broadcasts (structural scoping via
+//! [`crate::moq_authz::tenant_scoped_consumer`]). This is a **transport-plane,
+//! metadata/announce isolation boundary** on the `/moq` consumer path. It is
+//! NOT a cluster-wide tenant guarantee: frame content was already
+//! AEAD-sealed + chained-HMAC'd at the source (the relay/consumer holds no
+//! `enc_key`/`mac_key`), and other planes (RPC subject authorization, event
+//! prefixes, VFS) have their own independent stories documented in the #1128
+//! spike. Relay-mode (`with_moq_relay`) additionally refuses unauthenticated
+//! CONNECTs but the relay still routes by track name — it must, to rendezvous
+//! publisher and subscriber — so announce-name visibility through a relay is
+//! inherent to relay mode and not something this boundary removes.
+
+use std::sync::Arc;
+
+use ed25519_dalek::VerifyingKey;
+
+use crate::auth::jwt;
+use crate::moq_authz::PeerIdentity;
+
+/// HTTP/3 header carrying the bearer JWT.
+pub const AUTHORIZATION_HEADER: &str = "authorization";
+/// Scheme expected in the `Authorization` header value.
+pub const BEARER_SCHEME: &str = "Bearer";
+
+/// Server-side map from a **verified** subject to its tenant.
+///
+/// Authoritative server state (a subject→tenant provisioning table the
+/// operator controls), never a caller-supplied field — see the module docs on
+/// why a token claim is not used. The input is the verified `Claims::sub` from
+/// a JWT whose signature has already been checked; returning `None` fails the
+/// CONNECT closed.
+pub type VerifiedSubjectTenantResolver = Arc<dyn Fn(&str) -> Option<String> + Send + Sync>;
+
+/// CONNECT-time authentication + tenant-binding config for the `/moq` plane.
+///
+/// When installed on a
+/// [`crate::transport::quinn_transport::QuinnRpcServer`], every `/moq`
+/// WebTransport CONNECT must present a bearer JWT verifiable with
+/// `verify_key`; the verified subject is then mapped to a tenant by
+/// `tenant_resolver`. [`MoqConnectAuthz::verify`] returns `None` on any
+/// failure — missing header, wrong scheme, bad signature, expired/token-not-
+/// yet-valid, wrong audience, or an authenticated subject with no tenant —
+/// and the accept loop refuses the CONNECT (fail-closed). There is no
+/// fall-through to an unscoped consumer: that is the #1145 pattern and the
+/// single most likely way to get this wrong.
+#[derive(Clone)]
+pub struct MoqConnectAuthz {
+    verify_key: VerifyingKey,
+    expected_aud: Option<String>,
+    tenant_resolver: VerifiedSubjectTenantResolver,
+}
+
+impl std::fmt::Debug for MoqConnectAuthz {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("MoqConnectAuthz")
+            .field("expected_aud", &self.expected_aud)
+            .finish_non_exhaustive()
+    }
+}
+
+impl MoqConnectAuthz {
+    /// Build with the verifying key for the JWT issuer this `/moq` endpoint
+    /// trusts and the authoritative subject→tenant resolver. The endpoint
+    /// accepts any `aud` unless [`Self::with_expected_aud`] is set.
+    pub fn new(
+        verify_key: VerifyingKey,
+        tenant_resolver: VerifiedSubjectTenantResolver,
+    ) -> Self {
+        Self {
+            verify_key,
+            expected_aud: None,
+            tenant_resolver,
+        }
+    }
+
+    /// Require the JWT `aud` to equal `aud` (trailing-slash tolerant, matches
+    /// [`jwt::decode_with_key`]). A token with a different `aud` is rejected;
+    /// a token with no `aud` is still accepted (lenient on absence, strict on
+    /// mismatch) to interoperate with issuers that omit `aud`.
+    pub fn with_expected_aud(mut self, aud: impl Into<String>) -> Self {
+        self.expected_aud = Some(aud.into());
+        self
+    }
+
+    /// Verify the bearer credential in `headers` and resolve the tenant from
+    /// the *verified* subject.
+    ///
+    /// Returns `None` — meaning the CONNECT MUST be refused — if:
+    /// - no `Authorization: Bearer <jwt>` header is present,
+    /// - the JWT signature, `alg`, `exp`, or `iat` check fails,
+    /// - the `aud` check fails,
+    /// - or `tenant_resolver` returns `None` for the verified subject.
+    ///
+    /// Every branch is fail-closed; none falls back to an unscoped identity.
+    pub fn verify(&self, headers: &http::HeaderMap) -> Option<VerifiedConnect> {
+        let token = bearer_token(headers)?;
+        let claims = jwt::decode_with_key(&token, &self.verify_key, self.expected_aud.as_deref()).ok()?;
+        let tenant = (self.tenant_resolver)(&claims.sub)?;
+        Some(VerifiedConnect {
+            peer: PeerIdentity::authenticated(&claims.sub),
+            tenant,
+        })
+    }
+}
+
+/// The outcome of a successful CONNECT-time verification: a peer whose
+/// `subject` was verified by signature, and the tenant the server resolved
+/// for that subject. The tenant is authoritative server-side state, not a
+/// caller-supplied field.
+#[derive(Debug, Clone)]
+pub struct VerifiedConnect {
+    /// The verified application subject.
+    pub peer: PeerIdentity,
+    /// Server-resolved tenant for the verified subject.
+    pub tenant: String,
+}
+
+/// Extract the bearer token from the `Authorization` header.
+///
+/// Returns `None` if the header is absent, not valid UTF-8, not the `Bearer`
+/// scheme (compared case-insensitively per RFC 7235), or carries an empty
+/// token. Pure and independently testable.
+pub fn bearer_token(headers: &http::HeaderMap) -> Option<String> {
+    let raw = headers.get(AUTHORIZATION_HEADER)?.to_str().ok()?;
+    let mut split = raw.splitn(2, ' ');
+    let scheme = split.next()?;
+    if !scheme.trim().eq_ignore_ascii_case(BEARER_SCHEME) {
+        return None;
+    }
+    let token = split.next()?.trim();
+    if token.is_empty() {
+        None
+    } else {
+        Some(token.to_owned())
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::expect_used, clippy::unwrap_used)]
+mod tests {
+    use super::*;
+    use crate::auth::claims::Claims;
+    use ed25519_dalek::SigningKey;
+
+    fn mint(signing: &SigningKey, sub: &str, exp_delta_secs: i64) -> String {
+        let now = chrono::Utc::now().timestamp();
+        let claims = Claims::new(sub.to_owned(), now, now + exp_delta_secs);
+        crate::auth::jwt::encode(&claims, signing)
+    }
+
+    fn resolver(mapping: &'static [(&'static str, &'static str)]) -> VerifiedSubjectTenantResolver {
+        Arc::new(move |sub: &str| {
+            mapping
+                .iter()
+                .find(|(s, _)| *s == sub)
+                .map(|(_, t)| t.to_string())
+        })
+    }
+
+    #[test]
+    fn bearer_token_parses_well_formed_header() {
+        let mut h = http::HeaderMap::new();
+        h.insert("authorization", "Bearer abc.def.ghi".parse().unwrap());
+        assert_eq!(bearer_token(&h).as_deref(), Some("abc.def.ghi"));
+    }
+
+    #[test]
+    fn bearer_token_accepts_lowercase_scheme() {
+        // RFC 7235: scheme is case-insensitive.
+        let mut h = http::HeaderMap::new();
+        h.insert("authorization", "bearer t.ok.en".parse().unwrap());
+        assert_eq!(bearer_token(&h).as_deref(), Some("t.ok.en"));
+    }
+
+    #[test]
+    fn bearer_token_rejects_missing_or_wrong_scheme() {
+        let mut h = http::HeaderMap::new();
+        assert!(bearer_token(&h).is_none()); // absent
+        h.insert("authorization", "Basic dXNlcjpwYXNz".parse().unwrap());
+        assert!(bearer_token(&h).is_none()); // wrong scheme
+        h.insert("authorization", "Bearer   ".parse().unwrap());
+        assert!(bearer_token(&h).is_none()); // empty token
+    }
+
+    #[test]
+    fn verify_succeeds_for_known_subject_and_resolves_tenant() {
+        let key = SigningKey::from_bytes(&[1u8; 32]);
+        let vk = key.verifying_key();
+        let authz = MoqConnectAuthz::new(vk, resolver(&[("did:key:alice", "alice")]));
+        let tok = mint(&key, "did:key:alice", 60);
+        let mut h = http::HeaderMap::new();
+        h.insert("authorization", format!("Bearer {tok}").parse().unwrap());
+        let vc = authz.verify(&h).expect("verified");
+        assert_eq!(vc.peer.subject.as_deref(), Some("did:key:alice"));
+        assert_eq!(vc.tenant, "alice");
+        assert!(vc.peer.is_authenticated());
+    }
+
+    #[test]
+    fn verify_fails_when_no_authorization_header() {
+        let key = SigningKey::from_bytes(&[2u8; 32]);
+        let vk = key.verifying_key();
+        let authz = MoqConnectAuthz::new(vk, resolver(&[("s", "t")]));
+        assert!(authz.verify(&http::HeaderMap::new()).is_none());
+    }
+
+    #[test]
+    fn verify_fails_for_wrong_signature() {
+        // Signed by a different key than the verifier expects.
+        let issuer_key = SigningKey::from_bytes(&[3u8; 32]);
+        let rogue_key = SigningKey::from_bytes(&[4u8; 32]);
+        let authz = MoqConnectAuthz::new(issuer_key.verifying_key(), resolver(&[("s", "t")]));
+        let tok = mint(&rogue_key, "s", 60); // signed by rogue
+        let mut h = http::HeaderMap::new();
+        h.insert("authorization", format!("Bearer {tok}").parse().unwrap());
+        assert!(authz.verify(&h).is_none(), "forged signature must fail closed");
+    }
+
+    #[test]
+    fn verify_fails_for_expired_token() {
+        let key = SigningKey::from_bytes(&[5u8; 32]);
+        let vk = key.verifying_key();
+        let authz = MoqConnectAuthz::new(vk, resolver(&[("s", "t")]));
+        // exp in the past.
+        let now = chrono::Utc::now().timestamp();
+        let claims = Claims::new("s".to_owned(), now - 120, now - 60);
+        let tok = crate::auth::jwt::encode(&claims, &key);
+        let mut h = http::HeaderMap::new();
+        h.insert("authorization", format!("Bearer {tok}").parse().unwrap());
+        assert!(authz.verify(&h).is_none());
+    }
+
+    #[test]
+    fn verify_fails_when_subject_has_no_tenant() {
+        // Verified signature, but the resolver doesn't know this subject →
+        // fail closed (no wildcard tenant, no unscoped fallthrough).
+        let key = SigningKey::from_bytes(&[6u8; 32]);
+        let vk = key.verifying_key();
+        let authz = MoqConnectAuthz::new(vk, resolver(&[("did:key:alice", "alice")]));
+        let tok = mint(&key, "did:key:stranger", 60);
+        let mut h = http::HeaderMap::new();
+        h.insert("authorization", format!("Bearer {tok}").parse().unwrap());
+        assert!(authz.verify(&h).is_none());
+    }
+
+    #[test]
+    fn verify_enforces_expected_audience() {
+        let key = SigningKey::from_bytes(&[7u8; 32]);
+        let vk = key.verifying_key();
+        let authz =
+            MoqConnectAuthz::new(vk, resolver(&[("s", "t")])).with_expected_aud("moq.example");
+        // Mint a token with the wrong aud.
+        let now = chrono::Utc::now().timestamp();
+        let mut claims = Claims::new("s".to_owned(), now, now + 60);
+        claims.aud = Some("other.example".to_owned());
+        let tok = crate::auth::jwt::encode(&claims, &key);
+        let mut h = http::HeaderMap::new();
+        h.insert("authorization", format!("Bearer {tok}").parse().unwrap());
+        assert!(authz.verify(&h).is_none(), "wrong aud must fail closed");
+    }
+}

--- a/crates/hyprstream-rpc/src/transport/quinn_transport.rs
+++ b/crates/hyprstream-rpc/src/transport/quinn_transport.rs
@@ -555,6 +555,15 @@ impl QuinnRpcServer {
                             if let Some(relay_origin) = moq_relay_origin {
                                 let scoped_origin = match &moq_connect_verified {
                                     Some(verified) => {
+                                        if !crate::moq_authz::is_valid_tenant_segment(
+                                            &verified.tenant,
+                                        ) {
+                                            tracing::warn!(
+                                                tenant = %verified.tenant,
+                                                "quinn-moq-relay: invalid tenant segment; refusing publisher"
+                                            );
+                                            return;
+                                        }
                                         let prefix =
                                             crate::moq_authz::tenant_prefix(&verified.tenant);
                                         let path = moq_net::Path::new(&prefix);

--- a/crates/hyprstream-rpc/src/transport/quinn_transport.rs
+++ b/crates/hyprstream-rpc/src/transport/quinn_transport.rs
@@ -108,6 +108,10 @@ pub fn global_moq_connect_authz() -> Option<crate::transport::moq_connect_auth::
     GLOBAL_MOQ_CONNECT_AUTHZ.get().cloned()
 }
 
+/// One-shot guard so the "no authenticator on a served `/moq` plane" warning
+/// (#1153/F1) fires once per process rather than per-CONNECT.
+static MOQ_NO_AUTHZ_WARNED: std::sync::Once = std::sync::Once::new();
+
 /// A quinn-backed WebTransport server for the RPC plane.
 ///
 /// Accepts WebTransport sessions and spawns [`serve_rpc_connection`] for each.
@@ -202,10 +206,14 @@ impl QuinnRpcServer {
             moq_consumer: None,
             moq_relay_origin: None,
             moq_authz: crate::transport::iroh_moq::MoqAuthzConfig::default(),
-            // Pick up the process-global `/moq` CONNECT authenticator if the
-            // `hyprstream` crate registered one (shared-endpoint boundary);
-            // a builder call can still override it.
-            moq_connect_authz: global_moq_connect_authz(),
+            // #1153/F3: do NOT snapshot `global_moq_connect_authz()` here.
+            // Reading the OnceLock once at construction makes startup ordering
+            // a silent security property: a server built before the `hyprstream`
+            // crate registers the authenticator runs open forever with no error.
+            // The accept loop resolves the effective authenticator per-CONNECT
+            // (`builder override OR global`), so registration order is no longer
+            // load-bearing.
+            moq_connect_authz: None,
             // Pick up the process-global 9P handler if the `hyprstream` crate
             // registered one; a builder call can still override it.
             ninep_handler: global_ninep_handler(),
@@ -443,9 +451,35 @@ impl QuinnRpcServer {
                         let is_ninep = request.url.path() == crate::dial::NINEP_PATH;
                         let is_browser_rpc = request.url.path()
                             == crate::browser_provisioning::BROWSER_RPC_PATH;
+                        // #1153/F3: resolve the effective authenticator
+                        // per-CONNECT (builder override OR process-global),
+                        // NOT once at construction. This removes the
+                        // ordering-dependent silent downgrade where a server
+                        // built before `set_global_moq_connect_authz` ran open
+                        // forever.
+                        let moq_connect_authz = moq_connect_authz
+                            .clone()
+                            .or_else(global_moq_connect_authz);
+                        // #1153/F1: if this endpoint serves `/moq` but no
+                        // authenticator is configured (override or global), warn
+                        // loudly ONCE per process — the unset state is exactly
+                        // the #1145 shape (an absent expected value silently
+                        // disabling the boundary) and must be detectable.
+                        if is_moq
+                            && (moq_consumer.is_some() || moq_relay_origin.is_some())
+                            && moq_connect_authz.is_none()
+                        {
+                            MOQ_NO_AUTHZ_WARNED.call_once(|| {
+                                tracing::warn!(
+                                    "quinn-moq: /moq plane is served with NO CONNECT authenticator (#1153) — \
+                                     anonymous/unscoped admission is LIVE. This is the #1145 fail-open shape; \
+                                     install MoqConnectAuthz via set_global_moq_connect_authz for a shared endpoint."
+                                );
+                            });
+                        }
                         // #1153: authenticate the `/moq` CONNECT BEFORE the
                         // WebTransport session is established. When a
-                        // `MoqConnectAuthz` is installed, a `/moq` CONNECT must
+                        // `MoqConnectAuthz` is resolved, a `/moq` CONNECT must
                         // present a verifiable bearer JWT (Authorization header)
                         // whose subject the server resolves to a tenant; any
                         // failure refuses the CONNECT — we `return` here,
@@ -510,15 +544,41 @@ impl QuinnRpcServer {
                             // so announce-name visibility through a relay is
                             // inherent to relay mode; frame content is already
                             // AEAD-sealed + chained-HMAC'd at the source.
+                            //
+                            // #1153 CRITICAL 3 (relay authorization): bind the
+                            // publisher's INGEST to its verified tenant prefix by
+                            // handing `Server::with_origin` a *scoped* producer.
+                            // Authentication alone let Alice publish into Bob's
+                            // namespace; `OriginProducer::scope` restricts this
+                            // session's publishes to `{tenant}/`, so a publish
+                            // of another tenant's prefix is rejected at ingest.
                             if let Some(relay_origin) = moq_relay_origin {
-                                if let Some(verified) = &moq_connect_verified {
-                                    tracing::debug!(
-                                        subject = ?verified.peer.subject,
-                                        tenant = %verified.tenant,
-                                        "quinn-moq-relay: admitting authenticated publisher"
-                                    );
-                                }
-                                let server = moq_net::Server::new().with_origin(relay_origin);
+                                let scoped_origin = match &moq_connect_verified {
+                                    Some(verified) => {
+                                        let prefix =
+                                            crate::moq_authz::tenant_prefix(&verified.tenant);
+                                        let path = moq_net::Path::new(&prefix);
+                                        match relay_origin.scope(&[path]) {
+                                            Some(scoped) => {
+                                                tracing::debug!(
+                                                    subject = ?verified.peer.subject,
+                                                    tenant = %verified.tenant,
+                                                    "quinn-moq-relay: admitting authenticated publisher scoped to tenant prefix"
+                                                );
+                                                scoped
+                                            }
+                                            None => {
+                                                tracing::warn!(
+                                                    tenant = %verified.tenant,
+                                                    "quinn-moq-relay: tenant prefix out of relay scope; refusing publisher"
+                                                );
+                                                return;
+                                            }
+                                        }
+                                    }
+                                    None => relay_origin,
+                                };
+                                let server = moq_net::Server::new().with_origin(scoped_origin);
                                 match server.accept(session).await {
                                     Ok(moq_session) => {
                                         tokio::select! {

--- a/crates/hyprstream-rpc/src/transport/quinn_transport.rs
+++ b/crates/hyprstream-rpc/src/transport/quinn_transport.rs
@@ -83,6 +83,31 @@ pub fn global_ninep_handler() -> Option<Arc<dyn NinePWtHandler>> {
     GLOBAL_NINEP_HANDLER.get().cloned()
 }
 
+/// Process-global `/moq` CONNECT authenticator (#1153), populated by the
+/// `hyprstream` crate at server startup — where the authoritative
+/// subject→tenant provisioning map (PolicyManager) is available — so the
+/// `hyprstream-service` spawner (which cannot depend on `hyprstream`) can
+/// pick it up at construction via [`global_moq_connect_authz`]. Same seam
+/// pattern as [`set_global_ninep_handler`]. First write wins.
+static GLOBAL_MOQ_CONNECT_AUTHZ: std::sync::OnceLock<
+    crate::transport::moq_connect_auth::MoqConnectAuthz,
+> = std::sync::OnceLock::new();
+
+/// Register the process-global `/moq` CONNECT authenticator (idempotent,
+/// first-wins). The `hyprstream` crate calls this at startup with an
+/// [`MoqConnectAuthz`] built over its PolicyManager subject→tenant map.
+pub fn set_global_moq_connect_authz(
+    authz: crate::transport::moq_connect_auth::MoqConnectAuthz,
+) -> bool {
+    GLOBAL_MOQ_CONNECT_AUTHZ.set(authz).is_ok()
+}
+
+/// The process-global `/moq` CONNECT authenticator, if one has been
+/// registered.
+pub fn global_moq_connect_authz() -> Option<crate::transport::moq_connect_auth::MoqConnectAuthz> {
+    GLOBAL_MOQ_CONNECT_AUTHZ.get().cloned()
+}
+
 /// A quinn-backed WebTransport server for the RPC plane.
 ///
 /// Accepts WebTransport sessions and spawns [`serve_rpc_connection`] for each.
@@ -124,6 +149,13 @@ pub struct QuinnRpcServer {
     /// #276 subscribe-authz + per-tenant announce-scoping config for the `/moq`
     /// plane. Defaults to "off" (open subscribe preserved).
     moq_authz: crate::transport::iroh_moq::MoqAuthzConfig,
+    /// #1153 CONNECT-time authenticator for the `/moq` plane. When set, every
+    /// `/moq` CONNECT must present a verifiable bearer JWT and resolve to a
+    /// tenant from the *verified* subject, or the CONNECT is refused
+    /// (fail-closed) before any stream is established. `None` = the `/moq`
+    /// plane is single-tenant/open (the deployment has not opted into the
+    /// shared-endpoint boundary).
+    moq_connect_authz: Option<crate::transport::moq_connect_auth::MoqConnectAuthz>,
     /// Optional 9P export handler (H1b / #765). When set, sessions whose
     /// WebTransport CONNECT URL path is [`crate::dial::NINEP_PATH`] are handed to
     /// it instead of the RPC core. Defaults to [`global_ninep_handler`] at
@@ -170,6 +202,10 @@ impl QuinnRpcServer {
             moq_consumer: None,
             moq_relay_origin: None,
             moq_authz: crate::transport::iroh_moq::MoqAuthzConfig::default(),
+            // Pick up the process-global `/moq` CONNECT authenticator if the
+            // `hyprstream` crate registered one (shared-endpoint boundary);
+            // a builder call can still override it.
+            moq_connect_authz: global_moq_connect_authz(),
             // Pick up the process-global 9P handler if the `hyprstream` crate
             // registered one; a builder call can still override it.
             ninep_handler: global_ninep_handler(),
@@ -217,16 +253,40 @@ impl QuinnRpcServer {
     /// the `/moq` plane.
     ///
     /// **Identity caveat (documented seam):** the WebTransport `/moq` CONNECT is
-    /// *not* mutually authenticated — the server presents a pinned cert, but the
-    /// client is anonymous at the TLS layer. So the `tenant_resolver` is invoked
-    /// with [`crate::moq_authz::PeerIdentity::anonymous`]; per-tenant scoping on
-    /// this path is only effective if the resolver returns a tenant from
-    /// non-identity context (e.g. a single-tenant endpoint), and a policy-gated
-    /// authorizer will deny *private* subscribes here (fail-closed) while public
-    /// broadcasts stay open. Cross-tenant enumeration defense for authenticated
-    /// peers lives on the iroh `moql` path.
+    /// *not* mutually authenticated at the TLS layer. Per-tenant announce
+    /// scoping via this config's `tenant_resolver` is only effective when a
+    /// resolver yields a tenant from non-identity context (e.g. a single-tenant
+    /// endpoint) — it receives [`crate::moq_authz::PeerIdentity::anonymous`] on
+    /// the open path. For a **shared multi-tenant** endpoint, install
+    /// [`Self::with_moq_connect_authz`] (#1153): that authenticates the CONNECT
+    /// (bearer JWT, verified before the handshake completes), resolves the
+    /// tenant from the *verified* subject, and — when set — takes precedence
+    /// over this config's anonymous resolver path, refusing unauthenticated /
+    /// tenant-less CONNECTs (fail-closed) and serving each authenticated peer
+    /// only its own tenant's broadcasts. Cross-tenant enumeration defense for
+    /// authenticated peers over the iroh `moql` ALPN lives in
+    /// [`crate::transport::iroh_moq`].
     pub fn with_moq_authz(mut self, authz: crate::transport::iroh_moq::MoqAuthzConfig) -> Self {
         self.moq_authz = authz;
+        self
+    }
+
+    /// Install the #1153 CONNECT-time authenticator for the `/moq` plane.
+    ///
+    /// When set, the accept loop verifies a bearer JWT from the CONNECT's
+    /// HTTP/3 `Authorization` header **before** completing the WebTransport
+    /// handshake, resolves the tenant from the *verified* subject via the
+    /// configured resolver, and refuses the CONNECT (fail-closed) on any
+    /// failure — missing header, bad signature, expired token, or a verified
+    /// subject with no tenant. A connected peer then sees only its own
+    /// tenant's broadcasts (structural scoping). With this unset, the `/moq`
+    /// plane stays single-tenant/open (no boundary), preserving the
+    /// pre-#1153 behaviour for deployments that have not opted in.
+    pub fn with_moq_connect_authz(
+        mut self,
+        authz: crate::transport::moq_connect_auth::MoqConnectAuthz,
+    ) -> Self {
+        self.moq_connect_authz = Some(authz);
         self
     }
 
@@ -369,6 +429,7 @@ impl QuinnRpcServer {
                     let moq_consumer = self.moq_consumer.clone();
                     let moq_relay_origin = self.moq_relay_origin.clone();
                     let moq_authz = self.moq_authz.clone();
+                    let moq_connect_authz = self.moq_connect_authz.clone();
                     let ninep_handler = self.ninep_handler.clone();
                     let carrier = self.carrier;
                     tokio::spawn(async move {
@@ -382,6 +443,32 @@ impl QuinnRpcServer {
                         let is_ninep = request.url.path() == crate::dial::NINEP_PATH;
                         let is_browser_rpc = request.url.path()
                             == crate::browser_provisioning::BROWSER_RPC_PATH;
+                        // #1153: authenticate the `/moq` CONNECT BEFORE the
+                        // WebTransport session is established. When a
+                        // `MoqConnectAuthz` is installed, a `/moq` CONNECT must
+                        // present a verifiable bearer JWT (Authorization header)
+                        // whose subject the server resolves to a tenant; any
+                        // failure refuses the CONNECT — we `return` here,
+                        // dropping `request` so `request.ok()` never runs and the
+                        // client's CONNECT never completes. This is fail-closed:
+                        // there is no anonymous/wildcard admission on a
+                        // boundary-configured endpoint.
+                        let moq_connect_verified = if is_moq {
+                            match &moq_connect_authz {
+                                Some(authz) => match authz.verify(&request.headers) {
+                                    Some(verified) => Some(verified),
+                                    None => {
+                                        tracing::warn!(
+                                            "quinn-moq: refusing unauthenticated or tenant-less /moq CONNECT (#1153)"
+                                        );
+                                        return;
+                                    }
+                                },
+                                None => None,
+                            }
+                        } else {
+                            None
+                        };
                         // Resolve the handshake INSIDE the task, bounded (#162),
                         // so a slow/stalled CONNECT never blocks the accept loop.
                         let session = match tokio::time::timeout(
@@ -411,7 +498,26 @@ impl QuinnRpcServer {
                             // track name, so publisher and subscriber rendezvous
                             // here without either dialing the other. The relay
                             // holds no stream keys — frames pass through opaquely.
+                            //
+                            // #1153: when a `MoqConnectAuthz` is installed, an
+                            // anonymous CONNECT was already refused above (before
+                            // `request.ok()`), so reaching here on a
+                            // boundary-configured endpoint means the publisher is
+                            // an authenticated, tenant-resolved subject —
+                            // anonymous relay publish (the #1128 relay-mode gap)
+                            // is closed. The relay still routes by track name
+                            // (it must, to rendezvous publisher and subscriber),
+                            // so announce-name visibility through a relay is
+                            // inherent to relay mode; frame content is already
+                            // AEAD-sealed + chained-HMAC'd at the source.
                             if let Some(relay_origin) = moq_relay_origin {
+                                if let Some(verified) = &moq_connect_verified {
+                                    tracing::debug!(
+                                        subject = ?verified.peer.subject,
+                                        tenant = %verified.tenant,
+                                        "quinn-moq-relay: admitting authenticated publisher"
+                                    );
+                                }
                                 let server = moq_net::Server::new().with_origin(relay_origin);
                                 match server.accept(session).await {
                                     Ok(moq_session) => {
@@ -431,32 +537,64 @@ impl QuinnRpcServer {
                             }
                             match moq_consumer {
                                 Some(consumer) => {
-                                    // #276: the `/moq` WebTransport CONNECT is NOT
-                                    // mutually authenticated, so no peer identity
-                                    // is available — treat the peer as anonymous.
-                                    let peer = crate::moq_authz::PeerIdentity::anonymous();
-                                    // Per-tenant announce scoping: only effective
-                                    // if the resolver yields a tenant from
-                                    // non-identity context (e.g. a single-tenant
-                                    // endpoint). With no resolver, serve unscoped
-                                    // (preserves the pre-#276 open model).
-                                    // TODO(#276): when the `/moq` plane gains a
-                                    // mutually-authenticated peer identity (client
-                                    // cert / app-level token), derive the tenant
-                                    // from it here instead of `anonymous()` so
-                                    // cross-tenant enumeration defense applies to
-                                    // network subscribers, not just iroh peers.
-                                    let publish_consumer = match moq_authz.tenant_for(&peer) {
-                                        Some(tenant) => {
-                                            match crate::moq_authz::tenant_scoped_consumer(&consumer, &tenant) {
-                                                Some(scoped) => scoped,
+                                    // #1153: resolve the publish consumer.
+                                    // - Authenticated path: a `MoqConnectAuthz`
+                                    //   is installed and the CONNECT was
+                                    //   verified; the tenant came from the
+                                    //   *verified* subject via the server-side
+                                    //   resolver. Serve ONLY that tenant's
+                                    //   broadcasts (structural scoping) — never
+                                    //   fall back to the unscoped consumer.
+                                    // - Open path: no authenticator installed.
+                                    //   Endpoint is single-tenant or explicitly
+                                    //   open; preserve the pre-#1153 resolver
+                                    //   behaviour.
+                                    let publish_consumer = match &moq_connect_verified {
+                                        Some(verified) => {
+                                            match crate::moq_authz::tenant_scoped_consumer(
+                                                &consumer,
+                                                &verified.tenant,
+                                            ) {
+                                                Some(scoped) => {
+                                                    tracing::debug!(
+                                                        subject = ?verified.peer.subject,
+                                                        tenant = %verified.tenant,
+                                                        "quinn-moq: CONNECT authenticated, serving tenant-scoped consumer"
+                                                    );
+                                                    scoped
+                                                }
                                                 None => {
-                                                    tracing::debug!(%tenant, "quinn-moq: tenant has no visible broadcasts; dropping session");
+                                                    tracing::debug!(
+                                                        tenant = %verified.tenant,
+                                                        "quinn-moq: tenant has no visible broadcasts; dropping session"
+                                                    );
                                                     return;
                                                 }
                                             }
                                         }
-                                        None => consumer,
+                                        None => {
+                                            // Legacy/open path: no CONNECT
+                                            // authenticator installed. The peer is
+                                            // anonymous and per-tenant scoping is
+                                            // only effective if the resolver
+                                            // yields a tenant from non-identity
+                                            // context (e.g. a single-tenant
+                                            // endpoint).
+                                            let peer =
+                                                crate::moq_authz::PeerIdentity::anonymous();
+                                            match moq_authz.tenant_for(&peer) {
+                                                Some(tenant) => {
+                                                    match crate::moq_authz::tenant_scoped_consumer(&consumer, &tenant) {
+                                                        Some(scoped) => scoped,
+                                                        None => {
+                                                            tracing::debug!(%tenant, "quinn-moq: tenant has no visible broadcasts; dropping session");
+                                                            return;
+                                                        }
+                                                    }
+                                                }
+                                                None => consumer,
+                                            }
+                                        }
                                     };
                                     // See iroh_moq::accept for why the authorizer
                                     // is not enforced per-track here (moq-net has
@@ -712,6 +850,29 @@ pub async fn connect_pinned_hashes_path(
         url::Url::parse(&format!("https://{addr}{path}")).map_err(|e| anyhow!("quinn url: {e}"))?;
     client
         .connect(url)
+        .await
+        .map_err(|e| anyhow!("quinn connect: {e}"))
+}
+
+/// [`connect_pinned_hashes_path`] variant that attaches extra HTTP/3 CONNECT
+/// headers to the WebTransport request — used by #1153 to carry the
+/// `Authorization: Bearer <jwt>` credential the `/moq` endpoint verifies at
+/// CONNECT time. Hermetic: dials an IP-literal URL.
+pub async fn connect_pinned_hashes_path_with_headers(
+    addr: std::net::SocketAddr,
+    cert_hashes: &[[u8; 32]],
+    path: &str,
+    headers: http::HeaderMap,
+) -> Result<web_transport_quinn::Session> {
+    let hashes: Vec<Vec<u8>> = cert_hashes.iter().map(|h| h.to_vec()).collect();
+    let client = external_client_builder()?
+        .with_server_certificate_hashes(hashes)
+        .map_err(|e| anyhow!("quinn client build: {e}"))?;
+    let url =
+        url::Url::parse(&format!("https://{addr}{path}")).map_err(|e| anyhow!("quinn url: {e}"))?;
+    let request = web_transport_quinn::proto::ConnectRequest::from(url).with_headers(headers);
+    client
+        .connect(request)
         .await
         .map_err(|e| anyhow!("quinn connect: {e}"))
 }

--- a/crates/hyprstream-rpc/tests/moq_connect_auth.rs
+++ b/crates/hyprstream-rpc/tests/moq_connect_auth.rs
@@ -1,0 +1,378 @@
+//! #1153 integration: authenticate the `/moq` WebTransport CONNECT and bind
+//! tenant scoping.
+//!
+//! These are the **inverted** assertions of the #1128 spike gap tests
+//! (`shared_endpoint_announces_cross_tenant_gap1128` and
+//! `relay_mode_client_publishes_without_authz_gap1128`), now that the
+//! `/moq` CONNECT is authenticated: a connected peer can only enumerate its
+//! own tenant's broadcasts, an unauthenticated CONNECT is refused, and an
+//! anonymous relay publish is refused.
+//!
+//! Boundary under test: a `MoqConnectAuthz` installed on the server verifies
+//! a bearer JWT in the CONNECT's `Authorization` header (signature, `alg`,
+//! `exp`, `iat`, `aud`) and resolves the tenant from the *verified* subject
+//! via a server-side resolver. See
+//! [`hyprstream_rpc::transport::moq_connect_auth`].
+
+#![allow(clippy::expect_used, clippy::unwrap_used)]
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use anyhow::{anyhow, Result};
+use ed25519_dalek::SigningKey;
+use rand::RngCore;
+
+use hyprstream_rpc::auth::claims::Claims;
+use hyprstream_rpc::auth::jwt;
+use hyprstream_rpc::dial::MOQ_PATH;
+use hyprstream_rpc::moq_authz::PeerIdentity;
+use hyprstream_rpc::transport::moq_connect_auth::{MoqConnectAuthz, VerifiedSubjectTenantResolver};
+use hyprstream_rpc::transport::quinn_transport::{
+    cert_sha256, connect_pinned_hashes_path_with_headers, QuinnRpcServer,
+};
+
+const ALICE_BROADCAST: &str = "alice/streams/run-1/i0";
+const BOB_BROADCAST: &str = "bob/streams/run-9/i0";
+const MALLORY_BROADCAST: &str = "mallory/injected/i0";
+
+fn fresh_signing_key() -> SigningKey {
+    let mut k = [0u8; 32];
+    rand::thread_rng().fill_bytes(&mut k);
+    SigningKey::from_bytes(&k)
+}
+
+fn authz_for(
+    verify_key: ed25519_dalek::VerifyingKey,
+    mapping: &'static [(&'static str, &'static str)],
+) -> MoqConnectAuthz {
+    let resolver: VerifiedSubjectTenantResolver = Arc::new(move |sub: &str| {
+        mapping
+            .iter()
+            .find(|(s, _)| *s == sub)
+            .map(|(_, t)| t.to_string())
+    });
+    MoqConnectAuthz::new(verify_key, resolver).with_expected_aud("moq.test")
+}
+
+fn mint_aud(signing: &SigningKey, sub: &str) -> String {
+    let now = chrono::Utc::now().timestamp();
+    let mut claims = Claims::new(sub.to_owned(), now, now + 60);
+    claims.aud = Some("moq.test".to_owned());
+    jwt::encode(&claims, signing)
+}
+
+fn build_server() -> Result<(
+    web_transport_quinn::Server,
+    std::net::SocketAddr,
+    Vec<u8>,
+)> {
+    let cert_key = rcgen::generate_simple_self_signed(vec!["localhost".to_owned()])?;
+    let cert_der = cert_key.cert.der().to_vec();
+    let key_der = cert_key.key_pair.serialize_der();
+    let chain = vec![rustls::pki_types::CertificateDer::from(cert_der.clone())];
+    let key = rustls::pki_types::PrivateKeyDer::Pkcs8(rustls::pki_types::PrivatePkcs8KeyDer::from(
+        key_der,
+    ));
+    let addr: std::net::SocketAddr = "127.0.0.1:0".parse()?;
+    let server = web_transport_quinn::ServerBuilder::new()
+        .with_addr(addr)
+        .with_certificate(chain, key)
+        .map_err(|e| anyhow!("quinn server build: {e}"))?;
+    let bound = server.local_addr()?;
+    Ok((server, bound, cert_der))
+}
+
+fn bearer_headers(token: &str) -> http::HeaderMap {
+    let mut h = http::HeaderMap::new();
+    h.insert(
+        http::HeaderName::from_static("authorization"),
+        http::HeaderValue::try_from(format!("Bearer {token}")).unwrap(),
+    );
+    h
+}
+
+/// Connect an authenticated moq client ("subject") and return its consumer
+/// view of the server's announces.
+async fn connect_authed(
+    addr: std::net::SocketAddr,
+    pin: [u8; 32],
+    token: &str,
+) -> Result<moq_net::OriginConsumer> {
+    let client_producer = moq_net::Origin::random().produce();
+    let client_consumer = client_producer.consume();
+    let moq_client = moq_net::Client::new().with_consume(client_producer);
+    let session =
+        connect_pinned_hashes_path_with_headers(addr, &[pin], MOQ_PATH, bearer_headers(token))
+            .await?;
+    let moq_session = moq_client
+        .connect(session)
+        .await
+        .map_err(|e| anyhow!("moq handshake: {e}"))?;
+    tokio::spawn(async move {
+        let _ = moq_session.closed().await;
+    });
+    Ok(client_consumer)
+}
+
+/// True once `name` is announced to this consumer within the timeout.
+async fn announces(consumer: &moq_net::OriginConsumer, name: &str) -> bool {
+    matches!(
+        tokio::time::timeout(Duration::from_secs(5), consumer.announced_broadcast(name)).await,
+        Ok(Some(_))
+    )
+}
+
+fn trivial_processor() -> Arc<dyn hyprstream_rpc::transport::rpc_session::IrohRequestProcessor> {
+    Arc::new(hyprstream_rpc::transport::rpc_session::from_fn(
+        |req: bytes::Bytes| async move { Ok(req) },
+    ))
+}
+
+/// #1153: an authenticated peer sees ONLY its own tenant's broadcasts on a
+/// shared endpoint; cross-tenant enumeration is structurally impossible.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn authenticated_peer_sees_only_own_tenant() -> Result<()> {
+    hyprstream_rpc::transport::install_pq_crypto_provider().expect("install PQ provider");
+
+    // One shared origin carrying BOTH tenants' broadcasts.
+    let producer = moq_net::Origin::random().produce();
+    let consumer = producer.consume();
+    let _alice = producer
+        .create_broadcast(ALICE_BROADCAST)
+        .ok_or_else(|| anyhow!("create alice"))?;
+    let _bob = producer
+        .create_broadcast(BOB_BROADCAST)
+        .ok_or_else(|| anyhow!("create bob"))?;
+
+    // Issuer key + authz mapping two subjects to two tenants.
+    let issuer = fresh_signing_key();
+    let authz = authz_for(
+        issuer.verifying_key(),
+        &[("did:key:alice", "alice"), ("did:key:bob", "bob")],
+    );
+
+    let (server, addr, cert_der) = build_server()?;
+    let rpc_server = QuinnRpcServer::with_capacity(
+        server,
+        trivial_processor(),
+        fresh_signing_key(),
+        hyprstream_rpc::transport::rpc_session::DEFAULT_STREAM_LIMIT,
+    )
+    .with_moq_consumer(consumer.clone())
+    .with_moq_connect_authz(authz);
+    let shutdown = rpc_server.shutdown_token();
+    let server_task = tokio::spawn(rpc_server.run());
+    let pin = cert_sha256(&cert_der);
+
+    // Subject A (alice) — authenticated, own tenant only.
+    let alice_tok = mint_aud(&issuer, "did:key:alice");
+    let alice_view = connect_authed(addr, pin, &alice_tok).await?;
+
+    assert!(
+        announces(&alice_view, ALICE_BROADCAST).await,
+        "alice sees her own tenant's broadcast"
+    );
+    assert!(
+        !announces(&alice_view, BOB_BROADCAST).await,
+        "alice must NOT see bob's broadcast (cross-tenant refused) — #1128 gap closed"
+    );
+
+    // Subject B (bob) — authenticated, own tenant only.
+    let bob_tok = mint_aud(&issuer, "did:key:bob");
+    let bob_view = connect_authed(addr, pin, &bob_tok).await?;
+    assert!(
+        announces(&bob_view, BOB_BROADCAST).await,
+        "bob sees his own tenant's broadcast"
+    );
+    assert!(
+        !announces(&bob_view, ALICE_BROADCAST).await,
+        "bob must NOT see alice's broadcast (cross-tenant refused)"
+    );
+
+    shutdown.cancel();
+    let _ = server_task.await;
+    Ok(())
+}
+
+/// #1153: an unauthenticated `/moq` CONNECT (no `Authorization` header) is
+/// REFUSED — the WebTransport CONNECT never completes. Fail-closed.
+#[tokio::test(flavor = "multi_thread", worker_threads = 3)]
+async fn unauthenticated_connect_is_refused() -> Result<()> {
+    hyprstream_rpc::transport::install_pq_crypto_provider().expect("install PQ provider");
+
+    let producer = moq_net::Origin::random().produce();
+    let consumer = producer.consume();
+    let _alice = producer
+        .create_broadcast(ALICE_BROADCAST)
+        .ok_or_else(|| anyhow!("create alice"))?;
+
+    let issuer = fresh_signing_key();
+    let authz = authz_for(issuer.verifying_key(), &[("did:key:alice", "alice")]);
+
+    let (server, addr, cert_der) = build_server()?;
+    let rpc_server = QuinnRpcServer::with_capacity(
+        server,
+        trivial_processor(),
+        fresh_signing_key(),
+        hyprstream_rpc::transport::rpc_session::DEFAULT_STREAM_LIMIT,
+    )
+    .with_moq_consumer(consumer.clone())
+    .with_moq_connect_authz(authz);
+    let shutdown = rpc_server.shutdown_token();
+    let server_task = tokio::spawn(rpc_server.run());
+    let pin = cert_sha256(&cert_der);
+
+    // No Authorization header → the server refuses the CONNECT before the
+    // handshake completes, so the WebTransport connect itself errors. A
+    // regression that admitted anonymous peers would return `Ok(_)` here,
+    // failing the assertion.
+    let empty = http::HeaderMap::new();
+    let res = tokio::time::timeout(
+        Duration::from_secs(10),
+        connect_pinned_hashes_path_with_headers(addr, &[pin], MOQ_PATH, empty),
+    )
+    .await;
+    match res {
+        Ok(Err(_)) => { /* expected: CONNECT refused */ }
+        Ok(Ok(_session)) => {
+            return Err(anyhow!(
+                "unauthenticated CONNECT was ADMITTED (server returned a session) — fail-open regression"
+            ));
+        }
+        Err(_) => return Err(anyhow!("unauthenticated CONNECT hung (no refusal)")),
+    }
+
+    shutdown.cancel();
+    let _ = server_task.await;
+    Ok(())
+}
+
+/// #1153: a forged credential (wrong signature) is REFUSED — verification,
+/// not parsing.
+#[tokio::test(flavor = "multi_thread", worker_threads = 3)]
+async fn forged_credential_is_refused() -> Result<()> {
+    hyprstream_rpc::transport::install_pq_crypto_provider().expect("install PQ provider");
+
+    let producer = moq_net::Origin::random().produce();
+    let consumer = producer.consume();
+    let _alice = producer
+        .create_broadcast(ALICE_BROADCAST)
+        .ok_or_else(|| anyhow!("create alice"))?;
+
+    let issuer = fresh_signing_key();
+    let rogue = fresh_signing_key();
+    let authz = authz_for(issuer.verifying_key(), &[("did:key:alice", "alice")]);
+
+    let (server, addr, cert_der) = build_server()?;
+    let rpc_server = QuinnRpcServer::with_capacity(
+        server,
+        trivial_processor(),
+        fresh_signing_key(),
+        hyprstream_rpc::transport::rpc_session::DEFAULT_STREAM_LIMIT,
+    )
+    .with_moq_consumer(consumer.clone())
+    .with_moq_connect_authz(authz);
+    let shutdown = rpc_server.shutdown_token();
+    let server_task = tokio::spawn(rpc_server.run());
+    let pin = cert_sha256(&cert_der);
+
+    // A token signed by a ROGUE key, but claiming alice's subject — must be
+    // refused because the signature does not verify against the issuer key.
+    // A regression that only PARSED (not verified) the token would admit the
+    // forged subject and return `Ok(_)` here, failing the assertion.
+    let forged = mint_aud(&rogue, "did:key:alice");
+    let res = tokio::time::timeout(
+        Duration::from_secs(10),
+        connect_pinned_hashes_path_with_headers(addr, &[pin], MOQ_PATH, bearer_headers(&forged)),
+    )
+    .await;
+    match res {
+        Ok(Err(_)) => {}
+        Ok(Ok(_session)) => {
+            return Err(anyhow!(
+                "forged-credential CONNECT was ADMITTED (signature not verified) — fail-open regression"
+            ));
+        }
+        Err(_) => return Err(anyhow!("forged CONNECT hung (no refusal)")),
+    }
+
+    shutdown.cancel();
+    let _ = server_task.await;
+    Ok(())
+}
+
+/// #1153 (relay mode): an anonymous client can no longer CONNECT to the
+/// shared relay endpoint — the inverted assertion of
+/// `relay_mode_client_publishes_without_authz_gap1128`. The gate is the same
+/// CONNECT-time auth as the consumer path: anonymous → refused before the
+/// handshake completes. Asserted at the connect level (deterministic), not via
+/// announce timing.
+#[tokio::test(flavor = "multi_thread", worker_threads = 3)]
+async fn relay_mode_refuses_anonymous_connect() -> Result<()> {
+    hyprstream_rpc::transport::install_pq_crypto_provider().expect("install PQ provider");
+
+    let relay_producer = moq_net::Origin::random().produce();
+    let relay_consumer = relay_producer.consume();
+
+    let issuer = fresh_signing_key();
+    let authz = authz_for(issuer.verifying_key(), &[("did:key:alice", "alice")]);
+
+    let (server, addr, cert_der) = build_server()?;
+    let rpc_server = QuinnRpcServer::with_capacity(
+        server,
+        trivial_processor(),
+        fresh_signing_key(),
+        hyprstream_rpc::transport::rpc_session::DEFAULT_STREAM_LIMIT,
+    )
+    .with_moq_relay(relay_producer.clone())
+    .with_moq_connect_authz(authz);
+    let shutdown = rpc_server.shutdown_token();
+    let server_task = tokio::spawn(rpc_server.run());
+    let pin = cert_sha256(&cert_der);
+
+    // "Mallory": an UNAUTHENTICATED client attempting to reach the shared
+    // relay origin. With #1153 the CONNECT is refused before the handshake
+    // completes. A regression that admitted anonymous relay publishers would
+    // return `Ok(_)` here, failing the assertion (and the relay would ingest
+    // mallory's broadcast — the #1128 relay-mode gap).
+    let empty = http::HeaderMap::new();
+    let res = tokio::time::timeout(
+        Duration::from_secs(10),
+        connect_pinned_hashes_path_with_headers(addr, &[pin], MOQ_PATH, empty),
+    )
+    .await;
+    match res {
+        Ok(Err(_)) => {}
+        Ok(Ok(_session)) => {
+            return Err(anyhow!(
+                "anonymous relay CONNECT was ADMITTED (fail-open regression — #1128 relay gap)"
+            ));
+        }
+        Err(_) => return Err(anyhow!("anonymous relay CONNECT hung (no refusal)")),
+    }
+
+    // Secondary, non-deterministic-by-timing guard: the relay origin must
+    // never ingest an anonymous publish regardless. Bounded so it can't hang
+    // the suite; the connect-level refusal above is the authoritative check.
+    let _ = relay_consumer;
+    assert!(
+        !announces(&relay_consumer, MALLORY_BROADCAST).await,
+        "relay must NOT ingest an anonymous publish"
+    );
+
+    shutdown.cancel();
+    let _ = server_task.await;
+    Ok(())
+}
+
+/// Compile-time check that the documented public API surface is wired.
+#[test]
+fn authz_surface_is_public() {
+    fn _assert(
+        _a: MoqConnectAuthz,
+        _r: VerifiedSubjectTenantResolver,
+        _p: PeerIdentity,
+    ) {
+    }
+}

--- a/crates/hyprstream-rpc/tests/moq_connect_auth.rs
+++ b/crates/hyprstream-rpc/tests/moq_connect_auth.rs
@@ -366,6 +366,116 @@ async fn relay_mode_refuses_anonymous_connect() -> Result<()> {
     Ok(())
 }
 
+/// #1153 CRITICAL 3 (relay authorization): an authenticated publisher may
+/// publish into its OWN tenant's namespace through the relay, but NOT into
+/// another tenant's namespace. Authentication without authorization was the
+/// gap (Alice could publish `bob/...`); the relay now scopes ingest to the
+/// verified tenant prefix.
+#[tokio::test(flavor = "multi_thread", worker_threads = 3)]
+async fn relay_authenticated_cross_tenant_publish_refused() -> Result<()> {
+    hyprstream_rpc::transport::install_pq_crypto_provider().expect("install PQ provider");
+
+    let relay_producer = moq_net::Origin::random().produce();
+    let relay_consumer = relay_producer.consume();
+
+    let issuer = fresh_signing_key();
+    // Mallory is provisioned as tenant "alice" but will attempt to publish
+    // into bob's namespace.
+    let authz = authz_for(issuer.verifying_key(), &[("did:key:mallory", "alice")]);
+
+    let (server, addr, cert_der) = build_server()?;
+    let rpc_server = QuinnRpcServer::with_capacity(
+        server,
+        trivial_processor(),
+        fresh_signing_key(),
+        hyprstream_rpc::transport::rpc_session::DEFAULT_STREAM_LIMIT,
+    )
+    .with_moq_relay(relay_producer.clone())
+    .with_moq_connect_authz(authz);
+    let shutdown = rpc_server.shutdown_token();
+    let server_task = tokio::spawn(rpc_server.run());
+    let pin = cert_sha256(&cert_der);
+
+    // Authenticated as alice, attempt to publish BOB_BROADCAST into the shared
+    // relay origin. The scoped ingest producer must reject the cross-tenant
+    // publish — the relay origin never announces bob/...
+    let tok = mint_aud(&issuer, "did:key:mallory");
+    let attacker_producer = moq_net::Origin::random().produce();
+    let _injected = attacker_producer
+        .create_broadcast(BOB_BROADCAST)
+        .ok_or_else(|| anyhow!("create bob broadcast"))?;
+    let moq_client = moq_net::Client::new().with_origin(attacker_producer);
+    let session =
+        connect_pinned_hashes_path_with_headers(addr, &[pin], MOQ_PATH, bearer_headers(&tok))
+            .await?;
+    let _moq_session = moq_client.connect(session).await?;
+    tokio::spawn(async move {
+        let _ = _moq_session.closed().await;
+    });
+
+    assert!(
+        !announces(&relay_consumer, BOB_BROADCAST).await,
+        "relay must NOT ingest a cross-tenant publish (Alice publishing bob/) — \
+         CRITICAL 3: authentication without authorization"
+    );
+
+    shutdown.cancel();
+    let _ = server_task.await;
+    Ok(())
+}
+
+/// #1153 CRITICAL 3 positive case: an authenticated publisher CAN publish into
+/// its OWN tenant's namespace through the relay (the scope does not over-restrict
+/// legitimate same-tenant traffic).
+#[tokio::test(flavor = "multi_thread", worker_threads = 3)]
+async fn relay_authenticated_own_tenant_publish_succeeds() -> Result<()> {
+    hyprstream_rpc::transport::install_pq_crypto_provider().expect("install PQ provider");
+
+    let relay_producer = moq_net::Origin::random().produce();
+    let relay_consumer = relay_producer.consume();
+
+    let issuer = fresh_signing_key();
+    let authz = authz_for(issuer.verifying_key(), &[("did:key:alice", "alice")]);
+
+    let (server, addr, cert_der) = build_server()?;
+    let rpc_server = QuinnRpcServer::with_capacity(
+        server,
+        trivial_processor(),
+        fresh_signing_key(),
+        hyprstream_rpc::transport::rpc_session::DEFAULT_STREAM_LIMIT,
+    )
+    .with_moq_relay(relay_producer.clone())
+    .with_moq_connect_authz(authz);
+    let shutdown = rpc_server.shutdown_token();
+    let server_task = tokio::spawn(rpc_server.run());
+    let pin = cert_sha256(&cert_der);
+
+    // Authenticated as alice, publish ALICE_BROADCAST — own-tenant, must be
+    // ingested and re-served by the relay.
+    let tok = mint_aud(&issuer, "did:key:alice");
+    let alice_producer = moq_net::Origin::random().produce();
+    let _a = alice_producer
+        .create_broadcast(ALICE_BROADCAST)
+        .ok_or_else(|| anyhow!("create alice broadcast"))?;
+    let moq_client = moq_net::Client::new().with_origin(alice_producer);
+    let session =
+        connect_pinned_hashes_path_with_headers(addr, &[pin], MOQ_PATH, bearer_headers(&tok))
+            .await?;
+    let _moq_session = moq_client.connect(session).await?;
+    tokio::spawn(async move {
+        let _ = _moq_session.closed().await;
+    });
+
+    assert!(
+        announces(&relay_consumer, ALICE_BROADCAST).await,
+        "relay must ingest an authenticated own-tenant publish"
+    );
+
+    shutdown.cancel();
+    let _ = server_task.await;
+    Ok(())
+}
+
 /// Compile-time check that the documented public API surface is wired.
 #[test]
 fn authz_surface_is_public() {

--- a/crates/hyprstream-service/src/service/spawner/service.rs
+++ b/crates/hyprstream-service/src/service/spawner/service.rs
@@ -176,31 +176,19 @@ impl<S: RequestService + Send + Sync + 'static> Spawnable for UnifiedServiceConf
                     let _moq_authz_default =
                         hyprstream_rpc::transport::iroh_moq::MoqAuthzConfig::default();
 
-                    // #1153: authenticate the `/moq` WebTransport CONNECT and
-                    // bind the session to a tenant on a *shared* multi-tenant
-                    // endpoint. The boundary is opt-in: the `hyprstream` crate
-                    // builds a `MoqConnectAuthz` over the authoritative
-                    // subject→tenant provisioning map (PolicyManager) and
-                    // registers it via
-                    // `QuinnRpcServer::set_global_moq_connect_authz` at startup;
-                    // `QuinnRpcServer::with_capacity` picks it up here
-                    // automatically (same global-seam pattern as the 9P
-                    // handler). When registered, an unauthenticated or
-                    // tenant-less CONNECT is refused before the handshake
-                    // completes (fail-closed) and each authenticated peer sees
-                    // only its own tenant's broadcasts. When NOT registered the
-                    // `/moq` plane stays single-tenant/open — a deployment
-                    // choice, not a hidden wildcard. NOTE: this does not
-                    // enumerate the registered resolver here; it is consumed
-                    // implicitly via the global inside `QuinnRpcServer`. The
-                    // explicit pickup below documents that we expect it.
-                    if hyprstream_rpc::transport::quinn_transport::global_moq_connect_authz()
-                        .is_some()
-                    {
-                        tracing::info!(
-                            "/moq CONNECT authentication is enabled (shared-endpoint tenant boundary #1153)"
-                        );
-                    }
+                    // #1153: the `/moq` CONNECT authenticator is resolved
+                    // per-CONNECT inside `QuinnRpcServer` (builder override OR
+                    // `global_moq_connect_authz()`), NOT snapshotted here at
+                    // construction — so registration order is not load-bearing.
+                    // The `hyprstream` crate registers an authenticator over its
+                    // authoritative subject→tenant provisioning map
+                    // (PolicyManager) via `set_global_moq_connect_authz` at
+                    // startup; until that wiring lands a served `/moq` plane
+                    // logs a one-time fail-open warning (the #1145 shape must be
+                    // detectable, not silent). See follow-up #1198 (client
+                    // credential threading) — flipping the boundary on before
+                    // clients can present a credential would outage every
+                    // legitimate Quinn subscriber/relay publisher.
                 }
 
                 // Register this endpoint for RPC resolution and, once, as the

--- a/crates/hyprstream-service/src/service/spawner/service.rs
+++ b/crates/hyprstream-service/src/service/spawner/service.rs
@@ -175,6 +175,32 @@ impl<S: RequestService + Send + Sync + 'static> Spawnable for UnifiedServiceConf
                     // `with_authz` is already honoured.
                     let _moq_authz_default =
                         hyprstream_rpc::transport::iroh_moq::MoqAuthzConfig::default();
+
+                    // #1153: authenticate the `/moq` WebTransport CONNECT and
+                    // bind the session to a tenant on a *shared* multi-tenant
+                    // endpoint. The boundary is opt-in: the `hyprstream` crate
+                    // builds a `MoqConnectAuthz` over the authoritative
+                    // subject→tenant provisioning map (PolicyManager) and
+                    // registers it via
+                    // `QuinnRpcServer::set_global_moq_connect_authz` at startup;
+                    // `QuinnRpcServer::with_capacity` picks it up here
+                    // automatically (same global-seam pattern as the 9P
+                    // handler). When registered, an unauthenticated or
+                    // tenant-less CONNECT is refused before the handshake
+                    // completes (fail-closed) and each authenticated peer sees
+                    // only its own tenant's broadcasts. When NOT registered the
+                    // `/moq` plane stays single-tenant/open — a deployment
+                    // choice, not a hidden wildcard. NOTE: this does not
+                    // enumerate the registered resolver here; it is consumed
+                    // implicitly via the global inside `QuinnRpcServer`. The
+                    // explicit pickup below documents that we expect it.
+                    if hyprstream_rpc::transport::quinn_transport::global_moq_connect_authz()
+                        .is_some()
+                    {
+                        tracing::info!(
+                            "/moq CONNECT authentication is enabled (shared-endpoint tenant boundary #1153)"
+                        );
+                    }
                 }
 
                 // Register this endpoint for RPC resolution and, once, as the


### PR DESCRIPTION
## What

**Mechanism for #1153** — does NOT close #1153 (see "Status & blockers"). Authenticates the `/moq` WebTransport CONNECT and binds the session to a tenant resolved from the **verified** identity, before any stream is established. Fail-closed where configured; relay ingest scoped to the verified tenant.

Root cause addressed (`#1128` spike, branch `spike/1128-tenancy`): every `/moq` peer was `PeerIdentity::anonymous()`, `tenant_for` returned `None`, and the `None => consumer` arm **failed open** to the process-global unscoped `OriginConsumer`; relay mode had no authz check. Demonstrated end-to-end by the `*_gap1128` tests.

## How

- **New `moq_connect_auth` module** — verifies a bearer JWT in the HTTP/3 `Authorization` header via `auth::jwt::decode_with_key` (EdDSA signature, `alg`-confusion reject, `exp`/`iat`, `aud` **presence + match**). Verification, not parsing — a forged signature fails closed. The tenant is derived **server-side from the verified `sub`**, never from a token claim (#1146: token claims are unenforceable at the verifier).
- **`QuinnRpcServer::with_moq_connect_authz`** — accept loop runs `verify(&request.headers)` **before** `request.ok()`; refusal drops the request so the CONNECT never completes. The effective authenticator is resolved **per-CONNECT** (builder override OR `global_moq_connect_authz()`), not snapshotted at construction (fable F3). Authenticated peers get a `tenant_scoped_consumer`; relay ingest is scoped to the tenant prefix (`OriginProducer::scope`) so Alice can't publish `bob/` (CRITICAL 3).
- **Fail-closed + fail-open detection.** Configured endpoint: unauthenticated/tenant-less CONNECT refused. Unconfigured endpoint: single-tenant/open, but a **one-time WARN** fires when `/moq` is served with no authenticator (fable F1 — the #1145 shape must be detectable, not silent).

## Tests — `tests/moq_connect_auth.rs` + 11 unit tests; each fail-closed test verified to fail when its hunk is reverted

- `authenticated_peer_sees_only_own_tenant` (inverted `shared_endpoint_announces_cross_tenant_gap1128`)
- `unauthenticated_connect_is_refused`, `forged_credential_is_refused` (verified, not parsed)
- `relay_mode_refuses_anonymous_connect` (inverted `relay_mode_client_publishes_without_authz_gap1128`)
- `relay_authenticated_cross_tenant_publish_refused` + `_succeeds` (CRITICAL 3 — Alice→bob/ refused, Alice→alice/ ingested)
- unit: missing-`aud` refused when audience configured (sol HIGH)

## Status & blockers — why this does NOT close #1153

The transport mechanism, relay authorization, and fail-open detection are landed and tested. **Two blockers remain**, filed as follow-ups; #1153's acceptance (the production plane failing closed) is not met until they land:

- **#1206** (sol CRITICAL 2 / fable F6) — production clients attach no `Authorization` header (`dial_stream`/`reach`/`relay` are headerless); enabling the server gate today outages every legitimate Quinn subscriber. Needs a client-credential vertical slice shipped atomically. **This is why the gate is not wired on here** — flipping it without the client side is an outage, not a fix.
- **#1207** (fable F2) — converge on the `verify_claims`-grade derivation shared with #1151 (`jti` revocation, `cnf` binding, strict `iss`), instead of the lighter `decode_with_key` fork. Depends on #1151 (unlanded).

## Honest scoping

Even with #1206 landed, this is a **transport-plane metadata/announce isolation boundary** on the `/moq` consumer path — not a cluster-wide tenant guarantee. Frame content is AEAD-sealed independently; other planes (RPC subject authz, event prefixes, VFS) have their own stories (#1128).

## Verify

- `buildq -- cargo test -p hyprstream-rpc` (lib 783; `moq_connect_auth` integration 7; 11 unit)
- `buildq -- cargo clippy -p hyprstream-rpc --all-targets -- -D warnings`; `-p hyprstream-service` builds clean.

Refs: #1128, #1151, #1154, #1206, #1207, #276, #1027, #1146.
