### PR TITLE
fix(auth): try all JWKS candidates for kid-less JWTs

### DIFF
--- a/crates/hyprstream-rpc/src/auth/jwt.rs
+++ b/crates/hyprstream-rpc/src/auth/jwt.rs
@@ -387,6 +387,62 @@ pub fn decode_with_key(
     decode_inner(token, verifying_key, expected_aud, true)
 }
 
+/// Try verifying a JWT against each candidate key, returning the first
+/// successful decode. Mirrors [`decode`] (strict audience: an absent `aud`
+/// is rejected when `expected_aud` is `Some`).
+///
+/// This is the safe verifier shape for a kid-less JWT: when the JOSE header
+/// carries no `kid`, the verifier cannot know which published key signed the
+/// token, so it MUST try every algorithm-compatible candidate rather than
+/// collapse the published set to a positional singleton (#1183 / #1184).
+/// Per-candidate failures are expected in the happy path (a JWKS with several
+/// keys has exactly one real verifier), so they are logged at `debug!`; the
+/// final failure surfaces `InvalidSignature`.
+///
+/// `candidates` MUST be non-empty; an empty slice is an `InvalidSignature`
+/// error rather than a panic.
+pub fn decode_with_any_key(
+    token: &str,
+    candidates: &[VerifyingKey],
+    expected_aud: Option<&str>,
+) -> Result<Claims, JwtError> {
+    decode_with_any_key_inner(token, candidates, expected_aud, false)
+}
+
+/// Lenient-audience twin of [`decode_with_any_key`], mirroring
+/// [`decode_with_key`]: a wrong `aud` is still rejected, but an absent `aud`
+/// is accepted when `expected_aud` is `Some`. Use this for federated tokens
+/// from issuers that do not set `aud`.
+pub fn decode_with_any_key_lenient(
+    token: &str,
+    candidates: &[VerifyingKey],
+    expected_aud: Option<&str>,
+) -> Result<Claims, JwtError> {
+    decode_with_any_key_inner(token, candidates, expected_aud, true)
+}
+
+fn decode_with_any_key_inner(
+    token: &str,
+    candidates: &[VerifyingKey],
+    expected_aud: Option<&str>,
+    lenient_aud: bool,
+) -> Result<Claims, JwtError> {
+    if candidates.is_empty() {
+        return Err(JwtError::InvalidSignature);
+    }
+    let mut last_err = JwtError::InvalidSignature;
+    for vk in candidates {
+        match decode_inner(token, vk, expected_aud, lenient_aud) {
+            Ok(claims) => return Ok(claims),
+            Err(e) => {
+                tracing::debug!(error = %e, "JWT candidate key did not verify; trying next");
+                last_err = e;
+            }
+        }
+    }
+    Err(last_err)
+}
+
 /// Internal decode implementation shared by `decode` and `decode_with_key`.
 ///
 /// `lenient_aud`: when true, accepts tokens with no `aud` claim even when

--- a/crates/hyprstream-rpc/src/auth/key_source.rs
+++ b/crates/hyprstream-rpc/src/auth/key_source.rs
@@ -55,6 +55,24 @@ pub trait JwtKeySource: Send + Sync + 'static {
     /// Returns error if the issuer is untrusted or key resolution fails.
     async fn get_key(&self, issuer: &str, kid: Option<&str>) -> Result<VerifyingKey>;
 
+    /// Resolve **all** algorithm-compatible candidates for an issuer/kid pair.
+    ///
+    /// This is the safe default for verifying a kid-less JWT: when no `kid`
+    /// selector is present the verifier cannot know which published key signed
+    /// the token, so it MUST retain every compatible candidate and try each
+    /// until one verifies — never collapse the published set to a positional
+    /// singleton (`first`/`next`/`values().next()`). See #1183 / #1184.
+    ///
+    /// Single-key sources return a one-element vec. JWKS-backed sources
+    /// override this to return every Ed25519 entry when `kid` is `None`.
+    ///
+    /// Callers pair this with [`crate::auth::jwt::decode_with_any_key`] to
+    /// try each candidate against the JWT signature.
+    async fn get_keys(&self, issuer: &str, kid: Option<&str>) -> Result<Vec<VerifyingKey>> {
+        let key = self.get_key(issuer, kid).await?;
+        Ok(vec![key])
+    }
+
     /// Check if an issuer is trusted (before attempting key fetch).
     ///
     /// Returns `true` for local issuers and configured federated issuers.
@@ -473,6 +491,74 @@ impl JwksKeySource {
 
         Ok(())
     }
