### PR TITLE
feat(cas): require labels at ingest seal

### DIFF
--- a/crates/hyprstream-rpc/src/cid.rs
+++ b/crates/hyprstream-rpc/src/cid.rs
@@ -55,7 +55,7 @@
 //! yields the same CID string (no randomness, no timestamps, no canonicalization
 //! ambiguity). Round-tripping `decode(encode(x)) == x` holds for all valid CIDs.
 
-use anyhow::{bail, ensure, Context, Result};
+use anyhow::{Context, Result, bail, ensure};
 use data_encoding::BASE32_NOPAD;
 
 // ---------------------------------------------------------------------------
@@ -140,6 +140,8 @@ pub enum Codec {
     XetShard = 0x72,
     /// at9p-capsule (LOCAL_CONVENTION, 0x73): an at9p capsule commitment.
     At9pCapsule = 0x73,
+    /// xet-manifest (LOCAL_CONVENTION, 0x74): a labeled CAS blob manifest.
+    XetManifest = 0x74,
 }
 
 impl Codec {
@@ -150,6 +152,7 @@ impl Codec {
             0x71 => Ok(Codec::XetXorb),
             0x72 => Ok(Codec::XetShard),
             0x73 => Ok(Codec::At9pCapsule),
+            0x74 => Ok(Codec::XetManifest),
             other => bail!("unsupported CID multicodec: 0x{other:x}"),
         }
     }

--- a/crates/hyprstream/src/services/registry.rs
+++ b/crates/hyprstream/src/services/registry.rs
@@ -1949,14 +1949,18 @@ impl RegistryService {
             .await
             .map_err(|e| anyhow!("write not authorized on '{}': {}", data.grant_repo, e))?;
 
-        // ── Chunk + store + SERVER-SIDE merkle (caller supplied only bytes) ──
-        // Ingest through the L1 CAS substrate's default (untenanted, BLAKE3, local)
-        // domain (#812). The `security_label` carrier is left `None` here — object
-        // labeling/enforcement is #699/#767's job, not the ingest path's.
+        // ── Chunk + seal a labeled manifest + SERVER-SIDE merkle ────────────
+        // An uploader without a verified MAC clearance cannot create a CAS
+        // object: there is no default label. The derived context is already
+        // clamped to the verified signature's assurance.
+        let security_label = *ctx
+            .security_context()
+            .ok_or_else(|| anyhow!("putBlob requires a verified security clearance label"))?
+            .clearance();
         let substrate = crate::storage::CasSubstrate::from_env();
         let domain = crate::storage::DedupDomain::local_default();
         let put = substrate
-            .put(&domain, &data.bytes, None)
+            .put(&domain, &data.bytes, security_label)
             .await
             .map_err(|e| anyhow!("CAS ingest failed: {e}"))?;
 

--- a/crates/hyprstream/src/storage/cas/manifest.rs
+++ b/crates/hyprstream/src/storage/cas/manifest.rs
@@ -6,34 +6,35 @@
 //! reconstructed byte length, and the `security_label` **carrier field** that
 //! unblocks #699 carrier-(b).
 
-use hyprstream_rpc::auth::mac::SecurityLabel;
-use hyprstream_rpc::cid::{decode_cid, encode_cid, Codec, HashAlgo};
+use hyprstream_rpc::auth::mac::{ContentBoundLabel, LabeledObject, SecurityLabel};
+use hyprstream_rpc::cid::{Codec, HashAlgo, decode_cid, encode_cid};
 use serde::{Deserialize, Serialize};
 
 use super::CasError;
 
-/// Multicodec for a full-file reconstruction address.
+/// Multicodec for a sealed labeled blob manifest.
 ///
-/// A CAS blob is addressed by its XET reconstruction *shard* (merkle) hash, so the
-/// content-type codec is [`Codec::XetShard`] — see `cid.rs`.
-pub const FILE_RECONSTRUCTION_CODEC: Codec = Codec::XetShard;
+/// The raw reconstruction shard remains keyed by its legacy merkle; the public
+/// CAS CID identifies the manifest that binds that shard to its label.
+pub const FILE_RECONSTRUCTION_CODEC: Codec = Codec::XetManifest;
 
 /// The L1 manifest describing one stored blob.
 ///
-/// This is the substrate-level result type. It supersedes `cas_serve::PutResult`
-/// for substrate callers by adding the canonical [`Self::cid`] and the
-/// [`Self::security_label`] carrier field, while keeping [`Self::merkle`] and
-/// [`Self::xorb_hashes`] so existing wire/provenance behavior is preserved.
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+/// This is the sealed substrate-level result type. It supersedes
+/// `cas_serve::PutResult` for substrate callers by adding the canonical
+/// [`Self::cid`] and required [`Self::security_label`], while keeping
+/// [`Self::merkle`] and [`Self::xorb_hashes`] so existing wire/provenance
+/// behavior is preserved.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct BlobManifest {
     /// Canonical self-describing content address (CIDv1, base32 multibase). Encodes
     /// the reconstruction codec + multihash algorithm + digest, so it is portable
     /// across the local registry, federation, and XET CAS uniformly.
     pub cid: String,
 
-    /// Legacy XET merkle root (hex). Identical to `cas_serve::PutResult::merkle`;
-    /// this is the digest embedded in [`Self::cid`]. Retained because the current
-    /// `putBlob`/`getBlob` wire and the provenance store key on it.
+    /// Legacy XET merkle root (hex). Identical to `cas_serve::PutResult::merkle`.
+    /// Retained because the current `putBlob`/`getBlob` wire and the provenance
+    /// store key on it.
     pub merkle: String,
 
     /// Reconstruction xorb set (hex xorb hashes), from the underlying store.
@@ -46,33 +47,100 @@ pub struct BlobManifest {
     /// Total byte length of the reconstructed content.
     pub byte_len: u64,
 
-    /// **Carrier field (#699 carrier-(b)).** The MAC object label for this blob.
-    ///
-    /// Plumb-through only: the substrate never populates this with real policy,
-    /// never derives it, and never enforces on it. Population + enforcement is
-    /// #699/#767's job. `None` means *unlabeled carrier* — NOT "public".
-    #[serde(default)]
-    pub security_label: Option<SecurityLabel>,
+    /// The MAC object label for this sealed blob. It is required and covered by
+    /// the manifest CID, so relabeling necessarily creates a distinct object.
+    pub security_label: SecurityLabel,
+}
+
+/// The exact, canonical preimage addressed by a [`BlobManifest`] CID. `cid` is
+/// intentionally excluded to avoid self-reference. `bytes_stored` is an ingest
+/// receipt (dedup accounting), not content truth, so it is also excluded; all
+/// semantic object fields, including the required label, are covered.
+#[derive(Serialize)]
+struct ManifestPreimage<'a> {
+    merkle: &'a str,
+    xorb_hashes: &'a [String],
+    byte_len: u64,
+    security_label: SecurityLabel,
+}
+
+impl BlobManifest {
+    /// Construct a sealed, labeled manifest and derive its content-bound CID.
+    pub fn new(
+        merkle: String,
+        xorb_hashes: Vec<String>,
+        bytes_stored: u64,
+        byte_len: u64,
+        security_label: SecurityLabel,
+    ) -> Result<Self, CasError> {
+        let mut manifest = Self {
+            cid: String::new(),
+            merkle,
+            xorb_hashes,
+            bytes_stored,
+            byte_len,
+            security_label,
+        };
+        manifest.cid = manifest.recomputed_cid()?;
+        Ok(manifest)
+    }
+
+    fn preimage(&self) -> ManifestPreimage<'_> {
+        ManifestPreimage {
+            merkle: &self.merkle,
+            xorb_hashes: &self.xorb_hashes,
+            byte_len: self.byte_len,
+            security_label: self.security_label,
+        }
+    }
+
+    /// Recompute the CID from the complete manifest preimage.
+    pub fn recomputed_cid(&self) -> Result<String, CasError> {
+        let bytes = serde_json::to_vec(&self.preimage())
+            .map_err(|e| CasError::Manifest(format!("serialize manifest preimage: {e}")))?;
+        let digest = blake3::hash(&bytes);
+        encode_cid(
+            FILE_RECONSTRUCTION_CODEC,
+            HashAlgo::Blake3,
+            digest.as_bytes(),
+        )
+        .map_err(|e| CasError::Cid(e.to_string()))
+    }
+}
+
+impl LabeledObject for BlobManifest {
+    fn security_label(&self) -> Option<SecurityLabel> {
+        Some(self.security_label)
+    }
+}
+
+impl ContentBoundLabel for BlobManifest {
+    fn content_id(&self) -> &[u8] {
+        self.cid.as_bytes()
+    }
+
+    fn verify_binding(&self) -> bool {
+        self.recomputed_cid().is_ok_and(|cid| cid == self.cid)
+    }
 }
 
 /// Encode a legacy XET merkle hex digest as a canonical CIDv1 for the given
 /// algorithm, using the reconstruction-shard codec.
 pub fn cid_from_merkle(algorithm: HashAlgo, merkle_hex: &str) -> Result<String, CasError> {
     let digest = hex::decode(merkle_hex).map_err(|e| CasError::Hex(e.to_string()))?;
-    encode_cid(FILE_RECONSTRUCTION_CODEC, algorithm, &digest).map_err(|e| CasError::Cid(e.to_string()))
+    encode_cid(Codec::XetShard, algorithm, &digest).map_err(|e| CasError::Cid(e.to_string()))
 }
 
