### PR TITLE
fix(service-identity): make service key resolution rotation-aware

### DIFF
--- a/crates/hyprstream-rpc-std/schema/policy.capnp
+++ b/crates/hyprstream-rpc-std/schema/policy.capnp
@@ -360,17 +360,32 @@ struct PendingSubscribers {
   pubkeys @0 :List(Data);
 }
 
-# Resolve a service name to its Ed25519 verifying key
+# Resolve a service name to its published Ed25519 verification-key set
 struct ResolveServiceKey {
   serviceName @0 :Text;
 }
 
-# Response containing a service's verifying key and optional CA-signed attestation
+# One named, CA-attested service verification key.
+struct ServiceKeyCandidate {
+  # Stable identifier derived from the Ed25519 public key.
+  keyId @0 :Text;
+  # Ed25519 verifying key (32 bytes).
+  verifyingKey @1 :Data;
+  # CA-signed JWT attesting this key (optional for bootstrap entries).
+  serviceJwt @2 :Text $optional;
+  # Unix timestamp at which this candidate stops being accepted (0 = no expiry).
+  notAfter @3 :Int64;
+}
+
+# Response containing every currently valid, named service verification key.
 struct ServiceKeyResponse {
-  # Ed25519 verifying key (32 bytes)
+  # Deprecated singleton projection. New producers leave this empty so old
+  # consumers fail closed instead of silently selecting an arbitrary key.
   verifyingKey @0 :Data;
-  # CA-signed JWT attesting this key (optional, for verification)
+  # Deprecated singleton projection; see `keys`.
   serviceJwt @1 :Text $optional;
+  # All compatible candidates; order conveys no authority.
+  keys @2 :List(ServiceKeyCandidate);
 }
 
 # Register a service's verifying key with the CA (PolicyService)

