### PR TITLE
fix(identity): resolve DID verification key sets

### DIFF
--- a/crates/hyprstream-rpc/src/auth/atproto_perimeter.rs
+++ b/crates/hyprstream-rpc/src/auth/atproto_perimeter.rs
@@ -439,13 +439,11 @@ mod tests {
     }
 
     fn hybrid_keys(ed25519: [u8; 32]) -> IdentityKeys {
-        IdentityKeys {
-            candidates: vec![IdentityKeyCandidate {
+        IdentityKeys::new(vec![IdentityKeyCandidate {
                 id: "did:web:peer.example#mesh".to_owned(),
                 ed25519,
                 ml_dsa_65: Some(an_ml_dsa_vk()),
-            }],
-        }
+            }])
     }
 
     /// Fixture resolver returning fixed key material — the #549 stand-in for #579,
@@ -526,8 +524,7 @@ mod tests {
     fn overlap_selects_each_admitted_signer_then_rejects_the_retired_candidate() {
         let old = [30u8; 32];
         let new = [31u8; 32];
-        let overlap = IdentityKeys {
-            candidates: vec![
+        let overlap = IdentityKeys::new(vec![
                 IdentityKeyCandidate {
                     id: "did:web:peer.example#mesh-old".to_owned(),
                     ed25519: old,
@@ -538,8 +535,7 @@ mod tests {
                     ed25519: new,
                     ml_dsa_65: Some(an_ml_dsa_vk()),
                 },
-            ],
-        };
+            ]);
         let old_peer = AtprotoPerimeterGateway::new(FixtureResolver(overlap.clone()))
             .enroll(&admitted(Some(DID_WEB), old))
             .expect("draining key remains accepted during overlap");

--- a/crates/hyprstream-rpc/src/auth/atproto_perimeter.rs
+++ b/crates/hyprstream-rpc/src/auth/atproto_perimeter.rs
@@ -127,38 +127,15 @@ impl<R: IdentityResolver> AtprotoPerimeterGateway<R> {
             .resolve_identity_keys(&did)
             .map_err(|e| anyhow!("perimeter enroll: DID {did} did not resolve: {e}"))?;
 
-        // Fail-closed on missing verifying key material for the asserted assurance:
-        // a `Classical`/`PqHybrid` assurance with no Ed25519 key, or a `PqHybrid`
-        // assurance with no ML-DSA-65 anchor, is an inconsistent resolution we will
-        // not enroll.
-        match keys.assurance {
-            Assurance::Unverified => {
-                return Err(anyhow!(
-                    "perimeter enroll: DID {did} resolved Unverified (no verifiable key) — fail-closed"
-                ));
-            }
-            Assurance::Classical => {
-                if keys.ed25519.is_none() {
-                    return Err(anyhow!(
-                        "perimeter enroll: DID {did} asserts Classical but published no Ed25519 key — fail-closed"
-                    ));
-                }
-            }
-            Assurance::PqHybrid => {
-                if keys.ed25519.is_none() {
-                    return Err(anyhow!(
-                        "perimeter enroll: DID {did} asserts PqHybrid but published no Ed25519 key — fail-closed"
-                    ));
-                }
-                if keys.ml_dsa_65.is_none() {
-                    return Err(anyhow!(
-                        "perimeter enroll: DID {did} asserts PqHybrid but published no ML-DSA-65 anchor — fail-closed"
-                    ));
-                }
-            }
-        }
-
-        let key_material = assurance_to_key_material(keys.assurance);
+        // Admission already verified `admitted.key` against the DID document.
+        // Select that exact candidate from the named set rather than granting
+        // document-order authority to another overlap/rotation slot.
+        let candidate = keys.candidate_for_ed25519(&admitted.key).ok_or_else(|| {
+            anyhow!(
+                "perimeter enroll: DID {did} no longer publishes the admitted Ed25519 signer — fail-closed"
+            )
+        })?;
+        let key_material = assurance_to_key_material(candidate.assurance());
         let derived = key_material.assurance();
 
         // Edge ceiling × clamp-DOWN to crypto-derived assurance (#548).
@@ -441,7 +418,7 @@ pub struct TranslatedAtprotoAuthorization {
 mod tests {
     use super::*;
     use crate::crypto::pq::ml_dsa_generate_keypair;
-    use crate::identity::{IdentityKeys, MlDsaVk};
+    use crate::identity::{IdentityKeyCandidate, IdentityKeys, MlDsaVk};
 
     const DID_WEB: &str = "did:web:peer.example";
 
@@ -455,6 +432,20 @@ mod tests {
 
     fn an_ml_dsa_vk() -> MlDsaVk {
         ml_dsa_generate_keypair().1
+    }
+
+    fn classical_keys(ed25519: [u8; 32]) -> IdentityKeys {
+        IdentityKeys::single_ed25519("did:web:peer.example#mesh", ed25519)
+    }
+
+    fn hybrid_keys(ed25519: [u8; 32]) -> IdentityKeys {
+        IdentityKeys {
+            candidates: vec![IdentityKeyCandidate {
+                id: "did:web:peer.example#mesh".to_owned(),
+                ed25519,
+                ml_dsa_65: Some(an_ml_dsa_vk()),
+            }],
+        }
     }
 
     /// Fixture resolver returning fixed key material — the #549 stand-in for #579,
@@ -476,11 +467,7 @@ mod tests {
 
     #[test]
     fn classical_peer_enrolls_at_classical_assurance() {
-        let keys = IdentityKeys {
-            ed25519: Some([7u8; 32]),
-            ml_dsa_65: None,
-            assurance: Assurance::Classical,
-        };
+        let keys = classical_keys([7u8; 32]);
         let gw = AtprotoPerimeterGateway::new(FixtureResolver(keys));
         let peer = gw
             .enroll(&admitted(Some(DID_WEB), [7u8; 32]))
@@ -497,11 +484,7 @@ mod tests {
 
     #[test]
     fn pqhybrid_peer_enrolls_at_pqhybrid_assurance() {
-        let keys = IdentityKeys {
-            ed25519: Some([9u8; 32]),
-            ml_dsa_65: Some(an_ml_dsa_vk()),
-            assurance: Assurance::PqHybrid,
-        };
+        let keys = hybrid_keys([9u8; 32]);
         let gw = AtprotoPerimeterGateway::new(FixtureResolver(keys));
         let peer = gw
             .enroll(&admitted(Some(DID_WEB), [9u8; 32]))
@@ -513,11 +496,7 @@ mod tests {
 
     #[test]
     fn unverified_resolution_fails_closed() {
-        let keys = IdentityKeys {
-            ed25519: None,
-            ml_dsa_65: None,
-            assurance: Assurance::Unverified,
-        };
+        let keys = IdentityKeys::default();
         let gw = AtprotoPerimeterGateway::new(FixtureResolver(keys));
         assert!(gw.enroll(&admitted(Some(DID_WEB), [0u8; 32])).is_err());
     }
@@ -531,36 +510,55 @@ mod tests {
     #[test]
     fn missing_did_fails_closed() {
         // Admission matched via JWKS fallback only — no DID to resolve.
-        let keys = IdentityKeys {
-            ed25519: Some([2u8; 32]),
-            ml_dsa_65: None,
-            assurance: Assurance::Classical,
-        };
+        let keys = classical_keys([2u8; 32]);
         let gw = AtprotoPerimeterGateway::new(FixtureResolver(keys));
         assert!(gw.enroll(&admitted(None, [2u8; 32])).is_err());
     }
 
     #[test]
-    fn pqhybrid_assertion_without_ml_dsa_fails_closed() {
-        // Inconsistent resolution: claims PqHybrid but published no PQ anchor.
-        let keys = IdentityKeys {
-            ed25519: Some([3u8; 32]),
-            ml_dsa_65: None,
-            assurance: Assurance::PqHybrid,
-        };
+    fn candidate_set_without_admitted_signer_fails_closed() {
+        let keys = classical_keys([4u8; 32]);
         let gw = AtprotoPerimeterGateway::new(FixtureResolver(keys));
         assert!(gw.enroll(&admitted(Some(DID_WEB), [3u8; 32])).is_err());
+    }
+
+    #[test]
+    fn overlap_selects_each_admitted_signer_then_rejects_the_retired_candidate() {
+        let old = [30u8; 32];
+        let new = [31u8; 32];
+        let overlap = IdentityKeys {
+            candidates: vec![
+                IdentityKeyCandidate {
+                    id: "did:web:peer.example#mesh-old".to_owned(),
+                    ed25519: old,
+                    ml_dsa_65: None,
+                },
+                IdentityKeyCandidate {
+                    id: "did:web:peer.example#mesh-new".to_owned(),
+                    ed25519: new,
+                    ml_dsa_65: Some(an_ml_dsa_vk()),
+                },
+            ],
+        };
+        let old_peer = AtprotoPerimeterGateway::new(FixtureResolver(overlap.clone()))
+            .enroll(&admitted(Some(DID_WEB), old))
+            .expect("draining key remains accepted during overlap");
+        let new_peer = AtprotoPerimeterGateway::new(FixtureResolver(overlap))
+            .enroll(&admitted(Some(DID_WEB), new))
+            .expect("new key is accepted during overlap");
+        assert_eq!(old_peer.assurance, Assurance::Classical);
+        assert_eq!(new_peer.assurance, Assurance::PqHybrid);
+
+        let retired = IdentityKeys::single_ed25519("did:web:peer.example#mesh-new", new);
+        let gateway = AtprotoPerimeterGateway::new(FixtureResolver(retired));
+        assert!(gateway.enroll(&admitted(Some(DID_WEB), old)).is_err());
     }
 
     #[test]
     fn classical_peer_cannot_obtain_pqhybrid_context() {
         // A classical-key peer, even resolved at the PqHybrid-capable edge, must
         // clamp to Classical and fail to dominate a PqHybrid object.
-        let keys = IdentityKeys {
-            ed25519: Some([4u8; 32]),
-            ml_dsa_65: None,
-            assurance: Assurance::Classical,
-        };
+        let keys = classical_keys([4u8; 32]);
         let gw = AtprotoPerimeterGateway::new(FixtureResolver(keys));
         let peer = gw.enroll(&admitted(Some(DID_WEB), [4u8; 32])).unwrap();
 
@@ -572,11 +570,7 @@ mod tests {
 
     #[test]
     fn enrollment_store_insert_get_roundtrip() {
-        let keys = IdentityKeys {
-            ed25519: Some([5u8; 32]),
-            ml_dsa_65: None,
-            assurance: Assurance::Classical,
-        };
+        let keys = classical_keys([5u8; 32]);
         let gw = AtprotoPerimeterGateway::new(FixtureResolver(keys));
         let peer = gw.enroll(&admitted(Some(DID_WEB), [5u8; 32])).unwrap();
 
@@ -601,11 +595,7 @@ mod tests {
         let native = crate::envelope::KeyedPqTrustStore::new();
         assert!(native.is_empty());
 
-        let keys = IdentityKeys {
-            ed25519: Some([6u8; 32]),
-            ml_dsa_65: Some(an_ml_dsa_vk()),
-            assurance: Assurance::PqHybrid,
-        };
+        let keys = hybrid_keys([6u8; 32]);
         let gw = AtprotoPerimeterGateway::new(FixtureResolver(keys));
         let peer = gw.enroll(&admitted(Some(DID_WEB), [6u8; 32])).unwrap();
 
@@ -618,11 +608,7 @@ mod tests {
     }
 
     fn classical_peer() -> EnrolledPeer {
-        let keys = IdentityKeys {
-            ed25519: Some([11u8; 32]),
-            ml_dsa_65: None,
-            assurance: Assurance::Classical,
-        };
+        let keys = classical_keys([11u8; 32]);
         AtprotoPerimeterGateway::new(FixtureResolver(keys))
             .enroll(&admitted(Some(DID_WEB), [11u8; 32]))
             .unwrap()

--- a/crates/hyprstream-rpc/src/auth/mod.rs
+++ b/crates/hyprstream-rpc/src/auth/mod.rs
@@ -37,7 +37,7 @@ pub mod ucan;
 pub use atproto_perimeter::{AtprotoPerimeterGateway, EnrolledPeer, EnrollmentStore};
 // The identity-resolution contract (#579) lives canonically in `crate::identity`;
 // re-exported here so existing `crate::auth::{IdentityResolver, ...}` paths keep working.
-pub use crate::identity::{Ed25519Vk, IdentityKeys, IdentityResolver, MlDsaVk};
+pub use crate::identity::{Ed25519Vk, IdentityKeyCandidate, IdentityKeys, IdentityResolver, MlDsaVk};
 pub use claims::{
     ActClaim, Claims, Cnf, CnfJwk, IdTokenClaims, OneOrMany, compute_jkt, is_local_iss,
 };

--- a/crates/hyprstream-rpc/src/identity.rs
+++ b/crates/hyprstream-rpc/src/identity.rs
@@ -213,7 +213,10 @@ mod did_tests {
         // A fixed 32-byte key → did:key → back to the same bytes.
         let key = [7u8; 32];
         let did = Did::from_ed25519(&key);
-        assert!(did.is_did_key(), "from_ed25519 must produce a did:key: {did}");
+        assert!(
+            did.is_did_key(),
+            "from_ed25519 must produce a did:key: {did}"
+        );
         assert_eq!(did.to_ed25519().expect("decode"), key);
     }
 
@@ -263,19 +266,67 @@ pub type Ed25519Vk = [u8; 32];
 /// primitive ([`crate::crypto::pq::MlDsaVerifyingKey`]).
 pub type MlDsaVk = MlDsaVerifyingKey;
 
-/// The key material a resolver returns for an identity.
+/// One named verification-key candidate published by an identity.
 ///
-/// `ml_dsa_65 == None` ⇒ classical-only edge; `Some` ⇒ a hybrid-PQC anchor is
-/// present. `assurance` is **crypto-derived by the resolver**, never
-/// self-asserted — consumers map it 1:1 into their MAC key material.
+/// A DID document is a key *set*, not a positional one-key container. `id` is
+/// the verification-method identifier that names this candidate. A hybrid
+/// candidate carries the ML-DSA key explicitly paired with this Ed25519 key;
+/// it is never formed by pairing unrelated entries based on document order.
 #[derive(Clone)]
-pub struct IdentityKeys {
-    /// The classical Ed25519 verifying key, if the identity published one.
-    pub ed25519: Option<Ed25519Vk>,
-    /// The bound ML-DSA-65 verifying key, if the identity published a PQ anchor.
+pub struct IdentityKeyCandidate {
+    /// Stable DID verification-method identifier.
+    pub id: String,
+    /// The candidate's classical Ed25519 verifying key.
+    pub ed25519: Ed25519Vk,
+    /// The ML-DSA-65 key explicitly bound to this candidate, when published.
     pub ml_dsa_65: Option<MlDsaVk>,
-    /// The assurance the resolver established for this identity (crypto-derived).
-    pub assurance: Assurance,
+}
+
+impl IdentityKeyCandidate {
+    /// Crypto-derived assurance for this one candidate.
+    pub fn assurance(&self) -> Assurance {
+        if self.ml_dsa_65.is_some() {
+            Assurance::PqHybrid
+        } else {
+            Assurance::Classical
+        }
+    }
+}
+
+/// The named verification-key candidates a resolver returns for an identity.
+///
+/// Consumers must select a candidate using a protocol-provided key identifier
+/// or verified signer, and must never use document order to choose authority.
+/// `did:key` is represented as a one-candidate set because its one-key wire
+/// format is intentional and self-certifying.
+#[derive(Clone, Default)]
+pub struct IdentityKeys {
+    pub candidates: Vec<IdentityKeyCandidate>,
+}
+
+impl IdentityKeys {
+    /// Return the named candidate whose Ed25519 key authenticated the peer.
+    pub fn candidate_for_ed25519(&self, key: &Ed25519Vk) -> Option<&IdentityKeyCandidate> {
+        let mut matches = self
+            .candidates
+            .iter()
+            .filter(|candidate| &candidate.ed25519 == key);
+        let candidate = matches.next()?;
+        // Duplicate named candidates for one signer are ambiguous: accepting an
+        // arbitrary one could attach a different hybrid binding.
+        matches.next().is_none().then_some(candidate)
+    }
+
+    /// Construct the intentional single-key `did:key` representation.
+    pub fn single_ed25519(id: impl Into<String>, ed25519: Ed25519Vk) -> Self {
+        Self {
+            candidates: vec![IdentityKeyCandidate {
+                id: id.into(),
+                ed25519,
+                ml_dsa_65: None,
+            }],
+        }
+    }
 }
 
 /// Resolves a `Did` to its verified key material.

--- a/crates/hyprstream-rpc/src/identity.rs
+++ b/crates/hyprstream-rpc/src/identity.rs
@@ -301,10 +301,29 @@ impl IdentityKeyCandidate {
 /// format is intentional and self-certifying.
 #[derive(Clone, Default)]
 pub struct IdentityKeys {
-    pub candidates: Vec<IdentityKeyCandidate>,
+    candidates: Vec<IdentityKeyCandidate>,
 }
 
 impl IdentityKeys {
+    /// Construct a named candidate set.
+    ///
+    /// The collection stays private so authority cannot accidentally be chosen
+    /// with `.first()` or an index. Callers must use a protocol selector such as
+    /// [`Self::candidate_for_ed25519`].
+    pub fn new(candidates: Vec<IdentityKeyCandidate>) -> Self {
+        Self { candidates }
+    }
+
+    /// Number of published candidates, for diagnostics and set-cardinality tests.
+    pub fn len(&self) -> usize {
+        self.candidates.len()
+    }
+
+    /// Whether the identity published no usable candidate.
+    pub fn is_empty(&self) -> bool {
+        self.candidates.is_empty()
+    }
+
     /// Return the named candidate whose Ed25519 key authenticated the peer.
     pub fn candidate_for_ed25519(&self, key: &Ed25519Vk) -> Option<&IdentityKeyCandidate> {
         let mut matches = self
@@ -312,20 +331,31 @@ impl IdentityKeys {
             .iter()
             .filter(|candidate| &candidate.ed25519 == key);
         let candidate = matches.next()?;
-        // Duplicate named candidates for one signer are ambiguous: accepting an
-        // arbitrary one could attach a different hybrid binding.
-        matches.next().is_none().then_some(candidate)
+        let binding = candidate
+            .ml_dsa_65
+            .as_ref()
+            .map(crate::crypto::pq::ml_dsa_vk_bytes);
+        // Compatibility aliases for the same signer are safe only when every
+        // alias carries the same hybrid binding. Differing bindings remain
+        // ambiguous and fail closed.
+        matches
+            .all(|other| {
+                other
+                    .ml_dsa_65
+                    .as_ref()
+                    .map(crate::crypto::pq::ml_dsa_vk_bytes)
+                    == binding
+            })
+            .then_some(candidate)
     }
 
     /// Construct the intentional single-key `did:key` representation.
     pub fn single_ed25519(id: impl Into<String>, ed25519: Ed25519Vk) -> Self {
-        Self {
-            candidates: vec![IdentityKeyCandidate {
-                id: id.into(),
-                ed25519,
-                ml_dsa_65: None,
-            }],
-        }
+        Self::new(vec![IdentityKeyCandidate {
+            id: id.into(),
+            ed25519,
+            ml_dsa_65: None,
+        }])
     }
 }
 

--- a/crates/hyprstream-rpc/src/identity_resolver.rs
+++ b/crates/hyprstream-rpc/src/identity_resolver.rs
@@ -17,11 +17,10 @@
 //! the DID method:
 //!
 //! - **`did:web`** — resolve the DID document and extract its verification
-//!   methods. An Ed25519 identity VM (for example `#mesh`) is the classical anchor; a
-//!   verified ML-DSA-65 VM (`#mesh-pq`, multicodec `0x1211`) is the PQ anchor.
-//!   Both present ⇒ [`Assurance::PqHybrid`] (a did:web we operate); Ed25519-only ⇒
-//!   [`Assurance::Classical`] (a third-party did:web). No Ed25519 VM ⇒ nothing to
-//!   bind ⇒ `Err` (fail-closed).
+//!   methods. An Ed25519 identity VM (for example `#mesh`) is the classical anchor;
+//!   its explicitly named ML-DSA-65 companion (`#mesh-pq`, multicodec `0x1211`)
+//!   makes that candidate [`Assurance::PqHybrid`]. Other candidates remain
+//!   [`Assurance::Classical`]. No Ed25519 VM ⇒ nothing to bind ⇒ `Err` (fail-closed).
 //! - **`did:key`** — a single Ed25519 key decoded from the DID string itself; no
 //!   fetch. A single classical key can never be hybrid, so the honest ceiling is
 //!   [`Assurance::Classical`].
@@ -56,12 +55,11 @@ use std::sync::Arc;
 use anyhow::{anyhow, Result};
 use serde_json::Value;
 
-use crate::auth::mac::Assurance;
+use crate::crypto::pq::{ml_dsa_vk_from_bytes, MlDsaVerifyingKey};
 use crate::did_web::{
-    did_key_to_ed25519, verification_method_ed25519_keys, verification_method_ml_dsa_65_keys,
+    decode_ed25519_multikey, decode_multikey, did_key_to_ed25519, MULTICODEC_ML_DSA_65_PUB,
 };
-use crate::crypto::pq::MlDsaVerifyingKey;
-use crate::identity::{Did, IdentityKeys, IdentityResolver};
+use crate::identity::{Did, IdentityKeyCandidate, IdentityKeys, IdentityResolver};
 
 /// A synchronous DID-document provider for the did:web arm.
 ///
@@ -229,7 +227,9 @@ pub trait At9pCapsuleResolver: Send + Sync {
     /// (admission path). Pure over the bytes — no fetch, no I/O.
     fn verify_bytes(&self, did: &str, capsule_bytes: &[u8]) -> Result<VerifiedAt9pKeys> {
         let _ = (did, capsule_bytes);
-        Err(anyhow!("at9p capsule-byte verification is not configured (fail-closed)"))
+        Err(anyhow!(
+            "at9p capsule-byte verification is not configured (fail-closed)"
+        ))
     }
 
     /// Fetch the capsule for `did` from the untrusted locator and GATE-verify it
@@ -237,7 +237,9 @@ pub trait At9pCapsuleResolver: Send + Sync {
     /// honest implementation returns `Err`.
     fn resolve(&self, did: &str) -> Result<VerifiedAt9pKeys> {
         let _ = did;
-        Err(anyhow!("at9p capsule resolution (locator fetch) is not configured (fail-closed)"))
+        Err(anyhow!(
+            "at9p capsule resolution (locator fetch) is not configured (fail-closed)"
+        ))
     }
 }
 
@@ -267,8 +269,9 @@ impl<P: DidDocumentProvider> MethodDispatchResolver<P> {
 
     /// The did:web arm: resolve the document and derive key material + assurance.
     ///
-    /// - Ed25519 VM present + ML-DSA-65 VM present ⇒ `PqHybrid`.
-    /// - Ed25519 VM present, no ML-DSA-65 VM ⇒ `Classical`.
+    /// Each usable Ed25519 VM becomes a named candidate. A same-name `-pq` VM
+    /// explicitly upgrades only that candidate to `PqHybrid`; unrelated PQ VMs
+    /// are never paired by document order.
     /// - No Ed25519 VM ⇒ `Err` (fail-closed: nothing to anchor).
     ///
     /// # Assurance quality — the at9p asymmetry
@@ -279,12 +282,10 @@ impl<P: DidDocumentProvider> MethodDispatchResolver<P> {
     /// document**, not on a content-binding between the two keys. Two caveats
     /// follow, consistent with the ratified #579/D1 "did:web we operate" model:
     ///
-    /// - **Arbitrary pairing when multiple VMs exist:** the first Ed25519 VM and
-    ///   the first ML-DSA-65 VM in the document are paired. If a document carries
-    ///   several of either, which two get bound is incidental to document order,
-    ///   not cryptographic. (Operated nodes publish one of each, so this is a
-    ///   document-shape concern for third-party docs, not a live risk for nodes we
-    ///   run.)
+    /// - **Named pairing:** an Ed25519 VM `#mesh-old` may be paired only with
+    ///   the explicitly named ML-DSA-65 VM `#mesh-old-pq`. This gives each
+    ///   overlap slot an independent hybrid binding; a PQ VM with no matching
+    ///   Ed25519 VM is ignored rather than attached to an arbitrary key.
     /// - **No content binding:** the document attests both keys, but nothing in the
     ///   TLS fetch proves the Ed25519 and ML-DSA-65 keys belong to the same
     ///   principal beyond the document's own say-so. The at9p capsule proves this
@@ -295,21 +296,11 @@ impl<P: DidDocumentProvider> MethodDispatchResolver<P> {
             .document(did.as_str())
             .map_err(|e| anyhow!("did:web {did} document did not resolve: {e}"))?;
 
-        // First Ed25519 VM is the classical application-signing anchor.
-        // A did:web with no Ed25519 VM cannot be bound (the PQ trust store is
-        // keyed BY the Ed25519 identity), so fail closed.
-        let ed25519 = verification_method_ed25519_keys(&doc).into_iter().next().ok_or_else(|| {
-            anyhow!("did:web {did}: no Ed25519 verificationMethod to anchor — fail-closed")
-        })?;
-
-        // A verified ML-DSA-65 VM (`#mesh-pq`) upgrades the edge to PqHybrid; its
-        // absence is the ordinary classical case, not an error.
-        let ml_dsa_65 = verification_method_ml_dsa_65_keys(&doc).into_iter().next();
-
-        let assurance =
-            if ml_dsa_65.is_some() { Assurance::PqHybrid } else { Assurance::Classical };
-
-        Ok(IdentityKeys { ed25519: Some(ed25519), ml_dsa_65, assurance })
+        let candidates = did_web_key_candidates(&doc);
+        if candidates.is_empty() {
+            anyhow::bail!("did:web {did}: no Ed25519 verificationMethod to anchor — fail-closed");
+        }
+        Ok(IdentityKeys { candidates })
     }
 
     /// The did:key arm: a single self-certifying Ed25519 key, no fetch.
@@ -319,11 +310,7 @@ impl<P: DidDocumentProvider> MethodDispatchResolver<P> {
     fn resolve_did_key(&self, did: &Did) -> Result<IdentityKeys> {
         let ed25519 = did_key_to_ed25519(did.as_str())
             .map_err(|e| anyhow!("did:key {did} is not a valid Ed25519 identity: {e}"))?;
-        Ok(IdentityKeys {
-            ed25519: Some(ed25519),
-            ml_dsa_65: None,
-            assurance: Assurance::Classical,
-        })
+        Ok(IdentityKeys::single_ed25519(did.as_str(), ed25519))
     }
 
     /// The did:at9p arm (#894, D2): GATE-verify the capsule and derive `PqHybrid`.
@@ -338,16 +325,8 @@ impl<P: DidDocumentProvider> MethodDispatchResolver<P> {
     /// # Set semantics (#1188 / #1183)
     ///
     /// The capsule publishes a *set* of subject keys so overlap rotation and
-    /// PQ-hybrid rollout work. The scalar [`IdentityKeys`] this arm returns is
-    /// the anonymous *resolve* path — no application-signer selector is supplied,
-    /// so there is no key id/relationship to select by. Per the durable rule
-    /// (#1183: "when no selector exists, try each compatible candidate or reject
-    /// ambiguity"), a single published key is projected unambiguously, while a
-    /// multi-key set has no non-positional way to pick one here and fails closed
-    /// rather than silently taking `keys[0]`. Selection *by application signer*
-    /// (the admission path) handles the overlap set correctly via
-    /// [`VerifiedAt9pKeys::for_ed25519`]; teaching this scalar arm to carry the
-    /// whole set is the separately-tracked identity-resolver work (#1187).
+    /// PQ-hybrid rollout work. Every content-verified pair becomes a candidate;
+    /// callers select by the admitted Ed25519 signer, never by capsule position.
     fn resolve_did_at9p(&self, did: &Did) -> Result<IdentityKeys> {
         let at9p = self.at9p.as_ref().ok_or_else(|| {
             anyhow!("did:at9p {did}: no capsule resolver configured — fail-closed")
@@ -355,22 +334,89 @@ impl<P: DidDocumentProvider> MethodDispatchResolver<P> {
         let verified = at9p
             .resolve(did.as_str())
             .map_err(|e| anyhow!("did:at9p {did}: capsule GATE failed: {e}"))?;
-        let keys = verified.keys();
-        if keys.len() != 1 {
-            return Err(anyhow!(
-                "did:at9p {did}: capsule publishes {} subject keys; the anonymous \
-                 resolve path has no selector to choose one non-positionally — \
-                 fail-closed (set-aware identity resolution is #1187)",
-                keys.len()
-            ));
-        }
-        let key = &keys[0];
         Ok(IdentityKeys {
-            ed25519: Some(*key.ed25519()),
-            ml_dsa_65: Some(key.ml_dsa_65().clone()),
-            assurance: Assurance::PqHybrid,
+            candidates: verified
+                .keys()
+                .iter()
+                .map(|key| IdentityKeyCandidate {
+                    id: format!(
+                        "{}#subject-{}",
+                        did.as_str(),
+                        bs58::encode(key.ed25519()).into_string()
+                    ),
+                    ed25519: *key.ed25519(),
+                    ml_dsa_65: Some(key.ml_dsa_65().clone()),
+                })
+                .collect(),
         })
     }
+}
+
+/// Decode the named DID verification-method set into compatible candidates.
+///
+/// DID VM ids are the selector. An Ed25519 VM `id` is upgraded only by an
+/// ML-DSA-65 VM whose id is `"{id}-pq"`; this is the mesh's stable, explicit
+/// hybrid binding convention (`#mesh` ↔ `#mesh-pq`). The function deliberately
+/// does not expose a positional selection API: callers receive every usable
+/// candidate and choose using a verified signer or another protocol selector.
+fn did_web_key_candidates(doc: &Value) -> Vec<IdentityKeyCandidate> {
+    let Some(vms) = doc.get("verificationMethod").and_then(Value::as_array) else {
+        return Vec::new();
+    };
+
+    // `authentication` names the VMs authorized to authenticate this DID when
+    // the document provides that relationship. Older/minimal DID documents may
+    // omit it, in which case `verificationMethod` remains the available key set.
+    let authentication = doc
+        .get("authentication")
+        .and_then(Value::as_array)
+        .map(|methods| {
+            methods
+                .iter()
+                .filter_map(Value::as_str)
+                .collect::<std::collections::HashSet<_>>()
+        });
+
+    let mut ed25519 = Vec::new();
+    let mut ml_dsa_65 = std::collections::HashMap::new();
+    for vm in vms {
+        let (Some(id), Some(multibase)) = (
+            vm.get("id").and_then(Value::as_str),
+            vm.get("publicKeyMultibase").and_then(Value::as_str),
+        ) else {
+            continue;
+        };
+        if authentication.as_ref().is_some_and(|ids| !ids.contains(id)) {
+            continue;
+        }
+        if let Ok(key) = decode_ed25519_multikey(multibase) {
+            ed25519.push((id.to_owned(), key));
+            continue;
+        }
+        let Ok(raw) = decode_multikey(multibase, &MULTICODEC_ML_DSA_65_PUB) else {
+            continue;
+        };
+        match ml_dsa_vk_from_bytes(&raw) {
+            Ok(key) => {
+                ml_dsa_65.insert(id.to_owned(), key);
+            }
+            Err(error) => {
+                tracing::debug!(%error, verification_method = %id, "skipping invalid ML-DSA-65 DID verification method");
+            }
+        }
+    }
+
+    ed25519
+        .into_iter()
+        .map(|(id, ed25519)| {
+            let pq_id = format!("{id}-pq");
+            IdentityKeyCandidate {
+                id,
+                ed25519,
+                ml_dsa_65: ml_dsa_65.remove(&pq_id),
+            }
+        })
+        .collect()
 }
 
 impl<P: DidDocumentProvider> IdentityResolver for MethodDispatchResolver<P> {
@@ -383,7 +429,9 @@ impl<P: DidDocumentProvider> IdentityResolver for MethodDispatchResolver<P> {
             self.resolve_did_at9p(did)
         } else {
             // Unknown DID method — fail closed (never a default-Unverified Ok).
-            Err(anyhow!("unsupported DID method for {did}: no resolver arm — fail-closed"))
+            Err(anyhow!(
+                "unsupported DID method for {did}: no resolver arm — fail-closed"
+            ))
         }
     }
 }
@@ -392,7 +440,8 @@ impl<P: DidDocumentProvider> IdentityResolver for MethodDispatchResolver<P> {
 #[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {
     use super::*;
-    use crate::crypto::pq::{ml_dsa_sk_to_vk_bytes, ml_dsa_generate_keypair, ml_dsa_vk_bytes};
+    use crate::auth::mac::Assurance;
+    use crate::crypto::pq::{ml_dsa_generate_keypair, ml_dsa_sk_to_vk_bytes, ml_dsa_vk_bytes};
     use crate::did_key::{ed25519_to_did_key, MULTICODEC_ED25519_PUB, MULTICODEC_ML_DSA_65_PUB};
     use ed25519_dalek::SigningKey;
     use rand::rngs::OsRng;
@@ -412,20 +461,70 @@ mod tests {
     /// A DID document with an Ed25519 `#mesh` VM and, optionally, an ML-DSA-65
     /// `#mesh-pq` VM.
     fn did_doc(ed: &[u8; 32], ml_dsa_vk_bytes: Option<&[u8]>) -> Value {
-        let mut vms = vec![json!({
-            "id": "did:web:peer.example#mesh",
-            "type": "Multikey",
-            "controller": "did:web:peer.example",
-            "publicKeyMultibase": encode_multikey(ed, MULTICODEC_ED25519_PUB),
-        })];
-        if let Some(pq) = ml_dsa_vk_bytes {
+        did_doc_with_named_vms(&[("mesh", ed)], ml_dsa_vk_bytes.map(|pq| ("mesh-pq", pq)))
+    }
+
+    fn did_doc_with_named_vms(
+        ed25519: &[(&str, &[u8; 32])],
+        ml_dsa_65: Option<(&str, &[u8])>,
+    ) -> Value {
+        let mut vms = Vec::with_capacity(ed25519.len() + usize::from(ml_dsa_65.is_some()));
+        for (name, key) in ed25519 {
             vms.push(json!({
-                "id": "did:web:peer.example#mesh-pq",
+                "id": format!("{DID_WEB}#{name}"),
                 "type": "Multikey",
-                "controller": "did:web:peer.example",
-                "publicKeyMultibase": encode_multikey(pq, MULTICODEC_ML_DSA_65_PUB),
+                "controller": DID_WEB,
+                "publicKeyMultibase": encode_multikey(*key, MULTICODEC_ED25519_PUB),
             }));
         }
+        if let Some((name, key)) = ml_dsa_65 {
+            vms.push(json!({
+                "id": format!("{DID_WEB}#{name}"),
+                "type": "Multikey",
+                "controller": DID_WEB,
+                "publicKeyMultibase": encode_multikey(key, MULTICODEC_ML_DSA_65_PUB),
+            }));
+        }
+        json!({
+            "@context": ["https://www.w3.org/ns/did/v1"],
+            "id": DID_WEB,
+            "verificationMethod": vms,
+            "service": [],
+        })
+    }
+
+    fn did_doc_with_two_hybrid_pairs(
+        old_ed: &[u8; 32],
+        old_pq: &[u8],
+        new_ed: &[u8; 32],
+        new_pq: &[u8],
+    ) -> Value {
+        let vms = vec![
+            json!({
+                "id": "did:web:peer.example#mesh-old",
+                "type": "Multikey",
+                "controller": "did:web:peer.example",
+                "publicKeyMultibase": encode_multikey(old_ed, MULTICODEC_ED25519_PUB),
+            }),
+            json!({
+                "id": "did:web:peer.example#mesh-old-pq",
+                "type": "Multikey",
+                "controller": "did:web:peer.example",
+                "publicKeyMultibase": encode_multikey(old_pq, MULTICODEC_ML_DSA_65_PUB),
+            }),
+            json!({
+                "id": "did:web:peer.example#mesh-new",
+                "type": "Multikey",
+                "controller": "did:web:peer.example",
+                "publicKeyMultibase": encode_multikey(new_ed, MULTICODEC_ED25519_PUB),
+            }),
+            json!({
+                "id": "did:web:peer.example#mesh-new-pq",
+                    "type": "Multikey",
+                    "controller": "did:web:peer.example",
+                "publicKeyMultibase": encode_multikey(new_pq, MULTICODEC_ML_DSA_65_PUB),
+            }),
+        ];
         json!({
             "@context": ["https://www.w3.org/ns/did/v1"],
             "id": "did:web:peer.example",
@@ -439,6 +538,23 @@ mod tests {
     impl DidDocumentProvider for FixtureDocs {
         fn document(&self, _did: &str) -> Result<Value> {
             Ok(self.0.clone())
+        }
+    }
+
+    #[derive(Clone)]
+    struct RotatingDocs(std::sync::Arc<parking_lot::Mutex<Value>>);
+    impl RotatingDocs {
+        fn new(document: Value) -> Self {
+            Self(std::sync::Arc::new(parking_lot::Mutex::new(document)))
+        }
+
+        fn publish(&self, document: Value) {
+            *self.0.lock() = document;
+        }
+    }
+    impl DidDocumentProvider for RotatingDocs {
+        fn document(&self, _did: &str) -> Result<Value> {
+            Ok(self.0.lock().clone())
         }
     }
 
@@ -467,9 +583,11 @@ mod tests {
         let keys = resolver
             .resolve_identity_keys(&Did::new(DID_WEB.to_owned()))
             .expect("ed25519-only did:web resolves");
-        assert_eq!(keys.assurance, Assurance::Classical);
-        assert_eq!(keys.ed25519, Some(ed));
-        assert!(keys.ml_dsa_65.is_none());
+        let candidate = keys
+            .candidate_for_ed25519(&ed)
+            .expect("published candidate");
+        assert_eq!(candidate.assurance(), Assurance::Classical);
+        assert!(candidate.ml_dsa_65.is_none());
     }
 
     #[test]
@@ -481,11 +599,13 @@ mod tests {
         let keys = resolver
             .resolve_identity_keys(&Did::new(DID_WEB.to_owned()))
             .expect("hybrid did:web resolves");
-        assert_eq!(keys.assurance, Assurance::PqHybrid);
-        assert_eq!(keys.ed25519, Some(ed));
+        let candidate = keys
+            .candidate_for_ed25519(&ed)
+            .expect("published candidate");
+        assert_eq!(candidate.assurance(), Assurance::PqHybrid);
         // The resolved PQ key is exactly the published one.
-        let resolved = keys.ml_dsa_65.expect("PQ anchor present");
-        assert_eq!(ml_dsa_vk_bytes(&resolved), pq_bytes);
+        let resolved = candidate.ml_dsa_65.as_ref().expect("PQ anchor present");
+        assert_eq!(ml_dsa_vk_bytes(resolved), pq_bytes);
     }
 
     #[test]
@@ -500,8 +620,74 @@ mod tests {
         let keys = resolver
             .resolve_identity_keys(&Did::new(DID_WEB.to_owned()))
             .expect("hybrid did:web resolves");
-        assert_eq!(keys.assurance, Assurance::PqHybrid);
-        assert_eq!(ml_dsa_vk_bytes(&keys.ml_dsa_65.unwrap()), pq_bytes);
+        let candidate = keys
+            .candidate_for_ed25519(&ed)
+            .expect("published candidate");
+        assert_eq!(candidate.assurance(), Assurance::PqHybrid);
+        assert_eq!(
+            ml_dsa_vk_bytes(candidate.ml_dsa_65.as_ref().unwrap()),
+            pq_bytes
+        );
+    }
+
+    #[test]
+    fn did_web_classical_overlap_accepts_both_then_rejects_retired_key_after_drain_window() {
+        let old = rand_ed25519();
+        let new = rand_ed25519();
+        let docs = RotatingDocs::new(did_doc_with_named_vms(
+            &[("mesh-old", &old), ("mesh-new", &new)],
+            None,
+        ));
+        let resolver = MethodDispatchResolver::new(docs.clone());
+
+        let overlap = resolver
+            .resolve_identity_keys(&Did::new(DID_WEB.to_owned()))
+            .expect("overlap document resolves");
+        assert_eq!(overlap.candidates.len(), 2);
+        assert_eq!(
+            overlap.candidate_for_ed25519(&old).unwrap().id,
+            format!("{DID_WEB}#mesh-old")
+        );
+        assert_eq!(
+            overlap.candidate_for_ed25519(&new).unwrap().id,
+            format!("{DID_WEB}#mesh-new")
+        );
+
+        // The old VM remains usable for the bounded drain window, then the
+        // publisher removes it. A fresh resolution must no longer accept it.
+        docs.publish(did_doc_with_named_vms(&[("mesh-new", &new)], None));
+        let after_drain = resolver
+            .resolve_identity_keys(&Did::new(DID_WEB.to_owned()))
+            .expect("post-drain document resolves");
+        assert!(after_drain.candidate_for_ed25519(&old).is_none());
+        assert!(after_drain.candidate_for_ed25519(&new).is_some());
+    }
+
+    #[test]
+    fn did_web_two_hybrid_pairs_remain_independent_overlap_candidates() {
+        let old_ed = rand_ed25519();
+        let new_ed = rand_ed25519();
+        let (_, old_pq) = ml_dsa_generate_keypair();
+        let (_, new_pq) = ml_dsa_generate_keypair();
+        let old_pq = ml_dsa_vk_bytes(&old_pq);
+        let new_pq = ml_dsa_vk_bytes(&new_pq);
+        let resolver = MethodDispatchResolver::new(FixtureDocs(did_doc_with_two_hybrid_pairs(
+            &old_ed, &old_pq, &new_ed, &new_pq,
+        )));
+
+        let keys = resolver
+            .resolve_identity_keys(&Did::new(DID_WEB.to_owned()))
+            .expect("hybrid overlap document resolves");
+        let old = keys
+            .candidate_for_ed25519(&old_ed)
+            .expect("old hybrid candidate");
+        let new = keys
+            .candidate_for_ed25519(&new_ed)
+            .expect("new hybrid candidate");
+        assert_eq!(old.assurance(), Assurance::PqHybrid);
+        assert_eq!(new.assurance(), Assurance::PqHybrid);
+        assert_eq!(ml_dsa_vk_bytes(old.ml_dsa_65.as_ref().unwrap()), old_pq);
+        assert_eq!(ml_dsa_vk_bytes(new.ml_dsa_65.as_ref().unwrap()), new_pq);
     }
 
     #[test]
@@ -516,20 +702,26 @@ mod tests {
             }],
         });
         let resolver = MethodDispatchResolver::new(FixtureDocs(doc));
-        assert!(resolver.resolve_identity_keys(&Did::new(DID_WEB.to_owned())).is_err());
+        assert!(resolver
+            .resolve_identity_keys(&Did::new(DID_WEB.to_owned()))
+            .is_err());
     }
 
     #[test]
     fn did_web_empty_doc_fails_closed() {
         let doc = json!({ "id": DID_WEB, "verificationMethod": [] });
         let resolver = MethodDispatchResolver::new(FixtureDocs(doc));
-        assert!(resolver.resolve_identity_keys(&Did::new(DID_WEB.to_owned())).is_err());
+        assert!(resolver
+            .resolve_identity_keys(&Did::new(DID_WEB.to_owned()))
+            .is_err());
     }
 
     #[test]
     fn did_web_fetch_failure_fails_closed() {
         let resolver = MethodDispatchResolver::new(FailingDocs);
-        assert!(resolver.resolve_identity_keys(&Did::new(DID_WEB.to_owned())).is_err());
+        assert!(resolver
+            .resolve_identity_keys(&Did::new(DID_WEB.to_owned()))
+            .is_err());
     }
 
     #[test]
@@ -540,9 +732,9 @@ mod tests {
         let keys = resolver
             .resolve_identity_keys(&Did::new(did))
             .expect("did:key resolves without fetch");
-        assert_eq!(keys.assurance, Assurance::Classical);
-        assert_eq!(keys.ed25519, Some(ed));
-        assert!(keys.ml_dsa_65.is_none());
+        let candidate = keys.candidate_for_ed25519(&ed).expect("did:key candidate");
+        assert_eq!(candidate.assurance(), Assurance::Classical);
+        assert!(candidate.ml_dsa_65.is_none());
     }
 
     #[test]
@@ -607,18 +799,25 @@ mod tests {
         // A GATE-verified capsule yields PqHybrid assurance, carrying the
         // capsule's own Ed25519 + ML-DSA-65 keys (crypto-derived, not asserted).
         let keys = verified_keys();
-        let fixture = Arc::new(FixtureCapsule { keys: keys.clone(), calls: Mutex::new(vec![]), fail: false });
+        let fixture = Arc::new(FixtureCapsule {
+            keys: keys.clone(),
+            calls: Mutex::new(vec![]),
+            fail: false,
+        });
         let resolver = MethodDispatchResolver::new(NeverDocs).with_at9p(fixture.clone());
         let did = Did::new("did:at9p:cid512abcdef".to_owned());
         let resolved = resolver
             .resolve_identity_keys(&did)
             .expect("verified capsule resolves at PqHybrid");
-        assert_eq!(resolved.assurance, Assurance::PqHybrid);
-        // Single-key capsule → the resolve path projects that one key
-        // unambiguously (set semantics, #1188).
         let only = &keys.keys()[0];
-        assert_eq!(resolved.ed25519, Some(*only.ed25519()));
-        assert_eq!(ml_dsa_vk_bytes(&resolved.ml_dsa_65.unwrap()), ml_dsa_vk_bytes(only.ml_dsa_65()));
+        let candidate = resolved
+            .candidate_for_ed25519(only.ed25519())
+            .expect("capsule candidate");
+        assert_eq!(candidate.assurance(), Assurance::PqHybrid);
+        assert_eq!(
+            ml_dsa_vk_bytes(candidate.ml_dsa_65.as_ref().unwrap()),
+            ml_dsa_vk_bytes(only.ml_dsa_65())
+        );
         // The arm routed through the capsule resolver exactly once.
         assert_eq!(fixture.calls.lock().as_slice(), &["did:at9p:cid512abcdef"]);
     }
@@ -648,11 +847,12 @@ mod tests {
             fail: false,
         });
         let ed = rand_ed25519();
-        let resolver = MethodDispatchResolver::new(FixtureDocs(did_doc(&ed, None))).with_at9p(fixture);
+        let resolver =
+            MethodDispatchResolver::new(FixtureDocs(did_doc(&ed, None))).with_at9p(fixture);
         let keys = resolver
             .resolve_identity_keys(&Did::new(DID_WEB.to_owned()))
             .expect("did:web resolves");
-        assert_eq!(keys.assurance, Assurance::Classical);
+        assert_eq!(keys.candidates[0].assurance(), Assurance::Classical);
     }
 
     #[test]

--- a/crates/hyprstream-rpc/src/identity_resolver.rs
+++ b/crates/hyprstream-rpc/src/identity_resolver.rs
@@ -52,12 +52,12 @@
 
 use std::sync::Arc;
 
-use anyhow::{anyhow, Result};
+use anyhow::{Result, anyhow};
 use serde_json::Value;
 
-use crate::crypto::pq::{ml_dsa_vk_from_bytes, MlDsaVerifyingKey};
+use crate::crypto::pq::{MlDsaVerifyingKey, ml_dsa_vk_from_bytes};
 use crate::did_web::{
-    decode_ed25519_multikey, decode_multikey, did_key_to_ed25519, MULTICODEC_ML_DSA_65_PUB,
+    MULTICODEC_ML_DSA_65_PUB, decode_ed25519_multikey, decode_multikey, did_key_to_ed25519,
 };
 use crate::identity::{Did, IdentityKeyCandidate, IdentityKeys, IdentityResolver};
 
@@ -252,12 +252,30 @@ pub trait At9pCapsuleResolver: Send + Sync {
 pub struct MethodDispatchResolver<P: DidDocumentProvider> {
     docs: P,
     at9p: Option<Arc<dyn At9pCapsuleResolver>>,
+    now: Arc<dyn Fn() -> i64 + Send + Sync>,
 }
 
 impl<P: DidDocumentProvider> MethodDispatchResolver<P> {
     /// Construct a resolver over a DID-document provider.
     pub fn new(docs: P) -> Self {
-        Self { docs, at9p: None }
+        Self {
+            docs,
+            at9p: None,
+            now: Arc::new(|| {
+                std::time::SystemTime::now()
+                    .duration_since(std::time::UNIX_EPOCH)
+                    .map_or(0, |duration| duration.as_secs() as i64)
+            }),
+        }
+    }
+
+    /// Override the wall clock used to enforce bounded DID verification methods.
+    ///
+    /// Production uses Unix time. Tests and embedders can inject a deterministic
+    /// clock to prove overlap and retirement behavior without sleeping.
+    pub fn with_clock(mut self, now: impl Fn() -> i64 + Send + Sync + 'static) -> Self {
+        self.now = Arc::new(now);
+        self
     }
 
     /// Attach the `did:at9p` capsule resolver (D2/#894). Without it a `did:at9p`
@@ -296,11 +314,11 @@ impl<P: DidDocumentProvider> MethodDispatchResolver<P> {
             .document(did.as_str())
             .map_err(|e| anyhow!("did:web {did} document did not resolve: {e}"))?;
 
-        let candidates = did_web_key_candidates(&doc);
+        let candidates = did_web_key_candidates(&doc, (self.now)());
         if candidates.is_empty() {
             anyhow::bail!("did:web {did}: no Ed25519 verificationMethod to anchor — fail-closed");
         }
-        Ok(IdentityKeys { candidates })
+        Ok(IdentityKeys::new(candidates))
     }
 
     /// The did:key arm: a single self-certifying Ed25519 key, no fetch.
@@ -334,8 +352,8 @@ impl<P: DidDocumentProvider> MethodDispatchResolver<P> {
         let verified = at9p
             .resolve(did.as_str())
             .map_err(|e| anyhow!("did:at9p {did}: capsule GATE failed: {e}"))?;
-        Ok(IdentityKeys {
-            candidates: verified
+        Ok(IdentityKeys::new(
+            verified
                 .keys()
                 .iter()
                 .map(|key| IdentityKeyCandidate {
@@ -348,7 +366,7 @@ impl<P: DidDocumentProvider> MethodDispatchResolver<P> {
                     ml_dsa_65: Some(key.ml_dsa_65().clone()),
                 })
                 .collect(),
-        })
+        ))
     }
 }
 
@@ -359,23 +377,10 @@ impl<P: DidDocumentProvider> MethodDispatchResolver<P> {
 /// hybrid binding convention (`#mesh` ↔ `#mesh-pq`). The function deliberately
 /// does not expose a positional selection API: callers receive every usable
 /// candidate and choose using a verified signer or another protocol selector.
-fn did_web_key_candidates(doc: &Value) -> Vec<IdentityKeyCandidate> {
+fn did_web_key_candidates(doc: &Value, now: i64) -> Vec<IdentityKeyCandidate> {
     let Some(vms) = doc.get("verificationMethod").and_then(Value::as_array) else {
         return Vec::new();
     };
-
-    // `authentication` names the VMs authorized to authenticate this DID when
-    // the document provides that relationship. Older/minimal DID documents may
-    // omit it, in which case `verificationMethod` remains the available key set.
-    let authentication = doc
-        .get("authentication")
-        .and_then(Value::as_array)
-        .map(|methods| {
-            methods
-                .iter()
-                .filter_map(Value::as_str)
-                .collect::<std::collections::HashSet<_>>()
-        });
 
     let mut ed25519 = Vec::new();
     let mut ml_dsa_65 = std::collections::HashMap::new();
@@ -386,7 +391,7 @@ fn did_web_key_candidates(doc: &Value) -> Vec<IdentityKeyCandidate> {
         ) else {
             continue;
         };
-        if authentication.as_ref().is_some_and(|ids| !ids.contains(id)) {
+        if !verification_method_is_live(vm, now) {
             continue;
         }
         if let Ok(key) = decode_ed25519_multikey(multibase) {
@@ -406,17 +411,44 @@ fn did_web_key_candidates(doc: &Value) -> Vec<IdentityKeyCandidate> {
         }
     }
 
+    let legacy_pq_id = doc
+        .get("id")
+        .and_then(Value::as_str)
+        .map(|did| format!("{did}#mesh-pq"));
+    let legacy_singleton = ed25519.len() == 1 && ed25519[0].0.ends_with("#key-1");
+
     ed25519
         .into_iter()
         .map(|(id, ed25519)| {
             let pq_id = format!("{id}-pq");
+            let explicit = ml_dsa_65.remove(&pq_id);
+            // Rolling-upgrade bridge for the previously published singleton
+            // `#key-1` + `#mesh-pq` document. It is deliberately restricted to
+            // that exact one-Ed25519 legacy shape so an unrelated PQ method can
+            // never be attached in a multi-candidate document.
+            let legacy = legacy_singleton
+                .then_some(legacy_pq_id.as_ref())
+                .flatten()
+                .and_then(|legacy_id| ml_dsa_65.remove(legacy_id));
             IdentityKeyCandidate {
                 id,
                 ed25519,
-                ml_dsa_65: ml_dsa_65.remove(&pq_id),
+                ml_dsa_65: explicit.or(legacy),
             }
         })
         .collect()
+}
+
+fn verification_method_is_live(vm: &Value, now: i64) -> bool {
+    let not_before = match vm.get("nbf") {
+        None => true,
+        Some(value) => value.as_i64().is_some_and(|nbf| now >= nbf),
+    };
+    let not_expired = match vm.get("exp") {
+        None => true,
+        Some(value) => value.as_i64().is_some_and(|exp| now < exp),
+    };
+    not_before && not_expired
 }
 
 impl<P: DidDocumentProvider> IdentityResolver for MethodDispatchResolver<P> {
@@ -442,7 +474,7 @@ mod tests {
     use super::*;
     use crate::auth::mac::Assurance;
     use crate::crypto::pq::{ml_dsa_generate_keypair, ml_dsa_sk_to_vk_bytes, ml_dsa_vk_bytes};
-    use crate::did_key::{ed25519_to_did_key, MULTICODEC_ED25519_PUB, MULTICODEC_ML_DSA_65_PUB};
+    use crate::did_key::{MULTICODEC_ED25519_PUB, MULTICODEC_ML_DSA_65_PUB, ed25519_to_did_key};
     use ed25519_dalek::SigningKey;
     use rand::rngs::OsRng;
     use serde_json::json;
@@ -609,6 +641,75 @@ mod tests {
     }
 
     #[test]
+    fn legacy_key_1_mesh_pq_document_remains_hybrid_during_upgrade() {
+        let ed = rand_ed25519();
+        let (_, pq) = ml_dsa_generate_keypair();
+        let pq = ml_dsa_vk_bytes(&pq);
+        let doc = did_doc_with_named_vms(&[("key-1", &ed)], Some(("mesh-pq", &pq)));
+        let keys = MethodDispatchResolver::new(FixtureDocs(doc))
+            .resolve_identity_keys(&Did::new(DID_WEB.to_owned()))
+            .expect("legacy singleton resolves");
+        let candidate = keys
+            .candidate_for_ed25519(&ed)
+            .expect("legacy signer candidate");
+        assert_eq!(candidate.assurance(), Assurance::PqHybrid);
+        assert_eq!(ml_dsa_vk_bytes(candidate.ml_dsa_65.as_ref().unwrap()), pq);
+    }
+
+    #[test]
+    fn authentication_relationship_is_not_a_second_inconsistent_authority_parser() {
+        let ed = rand_ed25519();
+        let mut doc = did_doc(&ed, None);
+        // Admission and identity resolution both consume verificationMethod.
+        // A malformed, relative, or embedded relationship cannot disable or
+        // tighten a separate enrollment-only filter because no such filter is
+        // applied here.
+        for authentication in [
+            json!("bad"),
+            json!({}),
+            json!(["#mesh"]),
+            json!([{
+                "id": format!("{DID_WEB}#mesh"),
+                "type": "Multikey",
+                "controller": DID_WEB,
+                "publicKeyMultibase": encode_multikey(&ed, MULTICODEC_ED25519_PUB),
+            }]),
+        ] {
+            doc["authentication"] = authentication;
+            let keys = MethodDispatchResolver::new(FixtureDocs(doc.clone()))
+                .resolve_identity_keys(&Did::new(DID_WEB.to_owned()))
+                .expect("verificationMethod remains authoritative");
+            assert!(keys.candidate_for_ed25519(&ed).is_some());
+        }
+    }
+
+    #[test]
+    fn bounded_verification_methods_follow_the_injected_clock() {
+        let old = rand_ed25519();
+        let new = rand_ed25519();
+        let mut doc = did_doc_with_named_vms(&[("mesh-old", &old), ("mesh-new", &new)], None);
+        let vms = doc["verificationMethod"].as_array_mut().unwrap();
+        vms[0]["nbf"] = json!(100);
+        vms[0]["exp"] = json!(200);
+        vms[1]["nbf"] = json!(150);
+        vms[1]["exp"] = json!(300);
+
+        let now = Arc::new(std::sync::atomic::AtomicI64::new(175));
+        let clock = Arc::clone(&now);
+        let resolver = MethodDispatchResolver::new(FixtureDocs(doc))
+            .with_clock(move || clock.load(std::sync::atomic::Ordering::SeqCst));
+        let did = Did::new(DID_WEB.to_owned());
+        let overlap = resolver.resolve_identity_keys(&did).unwrap();
+        assert!(overlap.candidate_for_ed25519(&old).is_some());
+        assert!(overlap.candidate_for_ed25519(&new).is_some());
+
+        now.store(200, std::sync::atomic::Ordering::SeqCst);
+        let retired = resolver.resolve_identity_keys(&did).unwrap();
+        assert!(retired.candidate_for_ed25519(&old).is_none());
+        assert!(retired.candidate_for_ed25519(&new).is_some());
+    }
+
+    #[test]
     fn did_web_derives_pq_key_from_signing_key_roundtrip() {
         // A mesh-derived ML-DSA key (as node_identity produces) round-trips
         // through the VM extractor into a usable verifying key.
@@ -643,7 +744,7 @@ mod tests {
         let overlap = resolver
             .resolve_identity_keys(&Did::new(DID_WEB.to_owned()))
             .expect("overlap document resolves");
-        assert_eq!(overlap.candidates.len(), 2);
+        assert_eq!(overlap.len(), 2);
         assert_eq!(
             overlap.candidate_for_ed25519(&old).unwrap().id,
             format!("{DID_WEB}#mesh-old")
@@ -702,26 +803,32 @@ mod tests {
             }],
         });
         let resolver = MethodDispatchResolver::new(FixtureDocs(doc));
-        assert!(resolver
-            .resolve_identity_keys(&Did::new(DID_WEB.to_owned()))
-            .is_err());
+        assert!(
+            resolver
+                .resolve_identity_keys(&Did::new(DID_WEB.to_owned()))
+                .is_err()
+        );
     }
 
     #[test]
     fn did_web_empty_doc_fails_closed() {
         let doc = json!({ "id": DID_WEB, "verificationMethod": [] });
         let resolver = MethodDispatchResolver::new(FixtureDocs(doc));
-        assert!(resolver
-            .resolve_identity_keys(&Did::new(DID_WEB.to_owned()))
-            .is_err());
+        assert!(
+            resolver
+                .resolve_identity_keys(&Did::new(DID_WEB.to_owned()))
+                .is_err()
+        );
     }
 
     #[test]
     fn did_web_fetch_failure_fails_closed() {
         let resolver = MethodDispatchResolver::new(FailingDocs);
-        assert!(resolver
-            .resolve_identity_keys(&Did::new(DID_WEB.to_owned()))
-            .is_err());
+        assert!(
+            resolver
+                .resolve_identity_keys(&Did::new(DID_WEB.to_owned()))
+                .is_err()
+        );
     }
 
     #[test]
@@ -823,6 +930,37 @@ mod tests {
     }
 
     #[test]
+    fn did_at9p_multi_key_capsule_preserves_the_full_candidate_set() {
+        let (_, old_pq) = ml_dsa_generate_keypair();
+        let (_, new_pq) = ml_dsa_generate_keypair();
+        let old = [10u8; 32];
+        let new = [11u8; 32];
+        let verified = VerifiedAt9pKeys::new_gate_verified_set(vec![
+            VerifiedAt9pKeys::key(old, old_pq),
+            VerifiedAt9pKeys::key(new, new_pq),
+        ])
+        .unwrap();
+        let fixture = Arc::new(FixtureCapsule {
+            keys: verified,
+            calls: Mutex::new(vec![]),
+            fail: false,
+        });
+        let resolved = MethodDispatchResolver::new(NeverDocs)
+            .with_at9p(fixture)
+            .resolve_identity_keys(&Did::new("did:at9p:cid512overlap".to_owned()))
+            .expect("verified overlap set resolves");
+        assert_eq!(resolved.len(), 2);
+        assert_eq!(
+            resolved.candidate_for_ed25519(&old).unwrap().assurance(),
+            Assurance::PqHybrid
+        );
+        assert_eq!(
+            resolved.candidate_for_ed25519(&new).unwrap().assurance(),
+            Assurance::PqHybrid
+        );
+    }
+
+    #[test]
     fn did_at9p_gate_failure_fails_closed() {
         // A capsule that fails the GATE (bad sig / wrong cid) is rejected — no
         // default assurance, no Ok.
@@ -852,7 +990,10 @@ mod tests {
         let keys = resolver
             .resolve_identity_keys(&Did::new(DID_WEB.to_owned()))
             .expect("did:web resolves");
-        assert_eq!(keys.candidates[0].assurance(), Assurance::Classical);
+        assert_eq!(
+            keys.candidate_for_ed25519(&ed).unwrap().assurance(),
+            Assurance::Classical
+        );
     }
 
     #[test]

--- a/crates/hyprstream/src/auth/key_rotation.rs
+++ b/crates/hyprstream/src/auth/key_rotation.rs
@@ -1101,6 +1101,11 @@ impl SigningKeyStore {
         slots.all().into_iter().cloned().collect()
     }
 
+    /// Snapshot the named drain/active/lead roles under one read guard.
+    pub async fn slots_snapshot(&self) -> KeySlots {
+        self.0.read().await.clone()
+    }
+
     /// Find a verifying key by kid across all slots (for token verification).
     pub async fn verifying_key_for_kid(&self, kid: &str) -> Option<ed25519_dalek::VerifyingKey> {
         let slots = self.0.read().await;
@@ -1234,6 +1239,59 @@ pub fn load_or_init_key_store(secrets_dir: &Path, config: &OAuthConfig) -> Signi
     })
 }
 
+/// Load the root-DID identity rotation set, seeding the first active slot from
+/// the already-provisioned node identity key.
+///
+/// `secrets_dir` is a dedicated subdirectory, so these durable slot files never
+/// collide with the JWT rotation set. Seeding from `initial_key` makes the first
+/// deployment a compatibility-preserving transition rather than a flag day.
+pub fn load_or_init_root_identity_key_store(
+    secrets_dir: &Path,
+    config: &OAuthConfig,
+    initial_key: SigningKey,
+) -> SigningKeyStore {
+    let now = chrono::Utc::now().timestamp();
+    let active_secs = config.active_secs();
+    let lead_secs = config.lead_secs();
+
+    let drain = load_slot(secrets_dir, "drain");
+    let mut active = load_slot(secrets_dir, "active");
+    let lead = load_slot(secrets_dir, "lead");
+
+    if active.is_none() {
+        let slot = KeySlot::new(initial_key, now, now + active_secs);
+        if let Err(error) = persist_slot(secrets_dir, "active", &slot) {
+            warn!("Could not persist root-DID active identity key: {error}");
+        } else {
+            info!("Seeded root-DID active identity key (kid={})", slot.kid());
+        }
+        active = Some(slot);
+    }
+
+    let should_generate_lead = lead.is_none()
+        && active
+            .as_ref()
+            .is_some_and(|slot| slot.exp - now < lead_secs);
+    if should_generate_lead {
+        let lead_nbf = active.as_ref().map_or(now, |slot| slot.exp - lead_secs);
+        let slot = generate_slot(lead_nbf, lead_nbf + active_secs);
+        if let Err(error) = persist_slot(secrets_dir, "lead", &slot) {
+            warn!("Could not persist root-DID lead identity key: {error}");
+        }
+    }
+    let lead = if should_generate_lead {
+        load_slot(secrets_dir, "lead")
+    } else {
+        lead
+    };
+
+    SigningKeyStore::new(KeySlots {
+        drain,
+        active,
+        lead,
+    })
+}
+
 // ── Rotation logic ──────────────────────────────────────────────────────────
 
 pub async fn rotate_jwt_keys(
@@ -1304,6 +1362,37 @@ pub async fn rotate_jwt_keys(
             }
         }
     }
+}
+
+/// Rotate only the root-DID Ed25519 identity set.
+///
+/// The same proven lead → active → bounded-drain state machine is reused, but
+/// the dedicated directory keeps its authority and persistence separate from
+/// JWT signing keys.
+pub fn spawn_root_identity_rotation_task(
+    config: Arc<OAuthConfig>,
+    secrets_dir: PathBuf,
+    store: Arc<SigningKeyStore>,
+) {
+    tokio::task::spawn_local(async move {
+        let mut interval = tokio::time::interval(
+            config
+                .rotation_check_interval()
+                .min(std::time::Duration::from_secs(60)),
+        );
+        interval.set_missed_tick_behavior(MissedTickBehavior::Skip);
+        interval.tick().await;
+        loop {
+            interval.tick().await;
+            rotate_jwt_keys(
+                &config,
+                &secrets_dir,
+                &store,
+                chrono::Utc::now().timestamp(),
+            )
+            .await;
+        }
+    });
 }
 
 // ── Background task ─────────────────────────────────────────────────────────
@@ -2829,58 +2918,58 @@ mod tests {
         // it is used later to prove the committed drain remains usable.
         let oauth_url = std::fs::read_to_string(dir.path().join("oauth-http-url")).unwrap();
         let old_token = runtime.block_on(async {
-            policy_client_for_socket(dir.path())?
-                .issue_token(&crate::services::generated::policy_client::IssueToken {
-                    requested_scopes: Some(vec!["read".to_owned()]),
-                    ttl: Some(60),
-                    audience: Some("multiprocess".to_owned()),
-                    subject: Some("pre-rotation-policy".to_owned()),
-                    user_pub_key: None,
-                    dpop_jkt: None,
-                    issuer: None,
-                })
-                .await?;
-            let client = reqwest::Client::new();
-            let authorization_code_form = [
-                ("grant_type", "authorization_code"),
-                ("client_id", "multiprocess-client"),
-                ("code", "multiprocess-code"),
-                ("redirect_uri", "https://client.test/callback"),
-                ("code_verifier", "multiprocess-pkce-verifier"),
-            ];
-            let response = client
-                .post(format!("{oauth_url}/oauth/token"))
-                .form(&authorization_code_form)
-                .send()
-                .await?;
-            if !response.status().is_success() {
-                let status = response.status();
-                let body = response.text().await.unwrap_or_default();
-                anyhow::bail!("pre-rotation OAuth endpoint returned {status}: {body}");
-            }
-            let body: serde_json::Value = response.json().await?;
-            let token = body
-                .get("access_token")
-                .and_then(serde_json::Value::as_str)
-                .map(str::to_owned)
+                policy_client_for_socket(dir.path())?
+                    .issue_token(&crate::services::generated::policy_client::IssueToken {
+                        requested_scopes: Some(vec!["read".to_owned()]),
+                        ttl: Some(60),
+                        audience: Some("multiprocess".to_owned()),
+                        subject: Some("pre-rotation-policy".to_owned()),
+                        user_pub_key: None,
+                        dpop_jkt: None,
+                        issuer: None,
+                    })
+                    .await?;
+                let client = reqwest::Client::new();
+                let authorization_code_form = [
+                    ("grant_type", "authorization_code"),
+                    ("client_id", "multiprocess-client"),
+                    ("code", "multiprocess-code"),
+                    ("redirect_uri", "https://client.test/callback"),
+                    ("code_verifier", "multiprocess-pkce-verifier"),
+                ];
+                let response = client
+                    .post(format!("{oauth_url}/oauth/token"))
+                    .form(&authorization_code_form)
+                    .send()
+                    .await?;
+                if !response.status().is_success() {
+                    let status = response.status();
+                    let body = response.text().await.unwrap_or_default();
+                    anyhow::bail!("pre-rotation OAuth endpoint returned {status}: {body}");
+                }
+                let body: serde_json::Value = response.json().await?;
+                let token = body
+                    .get("access_token")
+                    .and_then(serde_json::Value::as_str)
+                    .map(str::to_owned)
                 .ok_or_else(|| anyhow::anyhow!("pre-rotation OAuth response omitted access_token"))?;
-            let replay = client
-                .post(format!("{oauth_url}/oauth/token"))
-                .form(&authorization_code_form)
-                .send()
-                .await?;
-            anyhow::ensure!(
-                replay.status() == reqwest::StatusCode::BAD_REQUEST,
-                "authorization-code replay returned {}, expected 400",
-                replay.status()
-            );
-            let replay_body: serde_json::Value = replay.json().await?;
-            anyhow::ensure!(
-                replay_body.get("error").and_then(serde_json::Value::as_str)
-                    == Some("invalid_grant"),
-                "authorization-code replay was not rejected as invalid_grant: {replay_body}"
-            );
-            anyhow::Ok(token)
+                let replay = client
+                    .post(format!("{oauth_url}/oauth/token"))
+                    .form(&authorization_code_form)
+                    .send()
+                    .await?;
+                anyhow::ensure!(
+                    replay.status() == reqwest::StatusCode::BAD_REQUEST,
+                    "authorization-code replay returned {}, expected 400",
+                    replay.status()
+                );
+                let replay_body: serde_json::Value = replay.json().await?;
+                anyhow::ensure!(
+                    replay_body.get("error").and_then(serde_json::Value::as_str)
+                        == Some("invalid_grant"),
+                    "authorization-code replay was not rejected as invalid_grant: {replay_body}"
+                );
+                anyhow::Ok(token)
         }).unwrap();
         std::fs::write(dir.path().join("old-oauth-token"), old_token).unwrap();
 
@@ -3016,9 +3105,9 @@ mod tests {
             .collect();
         for kid in active_kids {
             assert!(jwks["keys"]
-                .as_array()
-                .unwrap()
-                .iter()
+                    .as_array()
+                    .unwrap()
+                    .iter()
                 .any(|key| { key.get("kid").and_then(serde_json::Value::as_str) == Some(kid) }));
         }
 
@@ -3168,9 +3257,9 @@ mod tests {
                 .any(|committed_pair| committed_pair.kid == candidate.kid)
         }) {
             assert!(!post_crash_jwks["keys"]
-                .as_array()
-                .unwrap()
-                .iter()
+                    .as_array()
+                    .unwrap()
+                    .iter()
                 .any(|key| key["kid"].as_str() == Some(pending_only.kid.as_str())));
         }
         let _ = (timeout_oauth_token, timeout_policy_token, post_crash_token);
@@ -3930,8 +4019,8 @@ mod tests {
         .await
         .unwrap();
         assert!(hyprstream_rpc::auth::global_composite_key_set()
-            .snapshot()
-            .pair(&old_kid)
+                .snapshot()
+                .pair(&old_kid)
             .is_none());
     }
 }

--- a/crates/hyprstream/src/services/oauth/did_document.rs
+++ b/crates/hyprstream/src/services/oauth/did_document.rs
@@ -628,7 +628,10 @@ pub async fn root_did_document(State(state): State<Arc<OAuthState>>) -> Response
         });
     }
 
-    let keys: Vec<(String, VerifyingKey)> = vec![("key-1".to_owned(), vk)];
+    // `#mesh` is the classical half of the explicitly named `#mesh-pq`
+    // hybrid candidate. Keeping the pair's stable shared name lets consumers
+    // bind it without relying on verification-method array order.
+    let keys: Vec<(String, VerifyingKey)> = vec![("mesh".to_owned(), vk)];
 
     let doc = build_did_document(
         &did,

--- a/crates/hyprstream/src/services/oauth/did_document.rs
+++ b/crates/hyprstream/src/services/oauth/did_document.rs
@@ -533,6 +533,117 @@ pub(crate) fn build_did_document(
     doc
 }
 
+#[derive(Clone)]
+struct RootIdentityMethod {
+    fragment: String,
+    vk: VerifyingKey,
+    pq_vk: Vec<u8>,
+    nbf: Option<i64>,
+    exp: Option<i64>,
+}
+
+fn root_identity_methods(
+    legacy_key: &ed25519_dalek::SigningKey,
+    legacy_pq: &[u8],
+    slots: Option<&crate::auth::key_rotation::KeySlots>,
+    now: i64,
+) -> Vec<RootIdentityMethod> {
+    let Some(slots) = slots else {
+        return vec![RootIdentityMethod {
+            fragment: "key-1".to_owned(),
+            vk: legacy_key.verifying_key(),
+            pq_vk: legacy_pq.to_vec(),
+            nbf: None,
+            exp: None,
+        }];
+    };
+
+    let legacy_bytes = legacy_key.verifying_key().to_bytes();
+    let legacy_slot = [&slots.active, &slots.drain, &slots.lead]
+        .into_iter()
+        .flatten()
+        .find(|slot| slot.verifying_key_bytes() == legacy_bytes && now < slot.exp);
+
+    let mut methods = Vec::new();
+    // Preserve the fleet's existing stable fragment during the bounded
+    // compatibility window. It aliases the exact same key and PQ binding as
+    // its named slot, so upgraded consumers can collapse it safely.
+    if let Some(slot) = legacy_slot {
+        methods.push(RootIdentityMethod {
+            fragment: "key-1".to_owned(),
+            vk: legacy_key.verifying_key(),
+            pq_vk: legacy_pq.to_vec(),
+            nbf: Some(slot.nbf),
+            exp: Some(slot.exp),
+        });
+    }
+
+    // Active is first for legacy order-based consumers after the compatibility
+    // alias retires. Drain and lead remain separately named and bounded.
+    for slot in [&slots.active, &slots.drain, &slots.lead]
+        .into_iter()
+        .flatten()
+    {
+        let pq = hyprstream_rpc::node_identity::derive_mesh_mldsa_key(&slot.key);
+        methods.push(RootIdentityMethod {
+            fragment: format!("mesh-{}", slot.kid()),
+            vk: slot.key.verifying_key(),
+            pq_vk: hyprstream_rpc::crypto::pq::ml_dsa_sk_to_vk_bytes(&pq),
+            nbf: Some(slot.nbf),
+            exp: Some(slot.exp),
+        });
+    }
+    methods
+}
+
+fn append_root_identity_methods(doc: &mut Value, did: &str, methods: &[RootIdentityMethod]) {
+    let Some(verification_methods) = doc
+        .get_mut("verificationMethod")
+        .and_then(Value::as_array_mut)
+    else {
+        return;
+    };
+    let mut relationship_ids = Vec::new();
+
+    for method in methods {
+        let mut ed = ed25519_verification_method(did, &method.fragment, &method.vk);
+        let mut ed_jwk = ed25519_verification_method_jwk(did, &method.fragment, &method.vk);
+        let pq_fragment = format!("{}-pq", method.fragment);
+        let mut pq = mldsa65_verification_method(did, &pq_fragment, &method.pq_vk);
+        for vm in [&mut ed, &mut ed_jwk, &mut pq] {
+            if let Some(nbf) = method.nbf {
+                vm["nbf"] = nbf.into();
+            }
+            if let Some(exp) = method.exp {
+                vm["exp"] = exp.into();
+            }
+        }
+        relationship_ids.extend([ed["id"].clone(), ed_jwk["id"].clone(), pq["id"].clone()]);
+        verification_methods.extend([ed, ed_jwk, pq]);
+    }
+
+    // Retain the old `#mesh-pq` DID URL as an alias for the first candidate's
+    // PQ half. Old consumers that pair by document order therefore preserve
+    // hybrid assurance in both mixed-version directions.
+    if let Some(first) = methods.first() {
+        let mut legacy_pq = mldsa65_verification_method(did, "mesh-pq", &first.pq_vk);
+        if let Some(nbf) = first.nbf {
+            legacy_pq["nbf"] = nbf.into();
+        }
+        if let Some(exp) = first.exp {
+            legacy_pq["exp"] = exp.into();
+        }
+        relationship_ids.push(legacy_pq["id"].clone());
+        verification_methods.push(legacy_pq);
+    }
+
+    for relationship in ["authentication", "assertionMethod"] {
+        if let Some(values) = doc.get_mut(relationship).and_then(Value::as_array_mut) {
+            values.extend(relationship_ids.iter().cloned());
+        }
+    }
+}
+
 /// `GET /.well-known/did.json` — root deployment DID document.
 ///
 /// `id = did:web:{authority}`. Verification methods: the OAuth issuer's
@@ -559,7 +670,18 @@ pub async fn root_did_document(State(state): State<Arc<OAuthState>>) -> Response
         )
             .into_response();
     };
-    let vk = sk.verifying_key();
+    let root_slots = if let Some(store) = &state.root_identity_key_store {
+        Some(store.slots_snapshot().await)
+    } else {
+        None
+    };
+    let now = chrono::Utc::now().timestamp();
+    let root_methods = root_identity_methods(
+        sk,
+        state.mesh_pq_verifying_key.as_deref().unwrap_or_default(),
+        root_slots.as_ref(),
+        now,
+    );
 
     // The active key signs new commits. Bounded drain/lead slots are published
     // only for verification overlap; they are never signing candidates.
@@ -574,19 +696,19 @@ pub async fn root_did_document(State(state): State<Arc<OAuthState>>) -> Response
         .as_ref()
         .zip(handle.as_deref())
         .map(|(active, handle)| AtprotoIdentity {
-        p256_vk: active.key.verifying_key(),
-        handle,
-        drain: drain_slot.as_ref().map(|slot| AtprotoOverlapKey {
-            vk: slot.key.verifying_key(),
-            nbf: slot.nbf,
-            exp: slot.exp,
-        }),
-        lead: lead_slot.as_ref().map(|slot| AtprotoOverlapKey {
-            vk: slot.key.verifying_key(),
-            nbf: slot.nbf,
-            exp: slot.exp,
-        }),
-    });
+            p256_vk: active.key.verifying_key(),
+            handle,
+            drain: drain_slot.as_ref().map(|slot| AtprotoOverlapKey {
+                vk: slot.key.verifying_key(),
+                nbf: slot.nbf,
+                exp: slot.exp,
+            }),
+            lead: lead_slot.as_ref().map(|slot| AtprotoOverlapKey {
+                vk: slot.key.verifying_key(),
+                nbf: slot.nbf,
+                exp: slot.exp,
+            }),
+        });
 
     // Transport `service` entries: populate QUIC entry when cert hash is available (#185).
     // The cert hash was set at OAuthService startup from the node's QUIC TLS cert,
@@ -628,20 +750,16 @@ pub async fn root_did_document(State(state): State<Arc<OAuthState>>) -> Response
         });
     }
 
-    // `#mesh` is the classical half of the explicitly named `#mesh-pq`
-    // hybrid candidate. Keeping the pair's stable shared name lets consumers
-    // bind it without relying on verification-method array order.
-    let keys: Vec<(String, VerifyingKey)> = vec![("mesh".to_owned(), vk)];
-
-    let doc = build_did_document(
+    let mut doc = build_did_document(
         &did,
         &state.issuer_url,
-        &keys,
+        &[],
         atproto.as_ref(),
         &transports,
-        state.mesh_pq_verifying_key.as_deref(),
+        None,
         state.mesh_kem_public.as_ref(),
     );
+    append_root_identity_methods(&mut doc, &did, &root_methods);
     (
         StatusCode::OK,
         [(header::CONTENT_TYPE, "application/did+json")],
@@ -836,9 +954,11 @@ mod tests {
     /// test replaces.
     #[tokio::test]
     async fn path_form_account_document_endpoint_is_a_hard_error() {
-        use crate::auth::user_store::{PubkeyEntry, UserFilter, UserProfile, UserProfilePatch, UserStore};
-        use crate::config::server::CorsConfig;
+        use crate::auth::user_store::{
+            PubkeyEntry, UserFilter, UserProfile, UserProfilePatch, UserStore,
+        };
         use crate::config::OAuthConfig;
+        use crate::config::server::CorsConfig;
         use crate::services::oauth::create_app;
         use crate::services::{DiscoveryClient, PolicyClient};
         use async_trait::async_trait;
@@ -865,10 +985,13 @@ mod tests {
             async fn set_profile(&self, _: &str, _: UserProfilePatch) -> anyhow::Result<()> {
                 unreachable!()
             }
-            async fn remove(&self, _: &str) -> anyhow::Result<bool> { unreachable!() }
-            async fn list_users(&self) -> Vec<String> { unreachable!() }
-            async fn search(&self, _: &UserFilter)
-                -> anyhow::Result<Vec<(String, UserProfile)>> {
+            async fn remove(&self, _: &str) -> anyhow::Result<bool> {
+                unreachable!()
+            }
+            async fn list_users(&self) -> Vec<String> {
+                unreachable!()
+            }
+            async fn search(&self, _: &UserFilter) -> anyhow::Result<Vec<(String, UserProfile)>> {
                 unreachable!()
             }
             async fn set_active(&self, _: &str, _: bool) -> anyhow::Result<()> {
@@ -878,17 +1001,22 @@ mod tests {
                 // This is the method the pre-PR `user_did_document` called to
                 // resolve keys before minting the path-form DID. Reaching it
                 // means the freeze was bypassed.
-                unreachable!(
-                    "frozen account-DID handler must not call list_pubkeys (#1159)"
-                )
+                unreachable!("frozen account-DID handler must not call list_pubkeys (#1159)")
             }
             async fn add_pubkey(
-                &self, _: &str, _: VerifyingKey, _: Option<String>,
+                &self,
+                _: &str,
+                _: VerifyingKey,
+                _: Option<String>,
             ) -> anyhow::Result<String> {
                 unreachable!()
             }
             async fn add_pubkey_hybrid(
-                &self, _: &str, _: VerifyingKey, _: Vec<u8>, _: Option<String>,
+                &self,
+                _: &str,
+                _: VerifyingKey,
+                _: Vec<u8>,
+                _: Option<String>,
             ) -> anyhow::Result<String> {
                 unreachable!()
             }
@@ -925,12 +1053,17 @@ mod tests {
                 DiscoveryClient::new(mk_client()),
                 [0x76; 32],
             )
-            .with_user_service(Arc::new(crate::services::oauth::user_service::UserService::new(
-                Arc::new(UntouchedUserStore),
-            ))),
+            .with_user_service(Arc::new(
+                crate::services::oauth::user_service::UserService::new(Arc::new(
+                    UntouchedUserStore,
+                )),
+            )),
         );
 
-        let cors = CorsConfig { enabled: false, ..Default::default() };
+        let cors = CorsConfig {
+            enabled: false,
+            ..Default::default()
+        };
         let app = create_app(state, &cors);
 
         let response = app
@@ -943,7 +1076,9 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(response.status(), StatusCode::GONE);
-        let body = axum::body::to_bytes(response.into_body(), 4096).await.unwrap();
+        let body = axum::body::to_bytes(response.into_body(), 4096)
+            .await
+            .unwrap();
         assert!(
             std::str::from_utf8(&body)
                 .unwrap()
@@ -996,7 +1131,7 @@ mod tests {
         assert_eq!(doc["id"].as_str().unwrap(), did);
         assert!(doc["@context"].is_array());
         assert_eq!(doc["verificationMethod"].as_array().unwrap().len(), 2); // multibase + jwk
-                                                                            // The ed25519 VM is emitted as a Multikey (#280) with a multibase key.
+        // The ed25519 VM is emitted as a Multikey (#280) with a multibase key.
         let vm = &doc["verificationMethod"][0];
         assert_eq!(vm["type"].as_str().unwrap(), "Multikey");
         assert!(vm["publicKeyMultibase"].as_str().unwrap().starts_with('z'));
@@ -1070,19 +1205,23 @@ mod tests {
         let vms = doc["verificationMethod"].as_array().unwrap();
         assert_eq!(vms[0]["id"].as_str().unwrap(), format!("{did}#atproto"));
         assert_eq!(vms[0]["type"].as_str().unwrap(), "Multikey");
-        assert!(vms[0]["publicKeyMultibase"]
-            .as_str()
-            .unwrap()
-            .starts_with('z'));
+        assert!(
+            vms[0]["publicKeyMultibase"]
+                .as_str()
+                .unwrap()
+                .starts_with('z')
+        );
         // Ed25519 mesh VMs still present after it.
         assert_eq!(vms.len(), 1 + 2);
         // The ed25519 mesh VM is also a Multikey (#280), not the deprecated
         // Ed25519VerificationKey2020 type, with a multibase key; JWK fallback kept.
         assert_eq!(vms[1]["type"].as_str().unwrap(), "Multikey");
-        assert!(vms[1]["publicKeyMultibase"]
-            .as_str()
-            .unwrap()
-            .starts_with('z'));
+        assert!(
+            vms[1]["publicKeyMultibase"]
+                .as_str()
+                .unwrap()
+                .starts_with('z')
+        );
         assert_eq!(vms[2]["type"].as_str().unwrap(), "JsonWebKey2020");
 
         // #atproto_pds first, origin-only (no path), correct type.
@@ -1145,15 +1284,19 @@ mod tests {
             "PDS serviceEndpoint MUST equal the AS issuer (PDS = its own AS)"
         );
         // The account handle alias is present.
-        assert_eq!(doc["alsoKnownAs"][0].as_str().unwrap(), "at://alice.pds.example.com");
+        assert_eq!(
+            doc["alsoKnownAs"][0].as_str().unwrap(),
+            "at://alice.pds.example.com"
+        );
         // The hosted-account #atproto VM (P-256 Multikey) is present.
-        assert!(doc["verificationMethod"]
-            .as_array()
-            .unwrap()
-            .iter()
-            .any(|vm| vm["id"].as_str() == Some(&format!("{did}#atproto"))));
+        assert!(
+            doc["verificationMethod"]
+                .as_array()
+                .unwrap()
+                .iter()
+                .any(|vm| vm["id"].as_str() == Some(&format!("{did}#atproto")))
+        );
     }
-
 
     /// #918 producer side: active remains the exact `#atproto` VM, while drain
     /// and lead are bounded distinct-fragment overlap VMs.
@@ -1221,6 +1364,118 @@ mod tests {
         assert_eq!(published.len(), 3);
         assert_eq!(published.live_keys(1_250).count(), 2, "active + drain");
         assert_eq!(published.live_keys(2_500).count(), 2, "active + lead");
+    }
+
+    #[test]
+    fn root_identity_publisher_and_consumer_enforce_bounded_overlap() {
+        use hyprstream_rpc::admission::AdmittedIdentity;
+        use hyprstream_rpc::auth::AtprotoPerimeterGateway;
+        use hyprstream_rpc::auth::mac::Assurance;
+        use hyprstream_rpc::identity_resolver::{DidDocumentProvider, MethodDispatchResolver};
+
+        #[derive(Clone)]
+        struct Docs(Value);
+        impl DidDocumentProvider for Docs {
+            fn document(&self, _did: &str) -> anyhow::Result<Value> {
+                Ok(self.0.clone())
+            }
+        }
+
+        let old = SigningKey::generate(&mut OsRng);
+        let new = SigningKey::generate(&mut OsRng);
+        let lead = SigningKey::generate(&mut OsRng);
+        let old_pq = hyprstream_rpc::node_identity::derive_mesh_mldsa_key(&old);
+        let old_pq = hyprstream_rpc::crypto::pq::ml_dsa_sk_to_vk_bytes(&old_pq);
+        let slots = crate::auth::key_rotation::KeySlots {
+            drain: Some(crate::auth::key_rotation::KeySlot::new(
+                old.clone(),
+                100,
+                200,
+            )),
+            active: Some(crate::auth::key_rotation::KeySlot::new(
+                new.clone(),
+                150,
+                400,
+            )),
+            lead: Some(crate::auth::key_rotation::KeySlot::new(
+                lead.clone(),
+                350,
+                550,
+            )),
+        };
+        let methods = root_identity_methods(&old, &old_pq, Some(&slots), 175);
+        let did = "did:web:peer.example";
+        let mut doc = build_did_document(did, "https://peer.example", &[], None, &[], None, None);
+        append_root_identity_methods(&mut doc, did, &methods);
+
+        let ids: Vec<_> = doc["verificationMethod"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .filter_map(|vm| vm["id"].as_str())
+            .collect();
+        assert!(ids.contains(&format!("{did}#key-1").as_str()));
+        assert!(ids.contains(&format!("{did}#key-1-pq").as_str()));
+        assert!(ids.contains(&format!("{did}#mesh-pq").as_str()));
+        assert!(
+            ids.iter().any(|id| id.contains("#mesh-")),
+            "named rotation slots must be published"
+        );
+        // Mixed-version producer direction: the pre-upgrade resolver chose the
+        // first compatible Ed25519 and first compatible ML-DSA method. During
+        // the compatibility window those are still the old exact pair.
+        let vms = doc["verificationMethod"].as_array().unwrap();
+        let first_ed = vms
+            .iter()
+            .filter_map(|vm| vm["publicKeyMultibase"].as_str())
+            .find_map(|multibase| {
+                hyprstream_rpc::did_web::decode_ed25519_multikey(multibase).ok()
+            })
+            .unwrap();
+        let first_pq = vms
+            .iter()
+            .filter_map(|vm| vm["publicKeyMultibase"].as_str())
+            .find_map(|multibase| {
+                hyprstream_rpc::did_web::decode_multikey(
+                    multibase,
+                    &hyprstream_rpc::did_web::MULTICODEC_ML_DSA_65_PUB,
+                )
+                .ok()
+            })
+            .unwrap();
+        assert_eq!(first_ed, old.verifying_key().to_bytes());
+        assert_eq!(first_pq, old_pq);
+
+        let now = Arc::new(std::sync::atomic::AtomicI64::new(175));
+        let clock = Arc::clone(&now);
+        let resolver = MethodDispatchResolver::new(Docs(doc))
+            .with_clock(move || clock.load(std::sync::atomic::Ordering::SeqCst));
+        let gateway = AtprotoPerimeterGateway::new(resolver);
+        let admitted = |key: &SigningKey| AdmittedIdentity {
+            origin: "https://peer.example".to_owned(),
+            did: Some(did.to_owned()),
+            key: key.verifying_key().to_bytes(),
+        };
+
+        let old_peer = gateway
+            .enroll(&admitted(&old))
+            .expect("drain signer accepted during overlap");
+        let new_peer = gateway
+            .enroll(&admitted(&new))
+            .expect("active signer accepted during overlap");
+        assert_eq!(old_peer.assurance, Assurance::PqHybrid);
+        assert_eq!(new_peer.assurance, Assurance::PqHybrid);
+        assert!(
+            gateway.enroll(&admitted(&lead)).is_err(),
+            "lead is published before use but not accepted before nbf"
+        );
+
+        now.store(200, std::sync::atomic::Ordering::SeqCst);
+        assert!(
+            gateway.enroll(&admitted(&old)).is_err(),
+            "retired signer must fail exactly when its bound closes"
+        );
+        assert!(gateway.enroll(&admitted(&new)).is_ok());
     }
 
     #[test]
@@ -1304,16 +1559,20 @@ mod tests {
         assert_eq!(&decoded[2..], vk_bytes.as_slice());
         // Referenced as both an authentication and assertion method.
         let mesh_pq_id = format!("{did}#mesh-pq");
-        assert!(doc["authentication"]
-            .as_array()
-            .unwrap()
-            .iter()
-            .any(|v| *v == mesh_pq_id));
-        assert!(doc["assertionMethod"]
-            .as_array()
-            .unwrap()
-            .iter()
-            .any(|v| *v == mesh_pq_id));
+        assert!(
+            doc["authentication"]
+                .as_array()
+                .unwrap()
+                .iter()
+                .any(|v| *v == mesh_pq_id)
+        );
+        assert!(
+            doc["assertionMethod"]
+                .as_array()
+                .unwrap()
+                .iter()
+                .any(|v| *v == mesh_pq_id)
+        );
     }
 
     #[test]
@@ -1480,17 +1739,21 @@ mod tests {
         assert_eq!(kas[1]["type"].as_str().unwrap(), "Multikey");
 
         let vms = doc["verificationMethod"].as_array().unwrap();
-        assert!(!vms
-            .iter()
-            .any(|v| v["id"] == format!("{did}#mesh-kem-x25519")));
-        assert!(!vms
-            .iter()
-            .any(|v| v["id"] == format!("{did}#mesh-kem-mlkem768")));
-        assert!(!doc["authentication"]
-            .as_array()
-            .unwrap()
-            .iter()
-            .any(|v| v.as_str().map(|s| s.contains("mesh-kem")).unwrap_or(false)));
+        assert!(
+            !vms.iter()
+                .any(|v| v["id"] == format!("{did}#mesh-kem-x25519"))
+        );
+        assert!(
+            !vms.iter()
+                .any(|v| v["id"] == format!("{did}#mesh-kem-mlkem768"))
+        );
+        assert!(
+            !doc["authentication"]
+                .as_array()
+                .unwrap()
+                .iter()
+                .any(|v| v.as_str().map(|s| s.contains("mesh-kem")).unwrap_or(false))
+        );
 
         // The published X25519 leg round-trips to the exact bytes derived —
         // consistency between the DID doc and the key the node actually holds.

--- a/crates/hyprstream/src/services/oauth/federation_entity.rs
+++ b/crates/hyprstream/src/services/oauth/federation_entity.rs
@@ -50,7 +50,7 @@ pub async fn entity_configuration(
 /// Factored out of the HTTP handler so Phase 0.5 Stage D
 /// (`publish_entity_statement_to_discovery`) can reuse it.
 pub async fn build_entity_configuration_jwt(state: &OAuthState) -> Result<String, &'static str> {
-    let Some(ref sk) = state.signing_key else {
+    let Some(sk) = state.active_root_identity_signing_key().await else {
         return Err("signing key not configured for OpenID Federation");
     };
     let vk = sk.verifying_key();
@@ -124,7 +124,7 @@ pub async fn build_entity_configuration_jwt(state: &OAuthState) -> Result<String
 
     Ok(build_entity_configuration_with_keys(
         issuer,
-        sk,
+        &sk,
         jwks_keys,
         as_metadata,
         &state.authority_hints,

--- a/crates/hyprstream/src/services/oauth/mod.rs
+++ b/crates/hyprstream/src/services/oauth/mod.rs
@@ -680,6 +680,24 @@ impl Spawnable for OAuthService {
                 }
             };
 
+            // Root DID identity rotation is independent of JWT rotation. Seed
+            // the first active generation from the already-published service
+            // identity key so upgrading does not change `#key-1` bytes, then
+            // persist lead/active/drain beneath a dedicated directory.
+            let root_identity_dir = secrets_dir.join("root-did");
+            let root_identity_store = Arc::new(
+                crate::auth::key_rotation::load_or_init_root_identity_key_store(
+                    &root_identity_dir,
+                    &self.config,
+                    self.signing_key.clone(),
+                ),
+            );
+            crate::auth::key_rotation::spawn_root_identity_rotation_task(
+                Arc::clone(&oauth_config_arc),
+                root_identity_dir,
+                Arc::clone(&root_identity_store),
+            );
+
             // Create shared state — JWKS serves the CA JWT verifying key (from PolicyService)
             let jwt_verifying_key = self.jwt_verifying_key;
             let mut oauth_state = OAuthState::new(
@@ -703,6 +721,7 @@ impl Spawnable for OAuthService {
             if let Some(store) = signing_key_store {
                 oauth_state = oauth_state.with_signing_key_store(store);
             }
+            oauth_state = oauth_state.with_root_identity_key_store(root_identity_store);
             oauth_state = oauth_state.with_es256_key_store(Arc::clone(&es256_store));
             {
                 oauth_state = oauth_state.with_ml_dsa_key_store(Arc::clone(&ml_dsa_store));

--- a/crates/hyprstream/src/services/oauth/state.rs
+++ b/crates/hyprstream/src/services/oauth/state.rs
@@ -907,6 +907,12 @@ pub struct OAuthState {
     /// Ed25519 signing key for signing entity configurations (OpenID Federation 1.0).
     /// `None` when not configured.
     pub signing_key: Option<ed25519_dalek::SigningKey>,
+    /// Named root-DID identity slots (drain/active/lead).
+    ///
+    /// This store is seeded from `signing_key` on first deployment, then rotated
+    /// independently with bounded overlap. The root DID publisher snapshots all
+    /// three roles; entity statements sign with the active role.
+    pub root_identity_key_store: Option<Arc<crate::auth::SigningKeyStore>>,
     /// OpenID Federation 1.0 Trust Anchor URLs.
     /// Included as `authority_hints` in the entity configuration JWT.
     pub authority_hints: Vec<String>,
@@ -1079,6 +1085,7 @@ impl OAuthState {
             verifying_key_bytes,
             user_service: None,
             signing_key: None,
+            root_identity_key_store: None,
             authority_hints: config.authority_hints.clone(),
             pending_external_auths: RwLock::new(HashMap::new()),
             oidc_discovery: std::sync::Arc::new(
@@ -1140,6 +1147,15 @@ impl OAuthState {
     /// When set, JWKS serves all slots and WIT issuance uses the active key.
     pub fn with_signing_key_store(mut self, store: Arc<crate::auth::SigningKeyStore>) -> Self {
         self.signing_key_store = Some(store);
+        self
+    }
+
+    /// Attach the independently persisted root-DID identity rotation set.
+    pub fn with_root_identity_key_store(
+        mut self,
+        store: Arc<crate::auth::SigningKeyStore>,
+    ) -> Self {
+        self.root_identity_key_store = Some(store);
         self
     }
 
@@ -1223,6 +1239,16 @@ impl OAuthState {
             }
         }
         self.ca_jwt_key.clone()
+    }
+
+    /// Active root-DID signing key, falling back to the pre-rotation singleton.
+    pub async fn active_root_identity_signing_key(&self) -> Option<Arc<ed25519_dalek::SigningKey>> {
+        if let Some(store) = &self.root_identity_key_store {
+            if let Some(key) = store.active_key().await {
+                return Some(key);
+            }
+        }
+        self.signing_key.clone().map(Arc::new)
     }
 
     /// Attach a user credential store. Creates a `UserService` backed by the store


### PR DESCRIPTION
Fixes #1187\n\nRelates #1183.\n\n- represent DID identity material as named candidates rather than positional scalars\n- bind hybrid candidates by VM id ( ↔ )\n- select the candidate matching the admission-verified signer\n- cover classical and hybrid overlap plus retired-key rejection