-/// Resolve a caller-supplied content address to the hex digest the underlying
-/// `cas_serve::CasStore` keys on.
+/// Resolve a legacy caller-supplied reconstruction address to the hex digest the
+/// underlying `cas_serve::CasStore` keys on.
 ///
 /// Accepts **either**:
-/// - a canonical CIDv1 string (`b…` base32 multibase) — decoded to its digest, or
+/// - a legacy reconstruction CIDv1 string (`b…` base32 multibase) — decoded to
+///   its digest, or
 /// - a legacy bare hex merkle (40 or 64 hex chars) — returned lowercased.
 ///
-/// This is the compatibility seam that lets existing callers keep passing a hex
-/// merkle while new callers pass a self-describing multihash. The two address
-/// spaces are unambiguous: our legacy merkles are exactly 20- or 32-byte digests
-/// (40/64 hex chars), and a CID is longer and uses the base32 alphabet.
+/// A labeled manifest CID deliberately cannot be reduced to a merkle: it must be
+/// resolved through its persisted manifest so the label binding is verified.
 pub fn merkle_from_address(address: &str) -> Result<String, CasError> {
     let looks_like_legacy_hex =
         matches!(address.len(), 40 | 64) && address.bytes().all(|b| b.is_ascii_hexdigit());
@@ -80,6 +148,11 @@ pub fn merkle_from_address(address: &str) -> Result<String, CasError> {
         return Ok(address.to_ascii_lowercase());
     }
     let cid = decode_cid(address).map_err(|e| CasError::Cid(e.to_string()))?;
+    if cid.codec != Codec::XetShard {
+        return Err(CasError::Cid(
+            "manifest CID must be resolved through the sealed manifest store".into(),
+        ));
+    }
     Ok(hex::encode(cid.multihash.digest))
 }
 
@@ -128,35 +201,26 @@ mod tests {
     }
 
     #[test]
-    fn manifest_security_label_carrier_serializes() {
+    fn sealed_manifest_serializes_with_a_required_label() {
         use hyprstream_rpc::auth::mac::{Assurance, CompartmentSet, Level};
-        let label = SecurityLabel::new(Level::Internal, Assurance::Classical, CompartmentSet::EMPTY);
-        let m = BlobManifest {
-            cid: "bexample".to_owned(),
-            merkle: "ab".repeat(32),
-            xorb_hashes: vec!["cd".repeat(32)],
-            bytes_stored: 42,
-            byte_len: 100,
-            security_label: Some(label),
-        };
+        let label =
+            SecurityLabel::new(Level::Internal, Assurance::Classical, CompartmentSet::EMPTY);
+        let m = BlobManifest::new("ab".repeat(32), vec!["cd".repeat(32)], 42, 100, label).unwrap();
         let json = serde_json::to_string(&m).unwrap();
         let back: BlobManifest = serde_json::from_str(&json).unwrap();
         assert_eq!(back, m);
-        assert_eq!(back.security_label, Some(label));
+        assert_eq!(back.security_label, label);
+        assert!(back.verify_binding());
     }
 
     #[test]
-    fn manifest_unlabeled_carrier_round_trips() {
-        let m = BlobManifest {
-            cid: "bexample".to_owned(),
-            merkle: "ab".repeat(32),
-            xorb_hashes: vec![],
-            bytes_stored: 0,
-            byte_len: 0,
-            security_label: None,
-        };
-        let json = serde_json::to_string(&m).unwrap();
-        let back: BlobManifest = serde_json::from_str(&json).unwrap();
-        assert_eq!(back.security_label, None, "None = unlabeled carrier, not public");
+    fn changing_a_label_rehashes_the_manifest_cid() {
+        use hyprstream_rpc::auth::mac::{Assurance, CompartmentSet, Level};
+        let internal =
+            SecurityLabel::new(Level::Internal, Assurance::Classical, CompartmentSet::EMPTY);
+        let secret = SecurityLabel::new(Level::Secret, Assurance::Classical, CompartmentSet::EMPTY);
+        let a = BlobManifest::new("ab".repeat(32), vec![], 0, 100, internal).unwrap();
+        let b = BlobManifest::new("ab".repeat(32), vec![], 0, 100, secret).unwrap();
+        assert_ne!(a.cid, b.cid, "relabeling must rehash the manifest");
     }
 }

--- a/crates/hyprstream/src/storage/cas/manifest.rs
+++ b/crates/hyprstream/src/storage/cas/manifest.rs
@@ -142,9 +142,7 @@ pub fn cid_from_merkle(algorithm: HashAlgo, merkle_hex: &str) -> Result<String, 
 /// A labeled manifest CID deliberately cannot be reduced to a merkle: it must be
 /// resolved through its persisted manifest so the label binding is verified.
 pub fn merkle_from_address(address: &str) -> Result<String, CasError> {
-    let looks_like_legacy_hex =
-        matches!(address.len(), 40 | 64) && address.bytes().all(|b| b.is_ascii_hexdigit());
-    if looks_like_legacy_hex {
+    if looks_like_legacy_hex(address) {
         return Ok(address.to_ascii_lowercase());
     }
     let cid = decode_cid(address).map_err(|e| CasError::Cid(e.to_string()))?;
@@ -154,6 +152,14 @@ pub fn merkle_from_address(address: &str) -> Result<String, CasError> {
         ));
     }
     Ok(hex::encode(cid.multihash.digest))
+}
+
+/// Whether `address` is a legacy bare SHA-1 or BLAKE3 merkle digest.
+///
+/// This predicate selects the compatibility path that bypasses sealed-manifest
+/// resolution, so all CAS callers must share this single definition.
+pub(crate) fn looks_like_legacy_hex(address: &str) -> bool {
+    matches!(address.len(), 40 | 64) && address.bytes().all(|b| b.is_ascii_hexdigit())
 }
 
 #[cfg(test)]