+
+    /// Resolve a single key by `kid`, consulting the offline local-CA path,
+    /// the JWKS cache, the negative cache, and (on miss) a refetch. The
+    /// `kid` selector makes the choice unambiguous — contrast with the
+    /// kid-less path in [`JwtKeySource::get_keys`] which must return every
+    /// candidate.
+    async fn resolve_by_kid(&self, issuer: &str, kid_str: &str) -> Result<VerifyingKey> {
+        // Authoritative local CA key (offline): for a LOCAL issuer whose
+        // `kid` matches the on-disk CA key thumbprint, resolve without any
+        // network fetch. This is the service-to-service WIT JWT path; the
+        // HTTP /oauth/jwks endpoint may not be up yet during startup, and
+        // #441 makes service-key registration a hard precondition, so this
+        // resolution must not depend on it. Never overrides a JWKS-published
+        // (rotated) key because it's keyed on the exact CA thumbprint.
+        if self.is_local(issuer) {
+            if let (Some(ca_kid), Some(ca_key)) = (self.local_ca_kid.as_deref(), self.local_ca_key) {
+                if ca_kid == kid_str {
+                    return Ok(ca_key);
+                }
+            }
+        }
+        {
+            let cache = self.cache.read().await;
+            if let Some(entry) = cache.get(kid_str) {
+                return Ok(entry.verifying_key);
+            }
+        }
+
+        // Check negative cache
+        {
+            let neg = self.negative_cache.read().await;
+            if let Some(&ts) = neg.get(kid_str) {
+                if ts.elapsed() < self.negative_ttl {
+                    anyhow::bail!("Key not found for kid={} (negative cached)", kid_str);
+                }
+            }
+        }
+
+        // On-miss refetch
+        if let Err(e) = self.fetch_and_cache(issuer).await {
+            tracing::warn!("JWKS fetch failed for issuer={}: {}", issuer, e);
+        }
+
+        // Retry from cache
+        let cache = self.cache.read().await;
+        if let Some(entry) = cache.get(kid_str) {
+            return Ok(entry.verifying_key);
+        }
+
+        // Add to negative cache
+        {
+            let mut neg = self.negative_cache.write().await;
+            neg.insert(kid_str.to_owned(), std::time::Instant::now());
+        }
+
+        anyhow::bail!("Key not found in JWKS for kid={}", kid_str)
+    }
+
+    /// Ensure the JWKS cache has been populated for `issuer` (refetch on
+    /// empty). Used by the kid-less resolution paths before they read every
+    /// candidate out of the cache.
+    async fn ensure_cached(&self, issuer: &str) {
+        if self.cache.read().await.is_empty() {
+            if let Err(e) = self.fetch_and_cache(issuer).await {
+                tracing::warn!("JWKS fetch failed for issuer={}: {}", issuer, e);
+            }
+        }
+    }
 }
 
 #[async_trait::async_trait]
@@ -482,71 +568,52 @@ impl JwtKeySource for JwksKeySource {
             anyhow::bail!("Untrusted issuer: {}", issuer);
         }
 
-        // Try cache first
+        // A presented `kid` is unambiguous: resolve that exact slot.
         if let Some(kid_str) = kid {
-            // Authoritative local CA key (offline): for a LOCAL issuer whose
-            // `kid` matches the on-disk CA key thumbprint, resolve without any
-            // network fetch. This is the service-to-service WIT JWT path; the
-            // HTTP /oauth/jwks endpoint may not be up yet during startup, and
-            // #441 makes service-key registration a hard precondition, so this
-            // resolution must not depend on it. Never overrides a JWKS-published
-            // (rotated) key because it's keyed on the exact CA thumbprint.
-            if self.is_local(issuer) {
-                if let (Some(ca_kid), Some(ca_key)) = (self.local_ca_kid.as_deref(), self.local_ca_key) {
-                    if ca_kid == kid_str {
-                        return Ok(ca_key);
-                    }
-                }
-            }
-            {
-                let cache = self.cache.read().await;
-                if let Some(entry) = cache.get(kid_str) {
-                    return Ok(entry.verifying_key);
-                }
-            }
-
-            // Check negative cache
-            {
-                let neg = self.negative_cache.read().await;
-                if let Some(&ts) = neg.get(kid_str) {
-                    if ts.elapsed() < self.negative_ttl {
-                        anyhow::bail!("Key not found for kid={} (negative cached)", kid_str);
-                    }
-                }
-            }
-
-            // On-miss refetch
-            if let Err(e) = self.fetch_and_cache(issuer).await {
-                tracing::warn!("JWKS fetch failed for issuer={}: {}", issuer, e);
-            }
-
-            // Retry from cache
-            let cache = self.cache.read().await;
-            if let Some(entry) = cache.get(kid_str) {
-                return Ok(entry.verifying_key);
-            }
-
-            // Add to negative cache
-            {
-                let mut neg = self.negative_cache.write().await;
-                neg.insert(kid_str.to_owned(), std::time::Instant::now());
-            }
-
-            anyhow::bail!("Key not found in JWKS for kid={}", kid_str)
-        } else {
-            // No kid: fetch JWKS and return the first Ed25519 key (fallback)
-            if self.cache.read().await.is_empty() {
-                if let Err(e) = self.fetch_and_cache(issuer).await {
-                    tracing::warn!("JWKS fetch failed for issuer={}: {}", issuer, e);
-                }
-            }
-
-            let cache = self.cache.read().await;
-            cache.values()
-                .next()
-                .map(|e| e.verifying_key)
-                .ok_or_else(|| anyhow::anyhow!("No Ed25519 keys in JWKS"))
+            return self.resolve_by_kid(issuer, kid_str).await;
         }