--- a/crates/hyprstream-service/src/service/factory.rs
+++ b/crates/hyprstream-service/src/service/factory.rs
@@ -820,9 +820,10 @@ impl ServiceContext {
                     let policy_vk = trust
                         .resolve_one("policy")
                         .unwrap_or_else(|| panic!("trust store has no policy key"));
-                    let discovery_vk = crate::service::trust_store::global_trust_store()
-                        .resolve_one("discovery")
-                        .unwrap_or_else(|| panic!("trust store has no discovery key"));
+                    let discovery_vk = self.service_signing_key("discovery").verifying_key();
+                    if !trust.is_authorized(&discovery_vk, "discovery") {
+                        panic!("trust store has no discovery key");
+                    }
                     Some(shared.for_service_with_announce(
                         service.name(),
                         port,

--- a/crates/hyprstream-service/src/service/factory.rs
+++ b/crates/hyprstream-service/src/service/factory.rs
@@ -810,11 +810,13 @@ impl ServiceContext {
                 if service.name() == "discovery" {
                     Some(shared.for_service(service.name(), port))
                 } else {
-                    // Read JWT from trust store attestation
+                    // Bind the announcement JWT to the exact signer. A
+                    // singleton lookup can select a sibling during overlap.
                     let trust = crate::service::trust_store::global_trust_store();
+                    let signing_key = self.service_signing_key(service.name());
                     let service_jwt = trust
-                        .resolve_one(service.name())
-                        .and_then(|vk| trust.get(&vk).and_then(|att| att.jwt.clone()));
+                        .get(&signing_key.verifying_key())
+                        .and_then(|att| att.jwt);
                     let policy_vk = trust
                         .resolve_one("policy")
                         .unwrap_or_else(|| panic!("trust store has no policy key"));
@@ -824,7 +826,7 @@ impl ServiceContext {
                     Some(shared.for_service_with_announce(
                         service.name(),
                         port,
-                        self.service_signing_key(service.name()),
+                        signing_key,
                         service_jwt,
                         policy_vk,
                         discovery_vk,

--- a/crates/hyprstream-service/src/service/trust_store.rs
+++ b/crates/hyprstream-service/src/service/trust_store.rs
@@ -27,6 +27,18 @@ use std::collections::HashSet;
 use std::sync::Arc;
 use tracing;
 
+/// A named, currently published service verification key.
+///
+/// `key_id` is derived from the public key, so it is stable across processes
+/// and cannot be chosen independently of the material it identifies.  The
+/// attestation carries the signed validity interval and proof of authorization.
+#[derive(Clone, Debug)]
+pub struct PublishedServiceKey {
+    pub key_id: String,
+    pub verifying_key: VerifyingKey,
+    pub attestation: Attestation,
+}
+
 /// An attestation binding a key to authorization scopes.
 #[derive(Clone, Debug)]
 pub struct Attestation {
@@ -124,16 +136,41 @@ impl TrustStore {
     /// Returns an empty Vec if no keys match. Useful for finding
     /// candidate endpoints when multiple instances exist.
     pub fn keys_for_scope(&self, scope: &str) -> Vec<VerifyingKey> {
-        let now = chrono::Utc::now().timestamp();
-        self.inner
+        self.published_keys_for_scope(scope)
+            .into_iter()
+            .map(|entry| entry.verifying_key)
+            .collect()
+    }
+
+    /// Get every named, unexpired verification key published for a service scope.
+    ///
+    /// Consumers must select an entry by `key_id`, or try every compatible
+    /// candidate.  This intentionally exposes no authority-bearing positional
+    /// selection: a service may publish a drain and lead key simultaneously.
+    pub fn published_keys_for_scope(&self, scope: &str) -> Vec<PublishedServiceKey> {
+        self.published_keys_for_scope_at(scope, chrono::Utc::now().timestamp())
+    }
+
+    /// Resolve the published key set at a supplied Unix timestamp.
+    ///
+    /// This is useful to consumers which evaluate a signed assertion at its
+    /// issuance time and to deterministic rotation tests.
+    pub fn published_keys_for_scope_at(&self, scope: &str, now: i64) -> Vec<PublishedServiceKey> {
+        let mut keys = self
+            .inner
             .iter()
             .filter(|entry| {
                 let att = entry.value();
-                (att.expires_at == 0 || att.expires_at > now)
-                    && att.scopes.contains(scope)
+                (att.expires_at == 0 || att.expires_at > now) && att.scopes.contains(scope)
             })
-            .map(|entry| *entry.key())
-            .collect()
+            .map(|entry| PublishedServiceKey {
+                key_id: service_key_id(entry.key()),
+                verifying_key: *entry.key(),
+                attestation: entry.value().clone(),
+            })
+            .collect::<Vec<_>>();
+        keys.sort_by(|left, right| left.key_id.cmp(&right.key_id));
+        keys
     }
 
     /// Get the attestation for a specific key, if present and not expired.
@@ -211,6 +248,13 @@ impl TrustStore {
     }
 }
 
+/// Canonical public identifier for an Ed25519 service verification key.
+pub fn service_key_id(key: &VerifyingKey) -> String {
+    use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine as _};
+
+    format!("ed25519:{}", URL_SAFE_NO_PAD.encode(key.to_bytes()))
+}
+
 impl Default for TrustStore {
     fn default() -> Self {
         Self::new()
@@ -261,8 +305,6 @@ static TRUST_STORE: once_cell::sync::Lazy<TrustStore> = once_cell::sync::Lazy::n
 pub fn global_trust_store() -> &'static TrustStore {
     &TRUST_STORE
 }
-
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -352,6 +394,40 @@ mod tests {
         assert_eq!(keys.len(), 2);
         assert!(keys.contains(&key_a));
         assert!(keys.contains(&key_b));
+    }
+
+    #[test]
+    fn published_key_set_keeps_overlap_until_retirement_window_ends() {
+        let store = TrustStore::new();
+        let (_, retired) = random_key();
+        let (_, lead) = random_key();
+        let now = chrono::Utc::now().timestamp();
+        let retirement = now + 60;
+
+        store.insert(retired, make_attestation(&["model"], retirement));
+        store.insert(lead, make_attestation(&["model"], 0));
+
+        let overlap = store.published_keys_for_scope_at("model", now);
+        assert_eq!(
+            overlap.len(),
+            2,
+            "drain and lead keys must publish together"
+        );
+        assert!(overlap.iter().any(|entry| entry.verifying_key == retired));
+        assert!(overlap.iter().any(|entry| entry.verifying_key == lead));
+        assert!(store.is_authorized(&retired, "model"));
+        assert!(store.is_authorized(&lead, "model"));
+        assert!(overlap
+            .iter()
+            .all(|entry| entry.key_id.starts_with("ed25519:")));
+
+        let after_retirement = store.published_keys_for_scope_at("model", retirement);
+        assert_eq!(
+            after_retirement.len(),
+            1,
+            "retired key must leave the set at its bounded expiry"
+        );
+        assert_eq!(after_retirement[0].verifying_key, lead);
     }
 
     #[test]

--- a/crates/hyprstream/src/services/factories.rs
+++ b/crates/hyprstream/src/services/factories.rs
@@ -1251,7 +1251,7 @@ fn create_xet_service(ctx: &ServiceContext) -> anyhow::Result<Box<dyn Spawnable>
         .resolve_one("policy")
         .ok_or_else(|| anyhow::anyhow!("trust store has no policy key"))?;
     let policy_client =
-        PolicyClient::for_local_bootstrap(sk.clone(), policy_vk, service_token("xet"))?;
+        PolicyClient::for_local_bootstrap(sk.clone(), policy_vk, service_token(&sk))?;
     let federation_resolver = Arc::new(
         crate::auth::FederationKeyResolver::new(&config.oauth.trusted_issuers)
             .with_policy_client(Arc::new(policy_client)),

--- a/crates/hyprstream/src/services/factories.rs
+++ b/crates/hyprstream/src/services/factories.rs
@@ -46,11 +46,10 @@ fn load_config() -> HyprConfig {
     HyprConfig::load().unwrap_or_default()
 }
 
-/// Get the JWT token for a service from the trust store.
-fn service_token(service_name: &str) -> Option<String> {
+/// Get the JWT bound to this service instance's exact signing key.
+fn service_token(signing_key: &SigningKey) -> Option<String> {
     let trust = hyprstream_service::global_trust_store();
-    let vk = trust.resolve_one(service_name)?;
-    trust.get(&vk).and_then(|att| att.jwt.clone())
+    trust.get(&signing_key.verifying_key()).and_then(|att| att.jwt)
 }
 
 /// Shared Git2DB registry instance. Lazily initialized by the first factory
@@ -208,8 +207,7 @@ fn register_service_key(
     let from_trust = {
         let trust = hyprstream_service::global_trust_store();
         trust
-            .resolve_one(service_name)
-            .and_then(|vk| trust.get(&vk))
+            .get(&signing_key.verifying_key())
             .and_then(|att| att.jwt.clone())
     };
     let jwt = resolve_registration_jwt(service_name, &creds_dir, from_trust)?;
@@ -328,9 +326,8 @@ fn spawn_jwt_renewal_task(
                     }
                 };
                 let svc_jwt = match trust
-                    .resolve_one(&service_name)
-                    .and_then(|vk| trust.get(&vk))
-                    .and_then(|att| att.jwt.clone())
+                    .get(&signing_key.verifying_key())
+                    .and_then(|att| att.jwt)
                 {
                     Some(j) => j,
                     None => {
@@ -363,12 +360,11 @@ fn spawn_jwt_renewal_task(
                 Ok(info) => {
                     // Update trust store with renewed JWT
                     let trust = hyprstream_service::global_trust_store();
-                    if let Some(vk) = trust.resolve_one(&service_name) {
-                        if let Some(mut att) = trust.get(&vk) {
-                            att.jwt = Some(info.token.clone());
-                            att.expires_at = info.expires_at;
-                            trust.insert(vk, att);
-                        }
+                    let vk = signing_key.verifying_key();
+                    if let Some(mut att) = trust.get(&vk) {
+                        att.jwt = Some(info.token.clone());
+                        att.expires_at = info.expires_at;
+                        trust.insert(vk, att);
                     }
                     tracing::info!(
                         service = service_name,
@@ -698,7 +694,7 @@ fn create_registry_service(ctx: &ServiceContext) -> anyhow::Result<Box<dyn Spawn
         .resolve_one("policy")
         .ok_or_else(|| anyhow::anyhow!("trust store has no policy key"))?;
     let policy_client =
-        PolicyClient::for_local_bootstrap(sk.clone(), policy_vk, service_token("registry"))?;
+        PolicyClient::for_local_bootstrap(sk.clone(), policy_vk, service_token(&sk))?;
 
     // #910a — the registry service is the sole PDS-record writer AND the sole
     // holder of the `#atproto` private key: it opens the durable store
@@ -949,11 +945,11 @@ fn create_model_service(ctx: &ServiceContext) -> anyhow::Result<Box<dyn Spawnabl
         .resolve_one("policy")
         .ok_or_else(|| anyhow::anyhow!("trust store has no policy key"))?;
     let policy_client =
-        PolicyClient::for_local_bootstrap(sk.clone(), policy_vk, service_token("model"))?;
+        PolicyClient::for_local_bootstrap(sk.clone(), policy_vk, service_token(&sk))?;
 
     // Create registry client
     let registry_client: RegistryClient =
-        RegistryClient::from_resolver(sk.clone(), service_token("model"))?;
+        RegistryClient::from_resolver(sk.clone(), service_token(&sk))?;
 
     #[allow(clippy::expect_used)]
     let mut model_service = tokio::task::block_in_place(|| {
@@ -1112,7 +1108,7 @@ fn create_worker_service(ctx: &ServiceContext) -> anyhow::Result<Box<dyn Spawnab
     let policy_client = crate::services::PolicyClient::for_local_bootstrap(
         sk.clone(),
         policy_vk,
-        service_token("worker"),
+        service_token(&sk),
     )?;
     worker_service.set_authorize_fn(super::worker::build_authorize_fn(policy_client));
     if let Some(issuer) = ctx.oauth_issuer_url() {
@@ -1147,16 +1143,16 @@ fn create_oai_service(ctx: &ServiceContext) -> anyhow::Result<Box<dyn Spawnable>
     register_service_key(ctx, "oai", &sk)?;
 
     // Create ZMQ clients for Model and Policy services
-    let model_client = ModelClient::from_resolver(sk.clone(), service_token("oai"))?;
+    let model_client = ModelClient::from_resolver(sk.clone(), service_token(&sk))?;
     let policy_vk = hyprstream_service::global_trust_store()
         .resolve_one("policy")
         .ok_or_else(|| anyhow::anyhow!("trust store has no policy key"))?;
     let policy_client =
-        PolicyClient::for_local_bootstrap(sk.clone(), policy_vk, service_token("oai"))?;
+        PolicyClient::for_local_bootstrap(sk.clone(), policy_vk, service_token(&sk))?;
 
     // Create registry client
     let registry_client: RegistryClient =
-        RegistryClient::from_resolver(sk.clone(), service_token("oai"))?;
+        RegistryClient::from_resolver(sk.clone(), service_token(&sk))?;
 
     // Create server state (blocking since we're in sync context)
     let resource_url = config.oai.resource_url();
@@ -1246,7 +1242,7 @@ fn create_xet_service(ctx: &ServiceContext) -> anyhow::Result<Box<dyn Spawnable>
 
     // Dial the registry — the authenticated write core the HTTP face translates to.
     let registry_client: RegistryClient =
-        RegistryClient::from_resolver(sk.clone(), service_token("xet"))?;
+        RegistryClient::from_resolver(sk.clone(), service_token(&sk))?;
 
     // Reuse the same narrow authentication core as OAI without constructing an
     // inference-oriented ServerState. The policy client is used by federated
@@ -1310,7 +1306,7 @@ fn create_flight_service(ctx: &ServiceContext) -> anyhow::Result<Box<dyn Spawnab
     let registry_client: Option<Arc<dyn hyprstream_metrics::RegistryClient>> =
         if config.flight.default_dataset.is_some() {
             let registry_client: RegistryClient =
-                RegistryClient::from_resolver(sk.clone(), service_token("flight"))?;
+                RegistryClient::from_resolver(sk.clone(), service_token(&sk))?;
             Some(Arc::new(registry_client))
         } else {
             None
@@ -1402,7 +1398,7 @@ fn create_mcp_service(ctx: &ServiceContext) -> anyhow::Result<Box<dyn Spawnable>
 
     let mcp_config = McpConfig {
         verifying_key: ctx.verifying_key(),
-        signing_key: sk,
+        signing_key: sk.clone(),
         transport: ctx.transport("mcp", SocketKind::Rep),
         ctx: None, // ServiceContext not yet available as Arc — handlers use signing_key directly
         policy_verifying_key: policy_vk,
@@ -1435,7 +1431,7 @@ fn create_mcp_service(ctx: &ServiceContext) -> anyhow::Result<Box<dyn Spawnable>
             let fallback_policy_client = std::sync::Arc::new(PolicyClient::for_local_bootstrap(
                 ctx.service_signing_key("mcp"),
                 policy_vk,
-                service_token("mcp"),
+                service_token(&sk),
             )?);
             std::sync::Arc::new(
                 crate::auth::FederationKeyResolver::new(&config.oauth.trusted_issuers)
@@ -1815,7 +1811,7 @@ fn create_tui_service(ctx: &ServiceContext) -> anyhow::Result<Box<dyn Spawnable>
         .resolve_one("policy")
         .ok_or_else(|| anyhow::anyhow!("trust store has no policy key"))?;
     let policy_client =
-        PolicyClient::for_local_bootstrap(sk.clone(), policy_vk, service_token("tui"))?;
+        PolicyClient::for_local_bootstrap(sk.clone(), policy_vk, service_token(&sk))?;
 
     // Build VFS namespace for ChatApps spawned via TUI RPC.
     let (vfs_ns, vfs_subject) = crate::tui::vfs::build_chat_vfs_namespace(&sk)?;
@@ -1889,7 +1885,7 @@ fn create_discovery_service(ctx: &ServiceContext) -> anyhow::Result<Box<dyn Spaw
         .resolve_one("policy")
         .ok_or_else(|| anyhow::anyhow!("trust store has no policy key"))?;
     let policy_client =
-        PolicyClient::for_local_bootstrap(sk.clone(), policy_vk, service_token("discovery"))?;
+        PolicyClient::for_local_bootstrap(sk.clone(), policy_vk, service_token(&sk))?;
     let auth_provider = crate::services::discovery::PolicyAuthProvider::new(policy_client);
 
     // #431 — record resolver backing getRecord/getRepo, over the durable
@@ -2032,7 +2028,7 @@ fn create_metrics_service(ctx: &ServiceContext) -> anyhow::Result<Box<dyn Spawna
         .resolve_one("policy")
         .ok_or_else(|| anyhow::anyhow!("trust store has no policy key"))?;
     let policy_client =
-        PolicyClient::for_local_bootstrap(sk.clone(), policy_vk, service_token("metrics"))?;
+        PolicyClient::for_local_bootstrap(sk.clone(), policy_vk, service_token(&sk))?;
 
     let mut metrics_service = MetricsService::new(
         orchestrator,

--- a/crates/hyprstream/src/services/oauth/jwt_bearer.rs
+++ b/crates/hyprstream/src/services/oauth/jwt_bearer.rs
@@ -165,41 +165,6 @@ fn decode_with_any_service_key_at(
     })
 }
 
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use ed25519_dalek::SigningKey;
-
-    fn attestation(expires_at: i64) -> hyprstream_service::Attestation {
-        hyprstream_service::Attestation { scopes: std::iter::once("model".to_owned()).collect(), subject: None, jwt: None, expires_at, attested_by: None }
-    }
-
-    #[test]
-    fn overlap_accepts_both_keys_then_rejects_retired_key_at_deadline() {
-        let trust = hyprstream_service::TrustStore::new();
-        let retired = SigningKey::generate(&mut rand::rngs::OsRng);
-        let lead = SigningKey::generate(&mut rand::rngs::OsRng);
-        let now = chrono::Utc::now().timestamp();
-        let retirement = now + 60;
-        trust.insert(retired.verifying_key(), attestation(retirement));
-        trust.insert(lead.verifying_key(), attestation(now + 600));
-        for signer in [&retired, &lead] {
-            let assertion = hyprstream_rpc::auth::jwt::encode(
-                &hyprstream_rpc::auth::Claims::new("service:model".to_owned(), now, now + 300)
-                    .with_issuer("https://issuer.example".to_owned())
-                    .with_audience(Some("https://issuer.example/oauth/token".to_owned())), signer);
-            let (_, verified) = decode_with_any_service_key_at(&trust, &assertion, "model", "https://issuer.example/oauth/token", now)
-                .expect("each overlap key must verify its own assertion");
-            assert_eq!(verified, signer.verifying_key());
-        }
-        let retired_assertion = hyprstream_rpc::auth::jwt::encode(
-            &hyprstream_rpc::auth::Claims::new("service:model".to_owned(), now, now + 300)
-                .with_issuer("https://issuer.example".to_owned())
-                .with_audience(Some("https://issuer.example/oauth/token".to_owned())), &retired);
-        assert!(decode_with_any_service_key_at(&trust, &retired_assertion, "model", "https://issuer.example/oauth/token", retirement).is_none());
-    }
-}
-
 /// Fetch a verifying key for a federated issuer by resolving JWKS.
 /// Matches the `kid` JWT header against keys in the JWKS endpoint.
 /// Falls back to the first Ed25519 (OKP/Ed25519) key when no `kid` matches.
@@ -278,4 +243,40 @@ fn jwt_bearer_error(status: StatusCode, error: &str, description: &str) -> Respo
         })),
     )
         .into_response()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ed25519_dalek::SigningKey;
+
+    fn attestation(expires_at: i64) -> hyprstream_service::Attestation {
+        hyprstream_service::Attestation { scopes: std::iter::once("model".to_owned()).collect(), subject: None, jwt: None, expires_at, attested_by: None }
+    }
+
+    #[test]
+    fn overlap_accepts_both_keys_then_rejects_retired_key_at_deadline() {
+        let trust = hyprstream_service::TrustStore::new();
+        let retired = SigningKey::generate(&mut rand::rngs::OsRng);
+        let lead = SigningKey::generate(&mut rand::rngs::OsRng);
+        let now = chrono::Utc::now().timestamp();
+        let retirement = now + 60;
+        trust.insert(retired.verifying_key(), attestation(retirement));
+        trust.insert(lead.verifying_key(), attestation(now + 600));
+        for signer in [&retired, &lead] {
+            let assertion = hyprstream_rpc::auth::jwt::encode(
+                &hyprstream_rpc::auth::Claims::new("service:model".to_owned(), now, now + 300)
+                    .with_issuer("https://issuer.example".to_owned())
+                    .with_audience(Some("https://issuer.example/oauth/token".to_owned())), signer);
+            let Some((_, verified)) = decode_with_any_service_key_at(&trust, &assertion, "model", "https://issuer.example/oauth/token", now) else {
+                panic!("each overlap key must verify its own assertion");
+            };
+            assert_eq!(verified, signer.verifying_key());
+        }
+        let retired_assertion = hyprstream_rpc::auth::jwt::encode(
+            &hyprstream_rpc::auth::Claims::new("service:model".to_owned(), now, now + 300)
+                .with_issuer("https://issuer.example".to_owned())
+                .with_audience(Some("https://issuer.example/oauth/token".to_owned())), &retired);
+        assert!(decode_with_any_service_key_at(&trust, &retired_assertion, "model", "https://issuer.example/oauth/token", retirement).is_none());
+    }
 }

--- a/crates/hyprstream/src/services/oauth/jwt_bearer.rs
+++ b/crates/hyprstream/src/services/oauth/jwt_bearer.rs
@@ -52,12 +52,13 @@ pub async fn exchange_jwt_bearer(
         }
     }
 
-    // Resolve the verification key based on subject / issuer.
-    let verifying_key: VerifyingKey = if sub.starts_with("service:") {
-        // Local service WIT — look up via global trust store.
+    // A service may publish drain and lead keys simultaneously. Verify against
+    // every current candidate and retain the exact key that succeeded.
+    let (claims, verified_service_key) = if sub.starts_with("service:") {
         let service_name = sub.trim_start_matches("service:");
-        match hyprstream_service::global_trust_store().resolve_one(service_name) {
-            Some(vk) => vk,
+        let token_endpoint = format!("{}/oauth/token", state.issuer_url.trim_end_matches('/'));
+        match decode_with_any_local_service_key(assertion, service_name, &token_endpoint) {
+            Some((claims, vk)) => (claims, Some(vk)),
             None => {
                 return jwt_bearer_error(
                     StatusCode::UNAUTHORIZED,
@@ -79,21 +80,18 @@ pub async fn exchange_jwt_bearer(
             }
         };
         // Fetch JWKS from the issuer's discovery document.
-        match resolve_federated_key(state, &iss, assertion, issuer_config.allow_http).await {
+        let vk = match resolve_federated_key(state, &iss, assertion, issuer_config.allow_http).await {
             Ok(vk) => vk,
             Err(e) => {
                 return jwt_bearer_error(StatusCode::UNAUTHORIZED, "invalid_grant", &e);
             }
-        }
-    };
-
-    // Full verification. Audience must be the token endpoint URL per RFC 7523 § 3.
-    let token_endpoint = format!("{}/oauth/token", state.issuer_url.trim_end_matches('/'));
-    let claims = match hyprstream_rpc::auth::decode_with_key(assertion, &verifying_key, Some(&token_endpoint)) {
-        Ok(c) => c,
-        Err(e) => {
-            return jwt_bearer_error(StatusCode::UNAUTHORIZED, "invalid_grant", &format!("Assertion verification failed: {e}"));
-        }
+        };
+        let token_endpoint = format!("{}/oauth/token", state.issuer_url.trim_end_matches('/'));
+        let claims = match hyprstream_rpc::auth::decode_with_key(assertion, &vk, Some(&token_endpoint)) {
+            Ok(claims) => claims,
+            Err(e) => return jwt_bearer_error(StatusCode::UNAUTHORIZED, "invalid_grant", &format!("Assertion verification failed: {e}")),
+        };
+        (claims, None)
     };
 
     let sub = claims.sub.clone();
@@ -107,7 +105,9 @@ pub async fn exchange_jwt_bearer(
             ttl: Some(state.token_ttl),
             audience: claims.aud.clone(),
             subject: Some(sub.clone()),
-            user_pub_key: None,
+            // OAuth signs the RPC envelope; PolicyService needs the service
+            // assertion key instead for its issued-token confirmation binding.
+            user_pub_key: verified_service_key.map(|key| URL_SAFE_NO_PAD.encode(key.to_bytes())),
             dpop_jkt: None,
             issuer: None,
         })
@@ -136,6 +136,67 @@ pub async fn exchange_jwt_bearer(
             tracing::error!(sub = %sub, error = %e, "JWT bearer token issuance failed");
             jwt_bearer_error(StatusCode::INTERNAL_SERVER_ERROR, "server_error", "Failed to issue token")
         }
+    }
+}
+
+/// Verify a local service assertion against each currently published key.
+/// The returned key is the successful verifier, not a sorted-set selection.
+pub(super) fn decode_with_any_local_service_key(
+    assertion: &str,
+    service_name: &str,
+    expected_audience: &str,
+) -> Option<(hyprstream_rpc::auth::Claims, VerifyingKey)> {
+    decode_with_any_service_key_at(
+        hyprstream_service::global_trust_store(), assertion, service_name,
+        expected_audience, chrono::Utc::now().timestamp(),
+    )
+}
+
+fn decode_with_any_service_key_at(
+    trust: &hyprstream_service::TrustStore,
+    assertion: &str,
+    service_name: &str,
+    expected_audience: &str,
+    now: i64,
+) -> Option<(hyprstream_rpc::auth::Claims, VerifyingKey)> {
+    trust.published_keys_for_scope_at(service_name, now).into_iter().find_map(|candidate| {
+        hyprstream_rpc::auth::decode_with_key(assertion, &candidate.verifying_key, Some(expected_audience))
+            .ok().map(|claims| (claims, candidate.verifying_key))
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ed25519_dalek::SigningKey;
+
+    fn attestation(expires_at: i64) -> hyprstream_service::Attestation {
+        hyprstream_service::Attestation { scopes: std::iter::once("model".to_owned()).collect(), subject: None, jwt: None, expires_at, attested_by: None }
+    }
+
+    #[test]
+    fn overlap_accepts_both_keys_then_rejects_retired_key_at_deadline() {
+        let trust = hyprstream_service::TrustStore::new();
+        let retired = SigningKey::generate(&mut rand::rngs::OsRng);
+        let lead = SigningKey::generate(&mut rand::rngs::OsRng);
+        let now = chrono::Utc::now().timestamp();
+        let retirement = now + 60;
+        trust.insert(retired.verifying_key(), attestation(retirement));
+        trust.insert(lead.verifying_key(), attestation(now + 600));
+        for signer in [&retired, &lead] {
+            let assertion = hyprstream_rpc::auth::jwt::encode(
+                &hyprstream_rpc::auth::Claims::new("service:model".to_owned(), now, now + 300)
+                    .with_issuer("https://issuer.example".to_owned())
+                    .with_audience(Some("https://issuer.example/oauth/token".to_owned())), signer);
+            let (_, verified) = decode_with_any_service_key_at(&trust, &assertion, "model", "https://issuer.example/oauth/token", now)
+                .expect("each overlap key must verify its own assertion");
+            assert_eq!(verified, signer.verifying_key());
+        }
+        let retired_assertion = hyprstream_rpc::auth::jwt::encode(
+            &hyprstream_rpc::auth::Claims::new("service:model".to_owned(), now, now + 300)
+                .with_issuer("https://issuer.example".to_owned())
+                .with_audience(Some("https://issuer.example/oauth/token".to_owned())), &retired);
+        assert!(decode_with_any_service_key_at(&trust, &retired_assertion, "model", "https://issuer.example/oauth/token", retirement).is_none());
     }
 }
 

--- a/crates/hyprstream/src/services/oauth/token_exchange.rs
+++ b/crates/hyprstream/src/services/oauth/token_exchange.rs
@@ -114,7 +114,7 @@ pub async fn exchange_token_exchange(
         );
     }
 
-    // Encode cnf key bytes for PolicyService (same path as user_pub_key in other flows).
+    // Service assertions carry the exact key which verified their signature.
     let user_pub_key = verified.cnf_key_bytes.map(|b| URL_SAFE_NO_PAD.encode(b));
 
     let result = state
@@ -243,27 +243,26 @@ async fn verify_jwt(state: &Arc<OAuthState>, token: &str) -> Result<VerifiedSubj
 
     let token_endpoint = format!("{}/oauth/token", state.issuer_url.trim_end_matches('/'));
 
-    let vk = if sub.starts_with("service:") {
+    let (claims, service_signing_key) = if sub.starts_with("service:") {
         let svc_name = sub.trim_start_matches("service:");
-        hyprstream_service::global_trust_store()
-            .resolve_one(svc_name)
-            .ok_or_else(|| format!("Unknown service in trust store: {svc_name}"))?
+        let (claims, vk) = super::jwt_bearer::decode_with_any_local_service_key(token, svc_name, &token_endpoint)
+            .ok_or_else(|| format!("JWT verification failed for service: {svc_name}"))?;
+        (claims, Some(vk.to_bytes()))
     } else {
         let cfg = state
             .trusted_issuers
             .get(&iss)
             .ok_or_else(|| format!("Issuer not in trusted_issuers allow-list: {iss}"))?
             .clone();
-        super::jwt_bearer::resolve_federated_key(state, &iss, token, cfg.allow_http)
+        let vk = super::jwt_bearer::resolve_federated_key(state, &iss, token, cfg.allow_http)
             .await
-            .map_err(|e| format!("JWKS key resolution failed for {iss}: {e}"))?
+            .map_err(|e| format!("JWKS key resolution failed for {iss}: {e}"))?;
+        let claims = hyprstream_rpc::auth::decode_with_key(token, &vk, Some(&token_endpoint))
+            .map_err(|e| format!("JWT verification failed: {e}"))?;
+        (claims, None)
     };
 
-    // Full verify with audience = token endpoint (RFC 7523 §3).
-    let claims = hyprstream_rpc::auth::decode_with_key(token, &vk, Some(&token_endpoint))
-        .map_err(|e| format!("JWT verification failed: {e}"))?;
-
-    let cnf_key_bytes = claims.cnf_key_bytes(); // carry cnf.jwk through (WIT key binding)
+    let cnf_key_bytes = service_signing_key.or_else(|| claims.cnf_key_bytes());
     Ok(VerifiedSubject {
         sub: claims.sub,
         cnf_key_bytes,

--- a/crates/hyprstream/src/services/policy.rs
+++ b/crates/hyprstream/src/services/policy.rs
@@ -255,8 +255,8 @@ fn validate_event_prefix(prefix: &str) -> Result<(), String> {
 
 /// Build the rotation-safe wire projection of a service's published key set.
 ///
-/// The scalar fields remain only for wire compatibility and are intentionally
-/// empty: consumers which cannot handle `keys` must fail closed.
+/// The scalar fields are a transition projection for one-key deployments.
+/// They are empty during overlap, where a positional singleton is unsafe.
 fn published_service_key_response(
     trust: &hyprstream_service::TrustStore,
     service_name: &str,
@@ -265,9 +265,10 @@ fn published_service_key_response(
     if keys.is_empty() {
         anyhow::bail!("service key '{service_name}' not registered");
     }
+    let singleton = (keys.len() == 1).then(|| &keys[0]);
     Ok(ServiceKeyResponse {
-        verifying_key: Vec::new(),
-        service_jwt: None,
+        verifying_key: singleton.map(|entry| entry.verifying_key.to_bytes().to_vec()).unwrap_or_default(),
+        service_jwt: singleton.and_then(|entry| entry.attestation.jwt.clone()),
         keys: keys.into_iter().map(|entry| ServiceKeyCandidate {
             key_id: entry.key_id,
             verifying_key: entry.verifying_key.to_bytes().to_vec(),
@@ -275,6 +276,25 @@ fn published_service_key_response(
             not_after: entry.attestation.expires_at,
         }).collect(),
     })
+}
+
+/// Confirmation material is mandatory: an absent or malformed `cnf.jwk` must
+/// never turn a valid CA token into authority for arbitrary key material.
+fn validate_service_key_registration(
+    claims: &hyprstream_rpc::auth::Claims,
+    service_name: &str,
+    verifying_key: &[u8; 32],
+) -> Result<()> {
+    let expected_sub = format!("service:{service_name}");
+    if claims.sub != expected_sub {
+        anyhow::bail!("JWT subject '{}' does not match service name '{}'", claims.sub, service_name);
+    }
+    let cnf_bytes = claims.cnf_key_bytes()
+        .ok_or_else(|| anyhow!("service JWT must contain a well-formed cnf.jwk"))?;
+    if cnf_bytes != *verifying_key {
+        anyhow::bail!("JWT cnf.jwk does not match provided verifying key");
+    }
+    Ok(())
 }
 
 #[async_trait::async_trait(?Send)]
@@ -410,21 +430,31 @@ impl PolicyHandler for PolicyService {
                 .join(" ")
         });
 
-        // Service tokens: cnf.jwk must be the service's REGISTERED key, never a
-        // CA-derived guess (#441/#806) — bootstrap generates independent random
-        // per-service keys (`load_or_generate_service_signing_key`), so a derived
-        // pubkey here would not match the key the service actually holds. If no
-        // registered key exists yet, error rather than sign a wrong key binding.
-        // User tokens: decode the caller-provided pubkey (from OAuth consent page).
+        // OAuth delegates for a service, so its envelope signer is OAuth's key,
+        // not the service assertion signer. Bind `cnf` to the explicitly passed
+        // assertion key. A registered service may attest a new sibling key.
         let service_key_bytes: Option<[u8; 32]> = if is_service_token {
             let svc_name = &subject["service:".len()..];
             let trust = hyprstream_service::global_trust_store();
-            let vk = VerifyingKey::from_bytes(&ctx.cnf)
-                .map_err(|_| anyhow!("service token caller has an invalid Ed25519 verifying key"))?;
-            if !trust.is_authorized(&vk, svc_name) {
-                anyhow::bail!("service key '{svc_name}' is not registered for the issuing caller; refusing to fabricate cnf.jwk");
+            use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine as _};
+            let requested_bytes: [u8; 32] = data.user_pub_key.as_deref()
+                .ok_or_else(|| anyhow!("service token issuance requires the assertion-verified Ed25519 public key"))
+                .and_then(|encoded| URL_SAFE_NO_PAD.decode(encoded)
+                    .map_err(|_| anyhow!("service token assertion key is not base64url"))?
+                    .try_into().map_err(|_| anyhow!("service token assertion key must be 32 bytes")))?;
+            let requested = VerifyingKey::from_bytes(&requested_bytes)
+                .map_err(|_| anyhow!("service token assertion key is not a valid Ed25519 verifying key"))?;
+            if trust.is_authorized(&requested, svc_name) {
+                Some(requested_bytes)
+            } else {
+                let caller = VerifyingKey::from_bytes(&ctx.cnf)
+                    .map_err(|_| anyhow!("service key rotation caller has an invalid Ed25519 verifying key"))?;
+                let expected_subject = format!("service:{svc_name}");
+                if ctx.subject().name() != Some(expected_subject.as_str()) || !trust.is_authorized(&caller, svc_name) {
+                    anyhow::bail!("unregistered service key for '{svc_name}' may only be attested by a registered sibling");
+                }
+                Some(requested_bytes)
             }
-            Some(*vk.as_bytes())
         } else {
             use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine as _};
             data.user_pub_key.as_deref().and_then(|s| {
@@ -1365,25 +1395,13 @@ impl PolicyHandler for PolicyService {
             None,
         ).map_err(|e| anyhow!("Invalid service JWT: {e}"))?;
 
-        let expected_sub = format!("service:{}", data.service_name);
-        if claims.sub != expected_sub {
-            anyhow::bail!(
-                "JWT subject '{}' does not match service name '{}'",
-                claims.sub, data.service_name
-            );
-        }
-
         // Verify the provided verifying key matches the JWT's cnf.jwk claim.
         let vk_bytes: [u8; 32] = data.verifying_key.as_slice().try_into()
             .map_err(|_| anyhow!("verifying_key must be 32 bytes"))?;
         let vk = VerifyingKey::from_bytes(&vk_bytes)
             .map_err(|e| anyhow!("Invalid Ed25519 verifying key: {e}"))?;
 
-        if let Some(cnf_bytes) = claims.cnf_key_bytes() {
-            if cnf_bytes != vk_bytes {
-                anyhow::bail!("JWT cnf.jwk does not match provided verifying key");
-            }
-        }
+        validate_service_key_registration(&claims, &data.service_name, &vk_bytes)?;
 
         // Store in trust store (key-centric: the key IS the identity)
         {
@@ -1806,5 +1824,31 @@ mod tests {
         assert!(response.keys.iter().any(|entry| entry.verifying_key == retired.to_bytes()));
         assert!(response.keys.iter().any(|entry| entry.verifying_key == lead.to_bytes()));
         assert!(response.keys.iter().all(|entry| entry.key_id.starts_with("ed25519:")));
+    }
+
+    #[test]
+    fn registration_requires_matching_present_confirmation_key() {
+        let key = SigningKey::generate(&mut rand::rngs::OsRng).verifying_key();
+        let now = chrono::Utc::now().timestamp();
+        let claims = hyprstream_rpc::auth::Claims::new("service:model".to_owned(), now, now + 60);
+        assert!(validate_service_key_registration(&claims, "model", key.as_bytes()).is_err());
+
+        let bound = claims.with_cnf_jwk(key.as_bytes());
+        assert!(validate_service_key_registration(&bound, "model", key.as_bytes()).is_ok());
+
+        let sibling = SigningKey::generate(&mut rand::rngs::OsRng).verifying_key();
+        assert!(validate_service_key_registration(&bound, "model", sibling.as_bytes()).is_err());
+    }
+
+    #[test]
+    fn one_key_response_keeps_legacy_projection_during_rollout() {
+        let trust = hyprstream_service::TrustStore::new();
+        let key = SigningKey::generate(&mut rand::rngs::OsRng).verifying_key();
+        trust.insert(key, attestation(chrono::Utc::now().timestamp() + 60, "certificate"));
+
+        let response = published_service_key_response(&trust, "model").unwrap();
+        assert_eq!(response.keys.len(), 1);
+        assert_eq!(response.verifying_key, key.to_bytes());
+        assert_eq!(response.service_jwt.as_deref(), Some("certificate"));
     }
 }

--- a/crates/hyprstream/src/services/policy.rs
+++ b/crates/hyprstream/src/services/policy.rs
@@ -437,21 +437,56 @@ impl PolicyHandler for PolicyService {
             let svc_name = &subject["service:".len()..];
             let trust = hyprstream_service::global_trust_store();
             use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine as _};
-            let requested_bytes: [u8; 32] = data.user_pub_key.as_deref()
-                .ok_or_else(|| anyhow!("service token issuance requires the assertion-verified Ed25519 public key"))
-                .and_then(|encoded| URL_SAFE_NO_PAD.decode(encoded)
-                    .map_err(|_| anyhow!("service token assertion key is not base64url"))?
-                    .try_into().map_err(|_| anyhow!("service token assertion key must be 32 bytes")))?;
-            let requested = VerifyingKey::from_bytes(&requested_bytes)
-                .map_err(|_| anyhow!("service token assertion key is not a valid Ed25519 verifying key"))?;
+            let invalid_assertion_key = |message: &str| {
+                PolicyResponseVariant::Error(ErrorInfo {
+                    message: message.to_owned(),
+                    code: "INVALID_ASSERTION_KEY".to_owned(),
+                    details: String::new(),
+                })
+            };
+            let Some(encoded) = data.user_pub_key.as_deref() else {
+                return Ok(invalid_assertion_key(
+                    "service token issuance requires the assertion-verified Ed25519 public key",
+                ));
+            };
+            let decoded = match URL_SAFE_NO_PAD.decode(encoded) {
+                Ok(decoded) => decoded,
+                Err(_) => return Ok(invalid_assertion_key(
+                    "service token assertion key is not base64url",
+                )),
+            };
+            let requested_bytes: [u8; 32] = match decoded.try_into() {
+                Ok(bytes) => bytes,
+                Err(_) => return Ok(invalid_assertion_key(
+                    "service token assertion key must be 32 bytes",
+                )),
+            };
+            let requested = match VerifyingKey::from_bytes(&requested_bytes) {
+                Ok(requested) => requested,
+                Err(_) => return Ok(invalid_assertion_key(
+                    "service token assertion key is not a valid Ed25519 verifying key",
+                )),
+            };
             if trust.is_authorized(&requested, svc_name) {
                 Some(requested_bytes)
             } else {
-                let caller = VerifyingKey::from_bytes(&ctx.cnf)
-                    .map_err(|_| anyhow!("service key rotation caller has an invalid Ed25519 verifying key"))?;
+                let caller = match VerifyingKey::from_bytes(&ctx.cnf) {
+                    Ok(caller) => caller,
+                    Err(_) => return Ok(PolicyResponseVariant::Error(ErrorInfo {
+                        message: "service key rotation caller has an invalid Ed25519 verifying key".to_owned(),
+                        code: "UNAUTHORIZED_SERVICE_KEY".to_owned(),
+                        details: String::new(),
+                    })),
+                };
                 let expected_subject = format!("service:{svc_name}");
                 if ctx.subject().name() != Some(expected_subject.as_str()) || !trust.is_authorized(&caller, svc_name) {
-                    anyhow::bail!("unregistered service key for '{svc_name}' may only be attested by a registered sibling");
+                    return Ok(PolicyResponseVariant::Error(ErrorInfo {
+                        message: format!(
+                            "unregistered service key for '{svc_name}' may only be attested by a registered sibling"
+                        ),
+                        code: "UNAUTHORIZED_SERVICE_KEY".to_owned(),
+                        details: String::new(),
+                    }));
                 }
                 Some(requested_bytes)
             }
@@ -1723,6 +1758,7 @@ pub(crate) async fn watch_policy_file(
 #[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {
     use super::*;
+    use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine as _};
 
     async fn test_service() -> (PolicyService, tempfile::TempDir) {
         let root = tempfile::tempdir().expect("test: create policy git directory");
@@ -1853,5 +1889,71 @@ mod tests {
         assert_eq!(response.keys.len(), 1);
         assert_eq!(response.verifying_key, key.to_bytes());
         assert_eq!(response.service_jwt.as_deref(), Some("certificate"));
+    }
+
+    #[tokio::test]
+    async fn issue_token_returns_structured_errors_for_invalid_service_keys() {
+        let (service, _root) = test_service().await;
+        let mut ctx = EnvelopeContext::from_callback_service(1, "rotation-error-test");
+        ctx.cnf = SigningKey::generate(&mut rand::rngs::OsRng)
+            .verifying_key()
+            .to_bytes();
+
+        let mut request = issue("service:rotation-error-test");
+        request.user_pub_key = Some("not-base64url!".to_owned());
+        let malformed = service
+            .handle_issue_token(&ctx, 1, &request)
+            .await
+            .expect("malformed assertion key is a policy response");
+        assert!(matches!(
+            malformed,
+            PolicyResponseVariant::Error(ErrorInfo { ref code, .. })
+                if code == "INVALID_ASSERTION_KEY"
+        ));
+
+        let requested = SigningKey::generate(&mut rand::rngs::OsRng).verifying_key();
+        request.user_pub_key = Some(URL_SAFE_NO_PAD.encode(requested.as_bytes()));
+        let unauthorized = service
+            .handle_issue_token(&ctx, 2, &request)
+            .await
+            .expect("unregistered sibling is a policy response");
+        assert!(matches!(
+            unauthorized,
+            PolicyResponseVariant::Error(ErrorInfo { ref code, .. })
+                if code == "UNAUTHORIZED_SERVICE_KEY"
+        ));
+    }
+
+    #[tokio::test]
+    async fn registered_sibling_reaches_service_token_signing_boundary() {
+        let (service, _root) = test_service().await;
+        let caller = SigningKey::generate(&mut rand::rngs::OsRng).verifying_key();
+        let requested = SigningKey::generate(&mut rand::rngs::OsRng).verifying_key();
+        let trust = hyprstream_service::global_trust_store();
+        trust.insert(caller, hyprstream_service::Attestation {
+            scopes: std::iter::once("rotation-sibling-test".to_owned()).collect(),
+            subject: None,
+            jwt: Some("registered-sibling".to_owned()),
+            expires_at: chrono::Utc::now().timestamp() + 60,
+            attested_by: None,
+        });
+
+        let mut ctx = EnvelopeContext::from_callback_service(1, "rotation-sibling-test");
+        ctx.cnf = caller.to_bytes();
+        let mut request = issue("service:rotation-sibling-test");
+        request.user_pub_key = Some(URL_SAFE_NO_PAD.encode(requested.as_bytes()));
+        let response = service.handle_issue_token(&ctx, 1, &request).await;
+        trust.remove(&caller);
+
+        match response.expect("registered sibling reaches the signing boundary") {
+            PolicyResponseVariant::IssueTokenResult(info) => {
+                let claims = hyprstream_rpc::auth::decode_unverified(&info.token)
+                    .expect("issued service token decodes");
+                assert_eq!(claims.cnf_key_bytes(), Some(requested.to_bytes()));
+            }
+            PolicyResponseVariant::Error(ErrorInfo { code, .. })
+                if code == "SIGNING_NOT_CONFIGURED" => {}
+            other => panic!("registered sibling was rejected before signing: {other:?}"),
+        }
     }
 }

--- a/crates/hyprstream/src/services/policy.rs
+++ b/crates/hyprstream/src/services/policy.rs
@@ -16,7 +16,7 @@ use crate::services::generated::policy_client::{
     AddGrouping, RemoveGrouping, SetBranchVisibility,
     RegisterEventPrefix, SubscribeEventPrefix, GetPendingSubscribers, DepositWrappedKeys,
     EventPrefixAccess, PendingSubscribers,
-    ResolveServiceKey, RegisterServiceKey, ServiceKeyResponse,
+    ResolveServiceKey, RegisterServiceKey, ServiceKeyCandidate, ServiceKeyResponse,
     RefreshServiceTokenRequest, ExchangeWit,
     dispatch_policy, serialize_response,
 };
@@ -253,6 +253,30 @@ fn validate_event_prefix(prefix: &str) -> Result<(), String> {
     Ok(())
 }
 
+/// Build the rotation-safe wire projection of a service's published key set.
+///
+/// The scalar fields remain only for wire compatibility and are intentionally
+/// empty: consumers which cannot handle `keys` must fail closed.
+fn published_service_key_response(
+    trust: &hyprstream_service::TrustStore,
+    service_name: &str,
+) -> Result<ServiceKeyResponse> {
+    let keys = trust.published_keys_for_scope(service_name);
+    if keys.is_empty() {
+        anyhow::bail!("service key '{service_name}' not registered");
+    }
+    Ok(ServiceKeyResponse {
+        verifying_key: Vec::new(),
+        service_jwt: None,
+        keys: keys.into_iter().map(|entry| ServiceKeyCandidate {
+            key_id: entry.key_id,
+            verifying_key: entry.verifying_key.to_bytes().to_vec(),
+            service_jwt: entry.attestation.jwt,
+            not_after: entry.attestation.expires_at,
+        }).collect(),
+    })
+}
+
 #[async_trait::async_trait(?Send)]
 impl PolicyHandler for PolicyService {
     async fn authorize(&self, ctx: &EnvelopeContext, resource: &str, operation: &str) -> Result<()> {
@@ -395,9 +419,11 @@ impl PolicyHandler for PolicyService {
         let service_key_bytes: Option<[u8; 32]> = if is_service_token {
             let svc_name = &subject["service:".len()..];
             let trust = hyprstream_service::global_trust_store();
-            let vk = trust.resolve_one(svc_name).ok_or_else(|| {
-                anyhow!("service key '{svc_name}' not registered; refusing to issue a service token with a fabricated cnf.jwk")
-            })?;
+            let vk = VerifyingKey::from_bytes(&ctx.cnf)
+                .map_err(|_| anyhow!("service token caller has an invalid Ed25519 verifying key"))?;
+            if !trust.is_authorized(&vk, svc_name) {
+                anyhow::bail!("service key '{svc_name}' is not registered for the issuing caller; refusing to fabricate cnf.jwk");
+            }
             Some(*vk.as_bytes())
         } else {
             use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine as _};
@@ -1314,18 +1340,12 @@ impl PolicyHandler for PolicyService {
         // because a guessed key produces a silent mis-verify ("Response signed by
         // unexpected key") three layers away at the envelope check. Registered-or-
         // error converts that into a clear, early failure.
-        let trust = hyprstream_service::global_trust_store();
-        let vk = trust.resolve_one(&data.service_name)
-            .ok_or_else(|| anyhow!("service key '{}' not registered", data.service_name))?;
-        let att = trust.get(&vk)
-            .ok_or_else(|| anyhow!("service key '{}' not registered (no attestation)", data.service_name))?;
-        debug!("Resolved service key for '{}'", data.service_name);
-        Ok(PolicyResponseVariant::ResolveServiceKeyResult(
-            ServiceKeyResponse {
-                verifying_key: vk.to_bytes().to_vec(),
-                service_jwt: att.jwt.clone(),
-            }
-        ))
+        let response = published_service_key_response(
+            hyprstream_service::global_trust_store(),
+            &data.service_name,
+        )?;
+        debug!(key_count = response.keys.len(), "Resolved service key set for '{}'", data.service_name);
+        Ok(PolicyResponseVariant::ResolveServiceKeyResult(response))
     }
 
     async fn handle_register_service_key(
@@ -1415,13 +1435,14 @@ impl PolicyHandler for PolicyService {
         let now = chrono::Utc::now().timestamp();
         let expires_at = now + ttl;
 
-        // cnf.jwk must be the service's REGISTERED key, never a CA-derived guess
-        // (#441/#806) — see handle_issue_token for the rationale. Registered-or-
-        // error: refuse to refresh a service token we can't bind to a real key.
+        // Bind the renewed JWT to the verified caller key, not an arbitrary
+        // sibling which happens to be published during overlap.
         let trust = hyprstream_service::global_trust_store();
-        let vk = trust.resolve_one(svc_name).ok_or_else(|| {
-            anyhow!("service key '{svc_name}' not registered; refusing to refresh a service token with a fabricated cnf.jwk")
-        })?;
+        let vk = VerifyingKey::from_bytes(&ctx.cnf)
+            .map_err(|_| anyhow!("refresh caller has an invalid Ed25519 verifying key"))?;
+        if !trust.is_authorized(&vk, svc_name) {
+            anyhow::bail!("service key '{svc_name}' is not registered for the renewing caller; refusing to fabricate cnf.jwk");
+        }
 
         let issuer = self.default_audience.clone().unwrap_or_default();
         let claims = hyprstream_rpc::auth::Claims::new(subject.clone(), now, expires_at)
@@ -1713,6 +1734,16 @@ mod tests {
         }
     }
 
+    fn attestation(expires_at: i64, jwt: &str) -> hyprstream_service::Attestation {
+        hyprstream_service::Attestation {
+            scopes: std::iter::once("model".to_owned()).collect(),
+            subject: None,
+            jwt: Some(jwt.to_owned()),
+            expires_at,
+            attested_by: None,
+        }
+    }
+
     #[tokio::test]
     async fn issue_token_rejects_path_form_subject_at_shared_signing_boundary() {
         let (service, _root) = test_service().await;
@@ -1754,5 +1785,26 @@ mod tests {
                 "legitimate subject {subject:?} was rejected by the path-form guard",
             );
         }
+    }
+
+    #[test]
+    fn resolve_service_key_publishes_every_overlap_candidate() {
+        let trust = hyprstream_service::TrustStore::new();
+        let retired = SigningKey::generate(&mut rand::rngs::OsRng).verifying_key();
+        let lead = SigningKey::generate(&mut rand::rngs::OsRng).verifying_key();
+        let now = chrono::Utc::now().timestamp();
+        trust.insert(retired, attestation(now + 60, "retired-attestation"));
+        trust.insert(lead, attestation(0, "lead-attestation"));
+
+        let response = match published_service_key_response(&trust, "model") {
+            Ok(response) => response,
+            Err(error) => panic!("key set: {error}"),
+        };
+        assert!(response.verifying_key.is_empty(), "no singleton fallback");
+        assert!(response.service_jwt.is_none(), "no singleton attestation fallback");
+        assert_eq!(response.keys.len(), 2, "overlap keys must both be published");
+        assert!(response.keys.iter().any(|entry| entry.verifying_key == retired.to_bytes()));
+        assert!(response.keys.iter().any(|entry| entry.verifying_key == lead.to_bytes()));
+        assert!(response.keys.iter().all(|entry| entry.key_id.starts_with("ed25519:")));
     }
 }

--- a/crates/hyprstream/src/services/policy.rs
+++ b/crates/hyprstream/src/services/policy.rs
@@ -1846,7 +1846,10 @@ mod tests {
         let key = SigningKey::generate(&mut rand::rngs::OsRng).verifying_key();
         trust.insert(key, attestation(chrono::Utc::now().timestamp() + 60, "certificate"));
 
-        let response = published_service_key_response(&trust, "model").unwrap();
+        let response = match published_service_key_response(&trust, "model") {
+            Ok(response) => response,
+            Err(error) => panic!("one-key response: {error}"),
+        };
         assert_eq!(response.keys.len(), 1);
         assert_eq!(response.verifying_key, key.to_bytes());
         assert_eq!(response.service_jwt.as_deref(), Some("certificate"));


### PR DESCRIPTION
Closes #1186.\n\nRelates to #1183.\n\nPublishes named, attested service-key candidate sets with stable key IDs and expiry, preserves overlap through bounded retirement, and binds registration/renewal to the caller's exact service key rather than an arbitrary sibling.