--- a/crates/hyprstream/src/storage/cas/mod.rs
+++ b/crates/hyprstream/src/storage/cas/mod.rs
@@ -39,13 +39,11 @@
 //! - **trust_boundary** — node-local content is never deduplicated against
 //!   shared-remote content (an existence/content oracle across the boundary, U5).
 //!
-//! ## MAC boundary (deliberate)
+//! ## MAC boundary
 //!
-//! [`BlobManifest`] carries a `security_label` **carrier field** (unblocks #699
-//! carrier-(b)). This is *plumb-through only*: the substrate never populates it
-//! with real policy, never derives clearance, and never enforces access. Object
-//! labeling and enforcement are #699/#767's job. A `None` label is an *unlabeled
-//! carrier*, NOT "public".
+//! A [`BlobManifest`] is a sealed, labeled object: its required
+//! `security_label` is part of the bytes hashed into its CID. Staging may be
+//! unlabeled, but it cannot seal until a label has been supplied.
 
 mod domain;
 mod manifest;
@@ -53,11 +51,11 @@ mod mount;
 mod substrate;
 
 pub use domain::{DedupDomain, InvalidDedupDomain, TrustBoundary};
-pub use manifest::{cid_from_merkle, merkle_from_address, BlobManifest, FILE_RECONSTRUCTION_CODEC};
+pub use manifest::{BlobManifest, FILE_RECONSTRUCTION_CODEC, cid_from_merkle, merkle_from_address};
 pub use mount::{
-    AllowAllCasAuthorizer, BootstrapCasAuthorizer, CasGrantSubject, CasMount, CasMountAuthorizer,
-    CasMountAuthzRequest, CasMountGrant, CasMountObjectKind, DenyAllCasAuthorizer, StagingConfig,
-    AUTHENTICATED_XORB_READ, DEFAULT_STAGING_SLOT_QUOTA, DEFAULT_STAGING_SUBJECT_QUOTA,
+    AUTHENTICATED_XORB_READ, AllowAllCasAuthorizer, BootstrapCasAuthorizer, CasGrantSubject,
+    CasMount, CasMountAuthorizer, CasMountAuthzRequest, CasMountGrant, CasMountObjectKind,
+    DEFAULT_STAGING_SLOT_QUOTA, DEFAULT_STAGING_SUBJECT_QUOTA, DenyAllCasAuthorizer, StagingConfig,
 };
 pub use substrate::CasSubstrate;
 
@@ -75,6 +73,10 @@ pub enum CasError {
     /// A hex digest was malformed.
     #[error("invalid hex digest: {0}")]
     Hex(String),
+
+    /// A persisted sealed manifest could not be read, decoded, or verified.
+    #[error("CAS manifest: {0}")]
+    Manifest(String),
 
     /// Ingest was requested for an algorithm the substrate cannot currently
     /// *produce*. The domain vocabulary supports every algorithm for keying, but

--- a/crates/hyprstream/src/storage/cas/mount.rs
+++ b/crates/hyprstream/src/storage/cas/mount.rs
@@ -69,7 +69,7 @@ pub enum CasMountObjectKind {
     Stage,
 }
 
-/// Authorization request made before a CAS object is opened/read/stat'ed.
+/// Authorization request made before a CAS operation.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct CasMountAuthzRequest<'a> {
     /// Which CAS object namespace is being accessed.
@@ -79,8 +79,15 @@ pub struct CasMountAuthzRequest<'a> {
     /// Dedup domain the mount is serving.
     pub domain: &'a DedupDomain,
     /// Operation name for policy/audit (e.g. `open`, `read`, `stat`,
-    /// `stage:create`, `stage:commit`).
+    /// `stage:create`, `stage:label`, `stage:commit`).
     pub operation: &'static str,
+    /// Parsed object label proposed by a `stage:label` operation. `None` for
+    /// every other operation.
+    ///
+    /// A clearance-aware authorizer must resolve the caller's verified
+    /// [`hyprstream_rpc::auth::mac::SecurityContext`] and reject labels it does
+    /// not authorize. The raw ctl input is never authoritative by itself.
+    pub requested_label: Option<&'a SecurityLabel>,
 }
 
 /// Per-op authorization hook for [`CasMount`].
@@ -252,6 +259,23 @@ impl CasMountAuthorizer for BootstrapCasAuthorizer {
         caller: &Subject,
         request: CasMountAuthzRequest<'_>,
     ) -> Result<(), MountError> {
+        // Bootstrap grants do not carry verified subject clearances, so they
+        // can never authorize caller-selected object labels. A clearance-aware
+        // authorizer must replace this bootstrap seam before staging is enabled.
+        if request.requested_label.is_some() {
+            warn!(
+                subject = %caller,
+                kind = ?request.kind,
+                address = request.address,
+                operation = request.operation,
+                "CAS bootstrap grant: deny label declaration (no verified clearance)"
+            );
+            return Err(MountError::PermissionDenied(format!(
+                "CAS {} {:?} {} denied for {}: bootstrap authorizer has no verified clearance",
+                request.operation, request.kind, request.address, caller
+            )));
+        }
+
         for grant in &self.grants {
             if grant.subject.accepts(caller)
                 && grant.kinds.contains(&request.kind)
@@ -658,6 +682,25 @@ impl CasMount {
                 address,
                 domain: &self.domain,
                 operation,
+                requested_label: None,
+            },
+        )
+    }
+
+    fn authorize_label(
+        &self,
+        caller: &Subject,
+        address: &str,
+        requested_label: &SecurityLabel,
+    ) -> Result<(), MountError> {
+        self.authorizer.authorize(
+            caller,
+            CasMountAuthzRequest {
+                kind: CasMountObjectKind::Stage,
+                address,
+                domain: &self.domain,
+                operation: "stage:label",
+                requested_label: Some(requested_label),
             },
         )
     }
