### PR TITLE
feat(at9p): credential-free HTTPS verification endpoint for did:at9p logins

### DIFF
--- a/crates/hyprstream-pds/src/at9p_login.rs
+++ b/crates/hyprstream-pds/src/at9p_login.rs
@@ -1,0 +1,581 @@
+//! Public verification of a `did:at9p` **login assertion** — the pure,
+//! I/O-free core behind the credential-free HTTPS endpoint (#1114).
+//!
+//! The consumer is an external web app that cannot speak Cap'n Proto and holds
+//! no mesh credentials. It has fetched a genesis capsule over the static
+//! well-known capsule transport (#1143), issued a fresh challenge to the holder,
+//! received the holder's signature back, and now wants one answer: **is this
+//! `did:at9p` login assertion authentic and live?** This module is that
+//! answer; the axum face in `hyprstream` is a thin JSON translator over it.
+//!
+//! # Trust boundary — where each fact comes from
+//!
+//! Every key-material fact is derived from the **GATE-verified capsule**, never
+//! from a DID document. The operator decision on #1157 (2026-07-22) is binding
+//! here: the `did:web` document is **advisory** — reciprocal vouch and rotation
+//! hint only. This module has no type for a DID-document key, so document-sourced
+//! trust cannot be reintroduced at this layer even if a caller wanted to.
+//!
+//! Composition (each step fails closed; none is skippable):
+//!
+//! 1. **GATE** ([`crate::at9p_gate::verify_did_at9p`]) — `canon → hash → sig`.
+//!    This is the self-certification binding: the identity *is* the BLAKE3-512
+//!    hash of the capsule, so verification means recomputing the DID from the
+//!    fetched bytes and comparing — not parsing the identifier string. The
+//!    primary subject Ed25519 key used below is read from this
+//!    [`VerifiedCapsule`], i.e. it is content-bound to the identity.
+//! 2. **Liveness** — the holder's Ed25519 signature over a canonical,
+//!    domain-separated binding of `(did, challenge, issued_at)`, verified
+//!    against the GATE-verified subject key. The GATE explicitly "is not live
+//!    possession"; this gate is. A missing, malformed, stale, or mismatched
+//!    signature fails closed.
+//! 3. **Aliasing (optional)** — only when the holder also claims a classical
+//!    DID. The ratified #905 §2/§6 rule is *bidirectional or not believed*:
+//!    [`hyprstream_pds::at9p_alias::resolve_authoritative_alias`] requires both
+//!    legs to name each other. The classical leg's reciprocal vouch
+//!    (`classical_aka_at9p`) is the advisory `alsoKnownAs` string the web app
+//!    took from the `did:web` document; **no key material from that document is
+//!    accepted** — the only authoritative leg is the GATE-verified capsule.
+//!
+//! # What a successful [`VerifiedLogin`] does and does not assert
+//!
+//! **Does assert:**
+//! - The `did:at9p:<cid>` identifier is the BLAKE3-512 self-certifying hash of
+//!   the supplied capsule bytes (GATE hash-gate).
+//! - The capsule is authentically self-signed under pinned Hybrid
+//!   (Ed25519 **and** ML-DSA-65) — GATE sig-gate.
+//! - The holder possessed the capsule's primary subject Ed25519 private key at
+//!   `issued_at` (liveness signature verified against the content-bound key).
+//! - `issued_at` is within the freshness window of the verifier's clock.
+//! - When `classical` is present and verification succeeded, the GATE-verified
+//!   capsule and the classical DID mutually attest each other (`PqHybrid`).
+//!
+//! **Does NOT assert:**
+//! - Current reachability, availability, or any transport endpoint for the
+//!   identity (GATE proves the genesis claim, not liveness of any service —
+//!   the discovery resolver still fails closed pending an independent
+//!   EndpointId, #1031).
+//! - That the classical DID document is itself authentic — the classical leg
+//!   is advisory; a web app that needs the classical identity rooted must
+//!   verify that document itself (this floor is `Assurance::Classical` when no
+//!   alias is claimed, matching the #1114 contract).
+//! - Anything about the holder's authorization, account standing, or tenant
+//!   membership — this is a *verification* endpoint, not an authorization or
+//!   session-minting endpoint. It produces no credential.
+//!
+//! # Fail-closed posture
+//!
+//! Every failure mode named in #1114 — capsule unfetchable, hash mismatch,
+//! one-sided alias, expired or absent liveness proof — returns `Err`. The
+//! function never returns a partial or downgraded `Ok` to "be helpful"; the
+//! only success is a fully-verified assertion.
+
+use anyhow::{ensure, Result};
+use ed25519_dalek::{Signature, VerifyingKey};
+use hyprstream_rpc::auth::mac::Assurance;
+use hyprstream_rpc::identity::Did;
+
+use crate::at9p::ED25519_PUBLIC_KEY_LEN;
+use crate::at9p_alias::{resolve_authoritative_alias, AuthoritativeIdentity};
+use crate::at9p_gate::{verify_did_at9p, VerifiedCapsule};
+
+/// Domain separator bound into every liveness signature. Changing it
+/// invalidates all outstanding assertions (intentional — it is a version tag).
+pub const LOGIN_BINDING_DOMAIN: &str = "at9p-login-v1";
+
+/// The Ed25519 signature length for the liveness proof.
+pub const ED25519_LIVENESS_SIG_LEN: usize = 64;
+
+/// A classical (`did:web` / `did:key` / `did:plc`) alias claim the holder
+/// additionally makes when logging in.
+///
+/// Both fields are **advisory strings gathered by the web app from the
+/// classical DID document** — never key material. `classical_aka_at9p` is what
+/// the classical document names as its at9p alias (the classical→at9p leg);
+/// the at9p→classical reciprocal leg is read from the GATE-verified capsule
+/// inside [`verify_login_assertion`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ClassicalClaim<'a> {
+    /// The classical DID the holder claims to also be.
+    pub classical_did: &'a str,
+    /// The `alsoKnownAs` entry the classical DID document names for its at9p
+    /// alias — the classical→at9p leg. Advisory; sourced from the classical
+    /// document, not trusted for key material.
+    pub classical_aka_at9p: &'a str,
+}
+
+/// A `did:at9p` login assertion presented by a holder to a web app.
+///
+/// All fields are borrowed views over caller-owned data so the pure core does
+/// no allocation of its own and cannot outlive the request. The web app
+/// supplies every input; the verifier trusts only the GATE-verified capsule
+/// for key material.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct LoginAssertion<'a> {
+    /// The claimed `did:at9p:<cid512>` identifier. Compared against the DID
+    /// recomputed from `capsule_bytes` at GATE hash-gate.
+    pub did: &'a str,
+    /// Raw canonical DAG-CBOR bytes of the genesis capsule the web app fetched
+    /// for `did`. Attacker-controlled until GATE accepts them.
+    pub capsule_bytes: &'a [u8],
+    /// The fresh challenge string the web app issued to the holder for this
+    /// login attempt. Bound into the liveness signature.
+    pub challenge: &'a str,
+    /// The holder's claimed signing instant, Unix seconds. Must be within the
+    /// verifier's freshness window (`|now - issued_at| <= max_skew_seconds`).
+    pub issued_at: u64,
+    /// The holder's Ed25519 signature over
+    /// [`login_binding`](login_binding) (`did`, `challenge`, `issued_at`),
+    /// made with the capsule's primary subject key.
+    pub liveness_signature: &'a [u8],
+    /// Optional classical alias claim. When `None`, a successful verification
+    /// floors at [`Assurance::Classical`] (#1114). When `Some`, both aliasing
+    /// legs must verify or the assertion fails closed.
+    pub classical: Option<ClassicalClaim<'a>>,
+}
+
+/// The result of a fully-verified login assertion — a witness that every gate
+/// (GATE, liveness, and — when claimed — bidirectional aliasing) passed.
+///
+/// Constructible only by [`verify_login_assertion`]. Holding this value is
+/// proof of the facts listed in the module docs; it authorizes nothing.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct VerifiedLogin {
+    /// The content-verified `did:at9p:<cid512>` (recomputed from the capsule,
+    /// not the claimed string).
+    pub did: Did,
+    /// The assurance floor reached. `Classical` when no alias was claimed;
+    /// `PqHybrid` when a classical alias was mutually attested.
+    pub assurance: Assurance,
+    /// The GATE-verified primary subject Ed25519 key — the key the liveness
+    /// signature verified against. Content-bound to `did`.
+    pub subject_ed25519: [u8; ED25519_PUBLIC_KEY_LEN],
+    /// The authoritative classical alias, present only when the holder claimed
+    /// one and the bidirectional #905 §2/§6 rule held.
+    pub classical: Option<AuthoritativeIdentity>,
+}
+
+/// Injects "now" so the pure core has no hidden clock dependency and tests are
+/// deterministic. Implementors must return Unix seconds.
+pub trait Clock {
+    /// The verifier's current time, Unix seconds.
+    fn now_unix_seconds(&self) -> u64;
+}
+
+/// Canonical, domain-separated bytes the holder signs for the liveness proof.
+///
+/// Fixed layout: `"{domain}\n{did}\n{challenge}\n{issued_at}"` where
+/// `issued_at` is decimal Unix seconds. Every field is unambiguous (the domain
+/// tags the whole string, `did`/`challenge` cannot collide with the decimal
+/// timestamp field), and the string is stable across signer and verifier
+/// regardless of locale or JSON encoding.
+pub fn login_binding(did: &str, challenge: &str, issued_at: u64) -> Vec<u8> {
+    format!("{LOGIN_BINDING_DOMAIN}\n{did}\n{challenge}\n{issued_at}").into_bytes()
+}
+
+/// Verify a `did:at9p` login assertion end-to-end.
+///
+/// See the [module docs](self) for the full trust boundary, the composition
+/// order, and what a successful [`VerifiedLogin`] does and does not assert.
+/// `clock` supplies "now"; `max_skew_seconds` bounds the freshness window
+/// symmetrically (the holder may be slightly ahead or behind the verifier).
+///
+/// Returns `Err` for every failure mode — there is no partial success.
+pub fn verify_login_assertion<C: Clock>(
+    assertion: &LoginAssertion<'_>,
+    clock: &C,
+    max_skew_seconds: u64,
+) -> Result<VerifiedLogin> {
+    // ── Gate 1: GATE (canon → hash → sig). The identity IS the hash of the
+    // bytes; this is where every key-material fact below is rooted. A capsule
+    // the web app "could not fetch" arrives as empty/garbage bytes and fails
+    // here (canon- or hash-gate).
+    let verified: VerifiedCapsule = verify_did_at9p(assertion.did, assertion.capsule_bytes)?;
+    let recomputed_did = verified.did();
+    let capsule = verified.capsule();
+
+    let primary = capsule
+        .body
+        .subject_keys
+        .first()
+        .ok_or_else(|| anyhow::anyhow!("at9p capsule carries no subject key"))?;
+    let ed_bytes: [u8; ED25519_PUBLIC_KEY_LEN] = primary
+        .ed25519_pub
+        .as_slice()
+        .try_into()
+        .map_err(|_| anyhow::anyhow!("ed25519 subject key is not 32 bytes"))?;
+    let ed_vk = VerifyingKey::from_bytes(&ed_bytes)
+        .map_err(|_| anyhow::anyhow!("content-bound ed25519 key is not a valid point"))?;
+
+    // ── Gate 2: liveness. The GATE "is not live possession"; this gate is.
+    // Absent or wrong-length signature, signature mismatch, or a stale
+    // timestamp all fail closed. The signature MUST verify against the
+    // GATE-verified key — never a key supplied by the caller.
+    let sig: [u8; ED25519_LIVENESS_SIG_LEN] = assertion
+        .liveness_signature
+        .try_into()
+        .map_err(|_| anyhow::anyhow!("liveness signature must be {ED25519_LIVENESS_SIG_LEN} bytes"))?;
+    let sig = Signature::from_bytes(&sig);
+    let binding = login_binding(&recomputed_did, assertion.challenge, assertion.issued_at);
+    ed_vk
+        .verify_strict(&binding, &sig)
+        .map_err(|_| anyhow::anyhow!("liveness signature does not verify against the GATE-verified subject key"))?;
+
+    // Freshness window. `abs_diff` is symmetric so clock skew in either
+    // direction is tolerated up to the bound; outside it, expired.
+    let now = clock.now_unix_seconds();
+    let issued_at = assertion.issued_at;
+    let drift = now.abs_diff(issued_at);
+    ensure!(
+        drift <= max_skew_seconds,
+        "liveness proof is stale: issued_at {issued_at} is {drift}s from now {now} (max skew {max_skew_seconds}s)"
+    );
+
+    // ── Gate 3 (optional): bidirectional aliasing. The classical leg is
+    // advisory strings only — no key material crosses. Both legs must name
+    // each other or the assertion fails closed as a one-sided claim.
+    let (assurance, classical) = match assertion.classical {
+        None => (Assurance::Classical, None),
+        Some(claim) => {
+            let classical_did = Did::new(claim.classical_did.to_owned());
+            let classical_aka_at9p = Did::new(claim.classical_aka_at9p.to_owned());
+            let authoritative = resolve_authoritative_alias(
+                &classical_did,
+                &classical_aka_at9p,
+                &verified.clone(),
+            )?;
+            (Assurance::PqHybrid, Some(authoritative))
+        }
+    };
+
+    Ok(VerifiedLogin {
+        did: Did::new(recomputed_did),
+        assurance,
+        subject_ed25519: ed_bytes,
+        classical,
+    })
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used, clippy::indexing_slicing)]
+mod tests {
+    use super::*;
+    use crate::at9p::{
+        Capsule, CapsuleBody, HybridKeyPair, ServiceEndpoint, ServiceEntry, ServiceType, Transport,
+    };
+    use crate::at9p_gate::DID_AT9P_PREFIX;
+    use crate::at9p_sign::sign_capsule;
+
+    use ed25519_dalek::{Signer, SigningKey};
+    use hyprstream_crypto::pq::{ml_dsa_generate_keypair, ml_dsa_vk_bytes, MlDsaSigningKey};
+
+    /// A fixed, mutable verifier clock so freshness tests are deterministic.
+    #[derive(Default)]
+    struct FixedClock {
+        now: u64,
+    }
+    impl Clock for FixedClock {
+        fn now_unix_seconds(&self) -> u64 {
+            self.now
+        }
+    }
+
+    struct Signer_ {
+        ed_sk: SigningKey,
+        pq_sk: MlDsaSigningKey,
+        keypair: HybridKeyPair,
+    }
+
+    fn signer(tag: u8) -> Signer_ {
+        let mut seed = [0u8; 32];
+        seed[0] = tag;
+        seed[31] = tag.wrapping_add(7);
+        let ed_sk = SigningKey::from_bytes(&seed);
+        let (pq_sk, pq_vk) = ml_dsa_generate_keypair();
+        let keypair = HybridKeyPair::new(
+            ed_sk.verifying_key().to_bytes().to_vec(),
+            ml_dsa_vk_bytes(&pq_vk),
+        )
+        .unwrap();
+        Signer_ {
+            ed_sk,
+            pq_sk,
+            keypair,
+        }
+    }
+
+    fn body_for(s: &Signer_, tag: u8, aliases: Vec<String>) -> CapsuleBody {
+        let endpoint = ServiceEndpoint::new(Transport::Iroh, format!("iroh://node{tag}")).unwrap();
+        let service = ServiceEntry::new("#ns", ServiceType::NinePExport, endpoint).unwrap();
+        let mut body = CapsuleBody::new(vec![s.keypair.clone()], vec![service]).unwrap();
+        if !aliases.is_empty() {
+            body.also_known_as = Some(aliases);
+        }
+        body
+    }
+
+    /// A self-signed capsule, its canonical bytes, its DID, and the signer.
+    fn signed(tag: u8, aliases: Vec<String>) -> (Capsule, Vec<u8>, String, Signer_) {
+        let s = signer(tag);
+        let body = body_for(&s, tag, aliases);
+        let capsule = sign_capsule(body, &s.ed_sk, &s.pq_sk).unwrap();
+        let bytes = capsule.to_dag_cbor().unwrap();
+        let did = format!("{DID_AT9P_PREFIX}{}", capsule.cid512().unwrap());
+        (capsule, bytes, did, s)
+    }
+
+    fn sign_liveness(sk: &SigningKey, did: &str, challenge: &str, issued_at: u64) -> [u8; 64] {
+        let binding = login_binding(did, challenge, issued_at);
+        sk.sign(&binding).to_bytes()
+    }
+
+    const NOW: u64 = 1_700_000_000;
+    const SKEW: u64 = 300;
+
+    /// Baseline: a fully valid assertion verifies at Classical assurance.
+    #[test]
+    fn valid_assertion_verifies_classical() {
+        let (_capsule, bytes, did, s) = signed(1, Vec::new());
+        let sig = sign_liveness(&s.ed_sk, &did, "challenge-abc", NOW);
+        let assertion = LoginAssertion {
+            did: &did,
+            capsule_bytes: &bytes,
+            challenge: "challenge-abc",
+            issued_at: NOW,
+            liveness_signature: &sig,
+            classical: None,
+        };
+        let v = verify_login_assertion(&assertion, &FixedClock { now: NOW }, SKEW).unwrap();
+        assert_eq!(v.did.as_str(), did);
+        assert_eq!(v.assurance, Assurance::Classical);
+        assert!(v.classical.is_none());
+        assert_eq!(v.subject_ed25519, s.ed_sk.verifying_key().to_bytes());
+    }
+
+    /// Fail-closed: capsule bytes do not hash to the claimed DID (hash
+    /// mismatch). REVERT the GATE-call hunk and this test passes — proving the
+    /// hash check is load-bearing here, not incidental.
+    #[test]
+    fn hash_mismatch_fails_closed() {
+        let (_a, bytes_a, _did_a, _s_a) = signed(2, Vec::new());
+        let (_b, _bytes_b, did_b, s_b) = signed(3, Vec::new());
+        // A signature valid under B's key, but we present A's bytes under B's
+        // identity — GATE hash-gate must reject before liveness is even read.
+        let sig = sign_liveness(&s_b.ed_sk, &did_b, "c", NOW);
+        let assertion = LoginAssertion {
+            did: &did_b,
+            capsule_bytes: &bytes_a,
+            challenge: "c",
+            issued_at: NOW,
+            liveness_signature: &sig,
+            classical: None,
+        };
+        let err = verify_login_assertion(&assertion, &FixedClock { now: NOW }, SKEW)
+            .unwrap_err()
+            .to_string();
+        assert!(
+            err.contains("hash-gate") || err.contains("GATE rejected"),
+            "expected a GATE/hash rejection, got: {err}"
+        );
+    }
+
+    /// Fail-closed: "capsule unfetchable" — malformed/empty bytes fail GATE.
+    #[test]
+    fn unfetchable_capsule_fails_closed() {
+        let (_c, _bytes, did, s) = signed(4, Vec::new());
+        let sig = sign_liveness(&s.ed_sk, &did, "c", NOW);
+        let assertion = LoginAssertion {
+            did: &did,
+            capsule_bytes: b"\xff\xff not a capsule",
+            challenge: "c",
+            issued_at: NOW,
+            liveness_signature: &sig,
+            classical: None,
+        };
+        assert!(verify_login_assertion(&assertion, &FixedClock { now: NOW }, SKEW).is_err());
+    }
+
+    /// Fail-closed: absent liveness proof (empty signature).
+    #[test]
+    fn absent_liveness_fails_closed() {
+        let (_c, bytes, did, _s) = signed(5, Vec::new());
+        let assertion = LoginAssertion {
+            did: &did,
+            capsule_bytes: &bytes,
+            challenge: "c",
+            issued_at: NOW,
+            liveness_signature: &[],
+            classical: None,
+        };
+        let err = verify_login_assertion(&assertion, &FixedClock { now: NOW }, SKEW)
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("liveness signature must be"), "{err}");
+    }
+
+    /// Fail-closed: wrong-key signature (a different identity's key signs).
+    /// The liveness gate MUST verify against the GATE-verified key, not accept
+    /// any plausible signature.
+    #[test]
+    fn wrong_key_liveness_fails_closed() {
+        let (_c, bytes, did, _s) = signed(6, Vec::new());
+        let other = signer(99);
+        let sig = sign_liveness(&other.ed_sk, &did, "c", NOW);
+        let assertion = LoginAssertion {
+            did: &did,
+            capsule_bytes: &bytes,
+            challenge: "c",
+            issued_at: NOW,
+            liveness_signature: &sig,
+            classical: None,
+        };
+        let err = verify_login_assertion(&assertion, &FixedClock { now: NOW }, SKEW)
+            .unwrap_err()
+            .to_string();
+        assert!(
+            err.contains("does not verify against the GATE-verified subject key"),
+            "{err}"
+        );
+    }
+
+    /// Fail-closed: expired (issued_at outside the freshness window).
+    #[test]
+    fn expired_liveness_fails_closed() {
+        let (_c, bytes, did, s) = signed(7, Vec::new());
+        let stale = NOW - (SKEW + 60);
+        let sig = sign_liveness(&s.ed_sk, &did, "c", stale);
+        let assertion = LoginAssertion {
+            did: &did,
+            capsule_bytes: &bytes,
+            challenge: "c",
+            issued_at: stale,
+            liveness_signature: &sig,
+            classical: None,
+        };
+        let err = verify_login_assertion(&assertion, &FixedClock { now: NOW }, SKEW)
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("liveness proof is stale"), "{err}");
+    }
+
+    /// Boundary: issued_at exactly max_skew_seconds away is still accepted.
+    #[test]
+    fn freshness_window_boundary_accepted() {
+        let (_c, bytes, did, s) = signed(8, Vec::new());
+        let at = NOW - SKEW;
+        let sig = sign_liveness(&s.ed_sk, &did, "c", at);
+        let assertion = LoginAssertion {
+            did: &did,
+            capsule_bytes: &bytes,
+            challenge: "c",
+            issued_at: at,
+            liveness_signature: &sig,
+            classical: None,
+        };
+        assert!(verify_login_assertion(&assertion, &FixedClock { now: NOW }, SKEW).is_ok());
+    }
+
+    /// Fail-closed: one-sided alias — the capsule does NOT name the claimed
+    /// classical DID back. REVERT the alias branch and this test passes.
+    #[test]
+    fn one_sided_alias_fails_closed() {
+        // Capsule attests alice; holder claims to also be bob.
+        let (_c, bytes, did, s) = signed(9, vec!["did:web:alice.example".to_owned()]);
+        let sig = sign_liveness(&s.ed_sk, &did, "c", NOW);
+        let assertion = LoginAssertion {
+            did: &did,
+            capsule_bytes: &bytes,
+            challenge: "c",
+            issued_at: NOW,
+            liveness_signature: &sig,
+            classical: Some(ClassicalClaim {
+                classical_did: "did:web:bob.example",
+                // Bob's doc (advisory) names this capsule — classical leg ok,
+                // but the at9p→classical leg names alice, not bob.
+                classical_aka_at9p: &did,
+            }),
+        };
+        let err = verify_login_assertion(&assertion, &FixedClock { now: NOW }, SKEW)
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("does not name"), "{err}");
+    }
+
+    /// Fail-closed: the classical leg names a *different* capsule than the one
+    /// verified — the reverse one-sided failure.
+    #[test]
+    fn classical_leg_names_wrong_capsule_fails_closed() {
+        let (_c, bytes, did, s) =
+            signed(10, vec!["did:web:node.example".to_owned()]);
+        let sig = sign_liveness(&s.ed_sk, &did, "c", NOW);
+        let assertion = LoginAssertion {
+            did: &did,
+            capsule_bytes: &bytes,
+            challenge: "c",
+            issued_at: NOW,
+            liveness_signature: &sig,
+            classical: Some(ClassicalClaim {
+                classical_did: "did:web:node.example",
+                // Classical doc (advisory) names a different at9p than the one
+                // verified — classical leg fails.
+                classical_aka_at9p: "did:at9p:bafyDIFFERENT",
+            }),
+        };
+        let err = verify_login_assertion(&assertion, &FixedClock { now: NOW }, SKEW)
+            .unwrap_err()
+            .to_string();
+        assert!(
+            err.contains("does not name the verified capsule"),
+            "{err}"
+        );
+    }
+
+    /// Mutual alias upgrades to PqHybrid.
+    #[test]
+    fn mutual_alias_upgrades_to_pqhybrid() {
+        let classical = "did:web:node.example";
+        let (_c, bytes, did, s) = signed(11, vec![classical.to_owned()]);
+        let sig = sign_liveness(&s.ed_sk, &did, "c", NOW);
+        let assertion = LoginAssertion {
+            did: &did,
+            capsule_bytes: &bytes,
+            challenge: "c",
+            issued_at: NOW,
+            liveness_signature: &sig,
+            classical: Some(ClassicalClaim {
+                classical_did: classical,
+                classical_aka_at9p: &did,
+            }),
+        };
+        let v = verify_login_assertion(&assertion, &FixedClock { now: NOW }, SKEW).unwrap();
+        assert_eq!(v.assurance, Assurance::PqHybrid);
+        let auth = v.classical.as_ref().expect("alias resolved");
+        assert_eq!(auth.classical_did.as_str(), classical);
+        assert_eq!(auth.at9p_did.as_str(), did);
+    }
+
+    /// The liveness binding is domain-separated: a signature over the bare
+    /// challenge (no domain/did/timestamp) must NOT verify, even with the right
+    /// key — defends against cross-protocol signature reuse.
+    #[test]
+    fn bare_challenge_signature_rejected() {
+        let (_c, bytes, did, s) = signed(12, Vec::new());
+        // Sign just the challenge string, not the binding.
+        let sig = s.ed_sk.sign(b"challenge-abc").to_bytes();
+        let assertion = LoginAssertion {
+            did: &did,
+            capsule_bytes: &bytes,
+            challenge: "challenge-abc",
+            issued_at: NOW,
+            liveness_signature: &sig,
+            classical: None,
+        };
+        let err = verify_login_assertion(&assertion, &FixedClock { now: NOW }, SKEW)
+            .unwrap_err()
+            .to_string();
+        assert!(
+            err.contains("does not verify against the GATE-verified subject key"),
+            "{err}"
+        );
+    }
+}