+
+        // No kid: refuse to collapse a multi-key published set to a positional
+        // singleton. `get_keys` is the safe API for kid-less tokens — it
+        // returns every Ed25519 candidate so the caller can try each. Here we
+        // only succeed when the JWKS publishes exactly one key, which is the
+        // unambiguous case. Two or more published keys is overlap rotation /
+        // PQ-hybrid rollout territory and MUST NOT be resolved to "the first
+        // one" (#1183 / #1184).
+        self.ensure_cached(issuer).await;
+        let cache = self.cache.read().await;
+        let mut iter = cache.values();
+        match (iter.next(), iter.next()) {
+            (Some(first), None) => Ok(first.verifying_key),
+            (None, _) => anyhow::bail!("No Ed25519 keys in JWKS for issuer {}", issuer),
+            (Some(_), Some(_)) => anyhow::bail!(
+                "Issuer {} publishes multiple Ed25519 keys and the JWT carries no kid; \
+                 use get_keys() and try each candidate (overlap rotation / hybrid rollout)",
+                issuer
+            ),
+        }
+    }
+
+    async fn get_keys(&self, issuer: &str, kid: Option<&str>) -> Result<Vec<VerifyingKey>> {
+        if !self.is_trusted(issuer) {
+            anyhow::bail!("Untrusted issuer: {}", issuer);
+        }
+
+        // A presented `kid` selects one slot.
+        if let Some(kid_str) = kid {
+            let vk = self.resolve_by_kid(issuer, kid_str).await?;
+            return Ok(vec![vk]);
+        }
+
+        // No kid: return EVERY Ed25519 candidate so the caller can try each
+        // until one verifies. Never positional selection (#1183 / #1184).
+        self.ensure_cached(issuer).await;
+        let cache = self.cache.read().await;
+        let v: Vec<VerifyingKey> = cache.values().map(|e| e.verifying_key).collect();
+        if v.is_empty() {
+            anyhow::bail!("No Ed25519 keys in JWKS for issuer {}", issuer);
+        }
+        Ok(v)
     }
 
     fn is_trusted(&self, issuer: &str) -> bool {
@@ -738,8 +805,11 @@ mod tests {
         assert!(result.is_err());
     }
 
+    /// #1184: with exactly one published key, `get_key(None)` is unambiguous
+    /// and resolves to that key. (Two or more published keys is the overlap
+    /// case, covered by `jwks_key_source_no_kid_multi_key_get_keys_tries_all`.)
     #[tokio::test]
-    async fn jwks_key_source_no_kid_returns_first() -> anyhow::Result<()> {
+    async fn jwks_key_source_no_kid_single_key_resolves() -> anyhow::Result<()> {
         let sk = SigningKey::from_bytes(&[0xDD; 32]);
         let jwks = mock_jwks_json(&[&sk]);
         let ks = JwksKeySource::new(
@@ -750,6 +820,85 @@ mod tests {
 
         let key = ks.get_key("http://localhost", None).await?;
         assert_eq!(key, sk.verifying_key());
+        Ok(())
+    }
+
+    /// #1184: `get_key(None)` MUST refuse to collapse a multi-key published
+    /// set to a positional singleton — that forecloses overlap rotation and
+    /// PQ-hybrid rollout. The previous implementation returned
+    /// `HashMap::values().next()` (nondeterministic); reverting this hunk to
+    /// "return the first candidate" makes the assertion below fail.
+    #[tokio::test]
+    async fn jwks_key_source_no_kid_multi_key_get_key_refuses_arbitrary() {
+        let sk_a = SigningKey::from_bytes(&[0x11; 32]);
+        let sk_b = SigningKey::from_bytes(&[0x22; 32]);
+        let jwks = mock_jwks_json(&[&sk_a, &sk_b]);
+        let ks = JwksKeySource::new(
+            JwksMode::Isolated { jwks_url: "http://localhost/oauth/jwks".to_owned() },
+            "http://localhost".to_owned(),
+            mock_fetcher(jwks),
+        );
+
+        let result = ks.get_key("http://localhost", None).await;
+        assert!(result.is_err(), "multi-key no-kid get_key must refuse arbitrary selection");
+        let msg = result.err().map(|e| e.to_string()).unwrap_or_default();
+        assert!(
+            msg.contains("multiple Ed25519 keys") && msg.contains("no kid"),
+            "expected a refusal to pick arbitrarily, got: {msg}"
+        );
+    }
+
+    /// #1184 overlap: two Ed25519 keys published simultaneously. `get_keys`
+    /// MUST return BOTH so a kid-less verifier can try each — overlap
+    /// rotation and PQ-hybrid rollout depend on this. A token signed by the
+    /// non-first key still verifies because both candidates are tried.
+    #[tokio::test]
+    async fn jwks_key_source_no_kid_multi_key_get_keys_tries_all() -> anyhow::Result<()> {
+        let sk_a = SigningKey::from_bytes(&[0x11; 32]); // "first" in JWKS order
+        let sk_b = SigningKey::from_bytes(&[0x22; 32]); // "second"
+        let vk_a = sk_a.verifying_key();
+        let vk_b = sk_b.verifying_key();
+
+        let jwks = mock_jwks_json(&[&sk_a, &sk_b]);
+        let ks = JwksKeySource::new(
+            JwksMode::Isolated { jwks_url: "http://localhost/oauth/jwks".to_owned() },
+            "http://localhost".to_owned(),
+            mock_fetcher(jwks),
+        );
+
+        let candidates = ks.get_keys("http://localhost", None).await?;
+        assert_eq!(candidates.len(), 2, "both published keys must be returned");
+        assert!(candidates.contains(&vk_a));
+        assert!(candidates.contains(&vk_b));
+        Ok(())
+    }
+
+    /// #1184 overlap: a token signed by the non-first published key verifies
+    /// when the caller uses `get_keys` + `decode_with_any_key`. Reverting
+    /// `JwksKeySource` to return a single arbitrary candidate makes this fail
+    /// (the wrong candidate is returned roughly half the time).
+    #[tokio::test]
+    async fn jwks_key_source_overlap_non_first_signer_verifies() -> anyhow::Result<()> {
+        use crate::auth::jwt::{decode_with_any_key_lenient, encode};
+
+        let sk_a = SigningKey::from_bytes(&[0x11; 32]);
+        let sk_b = SigningKey::from_bytes(&[0x22; 32]);
+
+        let jwks = mock_jwks_json(&[&sk_a, &sk_b]);
+        let ks = JwksKeySource::new(
+            JwksMode::Isolated { jwks_url: "http://localhost/oauth/jwks".to_owned() },
+            "http://localhost".to_owned(),
+            mock_fetcher(jwks),
+        );
+
+        // Sign with the SECOND key — no kid in the header, so the verifier
+        // must try both candidates.
+        let now = chrono::Utc::now().timestamp();
+        let claims = crate::auth::Claims::new("user-1".to_owned(), now, now + 300);
+        let token = encode(&claims, &sk_b);
+        let candidates = ks.get_keys("http://localhost", None).await?;
+        let verified = decode_with_any_key_lenient(&token, &candidates, None)?;
+        assert_eq!(verified.sub, "user-1");
         Ok(())
     }
 

--- a/crates/hyprstream-rpc/src/auth/mod.rs
+++ b/crates/hyprstream-rpc/src/auth/mod.rs
@@ -54,7 +54,8 @@ pub use mac::{
 #[cfg(not(target_arch = "wasm32"))]
 pub use federation::FederationKeySource;
 pub use jwt::{
-    composite_kid, decode, decode_unverified, decode_with_key, encode, encode_service_jwt,
+    composite_kid, decode, decode_unverified, decode_with_any_key, decode_with_any_key_lenient,
+    decode_with_key, encode, encode_service_jwt,
     header_alg, header_kid, is_rfc9068_access_token_type, jwk_thumbprint,
     parse_composite_dispatch, parse_protected_header, CompositeJwtDispatch, JwkThumbprintInput,
     JwtError, ProtectedHeader, RFC9068_ACCESS_TOKEN_TYPES,

--- a/crates/hyprstream-rpc/src/service/svc.rs
+++ b/crates/hyprstream-rpc/src/service/svc.rs
@@ -872,8 +872,13 @@ pub trait RequestService: 'static {
                 })?
             }
             "EdDSA" => {
-                let verifying_key = key_source
-                    .get_key(&unverified.iss, kid.as_deref())
+                // A kid-less JWT may have been signed by any of the issuer's
+                // simultaneously-published keys (overlap rotation / PQ-hybrid
+                // rollout). Resolve every candidate and try each rather than
+                // collapsing the published set to a positional singleton
+                // (#1183 / #1184).
+                let candidates = key_source
+                    .get_keys(&unverified.iss, kid.as_deref())
                     .await
                     .map_err(|e| {
                         tracing::warn!(
@@ -883,11 +888,15 @@ pub trait RequestService: 'static {
                         );
                         anyhow::anyhow!("JWT key resolution failed")
                     })?;
-                crate::auth::decode_with_key(&token, &verifying_key, self.expected_audience())
-                    .map_err(|e| {
-                        tracing::warn!("JWT verification failed: {}", e);
-                        anyhow::anyhow!("JWT verification failed")
-                    })?
+                crate::auth::decode_with_any_key_lenient(
+                    &token,
+                    &candidates,
+                    self.expected_audience(),
+                )
+                .map_err(|e| {
+                    tracing::warn!("JWT verification failed: {}", e);
+                    anyhow::anyhow!("JWT verification failed")
+                })?
             }
             _ => anyhow::bail!("unsupported JWT algorithm"),
         };

--- a/crates/hyprstream/src/auth/id_token_verify.rs
+++ b/crates/hyprstream/src/auth/id_token_verify.rs
@@ -67,32 +67,85 @@ pub async fn verify_id_token(
         .as_array()
         .ok_or_else(|| anyhow!("JWKS missing 'keys' array at {}", jwks_uri))?;
 
+    verify_id_token_with_keys(token, keys, expected_issuer, expected_audience)
+}
+
+/// Pure (HTTP-free) verification core: given the parsed JWKS `keys` array,
+/// verify an id_token's signature and claims. Exposed for tests so the
+/// overlap-rotation behaviour can be exercised without a mock server.
+///
+/// Selects every algorithm-compatible candidate and tries each until one
+/// verifies — never collapsing the published set to a positional singleton
+/// (#1183 / #1184).
+pub(crate) fn verify_id_token_with_keys(
+    token: &str,
+    keys: &[Value],
+    expected_issuer: &str,
+    expected_audience: &str,
+) -> Result<VerifiedIdToken> {
     // Extract the JWT header to get the `kid` for key selection
     let header = decode_jwt_header(token)?;
 
     let kid = header.get("kid").and_then(|v| v.as_str());
 
-    // Find the matching key from JWKS
-    let matching_key = find_matching_key(keys, kid, &header)?;
+    // Collect every algorithm-compatible candidate. When the JWT carries a
+    // `kid` the set is the kid-matched entries; when it does not, the set is
+    // every key whose `kty`/`crv` matches the header `alg`. The verifier then
+    // tries each until one verifies — never collapsing a published key SET to
+    // a positional singleton, which would foreclose overlap rotation and
+    // PQ-hybrid rollout (#1183 / #1184).
+    let candidates = candidate_keys(keys, kid, &header);
+    if candidates.is_empty() {
+        return Err(anyhow!(
+            "No JWKS key matches {} (kid={:?})",
+            header.get("alg").and_then(|v| v.as_str()).unwrap_or(""),
+            kid,
+        ));
+    }
 
-    // Build a jsonwebtoken::Validation with the correct algorithm
-    let alg = determine_algorithm(matching_key, &header)?;
+    // Build a jsonwebtoken::Validation. Algorithm is taken from the JWT header
+    // (each candidate shares the header `alg` because candidate_keys filtered
+    // on kty/crv consistency).
+    let alg = algorithm_from_header(&header)?;
     let mut validation = Validation::new(alg);
     validation.set_issuer(&[expected_issuer]);
     validation.set_audience(&[expected_audience]);
     // Allow 60 seconds of clock skew (same as provider.clock_skew_seconds default)
     validation.leeway = 60;
 
-    // Build the DecodingKey from the JWKS key
-    let decoding_key = build_decoding_key(matching_key)?;
+    // Try each candidate until one verifies. A JWKS may publish several keys
+    // simultaneously (overlap rotation / PQ-hybrid); only one is the real
+    // verifier and the rest are expected misses, logged at `debug`. An unknown
+    // or unsupported entry is skipped rather than failing the whole set.
+    let mut last_err: Option<anyhow::Error> = None;
+    for jwk in &candidates {
+        let decoding_key = match build_decoding_key(jwk) {
+            Ok(k) => k,
+            Err(e) => {
+                tracing::debug!(error = %e, "id_token: skipping JWKS key (invalid key material)");
+                last_err = Some(e);
+                continue;
+            }
+        };
+        match jsonwebtoken::decode::<Value>(token, &decoding_key, &validation) {
+            Ok(decoded) => {
+                return Ok(VerifiedIdToken {
+                    claims: decoded.claims,
+                });
+            }
+            Err(e) => {
+                tracing::debug!(error = %e, "id_token: candidate key did not verify; trying next");
+                last_err = Some(anyhow!("id_token signature verification failed: {}", e));
+            }
+        }
+    }
 
-    // Decode and verify
-    let decoded = jsonwebtoken::decode::<Value>(token, &decoding_key, &validation)
-        .map_err(|e| anyhow!("id_token signature verification failed: {}", e))?;
-
-    Ok(VerifiedIdToken {
-        claims: decoded.claims,
-    })
+    Err(last_err.unwrap_or_else(|| {
+        anyhow!(
+            "id_token verification failed: no candidate verified ({} candidates)",
+            candidates.len()
+        )
+    }))
 }
 
 /// Decode only the JWT header (without verification) for key selection.
@@ -108,71 +161,51 @@ fn decode_jwt_header(token: &str) -> Result<Value> {
         .map_err(|e| anyhow!("Invalid JSON in JWT header: {e}"))
 }
 
-/// Find the matching JWKS key by `kid` (if present) or by algorithm.
-fn find_matching_key<'a>(keys: &'a [Value], kid: Option<&str>, header: &Value) -> Result<&'a Value> {
-    // If kid is present, match by kid first
-    if let Some(kid) = kid {
-        for key in keys {
-            if key.get("kid").and_then(|v| v.as_str()) == Some(kid) {
-                return Ok(key);
-            }
-        }
-        return Err(anyhow!("No JWKS key found with kid='{}'", kid));
-    }
-
-    // No kid — try to match by algorithm from the header
+/// Collect every algorithm-compatible JWKS candidate for a JWT header.
+///
+/// When the JWT carries a `kid`, only entries with that exact `kid` are
+/// returned (there may be several — e.g. an Ed25519 entry and a composite
+/// entry published side-by-side under the same kid). When it carries no
+/// `kid`, every entry whose `kty`/`crv` matches the header `alg` is
+/// returned. Unknown / unsupported algorithms are skipped: the caller tries
+/// each candidate and a published set is never collapsed to a positional
+/// singleton (#1183 / #1184).
+fn candidate_keys<'a>(keys: &'a [Value], kid: Option<&str>, header: &Value) -> Vec<&'a Value> {
     let header_alg = header.get("alg").and_then(|v| v.as_str()).unwrap_or("");