@@ -699,7 +742,7 @@ impl CasMount {
     async fn seal_slot(&self, slot: &Arc<StagingSlot>) -> Result<String, MountError> {
         // An unlabeled slot is a staging-only state. Reject before taking bytes
         // or transitioning to Sealing so the caller may label it and retry.
-        if slot.joined_label().is_none() {
+        if slot.state() == SlotState::Open && slot.joined_label().is_none() {
             return Err(MountError::PermissionDenied(
                 "cannot seal an unlabeled staging slot; declare a label first".into(),
             ));
@@ -844,7 +887,7 @@ impl CasMount {
                     },
                 }
             }
-            Some("label") => self.declare_label_cmd(slot, tokens.collect()),
+            Some("label") => self.declare_label_cmd(id, slot, tokens.collect(), caller),
             Some(cmd) => Err(MountError::InvalidArgument(format!(
                 "unknown ctl command: {cmd}"
             ))),
@@ -853,8 +896,10 @@ impl CasMount {
 
     fn declare_label_cmd(
         &self,
+        id: &str,
         slot: &Arc<StagingSlot>,
         args: Vec<&str>,
+        caller: &Subject,
     ) -> Result<(), MountError> {
         // label <level> <assurance> [compartment...]
         let mut it = args.into_iter();
@@ -886,6 +931,10 @@ impl CasMount {
                 .label(level, assurance, comps)
                 .map_err(|e| MountError::InvalidArgument(format!("label: {e}")))?
         };
+        // Authorization sees the fully parsed label and runs before slot
+        // mutation. A rejection therefore cannot transition or persist label
+        // state, and a clearance-aware authorizer can enforce dominance.
+        self.authorize_label(caller, id, &label)?;
         slot.declare_label(label)
     }
 
@@ -1444,12 +1493,18 @@ mod tests {
     #[derive(Default)]
     struct RecordingAuthorizer {
         deny: bool,
+        deny_labels: bool,
         calls: Mutex<Vec<(String, CasMountObjectKind, String, &'static str)>>,
+        label_calls: Mutex<Vec<(String, String, SecurityLabel)>>,
     }
 
     impl RecordingAuthorizer {
         fn calls(&self) -> Vec<(String, CasMountObjectKind, String, &'static str)> {
             self.calls.lock().clone()
+        }
+
+        fn label_calls(&self) -> Vec<(String, String, SecurityLabel)> {
+            self.label_calls.lock().clone()
         }
     }
 
@@ -1465,7 +1520,14 @@ mod tests {
                 request.address.to_owned(),
                 request.operation,
             ));
-            if self.deny {
+            if let Some(label) = request.requested_label {
+                self.label_calls.lock().push((
+                    caller.to_string(),
+                    request.address.to_owned(),
+                    *label,
+                ));
+            }
+            if self.deny || (self.deny_labels && request.requested_label.is_some()) {
                 Err(MountError::PermissionDenied("denied by test".into()))
             } else {
                 Ok(())
@@ -1660,6 +1722,7 @@ mod tests {
             address: "aa00",
             domain: &domain,
             operation: "read",
+            requested_label: None,
         };
         let err = authz
             .authorize(&Subject::new("alice"), request)
@@ -1673,6 +1736,30 @@ mod tests {
         assert_eq!(grant.subject, CasGrantSubject::AnyAuthenticated);
         assert_eq!(grant.kinds, &[CasMountObjectKind::Xorb]);
         assert_eq!(grant.operations, &["open", "read"]);
+    }
+
+    #[test]
+    fn bootstrap_cannot_grant_labels_without_verified_clearance() {
+        let authz = BootstrapCasAuthorizer::with_grants(vec![CasMountGrant {
+            name: "test:stage-label",
+            subject: CasGrantSubject::AnyAuthenticated,
+            kinds: &[CasMountObjectKind::Stage],
+            operations: &["stage:label"],
+        }]);
+        let domain = DedupDomain::local_default();
+        let requested_label = label();
+        let request = CasMountAuthzRequest {
+            kind: CasMountObjectKind::Stage,
+            address: "1",
+            domain: &domain,
+            operation: "stage:label",
+            requested_label: Some(&requested_label),
+        };
+
+        let err = authz
+            .authorize(&Subject::new("alice"), request)
+            .unwrap_err();
+        assert!(matches!(err, MountError::PermissionDenied(_)));
     }
 
     // ── write-then-seal (#814) ─────────────────────────────────────────────
@@ -2225,6 +2312,38 @@ mod tests {
             .collect();
         assert_eq!(commit_calls.len(), 1);
         assert_eq!(commit_calls[0].2, id);
+        mount.clunk(data, &caller).await;
+        mount.clunk(ctl, &caller).await;
+    }
+
+    #[tokio::test]
+    async fn label_authorization_sees_requested_label_and_rejection_does_not_mutate_slot() {
+        let dir = tempfile::tempdir().unwrap();
+        let authz = std::sync::Arc::new(RecordingAuthorizer {
+            deny_labels: true,
+            ..RecordingAuthorizer::default()
+        });
+        let mount = CasMount::with_authorizer_and_staging(
+            CasSubstrate::new(dir.path()),
+            DedupDomain::local_default(),
+            authz.clone(),
+            StagingConfig::default(),
+        );
+        let caller = Subject::new("alice");
+        let (id, _root) = create_stage(&mount, &caller).await;
+        let (data, ctl) = open_data_ctl(&mount, &id, &caller).await;
+
+        let err = mount
+            .write(&ctl, 0, b"label internal classical\n", &caller)
+            .await
+            .unwrap_err();
+        assert!(matches!(err, MountError::PermissionDenied(_)));
+        assert_eq!(authz.label_calls(), vec![("alice".to_owned(), id, label())]);
+        let status = ctl_str(&mount, &ctl, &caller).await;
+        assert!(
+            status.contains("labels=0"),
+            "rejected label must not mutate slot: {status}"
+        );
         mount.clunk(data, &caller).await;
         mount.clunk(ctl, &caller).await;
     }

--- a/crates/hyprstream/src/storage/cas/mount.rs
+++ b/crates/hyprstream/src/storage/cas/mount.rs
@@ -28,21 +28,19 @@
 //!    the attested-resource saga convergence rule (#1064/#1066).
 //!
 //! The seal is the natural join point for [`crate::mac::ifc_join`]: any object
-//! labels declared via `label` ctl commands are joined (LUB) and plumbed through
-//! to the manifest's `security_label` carrier. Subject-clearance derivation
-//! (#698) is not wired here — MAC enforcement is dormant — so the join input is
-//! the caller-declared labels only today; the `Subject` contributes no clearance
-//! yet. The seam is in place for #699/#767 to widen.
+//! labels declared via `label` ctl commands are joined (LUB) and written into
+//! the manifest. A slot with no declared label cannot seal; unlabeled staging is
+//! transient only and is never admitted to the CAS.
 
 use std::collections::HashMap;
-use std::sync::atomic::{AtomicU64, AtomicU8, Ordering};
 use std::sync::Arc;
+use std::sync::atomic::{AtomicU8, AtomicU64, Ordering};
 
 use async_trait::async_trait;
 use cas_serve::StoreError;
-use hyprstream_rpc::auth::mac::{Assurance, CompartmentSet, Lattice, Level, SecurityLabel};
 use hyprstream_rpc::Subject;
-use hyprstream_vfs::{DirEntry, Fid, Mount, MountError, Stat, ORDWR, OREAD, OTRUNC, OWRITE};
+use hyprstream_rpc::auth::mac::{Assurance, CompartmentSet, Lattice, Level, SecurityLabel};
+use hyprstream_vfs::{DirEntry, Fid, Mount, MountError, ORDWR, OREAD, OTRUNC, OWRITE, Stat};
 use parking_lot::Mutex;
 use tokio::sync::Notify;
 use tracing::{debug, warn};
@@ -429,9 +427,9 @@ impl StagingSlot {
         self.declared_labels.lock().map_or(0, |(_, n)| n)
     }
 
-    /// The IFC-joined object label to plumb into the substrate at seal, or
-    /// `None` if the caller declared nothing. This is the #699 carrier-(b)
-    /// seam: subject clearance (#698) is not an input yet.
+    /// The IFC-joined object label to plumb into the substrate at seal. `None`
+    /// is valid only while staging; the seal boundary rejects it before bytes
+    /// are handed to CAS.
     fn joined_label(&self) -> Option<SecurityLabel> {
         self.declared_labels.lock().map(|(label, _)| label)
     }
@@ -699,6 +697,14 @@ impl CasMount {
     /// substrate, and record the CID (or void on failure). Idempotent — a
     /// second commit returns the same CID; concurrent commits serialize via CAS.
     async fn seal_slot(&self, slot: &Arc<StagingSlot>) -> Result<String, MountError> {
+        // An unlabeled slot is a staging-only state. Reject before taking bytes
+        // or transitioning to Sealing so the caller may label it and retry.
+        if slot.joined_label().is_none() {
+            return Err(MountError::PermissionDenied(
+                "cannot seal an unlabeled staging slot; declare a label first".into(),
+            ));
+        }
+
         loop {
             match slot.state.compare_exchange(
                 SlotState::Open as u8,
@@ -748,7 +754,22 @@ impl CasMount {
         // Won the CAS. Take the bytes + labels out from under their locks so we
         // don't hold them across the async substrate put.
         let bytes = std::mem::take(&mut *slot.buffer.lock());
-        let joined = slot.joined_label();
+        let joined = match slot.joined_label() {
+            Some(label) => label,
+            None => {
+                // `declare_label` only adds labels and the state transition above
+                // excludes concurrent declarations, so this is unreachable after
+                // the preflight. Preserve fail-closed terminal behavior if that
+                // invariant is ever changed.
+                let msg = "cannot seal an unlabeled staging slot".to_owned();
+                *slot.result.lock() = Some(Err(msg.clone()));
+                slot.state.store(SlotState::Voided as u8, Ordering::Release);
+                slot.seal_done.notify_waiters();
+                self.staging
+                    .adjust_subject(&slot.owner, -(bytes.len() as i64));
+                return Err(MountError::PermissionDenied(msg));
+            }
+        };
         let put_result = self.substrate.put(&self.domain, &bytes, joined).await;
 
         match put_result {
@@ -1385,6 +1406,7 @@ fn map_cas_error(err: CasError) -> MountError {
         CasError::Store(StoreError::InvalidHash(s)) | CasError::Cid(s) | CasError::Hex(s) => {
             MountError::InvalidArgument(s)
         }
+        CasError::Manifest(s) => MountError::InvalidArgument(s),
         CasError::Store(e) => MountError::Io(e.to_string()),
         CasError::UnsupportedIngestAlgorithm(algo) => {
             MountError::InvalidArgument(format!("unsupported CAS algorithm: {algo:?}"))
@@ -1407,6 +1429,17 @@ mod tests {
     use super::*;
     use hyprstream_vfs::{ORDWR, OWRITE};
     use parking_lot::Mutex;
+
+    fn label() -> SecurityLabel {
+        SecurityLabel::new(Level::Internal, Assurance::Classical, CompartmentSet::EMPTY)
+    }
+
+    async fn declare_test_label(mount: &CasMount, ctl: &Fid, caller: &Subject) {
+        mount
+            .write(ctl, 0, b"label internal classical\n", caller)
+            .await
+            .unwrap();
+    }
 
     #[derive(Default)]
     struct RecordingAuthorizer {
@@ -1448,7 +1481,7 @@ mod tests {
         let substrate = CasSubstrate::new(dir.path());
         let domain = DedupDomain::local_default();
         let manifest = substrate
-            .put(&domain, b"hello-cas-mount", None)
+            .put(&domain, b"hello-cas-mount", label())
             .await
             .unwrap();
         let authz = std::sync::Arc::new(RecordingAuthorizer::default());
@@ -1484,7 +1517,10 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let substrate = CasSubstrate::new(dir.path());
         let domain = DedupDomain::local_default();
-        let manifest = substrate.put(&domain, b"secret bytes", None).await.unwrap();
+        let manifest = substrate
+            .put(&domain, b"secret bytes", label())
+            .await
+            .unwrap();
         let mount = CasMount::new(substrate, domain);
         let caller = Subject::new("bob");
 
@@ -1502,7 +1538,7 @@ mod tests {
         let substrate = CasSubstrate::new(dir.path());
         let domain = DedupDomain::local_default();
         let manifest = substrate
-            .put(&domain, b"xorb-backed-payload", None)
+            .put(&domain, b"xorb-backed-payload", label())
             .await
             .unwrap();
         let xorb = manifest.xorb_hashes.first().expect("xorb hash").clone();
@@ -1540,7 +1576,7 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let substrate = CasSubstrate::new(dir.path());
         let manifest = substrate
-            .put(&DedupDomain::local_default(), bytes, None)
+            .put(&DedupDomain::local_default(), bytes, label())
             .await
             .unwrap();
         let xorb = manifest.xorb_hashes.first().expect("xorb hash").clone();
@@ -1584,7 +1620,7 @@ mod tests {
     async fn bootstrap_grant_denies_obj_reads_and_stage_ops() {
         let (_dir, substrate, xorb) = substrate_with_xorb(b"bootstrap-xorb").await;
         let manifest = substrate
-            .put(&DedupDomain::local_default(), b"obj-bytes", None)
+            .put(&DedupDomain::local_default(), b"obj-bytes", label())
             .await
             .unwrap();
         let mount = CasMount::with_authorizer(
@@ -1595,10 +1631,7 @@ mod tests {
         let caller = Subject::new("alice");
 
         // obj/* reads are outside the day-one grant.
-        let mut fid = mount
-            .walk(&["obj", &manifest.cid], &caller)
-            .await
-            .unwrap();
+        let mut fid = mount.walk(&["obj", &manifest.cid], &caller).await.unwrap();
         let err = mount.open(&mut fid, OREAD, &caller).await.unwrap_err();
         assert!(matches!(err, MountError::PermissionDenied(_)));
 
@@ -1628,7 +1661,9 @@ mod tests {
             domain: &domain,
             operation: "read",
         };
-        let err = authz.authorize(&Subject::new("alice"), request).unwrap_err();
+        let err = authz
+            .authorize(&Subject::new("alice"), request)
+            .unwrap_err();
         assert!(matches!(err, MountError::PermissionDenied(_)));
     }
 
@@ -1700,6 +1735,7 @@ mod tests {
         mount.write(&data, 6, b"world", &caller).await.unwrap();
 
         // Seal.
+        declare_test_label(&mount, &ctl, &caller).await;
         let n = mount.write(&ctl, 0, b"commit\n", &caller).await.unwrap();
         assert_eq!(n, 7);
 
@@ -1746,6 +1782,7 @@ mod tests {
         assert_eq!(&buf[5..8], b"xyz");
         assert_eq!(&buf[..5], &[0, 0, 0, 0, 0]);
 
+        declare_test_label(&mount, &ctl, &caller).await;
         mount.write(&ctl, 0, b"commit\n", &caller).await.unwrap();
         let status = ctl_str(&mount, &ctl, &caller).await;
         let cid = status.split("cid=").nth(1).unwrap().trim().to_owned();
@@ -1825,6 +1862,7 @@ mod tests {
         let (data, ctl) = open_data_ctl(&mount, &id, &caller).await;
         mount.write(&data, 0, b"payload", &caller).await.unwrap();
 
+        declare_test_label(&mount, &ctl, &caller).await;
         mount.write(&ctl, 0, b"commit\n", &caller).await.unwrap();
         let cid1 = {
             let s = ctl_str(&mount, &ctl, &caller).await;
@@ -1908,9 +1946,22 @@ mod tests {
 
     #[tokio::test]
     async fn seal_joins_declared_labels_into_manifest() {
-        use hyprstream_rpc::auth::mac::{Assurance, Level};
+        use hyprstream_rpc::auth::mac::{Compartment, LatticeVersion};
         let dir = tempfile::tempdir().unwrap();
-        let mount = staging_mount(CasSubstrate::new(dir.path()), 1 << 20, 4 << 20);
+        let lattice = Arc::new(Lattice::new(
+            LatticeVersion(1),
+            [Compartment::new("pii"), Compartment::new("finance")],
+        ));
+        let mount = CasMount::with_authorizer_and_staging(
+            CasSubstrate::new(dir.path()),
+            DedupDomain::local_default(),
+            AllowAllCasAuthorizer,
+            StagingConfig {
+                slot_quota_bytes: 1 << 20,
+                subject_quota_bytes: 4 << 20,
+                lattice: Some(lattice.clone()),
+            },
+        );
         let caller = Subject::new("alice");
         let (id, _root) = create_stage(&mount, &caller).await;
         let (data, ctl) = open_data_ctl(&mount, &id, &caller).await;
@@ -1921,11 +1972,11 @@ mod tests {
 
         // Declare two labels; the seal must join them (LUB).
         mount
-            .write(&ctl, 0, b"label internal classical\n", &caller)
+            .write(&ctl, 0, b"label internal classical pii\n", &caller)
             .await
             .unwrap();
         mount
-            .write(&ctl, 0, b"label secret pqhybrid\n", &caller)
+            .write(&ctl, 0, b"label confidential pqhybrid finance\n", &caller)
             .await
             .unwrap();
 
@@ -1938,19 +1989,56 @@ mod tests {
             s.split("cid=").nth(1).unwrap().trim().to_owned()
         };
 
-        // The joined label is the LUB: Secret × PqHybrid (no compartments).
-        let joined = SecurityLabel::new(Level::Secret, Assurance::PqHybrid, CompartmentSet::EMPTY);
-        // Reconstruct directly from the substrate to read the manifest carrier.
-        // The substrate `get` returns bytes only; verify via a fresh put that
-        // the same content with the same joined label yields the same CID and
-        // that the carrier round-trips through BlobManifest.
-        let manifest = mount
-            .substrate
-            .put(&mount.domain, b"labeled-bytes", Some(joined))
+        let pii = lattice
+            .label(
+                Level::Internal,
+                Assurance::Classical,
+                [Compartment::new("pii")],
+            )
+            .unwrap();
+        let finance = lattice
+            .label(
+                Level::Confidential,
+                Assurance::PqHybrid,
+                [Compartment::new("finance")],
+            )
+            .unwrap();
+        let joined = ifc_join(&[pii, finance]);
+        let manifest = mount.substrate.manifest(&mount.domain, &cid).unwrap();
+        assert_eq!(manifest.security_label, joined);
+        assert!(manifest.security_label.can_access(&pii));
+        assert!(manifest.security_label.can_access(&finance));
+        assert!(manifest.security_label.compartments.contains(0));
+        assert!(manifest.security_label.compartments.contains(1));
+        mount.clunk(data, &caller).await;
+        mount.clunk(ctl, &caller).await;
+    }
+
+    #[tokio::test]
+    async fn seal_without_a_label_fails_closed_before_cas_ingest() {
+        let dir = tempfile::tempdir().unwrap();
+        let mount = staging_mount(CasSubstrate::new(dir.path()), 1 << 20, 4 << 20);
+        let caller = Subject::new("alice");
+        let (id, _root) = create_stage(&mount, &caller).await;
+        let (data, ctl) = open_data_ctl(&mount, &id, &caller).await;
+        mount
+            .write(&data, 0, b"must-not-seal", &caller)
             .await
             .unwrap();
-        assert_eq!(manifest.cid, cid);
-        assert_eq!(manifest.security_label, Some(joined));
+
+        let err = mount
+            .write(&ctl, 0, b"commit\n", &caller)
+            .await
+            .unwrap_err();
+        assert!(matches!(err, MountError::PermissionDenied(_)));
+        assert!(
+            ctl_str(&mount, &ctl, &caller)
+                .await
+                .contains("state=staging")
+        );
+
+        declare_test_label(&mount, &ctl, &caller).await;
+        mount.write(&ctl, 0, b"commit\n", &caller).await.unwrap();
         mount.clunk(data, &caller).await;
         mount.clunk(ctl, &caller).await;
     }
@@ -2043,6 +2131,7 @@ mod tests {
             .write(&data, 0, b"sealed-bytes", &caller)
             .await
             .unwrap();
+        declare_test_label(&mount, &ctl, &caller).await;
         mount.write(&ctl, 0, b"commit\n", &caller).await.unwrap();
         let err = mount.write(&ctl, 0, b"abort\n", &caller).await.unwrap_err();
         assert!(matches!(err, MountError::InvalidArgument(_)));
@@ -2070,6 +2159,7 @@ mod tests {
         let (id, _root) = create_stage(&mount, &caller).await;
         let (data, ctl) = open_data_ctl(&mount, &id, &caller).await;
         mount.write(&data, 0, b"bytes", &caller).await.unwrap();
+        declare_test_label(&mount, &ctl, &caller).await;
         mount.write(&ctl, 0, b"commit\n", &caller).await.unwrap();
         let err = mount
             .write(&ctl, 0, b"label secret pqhybrid\n", &caller)
@@ -2091,6 +2181,7 @@ mod tests {
             .write(&data, 0, b"raced-bytes", &caller)
             .await
             .unwrap();
+        declare_test_label(&mount, &ctl, &caller).await;
 
         // Two commits racing on the same slot: exactly one seals, the other
         // waits on the seal (never spinning) and converges on the same CID.
@@ -2123,6 +2214,7 @@ mod tests {
             .write(&data, 0, b"authz-bytes", &caller)
             .await
             .unwrap();
+        declare_test_label(&mount, &ctl, &caller).await;
         mount.write(&ctl, 0, b"commit\n", &caller).await.unwrap();
 
         // The commit authorization must address the staging id, not "ctl".

--- a/crates/hyprstream/src/storage/cas/mount.rs
+++ b/crates/hyprstream/src/storage/cas/mount.rs
@@ -2057,7 +2057,7 @@ mod tests {
             .await
             .unwrap();
 
-        // Declare two labels; the seal must join them (LUB).
+        // Declare two labels; the seal must apply the IFC provenance join.
         mount
             .write(&ctl, 0, b"label internal classical pii\n", &caller)
             .await
@@ -2083,18 +2083,29 @@ mod tests {
                 [Compartment::new("pii")],
             )
             .unwrap();
-        let finance = lattice
+        let pqhybrid_finance_input = lattice
             .label(
                 Level::Confidential,
                 Assurance::PqHybrid,
                 [Compartment::new("finance")],
             )
             .unwrap();
-        let joined = ifc_join(&[pii, finance]);
+        let joined = ifc_join(&[pii, pqhybrid_finance_input]);
+        let finance_at_joined_assurance = lattice
+            .label(
+                Level::Confidential,
+                joined.assurance,
+                [Compartment::new("finance")],
+            )
+            .unwrap();
         let manifest = mount.substrate.manifest(&mount.domain, &cid).unwrap();
         assert_eq!(manifest.security_label, joined);
+        assert_eq!(manifest.security_label.assurance, Assurance::Classical);
         assert!(manifest.security_label.can_access(&pii));
-        assert!(manifest.security_label.can_access(&finance));
+        assert!(manifest
+            .security_label
+            .can_access(&finance_at_joined_assurance));
+        assert!(!manifest.security_label.can_access(&pqhybrid_finance_input));
         assert!(manifest.security_label.compartments.contains(0));
         assert!(manifest.security_label.compartments.contains(1));
         mount.clunk(data, &caller).await;

--- a/crates/hyprstream/src/storage/cas/substrate.rs
+++ b/crates/hyprstream/src/storage/cas/substrate.rs
@@ -15,7 +15,7 @@ use hyprstream_rpc::cid::{Codec, HashAlgo, decode_cid, encode_cid};
 
 use super::CasError;
 use super::domain::DedupDomain;
-use super::manifest::{BlobManifest, merkle_from_address};
+use super::manifest::{BlobManifest, looks_like_legacy_hex, merkle_from_address};
 
 /// Hex-character length of a `digest_length`-byte digest (2 hex chars per byte).
 const fn hex_digest_len(digest_length: u16) -> usize {
@@ -192,10 +192,6 @@ impl CasSubstrate {
         };
         merkle.is_ok_and(|merkle| self.store_for(domain).exists(&merkle))
     }
-}
-
-fn looks_like_legacy_hex(address: &str) -> bool {
-    matches!(address.len(), 40 | 64) && address.bytes().all(|b| b.is_ascii_hexdigit())
 }
 
 #[cfg(test)]

--- a/crates/hyprstream/src/storage/cas/substrate.rs
+++ b/crates/hyprstream/src/storage/cas/substrate.rs
@@ -6,15 +6,16 @@
 //! trust_boundary)` domain. Addressing is multihash: ingest returns a canonical
 //! CID, and reads accept either a CID or a legacy hex merkle.
 
+use std::fs;
 use std::path::{Path, PathBuf};
 
 use cas_serve::CasStore;
 use hyprstream_rpc::auth::mac::SecurityLabel;
-use hyprstream_rpc::cid::HashAlgo;
+use hyprstream_rpc::cid::{Codec, HashAlgo, decode_cid, encode_cid};
 
-use super::domain::DedupDomain;
-use super::manifest::{cid_from_merkle, merkle_from_address, BlobManifest};
 use super::CasError;
+use super::domain::DedupDomain;
+use super::manifest::{BlobManifest, merkle_from_address};
 
 /// Hex-character length of a `digest_length`-byte digest (2 hex chars per byte).
 const fn hex_digest_len(digest_length: u16) -> usize {
@@ -50,12 +51,68 @@ impl CasSubstrate {
         CasStore::new(self.root.join(domain.relative_path()))
     }
 
+    fn manifest_dir(&self, domain: &DedupDomain) -> PathBuf {
+        self.root.join(domain.relative_path()).join("manifests")
+    }
+
+    fn manifest_path(&self, domain: &DedupDomain, cid: &str) -> PathBuf {
+        self.manifest_dir(domain).join(format!("{cid}.json"))
+    }
+
+    fn canonical_cid(address: &str) -> Result<String, CasError> {
+        let decoded = decode_cid(address).map_err(|e| CasError::Cid(e.to_string()))?;
+        encode_cid(
+            decoded.codec,
+            decoded.multihash.algo,
+            &decoded.multihash.digest,
+        )
+        .map_err(|e| CasError::Cid(e.to_string()))
+    }
+
+    fn persist_manifest(
+        &self,
+        domain: &DedupDomain,
+        manifest: &BlobManifest,
+    ) -> Result<(), CasError> {
+        let dir = self.manifest_dir(domain);
+        fs::create_dir_all(&dir)
+            .map_err(|e| CasError::Manifest(format!("create {}: {e}", dir.display())))?;
+        let bytes = serde_json::to_vec(manifest)
+            .map_err(|e| CasError::Manifest(format!("serialize manifest: {e}")))?;
+        let path = self.manifest_path(domain, &manifest.cid);
+        fs::write(&path, bytes)
+            .map_err(|e| CasError::Manifest(format!("write {}: {e}", path.display())))
+    }
+
+    fn load_manifest(&self, domain: &DedupDomain, address: &str) -> Result<BlobManifest, CasError> {
+        let cid = Self::canonical_cid(address)?;
+        let decoded = decode_cid(&cid).map_err(|e| CasError::Cid(e.to_string()))?;
+        if decoded.codec != Codec::XetManifest {
+            return Err(CasError::Cid(
+                "CID does not address a labeled CAS manifest".into(),
+            ));
+        }
+        let path = self.manifest_path(domain, &cid);
+        let bytes = fs::read(&path)
+            .map_err(|e| CasError::Manifest(format!("read {}: {e}", path.display())))?;
+        let manifest: BlobManifest = serde_json::from_slice(&bytes)
+            .map_err(|e| CasError::Manifest(format!("decode {}: {e}", path.display())))?;
+        if manifest.cid != cid
+            || !hyprstream_rpc::auth::mac::ContentBoundLabel::verify_binding(&manifest)
+        {
+            return Err(CasError::Manifest(format!(
+                "CID binding verification failed for {cid}"
+            )));
+        }
+        Ok(manifest)
+    }
+
     /// Ingest bytes into a dedup domain.
     ///
     /// Chunking (gearhash CDC), xorb aggregation, content-addressed dedup, and the
     /// server-computed merkle all happen inside the underlying `CasStore` — byte
     /// boundaries stay identical to xet-core. The substrate adds the canonical
-    /// multihash CID and attaches the `security_label` carrier (plumb-through only).
+    /// manifest CID with a required, content-bound `security_label`.
     ///
     /// Only **BLAKE3-256** ingest is implemented today: the merkle the store
     /// computes is the 32-byte BLAKE3 reconstruction hash, so the domain must
@@ -69,7 +126,7 @@ impl CasSubstrate {
         &self,
         domain: &DedupDomain,
         data: &[u8],
-        security_label: Option<SecurityLabel>,
+        security_label: SecurityLabel,
     ) -> Result<BlobManifest, CasError> {
         if domain.algorithm != HashAlgo::Blake3 || domain.digest_length != 32 {
             return Err(CasError::UnsupportedIngestAlgorithm(domain.algorithm));
@@ -84,15 +141,15 @@ impl CasSubstrate {
             "store merkle must be the declared {}-byte digest",
             domain.digest_length
         );
-        let cid = cid_from_merkle(domain.algorithm, &put.merkle)?;
-        Ok(BlobManifest {
-            cid,
-            merkle: put.merkle,
-            xorb_hashes: put.xorb_hashes,
-            bytes_stored: put.bytes_stored,
-            byte_len: data.len() as u64,
+        let manifest = BlobManifest::new(
+            put.merkle,
+            put.xorb_hashes,
+            put.bytes_stored,
+            data.len() as u64,
             security_label,
-        })
+        )?;
+        self.persist_manifest(domain, &manifest)?;
+        Ok(manifest)
     }
 
     /// Reconstruct a blob's bytes by content address within a domain.
@@ -100,9 +157,18 @@ impl CasSubstrate {
     /// `address` may be a canonical CID or a legacy hex merkle (see
     /// [`merkle_from_address`]).
     pub async fn get(&self, domain: &DedupDomain, address: &str) -> Result<Vec<u8>, CasError> {
-        let merkle = merkle_from_address(address)?;
+        let merkle = if looks_like_legacy_hex(address) {
+            merkle_from_address(address)?
+        } else {
+            self.load_manifest(domain, address)?.merkle
+        };
         let store = self.store_for(domain);
         Ok(store.get_file_bytes(&merkle).await?)
+    }
+
+    /// Load and verify the sealed manifest named by a manifest CID.
+    pub fn manifest(&self, domain: &DedupDomain, cid: &str) -> Result<BlobManifest, CasError> {
+        self.load_manifest(domain, cid)
     }
 
     /// Read the raw bytes of a single stored xorb, keyed by its hex xorb hash,
@@ -118,18 +184,29 @@ impl CasSubstrate {
 
     /// True if the substrate can serve this content address within the domain.
     pub fn exists(&self, domain: &DedupDomain, address: &str) -> bool {
-        match merkle_from_address(address) {
-            Ok(merkle) => self.store_for(domain).exists(&merkle),
-            Err(_) => false,
-        }
+        let merkle = if looks_like_legacy_hex(address) {
+            merkle_from_address(address)
+        } else {
+            self.load_manifest(domain, address)
+                .map(|manifest| manifest.merkle)
+        };
+        merkle.is_ok_and(|merkle| self.store_for(domain).exists(&merkle))
     }
+}
+
+fn looks_like_legacy_hex(address: &str) -> bool {
+    matches!(address.len(), 40 | 64) && address.bytes().all(|b| b.is_ascii_hexdigit())
 }
 
 #[cfg(test)]
 #[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {
     use super::*;
-    use hyprstream_rpc::auth::mac::Compartment;
+    use hyprstream_rpc::auth::mac::{Assurance, Compartment, CompartmentSet, Level};
+
+    fn label() -> SecurityLabel {
+        SecurityLabel::new(Level::Internal, Assurance::Classical, CompartmentSet::EMPTY)
+    }
 
     fn payload(seed: u8, len: usize) -> Vec<u8> {
         (0..len)
@@ -144,7 +221,7 @@ mod tests {
         let domain = DedupDomain::local_default();
         let original = payload(7, 256 * 1024);
 
-        let m = sub.put(&domain, &original, None).await.unwrap();
+        let m = sub.put(&domain, &original, label()).await.unwrap();
         assert!(m.cid.starts_with('b'));
         assert_eq!(m.byte_len, original.len() as u64);
         assert!(m.bytes_stored > 0);
@@ -165,7 +242,7 @@ mod tests {
         let original = payload(3, 200 * 1024);
 
         let m = sub
-            .put(&DedupDomain::local_default(), &original, None)
+            .put(&DedupDomain::local_default(), &original, label())
             .await
             .unwrap();
 
@@ -184,8 +261,8 @@ mod tests {
         let default_domain = DedupDomain::local_default();
         let tenant_domain = DedupDomain::local_tenant(Compartment::new("tenant:acme"));
 
-        let a = sub.put(&default_domain, &original, None).await.unwrap();
-        let b = sub.put(&tenant_domain, &original, None).await.unwrap();
+        let a = sub.put(&default_domain, &original, label()).await.unwrap();
+        let b = sub.put(&tenant_domain, &original, label()).await.unwrap();
 
         // Content-addressed ⇒ identical merkle regardless of domain.
         assert_eq!(a.merkle, b.merkle);
@@ -207,8 +284,8 @@ mod tests {
         let domain = DedupDomain::local_default();
         let original = payload(11, 200 * 1024);
 
-        let first = sub.put(&domain, &original, None).await.unwrap();
-        let second = sub.put(&domain, &original, None).await.unwrap();
+        let first = sub.put(&domain, &original, label()).await.unwrap();
+        let second = sub.put(&domain, &original, label()).await.unwrap();
         assert_eq!(first.merkle, second.merkle);
         assert_eq!(second.bytes_stored, 0, "same-domain re-upload fully dedups");
     }
@@ -222,7 +299,7 @@ mod tests {
             digest_length: 32,
             ..DedupDomain::local_default()
         };
-        let err = sub.put(&domain, b"hello", None).await.unwrap_err();
+        let err = sub.put(&domain, b"hello", label()).await.unwrap_err();
         assert!(matches!(err, CasError::UnsupportedIngestAlgorithm(_)));
     }
 
@@ -238,7 +315,7 @@ mod tests {
             digest_length: 64,
             ..DedupDomain::local_default()
         };
-        let err = sub.put(&domain, b"hello", None).await.unwrap_err();
+        let err = sub.put(&domain, b"hello", label()).await.unwrap_err();
         assert!(
             matches!(err, CasError::UnsupportedIngestAlgorithm(_)),
             "BLAKE3-512 ingest must be rejected until #881 lands"
@@ -250,11 +327,30 @@ mod tests {
         use hyprstream_rpc::auth::mac::{Assurance, CompartmentSet, Level};
         let dir = tempfile::tempdir().unwrap();
         let sub = CasSubstrate::new(dir.path());
-        let label = SecurityLabel::new(Level::Internal, Assurance::Classical, CompartmentSet::EMPTY);
+        let label =
+            SecurityLabel::new(Level::Internal, Assurance::Classical, CompartmentSet::EMPTY);
         let m = sub
-            .put(&DedupDomain::local_default(), b"payload-bytes", Some(label))
+            .put(&DedupDomain::local_default(), b"payload-bytes", label)
             .await
             .unwrap();
-        assert_eq!(m.security_label, Some(label), "carrier field plumbs through unchanged");
+        assert_eq!(
+            m.security_label, label,
+            "required label plumbs through unchanged"
+        );
+    }
+
+    #[tokio::test]
+    async fn manifest_cid_remains_resolvable_after_reopening_the_substrate() {
+        let dir = tempfile::tempdir().unwrap();
+        let domain = DedupDomain::local_default();
+        let manifest = CasSubstrate::new(dir.path())
+            .put(&domain, b"durable-manifest", label())
+            .await
+            .unwrap();
+        let reopened = CasSubstrate::new(dir.path());
+        assert_eq!(
+            reopened.get(&domain, &manifest.cid).await.unwrap(),
+            b"durable-manifest"
+        );
     }
 }


### PR DESCRIPTION
## Summary
- require a security label to construct or ingest a sealed CAS manifest
- content-bind the label into a manifest CID and persist/verify manifest resolution
- fail closed on unlabeled staging seals; join declared input labels at seal

## Validation
- `buildq -- cargo test -p hyprstream storage::cas --lib`
- `buildq -- cargo build`
- `buildq -- cargo clippy --all-targets -- -D warnings`

Refs #699 (scope items 2+3), #547, #812, #814, and #710.