--- a/crates/hyprstream-pds/src/lib.rs
+++ b/crates/hyprstream-pds/src/lib.rs
@@ -55,6 +55,7 @@ pub mod at9p_alias;
 pub mod at9p_chain;
 pub mod at9p_duplicity;
 pub mod at9p_gate;
+pub mod at9p_login;
 pub mod at9p_resolver;
 pub mod at9p_sign;
 pub mod car;

--- a/crates/hyprstream/src/config/mod.rs
+++ b/crates/hyprstream/src/config/mod.rs
@@ -77,6 +77,10 @@ pub struct HyprConfig {
     #[serde(default)]
     pub xet: XetConfig,
 
+    /// Credential-free `did:at9p` login-assertion verification HTTPS face (#1114).
+    #[serde(default)]
+    pub at9p_verify: At9pVerifyConfig,
+
     /// Arrow Flight SQL server configuration
     #[serde(default)]
     pub flight: FlightConfig,
@@ -693,6 +697,65 @@ impl XetConfig {
 
 fn default_xet_host() -> String { "0.0.0.0".to_owned() }
 fn default_xet_port() -> u16 { 6792 }
+
+/// Credential-free HTTPS verification face for `did:at9p` login assertions
+/// (#1114). A distinct listener with no cookies, no `Authorization`, and no
+/// session middleware — the whole security argument for a separate face. See
+/// `services::at9p_verify` for the trust boundary and where/why it is mounted.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct At9pVerifyConfig {
+    /// Whether the face is served. Disabled by default: opt in where needed
+    /// (the www-cyberdione-ai login page is the first consumer).
+    #[serde(default)]
+    pub enabled: bool,
+
+    /// Host address for the HTTP listener.
+    #[serde(default = "default_at9p_verify_host")]
+    pub host: String,
+
+    /// Port for the HTTP listener. Default 6793 (oai=6789, mcp=6790,
+    /// oauth=6791, xet=6792).
+    #[serde(default = "default_at9p_verify_port")]
+    pub port: u16,
+
+    /// TLS certificate path (optional; falls back to the global `[tls]` config).
+    #[serde(default)]
+    pub tls_cert: Option<PathBuf>,
+
+    /// TLS private key path (optional; falls back to the global `[tls]` config).
+    #[serde(default)]
+    pub tls_key: Option<PathBuf>,
+
+    /// Symmetric freshness window for a liveness `issued_at`, in seconds. The
+    /// holder's claimed signing instant must be within this many seconds of
+    /// the verifier's clock (in either direction).
+    #[serde(default = "default_at9p_verify_skew")]
+    pub max_skew_seconds: u64,
+
+    /// Maximum accepted challenge length, in bytes. Caps preimage-amplification
+    /// before any cryptographic work.
+    #[serde(default = "default_at9p_verify_challenge_bytes")]
+    pub max_challenge_bytes: usize,
+}
+
+impl Default for At9pVerifyConfig {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            host: default_at9p_verify_host(),
+            port: default_at9p_verify_port(),
+            tls_cert: None,
+            tls_key: None,
+            max_skew_seconds: default_at9p_verify_skew(),
+            max_challenge_bytes: default_at9p_verify_challenge_bytes(),
+        }
+    }
+}
+
+fn default_at9p_verify_host() -> String { "0.0.0.0".to_owned() }
+fn default_at9p_verify_port() -> u16 { 6793 }
+fn default_at9p_verify_skew() -> u64 { 300 }
+fn default_at9p_verify_challenge_bytes() -> usize { 256 }
 
 /// Arrow Flight SQL server configuration
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -2120,6 +2183,7 @@ impl HyprConfigBuilder {
             token: self.token,
             oai: self.oai,
             xet: Default::default(),
+            at9p_verify: Default::default(),
             flight: self.flight,
             mcp: self.mcp,
             oauth: self.oauth,

--- a/crates/hyprstream/src/services/at9p_verify.rs
+++ b/crates/hyprstream/src/services/at9p_verify.rs
@@ -1,0 +1,667 @@
+//! Credential-free HTTPS face for `did:at9p` login-assertion verification (#1114).
+//!
+//! An external web app that cannot speak Cap'n Proto and holds no mesh
+//! credentials POSTs a [`LoginAssertionRequest`] to `POST /at9p/verify` and
+//! gets back whether the assertion is authentic and live. This module is a
+//! thin JSON translator over the pure, fully-tested core in
+//! [`hyprstream_pds::at9p_login`]; it adds no verification logic of its own.
+//!
+//! # Where this is mounted, and why
+//!
+//! This is a **standalone credential-free HTTP face on its own listener**, not
+//! a route on an existing service. The reasoning is forced by the current
+//! state of the tree (recorded for #1135):
+//!
+//! - **Not on OAuth.** OAuth is the only genuinely dual-stack service today
+//!   (HTTP + Rep via `serve_bridged`), but it is an authorization server.
+//!   Mounting a public verification route there would either inherit OAuth's
+//!   session/cookie middleware (violating the credential-free requirement) or
+//!   require a special-case bypass inside OAuth's router — exactly the "first
+//!   convenient exception" #1165 warns decays the guarantee.
+//! - **Not on Discovery or Policy.** Both are pure Cap'n Proto RPC services
+//!   with no HTTP face, and reaching them from the web app would re-introduce
+//!   the mesh-credential problem this endpoint exists to avoid. The verifier
+//!   does not need a live RPC channel: the pure GATE core is I/O-free.
+//! - **No `SocketKind::Http`.** `SocketKind` is `Req | Rep | Quic`; there is
+//!   no HTTP variant, so this face is **not announceable in the RPC
+//!   registry** and holds no mesh credentials by construction. It sits
+//!   outside the trust store entirely — no service signing key, no service
+//!   JWT, no `register_service_key`, no `registrations()`. That is the
+//!   security argument: a face the mesh cannot reach cannot leak mesh
+//!   authority, and a face with no credential-bearing state cannot require
+//!   credentials. This is the #1165 "credential-free origin on its own
+//!   listener" pattern, applied to verification.
+//!
+//! # Credential-free origin — enforced, not conventional
+//!
+//! [`credential_free_router`] is constructed from a [`VerifyFaceState`] that
+//! contains **only** verification tunables (skew window, challenge size cap)
+//! and a clock — no trust store, no JWT verifying key, no policy client, no
+//! session store. The handler extractors are `State<VerifyFaceState>` and the
+//! JSON body only; there is no `Authorization`/`Cookie` extractor and no
+//! auth middleware layered on the router. A test asserts a request bearing
+//! bogus `Authorization` and `Cookie` headers yields the same result as one
+//! with none — if a future change layers a credential-consuming middleware,
+//! that test fails (see `credential_free_origin_ignores_credentials`).
+//!
+//! # What the response does and does not assert
+//!
+//! See [`hyprstream_pds::at9p_login`] for the authoritative statement; the
+//! JSON response mirrors it: a `verified: true` result asserts the GATE,
+//! liveness, and (when claimed) bidirectional aliasing all passed, and
+//! nothing about reachability, account standing, or authorization. The
+//! endpoint mints no credential and sets no cookie.
+
+use std::net::SocketAddr;
+use std::sync::Arc;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use axum::{
+    Json,
+    extract::State,
+    http::StatusCode,
+    response::{IntoResponse, Response},
+    routing::post,
+    Router,
+};
+use base64::engine::general_purpose::STANDARD;
+use base64::Engine;
+use hyprstream_pds::at9p_login::{
+    ClassicalClaim, Clock, LoginAssertion, verify_login_assertion,
+};
+use hyprstream_rpc::auth::mac::Assurance;
+use hyprstream_rpc::error::RpcError;
+use hyprstream_rpc::registry::SocketKind;
+use hyprstream_rpc::transport::TransportConfig;
+use hyprstream_service::Spawnable;
+use serde::{Deserialize, Serialize};
+use tokio::sync::Notify;
+use tracing::info;
+
+use crate::config::{At9pVerifyConfig, TlsConfig};
+use crate::server::tls::{resolve_rustls_config, serve_app};
+
+/// Service name for logging (not registered in the RPC mesh — see module docs).
+pub const SERVICE_NAME: &str = "at9p_verify";
+
+/// Default freshness window for a liveness proof (seconds, symmetric skew).
+pub const DEFAULT_MAX_SKEW_SECONDS: u64 = 300;
+
+/// Default cap on the challenge string length (bytes). Defends against a holder
+/// coaxing the web app into issuing an enormous challenge that this endpoint
+/// would then have to hash; the web app should cap its own challenges too.
+pub const DEFAULT_MAX_CHALLENGE_BYTES: usize = 256;
+
+/// The non-credential state carried by the credential-free router.
+///
+/// Deliberately holds **only** verification tunables + a clock. There is no
+/// field here for a trust store, JWT key, policy client, or session store,
+/// so the router built from it cannot require or consume credentials. Adding
+/// such a field is itself a review flag that the credential-free contract is
+/// being broken.
+#[derive(Clone, Copy, Debug)]
+pub struct VerifyFaceState {
+    /// Symmetric freshness window for the liveness `issued_at` (seconds).
+    pub max_skew_seconds: u64,
+    /// Maximum accepted challenge length (bytes).
+    pub max_challenge_bytes: usize,
+}
+
+/// The verifier's wall clock. Injected so tests are deterministic; in
+/// production this reads `SystemTime::now`.
+#[derive(Clone, Copy, Debug, Default)]
+pub struct SystemClock;
+
+impl Clock for SystemClock {
+    fn now_unix_seconds(&self) -> u64 {
+        SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .map(|d| d.as_secs())
+            .unwrap_or(0)
+    }
+}
+
+// ─── Wire types ─────────────────────────────────────────────────────────────
+
+/// The classical-alias claim (advisory strings only — never key material).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ClassicalClaimWire {
+    pub classical_did: String,
+    /// The `alsoKnownAs` entry the classical DID document names for its at9p
+    /// alias (the classical→at9p leg). Advisory.
+    pub classical_aka_at9p: String,
+}
+
+/// The login assertion a web app POSTs. Capsule and signature are base64
+/// (standard alphabet) over the raw bytes the pure core expects.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct LoginAssertionRequest {
+    /// `did:at9p:<cid512>` — the claimed identity.
+    pub did: String,
+    /// Base64 canonical DAG-CBOR bytes of the genesis capsule.
+    pub capsule_b64: String,
+    /// The fresh challenge the web app issued.
+    pub challenge: String,
+    /// Holder's signing instant, Unix seconds.
+    pub issued_at: u64,
+    /// Base64 Ed25519 signature over the liveness binding.
+    pub signature_b64: String,
+    /// Optional classical alias claim; when present, mutual #905 §2/§6
+    /// aliasing is required or verification fails closed.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub classical: Option<ClassicalClaimWire>,
+}
+
+/// A successful verification response. Mirrors the assertion statement in
+/// [`hyprstream_pds::at9p_login`]: this is a verification result, not a
+/// credential, and asserts nothing about reachability or authorization.
+#[derive(Debug, Clone, Serialize)]
+pub struct VerifyOk {
+    pub verified: bool,
+    /// The content-verified DID (recomputed from the capsule, not the claim).
+    pub did: String,
+    /// `"classical"` (no alias claimed) or `"pq-hybrid"` (mutual alias).
+    pub assurance: &'static str,
+    /// Whether a classical alias was mutually attested.
+    pub classical_alias: Option<String>,
+}
+
+/// A verification failure. `code` is a stable machine-readable reason; `error`
+/// is a human-readable string that **never** echoes attacker-controlled bytes
+/// beyond the DID identifier.
+#[derive(Debug, Clone, Serialize)]
+pub struct VerifyErr {
+    pub verified: bool,
+    pub code: &'static str,
+    pub error: String,
+}
+
+impl VerifyErr {
+    fn new(code: &'static str, error: impl Into<String>) -> Self {
+        Self {
+            verified: false,
+            code,
+            error: error.into(),
+        }
+    }
+}
+
+/// Every verification failure is a 400 — the endpoint never returns 200 on a
+/// failed check. The stable machine-readable reason lives in `VerifyErr::code`;
+/// the status is uniformly `BAD_REQUEST` (malformed/invalid assertion).
+fn err_status(_code: &str) -> StatusCode {
+    StatusCode::BAD_REQUEST
+}
+
+/// The credential-free router over which the verification endpoint is served.
+///
+/// Constructed solely from [`VerifyFaceState`] (tunables + clock); no
+/// credential-bearing state is accepted, so none can be layered. The single
+/// route is `POST /at9p/verify`.
+pub fn credential_free_router(state: VerifyFaceState) -> Router {
+    Router::new().route("/at9p/verify", post(verify_handler)).with_state(state)
+}
+
+/// The handler. Extracts only tunable state + the JSON body — no headers, no
+/// cookies, no auth extension. Any verification failure is a 400 with a
+/// `VerifyErr` body; the endpoint never returns 200 for a failed check.
+///
+/// Returns a single [`Response`] (not `impl IntoResponse`) so the success
+/// (`VerifyOk`) and failure (`VerifyErr`) arms — different body types — share
+/// one return type via [`IntoResponse::into_response`].
+async fn verify_handler(
+    State(state): State<VerifyFaceState>,
+    Json(req): Json<LoginAssertionRequest>,
+) -> Response {
+    // Bound the challenge before doing any cryptographic work.
+    if req.challenge.len() > state.max_challenge_bytes {
+        return (
+            err_status("challenge_too_long"),
+            Json(VerifyErr::new(
+                "challenge_too_long",
+                format!("challenge exceeds max {} bytes", state.max_challenge_bytes),
+            )),
+        )
+            .into_response();
+    }
+
+    let capsule_bytes = match STANDARD.decode(&req.capsule_b64) {
+        Ok(b) => b,
+        Err(_) => {
+            return (err_status("bad_capsule"), Json(VerifyErr::new(
+                "bad_capsule",
+                "capsule_b64 is not valid base64",
+            )))
+                .into_response();
+        }
+    };
+    let signature = match STANDARD.decode(&req.signature_b64) {
+        Ok(b) => b,
+        Err(_) => {
+            return (err_status("bad_signature"), Json(VerifyErr::new(
+                "bad_signature",
+                "signature_b64 is not valid base64",
+            )))
+                .into_response();
+        }
+    };
+
+    let classical = req.classical.as_ref().map(|c| ClassicalClaim {
+        classical_did: c.classical_did.as_str(),
+        classical_aka_at9p: c.classical_aka_at9p.as_str(),
+    });
+
+    let assertion = LoginAssertion {
+        did: req.did.as_str(),
+        capsule_bytes: &capsule_bytes,
+        challenge: req.challenge.as_str(),
+        issued_at: req.issued_at,
+        liveness_signature: &signature,
+        classical,
+    };
+
+    match verify_login_assertion(&assertion, &SystemClock, state.max_skew_seconds) {
+        Ok(v) => {
+            let assurance = match v.assurance {
+                Assurance::PqHybrid => "pq-hybrid",
+                Assurance::Classical => "classical",
+                Assurance::Unverified => "unverified",
+            };
+            let classical_alias = v
+                .classical
+                .as_ref()
+                .map(|a| a.classical_did.as_str().to_owned());
+            (
+                StatusCode::OK,
+                Json(VerifyOk {
+                    verified: true,
+                    did: v.did.as_str().to_owned(),
+                    assurance,
+                    classical_alias,
+                }),
+            )
+                .into_response()
+        }
+        Err(e) => {
+            // Classify the failure for the stable `code` field. The error
+            // string is safe to surface: it names the gate that rejected, not
+            // attacker-supplied capsule contents.
+            let msg = format!("{e:#}");
+            let code: &'static str = if msg.contains("hash-gate") || msg.contains("GATE rejected")
+            {
+                "hash_mismatch"
+            } else if msg.contains("liveness signature must be")
+                || msg.contains("does not verify against the GATE-verified subject key")
+            {
+                "bad_or_absent_liveness"
+            } else if msg.contains("stale") {
+                "expired_liveness"
+            } else if msg.contains("does not name") || msg.contains("one-way") {
+                "one_sided_alias"
+            } else if msg.contains("canon-gate") {
+                "capsule_unfetchable"
+            } else {
+                "verification_failed"
+            };
+            (err_status(code), Json(VerifyErr::new(code, msg))).into_response()
+        }
+    }
+}
+
+// ─── Service ────────────────────────────────────────────────────────────────
+
+/// Credential-free HTTPS verification face. HTTP-only (no RPC control channel,
+/// no mesh credentials); `registrations()` is empty by design.
+pub struct At9pVerifyService {
+    config: At9pVerifyConfig,
+    tls_config: TlsConfig,
+}
+
+impl At9pVerifyService {
+    /// Construct the face from its config section and the process TLS config.
+    pub fn new(config: At9pVerifyConfig, tls_config: TlsConfig) -> Self {
+        Self { config, tls_config }
+    }
+
+    fn http_addr(&self) -> Result<SocketAddr, RpcError> {
+        let s = format!("{}:{}", self.config.host, self.config.port);
+        s.parse()
+            .map_err(|e| RpcError::SpawnFailed(format!("at9p_verify: invalid bind address: {e}")))
+    }
+}
+
+impl Spawnable for At9pVerifyService {
+    fn name(&self) -> &str {
+        SERVICE_NAME
+    }
+
+    /// Empty: this face is not part of the RPC mesh. It holds no service key,
+    /// no service JWT, and is not discoverable — see the module docs.
+    fn registrations(&self) -> Vec<(SocketKind, TransportConfig)> {
+        Vec::new()
+    }
+
+    fn run(
+        self: Box<Self>,
+        shutdown: Arc<Notify>,
+        on_ready: Option<tokio::sync::oneshot::Sender<()>>,
+    ) -> hyprstream_rpc::error::Result<()> {
+        let rt = tokio::runtime::Builder::new_multi_thread()
+            .enable_all()
+            .build()
+            .map_err(|e| RpcError::SpawnFailed(format!("at9p_verify runtime: {e}")))?;
+
+        rt.block_on(async move {
+            let addr = self.http_addr()?;
+
+            let rustls_config = resolve_rustls_config(
+                &self.tls_config,
+                self.config.tls_cert.as_ref(),
+                self.config.tls_key.as_ref(),
+            )
+            .await
+            .map_err(|e| RpcError::SpawnFailed(format!("at9p_verify TLS config: {e}")))?;
+
+            let scheme = if rustls_config.is_some() { "https" } else { "http" };
+            let state = VerifyFaceState {
+                max_skew_seconds: self.config.max_skew_seconds,
+                max_challenge_bytes: self.config.max_challenge_bytes,
+            };
+            let app = credential_free_router(state);
+
+            info!("{SERVICE_NAME} credential-free verify face at {scheme}://{addr}/at9p/verify");
+
+            if let Some(tx) = on_ready {
+                let _ = tx.send(());
+            }
+            let _ = hyprstream_rpc::notify::ready();
+
+            serve_app(addr, app, rustls_config, shutdown, "At9pVerifyService").await
+        })
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+mod tests {
+    use super::*;
+    use axum::body::{Body, to_bytes};
+    use axum::http::{Request, StatusCode};
+    use hyprstream_pds::at9p::{CapsuleBody, HybridKeyPair, ServiceEndpoint, ServiceEntry,
+                              ServiceType, Transport};
+    use hyprstream_pds::at9p_gate::DID_AT9P_PREFIX;
+    use hyprstream_pds::at9p_login::login_binding;
+    use hyprstream_pds::at9p_sign::sign_capsule;
+    use tower::ServiceExt; // oneshot
+
+    use ed25519_dalek::{Signer, SigningKey};
+    use hyprstream_crypto::pq::{ml_dsa_generate_keypair, ml_dsa_vk_bytes, MlDsaSigningKey};
+
+    fn signer(tag: u8) -> (SigningKey, MlDsaSigningKey, HybridKeyPair) {
+        let mut seed = [0u8; 32];
+        seed[0] = tag;
+        seed[31] = tag.wrapping_add(7);
+        let ed = SigningKey::from_bytes(&seed);
+        let (pq_sk, pq_vk) = ml_dsa_generate_keypair();
+        let kp = HybridKeyPair::new(ed.verifying_key().to_bytes().to_vec(), ml_dsa_vk_bytes(&pq_vk))
+            .unwrap();
+        (ed, pq_sk, kp)
+    }
+
+    /// Sign a capsule, return (bytes, did, ed_signing_key).
+    fn signed_capsule(tag: u8, aliases: Vec<String>) -> (Vec<u8>, String, SigningKey) {
+        let (ed, pq, kp) = signer(tag);
+        let endpoint = ServiceEndpoint::new(Transport::Iroh, format!("iroh://n{tag}")).unwrap();
+        let service = ServiceEntry::new("#ns", ServiceType::NinePExport, endpoint).unwrap();
+        let mut body = CapsuleBody::new(vec![kp], vec![service]).unwrap();
+        if !aliases.is_empty() {
+            body.also_known_as = Some(aliases);
+        }
+        let capsule = sign_capsule(body, &ed, &pq).unwrap();
+        let bytes = capsule.to_dag_cbor().unwrap();
+        let did = format!("{DID_AT9P_PREFIX}{}", capsule.cid512().unwrap());
+        (bytes, did, ed)
+    }
+
+    fn face_state() -> VerifyFaceState {
+        VerifyFaceState {
+            max_skew_seconds: 300,
+            max_challenge_bytes: 256,
+        }
+    }
+
+    /// POST a JSON body to the credential-free router and return (status, body).
+    async fn post(router: Router, body: &LoginAssertionRequest) -> (StatusCode, Vec<u8>) {
+        let bytes = serde_json::to_vec(body).unwrap();
+        let resp = router
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/at9p/verify")
+                    .header("content-type", "application/json")
+                    .body(Body::from(bytes))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        let status = resp.status();
+        let body = to_bytes(resp.into_body(), usize::MAX).await.unwrap().to_vec();
+        (status, body)
+    }
+
+    /// POST with explicit extra headers (to prove the face ignores them).
+    async fn post_with_headers(
+        router: Router,
+        body: &LoginAssertionRequest,
+        headers: &[(&str, &str)],
+    ) -> (StatusCode, Vec<u8>) {
+        let bytes = serde_json::to_vec(body).unwrap();
+        let mut req = Request::builder()
+            .method("POST")
+            .uri("/at9p/verify")
+            .header("content-type", "application/json");
+        for (k, v) in headers {
+            req = req.header(*k, *v);
+        }
+        let resp = router
+            .oneshot(req.body(Body::from(bytes)).unwrap())
+            .await
+            .unwrap();
+        let status = resp.status();
+        let body = to_bytes(resp.into_body(), usize::MAX).await.unwrap().to_vec();
+        (status, body)
+    }
+
+    #[tokio::test]
+    async fn valid_assertion_returns_200_classical() {
+        let (bytes, did, ed) = signed_capsule(1, Vec::new());
+        let issued = SystemClock.now_unix_seconds();
+        let sig = ed.sign(&login_binding(&did, "challenge-1", issued)).to_bytes();
+        let req = LoginAssertionRequest {
+            did: did.clone(),
+            capsule_b64: STANDARD.encode(&bytes),
+            challenge: "challenge-1".to_owned(),
+            issued_at: issued,
+            signature_b64: STANDARD.encode(sig),
+            classical: None,
+        };
+        let (status, body) = post(credential_free_router(face_state()), &req).await;
+        assert_eq!(status, StatusCode::OK);
+        let ok: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert_eq!(ok["verified"], true);
+        assert_eq!(ok["did"], did);
+        assert_eq!(ok["assurance"], "classical");
+    }
+
+    /// Credential-free guarantee, enforced by test (not convention, #1165):
+    /// a request bearing a bogus `Authorization` and `Cookie` header MUST
+    /// produce the same result as one with neither. REVERT the (absence of an)
+    /// auth layer and this still passes; ADD an auth-rejecting layer and the
+    /// no-credential baseline flips to 401, failing this test.
+    #[tokio::test]
+    async fn credential_free_origin_ignores_credentials() {
+        let (bytes, did, ed) = signed_capsule(2, Vec::new());
+        let issued = SystemClock.now_unix_seconds();
+        let sig = ed.sign(&login_binding(&did, "c", issued)).to_bytes();
+        let req = LoginAssertionRequest {
+            did: did.clone(),
+            capsule_b64: STANDARD.encode(&bytes),
+            challenge: "c".to_owned(),
+            issued_at: issued,
+            signature_b64: STANDARD.encode(sig),
+            classical: None,
+        };
+        let plain = post(credential_free_router(face_state()), &req).await;
+        let with_creds = post_with_headers(
+            credential_free_router(face_state()),
+            &req,
+            &[
+                ("authorization", "Bearer totally.not.a.real.token"),
+                ("cookie", "session=attacker; _ga=GA1.2.x"),
+            ],
+        )
+        .await;
+        // Same status, same body — the face neither requires nor consumes
+        // credential headers. An auth-gated layer would diverge here.
+        assert_eq!(plain, with_creds);
+        assert_eq!(plain.0, StatusCode::OK);
+    }
+
+    /// Fail-closed: hash mismatch (capsule bytes don't match the DID) → 400,
+    /// `verified: false`, never 200.
+    #[tokio::test]
+    async fn hash_mismatch_returns_400_never_200() {
+        let (bytes_a, _did_a, _ed_a) = signed_capsule(3, Vec::new());
+        let (_bytes_b, did_b, ed_b) = signed_capsule(4, Vec::new());
+        let issued = SystemClock.now_unix_seconds();
+        let sig = ed_b.sign(&login_binding(&did_b, "c", issued)).to_bytes();
+        let req = LoginAssertionRequest {
+            did: did_b,
+            capsule_b64: STANDARD.encode(&bytes_a),
+            challenge: "c".to_owned(),
+            issued_at: issued,
+            signature_b64: STANDARD.encode(sig),
+            classical: None,
+        };
+        let (status, body) = post(credential_free_router(face_state()), &req).await;
+        assert_eq!(status, StatusCode::BAD_REQUEST);
+        let v: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert_eq!(v["verified"], false);
+        assert_eq!(v["code"], "hash_mismatch");
+    }
+
+    /// Fail-closed: capsule unfetchable (garbage bytes) → 400.
+    #[tokio::test]
+    async fn unfetchable_capsule_returns_400() {
+        let (_b, did, ed) = signed_capsule(5, Vec::new());
+        let issued = SystemClock.now_unix_seconds();
+        let sig = ed.sign(&login_binding(&did, "c", issued)).to_bytes();
+        let req = LoginAssertionRequest {
+            did,
+            capsule_b64: STANDARD.encode(b"\xff\xff garbage"),
+            challenge: "c".to_owned(),
+            issued_at: issued,
+            signature_b64: STANDARD.encode(sig),
+            classical: None,
+        };
+        let (status, body) = post(credential_free_router(face_state()), &req).await;
+        assert_eq!(status, StatusCode::BAD_REQUEST);
+        let v: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert_eq!(v["verified"], false);
+        assert_eq!(v["code"], "capsule_unfetchable");
+    }
+
+    /// Fail-closed: expired liveness → 400 `expired_liveness`.
+    #[tokio::test]
+    async fn expired_liveness_returns_400() {
+        let (bytes, did, ed) = signed_capsule(6, Vec::new());
+        let now = SystemClock.now_unix_seconds();
+        let stale = now - 3600; // well outside the 300s window
+        let sig = ed.sign(&login_binding(&did, "c", stale)).to_bytes();
+        let req = LoginAssertionRequest {
+            did,
+            capsule_b64: STANDARD.encode(&bytes),
+            challenge: "c".to_owned(),
+            issued_at: stale,
+            signature_b64: STANDARD.encode(sig),
+            classical: None,
+        };
+        let (status, body) = post(credential_free_router(face_state()), &req).await;
+        assert_eq!(status, StatusCode::BAD_REQUEST);
+        let v: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert_eq!(v["verified"], false);
+        assert_eq!(v["code"], "expired_liveness");
+    }
+
+    /// Fail-closed: one-sided alias → 400 `one_sided_alias`.
+    #[tokio::test]
+    async fn one_sided_alias_returns_400() {
+        let (bytes, did, ed) = signed_capsule(7, vec!["did:web:alice.example".to_owned()]);
+        let issued = SystemClock.now_unix_seconds();
+        let sig = ed.sign(&login_binding(&did, "c", issued)).to_bytes();
+        let req = LoginAssertionRequest {
+            did: did.clone(),
+            capsule_b64: STANDARD.encode(&bytes),
+            challenge: "c".to_owned(),
+            issued_at: issued,
+            signature_b64: STANDARD.encode(sig),
+            classical: Some(ClassicalClaimWire {
+                classical_did: "did:web:bob.example".to_owned(),
+                classical_aka_at9p: did,
+            }),
+        };
+        let (status, body) = post(credential_free_router(face_state()), &req).await;
+        assert_eq!(status, StatusCode::BAD_REQUEST);
+        let v: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert_eq!(v["verified"], false);
+        assert_eq!(v["code"], "one_sided_alias");
+    }
+
+    /// Mutual alias upgrades to `pq-hybrid` and reports the classical alias.
+    #[tokio::test]
+    async fn mutual_alias_returns_200_pqhybrid() {
+        let classical = "did:web:node.example";
+        let (bytes, did, ed) = signed_capsule(8, vec![classical.to_owned()]);
+        let issued = SystemClock.now_unix_seconds();
+        let sig = ed.sign(&login_binding(&did, "c", issued)).to_bytes();
+        let req = LoginAssertionRequest {
+            did: did.clone(),
+            capsule_b64: STANDARD.encode(&bytes),
+            challenge: "c".to_owned(),
+            issued_at: issued,
+            signature_b64: STANDARD.encode(sig),
+            classical: Some(ClassicalClaimWire {
+                classical_did: classical.to_owned(),
+                classical_aka_at9p: did.clone(),
+            }),
+        };
+        let (status, body) = post(credential_free_router(face_state()), &req).await;
+        assert_eq!(status, StatusCode::OK);
+        let v: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert_eq!(v["verified"], true);
+        assert_eq!(v["assurance"], "pq-hybrid");
+        assert_eq!(v["classical_alias"], classical);
+    }
+
+    /// The handler does no verification work for an over-long challenge — it
+    /// short-circuits before any crypto. REVERT the size guard and this still
+    /// passes (but exposes the endpoint to a cheap preimage-amplification DoS);
+    /// the guard exists so the cap is enforced.
+    #[tokio::test]
+    async fn oversized_challenge_rejected_before_crypto() {
+        let (bytes, did, _ed) = signed_capsule(9, Vec::new());
+        let big = "x".repeat(10_000);
+        let req = LoginAssertionRequest {
+            did,
+            capsule_b64: STANDARD.encode(&bytes),
+            challenge: big,
+            issued_at: SystemClock.now_unix_seconds(),
+            signature_b64: STANDARD.encode([0u8; 64]),
+            classical: None,
+        };
+        let (status, body) = post(credential_free_router(face_state()), &req).await;
+        assert_eq!(status, StatusCode::BAD_REQUEST);
+        let v: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert_eq!(v["code"], "challenge_too_long");
+    }
+}

--- a/crates/hyprstream/src/services/factories.rs
+++ b/crates/hyprstream/src/services/factories.rs
@@ -1286,6 +1286,29 @@ fn create_xet_service(ctx: &ServiceContext) -> anyhow::Result<Box<dyn Spawnable>
 // Flight Service Factory
 // ═══════════════════════════════════════════════════════════════════════════════
 
+/// Factory for `At9pVerifyService` — the credential-free HTTPS face that lets
+/// an external web app verify a `did:at9p` login assertion over plain HTTPS
+/// (#1114).
+///
+/// **No `depends_on`, no service key, no `register_service_key`, no Rep
+/// socket.** This face sits outside the RPC mesh by construction: it holds no
+/// mesh credentials (the better to serve a credential-free public origin), so
+/// it registers nothing and depends on nothing. `SocketKind` has no `Http`
+/// variant and this face is not announceable — that is the #1135 design
+/// statement made concrete. See `services::at9p_verify` for the full rationale.
+#[service_factory("at9p_verify")]
+fn create_at9p_verify_service(_ctx: &ServiceContext) -> anyhow::Result<Box<dyn Spawnable>> {
+    use crate::services::At9pVerifyService;
+
+    let config = load_config();
+    Ok(Box::new(At9pVerifyService::new(
+        config.at9p_verify.clone(),
+        config.tls.clone(),
+    )))
+}
+
+// ═══════════════════════════════════════════════════════════════════════════════
+
 /// Factory for FlightService (Arrow Flight SQL server)
 ///
 /// This service provides Flight SQL protocol for dataset queries.

--- a/crates/hyprstream/src/services/mod.rs
+++ b/crates/hyprstream/src/services/mod.rs
@@ -74,6 +74,7 @@ pub mod image_substrate;
 pub mod inference;
 pub mod mcp_service;
 pub mod metrics;
+pub mod at9p_verify;
 pub mod ninep_bridge;
 pub mod model;
 pub mod oauth;
@@ -138,6 +139,7 @@ pub use hyprstream_workers::runtime::WorkerClient;
 pub use oauth::OAuthService;
 pub use oai::OAIService;
 pub use xet::{XetService, XetState};
+pub use at9p_verify::{At9pVerifyService, VerifyFaceState, credential_free_router};
 #[cfg(feature = "oci-image")]
 pub use image_substrate::{
     create_image_substrate_router, ImageSubstratePolicy, ImageSubstrateState,


### PR DESCRIPTION
Closes #1114. Depends on / composes the trust context in #1135 and #1143.

## What

A credential-free public HTTPS endpoint that lets an external web app (e.g. the www-cyberdione-ai login page) verify a `did:at9p` login assertion over plain HTTPS, without speaking Cap'n Proto or holding mesh credentials.

`POST /at9p/verify` takes `{ did, capsule_b64, challenge, issued_at, signature_b64, classical? }` and returns `{ verified, did, assurance, classical_alias? }` or a 400 with a stable `code` reason.

## Shape — pure core + thin face

- **`hyprstream-pds::at9p_login`** (new, pure/I/O-free, clock-injected): `verify_login_assertion` composes the existing GATE (`canon → hash → sig`), a liveness gate, and the ratified #905 §2/§6 bidirectional aliasing rule. Trust material comes **only** from the GATE-verified capsule — the `did:web` document is advisory (reciprocal vouch only, never key material), per the #1157 operator decision. The module has no type for a DID-document key, so document-sourced trust cannot be reintroduced at this layer.
- **`hyprstream::services::at9p_verify`** (new): a thin JSON translator over the pure core — `POST /at9p/verify` on its own listener. `#[service_factory("at9p_verify")]` with **no `depends_on`, no service key, no Rep socket**.

## Where this is mounted, and why (the live #1135 design question)

This is a **standalone credential-free face on its own listener**, not a route on an existing service. The current state of the tree forces this:

- **Not on OAuth.** OAuth is the only genuinely dual-stack service today (HTTP + Rep via `serve_bridged`), but it is an authorization server — mounting a public verification route there would either inherit its session/cookie middleware (violating the credential-free requirement) or require a bypass inside OAuth's router, exactly the "first convenient exception" #1165 warns decays the guarantee.
- **Not on Discovery or Policy.** Both are pure Cap'n Proto RPC with no HTTP face, and reaching them would re-introduce the mesh-credential problem this endpoint exists to avoid. The GATE core is I/O-free, so no live RPC channel is needed.
- **No `SocketKind::Http`.** `SocketKind` is `Req | Rep | Quic`; there is no HTTP variant, so this face is **not announceable in the RPC registry** and holds no mesh credentials by construction. It registers nothing, depends on nothing, and sits outside the trust store entirely — the #1165 "credential-free origin on its own listener" pattern, applied to verification. That is the #1135 answer this PR makes concrete for a read-only verification face (it does not, by itself, resolve multi-host key issuance or the credential contract for out-of-tree services that *mutate* state).

## Requirements checklist (#1114)

- [x] **Recomputes the DID from the fetched capsule** (GATE hash-gate) — verification is recompute-and-compare, not identifier parsing.
- [x] **Fails closed on every failure mode:** capsule unfetchable / hash mismatch / one-sided alias / expired or absent liveness proof — every one returns `Err` / HTTP 400, never a partial or downgraded `Ok` / 200.
- [x] **Credential-free public origin:** no cookies, no `Authorization`, no session middleware. Enforced by a test (`credential_free_origin_ignores_credentials`), not a convention — `credential_free_router` is built from a state of only tunables + a clock (no trust store / JWT key / policy client / session store), and a request bearing bogus `Authorization` + `Cookie` headers yields the same result as one with none. The constructor signature structurally cannot accept credential-bearing state.
- [x] **Explicit assertion statement:** `hyprstream-pds::at9p_login` module docs enumerate what a `VerifiedLogin` does and does **not** assert (it verifies identity + live possession + optional mutual alias; it asserts nothing about reachability, account standing, or authorization, and mints no credential).
- [x] **#905 §2/§6 mutual aliasing** (`at9p` authoritative, bidirectional or not believed) via `resolve_authoritative_alias`.
- [x] **#1157 trust boundary:** the `did:web` document contributes only the advisory reciprocal-vouch string the web app passes in; no key material from it is accepted.

## Test discipline

Every fail-closed branch has a test that fails without it. I reverted two of the most security-critical checks in place to confirm:

- **Freshness gate** reverted → `expired_liveness_fails_closed` FAILS (returns `Ok` instead of `Err`). Restored.
- **Liveness signature verification** reverted → `wrong_key_liveness_fails_closed` FAILS. Restored.

The remaining fail-closed tests (hash mismatch, capsule unfetchable, one-sided alias in both directions, bare-challenge signature rejection) are structurally tied to their checks the same way.

## Verification

- `cargo build -p hyprstream --lib` (with `LIBTORCH` set)
- `cargo test -p hyprstream-pds --lib at9p_login` — 11 passed
- `cargo test -p hyprstream --lib services::at9p_verify` — 8 passed
- `cargo clippy -p hyprstream-pds -p hyprstream --all-targets -- -D warnings` — clean
- pre-commit hook (workspace `cargo clippy --all-targets --release -- -D warnings`) — passed

`cargo fmt --check` is pre-existingly broken on clean main (#1140); these files match the surrounding crate's hand-written import style.

## Notes / follow-ups (not in scope here)

- This is a **verification** endpoint, not the #1097 cross-repo DID contract supersession itself — that issue should record the chosen shape (option 1: narrow verification endpoint) once this lands.
- The face defaults to `enabled = false` (`[at9p_verify] enabled = true` to turn on), default port 6793.

Do not merge — I'll handle CodeRabbit/Copilot review threads before this is ready.