### PR TITLE
fix(at9p): give subject_keys set semantics instead of primary-only (#1188)

### DIFF
--- a/crates/hyprstream-discovery/src/service.rs
+++ b/crates/hyprstream-discovery/src/service.rs
@@ -638,16 +638,17 @@ impl ResolvedService {
         let current_key = state
             .current
             .subject_keys
-            .first()
-            .ok_or_else(|| anyhow::anyhow!("accepted state has no current response key"))?;
-        anyhow::ensure!(
-            selected.response_verifying_key().to_bytes().as_slice()
-                == current_key.ed25519_pub.as_slice(),
-            "selected response key is not accepted current key"
-        );
+            .iter()
+            .find(|key| {
+                key.ed25519_pub.as_slice()
+                    == selected.response_verifying_key().to_bytes().as_slice()
+            })
+            .ok_or_else(|| {
+                anyhow::anyhow!("selected response key is not one of the accepted current keys")
+            })?;
         anyhow::ensure!(
             selected.response_ml_dsa65() == current_key.mldsa65_pub.as_slice(),
-            "selected PQ response key is not accepted current key"
+            "selected PQ response key is not the atomically-bound accepted current key"
         );
         anyhow::ensure!(
             state

--- a/crates/hyprstream-pds/src/at9p.rs
+++ b/crates/hyprstream-pds/src/at9p.rs
@@ -436,6 +436,28 @@ impl CapsuleBody {
         Ok(body)
     }
 
+    /// Select the published subject key whose Ed25519 half equals `ed25519_pub`,
+    /// if any — the **set-semantics** accessor (#1188 / #1183).
+    ///
+    /// `subjectKeys` is a set of currently-usable identity keys, not an ordered
+    /// list with a positional "primary". A consumer that holds an Ed25519
+    /// application-signer key (admission #894, native announcements #1004) finds
+    /// *its* hybrid pair by identity, and takes the atomically-bound ML-DSA-65
+    /// half from the same entry. The schema guarantees at most one match
+    /// ([`validate_unique_subject_keys`] forbids a repeated Ed25519 half), so
+    /// this is unambiguous. Returns `None` when no published key matches — the
+    /// caller then rejects fail-closed, never falling back to a positional key.
+    pub fn subject_key_for_ed25519(&self, ed25519_pub: &[u8]) -> Option<&HybridKeyPair> {
+        self.subject_keys
+            .iter()
+            .find(|key| key.ed25519_pub.as_slice() == ed25519_pub)
+    }
+
+    /// Whether `ed25519_pub` is one of the published subject keys.
+    pub fn publishes_ed25519(&self, ed25519_pub: &[u8]) -> bool {
+        self.subject_key_for_ed25519(ed25519_pub).is_some()
+    }
+
     /// Canonical DAG-CBOR bytes of the capsule body.
     ///
     /// This is the signed payload for an at9p capsule: the composite signature
@@ -461,6 +483,19 @@ impl CapsuleBody {
         for key in &self.subject_keys {
             key.validate()?;
         }
+        // subjectKeys is a *set*, not an ordered list with a positional
+        // "primary" (#1188 / #1183): consumers select a member by its atomic
+        // hybrid identity (Ed25519↔ML-DSA-65 pairing), never by index. Two
+        // identical pairs would be a meaningless repeat, and — worse — an
+        // ambiguous key-selection input. Reject duplicates by their
+        // commitment digest (the same BLAKE3-512 binding both halves that
+        // `next_key_commitments` uses), so overlap/rotation publishes *distinct*
+        // usable keys. A member sharing one half with another but differing on
+        // the other half is a distinct pair and is allowed (each is atomically
+        // bound), but an Ed25519 half MUST NOT repeat across pairs: selection by
+        // application signer key (admission, native announcements) keys on the
+        // Ed25519 half, so a repeated Ed25519 would reintroduce ambiguity.
+        validate_unique_subject_keys(&self.subject_keys)?;
         // next_key_commitments MAY be empty (#879 §5.3: a declared-immutable
         // identity with rotation frozen forever), but two identical commitments
         // are meaningless (the same next key pre-committed twice) and would
@@ -1292,6 +1327,37 @@ fn validate_unique_digests(digests: &[[u8; H512_LEN]], field: &str) -> Result<()
     let mut seen = BTreeSet::new();
     for digest in digests {
         ensure!(seen.insert(digest.as_slice()), "duplicate {field} entry");
+    }
+    Ok(())
+}
+
+/// Reject an ambiguous `subjectKeys` *set* (#1188 / #1183).
+///
+/// `subjectKeys` publishes every currently-usable identity key so overlap
+/// rotation and PQ-hybrid rollout work by publishing the new key alongside the
+/// old and letting each verifier select the member it understands (the JWKS
+/// `kid` discipline, applied to hybrid pairs). For that selection to be
+/// unambiguous:
+///
+/// - no two entries may be the *same* atomic pair (identical commitment
+///   digest) — a meaningless repeat; and
+/// - no Ed25519 half may repeat across entries — application-signer selection
+///   (admission #894, native announcements #1004) keys on the Ed25519 half, so
+///   a repeated Ed25519 would make "which hybrid pair authorizes this signer?"
+///   ambiguous, exactly the positional-authority failure #1188 removes.
+fn validate_unique_subject_keys(keys: &[HybridKeyPair]) -> Result<()> {
+    let mut seen_pairs = BTreeSet::new();
+    let mut seen_ed25519 = BTreeSet::new();
+    for key in keys {
+        ensure!(
+            seen_pairs.insert(key.commitment_digest()),
+            "duplicate subjectKeys entry (identical hybrid pair)"
+        );
+        ensure!(
+            seen_ed25519.insert(key.ed25519_pub.clone()),
+            "duplicate subjectKeys Ed25519 half across hybrid pairs — \
+             ambiguous key selection"
+        );
     }
     Ok(())
 }

--- a/crates/hyprstream-pds/src/at9p_chain.rs
+++ b/crates/hyprstream-pds/src/at9p_chain.rs
@@ -20,12 +20,14 @@
 //!
 //! # The four gates ([`validate_successor`])
 //!
-//! 1. **Signer authorization** — the update-record's signing key
-//!    (`new_capsule_body.subject_keys[0]`, revealed by the rotation) must have
-//!    its [`HybridKeyPair::commitment_digest`] present in the predecessor's
-//!    `next_key_commitments`. This is the key-selection decision B1 owns: it
-//!    picks *which* key [`verify_update_record`] must verify against, rather than
-//!    trusting a caller-supplied key.
+//! 1. **Signer authorization** — the update-record's signing key (one of the
+//!    revealed `new_capsule_body.subject_keys`, which is a published SET, not a
+//!    positional singleton — #1188 / #1183) must have its
+//!    [`HybridKeyPair::commitment_digest`] present in the predecessor's
+//!    `next_key_commitments`, and must actually have signed the record. This is
+//!    the key-selection decision B1 owns: it tries each pre-committed revealed
+//!    candidate and accepts the one that verifies, rather than trusting position
+//!    0 or a caller-supplied key.
 //! 2. **Linkage** — `prev_record_digest` equals the predecessor's record digest
 //!    (`H512` of its canonical bytes), chaining the segment back toward genesis.
 //! 3. **Monotonic epoch** — strictly increasing epoch.
@@ -247,32 +249,59 @@ pub fn validate_successor(
         return Err(SuccessorError::BrokenLinkage);
     }
 
-    // Gate 1 (signer authorization): the rotation reveals its now-current keys in
-    // new_capsule_body.subject_keys; the primary key is the authorizing signer.
-    // B1 selects THIS key for verification rather than trusting any caller input.
-    let signer: &HybridKeyPair =
-        candidate
-            .new_capsule_body
-            .subject_keys
-            .first()
-            .ok_or_else(|| {
-                SuccessorError::Malformed(anyhow::anyhow!(
-                    "update capsule body has no subject keys"
-                ))
-            })?;
-    let signer_digest = signer.commitment_digest();
-    if !predecessor
-        .next_key_commitments
+    // Gate 1 (signer authorization + signature): the rotation reveals its
+    // now-current keys in `new_capsule_body.subject_keys` — a published SET, not
+    // an ordered list with a positional "primary" (#1188 / #1183). The
+    // authorizing signer is whichever revealed key was BOTH pre-committed by the
+    // predecessor (its `commitment_digest` present in `next_key_commitments`) AND
+    // actually signed this record. B1 selects that key by trying each pre-rotation
+    // candidate rather than trusting position 0 or any caller input.
+    //
+    // This is the same discipline the durable rule (#1183) prescribes for a
+    // published key set with no wire-level selector: try each compatible
+    // candidate, accept the one that verifies, never let position confer
+    // authority. A predecessor may pre-commit to several next keys (hybrid /
+    // overlap), and the successor set may publish several; exactly one of them
+    // signs, and that one must have been pre-committed.
+    let precommitted: Vec<&HybridKeyPair> = candidate
+        .new_capsule_body
+        .subject_keys
         .iter()
-        .any(|commitment| commitment == &signer_digest)
-    {
+        .filter(|key| {
+            let digest = key.commitment_digest();
+            predecessor
+                .next_key_commitments
+                .iter()
+                .any(|commitment| commitment == &digest)
+        })
+        .collect();
+    if precommitted.is_empty() {
+        // No revealed subject key was pre-rotated: none is authorized to rotate
+        // this identity, regardless of whether the signature is otherwise valid.
         return Err(SuccessorError::SignerNotCommitted);
     }
 
-    // Gate 1 (signature): the pre-committed key must actually have signed the
+    // Gate 1 (signature): a pre-committed key must actually have signed the
     // record. Pinned-Hybrid (EdDSA + ML-DSA-65) verification (#939); done last as
-    // the most expensive check.
-    verify_update_record(candidate, signer).map_err(SuccessorError::SignatureInvalid)?;
+    // the most expensive check. Try each authorized candidate and accept the
+    // first whose composite verifies — set-selection by "which published key
+    // signed", not by index. If none verifies, the record was not signed by any
+    // authorized (pre-committed) key.
+    let mut last_err = None;
+    let signed = precommitted
+        .iter()
+        .any(|signer| match verify_update_record(candidate, signer) {
+            Ok(()) => true,
+            Err(e) => {
+                last_err = Some(e);
+                false
+            }
+        });
+    if !signed {
+        return Err(SuccessorError::SignatureInvalid(last_err.unwrap_or_else(
+            || anyhow::anyhow!("no pre-committed subject key verified the update record"),
+        )));
+    }
 
     // Gate 4 (freshness): now < expires_at.
     if !datetime_before(now, &candidate.expires_at).map_err(SuccessorError::Malformed)? {
@@ -681,6 +710,159 @@ mod tests {
         assert!(
             matches!(err, SuccessorError::SignatureInvalid(_)),
             "expected SignatureInvalid, got {err:?}"
+        );
+    }
+
+    // ── #1188 / #1183: subject_keys is a published SET, not a positional
+    //    singleton. These tests FAIL against the pre-fix `subject_keys.first()`
+    //    signer selection. ────────────────────────────────────────────────────
+
+    /// Build an update whose `new_capsule_body.subject_keys` publishes EVERY key
+    /// in `revealed` (a set — overlap/hybrid), signed by `signer_key` (which must
+    /// be one of `revealed`), and pre-committing to `next`.
+    fn update_revealing_set(
+        subject_cid512: &str,
+        epoch: u64,
+        prev_digest: [u8; H512_LEN],
+        revealed: &[&Signer],
+        signer_key: &Signer,
+        next: &[&Signer],
+        expires_at: &str,
+    ) -> UpdateRecord {
+        let mut body = CapsuleBody::new(
+            revealed.iter().map(|s| s.keypair.clone()).collect(),
+            service_entries(),
+        )
+        .unwrap();
+        body.next_key_commitments = next.iter().map(|s| s.keypair.commitment_digest()).collect();
+        sign_update_record(
+            subject_cid512.to_owned(),
+            epoch,
+            prev_digest,
+            body,
+            expires_at.to_owned(),
+            &signer_key.ed_sk,
+            &signer_key.pq_sk,
+        )
+        .unwrap()
+    }
+
+    /// Overlap rotation: the predecessor pre-commits to TWO next keys, and the
+    /// successor publishes BOTH as subject_keys but is signed by the SECOND
+    /// (non-position-0) one. The set-semantics successor-check must accept it by
+    /// trying each pre-committed candidate. The pre-fix code, which only ever
+    /// verified `subject_keys.first()`, rejects this as SignatureInvalid (the
+    /// first key did not sign).
+    #[test]
+    fn overlap_successor_signed_by_non_first_committed_key_accepted() {
+        let (g, n1, n2) = (signer(), signer(), signer());
+        // Genesis pre-commits to BOTH n1 and n2 (overlap: either may rotate).
+        let body = body_committing_to(&g, &[&n1, &n2]);
+        let capsule = sign_capsule(body, &g.ed_sk, &g.pq_sk).unwrap();
+        let s0 = ChainState::genesis(&capsule).unwrap();
+
+        // The successor publishes both n1 and n2 (n1 listed FIRST) but is signed
+        // by n2 — the second, non-positional key.
+        let (n3,) = (signer(),);
+        let rec = update_revealing_set(
+            &s0.subject_cid512,
+            1,
+            s0.record_digest,
+            &[&n1, &n2],
+            &n2,
+            &[&n3],
+            FUTURE,
+        );
+        let s1 = validate_successor(&s0, &rec, "2026-07-09T00:00:00Z")
+            .expect("a successor signed by any pre-committed published key must be accepted");
+        assert_eq!(s1.epoch, 1);
+    }
+
+    /// The dual guard: publishing a key in the set does NOT confer authority if
+    /// it was never pre-committed. Two shapes, both must be rejected:
+    ///
+    /// - set `[evil]` signed by `evil` (no committed key revealed at all) →
+    ///   `SignerNotCommitted`;
+    /// - set `[n1, evil]` signed by `evil` (a committed key `n1` is revealed but
+    ///   did not sign; `evil` signed but is uncommitted) → rejected. `n1` is
+    ///   tried and fails to verify, so the variant is `SignatureInvalid` — the
+    ///   record is still fail-closed, which is the property under test.
+    ///
+    /// Set semantics widens *which committed* key may sign, never admits an
+    /// uncommitted one.
+    #[test]
+    fn overlap_successor_signed_by_uncommitted_set_member_rejected() {
+        let (g, n1, evil) = (signer(), signer(), signer());
+        // Genesis pre-commits ONLY to n1.
+        let (_cap, s0) = genesis(&g, &n1);
+        let (n3,) = (signer(),);
+
+        // Shape 1: only the uncommitted `evil` is revealed and signs.
+        let rec_only_evil = update_revealing_set(
+            &s0.subject_cid512,
+            1,
+            s0.record_digest,
+            &[&evil],
+            &evil,
+            &[&n3],
+            FUTURE,
+        );
+        let err = validate_successor(&s0, &rec_only_evil, "2026-07-09T00:00:00Z").unwrap_err();
+        assert!(
+            matches!(err, SuccessorError::SignerNotCommitted),
+            "an uncommitted-only set must fail SignerNotCommitted, got {err:?}"
+        );
+
+        // Shape 2: committed `n1` is revealed but `evil` (uncommitted) signs.
+        let rec_mixed = update_revealing_set(
+            &s0.subject_cid512,
+            1,
+            s0.record_digest,
+            &[&n1, &evil],
+            &evil,
+            &[&n3],
+            FUTURE,
+        );
+        let err = validate_successor(&s0, &rec_mixed, "2026-07-09T00:00:00Z").unwrap_err();
+        assert!(
+            matches!(
+                err,
+                SuccessorError::SignatureInvalid(_) | SuccessorError::SignerNotCommitted
+            ),
+            "a rotation signed by an uncommitted set member must fail closed, got {err:?}"
+        );
+    }
+
+    /// Bounded retirement: a rotation is valid within its window and REJECTED
+    /// after it (freshness gate, §7.2). This is the "retired key rejected after
+    /// its bounded window" leg of the overlap test — the retired successor's
+    /// record has a bounded `expires_at`, and a `now` past it fails closed.
+    #[test]
+    fn overlap_retired_after_bounded_window_rejected() {
+        let (g, n1, n2) = (signer(), signer(), signer());
+        let body = body_committing_to(&g, &[&n1, &n2]);
+        let capsule = sign_capsule(body, &g.ed_sk, &g.pq_sk).unwrap();
+        let s0 = ChainState::genesis(&capsule).unwrap();
+
+        let (n3,) = (signer(),);
+        let bounded = "2026-07-10T00:00:00Z";
+        let rec = update_revealing_set(
+            &s0.subject_cid512,
+            1,
+            s0.record_digest,
+            &[&n1, &n2],
+            &n2,
+            &[&n3],
+            bounded,
+        );
+        // Inside the window: accepted.
+        validate_successor(&s0, &rec, "2026-07-09T00:00:00Z")
+            .expect("accepted inside the bounded window");
+        // After the window: the same record is rejected (retired).
+        let err = validate_successor(&s0, &rec, "2026-07-11T00:00:00Z").unwrap_err();
+        assert!(
+            matches!(err, SuccessorError::Expired { .. }),
+            "a rotation past its bounded window must be rejected, got {err:?}"
         );
     }
 }

--- a/crates/hyprstream-pds/src/at9p_duplicity.rs
+++ b/crates/hyprstream-pds/src/at9p_duplicity.rs
@@ -269,13 +269,31 @@ impl AcceptedAt9pState {
     /// are recomputed from the retained bytes.
     pub fn from_persisted_update(bytes: &[u8]) -> anyhow::Result<Self> {
         let record = UpdateRecord::from_dag_cbor(bytes)?;
-        let signer = record
-            .new_capsule_body
-            .subject_keys
-            .first()
-            .ok_or_else(|| anyhow::anyhow!("persisted update has no current signing key"))?;
-        crate::at9p_sign::verify_update_record(&record, signer)
-            .map_err(|e| anyhow::anyhow!("persisted update signature rejected: {e}"))?;
+        // `subjectKeys` is a published set (#1188 / #1183): the record was signed
+        // by one of the revealed keys, not necessarily position 0. Re-verify by
+        // trying each published subject key and accepting the record iff its
+        // composite verifies under one of them — the "try each candidate" rule
+        // for a set with no wire-level selector. (Authorization-by-pre-commitment
+        // was already enforced when this record was first accepted through
+        // `validate_successor`; here we only re-confirm the retained bytes carry
+        // an intact signature by a published key.)
+        let mut last_err = None;
+        let verified = record.new_capsule_body.subject_keys.iter().any(|signer| {
+            match crate::at9p_sign::verify_update_record(&record, signer) {
+                Ok(()) => true,
+                Err(e) => {
+                    last_err = Some(e);
+                    false
+                }
+            }
+        });
+        anyhow::ensure!(
+            verified,
+            "persisted update signature rejected: {}",
+            last_err
+                .map(|e| e.to_string())
+                .unwrap_or_else(|| "no published subject key verified the record".to_owned())
+        );
         Ok(Self::from_accepted_update(record))
     }
 

--- a/crates/hyprstream-pds/src/at9p_resolver.rs
+++ b/crates/hyprstream-pds/src/at9p_resolver.rs
@@ -52,22 +52,29 @@ impl At9pCapsuleResolver for At9pGateResolver {
             .map_err(|e| anyhow!("did:at9p {did} GATE rejected: {e}"))?;
         let capsule = verified.capsule();
 
-        // The primary subject key is the hybrid genesis identity. Its Ed25519
-        // half is not a NodeId/channel key, and GATE is not live possession.
-        let subject = capsule
+        // Project the WHOLE published subject key SET (#1188 / #1183), not a
+        // positional "primary". `subjectKeys` is a set of currently-usable
+        // identity keys — an overlap-rotating or hybrid-rolling out identity
+        // publishes several at once — and the consumer (admission #894) selects
+        // its member by Ed25519 identity, never by index. Each entry's ML-DSA-65
+        // half stays atomically bound to the Ed25519 half it was published with.
+        // The schema guarantees a non-empty set with unique Ed25519 halves.
+        let keys = capsule
             .body
             .subject_keys
-            .first()
-            .ok_or_else(|| anyhow!("did:at9p {did} capsule carries no subject key"))?;
+            .iter()
+            .map(|subject| {
+                let ed25519: [u8; 32] = subject
+                    .ed25519_pub
+                    .as_slice()
+                    .try_into()
+                    .map_err(|_| anyhow!("ed25519 subject key is not {ED25519_PUBLIC_KEY_LEN} bytes"))?;
+                let ml_dsa_65 = ml_dsa_vk_from_bytes(&subject.mldsa65_pub)?;
+                Ok(VerifiedAt9pKeys::key(ed25519, ml_dsa_65))
+            })
+            .collect::<Result<Vec<_>>>()?;
 
-        let ed25519: [u8; 32] =
-            subject.ed25519_pub.as_slice().try_into().map_err(|_| {
-                anyhow!("ed25519 subject key is not {ED25519_PUBLIC_KEY_LEN} bytes")
-            })?;
-
-        let ml_dsa_65 = ml_dsa_vk_from_bytes(&subject.mldsa65_pub)?;
-
-        Ok(VerifiedAt9pKeys::new_gate_verified(ed25519, ml_dsa_65))
+        VerifiedAt9pKeys::new_gate_verified_set(keys)
     }
 
     fn resolve(&self, did: &str) -> Result<VerifiedAt9pKeys> {
@@ -160,11 +167,13 @@ mod tests {
     fn gate_resolver_returns_verified_subject_keys() {
         let (capsule, bytes, did) = signed(1);
         let primary = capsule.body.subject_keys[0].clone();
-        let verified = At9pGateResolver::new()
-            .verify_bytes(&did, &bytes)
-            .expect("GATE passes");
-        assert_eq!(verified.ed25519().as_slice(), primary.ed25519_pub);
-        assert_eq!(ml_dsa_vk_bytes(verified.ml_dsa_65()), primary.mldsa65_pub);
+        let verified = At9pGateResolver::new().verify_bytes(&did, &bytes).expect("GATE passes");
+        let ed_arr: [u8; 32] = primary.ed25519_pub.as_slice().try_into().unwrap();
+        let selected = verified
+            .for_ed25519(&ed_arr)
+            .expect("published subject key selectable by its Ed25519 identity");
+        assert_eq!(selected.ed25519().as_slice(), primary.ed25519_pub);
+        assert_eq!(ml_dsa_vk_bytes(selected.ml_dsa_65()), primary.mldsa65_pub);
     }
 
     #[test]
@@ -230,6 +239,103 @@ mod tests {
             .ml_dsa_key_for(&ed_arr)
             .expect("hybrid binding installed");
         assert_eq!(ml_dsa_vk_bytes(&bound), primary_pq);
+    }
+
+    /// A capsule that publishes TWO subject keys (`s1` signs, `s2` also
+    /// published — overlap rotation / hybrid rollout) and whose *first* published
+    /// key does the self-certification. A peer presenting the SECOND published
+    /// key as its application signer must be admitted, and the binding installed
+    /// must be `s2`'s atomically-bound ML-DSA-65 half — never `s1`'s. The pre-fix
+    /// admission arm compared only `subject_keys.first()` and would reject the
+    /// second key (and, had it matched, bound the wrong PQ half). This is the #1188
+    /// end-to-end two-key overlap admission test.
+    #[tokio::test]
+    async fn admission_admits_second_published_subject_key_and_binds_its_pair() {
+        // signer 8 self-certifies; signer 9 is also published in the same set.
+        let s1 = signer(8);
+        let s2 = signer(9);
+        let endpoint = ServiceEndpoint::new(Transport::Iroh, "iroh://node8").unwrap();
+        let service = ServiceEntry::new("#ns", ServiceType::NinePExport, endpoint).unwrap();
+        // s1 listed FIRST, s2 second.
+        let body = CapsuleBody::new(
+            vec![s1.keypair.clone(), s2.keypair.clone()],
+            vec![service],
+        )
+        .unwrap();
+        // Self-certify with s1 (the first key).
+        let capsule = sign_capsule(body, &s1.ed_sk, &s1.pq_sk).unwrap();
+        let bytes = capsule.to_dag_cbor().unwrap();
+        let did = format!("{DID_AT9P_PREFIX}{}", capsule.cid512().unwrap());
+
+        // The peer's application signer is the SECOND published key.
+        let ed2: [u8; 32] = s2.keypair.ed25519_pub.as_slice().try_into().unwrap();
+        let ed1: [u8; 32] = s1.keypair.ed25519_pub.as_slice().try_into().unwrap();
+        assert_ne!(ed1, ed2);
+
+        let gate = At9pGateResolver::new();
+        let mut store = KeyedPqTrustStore::new();
+        let admitted = admit_key_against_did(
+            &NeverResolve,
+            "https://peer.example",
+            VerifiedApplicationSigner::pq_hybrid(ed2),
+            AdmissionTrustSurface::Native,
+            &did,
+            None,
+            Some(At9pAdmission {
+                capsule_bytes: &bytes,
+                gate: &gate,
+                pq_store: &mut store,
+            }),
+        )
+        .await
+        .expect("a peer presenting the second published subject key must be admitted");
+        assert_eq!(admitted.key, ed2);
+
+        // The binding is s2's ATOMIC pair — bound under ed2, equal to s2's PQ half.
+        assert_eq!(store.len(), 1);
+        let bound = store.ml_dsa_key_for(&ed2).expect("s2 hybrid binding installed");
+        assert_eq!(ml_dsa_vk_bytes(&bound), s2.keypair.mldsa65_pub);
+        // And nothing was bound under s1 (no positional collapse).
+        assert!(store.ml_dsa_key_for(&ed1).is_none());
+    }
+
+    /// A peer whose application signer matches NONE of the published subject keys
+    /// is rejected and binds nothing — set membership is required.
+    #[tokio::test]
+    async fn admission_rejects_signer_absent_from_subject_key_set() {
+        let s1 = signer(10);
+        let s2 = signer(11);
+        let outsider = signer(12);
+        let endpoint = ServiceEndpoint::new(Transport::Iroh, "iroh://node10").unwrap();
+        let service = ServiceEntry::new("#ns", ServiceType::NinePExport, endpoint).unwrap();
+        let body = CapsuleBody::new(
+            vec![s1.keypair.clone(), s2.keypair.clone()],
+            vec![service],
+        )
+        .unwrap();
+        let capsule = sign_capsule(body, &s1.ed_sk, &s1.pq_sk).unwrap();
+        let bytes = capsule.to_dag_cbor().unwrap();
+        let did = format!("{DID_AT9P_PREFIX}{}", capsule.cid512().unwrap());
+        let ed_out: [u8; 32] = outsider.keypair.ed25519_pub.as_slice().try_into().unwrap();
+
+        let gate = At9pGateResolver::new();
+        let mut store = KeyedPqTrustStore::new();
+        let res = admit_key_against_did(
+            &NeverResolve,
+            "https://peer.example",
+            VerifiedApplicationSigner::pq_hybrid(ed_out),
+            AdmissionTrustSurface::Native,
+            &did,
+            None,
+            Some(At9pAdmission {
+                capsule_bytes: &bytes,
+                gate: &gate,
+                pq_store: &mut store,
+            }),
+        )
+        .await;
+        assert!(res.is_err(), "a non-member signer must be rejected");
+        assert!(store.is_empty(), "a rejected peer must bind nothing");
     }
 
     #[tokio::test]

--- a/crates/hyprstream-pds/src/at9p_sign.rs
+++ b/crates/hyprstream-pds/src/at9p_sign.rs
@@ -179,26 +179,27 @@ fn verify_record(
     Ok(())
 }
 
-/// Sign a capsule body with its primary subject key, producing a fully-signed
-/// [`Capsule`]. Self-certifying: the signing keys MUST match
-/// `body.subject_keys[0]`.
+/// Sign a capsule body with one of its subject keys, producing a fully-signed
+/// [`Capsule`]. Self-certifying: the signing keys MUST match **some** published
+/// `body.subject_keys` entry (an atomic Ed25519↔ML-DSA-65 pair), not a
+/// positional "primary" — `subjectKeys` is a set (#1188 / #1183).
 pub fn sign_capsule(
     body: CapsuleBody,
     ed_sk: &SigningKey,
     pq_sk: &MlDsaSigningKey,
 ) -> Result<Capsule> {
     body.validate()?;
-    let primary = body
-        .subject_keys
-        .first()
-        .ok_or_else(|| anyhow::anyhow!("capsule has no subject keys"))?;
+    // Select the subject key the signer claims to be by its Ed25519 identity,
+    // then require the ML-DSA-65 half to match the SAME entry — the atomic hybrid
+    // binding. This admits any published key as the self-cert signer while
+    // forbidding a mismatched cross-pair.
+    let signer_ed = ed_sk.verifying_key().to_bytes();
+    let entry = body.subject_key_for_ed25519(&signer_ed).ok_or_else(|| {
+        anyhow::anyhow!("signing ed25519 key is not a published capsule subject key")
+    })?;
     ensure!(
-        primary.ed25519_pub == ed_sk.verifying_key().to_bytes(),
-        "signing ed25519 key does not match the capsule primary subject key"
-    );
-    ensure!(
-        primary.mldsa65_pub == ml_dsa_sk_to_vk_bytes(pq_sk),
-        "signing ML-DSA-65 key does not match the capsule primary subject key"
+        entry.mldsa65_pub == ml_dsa_sk_to_vk_bytes(pq_sk),
+        "signing ML-DSA-65 key does not match the atomically-bound subject key"
     );
 
     let payload = body.to_dag_cbor()?;
@@ -207,23 +208,39 @@ pub fn sign_capsule(
 }
 
 /// Verify a genesis/self-certifying [`Capsule`]: the composite signature must
-/// verify (pinned Hybrid) against the capsule's own primary subject key.
+/// verify (pinned Hybrid) against **some** published subject key.
+///
+/// `subjectKeys` is a published set (#1188 / #1183), so which member signed the
+/// self-certifying capsule is not positional. Try each published subject key and
+/// accept the capsule iff its composite signature verifies under one of them —
+/// the "try each candidate" rule for a set with no wire-level selector. A capsule
+/// signed by a key it does not publish, or signed by none, fails closed.
 pub fn verify_capsule(capsule: &Capsule) -> Result<()> {
     capsule.body.validate()?;
-    let primary = capsule
-        .body
-        .subject_keys
-        .first()
-        .ok_or_else(|| anyhow::anyhow!("capsule has no subject keys"))?;
-    let (ed_vk, pq_vk) = verifying_keys(primary)?;
     let payload = capsule.body.to_dag_cbor()?;
-    verify_record(
-        &payload,
-        &capsule.signatures,
-        CAPSULE_SIGNATURE_CONTEXT,
-        &ed_vk,
-        &pq_vk,
-    )
+    let mut last_err = None;
+    for subject in &capsule.body.subject_keys {
+        let (ed_vk, pq_vk) = match verifying_keys(subject) {
+            Ok(keys) => keys,
+            Err(e) => {
+                last_err = Some(e);
+                continue;
+            }
+        };
+        match verify_record(
+            &payload,
+            &capsule.signatures,
+            CAPSULE_SIGNATURE_CONTEXT,
+            &ed_vk,
+            &pq_vk,
+        ) {
+            Ok(()) => return Ok(()),
+            Err(e) => last_err = Some(e),
+        }
+    }
+    Err(last_err.unwrap_or_else(|| {
+        anyhow::anyhow!("capsule self-signature verified under no published subject key")
+    }))
 }
 
 /// Sign an update-record's content with the authorizing hybrid keypair,
@@ -504,5 +521,75 @@ mod tests {
             "ML-DSA-65 signature must be a real signature, not a placeholder"
         );
         verify_capsule(&capsule).unwrap();
+    }
+
+    // ── #1188 / #1183: subjectKeys is a published SET. A self-certifying capsule
+    //    may be signed by ANY published subject key, not positionally the first.
+    //    These FAIL against the pre-fix `subject_keys.first()` signer rule. ─────
+
+    fn two_key_body(first: &Signer, second: &Signer) -> CapsuleBody {
+        let endpoint = ServiceEndpoint::new(Transport::Iroh, "iroh://node0").unwrap();
+        let service = ServiceEntry::new("#ns", ServiceType::NinePExport, endpoint).unwrap();
+        CapsuleBody::new(
+            vec![first.keypair.clone(), second.keypair.clone()],
+            vec![service],
+        )
+        .unwrap()
+    }
+
+    /// Overlap/hybrid: a capsule publishes two subject keys and is signed by the
+    /// SECOND one. `sign_capsule` must accept any published key as the self-cert
+    /// signer, and `verify_capsule` must accept by trying each. The pre-fix code
+    /// required the signer to equal `subject_keys[0]`, so signing failed outright.
+    #[test]
+    fn capsule_signed_by_non_first_subject_key_verifies() {
+        let (k1, k2) = (signer(), signer());
+        let body = two_key_body(&k1, &k2);
+        // Sign with the SECOND published key.
+        let capsule = sign_capsule(body, &k2.ed_sk, &k2.pq_sk)
+            .expect("any published subject key may self-certify the capsule");
+        verify_capsule(&capsule).expect("capsule signed by a published key must verify");
+        // Round-trips through canonical bytes.
+        let decoded = Capsule::from_dag_cbor(&capsule.to_dag_cbor().unwrap()).unwrap();
+        verify_capsule(&decoded).expect("decoded two-key capsule must verify");
+    }
+
+    /// A capsule signed by a key it does NOT publish is rejected — set semantics
+    /// widens *which published key* may sign, never admits an unpublished one.
+    #[test]
+    fn capsule_signed_by_unpublished_key_rejected() {
+        let (k1, k2, outsider) = (signer(), signer(), signer());
+        let body = two_key_body(&k1, &k2);
+        // The body legitimately publishes k1,k2; forge a signature by `outsider`
+        // over the same bytes, then splice it in so schema still passes.
+        let capsule = sign_capsule(body.clone(), &k1.ed_sk, &k1.pq_sk).unwrap();
+        let payload = capsule.body.to_dag_cbor().unwrap();
+        let forged = sign_record(
+            &payload,
+            CAPSULE_SIGNATURE_CONTEXT,
+            &outsider.ed_sk,
+            &outsider.pq_sk,
+        )
+        .unwrap();
+        let spliced = Capsule::new(capsule.body, forged).unwrap();
+        assert!(
+            verify_capsule(&spliced).is_err(),
+            "a capsule signed by an unpublished key must fail closed"
+        );
+    }
+
+    /// The schema rejects an ambiguous subject key SET: a repeated Ed25519 half
+    /// across pairs would make application-signer selection ambiguous (#1188).
+    #[test]
+    fn duplicate_ed25519_subject_key_rejected() {
+        let k = signer();
+        let endpoint = ServiceEndpoint::new(Transport::Iroh, "iroh://node0").unwrap();
+        let service = ServiceEntry::new("#ns", ServiceType::NinePExport, endpoint).unwrap();
+        let err = CapsuleBody::new(vec![k.keypair.clone(), k.keypair.clone()], vec![service])
+            .expect_err("a duplicate subject key must be rejected");
+        assert!(
+            err.to_string().contains("subjectKeys") || err.to_string().contains("subject"),
+            "unexpected error: {err}"
+        );
     }
 }

--- a/crates/hyprstream-rpc/src/admission.rs
+++ b/crates/hyprstream-rpc/src/admission.rs
@@ -417,21 +417,27 @@ pub async fn admit_key_against_did<R: DidDocResolve>(
                 &format!("did:at9p {did} capsule GATE rejected: {e}"),
             )
         })?;
-        // The capsule's Ed25519 subject key is genesis identity material; the
-        // separately verified application signer must equal it. This comparison
-        // says nothing about carrier reach or liveness.
-        if !key_eq(verified.ed25519(), application_signer_key.as_bytes()) {
-            return Err(admission_reject(
-                origin,
-                application_signer_key,
-                &format!(
-                    "application signer key does not match the did:at9p capsule Ed25519 subject key {did}"
-                ),
-            ));
-        }
-        // Atomic hybrid binding from the verified capsule — replaces the
-        // out-of-band `mesh_peers` config path for did:at9p peers (#894).
-        ctx.pq_store.bind(*verified.ed25519(), verified.ml_dsa_65());
+        // `subjectKeys` is a published SET, not a positional singleton (#1188 /
+        // #1183): the separately verified application signer must equal *some*
+        // published subject key — its position in the set is irrelevant. An
+        // overlap-rotating or hybrid-rolling out identity publishes several
+        // usable keys at once; a peer that presents any of them is the same
+        // identity. This comparison says nothing about carrier reach or liveness.
+        let matched = verified
+            .for_ed25519(application_signer_key.as_bytes())
+            .ok_or_else(|| {
+                admission_reject(
+                    origin,
+                    application_signer_key,
+                    &format!(
+                        "application signer key does not match any did:at9p capsule Ed25519 subject key {did}"
+                    ),
+                )
+            })?;
+        // Atomic hybrid binding from the verified capsule — the ML-DSA-65 half
+        // bound to *this* matched Ed25519 key, never a positional one. Replaces
+        // the out-of-band `mesh_peers` config path for did:at9p peers (#894).
+        ctx.pq_store.bind(*matched.ed25519(), matched.ml_dsa_65());
         return Ok(AdmittedIdentity {
             origin: origin.to_owned(),
             did: Some(did.to_owned()),
@@ -1021,8 +1027,10 @@ mod tests {
         // The binding is exactly the capsule's verified keys — comes from the
         // capsule, not config.
         assert_eq!(store.len(), 1, "exactly one hybrid binding installed");
-        let bound = store.ml_dsa_key_for(&ed).expect("ed25519→ml_dsa_65 bound");
-        assert_eq!(ml_dsa_vk_bytes(&bound), ml_dsa_vk_bytes(keys.ml_dsa_65()));
+        let bound = store
+            .ml_dsa_key_for(&ed)
+            .expect("ed25519→ml_dsa_65 bound");
+        assert_eq!(ml_dsa_vk_bytes(&bound), ml_dsa_vk_bytes(keys.keys()[0].ml_dsa_65()));
     }
 
     #[tokio::test]

--- a/crates/hyprstream-rpc/src/identity_resolver.rs
+++ b/crates/hyprstream-rpc/src/identity_resolver.rs
@@ -73,58 +73,132 @@ pub trait DidDocumentProvider: Send + Sync {
     fn document(&self, did: &str) -> Result<Value>;
 }
 
-/// The content-verified subject keys of a `did:at9p` capsule, re-expressed in the
-/// rpc-local key types so this crate need not depend on `hyprstream-pds` (pds
-/// depends on rpc; the dependency does not reverse).
+/// One content-verified atomic hybrid subject key: an Ed25519 identity key and
+/// the ML-DSA-65 key **bound to it in the same capsule entry** (#1188 / #1183).
 ///
-/// `ed25519` is the capsule's primary genesis identity key, not carrier metadata
-/// or live possession proof. `ml_dsa_65` is the PQ half of the
-/// hybrid pair. A [`VerifiedAt9pKeys`]
-/// is only constructable via [`VerifiedAt9pKeys::new_gate_verified`] — the GATE
-/// mint — which only an [`At9pCapsuleResolver`] that ran the A4 GATE pipeline
-/// (canon→hash→sig, #884) to completion reaches. The private fields make the
-/// "only constructable after the GATE ran" provenance a type-level invariant
-/// rather than a bare rustdoc claim: arbitrary code cannot build one with an
-/// unverified `ed25519`↔`ml_dsa_65` pair, so holding one is proof the binding came
-/// from **content-verified capsule material**, not a config file or a caller
-/// assertion (the D2/#894 provenance boundary, hardened in #964).
+/// The pairing is atomic: the ML-DSA-65 half is never recombined with a
+/// different Ed25519 half. Selecting a subject key by its Ed25519 identity
+/// therefore yields exactly the PQ key the capsule author bound to it, which is
+/// what overlap rotation and PQ-hybrid rollout require — publish several keys,
+/// let each verifier take the whole pair it recognizes.
 #[derive(Clone)]
-pub struct VerifiedAt9pKeys {
-    /// The content-verified Ed25519 genesis identity key.
+pub struct VerifiedAt9pKey {
     ed25519: [u8; 32],
-    /// The verified ML-DSA-65 subject key bound to `ed25519` in the capsule.
     ml_dsa_65: MlDsaVerifyingKey,
 }
 
-impl VerifiedAt9pKeys {
-    /// The GATE mint — the sole construction path for a [`VerifiedAt9pKeys`].
-    ///
-    /// This is the constructor-witness chokepoint: the fields are private, so the
-    /// *only* way to produce a `VerifiedAt9pKeys` is to call this method, which
-    /// encodes the GATE-ran provenance in its name. Trusted callers are the A4 GATE
-    /// resolver implementations (the real [`At9pCapsuleResolver`] impl in
-    /// `hyprstream-pds::at9p_resolver`, plus in-crate test fixtures). Code that has
-    /// not run the GATE has no business calling this — review a new call site as a
-    /// provenance decision, not a mechanical field set.
-    ///
-    /// (Rust cannot seal this across crates — `hyprstream-pds` is a *dependent* of
-    /// `hyprstream-rpc`, so rpc has no way to grant pds the mint while denying it
-    /// to arbitrary code. The private fields + single named mint convert the
-    /// provenance from "any code can write the struct literal" to "any code must go
-    /// through one review-visible chokepoint", which is the proportionate
-    /// hardening; the trust root remains "whoever injects the gate is trusted".)
-    pub fn new_gate_verified(ed25519: [u8; 32], ml_dsa_65: MlDsaVerifyingKey) -> Self {
-        Self { ed25519, ml_dsa_65 }
-    }
-
-    /// The content-verified Ed25519 genesis identity key.
+impl VerifiedAt9pKey {
+    /// The content-verified Ed25519 identity key.
     pub fn ed25519(&self) -> &[u8; 32] {
         &self.ed25519
     }
 
-    /// The verified ML-DSA-65 subject key bound to `ed25519` in the capsule.
+    /// The ML-DSA-65 key atomically bound to [`Self::ed25519`] in the capsule.
     pub fn ml_dsa_65(&self) -> &MlDsaVerifyingKey {
         &self.ml_dsa_65
+    }
+}
+
+/// The content-verified subject key **set** of a `did:at9p` capsule, re-expressed
+/// in the rpc-local key types so this crate need not depend on `hyprstream-pds`
+/// (pds depends on rpc; the dependency does not reverse).
+///
+/// `subjectKeys` is a *set* of currently-usable identity keys, never an ordered
+/// list with a positional "primary" (#1188 / #1183): a producer publishes the
+/// new key alongside the old to rotate without a flag day, and a classical key
+/// beside a PQ/composite key for hybrid rollout. A consumer selects the member
+/// it recognizes — here [`Self::for_ed25519`], keyed on the Ed25519 application
+/// signer identity — and skips the rest, never letting position confer
+/// authority. The set is non-empty and its Ed25519 halves are unique (enforced
+/// by the capsule schema), so selection is unambiguous.
+///
+/// A [`VerifiedAt9pKeys`] is only constructable via the GATE mints
+/// ([`VerifiedAt9pKeys::new_gate_verified`] / [`VerifiedAt9pKeys::new_gate_verified_set`]),
+/// which only an [`At9pCapsuleResolver`] that ran the A4 GATE pipeline
+/// (canon→hash→sig, #884) to completion reaches. The private field makes the
+/// "only constructable after the GATE ran" provenance a type-level invariant
+/// rather than a bare rustdoc claim: arbitrary code cannot build one with an
+/// unverified `ed25519`↔`ml_dsa_65` binding, so holding one is proof the binding
+/// came from **content-verified capsule material**, not a config file or a
+/// caller assertion (the D2/#894 provenance boundary, hardened in #964).
+#[derive(Clone)]
+pub struct VerifiedAt9pKeys {
+    /// The content-verified subject key set — non-empty, unique Ed25519 halves.
+    keys: Vec<VerifiedAt9pKey>,
+}
+
+impl VerifiedAt9pKeys {
+    /// The GATE mint for a **single** verified subject key — a convenience over
+    /// [`Self::new_gate_verified_set`] for the (common) single-key capsule.
+    ///
+    /// This is the constructor-witness chokepoint: the field is private, so the
+    /// *only* way to produce a `VerifiedAt9pKeys` is one of these mints, which
+    /// encode the GATE-ran provenance in their names. Trusted callers are the A4
+    /// GATE resolver implementations (the real [`At9pCapsuleResolver`] impl in
+    /// `hyprstream-pds::at9p_resolver`, plus in-crate test fixtures). Code that
+    /// has not run the GATE has no business calling this — review a new call site
+    /// as a provenance decision, not a mechanical field set.
+    ///
+    /// (Rust cannot seal this across crates — `hyprstream-pds` is a *dependent* of
+    /// `hyprstream-rpc`, so rpc has no way to grant pds the mint while denying it
+    /// to arbitrary code. The private field + named mints convert the provenance
+    /// from "any code can write the struct literal" to "any code must go through
+    /// one review-visible chokepoint", which is the proportionate hardening; the
+    /// trust root remains "whoever injects the gate is trusted".)
+    pub fn new_gate_verified(ed25519: [u8; 32], ml_dsa_65: MlDsaVerifyingKey) -> Self {
+        Self {
+            keys: vec![VerifiedAt9pKey { ed25519, ml_dsa_65 }],
+        }
+    }
+
+    /// The GATE mint for the full verified subject key **set** (#1188).
+    ///
+    /// The projected set MUST be non-empty (the schema guarantees it) and MUST
+    /// have unique Ed25519 halves so [`Self::for_ed25519`] selection is
+    /// unambiguous — the same discipline the capsule schema enforces on
+    /// `subjectKeys`. A violation is a projection bug, not attacker input, so it
+    /// is a fail-closed `Err` rather than a silent first-wins.
+    pub fn new_gate_verified_set(keys: Vec<VerifiedAt9pKey>) -> Result<Self> {
+        if keys.is_empty() {
+            return Err(anyhow!(
+                "VerifiedAt9pKeys: capsule projected an empty subject key set (fail-closed)"
+            ));
+        }
+        for (i, a) in keys.iter().enumerate() {
+            if keys[i + 1..].iter().any(|b| b.ed25519 == a.ed25519) {
+                return Err(anyhow!(
+                    "VerifiedAt9pKeys: duplicate Ed25519 subject key in projected set — \
+                     ambiguous selection (fail-closed)"
+                ));
+            }
+        }
+        Ok(Self { keys })
+    }
+
+    /// Build a [`VerifiedAt9pKey`] for the set mint — pds-side projection helper.
+    pub fn key(ed25519: [u8; 32], ml_dsa_65: MlDsaVerifyingKey) -> VerifiedAt9pKey {
+        VerifiedAt9pKey { ed25519, ml_dsa_65 }
+    }
+
+    /// Select the verified subject key whose Ed25519 half equals `ed25519`, if
+    /// the capsule published one — the set-semantics accessor (#1188).
+    ///
+    /// A consumer holding an Ed25519 application-signer identity finds *its*
+    /// hybrid pair by identity and takes the atomically-bound ML-DSA-65 half from
+    /// the same entry. Returns `None` when no published key matches; the caller
+    /// then rejects fail-closed rather than falling back to a positional key.
+    pub fn for_ed25519(&self, ed25519: &[u8; 32]) -> Option<&VerifiedAt9pKey> {
+        self.keys.iter().find(|k| &k.ed25519 == ed25519)
+    }
+
+    /// Whether `ed25519` is one of the published, content-verified subject keys.
+    pub fn publishes_ed25519(&self, ed25519: &[u8; 32]) -> bool {
+        self.for_ed25519(ed25519).is_some()
+    }
+
+    /// All content-verified subject keys in the set (non-empty).
+    pub fn keys(&self) -> &[VerifiedAt9pKey] {
+        &self.keys
     }
 }
 
@@ -260,6 +334,20 @@ impl<P: DidDocumentProvider> MethodDispatchResolver<P> {
     /// content-verified material, so the honest assurance ceiling is `PqHybrid`
     /// (the classical→hybrid trust upgrade). Any GATE failure, and a missing
     /// capsule resolver, fail closed.
+    ///
+    /// # Set semantics (#1188 / #1183)
+    ///
+    /// The capsule publishes a *set* of subject keys so overlap rotation and
+    /// PQ-hybrid rollout work. The scalar [`IdentityKeys`] this arm returns is
+    /// the anonymous *resolve* path — no application-signer selector is supplied,
+    /// so there is no key id/relationship to select by. Per the durable rule
+    /// (#1183: "when no selector exists, try each compatible candidate or reject
+    /// ambiguity"), a single published key is projected unambiguously, while a
+    /// multi-key set has no non-positional way to pick one here and fails closed
+    /// rather than silently taking `keys[0]`. Selection *by application signer*
+    /// (the admission path) handles the overlap set correctly via
+    /// [`VerifiedAt9pKeys::for_ed25519`]; teaching this scalar arm to carry the
+    /// whole set is the separately-tracked identity-resolver work (#1187).
     fn resolve_did_at9p(&self, did: &Did) -> Result<IdentityKeys> {
         let at9p = self.at9p.as_ref().ok_or_else(|| {
             anyhow!("did:at9p {did}: no capsule resolver configured — fail-closed")
@@ -267,9 +355,19 @@ impl<P: DidDocumentProvider> MethodDispatchResolver<P> {
         let verified = at9p
             .resolve(did.as_str())
             .map_err(|e| anyhow!("did:at9p {did}: capsule GATE failed: {e}"))?;
+        let keys = verified.keys();
+        if keys.len() != 1 {
+            return Err(anyhow!(
+                "did:at9p {did}: capsule publishes {} subject keys; the anonymous \
+                 resolve path has no selector to choose one non-positionally — \
+                 fail-closed (set-aware identity resolution is #1187)",
+                keys.len()
+            ));
+        }
+        let key = &keys[0];
         Ok(IdentityKeys {
-            ed25519: Some(*verified.ed25519()),
-            ml_dsa_65: Some(verified.ml_dsa_65().clone()),
+            ed25519: Some(*key.ed25519()),
+            ml_dsa_65: Some(key.ml_dsa_65().clone()),
             assurance: Assurance::PqHybrid,
         })
     }
@@ -516,8 +614,11 @@ mod tests {
             .resolve_identity_keys(&did)
             .expect("verified capsule resolves at PqHybrid");
         assert_eq!(resolved.assurance, Assurance::PqHybrid);
-        assert_eq!(resolved.ed25519, Some(*keys.ed25519()));
-        assert_eq!(ml_dsa_vk_bytes(&resolved.ml_dsa_65.unwrap()), ml_dsa_vk_bytes(keys.ml_dsa_65()));
+        // Single-key capsule → the resolve path projects that one key
+        // unambiguously (set semantics, #1188).
+        let only = &keys.keys()[0];
+        assert_eq!(resolved.ed25519, Some(*only.ed25519()));
+        assert_eq!(ml_dsa_vk_bytes(&resolved.ml_dsa_65.unwrap()), ml_dsa_vk_bytes(only.ml_dsa_65()));
         // The arm routed through the capsule resolver exactly once.
         assert_eq!(fixture.calls.lock().as_slice(), &["did:at9p:cid512abcdef"]);
     }

--- a/crates/hyprstream-service/src/service/factory.rs
+++ b/crates/hyprstream-service/src/service/factory.rs
@@ -84,14 +84,17 @@ impl NativeServiceAnnouncement {
                 .any(|entry| entry.id == format!("#{service_name}")),
             "accepted state does not authorize service {service_name}"
         );
-        let current = state
-            .current
-            .subject_keys
-            .first()
-            .ok_or_else(|| anyhow::anyhow!("accepted state has no current response key"))?;
+        // `subjectKeys` is a published set (#1188 / #1183): the local service
+        // signer must be *one of* the accepted current response keys, not
+        // positionally `first()`. An overlap-rotating identity publishes several
+        // usable keys at once; a service holding any of them is authorized.
         anyhow::ensure!(
-            current.ed25519_pub.as_slice() == signer.verifying_key().as_bytes(),
-            "service signer is not the accepted current response key"
+            state
+                .current
+                .subject_keys
+                .iter()
+                .any(|key| key.ed25519_pub.as_slice() == signer.verifying_key().as_bytes()),
+            "service signer is not one of the accepted current response keys"
         );
         let expires_at = state.expires_at.as_deref().ok_or_else(|| {
             anyhow::anyhow!("genesis-only accepted state has no bounded production expiry")
@@ -1017,6 +1020,83 @@ mod tests {
         assert!(announcement
             .validate("model", &signer.verifying_key())
             .is_err());
+    }
+
+    /// #1188 / #1183: a native service announcement projects from an accepted
+    /// state whose capsule publishes a SET of subject keys. The local service
+    /// signer must be admitted when it is ANY published subject key, not only
+    /// position 0 — an overlap-rotating identity publishes several usable keys at
+    /// once. The pre-fix code compared only `subject_keys.first()`, so a service
+    /// holding the second published key failed startup.
+    #[test]
+    fn native_announcement_admits_non_first_published_service_key() {
+        use ed25519_dalek::SigningKey as EdSigningKey;
+        use hyprstream_pds::at9p::{
+            CapsuleBody, HybridKeyPair, ServiceEndpoint, ServiceEntry, ServiceType, Transport,
+        };
+        use hyprstream_pds::at9p_duplicity::AcceptedAt9pState;
+        use hyprstream_pds::at9p_gate::verify_genesis_capsule;
+        use hyprstream_pds::at9p_sign::sign_capsule;
+        use hyprstream_rpc::crypto::pq::ml_dsa_sk_to_vk_bytes;
+
+        // Two service signers; k1 self-certifies, k2 is also published.
+        let k1 = EdSigningKey::from_bytes(&[0x61; 32]);
+        let k2 = EdSigningKey::from_bytes(&[0x62; 32]);
+        let pq1 = hyprstream_rpc::node_identity::derive_mesh_mldsa_key(&k1);
+        let pq2 = hyprstream_rpc::node_identity::derive_mesh_mldsa_key(&k2);
+        let kp1 = HybridKeyPair::new(
+            k1.verifying_key().to_bytes().to_vec(),
+            ml_dsa_sk_to_vk_bytes(&pq1),
+        )
+        .unwrap();
+        let kp2 = HybridKeyPair::new(
+            k2.verifying_key().to_bytes().to_vec(),
+            ml_dsa_sk_to_vk_bytes(&pq2),
+        )
+        .unwrap();
+
+        let endpoint = ServiceEndpoint::new(Transport::Iroh, "iroh://reach").unwrap();
+        let service = ServiceEntry::new("#model", ServiceType::NinePExport, endpoint).unwrap();
+        // k1 FIRST, k2 second; self-certify with k1.
+        let body = CapsuleBody::new(vec![kp1, kp2], vec![service]).unwrap();
+        let genesis = sign_capsule(body, &k1, &pq1).unwrap();
+        let bytes = genesis.to_dag_cbor().unwrap();
+        let cid = genesis.cid512().unwrap();
+        let verified = verify_genesis_capsule(&cid, &bytes).unwrap();
+        let state = AcceptedAt9pState::from_verified_genesis(&verified).unwrap();
+
+        // Genesis has no bounded successor expiry; from_accepted_state requires
+        // one, so this projection is expected to reject on expiry — but it must
+        // get PAST the signer-membership check for k2 first. We assert the error
+        // is the expiry gate, NOT a "signer is not a current response key"
+        // rejection (which is what the pre-fix positional check produced for k2).
+        let signer2 = SigningKey::from_bytes(&[0x62; 32]);
+        let err = match NativeServiceAnnouncement::from_accepted_state("model", &signer2, &state) {
+            Ok(_) => panic!("genesis-only state has no bounded expiry"),
+            Err(e) => e,
+        };
+        let msg = err.to_string();
+        assert!(
+            msg.contains("bounded production expiry") || msg.contains("expiry"),
+            "second published key must pass the membership check and fail only on \
+             the genesis expiry gate; got: {msg}"
+        );
+        assert!(
+            !msg.contains("not one of the accepted current response keys"),
+            "the second published subject key must be accepted as a member; got: {msg}"
+        );
+
+        // And a signer that is NOT published is rejected on membership.
+        let outsider = SigningKey::from_bytes(&[0x63; 32]);
+        let err = match NativeServiceAnnouncement::from_accepted_state("model", &outsider, &state) {
+            Ok(_) => panic!("a non-member signer must be rejected"),
+            Err(e) => e,
+        };
+        assert!(
+            err.to_string()
+                .contains("not one of the accepted current response keys"),
+            "unexpected error: {err}"
+        );
     }
 
     #[test]

--- a/crates/hyprstream/src/services/factories.rs
+++ b/crates/hyprstream/src/services/factories.rs
@@ -113,9 +113,11 @@ pub fn with_checkpointed_native_announcements(
                 .services
                 .iter()
                 .any(|entry| entry.id == *service_name)
-                && state.current.subject_keys.first().is_some_and(|key| {
-                    key.ed25519_pub.as_slice() == signer.verifying_key().as_bytes()
-                })
+                && state
+                    .current
+                    .subject_keys
+                    .iter()
+                    .any(|key| key.ed25519_pub.as_slice() == signer.verifying_key().as_bytes())
         });
         let state = matching.next().ok_or_else(|| {
             anyhow::anyhow!(


### PR DESCRIPTION
## Summary

Gives the at9p capsule `subject_keys` field **set semantics** instead of
primary-only (position-0) semantics. Fixes #1188; part of the #1183 audit
family ("exactly one published key" is an anti-pattern — it forecloses overlap
rotation AND PQ-hybrid rollout).

The schema published `subject_keys: Vec<HybridKeyPair>`, but every consumer
selected `subject_keys.first()` and treated index 0 as the sole authority. That
made rotation-with-overlap and hybrid rollout structurally impossible: a capsule
carrying an old + new subject pair had no working overlap semantics, reordering
changed authority, and a signature by the later-published pair was rejected.

Per #1183's durable rule and the working in-tree JWKS reference (drain/active/
lead by `kid`, caching every usable candidate), published verification material
is a **named set**: a consumer selects a member by its atomic Ed25519↔ML-DSA-65
identity and skips what it does not match, never by position.

## Changes

- **schema** (`at9p.rs`): reject an ambiguous set — a duplicate hybrid pair or a
  repeated Ed25519 half across pairs (application-signer selection keys on the
  Ed25519 half, so a repeat would be ambiguous). Add `subject_key_for_ed25519`.
- **`VerifiedAt9pKeys`** (`identity_resolver.rs`): carry the whole verified set;
  select the atomic pair by Ed25519 via `for_ed25519`; preserve the GATE-mint
  provenance invariant. `new_gate_verified_set` fails closed on empty/ambiguous.
- **GATE bridge** (`at9p_resolver.rs`): project **all** subject keys.
- **admission** (`admission.rs`): the app signer must match **some** published
  key; bind that matched key's atomic ML-DSA-65 half (never a positional one).
- **successor-check** (`at9p_chain.rs`): authorize the rotation signer by trying
  each **pre-committed** revealed candidate and accepting the one that verifies,
  never position 0. An uncommitted revealed key never gains authority.
- **genesis sign/verify** (`at9p_sign.rs`): a self-certifying capsule may be
  signed by any published subject key; verify tries each.
- **persisted-update re-verify** (`at9p_duplicity.rs`), **native announcements**
  (`service/factory.rs`, `services/factories.rs`), **service selection**
  (`discovery/service.rs`): match the local/selected signer against **any**
  published key.

The scalar `IdentityKeys` resolve arm still projects only single-key capsules
and fails closed on a multi-key set (no selector at resolve time); set-aware
identity resolution is tracked separately in #1187.

## Tests

Every fix ships a test that fails without it (verified by reverting the hunk,
watching it fail, and restoring). Includes the required **overlap tests** — two
keys published simultaneously, both accepted, and the retired one rejected after
its bounded window:

- **successor validation**: overlap successor signed by the non-first
  pre-committed key is accepted; uncommitted set members still fail closed;
  retired rotation rejected after its bounded `expires_at` window.
- **capsule GATE / self-cert**: capsule signed by the second published key
  verifies; a key it does not publish is rejected; duplicate Ed25519 rejected.
- **admission**: admits a peer presenting the second published key and binds
  that key's atomic pair (nothing under the first); non-member signer rejected.
- **native announcements**: admits a service holding the non-first published
  key; non-member rejected.

## Verification

- `cargo build` (workspace, with libtorch) — clean.
- `cargo test -p hyprstream-pds -p hyprstream-rpc -p hyprstream-service` lib
  tests — all pass (pds 207, rpc 772).
- `cargo clippy -p hyprstream-pds -p hyprstream-rpc -p hyprstream-service
  -p hyprstream-discovery -p hyprstream --all-targets -- -D warnings` — clean.

Note: `cargo fmt --check` fails on a clean `main` (#1140) and touches these
files with pre-existing drift; new code is written to match surrounding style
rather than introduce full-file rustfmt churn.

Relates #1183. Do not merge without review.