-    for key in keys {
-        let key_kty = key.get("kty").and_then(|v| v.as_str()).unwrap_or("");
-        let matches = match header_alg {
-            "RS256" => key_kty == "RSA",
-            "ES256" => key_kty == "EC",
-            "EdDSA" => key_kty == "OKP",
-            _ => false,
-        };
-        if matches {
-            return Ok(key);
-        }
-    }
 
-    // Fallback: return first key
-    keys.first()
-        .ok_or_else(|| anyhow!("JWKS keys array is empty"))
+    keys.iter()
+        .filter(|key| {
+            // If a kid is presented, select by it; otherwise keep every
+            // algorithm-compatible entry.
+            if let Some(want) = kid {
+                let k = key.get("kid").and_then(|v| v.as_str());
+                return k == Some(want);
+            }
+            let key_kty = key.get("kty").and_then(|v| v.as_str()).unwrap_or("");
+            match header_alg {
+                "RS256" => key_kty == "RSA",
+                "ES256" => key_kty == "EC",
+                "EdDSA" => key_kty == "OKP",
+                _ => false,
+            }
+        })
+        .collect()
 }
 
-/// Determine the Algorithm from the JWKS key and JWT header.
-fn determine_algorithm(jwks_key: &Value, header: &Value) -> Result<Algorithm> {
-    let header_alg = header.get("alg").and_then(|v| v.as_str());
-
-    // Trust the JWT header's alg if it's one we support
-    if let Some(alg_str) = header_alg {
-        let alg = match alg_str {
-            "RS256" => Algorithm::RS256,
-            "ES256" => Algorithm::ES256,
-            "EdDSA" => Algorithm::EdDSA,
-            other => return Err(anyhow!("Unsupported JWT algorithm: {}", other)),
-        };
-        // Verify the JWKS key type is consistent
-        let kty = jwks_key.get("kty").and_then(|v| v.as_str()).unwrap_or("");
-        let expected_kty = match alg {
-            Algorithm::RS256 => "RSA",
-            Algorithm::ES256 => "EC",
-            Algorithm::EdDSA => "OKP",
-            _ => unreachable!(),
-        };
-        if kty != expected_kty {
-            return Err(anyhow!(
-                "JWT algorithm {} expects kty='{}' but JWKS key has kty='{}'",
-                alg_str,
-                expected_kty,
-                kty
-            ));
-        }
-        return Ok(alg);
+/// Resolve the jsonwebtoken `Algorithm` from the JWT header `alg`, after
+/// [`candidate_keys`] has already filtered the JWKS to kty/crv-consistent
+/// entries.
+fn algorithm_from_header(header: &Value) -> Result<Algorithm> {
+    let alg_str = header
+        .get("alg")
+        .and_then(|v| v.as_str())
+        .ok_or_else(|| anyhow!("JWT header missing 'alg'"))?;
+    match alg_str {
+        "RS256" => Ok(Algorithm::RS256),
+        "ES256" => Ok(Algorithm::ES256),
+        "EdDSA" => Ok(Algorithm::EdDSA),
+        other => Err(anyhow!("Unsupported JWT algorithm: {}", other)),
     }
-
-    // Infer from JWKS key type
-    algorithm_for_key_pub(jwks_key)
 }
 
 /// Public alias for the algorithm-from-JWK helper. Used by client_auth.
@@ -287,48 +320,214 @@ mod tests {
     }
 
     #[test]
-    fn test_determine_algorithm_from_header() {
-        let key = serde_json::json!({"kty": "RSA", "n": "abc", "e": "AQAB"});
+    fn test_algorithm_from_header_rs256() {
         let header = serde_json::json!({"alg": "RS256"});
-        assert_eq!(determine_algorithm(&key, &header).unwrap(), Algorithm::RS256);
+        assert_eq!(algorithm_from_header(&header).unwrap(), Algorithm::RS256);
     }
 
     #[test]
-    fn test_determine_algorithm_kty_mismatch() {
-        let key = serde_json::json!({"kty": "EC", "x": "abc", "y": "def"});
-        let header = serde_json::json!({"alg": "RS256"});
-        assert!(determine_algorithm(&key, &header).is_err());
+    fn test_algorithm_from_header_missing() {
+        let header = serde_json::json!({});
+        assert!(algorithm_from_header(&header).is_err());
     }
 
     #[test]
-    fn test_determine_algorithm_infer_from_kty() {
-        let rsa_key = serde_json::json!({"kty": "RSA"});
-        let empty_header = serde_json::json!({});
-        assert_eq!(
-            determine_algorithm(&rsa_key, &empty_header).unwrap(),
-            Algorithm::RS256
-        );
+    fn test_algorithm_from_header_unsupported() {
+        let header = serde_json::json!({"alg": "RS512"});
+        assert!(algorithm_from_header(&header).is_err());
     }
 
     #[test]
-    fn test_find_matching_key_by_kid() {
+    fn test_candidate_keys_by_kid() {
         let keys = vec![
             serde_json::json!({"kty": "RSA", "kid": "key-1", "n": "abc", "e": "AQAB"}),
             serde_json::json!({"kty": "RSA", "kid": "key-2", "n": "def", "e": "AQAB"}),
         ];
         let header = serde_json::json!({"alg": "RS256", "kid": "key-2"});
-        let found = find_matching_key(&keys, Some("key-2"), &header).unwrap();
-        assert_eq!(found["kid"], "key-2");
+        let found = candidate_keys(&keys, Some("key-2"), &header);
+        assert_eq!(found.len(), 1);
+        assert_eq!(found[0]["kid"], "key-2");
     }
 
     #[test]
-    fn test_find_matching_key_no_kid_matches_alg() {
+    fn test_candidate_keys_no_kid_returns_all_alg_compatible() {
+        // Two simultaneously published RSA keys (overlap rotation). Without a
+        // `kid`, the verifier MUST retain BOTH candidates so it can try each —
+        // collapsing to "the first one" forecloses overlap rotation and
+        // PQ-hybrid rollout (#1183 / #1184).
         let keys = vec![
-            serde_json::json!({"kty": "RSA", "n": "abc", "e": "AQAB"}),
+            serde_json::json!({"kty": "RSA", "kid": "key-1", "n": "abc", "e": "AQAB"}),
+            serde_json::json!({"kty": "RSA", "kid": "key-2", "n": "def", "e": "AQAB"}),
         ];
         let header = serde_json::json!({"alg": "RS256"});
-        let found = find_matching_key(&keys, None, &header).unwrap();
-        assert_eq!(found["kty"], "RSA");
+        let found = candidate_keys(&keys, None, &header);
+        assert_eq!(found.len(), 2);
+    }
+
+    #[test]
+    fn test_candidate_keys_skips_unknown_alg() {
+        // An unsupported/unknown algorithm entry MUST be skipped rather than
+        // fail the whole set — a PQ-capable verifier ignores what it does not
+        // recognize while a classical verifier keeps working against the
+        // classical entry.
+        let keys = vec![
+            serde_json::json!({"kty": "AKP", "alg": "ML-DSA-65-Ed25519", "kid": "pq"}),
+            serde_json::json!({"kty": "RSA", "kid": "classic", "n": "abc", "e": "AQAB"}),
+        ];
+        let header = serde_json::json!({"alg": "RS256"});
+        let found = candidate_keys(&keys, None, &header);
+        assert_eq!(found.len(), 1);
+        assert_eq!(found[0]["kid"], "classic");
+    }
+
+    #[test]
+    fn test_candidate_keys_no_kid_no_match() {
+        let keys = vec![
+            serde_json::json!({"kty": "EC", "kid": "ec-1", "x": "a", "y": "b"}),
+        ];
+        let header = serde_json::json!({"alg": "RS256"});
+        let found = candidate_keys(&keys, None, &header);
+        assert!(found.is_empty());
+    }
+
+    /// Build an EdDSA JWT signed with `signing_key`. The header carries the
+    /// given optional `kid`. Used by the overlap-rotation tests so they can
+    /// sign with arbitrary Ed25519 keys without a PEM/DER round-trip.
+    fn sign_eddsa_jwt(
+        signing_key: &ed25519_dalek::SigningKey,
+        claims: &serde_json::Value,
+        kid: Option<&str>,
+    ) -> String {
+        use ed25519_dalek::Signer;
+        let mut header = serde_json::json!({"alg": "EdDSA", "typ": "JWT"});
+        if let Some(k) = kid {
+            header["kid"] = serde_json::Value::String(k.to_owned());
+        }
+        let header_b64 = URL_SAFE_NO_PAD.encode(serde_json::to_vec(&header).unwrap());
+        let payload_b64 = URL_SAFE_NO_PAD.encode(serde_json::to_vec(claims).unwrap());
+        let signing_input = format!("{header_b64}.{payload_b64}");
+        let sig = signing_key.sign(signing_input.as_bytes());
+        let sig_b64 = URL_SAFE_NO_PAD.encode(sig.to_bytes());
+        format!("{signing_input}.{sig_b64}")
+    }
+
+    fn jwks_ed25519(entries: &[(&str, &ed25519_dalek::VerifyingKey)]) -> Vec<Value> {
+        entries
+            .iter()
+            .map(|(kid, vk)| {
+                serde_json::json!({
+                    "kty": "OKP", "crv": "Ed25519", "alg": "EdDSA",
+                    "kid": kid,
+                    "x": URL_SAFE_NO_PAD.encode(vk.as_bytes()),
+                })
+            })
+            .collect()
+    }
+
+    /// #1184: a kid-less id_token signed by the SECOND of two simultaneously
+    /// published Ed25519 keys must verify against the JWKS set. The previous
+    /// implementation returned `keys.first()` and would fail for the non-first
+    /// signer; reverting this hunk to "try only the first candidate" makes
+    /// this test fail.
+    #[test]
+    fn id_token_kid_less_signer_is_non_first_published_key() -> anyhow::Result<()> {
+        let sk_a = ed25519_dalek::SigningKey::from_bytes(&[0xA0; 32]);
+        let sk_b = ed25519_dalek::SigningKey::from_bytes(&[0xB0; 32]);
+
+        // Publish BOTH keys (overlap window): lead first, drain second.
+        let keys = jwks_ed25519(&[("lead", &sk_a.verifying_key()), ("drain", &sk_b.verifying_key())]);
+
+        // Sign with the SECOND (drain) key — no `kid` in the header.
+        let claims = serde_json::json!({
+            "iss": "https://idp.example.com",
+            "aud": "client-42",
+            "sub": "user-1",
+            "exp": (jsonwebtoken::get_current_timestamp() + 300),
+        });
+        let token = sign_eddsa_jwt(&sk_b, &claims, None);
+
+        let verified = verify_id_token_with_keys(
+            &token,
+            &keys,
+            "https://idp.example.com",
+            "client-42",
+        )?;
+        assert_eq!(verified.claims["sub"], "user-1");
+        Ok(())
+    }
+
+    /// #1184 overlap: while both keys are published, a token signed by either
+    /// verifies (first AND non-first), and a token signed by an UNKNOWN key
+    /// that is not in the set is rejected.
+    #[test]
+    fn id_token_overlap_both_signers_accepted_unknown_rejected() -> anyhow::Result<()> {
+        let sk_lead = ed25519_dalek::SigningKey::from_bytes(&[0x11; 32]);
+        let sk_drain = ed25519_dalek::SigningKey::from_bytes(&[0x22; 32]);
+        let sk_unknown = ed25519_dalek::SigningKey::from_bytes(&[0x99; 32]);
+
+        let keys = jwks_ed25519(&[
+            ("lead", &sk_lead.verifying_key()),
+            ("drain", &sk_drain.verifying_key()),
+        ]);
+
+        let claims = serde_json::json!({
+            "iss": "https://idp.example.com",
+            "aud": "client-42",
+            "sub": "user-1",
+            "exp": (jsonwebtoken::get_current_timestamp() + 300),
+        });
+
+        // First (lead) signer — accepted.
+        let token_lead = sign_eddsa_jwt(&sk_lead, &claims, None);
+        let v = verify_id_token_with_keys(&token_lead, &keys, "https://idp.example.com", "client-42")?;
+        assert_eq!(v.claims["sub"], "user-1");
+
+        // Non-first (drain) signer — accepted.
+        let token_drain = sign_eddsa_jwt(&sk_drain, &claims, None);
+        let v = verify_id_token_with_keys(&token_drain, &keys, "https://idp.example.com", "client-42")?;
+        assert_eq!(v.claims["sub"], "user-1");
+
+        // Unknown signer (not in the published set) — rejected.
+        let token_bad = sign_eddsa_jwt(&sk_unknown, &claims, None);
+        let err = verify_id_token_with_keys(&token_bad, &keys, "https://idp.example.com", "client-42")
+            .unwrap_err();
+        assert!(
+            err.to_string().contains("signature verification failed")
+                || err.to_string().contains("no candidate verified"),
+            "unexpected error: {err}"
+        );
+        Ok(())
+    }
+
+    /// #1184: an unsupported/unknown algorithm entry in the JWKS MUST be
+    /// skipped rather than fail the whole set — a PQ-capable verifier ignores
+    /// what it does not recognize while a classical verifier keeps working
+    /// against the classical entry.
+    #[test]
+    fn id_token_skips_unsupported_alg_and_accepts_classical() -> anyhow::Result<()> {
+        let sk = ed25519_dalek::SigningKey::from_bytes(&[0x33; 32]);
+        let vk = sk.verifying_key();
+
+        let keys = vec![
+            // Unknown composite_alg entry — must be skipped, not fatal.
+            serde_json::json!({"kty": "AKP", "alg": "ML-DSA-65-Ed25519", "kid": "pq"}),
+            // Classical Ed25519 entry — the real verifier.
+            serde_json::json!({
+                "kty": "OKP", "crv": "Ed25519", "alg": "EdDSA", "kid": "classic",
+                "x": URL_SAFE_NO_PAD.encode(vk.as_bytes()),
+            }),
+        ];
+
+        let claims = serde_json::json!({
+            "iss": "https://idp.example.com",
+            "aud": "client-42",
+            "sub": "user-1",
+            "exp": (jsonwebtoken::get_current_timestamp() + 300),
+        });
+        let token = sign_eddsa_jwt(&sk, &claims, None);
+        let v = verify_id_token_with_keys(&token, &keys, "https://idp.example.com", "client-42")?;
+        assert_eq!(v.claims["sub"], "user-1");
+        Ok(())
     }
 
     #[test]

--- a/crates/hyprstream/src/auth/jwt.rs
+++ b/crates/hyprstream/src/auth/jwt.rs
@@ -3,7 +3,8 @@
 //! Re-exports EdDSA signing from hyprstream-rpc and adds ES256 (P-256) signing.
 
 pub use hyprstream_rpc::auth::{
-    decode, decode_with_key, encode, encode_service_jwt, Claims, JwtError,
+    decode, decode_with_any_key, decode_with_any_key_lenient, decode_with_key, encode,
+    encode_service_jwt, Claims, JwtError,
 };
 
 use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine as _};

--- a/crates/hyprstream/src/services/factories.rs
+++ b/crates/hyprstream/src/services/factories.rs
@@ -1477,8 +1477,12 @@ fn create_mcp_service(ctx: &ServiceContext) -> anyhow::Result<Box<dyn Spawnable>
                             let iss = crate::server::middleware::extract_iss_from_token(&t);
                             let kid = crate::server::middleware::extract_kid_from_token(&t);
                             let result = if let Some(ref key_source) = jwt_key_source {
-                                match key_source.get_key(&iss, kid.as_deref()).await {
-                                    Ok(key) => crate::auth::jwt::decode(&t, &key, Some(mcp_resource_url.as_str())),
+                                match key_source.get_keys(&iss, kid.as_deref()).await {
+                                    Ok(candidates) => crate::auth::jwt::decode_with_any_key(
+                                        &t,
+                                        &candidates,
+                                        Some(mcp_resource_url.as_str()),
+                                    ),
                                     Err(e) => {
                                         tracing::debug!(%method, %uri, issuer = %iss, error = %e, "MCP JWT key resolution failed");
                                         let mut res = (StatusCode::UNAUTHORIZED, "Authentication failed").into_response();


### PR DESCRIPTION
Closes #1184. Relates #1183.

## Problem

Two generic JWT/JWKS consumers collapsed a valid published key SET to a positional or arbitrary singleton, foreclosing both overlap rotation and PQ-hybrid rollout (#1183):

- `crates/hyprstream/src/auth/id_token_verify.rs` — `find_matching_key` returned the first same-algorithm key, then ultimately `keys.first()`. An externally issued id_token without `kid`, signed by the second simultaneously published RS256/ES256/EdDSA key, failed although its key was present.
- `crates/hyprstream-rpc/src/auth/key_source.rs` — `JwksKeySource::get_key(..., None)` returned an arbitrary `HashMap::values().next()` key. It could not know that the returned key verifies the token, and the result was nondeterministic across runs.

Both paths had single-key tests only; neither tested two simultaneously published same-algorithm keys with a kid-less token signed by the non-first key.

## Fix

Per the audit's durable rule — *"a consumer MUST select by the protocol's key id/relationship; when no selector exists, it MUST try each compatible candidate or reject ambiguity"* — the safe default is now structural: **retain every algorithm-compatible candidate and try each until one verifies**. Matches the in-tree reference implementation in `services/oauth/client_auth.rs` (which already did this).

### `hyprstream-rpc`
- **`JwtKeySource::get_keys(issuer, kid)`** — new trait method returning `Vec<VerifyingKey>`; default delegates to `get_key` for single-key sources. `JwksKeySource` overrides it to return every Ed25519 entry when `kid` is `None`, or the single kid-matched key when present.
- **`JwksKeySource::get_key(None)`** is now fail-closed when the JWKS publishes more than one key: it refuses to pick arbitrarily and points the caller at `get_keys()`. Single-key resolution is unchanged.
- **`jwt::decode_with_any_key`** (strict aud, mirrors `decode`) and **`decode_with_any_key_lenient`** (mirrors `decode_with_key`) try each candidate; per-candidate failures are `debug!`-level, unknown/unsupported algorithms are skipped rather than fatal to the set.
- `svc.rs` EdDSA path uses `get_keys` + `decode_with_any_key_lenient` (preserving the original lenient-aud choice).

### `hyprstream`
- `id_token_verify`: `find_matching_key`/`determine_algorithm` replaced by **`candidate_keys`** (kid-filtered or alg-compatible set) + **`algorithm_from_header`**. **`verify_id_token_with_keys`** is a pure (HTTP-free) verification core that iterates candidates; `verify_id_token` composes fetch + core. The old "fallback: return first key" is gone.
- `factories.rs` MCP path uses `get_keys` + `decode_with_any_key` (strict aud preserved — was `decode`).

## Tests

Every new test **fails without its fix hunk** (verified by reverting and re-running):

| Test | Asserts |
|---|---|
| `jwks_key_source_no_kid_multi_key_get_key_refuses_arbitrary` | `get_key(None)` errors when >1 key published (no arbitrary pick) |
| `jwks_key_source_no_kid_multi_key_get_keys_tries_all` | `get_keys(None)` returns BOTH published keys |
| `jwks_key_source_overlap_non_first_signer_verifies` | a kid-less token signed by the 2nd published key verifies via `get_keys` + `decode_with_any_key_lenient` |
| `id_token_kid_less_signer_is_non_first_published_key` | non-first signer verifies against a two-key JWKS |
| `id_token_overlap_both_signers_accepted_unknown_rejected` | both signers accepted; unknown signer rejected |
| `id_token_skips_unsupported_alg_and_accepts_classical` | an `ML-DSA-65-Ed25519` (AKP) entry is skipped, classical Ed25519 still verifies |

## Verify

```
buildq -- cargo build -p hyprstream-rpc -p hyprstream
buildq -- cargo test  -p hyprstream-rpc --lib key_source        # 18 ok
buildq -- cargo test  -p hyprstream --lib auth::id_token_verify # 14 ok
buildq -- cargo test  -p hyprstream-rpc --lib service::svc      # 23 ok
buildq -- cargo test  -p hyprstream --lib client_auth           # 11 ok
buildq -- cargo clippy --workspace --all-targets --release -- -D warnings
```

`cargo fmt --check` fails on a clean main (#1140) — not introduced here.

CodeRabbit threads will be handled on the PR.