### PR TITLE
fix(federation): make FederationKeyResolver JWKS rotation-aware (#1185)

### DIFF
--- a/crates/hyprstream-rpc/src/auth/federation.rs
+++ b/crates/hyprstream-rpc/src/auth/federation.rs
@@ -7,6 +7,17 @@
 use anyhow::Result;
 use ed25519_dalek::VerifyingKey;
 
+/// One named Ed25519 key published in a federation JWKS.
+///
+/// `kid` stays attached to its key until verification.  Collapsing this to a
+/// bare `VerifyingKey` would let a token that names one key verify with a
+/// different, merely co-published key.
+#[derive(Clone, Debug)]
+pub struct FederationKey {
+    pub kid: Option<String>,
+    pub verifying_key: VerifyingKey,
+}
+
 /// Resolves external JWT issuer URLs to Ed25519 verifying keys.
 ///
 /// Implemented by `hyprstream::auth::FederationKeyResolver`. Services that
@@ -17,12 +28,10 @@ use ed25519_dalek::VerifyingKey;
 /// # Key-set semantics (rotation-aware, #1185)
 ///
 /// A published JWKS is a **named set**, never an ordered singleton. `get_keys`
-/// returns every usable Ed25519 entry from the issuer's current JWKS so the
-/// caller can try each candidate — this is what makes overlap rotation (old +
-/// new keys published simultaneously) and future PQ-hybrid publication
-/// possible. When the JWT carries a `kid`, the matching candidate is ordered
-/// first; the rest follow so a verifier that prefers the kid still benefits
-/// from overlap fallback if the named key has been retired mid-window.
+/// returns every usable named Ed25519 entry from the issuer's current JWKS so
+/// a token without a `kid` can try each candidate. When the JWT carries a
+/// `kid`, it returns only entries with that exact `kid`; a named token must
+/// never verify with another co-published key.
 ///
 /// The resolver MUST NOT collapse the set to a positional singleton: returning
 /// the "first" Ed25519 key forecloses rotation (#1183). An empty result is an
@@ -50,11 +59,9 @@ pub trait FederationKeySource: Send + Sync + 'static {
     /// Fetch (or return from cache) the Ed25519 candidate verifying keys for
     /// `issuer`.
     ///
-    /// Returns every usable Ed25519 key from the issuer's JWKS, ordered so
-    /// that when `kid` is `Some` the matching candidate comes first and the
-    /// remaining overlap candidates follow. The caller SHOULD try each
-    /// candidate against the JWT and accept the first that verifies — this is
-    /// the rotation/pQ-hybrid publication model (#1183).
+    /// Returns every usable named Ed25519 key from the issuer's JWKS. When
+    /// `kid` is `Some`, every returned entry has that exact `kid`; when it is
+    /// `None`, the caller may try each candidate against the JWT.
     ///
     /// On a cache miss for the requested `kid`, the resolver refetches the
     /// JWKS once and re-checks. A `kid` that is still absent after a fresh
@@ -67,7 +74,7 @@ pub trait FederationKeySource: Send + Sync + 'static {
     /// - the issuer is not in the trusted list (`is_trusted` returns `false`), or
     /// - the JWKS endpoint is unreachable or returns no usable Ed25519 key, or
     /// - `kid` is `Some` and no candidate with that `kid` exists after refetch.
-    async fn get_keys(&self, issuer: &str, kid: Option<&str>) -> Result<Vec<VerifyingKey>>;
+    async fn get_keys(&self, issuer: &str, kid: Option<&str>) -> Result<Vec<FederationKey>>;
 }
 
 #[cfg(test)]
@@ -85,11 +92,7 @@ mod tests {
             false
         }
 
-        async fn get_keys(
-            &self,
-            issuer: &str,
-            _kid: Option<&str>,
-        ) -> Result<Vec<VerifyingKey>> {
+        async fn get_keys(&self, issuer: &str, _kid: Option<&str>) -> Result<Vec<FederationKey>> {
             let _ = issuer;
             anyhow::bail!("Issuer not trusted: {}", issuer)
         }
@@ -99,6 +102,10 @@ mod tests {
     async fn trait_object_compiles_and_rejects() {
         let src: Arc<dyn FederationKeySource> = Arc::new(AlwaysReject);
         assert!(!src.is_trusted("https://evil.example.com"));
-        assert!(src.get_keys("https://evil.example.com", None).await.is_err());
+        assert!(
+            src.get_keys("https://evil.example.com", None)
+                .await
+                .is_err()
+        );
     }
 }

--- a/crates/hyprstream-rpc/src/auth/federation.rs
+++ b/crates/hyprstream-rpc/src/auth/federation.rs
@@ -14,9 +14,23 @@ use ed25519_dalek::VerifyingKey;
 /// `RequestService::federation_key_source()` so the default `verify_claims()`
 /// can perform real key resolution instead of rejecting federated JWTs.
 ///
+/// # Key-set semantics (rotation-aware, #1185)
+///
+/// A published JWKS is a **named set**, never an ordered singleton. `get_keys`
+/// returns every usable Ed25519 entry from the issuer's current JWKS so the
+/// caller can try each candidate — this is what makes overlap rotation (old +
+/// new keys published simultaneously) and future PQ-hybrid publication
+/// possible. When the JWT carries a `kid`, the matching candidate is ordered
+/// first; the rest follow so a verifier that prefers the kid still benefits
+/// from overlap fallback if the named key has been retired mid-window.
+///
+/// The resolver MUST NOT collapse the set to a positional singleton: returning
+/// the "first" Ed25519 key forecloses rotation (#1183). An empty result is an
+/// `Err`.
+///
 /// # Note on `Send` bounds
 ///
-/// `get_key` uses the default (`Send`) flavour of `#[async_trait]` because
+/// `get_keys` uses the default (`Send`) flavour of `#[async_trait]` because
 /// `FederationKeyResolver` performs real async I/O (HTTPS JWKS fetch) whose
 /// future must be `Send`. Call sites inside `#[async_trait(?Send)]` contexts
 /// (e.g. `RequestService::verify_claims`) may `.await` this future directly:
@@ -28,23 +42,32 @@ use ed25519_dalek::VerifyingKey;
 pub trait FederationKeySource: Send + Sync + 'static {
     /// Return `true` if `issuer` is in the configured trusted-issuer list.
     ///
-    /// Callers should check this before calling `get_key` to distinguish an
+    /// Callers should check this before calling `get_keys` to distinguish an
     /// untrusted issuer (policy reject → 401) from a transient fetch error
     /// (retry eligible → 503).
     fn is_trusted(&self, issuer: &str) -> bool;
 
-    /// Fetch (or return from cache) the Ed25519 verifying key for `issuer`.
+    /// Fetch (or return from cache) the Ed25519 candidate verifying keys for
+    /// `issuer`.
+    ///
+    /// Returns every usable Ed25519 key from the issuer's JWKS, ordered so
+    /// that when `kid` is `Some` the matching candidate comes first and the
+    /// remaining overlap candidates follow. The caller SHOULD try each
+    /// candidate against the JWT and accept the first that verifies — this is
+    /// the rotation/pQ-hybrid publication model (#1183).
+    ///
+    /// On a cache miss for the requested `kid`, the resolver refetches the
+    /// JWKS once and re-checks. A `kid` that is still absent after a fresh
+    /// fetch fails closed (`Err`); the resolver MUST NOT silently substitute
+    /// another key for a named `kid`.
     ///
     /// # Errors
     ///
     /// Returns `Err` if:
     /// - the issuer is not in the trusted list (`is_trusted` returns `false`), or
-    /// - the JWKS endpoint is unreachable or returns an invalid key.
-    ///
-    /// Callers that need to distinguish these cases should call `is_trusted`
-    /// first; a subsequent `Err` from `get_key` then indicates a fetch/parse
-    /// failure rather than a policy rejection.
-    async fn get_key(&self, issuer: &str) -> Result<VerifyingKey>;
+    /// - the JWKS endpoint is unreachable or returns no usable Ed25519 key, or
+    /// - `kid` is `Some` and no candidate with that `kid` exists after refetch.
+    async fn get_keys(&self, issuer: &str, kid: Option<&str>) -> Result<Vec<VerifyingKey>>;
 }
 
 #[cfg(test)]
@@ -62,7 +85,12 @@ mod tests {
             false
         }
 
-        async fn get_key(&self, issuer: &str) -> Result<VerifyingKey> {
+        async fn get_keys(
+            &self,
+            issuer: &str,
+            _kid: Option<&str>,
+        ) -> Result<Vec<VerifyingKey>> {
+            let _ = issuer;
             anyhow::bail!("Issuer not trusted: {}", issuer)
         }
     }
@@ -71,6 +99,6 @@ mod tests {
     async fn trait_object_compiles_and_rejects() {
         let src: Arc<dyn FederationKeySource> = Arc::new(AlwaysReject);
         assert!(!src.is_trusted("https://evil.example.com"));
-        assert!(src.get_key("https://evil.example.com").await.is_err());
+        assert!(src.get_keys("https://evil.example.com", None).await.is_err());
     }
 }

--- a/crates/hyprstream-rpc/src/auth/jwt.rs
+++ b/crates/hyprstream-rpc/src/auth/jwt.rs
@@ -10,7 +10,7 @@
 //! - Payload: Claims (sub, exp, iat)
 //! - Signature: Ed25519 over `base64url(header).base64url(payload)`
 
-use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine};
+use base64::{Engine, engine::general_purpose::URL_SAFE_NO_PAD};
 use chrono::Utc;
 use ed25519_dalek::{Signature, Signer, SigningKey, Verifier, VerifyingKey};
 use thiserror::Error;
@@ -109,7 +109,7 @@ impl<'de> serde::Deserialize<'de> for ProtectedHeader {
                             return Err(A::Error::unknown_field(
                                 &key,
                                 &["alg", "typ", "kid", "crit"],
-                            ))
+                            ));
                         }
                     }
                 }
@@ -411,6 +411,28 @@ pub fn decode_with_candidates(
         }
     }
     Err(last_err)
+}
+
+/// Decode a federation JWT while retaining the JWKS `kid` binding.
+///
+/// A token that names a key may only be verified by entries carrying that
+/// exact name. A token without a selector may try every compatible published
+/// key, which is the overlap-rotation case.
+pub fn decode_with_federation_candidates(
+    token: &str,
+    candidates: &[super::FederationKey],
+    expected_aud: Option<&str>,
+) -> Result<Claims, JwtError> {
+    let kid = header_kid(token)?;
+    let keys: Vec<VerifyingKey> = candidates
+        .iter()
+        .filter(|candidate| match kid.as_deref() {
+            Some(named_kid) => candidate.kid.as_deref() == Some(named_kid),
+            None => true,
+        })
+        .map(|candidate| candidate.verifying_key)
+        .collect();
+    decode_with_candidates(token, &keys, expected_aud)
 }
 
 /// Internal decode implementation shared by `decode` and `decode_with_key`.
@@ -736,7 +758,10 @@ mod tests {
             "JWT",
             "wit+jwt",
         ] {
-            assert!(!is_rfc9068_access_token_type(rejected), "accepted {rejected:?}");
+            assert!(
+                !is_rfc9068_access_token_type(rejected),
+                "accepted {rejected:?}"
+            );
         }
     }
 
@@ -917,11 +942,12 @@ mod tests {
         let claims = Claims::new("overlap-test".to_owned(), 0, 9_999_999_999);
         let token = encode(&claims, &key_b); // signed by the second key
 
-        // Candidate set published kid-first as [old, new]; the token is
+        // Candidate set published in overlap order as [old, new]; the token is
         // signed by `new` (the second entry). The old code resolved only
         // the first key and this token would have failed.
         let candidates = vec![key_a.verifying_key(), key_b.verifying_key()];
-        let decoded = decode_with_candidates(&token, &candidates, None).expect("second key verifies");
+        let decoded =
+            decode_with_candidates(&token, &candidates, None).expect("second key verifies");
         assert_eq!(decoded.sub, "overlap-test");
     }
 
@@ -941,5 +967,31 @@ mod tests {
         let claims = Claims::new("empty".to_owned(), 0, 9_999_999_999);
         let token = encode(&claims, &make_key(0x22));
         assert!(decode_with_candidates(&token, &[], None).is_err());
+    }
+
+    #[test]
+    fn federation_candidates_reject_mismatched_named_key() {
+        use crate::auth::FederationKey;
+
+        let old = make_key(0xA1);
+        let new = make_key(0xB2);
+        let claims = Claims::new("kid-binding".to_owned(), 0, 9_999_999_999);
+        let token = encode(&claims, &old);
+        let old_kid = kid_for_key(&old);
+
+        // The token names `old_kid`, but only a different co-published key is
+        // attached to that name. The bare-key candidate loop would accept the
+        // `old` entry below; the federation path must reject it.
+        let candidates = vec![
+            FederationKey {
+                kid: Some(old_kid),
+                verifying_key: new.verifying_key(),
+            },
+            FederationKey {
+                kid: Some(kid_for_key(&new)),
+                verifying_key: old.verifying_key(),
+            },
+        ];
+        assert!(decode_with_federation_candidates(&token, &candidates, None).is_err());
     }
 }

--- a/crates/hyprstream-rpc/src/auth/jwt.rs
+++ b/crates/hyprstream-rpc/src/auth/jwt.rs
@@ -387,6 +387,32 @@ pub fn decode_with_key(
     decode_inner(token, verifying_key, expected_aud, true)
 }
 
+/// Decode a JWT by trying each candidate key in order, accepting the first
+/// that verifies. This is the rotation-aware federation verifier: a caller
+/// passes the candidate set returned by a key-set resolver (e.g.
+/// `FederationKeySource::get_keys`) and the token verifies if ANY published
+/// key validates it — the overlap-rotation and PQ-hybrid publication model
+/// (#1183/#1185). `candidates` SHOULD be ordered kid-first by the resolver
+/// so the preferred key is tried before overlap fallbacks.
+///
+/// Returns the last error if no candidate verifies (so a caller can surface
+/// a representative failure); `InvalidFormat` when the candidate set is empty
+/// (the resolver is contractually non-empty, so this is a fail-closed guard).
+pub fn decode_with_candidates(
+    token: &str,
+    candidates: &[VerifyingKey],
+    expected_aud: Option<&str>,
+) -> Result<Claims, JwtError> {
+    let mut last_err = JwtError::InvalidFormat;
+    for key in candidates {
+        match decode_with_key(token, key, expected_aud) {
+            Ok(claims) => return Ok(claims),
+            Err(e) => last_err = e,
+        }
+    }
+    Err(last_err)
+}
+
 /// Internal decode implementation shared by `decode` and `decode_with_key`.
 ///
 /// `lenient_aud`: when true, accepts tokens with no `aud` claim even when
@@ -879,5 +905,41 @@ mod tests {
 
         let kid = header_kid(&token).unwrap();
         assert!(kid.is_none());
+    }
+
+    // #1185 — decode_with_candidates is the rotation-aware federation
+    // verifier: it MUST accept a token signed by ANY published candidate,
+    // including a non-first key, and reject when none verify.
+    #[test]
+    fn decode_with_candidates_accepts_non_first_published_key() {
+        let key_a = make_key(0xA1);
+        let key_b = make_key(0xB2); // the "second" / rotated key
+        let claims = Claims::new("overlap-test".to_owned(), 0, 9_999_999_999);
+        let token = encode(&claims, &key_b); // signed by the second key
+
+        // Candidate set published kid-first as [old, new]; the token is
+        // signed by `new` (the second entry). The old code resolved only
+        // the first key and this token would have failed.
+        let candidates = vec![key_a.verifying_key(), key_b.verifying_key()];
+        let decoded = decode_with_candidates(&token, &candidates, None).expect("second key verifies");
+        assert_eq!(decoded.sub, "overlap-test");
+    }
+
+    #[test]
+    fn decode_with_candidates_rejects_when_no_candidate_verifies() {
+        let key_unrelated = make_key(0x99);
+        let claims = Claims::new("no-match".to_owned(), 0, 9_999_999_999);
+        let token = encode(&claims, &make_key(0x11));
+        let candidates = vec![key_unrelated.verifying_key()];
+        assert!(decode_with_candidates(&token, &candidates, None).is_err());
+    }
+
+    #[test]
+    fn decode_with_candidates_empty_set_fails_closed() {
+        // An empty candidate set is a fail-closed guard (the resolver is
+        // contractually non-empty); never silently accept.
+        let claims = Claims::new("empty".to_owned(), 0, 9_999_999_999);
+        let token = encode(&claims, &make_key(0x22));
+        assert!(decode_with_candidates(&token, &[], None).is_err());
     }
 }

--- a/crates/hyprstream-rpc/src/auth/key_source.rs
+++ b/crates/hyprstream-rpc/src/auth/key_source.rs
@@ -30,7 +30,7 @@
 #![allow(clippy::disallowed_types)]
 
 use anyhow::Result;
-use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine};
+use base64::{Engine, engine::general_purpose::URL_SAFE_NO_PAD};
 use ed25519_dalek::VerifyingKey;
 use std::collections::HashMap;
 use std::sync::Arc;
@@ -148,7 +148,10 @@ impl ClusterKeySource {
     /// Set the shared ML-DSA-65 verifying key list for PQ-hybrid JWT verification.
     ///
     /// The Arc is shared with the rotation task so keys stay current.
-    pub fn with_ml_dsa_verifying_keys(mut self, vks: Arc<std::sync::RwLock<Vec<crate::crypto::pq::MlDsaVerifyingKey>>>) -> Self {
+    pub fn with_ml_dsa_verifying_keys(
+        mut self,
+        vks: Arc<std::sync::RwLock<Vec<crate::crypto::pq::MlDsaVerifyingKey>>>,
+    ) -> Self {
         self.ml_dsa_vks = vks;
         self
     }
@@ -193,7 +196,10 @@ impl JwtKeySource for ClusterKeySource {
     }
 
     fn ml_dsa_verifying_keys(&self) -> Vec<crate::crypto::pq::MlDsaVerifyingKey> {
-        self.ml_dsa_vks.read().unwrap_or_else(std::sync::PoisonError::into_inner).clone()
+        self.ml_dsa_vks
+            .read()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .clone()
     }
 
     fn composite_key_set(&self) -> Arc<super::CompositeKeySet> {
@@ -235,16 +241,18 @@ impl JwtKeySource for FederatedKeySource {
         if self.local.is_trusted(issuer) {
             return self.local.get_key(issuer, kid).await;
         }
-        // Fall back to federation. The resolver returns the full candidate
-        // set ordered kid-first; we return the preferred (kid-matching, or
-        // first published) key for the single-key JwtKeySource contract.
-        // Rotation overlap is preserved because the resolver surfaces every
-        // published key and orders the requested kid first (#1185).
+        // Fall back to federation. A named token may use only the exact named
+        // key; a kid-less legacy caller retains the single-key fallback this
+        // trait requires.
         if self.federation.is_trusted(issuer) {
             let candidates = self.federation.get_keys(issuer, kid).await?;
             return candidates
-                .first()
-                .copied()
+                .iter()
+                .find(|candidate| match kid {
+                    Some(named_kid) => candidate.kid.as_deref() == Some(named_kid),
+                    None => true,
+                })
+                .map(|candidate| candidate.verifying_key)
                 .ok_or_else(|| anyhow::anyhow!("No Ed25519 key for issuer {}", issuer));
         }
         anyhow::bail!("Untrusted issuer: {}", issuer)
@@ -272,7 +280,14 @@ impl JwtKeySource for FederatedKeySource {
 }
 
 /// Async function that fetches raw JWKS JSON from a URL.
-pub type JwksFetcher = Arc<dyn Fn(String) -> std::pin::Pin<Box<dyn std::future::Future<Output = Result<serde_json::Value>> + Send>> + Send + Sync>;
+pub type JwksFetcher = Arc<
+    dyn Fn(
+            String,
+        )
+            -> std::pin::Pin<Box<dyn std::future::Future<Output = Result<serde_json::Value>> + Send>>
+        + Send
+        + Sync,
+>;
 
 /// Deployment mode for JWKS-backed key resolution.
 #[derive(Clone)]
@@ -280,14 +295,23 @@ pub enum JwksMode {
     /// Single-node: fetches JWKS from local `/oauth/jwks` endpoint.
     Isolated { jwks_url: String },
     /// Multi-node / cross-org: resolves issuer → JWKS URL via `IssuerResolver`.
-    Federated { local_jwks_url: String, resolver: Arc<dyn IssuerResolver> },
+    Federated {
+        local_jwks_url: String,
+        resolver: Arc<dyn IssuerResolver>,
+    },
 }
 
 impl std::fmt::Debug for JwksMode {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            Self::Isolated { jwks_url } => f.debug_struct("Isolated").field("jwks_url", jwks_url).finish(),
-            Self::Federated { local_jwks_url, .. } => f.debug_struct("Federated").field("local_jwks_url", local_jwks_url).finish(),
+            Self::Isolated { jwks_url } => f
+                .debug_struct("Isolated")
+                .field("jwks_url", jwks_url)
+                .finish(),
+            Self::Federated { local_jwks_url, .. } => f
+                .debug_struct("Federated")
+                .field("local_jwks_url", local_jwks_url)
+                .finish(),
         }
     }
 }
@@ -370,7 +394,10 @@ impl JwksKeySource {
     }
 
     /// Set the shared ML-DSA-65 verifying key list for PQ-hybrid JWT verification.
-    pub fn with_ml_dsa_verifying_keys(mut self, vks: Arc<std::sync::RwLock<Vec<crate::crypto::pq::MlDsaVerifyingKey>>>) -> Self {
+    pub fn with_ml_dsa_verifying_keys(
+        mut self,
+        vks: Arc<std::sync::RwLock<Vec<crate::crypto::pq::MlDsaVerifyingKey>>>,
+    ) -> Self {
         self.ml_dsa_vks = vks;
         self
     }
@@ -379,7 +406,9 @@ impl JwksKeySource {
     /// of local-issuer (service) JWTs. See the `local_ca_key` field docs.
     pub fn with_local_ca_key(mut self, ca_vk: VerifyingKey) -> Self {
         self.local_ca_kid = Some(crate::auth::jwt::jwk_thumbprint(
-            &crate::auth::jwt::JwkThumbprintInput::Ed25519 { x: ca_vk.as_bytes() },
+            &crate::auth::jwt::JwkThumbprintInput::Ed25519 {
+                x: ca_vk.as_bytes(),
+            },
         ));
         self.local_ca_key = Some(ca_vk);
         self
@@ -414,18 +443,24 @@ impl JwksKeySource {
         }
         match &self.mode {
             JwksMode::Federated { resolver, .. } => resolver.resolve(issuer).await,
-            JwksMode::Isolated { .. } => anyhow::bail!("Untrusted issuer in isolated mode: {}", issuer),
+            JwksMode::Isolated { .. } => {
+                anyhow::bail!("Untrusted issuer in isolated mode: {}", issuer)
+            }
         }
     }
 
     async fn fetch_and_cache(&self, issuer: &str) -> Result<()> {
-        let _permit = self.fetch_semaphore.acquire().await
+        let _permit = self
+            .fetch_semaphore
+            .acquire()
+            .await
             .map_err(|_| anyhow::anyhow!("JWKS fetch semaphore closed"))?;
 
         let url = self.resolve_jwks_url(issuer).await?;
         let jwks = (self.fetcher)(url).await?;
 
-        let keys = jwks.get("keys")
+        let keys = jwks
+            .get("keys")
             .and_then(|v| v.as_array())
             .ok_or_else(|| anyhow::anyhow!("JWKS response missing 'keys' array"))?;
 
@@ -460,10 +495,13 @@ impl JwksKeySource {
                                 let mut arr = [0u8; 32];
                                 arr.copy_from_slice(&x_bytes);
                                 if let Ok(vk) = VerifyingKey::from_bytes(&arr) {
-                                    cache.insert(kid, CachedKey {
-                                        verifying_key: vk,
-                                        fetched_at: now,
-                                    });
+                                    cache.insert(
+                                        kid,
+                                        CachedKey {
+                                            verifying_key: vk,
+                                            fetched_at: now,
+                                        },
+                                    );
                                 }
                             }
                         }
@@ -500,7 +538,9 @@ impl JwtKeySource for JwksKeySource {
             // resolution must not depend on it. Never overrides a JWKS-published
             // (rotated) key because it's keyed on the exact CA thumbprint.
             if self.is_local(issuer) {
-                if let (Some(ca_kid), Some(ca_key)) = (self.local_ca_kid.as_deref(), self.local_ca_key) {
+                if let (Some(ca_kid), Some(ca_key)) =
+                    (self.local_ca_kid.as_deref(), self.local_ca_key)
+                {
                     if ca_kid == kid_str {
                         return Ok(ca_key);
                     }
@@ -550,7 +590,8 @@ impl JwtKeySource for JwksKeySource {
             }
 
             let cache = self.cache.read().await;
-            cache.values()
+            cache
+                .values()
                 .next()
                 .map(|e| e.verifying_key)
                 .ok_or_else(|| anyhow::anyhow!("No Ed25519 keys in JWKS"))
@@ -574,11 +615,18 @@ impl JwtKeySource for JwksKeySource {
     }
 
     fn ml_dsa_verifying_keys(&self) -> Vec<crate::crypto::pq::MlDsaVerifyingKey> {
-        self.ml_dsa_vks.read().unwrap_or_else(std::sync::PoisonError::into_inner).clone()
+        self.ml_dsa_vks
+            .read()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .clone()
     }
 
     fn kid_algs(&self, kid: &str) -> Vec<String> {
-        self.kid_alg_map.read().get(kid).cloned().unwrap_or_default()
+        self.kid_alg_map
+            .read()
+            .get(kid)
+            .cloned()
+            .unwrap_or_default()
     }
 }
 
@@ -613,14 +661,18 @@ mod tests {
     async fn jwks_source_resolves_local_ca_key_offline() -> anyhow::Result<()> {
         // A fetcher that always fails — proves resolution does NOT touch it.
         let fetcher: JwksFetcher = std::sync::Arc::new(|_url: String| {
-            Box::pin(async move { anyhow::bail!("network must not be used for local CA resolution") })
+            Box::pin(
+                async move { anyhow::bail!("network must not be used for local CA resolution") },
+            )
         });
         let ca_sk = SigningKey::from_bytes(&[7u8; 32]);
         let ca_vk = ca_sk.verifying_key();
         let ca_kid = crate::auth::jwt::kid_for_key(&ca_sk);
 
         let ks = JwksKeySource::new(
-            JwksMode::Isolated { jwks_url: "http://127.0.0.1:1/oauth/jwks".to_owned() },
+            JwksMode::Isolated {
+                jwks_url: "http://127.0.0.1:1/oauth/jwks".to_owned(),
+            },
             "http://localhost:9080".to_owned(),
             fetcher,
         )
@@ -647,7 +699,9 @@ mod tests {
         });
         let ca_vk = SigningKey::from_bytes(&[7u8; 32]).verifying_key();
         let ks = JwksKeySource::new(
-            JwksMode::Isolated { jwks_url: "http://127.0.0.1:1/oauth/jwks".to_owned() },
+            JwksMode::Isolated {
+                jwks_url: "http://127.0.0.1:1/oauth/jwks".to_owned(),
+            },
             "http://localhost:9080".to_owned(),
             fetcher,
         )
@@ -655,10 +709,18 @@ mod tests {
 
         // Local issuer but a different kid -> CA fallback does NOT fire; the
         // JWKS fetch is attempted and fails -> error (not the CA key).
-        assert!(ks.get_key("http://localhost:9080", Some("some-other-kid")).await.is_err());
+        assert!(
+            ks.get_key("http://localhost:9080", Some("some-other-kid"))
+                .await
+                .is_err()
+        );
 
         // Non-local issuer is untrusted in isolated mode regardless of kid.
-        assert!(ks.get_key("https://evil.example.com", Some("some-other-kid")).await.is_err());
+        assert!(
+            ks.get_key("https://evil.example.com", Some("some-other-kid"))
+                .await
+                .is_err()
+        );
     }
 
     #[tokio::test]
@@ -687,19 +749,22 @@ mod tests {
     }
 
     fn mock_jwks_json(keys: &[&SigningKey]) -> serde_json::Value {
-        let jwk_entries: Vec<serde_json::Value> = keys.iter().map(|sk| {
-            let vk = sk.verifying_key();
-            let x = base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(vk.as_bytes());
-            let kid = crate::auth::jwt::kid_for_key(sk);
-            serde_json::json!({
-                "kty": "OKP",
-                "crv": "Ed25519",
-                "use": "sig",
-                "alg": "EdDSA",
-                "kid": kid,
-                "x": x,
+        let jwk_entries: Vec<serde_json::Value> = keys
+            .iter()
+            .map(|sk| {
+                let vk = sk.verifying_key();
+                let x = base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(vk.as_bytes());
+                let kid = crate::auth::jwt::kid_for_key(sk);
+                serde_json::json!({
+                    "kty": "OKP",
+                    "crv": "Ed25519",
+                    "use": "sig",
+                    "alg": "EdDSA",
+                    "kid": kid,
+                    "x": x,
+                })
             })
-        }).collect();
+            .collect();
         serde_json::json!({ "keys": jwk_entries })
     }
 
@@ -719,7 +784,9 @@ mod tests {
 
         let jwks = mock_jwks_json(&[&sk_a, &sk_b]);
         let ks = JwksKeySource::new(
-            JwksMode::Isolated { jwks_url: "http://localhost/oauth/jwks".to_owned() },
+            JwksMode::Isolated {
+                jwks_url: "http://localhost/oauth/jwks".to_owned(),
+            },
             "http://localhost".to_owned(),
             mock_fetcher(jwks),
         );
@@ -737,12 +804,16 @@ mod tests {
         let sk = SigningKey::from_bytes(&[0xCC; 32]);
         let jwks = mock_jwks_json(&[&sk]);
         let ks = JwksKeySource::new(
-            JwksMode::Isolated { jwks_url: "http://localhost/oauth/jwks".to_owned() },
+            JwksMode::Isolated {
+                jwks_url: "http://localhost/oauth/jwks".to_owned(),
+            },
             "http://localhost".to_owned(),
             mock_fetcher(jwks),
         );
 
-        let result = ks.get_key("http://localhost", Some("nonexistent-kid")).await;
+        let result = ks
+            .get_key("http://localhost", Some("nonexistent-kid"))
+            .await;
         assert!(result.is_err());
     }
 
@@ -751,7 +822,9 @@ mod tests {
         let sk = SigningKey::from_bytes(&[0xDD; 32]);
         let jwks = mock_jwks_json(&[&sk]);
         let ks = JwksKeySource::new(
-            JwksMode::Isolated { jwks_url: "http://localhost/oauth/jwks".to_owned() },
+            JwksMode::Isolated {
+                jwks_url: "http://localhost/oauth/jwks".to_owned(),
+            },
             "http://localhost".to_owned(),
             mock_fetcher(jwks),
         );
@@ -777,7 +850,9 @@ mod tests {
         });
 
         let ks = JwksKeySource::new(
-            JwksMode::Isolated { jwks_url: "http://localhost/oauth/jwks".to_owned() },
+            JwksMode::Isolated {
+                jwks_url: "http://localhost/oauth/jwks".to_owned(),
+            },
             "http://localhost".to_owned(),
             fetcher,
         );
@@ -800,7 +875,9 @@ mod tests {
         let sk = SigningKey::from_bytes(&[0xFF; 32]);
         let jwks = mock_jwks_json(&[&sk]);
         let ks = JwksKeySource::new(
-            JwksMode::Isolated { jwks_url: "http://localhost/oauth/jwks".to_owned() },
+            JwksMode::Isolated {
+                jwks_url: "http://localhost/oauth/jwks".to_owned(),
+            },
             "http://localhost".to_owned(),
             mock_fetcher(jwks),
         );
@@ -828,7 +905,9 @@ mod tests {
             ]
         });
         let ks = JwksKeySource::new(
-            JwksMode::Isolated { jwks_url: "http://localhost/oauth/jwks".to_owned() },
+            JwksMode::Isolated {
+                jwks_url: "http://localhost/oauth/jwks".to_owned(),
+            },
             "http://localhost".to_owned(),
             mock_fetcher(jwks),
         );
@@ -848,7 +927,8 @@ mod tests {
     async fn dpop_stripping_jwks_multi_alg_per_kid() -> anyhow::Result<()> {
         let sk = SigningKey::from_bytes(&[0x77; 32]);
         let kid = crate::auth::jwt::kid_for_key(&sk);
-        let x = base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(sk.verifying_key().as_bytes());
+        let x =
+            base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(sk.verifying_key().as_bytes());
         let jwks = serde_json::json!({
             "keys": [
                 {"kty": "OKP", "crv": "Ed25519", "use": "sig", "alg": "EdDSA", "kid": kid.clone(), "x": x},
@@ -857,7 +937,9 @@ mod tests {
             ]
         });
         let ks = JwksKeySource::new(
-            JwksMode::Isolated { jwks_url: "http://localhost/oauth/jwks".to_owned() },
+            JwksMode::Isolated {
+                jwks_url: "http://localhost/oauth/jwks".to_owned(),
+            },
             "http://localhost".to_owned(),
             mock_fetcher(jwks),
         );
@@ -882,7 +964,9 @@ mod tests {
         let sk = SigningKey::from_bytes(&[0x11; 32]);
         let jwks = mock_jwks_json(&[&sk]);
         let ks = JwksKeySource::new(
-            JwksMode::Isolated { jwks_url: "http://localhost/oauth/jwks".to_owned() },
+            JwksMode::Isolated {
+                jwks_url: "http://localhost/oauth/jwks".to_owned(),
+            },
             "http://localhost".to_owned(),
             mock_fetcher(jwks),
         );

--- a/crates/hyprstream-rpc/src/auth/key_source.rs
+++ b/crates/hyprstream-rpc/src/auth/key_source.rs
@@ -235,9 +235,17 @@ impl JwtKeySource for FederatedKeySource {
         if self.local.is_trusted(issuer) {
             return self.local.get_key(issuer, kid).await;
         }
-        // Fall back to federation
+        // Fall back to federation. The resolver returns the full candidate
+        // set ordered kid-first; we return the preferred (kid-matching, or
+        // first published) key for the single-key JwtKeySource contract.
+        // Rotation overlap is preserved because the resolver surfaces every
+        // published key and orders the requested kid first (#1185).
         if self.federation.is_trusted(issuer) {
-            return self.federation.get_key(issuer).await;
+            let candidates = self.federation.get_keys(issuer, kid).await?;
+            return candidates
+                .first()
+                .copied()
+                .ok_or_else(|| anyhow::anyhow!("No Ed25519 key for issuer {}", issuer));
         }
         anyhow::bail!("Untrusted issuer: {}", issuer)
     }

--- a/crates/hyprstream-rpc/src/auth/mod.rs
+++ b/crates/hyprstream-rpc/src/auth/mod.rs
@@ -18,13 +18,13 @@ pub mod composite;
 pub mod federation;
 pub mod jti_blocklist;
 pub mod jwt;
-/// Native MAC: security labels, lattice, subject contexts, genesis labeling
-/// (S1, #567). Platform-independent (no std-only deps) so it compiles for wasm.
-pub mod mac;
 #[cfg(not(target_arch = "wasm32"))]
 pub mod key_source;
 #[cfg(not(target_arch = "wasm32"))]
 pub mod key_subject_resolver;
+/// Native MAC: security labels, lattice, subject contexts, genesis labeling
+/// (S1, #567). Platform-independent (no std-only deps) so it compiles for wasm.
+pub mod mac;
 pub mod scope;
 #[cfg(not(target_arch = "wasm32"))]
 pub mod scope_registry;
@@ -38,35 +38,41 @@ pub use atproto_perimeter::{AtprotoPerimeterGateway, EnrolledPeer, EnrollmentSto
 // The identity-resolution contract (#579) lives canonically in `crate::identity`;
 // re-exported here so existing `crate::auth::{IdentityResolver, ...}` paths keep working.
 pub use crate::identity::{Ed25519Vk, IdentityKeys, IdentityResolver, MlDsaVk};
-pub use claims::{ActClaim, Claims, Cnf, CnfJwk, IdTokenClaims, OneOrMany, compute_jkt, is_local_iss};
+pub use claims::{
+    ActClaim, Claims, Cnf, CnfJwk, IdTokenClaims, OneOrMany, compute_jkt, is_local_iss,
+};
 #[cfg(not(target_arch = "wasm32"))]
 pub use composite::{
-    global_composite_key_set, CompositeKeyPair, CompositeKeySet, CompositeKeySetSnapshot,
-    CompositePairRole, CompositePairState,
+    CompositeKeyPair, CompositeKeySet, CompositeKeySetSnapshot, CompositePairRole,
+    CompositePairState, global_composite_key_set,
 };
+#[cfg(not(target_arch = "wasm32"))]
+pub use federation::{FederationKey, FederationKeySource};
 pub use jti_blocklist::{InMemoryJtiBlocklist, JtiBlocklist};
-pub use mac::{
-    bind_time_label, import_label, Assurance, Compartment, CompartmentSet, ContentBoundLabel,
-    GenesisMap, GenesisReport, LabelError, LabeledObject, Lattice, LatticeCodecError,
-    LatticeDecodeError, LatticeVersion, Level, ObjectLabelResolver, ObjectRef, SecurityContext,
-    SecurityLabel, StaticNodeLabel, SubjectContextClaims, VerifiedKeyMaterial, MAX_COMPARTMENTS,
-};
-#[cfg(not(target_arch = "wasm32"))]
-pub use federation::FederationKeySource;
 pub use jwt::{
-    composite_kid, decode, decode_unverified, decode_with_candidates, decode_with_key, encode,
-    encode_service_jwt, header_alg, header_kid, is_rfc9068_access_token_type, jwk_thumbprint,
-    parse_composite_dispatch, parse_protected_header, CompositeJwtDispatch, JwkThumbprintInput,
-    JwtError, ProtectedHeader, RFC9068_ACCESS_TOKEN_TYPES,
+    CompositeJwtDispatch, JwkThumbprintInput, JwtError, ProtectedHeader,
+    RFC9068_ACCESS_TOKEN_TYPES, composite_kid, decode, decode_unverified, decode_with_candidates,
+    decode_with_federation_candidates, decode_with_key, encode, encode_service_jwt, header_alg,
+    header_kid, is_rfc9068_access_token_type, jwk_thumbprint, parse_composite_dispatch,
+    parse_protected_header,
 };
 #[cfg(not(target_arch = "wasm32"))]
-pub use key_source::{ClusterKeySource, FederatedKeySource, IssuerResolver, JwksFetcher, JwksKeySource, JwksMode, JwtKeySource};
+pub use key_source::{
+    ClusterKeySource, FederatedKeySource, IssuerResolver, JwksFetcher, JwksKeySource, JwksMode,
+    JwtKeySource,
+};
 #[cfg(not(target_arch = "wasm32"))]
 pub use key_subject_resolver::{KeySubjectResolver, set_global as set_global_key_subject_resolver};
+pub use mac::{
+    Assurance, Compartment, CompartmentSet, ContentBoundLabel, GenesisMap, GenesisReport,
+    LabelError, LabeledObject, Lattice, LatticeCodecError, LatticeDecodeError, LatticeVersion,
+    Level, MAX_COMPARTMENTS, ObjectLabelResolver, ObjectRef, SecurityContext, SecurityLabel,
+    StaticNodeLabel, SubjectContextClaims, VerifiedKeyMaterial, bind_time_label, import_label,
+};
 pub use scope::Scope;
 #[cfg(not(target_arch = "wasm32"))]
 pub use scope_registry::ScopeDefinition;
 pub use ucan::{
-    set_attenuates, Ability, ApprovalBinding, ApprovalError, Capability, CaveatValue, Caveats,
-    ChainError, Did, Resource, SignedApproval, Ucan, UcanError, UcanPayload, UcanVerifier,
+    Ability, ApprovalBinding, ApprovalError, Capability, CaveatValue, Caveats, ChainError, Did,
+    Resource, SignedApproval, Ucan, UcanError, UcanPayload, UcanVerifier, set_attenuates,
 };

--- a/crates/hyprstream-rpc/src/auth/mod.rs
+++ b/crates/hyprstream-rpc/src/auth/mod.rs
@@ -54,8 +54,8 @@ pub use mac::{
 #[cfg(not(target_arch = "wasm32"))]
 pub use federation::FederationKeySource;
 pub use jwt::{
-    composite_kid, decode, decode_unverified, decode_with_key, encode, encode_service_jwt,
-    header_alg, header_kid, is_rfc9068_access_token_type, jwk_thumbprint,
+    composite_kid, decode, decode_unverified, decode_with_candidates, decode_with_key, encode,
+    encode_service_jwt, header_alg, header_kid, is_rfc9068_access_token_type, jwk_thumbprint,
     parse_composite_dispatch, parse_protected_header, CompositeJwtDispatch, JwkThumbprintInput,
     JwtError, ProtectedHeader, RFC9068_ACCESS_TOKEN_TYPES,
 };

--- a/crates/hyprstream-rpc/src/federated_identity.rs
+++ b/crates/hyprstream-rpc/src/federated_identity.rs
@@ -9,10 +9,10 @@ use anyhow::Result;
 use async_trait::async_trait;
 use std::sync::Arc;
 
+use crate::Subject;
 use crate::auth::FederationKeySource;
 use crate::identity::{IdentityProvider, SigningIdentity};
 use crate::node_identity::NodeIdentityProvider;
-use crate::Subject;
 
 /// Identity provider with cross-node trust via federation.
 ///
@@ -76,7 +76,7 @@ mod tests {
             &self,
             _issuer: &str,
             _kid: Option<&str>,
-        ) -> Result<Vec<ed25519_dalek::VerifyingKey>> {
+        ) -> Result<Vec<crate::auth::FederationKey>> {
             anyhow::bail!("mock: no key")
         }
     }

--- a/crates/hyprstream-rpc/src/federated_identity.rs
+++ b/crates/hyprstream-rpc/src/federated_identity.rs
@@ -72,7 +72,11 @@ mod tests {
         fn is_trusted(&self, _issuer: &str) -> bool {
             true
         }
-        async fn get_key(&self, _issuer: &str) -> Result<ed25519_dalek::VerifyingKey> {
+        async fn get_keys(
+            &self,
+            _issuer: &str,
+            _kid: Option<&str>,
+        ) -> Result<Vec<ed25519_dalek::VerifyingKey>> {
             anyhow::bail!("mock: no key")
         }
     }

--- a/crates/hyprstream/src/auth/federation.rs
+++ b/crates/hyprstream/src/auth/federation.rs
@@ -12,16 +12,16 @@
 //! positional singleton — that anti-pattern forecloses both overlap rotation
 //! and PQ-hybrid publication (#1183).
 
+use anyhow::{Result, anyhow};
+use base64::{Engine, engine::general_purpose::URL_SAFE_NO_PAD};
+use ed25519_dalek::VerifyingKey;
+use hyprstream_discovery::DiscoveryClient;
+use hyprstream_rpc::auth::{FederationKey, FederationKeySource};
 use std::collections::HashMap;
 use std::pin::Pin;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
-use tokio::sync::Mutex;
-use anyhow::{anyhow, Result};
-use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine};
-use ed25519_dalek::VerifyingKey;
-use hyprstream_rpc::auth::FederationKeySource;
-use hyprstream_discovery::DiscoveryClient;
+use tokio::sync::{Mutex, RwLock};
 
 /// Async function that fetches raw JWKS JSON from a URL. Defaults to a
 /// reqwest GET; injectable for tests.
@@ -63,11 +63,13 @@ impl CachedJwks {
 pub struct FederationKeyResolver {
     /// issuer_url → cached JWKS key set.
     ///
-    /// A single `Mutex` (not `RwLock`) serialises both reads and writes so
-    /// that concurrent cache-miss events for the same issuer do not race:
-    /// the first waiter fetches, writes the result, and the second waiter
-    /// then finds a valid entry on re-check.
-    cache: Mutex<HashMap<String, CachedJwks>>,
+    cache: RwLock<HashMap<String, CachedJwks>>,
+    /// Short-lived cache of named keys that were absent after a refresh.
+    /// This bounds attacker-controlled repeated unknown-`kid` requests.
+    negative_cache: Mutex<HashMap<(String, String), Instant>>,
+    /// Per-issuer single-flight guards. Different trusted issuers never block
+    /// each other while one issuer refreshes its JWKS.
+    fetch_locks: Mutex<HashMap<String, Arc<Mutex<()>>>>,
     /// issuer_url → (optional jwks_uri_override, ttl, allow_http)
     config: HashMap<String, (Option<String>, Duration, bool)>,
     http: reqwest::Client,
@@ -97,9 +99,7 @@ pub struct FederationKeyResolver {
 }
 
 impl FederationKeyResolver {
-    pub fn new(
-        trusted_issuers: &HashMap<String, crate::config::TrustedIssuerConfig>,
-    ) -> Self {
+    pub fn new(trusted_issuers: &HashMap<String, crate::config::TrustedIssuerConfig>) -> Self {
         let config = trusted_issuers
             .iter()
             .map(|(iss, cfg)| {
@@ -113,15 +113,18 @@ impl FederationKeyResolver {
                 )
             })
             .collect();
+        let http = reqwest::Client::builder()
+            .timeout(Duration::from_secs(10))
+            .build()
+            .unwrap_or_default();
         Self {
-            cache: Mutex::new(HashMap::new()),
+            cache: RwLock::new(HashMap::new()),
+            negative_cache: Mutex::new(HashMap::new()),
+            fetch_locks: Mutex::new(HashMap::new()),
             config,
             // TLS certificate verification is enabled by default (reqwest default).
-            http: reqwest::Client::builder()
-                .timeout(Duration::from_secs(10))
-                .build()
-                .unwrap_or_default(),
-            jwks_fetcher: default_jwks_fetcher(),
+            jwks_fetcher: default_jwks_fetcher(http.clone()),
+            http,
             discovery_client: None,
             policy_client: None,
         }
@@ -174,11 +177,7 @@ impl FederationKeyResolver {
     /// requests for the same issuer serialise: the second waiter re-checks the
     /// cache after the first finishes, finding a fresh entry rather than issuing
     /// a redundant JWKS fetch.
-    pub async fn get_keys(
-        &self,
-        issuer: &str,
-        kid: Option<&str>,
-    ) -> Result<Vec<VerifyingKey>> {
+    pub async fn get_keys(&self, issuer: &str, kid: Option<&str>) -> Result<Vec<FederationKey>> {
         // Look up config before acquiring cache lock (config is immutable after new())
         let (jwks_uri_override, ttl, allow_http) = self
             .config
@@ -231,27 +230,30 @@ impl FederationKeyResolver {
             }
         }
 
-        // Acquire the cache lock once. Check first; fetch only if
-        // expired/absent OR if the requested kid is not present in a
-        // fresh entry (rotation: a newly-published kid must trigger one
-        // refetch before we fail closed).
-        let mut cache = self.cache.lock().await;
-
-        // Helper: does a fresh cached entry satisfy `kid`?
-        fn has_fresh_kid(entry: &CachedJwks, kid: Option<&str>) -> bool {
-            match kid {
-                None => {
-                    // No selector: any non-empty fresh set suffices.
-                    !entry.entries.is_empty()
-                }
-                Some(k) => entry.entries.iter().any(|e| e.kid.as_deref() == Some(k)),
-            }
+        if let Some(candidates) = self.fresh_candidates(issuer, kid).await {
+            return Ok(candidates);
+        }
+        if self.is_negative_cached(issuer, kid).await {
+            anyhow::bail!("JWKS has no Ed25519 key with requested kid (negative cached)");
         }
 
-        if let Some(entry) = cache.get(issuer) {
-            if !entry.is_expired() && has_fresh_kid(entry, kid) {
-                return Ok(order_candidates(&entry.entries, kid));
-            }
+        // Recheck cache and the negative cache after acquiring this issuer's
+        // single-flight guard. This makes one refresh serve all same-issuer
+        // waiters without globally head-of-line blocking unrelated issuers.
+        let fetch_lock = {
+            let mut locks = self.fetch_locks.lock().await;
+            Arc::clone(
+                locks
+                    .entry(issuer.to_owned())
+                    .or_insert_with(|| Arc::new(Mutex::new(()))),
+            )
+        };
+        let _fetch_guard = fetch_lock.lock().await;
+        if let Some(candidates) = self.fresh_candidates(issuer, kid).await {
+            return Ok(candidates);
+        }
+        if self.is_negative_cached(issuer, kid).await {
+            anyhow::bail!("JWKS has no Ed25519 key with requested kid (negative cached)");
         }
 
         // Phase 0.5 Stage D — try DiscoveryService first if configured.
@@ -262,16 +264,19 @@ impl FederationKeyResolver {
         if let Some(ref dc) = self.discovery_client {
             match self.try_get_keys_from_discovery(dc, issuer).await {
                 Ok(entries) if !entries.is_empty() => {
-                    let ordered = order_candidates(&entries, kid);
-                    cache.insert(
-                        issuer.to_owned(),
-                        CachedJwks {
-                            entries,
-                            fetched_at: Instant::now(),
-                            ttl,
-                        },
-                    );
-                    return Ok(ordered);
+                    if has_requested_kid(&entries, kid) {
+                        self.cache_entries(issuer, entries, ttl).await;
+                        self.clear_negative_cache(issuer, kid).await;
+                        // A selector exists only to select: do not return
+                        // unrelated co-published keys as signature fallbacks.
+                        return self.fresh_candidates(issuer, kid).await.ok_or_else(|| {
+                            anyhow!("fresh Discovery JWKS unexpectedly missing requested key")
+                        });
+                    }
+                    // A stale Discovery statement cannot hide an HTTPS JWKS
+                    // rotation. Preserve it for kid-less callers only if the
+                    // authoritative HTTPS lookup below fails.
+                    self.cache_entries(issuer, entries, ttl).await;
                 }
                 Ok(_) => {
                     tracing::debug!(
@@ -305,32 +310,37 @@ impl FederationKeyResolver {
             anyhow::bail!("No Ed25519 key found in JWKS at {}", jwks_uri);
         }
 
-        // If a kid was requested, a fresh fetch that does not carry it
-        // fails closed — never substitute another key for a named kid
-        // (anti-pattern: positional singleton, #1183).
-        if let Some(k) = kid {
-            let found = entries.iter().any(|e| e.kid.as_deref() == Some(k));
-            if !found {
-                // Cache the fresh set anyway so a concurrent request for
-                // a kid that *is* present benefits, then fail closed.
-                cache.insert(
-                    issuer.to_owned(),
-                    CachedJwks {
-                        entries,
-                        fetched_at: Instant::now(),
-                        ttl,
-                    },
-                );
-                anyhow::bail!(
-                    "JWKS at {} has no Ed25519 key with kid={}",
-                    jwks_uri,
-                    k
-                );
-            }
+        let found = has_requested_kid(&entries, kid);
+        self.cache_entries(issuer, entries, ttl).await;
+        if !found {
+            self.record_negative_cache(issuer, kid).await;
+            let Some(requested_kid) = kid else {
+                anyhow::bail!("JWKS unexpectedly contained no usable Ed25519 key");
+            };
+            anyhow::bail!(
+                "JWKS at {} has no Ed25519 key with kid={}",
+                jwks_uri,
+                requested_kid
+            );
         }
+        self.clear_negative_cache(issuer, kid).await;
+        let cache = self.cache.read().await;
+        Ok(select_candidates(&cache[issuer].entries, kid))
+    }
 
-        let ordered = order_candidates(&entries, kid);
-        cache.insert(
+    async fn fresh_candidates(
+        &self,
+        issuer: &str,
+        kid: Option<&str>,
+    ) -> Option<Vec<FederationKey>> {
+        let cache = self.cache.read().await;
+        let entry = cache.get(issuer)?;
+        (!entry.is_expired() && has_requested_kid(&entry.entries, kid))
+            .then(|| select_candidates(&entry.entries, kid))
+    }
+
+    async fn cache_entries(&self, issuer: &str, entries: Vec<JwksEntry>, ttl: Duration) {
+        self.cache.write().await.insert(
             issuer.to_owned(),
             CachedJwks {
                 entries,
@@ -338,8 +348,48 @@ impl FederationKeyResolver {
                 ttl,
             },
         );
+    }
 
-        Ok(ordered)
+    async fn is_negative_cached(&self, issuer: &str, kid: Option<&str>) -> bool {
+        const NEGATIVE_TTL: Duration = Duration::from_secs(5);
+        let Some(kid) = kid else {
+            return false;
+        };
+        let key = (issuer.to_owned(), kid.to_owned());
+        let mut misses = self.negative_cache.lock().await;
+        match misses.get(&key) {
+            Some(seen) if seen.elapsed() < NEGATIVE_TTL => true,
+            Some(_) => {
+                misses.remove(&key);
+                false
+            }
+            None => false,
+        }
+    }
+
+    async fn record_negative_cache(&self, issuer: &str, kid: Option<&str>) {
+        const NEGATIVE_TTL: Duration = Duration::from_secs(5);
+        const MAX_NEGATIVE_ENTRIES: usize = 1024;
+        let Some(kid) = kid else {
+            return;
+        };
+        let mut misses = self.negative_cache.lock().await;
+        misses.retain(|_, seen| seen.elapsed() < NEGATIVE_TTL);
+        if misses.len() >= MAX_NEGATIVE_ENTRIES {
+            if let Some(key) = misses.keys().next().cloned() {
+                misses.remove(&key);
+            }
+        }
+        misses.insert((issuer.to_owned(), kid.to_owned()), Instant::now());
+    }
+
+    async fn clear_negative_cache(&self, issuer: &str, kid: Option<&str>) {
+        if let Some(kid) = kid {
+            self.negative_cache
+                .lock()
+                .await
+                .remove(&(issuer.to_owned(), kid.to_owned()));
+        }
     }
 
     /// Try fetching the Ed25519 verifying keys for `issuer` via DiscoveryService.
@@ -415,10 +465,7 @@ impl FederationKeyResolver {
             )
         } else {
             // Non-HTTP(S) scheme (ftp://, file://, javascript:, etc.)
-            anyhow::bail!(
-                "JWKS URI must use HTTPS or HTTP scheme (got '{}').",
-                url
-            )
+            anyhow::bail!("JWKS URI must use HTTPS or HTTP scheme (got '{}').", url)
         }
     }
 
@@ -426,13 +473,7 @@ impl FederationKeyResolver {
         // Validate the issuer URL scheme before fetching AS metadata
         self.check_scheme(issuer, allow_http)?;
         let meta_url = format!("{}/.well-known/oauth-authorization-server", issuer);
-        let meta: serde_json::Value = self
-            .http
-            .get(&meta_url)
-            .send()
-            .await?
-            .json()
-            .await?;
+        let meta: serde_json::Value = self.http.get(&meta_url).send().await?.json().await?;
         let jwks_uri = meta["jwks_uri"]
             .as_str()
             .map(str::to_owned)
@@ -454,19 +495,12 @@ impl FederationKeyResolver {
 /// The default JWKS fetcher: a reqwest GET returning the parsed JSON body.
 /// Captured as a `JwksFetcher` so the production path and the test seam
 /// share one shape (#1185).
-fn default_jwks_fetcher() -> JwksFetcher {
-    // The client is rebuilt per-call here only as a closure capture; the
-    // resolver also holds `http` for AS-metadata discovery, so this is a
-    // thin wrapper. A dedicated client is used so a future reqwest tuning
-    // (timeouts, TLS) applies uniformly.
-    Arc::new(|url: &str| {
+fn default_jwks_fetcher(http: reqwest::Client) -> JwksFetcher {
+    Arc::new(move |url: &str| {
         let url = url.to_owned();
+        let http = http.clone();
         Box::pin(async move {
-            let client = reqwest::Client::builder()
-                .timeout(Duration::from_secs(10))
-                .build()
-                .unwrap_or_default();
-            let jwks: serde_json::Value = client.get(&url).send().await?.json().await?;
+            let jwks: serde_json::Value = http.get(&url).send().await?.json().await?;
             Ok(jwks)
         })
     })
@@ -510,23 +544,29 @@ fn parse_jwks_ed25519(jwks: &serde_json::Value, jwks_uri: &str) -> Vec<JwksEntry
     out
 }
 
-/// Order `entries` so the `kid`-matching entry (if any) comes first, followed
-/// by every remaining usable key. A verifier that prefers the named kid thus
-/// still gets overlap candidates as a fallback, and a kid-less caller simply
-/// receives the full published set in JWKS order. This is the
-/// select-by-id-or-try-each rule from the #1183 key-set audit.
-fn order_candidates(entries: &[JwksEntry], kid: Option<&str>) -> Vec<VerifyingKey> {
-    let mut ordered: Vec<VerifyingKey> = Vec::with_capacity(entries.len());
-    if let Some(k) = kid {
-        ordered.extend(entries.iter().filter(|e| e.kid.as_deref() == Some(k)).map(|e| e.key));
+/// A named token selects only its exact entry. A kid-less token can try every
+/// compatible published key, preserving the overlap-rotation case.
+fn select_candidates(entries: &[JwksEntry], kid: Option<&str>) -> Vec<FederationKey> {
+    entries
+        .iter()
+        .filter(|entry| match kid {
+            Some(requested_kid) => entry.kid.as_deref() == Some(requested_kid),
+            None => true,
+        })
+        .map(|entry| FederationKey {
+            kid: entry.kid.clone(),
+            verifying_key: entry.key,
+        })
+        .collect()
+}
+
+fn has_requested_kid(entries: &[JwksEntry], kid: Option<&str>) -> bool {
+    match kid {
+        Some(requested_kid) => entries
+            .iter()
+            .any(|entry| entry.kid.as_deref() == Some(requested_kid)),
+        None => !entries.is_empty(),
     }
-    for e in entries {
-        if kid.is_some() && e.kid.as_deref() == kid {
-            continue;
-        }
-        ordered.push(e.key);
-    }
-    ordered
 }
 
 /// Phase 0.5 Stage D — self-validating signature verification of an
@@ -571,10 +611,7 @@ pub(crate) fn verify_self_issued_entity_statement(
 /// set is retained — not collapsed to the signer — so overlap rotation and
 /// PQ-hybrid publication work through the Discovery path as they do through
 /// HTTPS JWKS (#1185).
-fn extract_self_issued_jwks(
-    jwt: &str,
-    expected_issuer: &str,
-) -> Result<Vec<JwksEntry>> {
+fn extract_self_issued_jwks(jwt: &str, expected_issuer: &str) -> Result<Vec<JwksEntry>> {
     let (entries, _signer) = parse_self_issued_entity_statement(jwt, expected_issuer)?;
     Ok(entries)
 }
@@ -604,7 +641,10 @@ fn parse_self_issued_entity_statement(
         .map_err(|e| anyhow!("entity statement JWT header not JSON: {}", e))?;
     let alg = header.get("alg").and_then(|v| v.as_str()).unwrap_or("");
     if alg != "EdDSA" {
-        anyhow::bail!("entity statement JWT alg is '{}', only EdDSA supported", alg);
+        anyhow::bail!(
+            "entity statement JWT alg is '{}', only EdDSA supported",
+            alg
+        );
     }
 
     // Payload — iss/sub bind to expected issuer; exp not expired.
@@ -617,10 +657,17 @@ fn parse_self_issued_entity_statement(
     let iss = claims.get("iss").and_then(|v| v.as_str()).unwrap_or("");
     let sub = claims.get("sub").and_then(|v| v.as_str()).unwrap_or("");
     if iss != expected_issuer {
-        anyhow::bail!("entity statement iss '{}' != expected issuer '{}'", iss, expected_issuer);
+        anyhow::bail!(
+            "entity statement iss '{}' != expected issuer '{}'",
+            iss,
+            expected_issuer
+        );
     }
     if sub != expected_issuer {
-        anyhow::bail!("entity statement sub '{}' != iss (must be self-issued)", sub);
+        anyhow::bail!(
+            "entity statement sub '{}' != iss (must be self-issued)",
+            sub
+        );
     }
 
     if let Some(exp) = claims.get("exp").and_then(serde_json::Value::as_i64) {
@@ -647,7 +694,10 @@ fn parse_self_issued_entity_statement(
         .decode(parts[2])
         .map_err(|e| anyhow!("entity statement signature not base64url: {}", e))?;
     if sig_bytes.len() != 64 {
-        anyhow::bail!("Ed25519 signature must be 64 bytes, got {}", sig_bytes.len());
+        anyhow::bail!(
+            "Ed25519 signature must be 64 bytes, got {}",
+            sig_bytes.len()
+        );
     }
     let mut sig_arr = [0u8; 64];
     sig_arr.copy_from_slice(&sig_bytes);
@@ -682,7 +732,11 @@ fn parse_self_issued_entity_statement(
             .and_then(|v| v.as_str())
             .filter(|s| !s.is_empty())
             .map(str::to_owned);
-        if signer.is_none() && vk.verify_strict(signing_input.as_bytes(), &signature).is_ok() {
+        if signer.is_none()
+            && vk
+                .verify_strict(signing_input.as_bytes(), &signature)
+                .is_ok()
+        {
             signer = Some(vk);
         }
         entries.push(JwksEntry { kid, key: vk });
@@ -709,7 +763,7 @@ impl FederationKeySource for FederationKeyResolver {
         &self,
         issuer: &str,
         kid: Option<&str>,
-    ) -> anyhow::Result<Vec<ed25519_dalek::VerifyingKey>> {
+    ) -> anyhow::Result<Vec<FederationKey>> {
         FederationKeyResolver::get_keys(self, issuer, kid).await
     }
 }
@@ -747,6 +801,7 @@ mod tests {
     // ──────────────────────────────────────────────────────────────────
 
     use ed25519_dalek::{Signer, SigningKey};
+    use hyprstream_rpc::auth::{Claims, jwt};
     use rand::rngs::OsRng;
 
     fn b64u(bytes: &[u8]) -> String {
@@ -1011,6 +1066,20 @@ mod tests {
         })
     }
 
+    fn federation_token(signing_key: &SigningKey, kid: &str, sub: &str) -> String {
+        let exp = future_exp();
+        let claims = Claims::new(sub.to_owned(), exp - 3600, exp)
+            .with_issuer("https://fed.example".to_owned());
+        let header = serde_json::json!({"alg": "EdDSA", "typ": "at+jwt", "kid": kid});
+        let signing_input = format!(
+            "{}.{}",
+            b64u_json(&header),
+            b64u(&serde_json::to_vec(&claims).expect("claims json"))
+        );
+        let signature = signing_key.sign(signing_input.as_bytes());
+        format!("{}.{}", signing_input, b64u(&signature.to_bytes()))
+    }
+
     fn trusted_issuer(jwks_uri: &str) -> HashMap<String, crate::config::TrustedIssuerConfig> {
         let mut issuers = HashMap::new();
         issuers.insert(
@@ -1043,10 +1112,9 @@ mod tests {
         assert!(kids.contains(&Some("kid-new")));
     }
 
-    /// The anti-pattern this ticket fixes: with two keys published and the
-    /// token signed by the SECOND key, `get_keys` must surface that key. The
-    /// old `fetch_ed25519_key` returned only the first key, so a verifier
-    /// had no candidate that could verify a second-key signature.
+    /// Production-boundary overlap acceptance: two published keys each verify
+    /// their own named token. A named token is never allowed to fall back to a
+    /// different co-published key.
     #[tokio::test]
     async fn get_keys_overlap_returns_both_and_resolves_second_by_kid() {
         let sk_old = SigningKey::generate(&mut OsRng);
@@ -1063,28 +1131,44 @@ mod tests {
             let jwks = jwks.clone();
             Box::pin(async move { Ok(jwks) })
         });
-        let resolver =
-            FederationKeyResolver::new(&trusted_issuer("https://fed.example/jwks"))
-                .with_jwks_fetcher(fetcher);
+        let resolver = FederationKeyResolver::new(&trusted_issuer("https://fed.example/jwks"))
+            .with_jwks_fetcher(fetcher);
 
-        // No kid → ALL candidates returned so the verifier can try each.
-        let all = resolver.get_keys("https://fed.example", None).await.expect("both keys");
+        let old_token = federation_token(&sk_old, "kid-old", "old-subject");
+        let new_token = federation_token(&sk_new, "kid-new", "new-subject");
+
+        // No kid → all candidates are available to a genuinely kid-less token.
+        let all = resolver
+            .get_keys("https://fed.example", None)
+            .await
+            .expect("both keys");
         assert_eq!(all.len(), 2, "overlap: both keys must be returned");
 
-        // kid-new must resolve to the new (second-published) key, ordered first.
-        let ordered = resolver
+        let new_candidates = resolver
             .get_keys("https://fed.example", Some("kid-new"))
             .await
             .expect("kid-new resolves");
-        assert_eq!(ordered.first().copied(), Some(vk_new), "kid-new is first");
-        assert!(ordered.contains(&vk_old), "old key retained as overlap candidate");
+        assert_eq!(new_candidates.len(), 1, "named lookup must not fall back");
+        assert_eq!(new_candidates[0].verifying_key, vk_new);
+        assert_eq!(
+            jwt::decode_with_federation_candidates(&new_token, &new_candidates, None)
+                .expect("new overlap token verifies")
+                .sub,
+            "new-subject"
+        );
 
-        // kid-old still resolves during the overlap window.
-        let ordered_old = resolver
+        let old_candidates = resolver
             .get_keys("https://fed.example", Some("kid-old"))
             .await
             .expect("kid-old resolves");
-        assert_eq!(ordered_old.first().copied(), Some(vk_old));
+        assert_eq!(old_candidates.len(), 1, "named lookup must not fall back");
+        assert_eq!(old_candidates[0].verifying_key, vk_old);
+        assert_eq!(
+            jwt::decode_with_federation_candidates(&old_token, &old_candidates, None)
+                .expect("old overlap token verifies")
+                .sub,
+            "old-subject"
+        );
     }
 
     /// A named `kid` that is not in the published set after a fresh fetch
@@ -1093,15 +1177,13 @@ mod tests {
     #[tokio::test]
     async fn get_keys_unknown_kid_fails_closed_without_substitution() {
         let sk = SigningKey::generate(&mut OsRng);
-        let jwks =
-            serde_json::json!({"keys": [jwk_with_kid(&sk.verifying_key(), "kid-real")]});
+        let jwks = serde_json::json!({"keys": [jwk_with_kid(&sk.verifying_key(), "kid-real")]});
         let fetcher: JwksFetcher = Arc::new(move |_url| {
             let jwks = jwks.clone();
             Box::pin(async move { Ok(jwks) })
         });
-        let resolver =
-            FederationKeyResolver::new(&trusted_issuer("https://fed.example/jwks"))
-                .with_jwks_fetcher(fetcher);
+        let resolver = FederationKeyResolver::new(&trusted_issuer("https://fed.example/jwks"))
+            .with_jwks_fetcher(fetcher);
 
         let err = resolver
             .get_keys("https://fed.example", Some("kid-ghost"))
@@ -1110,6 +1192,38 @@ mod tests {
         assert!(
             format!("{err}").contains("kid-ghost"),
             "error must name the missing kid: {err}"
+        );
+    }
+
+    #[tokio::test]
+    async fn repeated_unknown_kid_uses_one_refresh_within_negative_ttl() {
+        let sk = SigningKey::generate(&mut OsRng);
+        let jwks = serde_json::json!({"keys": [jwk_with_kid(&sk.verifying_key(), "kid-real")]});
+        let fetch_count = Arc::new(AtomicU32::new(0));
+        let count = Arc::clone(&fetch_count);
+        let fetcher: JwksFetcher = Arc::new(move |_url| {
+            let jwks = jwks.clone();
+            let count = Arc::clone(&count);
+            Box::pin(async move {
+                count.fetch_add(1, Ordering::SeqCst);
+                Ok(jwks)
+            })
+        });
+        let resolver = FederationKeyResolver::new(&trusted_issuer("https://fed.example/jwks"))
+            .with_jwks_fetcher(fetcher);
+
+        for _ in 0..3 {
+            assert!(
+                resolver
+                    .get_keys("https://fed.example", Some("kid-ghost"))
+                    .await
+                    .is_err()
+            );
+        }
+        assert_eq!(
+            fetch_count.load(Ordering::SeqCst),
+            1,
+            "one miss → one refresh per negative TTL"
         );
     }
 
@@ -1146,11 +1260,7 @@ mod tests {
             let rotated = rotated.clone();
             Box::pin(async move {
                 let n = cc.fetch_add(1, Ordering::SeqCst);
-                if n == 0 {
-                    Ok(overlap)
-                } else {
-                    Ok(rotated)
-                }
+                if n == 0 { Ok(overlap) } else { Ok(rotated) }
             })
         });
 
@@ -1164,15 +1274,25 @@ mod tests {
                 allow_http: true,
             },
         );
-        let resolver =
-            FederationKeyResolver::new(&issuers).with_jwks_fetcher(fetcher);
+        let resolver = FederationKeyResolver::new(&issuers).with_jwks_fetcher(fetcher);
 
-        // Overlap: old key still honoured.
+        let old_token = federation_token(&sk_old, "kid-old", "old-subject");
+        let new_token = federation_token(&sk_new, "kid-new", "new-subject");
+
+        // During overlap both signed tokens verify at the resolver/verifier
+        // boundary, not merely by inspecting returned vectors.
         let during_overlap = resolver
             .get_keys("https://fed.example", Some("kid-old"))
             .await
             .expect("old key honoured during overlap");
-        assert!(during_overlap.contains(&vk_old));
+        assert!(jwt::decode_with_federation_candidates(&old_token, &during_overlap, None).is_ok());
+        let new_during_overlap = resolver
+            .get_keys("https://fed.example", Some("kid-new"))
+            .await
+            .expect("new key honoured during overlap");
+        assert!(
+            jwt::decode_with_federation_candidates(&new_token, &new_during_overlap, None).is_ok()
+        );
 
         // After rotation drains, the old kid is gone — refetch, fail closed.
         let err = resolver
@@ -1189,6 +1309,6 @@ mod tests {
             .get_keys("https://fed.example", Some("kid-new"))
             .await
             .expect("new key still resolves");
-        assert!(after.contains(&vk_new));
+        assert!(jwt::decode_with_federation_candidates(&new_token, &after, None).is_ok());
     }
 }

--- a/crates/hyprstream/src/auth/federation.rs
+++ b/crates/hyprstream/src/auth/federation.rs
@@ -2,8 +2,18 @@
 //!
 //! `FederationKeyResolver` resolves external issuer URLs to Ed25519 verifying
 //! keys by fetching and caching JWKS (RFC 7517) documents.
+//!
+//! # Rotation-aware key set (#1185)
+//!
+//! The cache retains **every** usable Ed25519 key an issuer publishes, keyed by
+//! `kid`, so two keys published simultaneously during an overlap rotation both
+//! verify. A `kid` hint selects the preferred candidate; without one, the
+//! caller tries each. The resolver never collapses the published set to a
+//! positional singleton — that anti-pattern forecloses both overlap rotation
+//! and PQ-hybrid publication (#1183).
 
 use std::collections::HashMap;
+use std::pin::Pin;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 use tokio::sync::Mutex;
@@ -13,13 +23,29 @@ use ed25519_dalek::VerifyingKey;
 use hyprstream_rpc::auth::FederationKeySource;
 use hyprstream_discovery::DiscoveryClient;
 
-struct CachedKey {
+/// Async function that fetches raw JWKS JSON from a URL. Defaults to a
+/// reqwest GET; injectable for tests.
+type JwksFetcher = Arc<
+    dyn Fn(&str) -> Pin<Box<dyn std::future::Future<Output = Result<serde_json::Value>> + Send>>
+        + Send
+        + Sync,
+>;
+
+/// One Ed25519 entry from a published JWKS, with its optional `kid`.
+#[derive(Clone)]
+struct JwksEntry {
+    kid: Option<String>,
     key: VerifyingKey,
+}
+
+/// All Ed25519 keys currently published by one issuer, plus cache bookkeeping.
+struct CachedJwks {
+    entries: Vec<JwksEntry>,
     fetched_at: Instant,
     ttl: Duration,
 }
 
-impl CachedKey {
+impl CachedJwks {
     fn is_expired(&self) -> bool {
         self.fetched_at.elapsed() > self.ttl
     }
@@ -35,19 +61,23 @@ impl CachedKey {
 /// Set `allow_http: true` in `TrustedIssuerConfig` on a per-issuer basis to
 /// permit plain HTTP (development / internal use only).
 pub struct FederationKeyResolver {
-    /// issuer_url → cached key.
+    /// issuer_url → cached JWKS key set.
     ///
     /// A single `Mutex` (not `RwLock`) serialises both reads and writes so
     /// that concurrent cache-miss events for the same issuer do not race:
     /// the first waiter fetches, writes the result, and the second waiter
     /// then finds a valid entry on re-check.
-    cache: Mutex<HashMap<String, CachedKey>>,
+    cache: Mutex<HashMap<String, CachedJwks>>,
     /// issuer_url → (optional jwks_uri_override, ttl, allow_http)
     config: HashMap<String, (Option<String>, Duration, bool)>,
     http: reqwest::Client,
+    /// Injectable JWKS fetcher (url → raw JWKS JSON). Defaults to a reqwest
+    /// GET; overridable in tests so the rotation/overlap behaviour of
+    /// `get_keys` can be exercised end-to-end without a network mock.
+    jwks_fetcher: JwksFetcher,
     /// Phase 0.5 Stage D — optional DiscoveryService client.
     ///
-    /// When configured, `get_key` consults DiscoveryService for a cached
+    /// When configured, `get_keys` consults DiscoveryService for a cached
     /// signed entity statement before falling back to HTTPS JWKS fetch.
     /// This avoids the HTTPS round-trip for local-issuer verification and
     /// the 300s TTL becomes irrelevant for cluster-internal traffic.
@@ -55,7 +85,7 @@ pub struct FederationKeyResolver {
     /// trust on missing data).
     discovery_client: Option<Arc<DiscoveryClient>>,
     /// Unified federation trust gate (atproto-style). When set, every
-    /// `get_key` call additionally verifies the issuer's origin is
+    /// `get_keys` call additionally verifies the issuer's origin is
     /// permitted by PolicyService `federation:register` — same gate as
     /// CIMD client registration. The `trusted_issuers` config carries
     /// operational metadata (jwks_uri override, scheme, TTL); this
@@ -91,14 +121,24 @@ impl FederationKeyResolver {
                 .timeout(Duration::from_secs(10))
                 .build()
                 .unwrap_or_default(),
+            jwks_fetcher: default_jwks_fetcher(),
             discovery_client: None,
             policy_client: None,
         }
     }
 
-    /// Wire the PolicyService client so [`get_key`] enforces the
+    /// Override the JWKS fetcher (url → raw JWKS JSON). Test-only seam that
+    /// lets the rotation/overlap behaviour of [`get_keys`] be exercised
+    /// end-to-end without standing up an HTTPS server.
+    #[cfg(test)]
+    pub(crate) fn with_jwks_fetcher(mut self, fetcher: JwksFetcher) -> Self {
+        self.jwks_fetcher = fetcher;
+        self
+    }
+
+    /// Wire the PolicyService client so [`get_keys`] enforces the
     /// `federation:register` trust gate before any HTTPS fetch. When
-    /// set, calls to `get_key` for issuers that aren't currently
+    /// set, calls to `get_keys` for issuers that aren't currently
     /// permitted by PolicyService policy return Err — fail-closed,
     /// matching the CIMD client path.
     pub fn with_policy_client(mut self, client: Arc<crate::services::PolicyClient>) -> Self {
@@ -107,7 +147,7 @@ impl FederationKeyResolver {
     }
 
     /// Phase 0.5 Stage D — wire a DiscoveryService client for federation
-    /// directory consultation. When set, [`get_key`] will try fetching the
+    /// directory consultation. When set, [`get_keys`] will try fetching the
     /// issuer's signed entity statement via DiscoveryService before falling
     /// back to HTTPS JWKS fetch.
     ///
@@ -126,13 +166,19 @@ impl FederationKeyResolver {
         self.config.contains_key(issuer)
     }
 
-    /// Get the verifying key for an issuer, fetching/refreshing JWKS as needed.
+    /// Get the Ed25519 candidate verifying keys for an issuer, fetching /
+    /// refreshing JWKS as needed. See the trait docs for the rotation-aware
+    /// key-set contract (#1185).
     ///
     /// Uses a single `Mutex` for both cache reads and writes so that concurrent
     /// requests for the same issuer serialise: the second waiter re-checks the
     /// cache after the first finishes, finding a fresh entry rather than issuing
     /// a redundant JWKS fetch.
-    pub async fn get_key(&self, issuer: &str) -> Result<VerifyingKey> {
+    pub async fn get_keys(
+        &self,
+        issuer: &str,
+        kid: Option<&str>,
+    ) -> Result<Vec<VerifyingKey>> {
         // Look up config before acquiring cache lock (config is immutable after new())
         let (jwks_uri_override, ttl, allow_http) = self
             .config
@@ -185,11 +231,26 @@ impl FederationKeyResolver {
             }
         }
 
-        // Acquire the cache lock once. Check first; only fetch if expired/absent.
+        // Acquire the cache lock once. Check first; fetch only if
+        // expired/absent OR if the requested kid is not present in a
+        // fresh entry (rotation: a newly-published kid must trigger one
+        // refetch before we fail closed).
         let mut cache = self.cache.lock().await;
+
+        // Helper: does a fresh cached entry satisfy `kid`?
+        fn has_fresh_kid(entry: &CachedJwks, kid: Option<&str>) -> bool {
+            match kid {
+                None => {
+                    // No selector: any non-empty fresh set suffices.
+                    !entry.entries.is_empty()
+                }
+                Some(k) => entry.entries.iter().any(|e| e.kid.as_deref() == Some(k)),
+            }
+        }
+
         if let Some(entry) = cache.get(issuer) {
-            if !entry.is_expired() {
-                return Ok(entry.key);
+            if !entry.is_expired() && has_fresh_kid(entry, kid) {
+                return Ok(order_candidates(&entry.entries, kid));
             }
         }
 
@@ -199,17 +260,25 @@ impl FederationKeyResolver {
         // round-trip. Conservative on errors: any failure falls through
         // to the existing HTTPS path. Never downgrades trust.
         if let Some(ref dc) = self.discovery_client {
-            match self.try_get_key_from_discovery(dc, issuer).await {
-                Ok(key) => {
+            match self.try_get_keys_from_discovery(dc, issuer).await {
+                Ok(entries) if !entries.is_empty() => {
+                    let ordered = order_candidates(&entries, kid);
                     cache.insert(
                         issuer.to_owned(),
-                        CachedKey {
-                            key,
+                        CachedJwks {
+                            entries,
                             fetched_at: Instant::now(),
                             ttl,
                         },
                     );
-                    return Ok(key);
+                    return Ok(ordered);
+                }
+                Ok(_) => {
+                    tracing::debug!(
+                        issuer = %issuer,
+                        "DiscoveryService federation lookup returned no Ed25519 keys; \
+                         falling through to HTTPS"
+                    );
                 }
                 Err(e) => {
                     tracing::debug!(
@@ -221,8 +290,9 @@ impl FederationKeyResolver {
             }
         }
 
-        // Cache miss or expired — fetch while holding the lock so concurrent
-        // callers for the same issuer block here and reuse the result.
+        // Cache miss, expired, or unknown kid — fetch while holding the
+        // lock so concurrent callers for the same issuer block here and
+        // reuse the result.
         let jwks_uri = if let Some(uri) = jwks_uri_override {
             self.check_scheme(&uri, allow_http)?;
             uri
@@ -230,21 +300,49 @@ impl FederationKeyResolver {
             self.discover_jwks_uri(issuer, allow_http).await?
         };
 
-        let key = self.fetch_ed25519_key(&jwks_uri).await?;
+        let entries = self.fetch_ed25519_keys(&jwks_uri).await?;
+        if entries.is_empty() {
+            anyhow::bail!("No Ed25519 key found in JWKS at {}", jwks_uri);
+        }
 
+        // If a kid was requested, a fresh fetch that does not carry it
+        // fails closed — never substitute another key for a named kid
+        // (anti-pattern: positional singleton, #1183).
+        if let Some(k) = kid {
+            let found = entries.iter().any(|e| e.kid.as_deref() == Some(k));
+            if !found {
+                // Cache the fresh set anyway so a concurrent request for
+                // a kid that *is* present benefits, then fail closed.
+                cache.insert(
+                    issuer.to_owned(),
+                    CachedJwks {
+                        entries,
+                        fetched_at: Instant::now(),
+                        ttl,
+                    },
+                );
+                anyhow::bail!(
+                    "JWKS at {} has no Ed25519 key with kid={}",
+                    jwks_uri,
+                    k
+                );
+            }
+        }
+
+        let ordered = order_candidates(&entries, kid);
         cache.insert(
             issuer.to_owned(),
-            CachedKey {
-                key,
+            CachedJwks {
+                entries,
                 fetched_at: Instant::now(),
                 ttl,
             },
         );
 
-        Ok(key)
+        Ok(ordered)
     }
 
-    /// Try fetching the Ed25519 verifying key for `issuer` via DiscoveryService.
+    /// Try fetching the Ed25519 verifying keys for `issuer` via DiscoveryService.
     ///
     /// Calls `DiscoveryClient::get_entity_statement(issuer)` to retrieve a
     /// cached signed OIDF entity statement, then performs self-validating
@@ -254,7 +352,7 @@ impl FederationKeyResolver {
     /// 2. Parse JWT payload → require `iss == sub == issuer` (self-issued check)
     /// 3. Parse JWT payload → extract `jwks.keys`
     /// 4. For each Ed25519 key in the JWKS: try verifying the JWT signature
-    /// 5. Return the FIRST key that successfully verifies the JWT
+    /// 5. Return the full candidate set once SOME embedded key verifies
     ///
     /// This self-validation establishes that the JWT was signed by a key
     /// listed in its own embedded JWKS — defeats tampering during delivery
@@ -279,11 +377,11 @@ impl FederationKeyResolver {
     /// Self-validation is the strongest check we can do without trust anchors;
     /// the existing per-issuer `trusted_issuers` config provides the trust root
     /// for the *result* (since only configured issuers reach this path at all).
-    async fn try_get_key_from_discovery(
+    async fn try_get_keys_from_discovery(
         &self,
         dc: &DiscoveryClient,
         issuer: &str,
-    ) -> Result<VerifyingKey> {
+    ) -> Result<Vec<JwksEntry>> {
         let stmt = dc
             .get_entity_statement(issuer)
             .await
@@ -293,7 +391,11 @@ impl FederationKeyResolver {
             anyhow::bail!("DiscoveryService returned empty entity statement JWT");
         }
 
-        verify_self_issued_entity_statement(&stmt.jwt, issuer)
+        // Self-validation establishes which embedded key signed the statement.
+        // The full published JWKS is retained (all Ed25519 entries with their
+        // kids) so overlap candidates survive a Discovery lookup, matching the
+        // HTTPS JWKS path's rotation semantics (#1185).
+        extract_self_issued_jwks(&stmt.jwt, issuer)
     }
 
     /// Validate that `url` uses HTTPS (or HTTP when explicitly permitted).
@@ -340,31 +442,91 @@ impl FederationKeyResolver {
         Ok(jwks_uri)
     }
 
-    async fn fetch_ed25519_key(&self, jwks_uri: &str) -> Result<VerifyingKey> {
-        let jwks: serde_json::Value = self
-            .http
-            .get(jwks_uri)
-            .send()
-            .await?
-            .json()
-            .await?;
-        let keys = jwks["keys"]
-            .as_array()
-            .ok_or_else(|| anyhow!("JWKS missing 'keys' array at {}", jwks_uri))?;
-        for key in keys {
-            if key["kty"].as_str() == Some("OKP") && key["crv"].as_str() == Some("Ed25519") {
-                let x = key["x"]
-                    .as_str()
-                    .ok_or_else(|| anyhow!("OKP key missing 'x' field"))?;
-                let raw = URL_SAFE_NO_PAD.decode(x)?;
-                let bytes: [u8; 32] = raw
-                    .try_into()
-                    .map_err(|_| anyhow!("Ed25519 key must be 32 bytes"))?;
-                return VerifyingKey::from_bytes(&bytes).map_err(|e| anyhow!("{}", e));
-            }
-        }
-        Err(anyhow!("No Ed25519 key found in JWKS at {}", jwks_uri))
+    /// Fetch every Ed25519 key in the JWKS at `jwks_uri`, each with its
+    /// optional `kid`. All usable entries are retained — callers select by
+    /// `kid` and/or try each candidate (rotation overlap, PQ-hybrid).
+    async fn fetch_ed25519_keys(&self, jwks_uri: &str) -> Result<Vec<JwksEntry>> {
+        let jwks = (self.jwks_fetcher)(jwks_uri).await?;
+        Ok(parse_jwks_ed25519(&jwks, jwks_uri))
     }
+}
+
+/// The default JWKS fetcher: a reqwest GET returning the parsed JSON body.
+/// Captured as a `JwksFetcher` so the production path and the test seam
+/// share one shape (#1185).
+fn default_jwks_fetcher() -> JwksFetcher {
+    // The client is rebuilt per-call here only as a closure capture; the
+    // resolver also holds `http` for AS-metadata discovery, so this is a
+    // thin wrapper. A dedicated client is used so a future reqwest tuning
+    // (timeouts, TLS) applies uniformly.
+    Arc::new(|url: &str| {
+        let url = url.to_owned();
+        Box::pin(async move {
+            let client = reqwest::Client::builder()
+                .timeout(Duration::from_secs(10))
+                .build()
+                .unwrap_or_default();
+            let jwks: serde_json::Value = client.get(&url).send().await?.json().await?;
+            Ok(jwks)
+        })
+    })
+}
+
+/// Parse every Ed25519 entry (with its `kid`) out of a JWKS document. All
+/// usable entries are retained — callers select by `kid` and/or try each
+/// candidate. Pure (no I/O) so rotation/overlap behaviour is unit-testable.
+fn parse_jwks_ed25519(jwks: &serde_json::Value, jwks_uri: &str) -> Vec<JwksEntry> {
+    let mut out = Vec::new();
+    let Some(keys) = jwks["keys"].as_array() else {
+        return out;
+    };
+    for key in keys {
+        if key["kty"].as_str() != Some("OKP") || key["crv"].as_str() != Some("Ed25519") {
+            continue;
+        }
+        let x = match key["x"].as_str() {
+            Some(s) => s,
+            None => continue,
+        };
+        let raw = match URL_SAFE_NO_PAD.decode(x) {
+            Ok(r) => r,
+            Err(_) => continue,
+        };
+        let bytes: [u8; 32] = match raw.try_into() {
+            Ok(b) => b,
+            Err(_) => continue,
+        };
+        let vk = match VerifyingKey::from_bytes(&bytes) {
+            Ok(v) => v,
+            Err(_) => continue,
+        };
+        let kid = key["kid"]
+            .as_str()
+            .filter(|s| !s.is_empty())
+            .map(str::to_owned);
+        out.push(JwksEntry { kid, key: vk });
+    }
+    let _ = jwks_uri; // context only (error reporting is at call sites)
+    out
+}
+
+/// Order `entries` so the `kid`-matching entry (if any) comes first, followed
+/// by every remaining usable key. A verifier that prefers the named kid thus
+/// still gets overlap candidates as a fallback, and a kid-less caller simply
+/// receives the full published set in JWKS order. This is the
+/// select-by-id-or-try-each rule from the #1183 key-set audit.
+fn order_candidates(entries: &[JwksEntry], kid: Option<&str>) -> Vec<VerifyingKey> {
+    let mut ordered: Vec<VerifyingKey> = Vec::with_capacity(entries.len());
+    if let Some(k) = kid {
+        ordered.extend(entries.iter().filter(|e| e.kid.as_deref() == Some(k)).map(|e| e.key));
+    }
+    for e in entries {
+        if kid.is_some() && e.kid.as_deref() == kid {
+            continue;
+        }
+        ordered.push(e.key);
+    }
+    ordered
 }
 
 /// Phase 0.5 Stage D — self-validating signature verification of an
@@ -380,7 +542,8 @@ impl FederationKeyResolver {
 /// 4. `exp` (if present) is in the future
 /// 5. SOME Ed25519 key in the embedded JWKS verifies the JWT signature
 ///
-/// Returns the verifying key that produced the signature.
+/// Returns the verifying key that produced the signature. For the full
+/// published key set (rotation-aware), use [`extract_self_issued_jwks`].
 ///
 /// This defeats tampering during delivery: a man-in-the-middle (or a
 /// compromised intermediary like DiscoveryService) cannot substitute
@@ -391,10 +554,43 @@ impl FederationKeyResolver {
 /// caller is expected to have already established that `expected_issuer`
 /// is in the trusted-issuer config; self-validation defeats tampering of
 /// the delivered statement, not initial trust establishment.
+#[cfg(test)]
 pub(crate) fn verify_self_issued_entity_statement(
     jwt: &str,
     expected_issuer: &str,
 ) -> Result<VerifyingKey> {
+    let (_entries, signer) = parse_self_issued_entity_statement(jwt, expected_issuer)?;
+    Ok(signer)
+}
+
+/// Phase 0.5 Stage D — self-validating signature verification of an
+/// OpenID Federation 1.0 entity statement received from DiscoveryService.
+///
+/// Returns the full published Ed25519 key set (each with its `kid`) after
+/// confirming at least one of them produced the statement's signature. The
+/// set is retained — not collapsed to the signer — so overlap rotation and
+/// PQ-hybrid publication work through the Discovery path as they do through
+/// HTTPS JWKS (#1185).
+fn extract_self_issued_jwks(
+    jwt: &str,
+    expected_issuer: &str,
+) -> Result<Vec<JwksEntry>> {
+    let (entries, _signer) = parse_self_issued_entity_statement(jwt, expected_issuer)?;
+    Ok(entries)
+}
+
+/// Shared parse + self-validation for a self-issued entity statement.
+///
+/// Performs the full structural/claim/exp checks and self-validates the
+/// signature against the embedded JWKS, returning both the complete
+/// Ed25519 candidate list (with kids) and the key that produced the
+/// signature. Both entry points (`verify_self_issued_entity_statement`
+/// for the single signer key, `extract_self_issued_jwks` for the rotation
+/// set) run this identical check.
+fn parse_self_issued_entity_statement(
+    jwt: &str,
+    expected_issuer: &str,
+) -> Result<(Vec<JwksEntry>, VerifyingKey)> {
     let parts: Vec<&str> = jwt.split('.').collect();
     if parts.len() != 3 {
         anyhow::bail!("entity statement JWT not in 3-part compact form");
@@ -437,7 +633,8 @@ pub(crate) fn verify_self_issued_entity_statement(
         }
     }
 
-    // JWKS — extract Ed25519 candidates.
+    // JWKS — extract every Ed25519 candidate, retaining each `kid` so the
+    // caller can select by id and keep overlap candidates (#1185).
     let keys = claims
         .get("jwks")
         .and_then(|j| j.get("keys"))
@@ -456,6 +653,8 @@ pub(crate) fn verify_self_issued_entity_statement(
     sig_arr.copy_from_slice(&sig_bytes);
     let signature = ed25519_dalek::Signature::from_bytes(&sig_arr);
 
+    let mut entries: Vec<JwksEntry> = Vec::new();
+    let mut signer: Option<VerifyingKey> = None;
     for key in keys {
         if key.get("kty").and_then(|v| v.as_str()) != Some("OKP")
             || key.get("crv").and_then(|v| v.as_str()) != Some("Ed25519")
@@ -478,15 +677,23 @@ pub(crate) fn verify_self_issued_entity_statement(
             Ok(v) => v,
             Err(_) => continue,
         };
-
-        if vk.verify_strict(signing_input.as_bytes(), &signature).is_ok() {
-            return Ok(vk);
+        let kid = key
+            .get("kid")
+            .and_then(|v| v.as_str())
+            .filter(|s| !s.is_empty())
+            .map(str::to_owned);
+        if signer.is_none() && vk.verify_strict(signing_input.as_bytes(), &signature).is_ok() {
+            signer = Some(vk);
         }
+        entries.push(JwksEntry { kid, key: vk });
     }
 
-    anyhow::bail!(
-        "entity statement self-validation failed: no Ed25519 key in jwks verifies the signature"
-    )
+    match signer {
+        Some(vk) => Ok((entries, vk)),
+        None => anyhow::bail!(
+            "entity statement self-validation failed: no Ed25519 key in jwks verifies the signature"
+        ),
+    }
 }
 
 // Adapter: delegates to the inherent methods. Using fully-qualified paths
@@ -498,8 +705,12 @@ impl FederationKeySource for FederationKeyResolver {
         FederationKeyResolver::is_trusted(self, issuer)
     }
 
-    async fn get_key(&self, issuer: &str) -> anyhow::Result<ed25519_dalek::VerifyingKey> {
-        FederationKeyResolver::get_key(self, issuer).await
+    async fn get_keys(
+        &self,
+        issuer: &str,
+        kid: Option<&str>,
+    ) -> anyhow::Result<Vec<ed25519_dalek::VerifyingKey>> {
+        FederationKeyResolver::get_keys(self, issuer, kid).await
     }
 }
 
@@ -781,5 +992,203 @@ mod tests {
         let err = verify_self_issued_entity_statement("not.a.jwt.with.too.many.parts", "x")
             .expect_err("malformed JWT must reject");
         assert!(format!("{err}").contains("3-part"), "got: {err}");
+    }
+
+    // ──────────────────────────────────────────────────────────────────
+    // #1185 — rotation-aware JWKS key set (overlap + kid selection)
+    // ──────────────────────────────────────────────────────────────────
+
+    use std::sync::atomic::{AtomicU32, Ordering};
+
+    fn jwk_with_kid(vk: &VerifyingKey, kid: &str) -> serde_json::Value {
+        serde_json::json!({
+            "kty": "OKP",
+            "crv": "Ed25519",
+            "x": b64u(vk.as_bytes()),
+            "use": "sig",
+            "alg": "EdDSA",
+            "kid": kid,
+        })
+    }
+
+    fn trusted_issuer(jwks_uri: &str) -> HashMap<String, crate::config::TrustedIssuerConfig> {
+        let mut issuers = HashMap::new();
+        issuers.insert(
+            "https://fed.example".to_owned(),
+            crate::config::TrustedIssuerConfig {
+                jwks_uri: Some(jwks_uri.to_owned()),
+                jwks_cache_ttl_secs: 300,
+                allow_http: true,
+            },
+        );
+        issuers
+    }
+
+    /// `parse_jwks_ed25519` retains EVERY published Ed25519 key with its kid,
+    /// not just the first — the core anti-singleton invariant from #1183.
+    #[test]
+    fn parse_jwks_retains_all_ed25519_entries_with_kids() {
+        let sk_a = SigningKey::generate(&mut OsRng);
+        let sk_b = SigningKey::generate(&mut OsRng);
+        let jwks = serde_json::json!({
+            "keys": [
+                jwk_with_kid(&sk_a.verifying_key(), "kid-old"),
+                jwk_with_kid(&sk_b.verifying_key(), "kid-new"),
+            ]
+        });
+        let entries = parse_jwks_ed25519(&jwks, "https://fed.example/jwks");
+        assert_eq!(entries.len(), 2, "both published keys must be retained");
+        let kids: Vec<Option<&str>> = entries.iter().map(|e| e.kid.as_deref()).collect();
+        assert!(kids.contains(&Some("kid-old")));
+        assert!(kids.contains(&Some("kid-new")));
+    }
+
+    /// The anti-pattern this ticket fixes: with two keys published and the
+    /// token signed by the SECOND key, `get_keys` must surface that key. The
+    /// old `fetch_ed25519_key` returned only the first key, so a verifier
+    /// had no candidate that could verify a second-key signature.
+    #[tokio::test]
+    async fn get_keys_overlap_returns_both_and_resolves_second_by_kid() {
+        let sk_old = SigningKey::generate(&mut OsRng);
+        let sk_new = SigningKey::generate(&mut OsRng);
+        let vk_old = sk_old.verifying_key();
+        let vk_new = sk_new.verifying_key();
+        let jwks = serde_json::json!({
+            "keys": [
+                jwk_with_kid(&vk_old, "kid-old"),
+                jwk_with_kid(&vk_new, "kid-new"),
+            ]
+        });
+        let fetcher: JwksFetcher = Arc::new(move |_url| {
+            let jwks = jwks.clone();
+            Box::pin(async move { Ok(jwks) })
+        });
+        let resolver =
+            FederationKeyResolver::new(&trusted_issuer("https://fed.example/jwks"))
+                .with_jwks_fetcher(fetcher);
+
+        // No kid → ALL candidates returned so the verifier can try each.
+        let all = resolver.get_keys("https://fed.example", None).await.expect("both keys");
+        assert_eq!(all.len(), 2, "overlap: both keys must be returned");
+
+        // kid-new must resolve to the new (second-published) key, ordered first.
+        let ordered = resolver
+            .get_keys("https://fed.example", Some("kid-new"))
+            .await
+            .expect("kid-new resolves");
+        assert_eq!(ordered.first().copied(), Some(vk_new), "kid-new is first");
+        assert!(ordered.contains(&vk_old), "old key retained as overlap candidate");
+
+        // kid-old still resolves during the overlap window.
+        let ordered_old = resolver
+            .get_keys("https://fed.example", Some("kid-old"))
+            .await
+            .expect("kid-old resolves");
+        assert_eq!(ordered_old.first().copied(), Some(vk_old));
+    }
+
+    /// A named `kid` that is not in the published set after a fresh fetch
+    /// MUST fail closed — never silently substitute another published key
+    /// (the positional-singleton anti-pattern, #1183).
+    #[tokio::test]
+    async fn get_keys_unknown_kid_fails_closed_without_substitution() {
+        let sk = SigningKey::generate(&mut OsRng);
+        let jwks =
+            serde_json::json!({"keys": [jwk_with_kid(&sk.verifying_key(), "kid-real")]});
+        let fetcher: JwksFetcher = Arc::new(move |_url| {
+            let jwks = jwks.clone();
+            Box::pin(async move { Ok(jwks) })
+        });
+        let resolver =
+            FederationKeyResolver::new(&trusted_issuer("https://fed.example/jwks"))
+                .with_jwks_fetcher(fetcher);
+
+        let err = resolver
+            .get_keys("https://fed.example", Some("kid-ghost"))
+            .await
+            .expect_err("unknown kid must fail closed");
+        assert!(
+            format!("{err}").contains("kid-ghost"),
+            "error must name the missing kid: {err}"
+        );
+    }
+
+    /// Overlap rotation lifecycle: publish [old,new] (both accepted), then
+    /// publish [new] only — the rotation completed and `old` is now retired
+    /// past its bounded observation window. A subsequent request for `old`
+    /// refetches and finds it gone, so it fails closed. This is the
+    /// "retired one rejected after bounded window" overlap test.
+    #[tokio::test]
+    async fn get_keys_retired_key_rejected_after_rotation_completes() {
+        let sk_old = SigningKey::generate(&mut OsRng);
+        let sk_new = SigningKey::generate(&mut OsRng);
+        let vk_old = sk_old.verifying_key();
+        let vk_new = sk_new.verifying_key();
+
+        // Overlap window: both keys published.
+        let overlap = serde_json::json!({
+            "keys": [
+                jwk_with_kid(&vk_old, "kid-old"),
+                jwk_with_kid(&vk_new, "kid-new"),
+            ]
+        });
+        // Post-rotation: only the new key remains (old retired).
+        let rotated = serde_json::json!({"keys": [jwk_with_kid(&vk_new, "kid-new")]});
+
+        // The fetcher returns `overlap` for the first call and `rotated`
+        // thereafter — modelling a JWKS that drops the old key between
+        // the two observations (the bounded drain window elapsing).
+        let call_count = Arc::new(AtomicU32::new(0));
+        let cc = call_count.clone();
+        let fetcher: JwksFetcher = Arc::new(move |_url| {
+            let cc = cc.clone();
+            let overlap = overlap.clone();
+            let rotated = rotated.clone();
+            Box::pin(async move {
+                let n = cc.fetch_add(1, Ordering::SeqCst);
+                if n == 0 {
+                    Ok(overlap)
+                } else {
+                    Ok(rotated)
+                }
+            })
+        });
+
+        // Use a zero TTL so the second lookup forces a fresh refetch.
+        let mut issuers = HashMap::new();
+        issuers.insert(
+            "https://fed.example".to_owned(),
+            crate::config::TrustedIssuerConfig {
+                jwks_uri: Some("https://fed.example/jwks".to_owned()),
+                jwks_cache_ttl_secs: 0,
+                allow_http: true,
+            },
+        );
+        let resolver =
+            FederationKeyResolver::new(&issuers).with_jwks_fetcher(fetcher);
+
+        // Overlap: old key still honoured.
+        let during_overlap = resolver
+            .get_keys("https://fed.example", Some("kid-old"))
+            .await
+            .expect("old key honoured during overlap");
+        assert!(during_overlap.contains(&vk_old));
+
+        // After rotation drains, the old kid is gone — refetch, fail closed.
+        let err = resolver
+            .get_keys("https://fed.example", Some("kid-old"))
+            .await
+            .expect_err("retired key must be rejected after drain");
+        assert!(
+            format!("{err}").contains("kid-old"),
+            "retired-key error must name the kid: {err}"
+        );
+
+        // The new key is unaffected.
+        let after = resolver
+            .get_keys("https://fed.example", Some("kid-new"))
+            .await
+            .expect("new key still resolves");
+        assert!(after.contains(&vk_new));
     }
 }

--- a/crates/hyprstream/src/auth/jwt.rs
+++ b/crates/hyprstream/src/auth/jwt.rs
@@ -3,7 +3,8 @@
 //! Re-exports EdDSA signing from hyprstream-rpc and adds ES256 (P-256) signing.
 
 pub use hyprstream_rpc::auth::{
-    decode, decode_with_candidates, decode_with_key, encode, encode_service_jwt, Claims, JwtError,
+    decode, decode_with_candidates, decode_with_federation_candidates, decode_with_key, encode,
+    encode_service_jwt, Claims, JwtError,
 };
 
 use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine as _};

--- a/crates/hyprstream/src/auth/jwt.rs
+++ b/crates/hyprstream/src/auth/jwt.rs
@@ -3,7 +3,7 @@
 //! Re-exports EdDSA signing from hyprstream-rpc and adds ES256 (P-256) signing.
 
 pub use hyprstream_rpc::auth::{
-    decode, decode_with_key, encode, encode_service_jwt, Claims, JwtError,
+    decode, decode_with_candidates, decode_with_key, encode, encode_service_jwt, Claims, JwtError,
 };
 
 use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine as _};

--- a/crates/hyprstream/src/server/middleware.rs
+++ b/crates/hyprstream/src/server/middleware.rs
@@ -444,10 +444,33 @@ pub(crate) async fn verify_token_claims(
         if !state.federation_resolver.is_trusted(&iss) {
             return Err("untrusted federation issuer");
         }
-        match state.federation_resolver.get_key(&iss).await {
-            Ok(key) => jwt::decode_with_key(token, &key, Some(&state.resource_url))
-                .map_err(|_| "JWT validation failed")?,
-            Err(_) => return Err("federation key resolution failed"),
+        // Rotation-aware federation verification (#1185): the resolver
+        // returns every Ed25519 key the issuer currently publishes
+        // (ordered kid-first), and we accept the token if ANY candidate
+        // verifies it. This is what makes overlap rotation safe — a
+        // token signed by a non-first key succeeds when its kid is
+        // published — and mirrors `decode_local_multi_key` for external
+        // issuers. The token's own `kid`, when present, is passed to
+        // the resolver so it can refetch on an unknown kid.
+        let kid = extract_kid_from_token(token);
+        match state.federation_resolver.get_keys(&iss, kid.as_deref()).await {
+            Ok(candidates) if !candidates.is_empty() => {
+                let mut verified: Option<jwt::Claims> = None;
+                for key in &candidates {
+                    if let Ok(claims) =
+                        jwt::decode_with_key(token, key, Some(&state.resource_url))
+                    {
+                        verified = Some(claims);
+                        break;
+                    }
+                }
+                match verified {
+                    Some(claims) => claims,
+                    None => return Err("JWT validation failed"),
+                }
+            }
+            // Empty candidate set or fetch failure: fail closed either way.
+            Ok(_) | Err(_) => return Err("federation key resolution failed"),
         }
     };
 

--- a/crates/hyprstream/src/server/middleware.rs
+++ b/crates/hyprstream/src/server/middleware.rs
@@ -4,7 +4,7 @@ use crate::auth::jwt;
 use crate::server::state::ServerState;
 use axum::{
     extract::{Request, State},
-    http::{header, HeaderValue, StatusCode},
+    http::{HeaderValue, StatusCode, header},
     middleware::Next,
     response::{IntoResponse, Response},
 };
@@ -379,7 +379,9 @@ fn decode_composite_multi(
         hyprstream_rpc::auth::RFC9068_ACCESS_TOKEN_TYPES,
     )
     .map_err(|_| "JWT validation failed")?;
-    if dispatch.kid() != header.kid { return Err("JWT validation failed"); }
+    if dispatch.kid() != header.kid {
+        return Err("JWT validation failed");
+    }
     let pair = published_composite
         .iter()
         .find(|pair| pair.kid() == header.kid)
@@ -453,11 +455,17 @@ pub(crate) async fn verify_token_claims(
         // issuers. The token's own `kid`, when present, is passed to
         // the resolver so it can refetch on an unknown kid.
         let kid = extract_kid_from_token(token);
-        match state.federation_resolver.get_keys(&iss, kid.as_deref()).await {
-            Ok(candidates) if !candidates.is_empty() => {
-                jwt::decode_with_candidates(token, &candidates, Some(&state.resource_url))
-                    .map_err(|_| "JWT validation failed")?
-            }
+        match state
+            .federation_resolver
+            .get_keys(&iss, kid.as_deref())
+            .await
+        {
+            Ok(candidates) if !candidates.is_empty() => jwt::decode_with_federation_candidates(
+                token,
+                &candidates,
+                Some(&state.resource_url),
+            )
+            .map_err(|_| "JWT validation failed")?,
             // Empty candidate set or fetch failure: fail closed either way.
             Ok(_) | Err(_) => return Err("federation key resolution failed"),
         }
@@ -496,7 +504,7 @@ fn unauthorized_response(message: &str, www_authenticate: &str) -> Response {
 /// Exported for use in other middleware-like contexts (e.g. MCP inline auth).
 /// Returns an empty string on any parse failure.
 pub fn extract_iss_from_token(token: &str) -> String {
-    use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine};
+    use base64::{Engine, engine::general_purpose::URL_SAFE_NO_PAD};
     let parts: Vec<&str> = token.splitn(3, '.').collect();
     if parts.len() < 2 {
         return String::new();
@@ -522,7 +530,7 @@ pub fn extract_iss_from_token(token: &str) -> String {
 
 /// Extract `kid` from a JWT header without full validation.
 pub fn extract_kid_from_token(token: &str) -> Option<String> {
-    use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine};
+    use base64::{Engine, engine::general_purpose::URL_SAFE_NO_PAD};
     let header_b64 = token.split('.').next()?;
     if header_b64.len() > 4096 {
         return None;
@@ -655,7 +663,7 @@ mod tests {
 
     #[test]
     fn test_extract_iss_from_token() {
-        use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine};
+        use base64::{Engine, engine::general_purpose::URL_SAFE_NO_PAD};
 
         // Craft a JWT with iss in payload: header.payload.sig
         // payload = base64url({"iss":"https://node-a","sub":"alice","exp":9999999999,"iat":0})
@@ -684,7 +692,7 @@ mod tests {
 #[allow(clippy::unwrap_used, clippy::expect_used)]
 mod rotation_aware_tests {
     use super::*;
-    use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine as _};
+    use base64::{Engine as _, engine::general_purpose::URL_SAFE_NO_PAD};
     use ed25519_dalek::{Signer as _, SigningKey};
 
     const AUD: &str = "https://node-a/resource";
@@ -703,12 +711,7 @@ mod rotation_aware_tests {
         signed_token_with_type(key, aud, jti, "at+jwt")
     }
 
-    fn signed_token_with_type(
-        key: &SigningKey,
-        aud: &str,
-        jti: Option<&str>,
-        typ: &str,
-    ) -> String {
+    fn signed_token_with_type(key: &SigningKey, aud: &str, jti: Option<&str>, typ: &str) -> String {
         let n = now();
         let mut claims =
             jwt::Claims::new("alice".to_owned(), n, n + 3600).with_audience(Some(aud.to_owned()));
@@ -829,7 +832,7 @@ mod rotation_aware_tests {
             Some(AUD),
             true,
         )
-            .unwrap_err();
+        .unwrap_err();
         assert_eq!(err, "JWT validation failed");
     }
 
@@ -850,7 +853,7 @@ mod rotation_aware_tests {
             Some(AUD),
             true,
         )
-            .unwrap_err();
+        .unwrap_err();
         assert_eq!(err, "JWT validation failed");
     }
 
@@ -921,7 +924,7 @@ mod rotation_aware_tests {
 mod composite_aware_tests {
     use super::*;
     use crate::auth::jwt::encode_composite_ml_dsa_65_ed25519;
-    use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine};
+    use base64::{Engine, engine::general_purpose::URL_SAFE_NO_PAD};
     use ed25519_dalek::SigningKey;
 
     const AUD: &str = "https://node-a/resource";
@@ -1098,15 +1101,17 @@ mod composite_aware_tests {
             published_pair(pq_b_vk, ed_b.verifying_key()),
         ];
 
-        assert!(decode_local_multi_key(
-            &cross_token,
-            &ca.verifying_key(),
-            &[ed_a.verifying_key(), ed_b.verifying_key()],
-            &published,
-            Some(AUD),
-            false,
-        )
-        .is_err());
+        assert!(
+            decode_local_multi_key(
+                &cross_token,
+                &ca.verifying_key(),
+                &[ed_a.verifying_key(), ed_b.verifying_key()],
+                &published,
+                Some(AUD),
+                false,
+            )
+            .is_err()
+        );
     }
 
     #[test]
@@ -1159,7 +1164,7 @@ mod composite_aware_tests {
             (
                 "future",
                 jwt::Claims::new("future".to_owned(), now() + 120, now() + 3600)
-                .with_audience(Some(AUD.to_owned())),
+                    .with_audience(Some(AUD.to_owned())),
             ),
             (
                 "no-aud",
@@ -1177,13 +1182,13 @@ mod composite_aware_tests {
             );
             assert!(
                 decode_local_multi_key(
-                &token,
-                &ca.verifying_key(),
-                &[ed.verifying_key()],
-                std::slice::from_ref(&pair),
-                Some(AUD),
-                false,
-            )
+                    &token,
+                    &ca.verifying_key(),
+                    &[ed.verifying_key()],
+                    std::slice::from_ref(&pair),
+                    Some(AUD),
+                    false,
+                )
                 .is_err(),
                 "accepted invalid {case} claims"
             );
@@ -1244,15 +1249,17 @@ mod composite_aware_tests {
         let sig_bytes = URL_SAFE_NO_PAD.decode(sig_b64).unwrap();
         for stripped in [&sig_bytes[..3309], &sig_bytes[3309..]] {
             let tampered = format!("{}.{}", &token[..dot2], URL_SAFE_NO_PAD.encode(stripped));
-            assert!(decode_local_multi_key(
-                &tampered,
-                &ca.verifying_key(),
-                &published_ed,
-                &pairs,
-                Some(AUD),
-                false,
-            )
-            .is_err());
+            assert!(
+                decode_local_multi_key(
+                    &tampered,
+                    &ca.verifying_key(),
+                    &published_ed,
+                    &pairs,
+                    Some(AUD),
+                    false,
+                )
+                .is_err()
+            );
         }
     }
 
@@ -1281,15 +1288,17 @@ mod composite_aware_tests {
         .unwrap();
         assert_eq!(claims.sub, "alice");
 
-        assert!(decode_local_multi_key(
-            &token,
-            &ca.verifying_key(),
-            &published_ed,
-            &pairs,
-            Some(AUD),
-            false,
-        )
-        .is_err());
+        assert!(
+            decode_local_multi_key(
+                &token,
+                &ca.verifying_key(),
+                &published_ed,
+                &pairs,
+                Some(AUD),
+                false,
+            )
+            .is_err()
+        );
     }
 
     #[test]
@@ -1380,7 +1389,7 @@ mod composite_aware_tests {
 #[allow(clippy::expect_used)]
 mod browser_provisioning_rate_limit_tests {
     use super::*;
-    use axum::{body::Body, http::Request as HttpRequest, middleware, routing::get, Router};
+    use axum::{Router, body::Body, http::Request as HttpRequest, middleware, routing::get};
     use std::sync::atomic::{AtomicUsize, Ordering};
     use tower::ServiceExt;
 
@@ -1407,11 +1416,19 @@ mod browser_provisioning_rate_limit_tests {
 
         let first = app
             .clone()
-            .oneshot(HttpRequest::get("/provision").body(Body::empty()).expect("request"))
+            .oneshot(
+                HttpRequest::get("/provision")
+                    .body(Body::empty())
+                    .expect("request"),
+            )
             .await
             .expect("first response");
         let rejected = app
-            .oneshot(HttpRequest::get("/provision").body(Body::empty()).expect("request"))
+            .oneshot(
+                HttpRequest::get("/provision")
+                    .body(Body::empty())
+                    .expect("request"),
+            )
             .await
             .expect("limited response");
 

--- a/crates/hyprstream/src/server/middleware.rs
+++ b/crates/hyprstream/src/server/middleware.rs
@@ -455,19 +455,8 @@ pub(crate) async fn verify_token_claims(
         let kid = extract_kid_from_token(token);
         match state.federation_resolver.get_keys(&iss, kid.as_deref()).await {
             Ok(candidates) if !candidates.is_empty() => {
-                let mut verified: Option<jwt::Claims> = None;
-                for key in &candidates {
-                    if let Ok(claims) =
-                        jwt::decode_with_key(token, key, Some(&state.resource_url))
-                    {
-                        verified = Some(claims);
-                        break;
-                    }
-                }
-                match verified {
-                    Some(claims) => claims,
-                    None => return Err("JWT validation failed"),
-                }
+                jwt::decode_with_candidates(token, &candidates, Some(&state.resource_url))
+                    .map_err(|_| "JWT validation failed")?
             }
             // Empty candidate set or fetch failure: fail closed either way.
             Ok(_) | Err(_) => return Err("federation key resolution failed"),

--- a/crates/hyprstream/src/services/factories.rs
+++ b/crates/hyprstream/src/services/factories.rs
@@ -1495,26 +1495,11 @@ fn create_mcp_service(ctx: &ServiceContext) -> anyhow::Result<Box<dyn Spawnable>
                                 // verifies during overlap rotation.
                                 match federation_resolver.get_keys(&iss, kid.as_deref()).await {
                                     Ok(candidates) if !candidates.is_empty() => {
-                                        let mut decoded: Option<crate::auth::jwt::Claims> = None;
-                                        let mut last_err: Option<crate::auth::jwt::JwtError> = None;
-                                        for key in &candidates {
-                                            match crate::auth::jwt::decode_with_key(
-                                                &t,
-                                                key,
-                                                Some(mcp_resource_url.as_str()),
-                                            ) {
-                                                Ok(c) => {
-                                                    decoded = Some(c);
-                                                    break;
-                                                }
-                                                Err(e) => last_err = Some(e),
-                                            }
-                                        }
-                                        match (decoded, last_err) {
-                                            (Some(c), _) => Ok(c),
-                                            (None, Some(e)) => Err(e),
-                                            (None, None) => Err(crate::auth::jwt::JwtError::InvalidFormat),
-                                        }
+                                        crate::auth::jwt::decode_with_candidates(
+                                            &t,
+                                            &candidates,
+                                            Some(mcp_resource_url.as_str()),
+                                        )
                                     }
                                     Ok(_) => Err(crate::auth::jwt::JwtError::InvalidFormat),
                                     Err(e) => {

--- a/crates/hyprstream/src/services/factories.rs
+++ b/crates/hyprstream/src/services/factories.rs
@@ -1489,8 +1489,34 @@ fn create_mcp_service(ctx: &ServiceContext) -> anyhow::Result<Box<dyn Spawnable>
                                     }
                                 }
                             } else {
-                                match federation_resolver.get_key(&iss).await {
-                                    Ok(key) => crate::auth::jwt::decode_with_key(&t, &key, Some(mcp_resource_url.as_str())),
+                                // Rotation-aware federation verification (#1185):
+                                // try each published candidate (kid-first) so a
+                                // token signed by a non-first published key
+                                // verifies during overlap rotation.
+                                match federation_resolver.get_keys(&iss, kid.as_deref()).await {
+                                    Ok(candidates) if !candidates.is_empty() => {
+                                        let mut decoded: Option<crate::auth::jwt::Claims> = None;
+                                        let mut last_err: Option<crate::auth::jwt::JwtError> = None;
+                                        for key in &candidates {
+                                            match crate::auth::jwt::decode_with_key(
+                                                &t,
+                                                key,
+                                                Some(mcp_resource_url.as_str()),
+                                            ) {
+                                                Ok(c) => {
+                                                    decoded = Some(c);
+                                                    break;
+                                                }
+                                                Err(e) => last_err = Some(e),
+                                            }
+                                        }
+                                        match (decoded, last_err) {
+                                            (Some(c), _) => Ok(c),
+                                            (None, Some(e)) => Err(e),
+                                            (None, None) => Err(crate::auth::jwt::JwtError::InvalidFormat),
+                                        }
+                                    }
+                                    Ok(_) => Err(crate::auth::jwt::JwtError::InvalidFormat),
                                     Err(e) => {
                                         tracing::debug!(%method, %uri, issuer = %iss, error = %e, "MCP federation key resolution failed");
                                         let mut res = (StatusCode::UNAUTHORIZED, "Authentication failed").into_response();

--- a/crates/hyprstream/src/services/factories.rs
+++ b/crates/hyprstream/src/services/factories.rs
@@ -32,8 +32,8 @@ use hyprstream_service::{ServiceContext, Spawnable};
 use tokio::sync::RwLock;
 use tracing::info;
 
-use crate::auth::identity_store::credentials_dir;
 use crate::auth::PolicyManager;
+use crate::auth::identity_store::credentials_dir;
 use crate::config::{HyprConfig, TokenConfig};
 use crate::services::generated::policy_client::{RefreshServiceTokenRequest, RegisterServiceKey};
 use crate::services::{
@@ -269,8 +269,8 @@ fn register_service_key(
 /// Used for local-disk JWTs that we issued ourselves — signature is verified
 /// by PolicyService; here we only need the expiry to decide whether to renew.
 fn decode_jwt_exp(jwt: &str) -> Option<i64> {
-    use base64::engine::general_purpose::URL_SAFE_NO_PAD;
     use base64::Engine as _;
+    use base64::engine::general_purpose::URL_SAFE_NO_PAD;
     let payload_b64 = jwt.split('.').nth(1)?;
     let payload = URL_SAFE_NO_PAD.decode(payload_b64).ok()?;
     let value: serde_json::Value = serde_json::from_slice(&payload).ok()?;
@@ -494,7 +494,9 @@ fn create_ledger_service(ctx: &ServiceContext) -> anyhow::Result<Box<dyn Spawnab
     let config = load_config();
     let lcfg = config.ledger.clone();
     if !lcfg.is_enabled() {
-        anyhow::bail!("ledger service requested but [ledger] enabled = false (the Phase-1 enforcer is opt-in)");
+        anyhow::bail!(
+            "ledger service requested but [ledger] enabled = false (the Phase-1 enforcer is opt-in)"
+        );
     }
 
     // Cell identity = did:key over the service Ed25519 key.
@@ -517,7 +519,11 @@ fn create_ledger_service(ctx: &ServiceContext) -> anyhow::Result<Box<dyn Spawnab
             tokio::runtime::Handle::current().block_on(async { store.active_key().await })
         });
         match pq_key {
-            Some(k) => Arc::new(CoseCheckpointSigner::hybrid(cell_identity.clone(), ed_sk, (*k).clone())),
+            Some(k) => Arc::new(CoseCheckpointSigner::hybrid(
+                cell_identity.clone(),
+                ed_sk,
+                (*k).clone(),
+            )),
             None => anyhow::bail!(
                 "ledger: require_pq_signatures is set but no ML-DSA-65 key is available (fail-closed)"
             ),
@@ -994,7 +1000,7 @@ fn create_worker_service(ctx: &ServiceContext) -> anyhow::Result<Box<dyn Spawnab
     use hyprstream_workers::config::PoolConfig;
     #[cfg(feature = "oci-image")]
     use hyprstream_workers::image::RafsStore;
-    use hyprstream_workers::{resolve_backend, BackendCtx, SandboxBackend, WorkerService};
+    use hyprstream_workers::{BackendCtx, SandboxBackend, WorkerService, resolve_backend};
 
     let config = load_config();
     let worker_quic_port = config.worker.as_ref().and_then(|w| w.quic_port);
@@ -1110,8 +1116,8 @@ fn create_oai_service(ctx: &ServiceContext) -> anyhow::Result<Box<dyn Spawnable>
     info!("Creating OAIService");
 
     use crate::server::state::ServerState;
-    use crate::services::generated::model_client::ModelClient;
     use crate::services::OAIService;
+    use crate::services::generated::model_client::ModelClient;
 
     // Load full config for OAI settings
     let config = load_config();
@@ -1291,7 +1297,9 @@ fn create_oauth_service(ctx: &ServiceContext) -> anyhow::Result<Box<dyn Spawnabl
     if let Some(bl) = SHARED_JTI_BLOCKLIST.get() {
         oauth_service = oauth_service.with_jti_blocklist(Arc::clone(bl));
     } else {
-        tracing::warn!("JTI blocklist not set by PolicyService factory — revoked access tokens will not be blocked at RPC layer");
+        tracing::warn!(
+            "JTI blocklist not set by PolicyService factory — revoked access tokens will not be blocked at RPC layer"
+        );
     }
 
     Ok(Box::new(oauth_service))
@@ -1495,7 +1503,7 @@ fn create_mcp_service(ctx: &ServiceContext) -> anyhow::Result<Box<dyn Spawnable>
                                 // verifies during overlap rotation.
                                 match federation_resolver.get_keys(&iss, kid.as_deref()).await {
                                     Ok(candidates) if !candidates.is_empty() => {
-                                        crate::auth::jwt::decode_with_candidates(
+                                        crate::auth::jwt::decode_with_federation_candidates(
                                             &t,
                                             &candidates,
                                             Some(mcp_resource_url.as_str()),
@@ -1701,7 +1709,7 @@ fn create_mcp_service(ctx: &ServiceContext) -> anyhow::Result<Box<dyn Spawnable>
 fn create_tui_service(ctx: &ServiceContext) -> anyhow::Result<Box<dyn Spawnable>> {
     info!("Creating TuiService");
 
-    use crate::tui::{service::TuiService, TuiState};
+    use crate::tui::{TuiState, service::TuiService};
 
     // TUI publishes terminal frames (stdin/stdout) over moq via
     // StreamChannel::publisher(), and returns its per-PID moq UDS path to the
@@ -1892,9 +1900,9 @@ fn create_metrics_service(ctx: &ServiceContext) -> anyhow::Result<Box<dyn Spawna
     init_local_moq_stream_plane("metrics");
 
     use crate::services::MetricsService;
+    use hyprstream_metrics::StorageBackend as _;
     use hyprstream_metrics::query::QueryOrchestrator;
     use hyprstream_metrics::storage::duckdb::DuckDbBackend;
-    use hyprstream_metrics::StorageBackend as _;
 
     let config = load_config();
     let mc = &config.metrics;


### PR DESCRIPTION
## What

The legacy federation path reduced a published JWKS to its first Ed25519 entry before it ever saw the JWT's `kid`, so an issuer publishing old+new keys during overlap rotation could not rotate safely — tokens signed by any non-first key failed despite a valid published `kid`. This is the federation instance of the `#1183` *"exactly one published key is an anti-pattern"* audit.

Closes #1185. Parent: #1183.

## Change

Matched the in-tree reference (`JwksKeySource` resolves by `kid` and caches every candidate; `client_auth` filters on `kid` and otherwise tries all) rather than inventing a new pattern.

- **`FederationKeySource::get_key(issuer)` → `get_keys(issuer, kid)`** returning every Ed25519 candidate an issuer publishes, ordered kid-first. The cache retains all entries (`kid → key`) instead of one positional key per issuer.
- **`FederatedKeySource`** (the `JwtKeySource` adapter on the RPC path) no longer drops the `kid`; it threads it through and returns the kid-matching candidate first, with overlap candidates as fallback.
- **HTTP middleware** and the **MCP auth path** extract the token's `kid` and try each published candidate (mirroring `decode_local_multi_key`), so a token signed by a non-first published key verifies during overlap.
- **Unknown `kid` after a fresh refetch fails closed** — no positional substitution (the anti-pattern that forecloses both overlap rotation and PQ-hybrid rollout, #1183).
- **Discovery path**: the self-validating entity-statement parser now retains the full published JWKS, not just the signer.
- Added a `JwksFetcher` seam (default = reqwest GET) so the rotation behaviour is exercisable end-to-end without standing up an HTTPS server.

## Tests (each fails on the reverted hunk)

- `parse_jwks_retains_all_ed25519_entries_with_kids` — the anti-singleton invariant.
- `get_keys_overlap_returns_both_and_resolves_second_by_kid` — two-key JWKS, token signed by the **second** key resolves via `kid`; old key retained as overlap candidate.
- `get_keys_unknown_kid_fails_closed_without_substitution` — named `kid` absent after a fresh fetch is an error, never another key.
- `get_keys_retired_key_rejected_after_rotation_completes` — overlap window honours the old key; once the JWKS drops it, the old `kid` is rejected after a bounded refetch while the new key keeps resolving.

## Verify

- `cargo build -p hyprstream-rpc -p hyprstream`
- `cargo test -p hyprstream --lib auth::federation` (19 passed)
- `cargo test -p hyprstream-rpc --lib` (772 passed)
- `cargo clippy -p hyprstream-rpc -p hyprstream --all-targets -- -D warnings` (clean; pre-commit workspace release clippy also clean)

> Note: `cargo fmt --check` fails on a clean `main` (#1140) — pre-existing, not from this PR.

## Reviewer notes / CodeRabbit

I will handle CodeRabbit threads on this PR — advisory, judged independently, never resolved without a written reason.