### PR TITLE
feat(mac): enforce labels on every 9P object access

### DIFF
--- a/crates/hyprstream-9p/examples/serve_mount_uds.rs
+++ b/crates/hyprstream-9p/examples/serve_mount_uds.rs
@@ -44,5 +44,11 @@ async fn main() -> anyhow::Result<()> {
     let subject = Subject::new("tenant-a");
 
     eprintln!("serving 9P mount at {path}");
-    serve_mount_uds(mount, subject, &path).await
+    serve_mount_uds(
+        mount,
+        subject,
+        Arc::new(hyprstream_9p::DenyAllDecider),
+        &path,
+    )
+    .await
 }

--- a/crates/hyprstream-9p/src/lib.rs
+++ b/crates/hyprstream-9p/src/lib.rs
@@ -46,11 +46,9 @@ pub mod memory;
 // The browser/wasm build reaches the backend through the DMA/Wanix client path.
 #[cfg(not(target_arch = "wasm32"))]
 pub mod translator;
-// 9P reference-monitor contract (S2 / #568): the attach-time token seam, the
-// per-op mediation composition (`ReferenceMonitor`), and fail-closed defaults.
-// Dormant groundwork — `Translator` runs without a monitor unless the
-// application installs one (activation is blocked on #698). Native-only
-// alongside `translator`, its only consumer today.
+// 9P reference-monitor contract (S2 / #568): attach-time token verification,
+// optional full token/IFC composition, and the mandatory per-op access-decider
+// seam. Native-only alongside `translator`, its only consumer today.
 #[cfg(not(target_arch = "wasm32"))]
 pub mod mac_seam;
 // `MountBackend` bridges a VFS `Mount` (+ `Subject`) to the `Backend` seam so

--- a/crates/hyprstream-9p/src/mac_seam.rs
+++ b/crates/hyprstream-9p/src/mac_seam.rs
@@ -101,6 +101,7 @@ pub use hyprstream_rpc::auth::mac::{ObjectLabelResolver, ObjectRef};
 /// deliberately not mediated.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum Action {
+    Attach,
     Walk,
     Open,
     Read,
@@ -304,28 +305,31 @@ impl ObjectLabelResolver for DenyUnlabeledResolver {
     }
 }
 
-/// The policy decision point behind the mandatory token and IFC gates.
+/// Authorizes one operation against a subject's cached [`SecurityContext`] and
+/// exact walked object reference.
 ///
-/// `check` is called only after the monitor has resolved a non-optional
-/// object label, checked the attached token's operation/ceiling/TTL, and
-/// enforced `subject.ctx ⊒ object.label`. The concrete application
-/// implementation is a local AVC lookup (with a PDP miss); it must not perform
-/// UCAN chain validation or Casbin matching per operation.
+/// Resolution belongs to the concrete implementation in `hyprstream`, which
+/// owns the production content-truth label resolver and tamper-evident audit
+/// sink. Passing the object reference—not an optional caller-supplied
+/// label—keeps label resolution and auditing inside the authoritative PEP.
 pub trait AccessDecider: Send + Sync {
-    fn check(&self, ctx: &SecurityContext, object_label: &SecurityLabel, action: Action) -> bool;
+    fn check(&self, ctx: &SecurityContext, object: ObjectRef<'_>, action: Action) -> bool;
 }
 
-/// The fail-closed default policy monitor. It permits nothing.
+/// Fail-closed fallback for layers that cannot construct the production
+/// resolver-backed, audited decider.
 #[derive(Debug, Default, Clone, Copy)]
 pub struct DenyAllDecider;
 
 impl AccessDecider for DenyAllDecider {
-    fn check(
-        &self,
-        _ctx: &SecurityContext,
-        _object_label: &SecurityLabel,
-        _action: Action,
-    ) -> bool {
+    fn check(&self, ctx: &SecurityContext, object: ObjectRef<'_>, action: Action) -> bool {
+        tracing::warn!(
+            target: "hyprstream.mac.audit",
+            ?object,
+            ?action,
+            clearance = ?ctx.clearance(),
+            "9P access denied: production MAC decider unavailable"
+        );
         false
     }
 }
@@ -389,8 +393,11 @@ impl ReferenceMonitor {
             return false;
         }
 
-        self.decider
-            .check(session.security_context(), &object_label, action)
+        self.decider.check(
+            session.security_context(),
+            ObjectRef::Path(&components),
+            action,
+        )
     }
 }
 
@@ -430,7 +437,7 @@ mod tests {
         fn check(
             &self,
             _ctx: &SecurityContext,
-            _object_label: &SecurityLabel,
+            _object: ObjectRef<'_>,
             _action: Action,
         ) -> bool {
             true

--- a/crates/hyprstream-9p/src/translator.rs
+++ b/crates/hyprstream-9p/src/translator.rs
@@ -526,8 +526,16 @@ impl Translator {
         let base = self.fids.path(fid).unwrap_or_default();
 
         // Complete mediation: authorize every hop, not only the final
-        // destination. Labels need not be monotone with path depth.
+        // destination. Labels need not be monotone with path depth. An empty
+        // walk is a fid clone and still mediates the object bound to the source
+        // fid; otherwise an unattached connection could clone another
+        // connection's fid without passing the monitor.
         let mut prefix = base.clone();
+        if wnames.is_empty()
+            && !self.authorize_path(session.as_ref(), &prefix, Action::Walk)
+        {
+            return Ok(Response::Error { ecode: libc_eperm() });
+        }
         for component in &wnames {
             prefix.push(component.clone());
             if !self.authorize_path(session.as_ref(), &prefix, Action::Walk) {
@@ -1044,7 +1052,7 @@ mod tests {
         }
 
         let backend = MountBackend::new(Arc::new(StubMount), Subject::new("tenant"));
-        let t = Arc::new(Translator::new(Arc::new(backend)));
+        let t = Arc::new(Translator::new(Arc::new(backend), test_decider()));
 
         // Attach fid 0 as root (empty walk succeeds).
         t.handle_message(&msg::tattach(1, 0, u32::MAX, "u", "")).await.unwrap();
@@ -1063,7 +1071,7 @@ mod tests {
 
     #[tokio::test]
     async fn version_round_trips() {
-        let t = Translator::new(Arc::new(MemoryBackend::default()));
+        let t = Translator::new(Arc::new(MemoryBackend::default()), test_decider());
         // Build a Tversion by hand via the codec and decode the response.
         let req = msg::tversion(1, 4096, "9P2000.L");
         let (tag, resp) = t.handle_message(&req).await.unwrap();
@@ -1081,7 +1089,7 @@ mod tests {
     async fn attach_then_walk_open_read_clunk() {
         let backend = MemoryBackend::default();
         backend.add_file("/hello.txt", b"hello world");
-        let t = Translator::new(Arc::new(backend));
+        let t = Translator::new(Arc::new(backend), test_decider());
 
         // Attach: fid 0 becomes the root.
         let req = msg::tattach(1, 0, u32::MAX, "user", "/");
@@ -1161,6 +1169,7 @@ mod tests {
     }
 
     const ALL_OPS: &[Action] = &[
+        Action::Attach,
         Action::Walk,
         Action::Open,
         Action::Read,
@@ -1192,11 +1201,15 @@ mod tests {
         fn check(
             &self,
             _ctx: &SecurityContext,
-            _object_label: &SecurityLabel,
+            _object: ObjectRef<'_>,
             _action: Action,
         ) -> bool {
             true
         }
+    }
+
+    fn test_decider() -> Arc<dyn AccessDecider> {
+        Arc::new(AllowAll)
     }
 
     fn monitor(
@@ -1215,7 +1228,7 @@ mod tests {
     /// the root fid is a mediated object with no synthetic exemption.
     #[tokio::test]
     async fn monitor_denies_unlabeled_root_at_attach() {
-        let t = Translator::new(Arc::new(MemoryBackend::default())).with_reference_monitor(
+        let t = Translator::new(Arc::new(MemoryBackend::default()), test_decider()).with_reference_monitor(
             monitor(permit_session(Level::Secret, ALL_OPS), None, Arc::new(AllowAll)),
         );
         let (_, resp) = t.handle_message(&msg::tattach(1, 0, u32::MAX, "user", "/")).await.unwrap();
@@ -1229,7 +1242,7 @@ mod tests {
     /// backend object handle exists.
     #[tokio::test]
     async fn monitor_denies_missing_token_at_attach() {
-        let t = Translator::new(Arc::new(MemoryBackend::default())).with_reference_monitor(
+        let t = Translator::new(Arc::new(MemoryBackend::default()), test_decider()).with_reference_monitor(
             monitor(SessionContext::deny(), Some(label(Level::Public)), Arc::new(AllowAll)),
         );
         let (_, resp) = t.handle_message(&msg::tattach(1, 0, u32::MAX, "user", "/")).await.unwrap();
@@ -1250,7 +1263,7 @@ mod tests {
                 Instant::now() - Duration::from_secs(1),
             ),
         );
-        let t = Translator::new(Arc::new(MemoryBackend::default())).with_reference_monitor(
+        let t = Translator::new(Arc::new(MemoryBackend::default()), test_decider()).with_reference_monitor(
             monitor(expired, Some(label(Level::Public)), Arc::new(AllowAll)),
         );
         let (_, resp) = t.handle_message(&msg::tattach(1, 0, u32::MAX, "user", "/")).await.unwrap();
@@ -1267,7 +1280,7 @@ mod tests {
     async fn monitor_allows_when_all_gates_pass() {
         let backend = MemoryBackend::default();
         backend.add_file("/hello.txt", b"hello world");
-        let t = Translator::new(Arc::new(backend)).with_reference_monitor(monitor(
+        let t = Translator::new(Arc::new(backend), test_decider()).with_reference_monitor(monitor(
             permit_session(Level::Secret, ALL_OPS),
             Some(label(Level::Public)),
             Arc::new(AllowAll),
@@ -1297,7 +1310,7 @@ mod tests {
             fn check(
                 &self,
                 _ctx: &SecurityContext,
-                _object_label: &SecurityLabel,
+                _object: ObjectRef<'_>,
                 action: Action,
             ) -> bool {
                 !matches!(action, Action::Read)
@@ -1306,7 +1319,7 @@ mod tests {
 
         let backend = MemoryBackend::default();
         backend.add_file("/hello.txt", b"hello world");
-        let t = Translator::new(Arc::new(backend)).with_reference_monitor(monitor(
+        let t = Translator::new(Arc::new(backend), test_decider()).with_reference_monitor(monitor(
             permit_session(Level::Secret, ALL_OPS),
             Some(label(Level::Public)),
             Arc::new(DenyReads),
@@ -1332,8 +1345,11 @@ mod tests {
     async fn monitor_denies_op_outside_token_scope() {
         let backend = MemoryBackend::default();
         backend.add_file("/hello.txt", b"hello world");
-        let t = Translator::new(Arc::new(backend)).with_reference_monitor(monitor(
-            permit_session(Level::Secret, &[Action::Walk, Action::Open, Action::Read]),
+        let t = Translator::new(Arc::new(backend), test_decider()).with_reference_monitor(monitor(
+            permit_session(
+                Level::Secret,
+                &[Action::Attach, Action::Walk, Action::Open, Action::Read],
+            ),
             Some(label(Level::Public)),
             Arc::new(AllowAll),
         ));
@@ -1379,7 +1395,7 @@ mod tests {
         let backend = MemoryBackend::default();
         backend.add_file("/hello.txt", b"hi");
         backend.add_file("/secret.txt", b"classified");
-        let t = Translator::new(Arc::new(backend)).with_reference_monitor(Arc::new(
+        let t = Translator::new(Arc::new(backend), test_decider()).with_reference_monitor(Arc::new(
             ReferenceMonitor::new(
                 Arc::new(StaticAuth(session)),
                 Arc::new(ByName),
@@ -1414,7 +1430,7 @@ mod tests {
         }
         let backend = MemoryBackend::default();
         backend.add_file("/secret.txt", b"classified");
-        let t = Translator::new(Arc::new(backend)).with_reference_monitor(Arc::new(
+        let t = Translator::new(Arc::new(backend), test_decider()).with_reference_monitor(Arc::new(
             ReferenceMonitor::new(
                 Arc::new(StaticAuth(permit_session(Level::Public, ALL_OPS))),
                 Arc::new(AllSecret),
@@ -1437,8 +1453,8 @@ mod tests {
     async fn clunk_is_not_mediated() {
         let backend = MemoryBackend::default();
         backend.add_file("/hello.txt", b"hi");
-        let t = Translator::new(Arc::new(backend)).with_reference_monitor(monitor(
-            permit_session(Level::Secret, &[Action::Walk]),
+        let t = Translator::new(Arc::new(backend), test_decider()).with_reference_monitor(monitor(
+            permit_session(Level::Secret, &[Action::Attach, Action::Walk]),
             Some(label(Level::Public)),
             Arc::new(AllowAll),
         ));
@@ -1458,7 +1474,7 @@ mod tests {
             fn check(
                 &self,
                 _ctx: &SecurityContext,
-                _object_label: &SecurityLabel,
+                _object: ObjectRef<'_>,
                 action: Action,
             ) -> bool {
                 !matches!(action, Action::Getattr)
@@ -1467,7 +1483,7 @@ mod tests {
 
         let backend = MemoryBackend::default();
         backend.add_file("/hello.txt", b"hi");
-        let t = Translator::new(Arc::new(backend)).with_reference_monitor(monitor(
+        let t = Translator::new(Arc::new(backend), test_decider()).with_reference_monitor(monitor(
             permit_session(Level::Secret, ALL_OPS),
             Some(label(Level::Public)),
             Arc::new(DenyGetattr),
@@ -1490,7 +1506,7 @@ mod tests {
     /// deny an already-authenticated client).
     #[tokio::test]
     async fn walk_clone_inherits_source_context() {
-        let t = Translator::new(Arc::new(MemoryBackend::default())).with_reference_monitor(
+        let t = Translator::new(Arc::new(MemoryBackend::default()), test_decider()).with_reference_monitor(
             monitor(
                 permit_session(Level::Secret, ALL_OPS),
                 Some(label(Level::Public)),
@@ -1533,16 +1549,16 @@ mod tests {
             fn check(
                 &self,
                 _ctx: &SecurityContext,
-                object_label: &SecurityLabel,
+                object: ObjectRef<'_>,
                 action: Action,
             ) -> bool {
-                !(action == Action::Read && object_label.level == Level::Secret)
+                !(action == Action::Read && matches!(object, ObjectRef::Path([])))
             }
         }
 
         let backend = MemoryBackend::default();
         backend.add_file("/public.txt", b"public");
-        let t = Translator::new(Arc::new(backend)).with_reference_monitor(Arc::new(
+        let t = Translator::new(Arc::new(backend), test_decider()).with_reference_monitor(Arc::new(
             ReferenceMonitor::new(
                 Arc::new(StaticAuth(permit_session(Level::Secret, ALL_OPS))),
                 Arc::new(ByPath),
@@ -1564,7 +1580,7 @@ mod tests {
 
     #[tokio::test]
     async fn connection_scoped_translators_do_not_share_fid_context() {
-        let root = Translator::new(Arc::new(MemoryBackend::default())).with_reference_monitor(
+        let root = Translator::new(Arc::new(MemoryBackend::default()), test_decider()).with_reference_monitor(
             monitor(
                 permit_session(Level::Secret, ALL_OPS),
                 Some(label(Level::Public)),
@@ -1605,7 +1621,7 @@ mod tests {
             }
         }
 
-        let t = Translator::new(Arc::new(MemoryBackend::default())).with_reference_monitor(
+        let t = Translator::new(Arc::new(MemoryBackend::default()), test_decider()).with_reference_monitor(
             Arc::new(ReferenceMonitor::new(
                 Arc::new(TicketAuth),
                 Arc::new(StaticLabels(Some(label(Level::Public)))),
@@ -1647,7 +1663,7 @@ mod tests {
             }
         }
 
-        let t = Translator::new(Arc::new(MemoryBackend::default())).with_reference_monitor(
+        let t = Translator::new(Arc::new(MemoryBackend::default()), test_decider()).with_reference_monitor(
             Arc::new(ReferenceMonitor::new(
                 Arc::new(FreshDeadlineAuth),
                 Arc::new(StaticLabels(Some(label(Level::Public)))),
@@ -1685,7 +1701,7 @@ mod tests {
                 }
             }
         }
-        let t = Translator::new(Arc::new(MemoryBackend::default())).with_reference_monitor(
+        let t = Translator::new(Arc::new(MemoryBackend::default()), test_decider()).with_reference_monitor(
             Arc::new(ReferenceMonitor::new(
                 Arc::new(TicketAuth),
                 Arc::new(StaticLabels(Some(label(Level::Public)))),
@@ -1720,8 +1736,8 @@ mod tests {
         }
         struct DenySecretReads;
         impl AccessDecider for DenySecretReads {
-            fn check(&self, _ctx: &SecurityContext, object_label: &SecurityLabel, action: Action) -> bool {
-                !(action == Action::Read && object_label.level == Level::Secret)
+            fn check(&self, _ctx: &SecurityContext, object: ObjectRef<'_>, action: Action) -> bool {
+                !(action == Action::Read && matches!(object, ObjectRef::Path(["a", "b"])))
             }
         }
         let root = SyntheticNode::dir().with_child(
@@ -1732,7 +1748,7 @@ mod tests {
             Arc::new(SyntheticMount::new(root)),
             hyprstream_rpc::Subject::new("tenant"),
         );
-        let t = Translator::new(Arc::new(backend)).with_reference_monitor(Arc::new(
+        let t = Translator::new(Arc::new(backend), test_decider()).with_reference_monitor(Arc::new(
             ReferenceMonitor::new(
                 Arc::new(StaticAuth(permit_session(Level::Secret, ALL_OPS))),
                 Arc::new(ByPath),
@@ -1774,7 +1790,7 @@ mod tests {
         }
         let backend = MemoryBackend::default();
         backend.add_file("/secret", b"classified");
-        let t = Translator::new(Arc::new(backend)).with_reference_monitor(Arc::new(
+        let t = Translator::new(Arc::new(backend), test_decider()).with_reference_monitor(Arc::new(
             ReferenceMonitor::new(
                 Arc::new(StaticAuth(permit_session(Level::Public, ALL_OPS))),
                 Arc::new(ByDepth),
@@ -1851,7 +1867,7 @@ mod tests {
         }
 
         // No monitor: this isolates the path-caching fix from mediation.
-        let t = Translator::new(Arc::new(PartialWalkBackend));
+        let t = Translator::new(Arc::new(PartialWalkBackend), test_decider());
         t.handle_message(&msg::tattach(1, 0, u32::MAX, "user", "/")).await.unwrap();
         t.handle_message(&msg::twalk(2, 0, 1, &["a", "b"])).await.unwrap();
 
@@ -1888,7 +1904,7 @@ mod tests {
         let backend = MemoryBackend::default();
         backend.add_file("/one.txt", b"111");
         backend.add_file("/two.txt", b"22");
-        let t = Arc::new(Translator::new(Arc::new(backend)));
+        let t = Arc::new(Translator::new(Arc::new(backend), test_decider()));
 
         // Attach fid 0 as the (directory) root, then open + readdir it.
         t.handle_message(&msg::tattach(1, 0, u32::MAX, "u", "/")).await.unwrap();
@@ -1934,7 +1950,7 @@ mod tests {
         let backend = MemoryBackend::default();
         backend.add_file("/hello.txt", b"hello vsock");
         let listener = UnixListener::bind(&sock).expect("bind hybrid-vsock host UDS");
-        let translator = Translator::new(Arc::new(backend));
+        let translator = Translator::new(Arc::new(backend), test_decider());
         let server = tokio::spawn(translator.serve_vsock(listener));
 
         // ── Client side ─────────────────────────────────────────────────
@@ -2018,7 +2034,7 @@ mod tests {
         let backend = MemoryBackend::default();
         backend.add_file("/hello.txt", b"hello raw");
         let listener = UnixListener::bind(&sock).expect("bind raw vsock per-port host UDS");
-        let translator = Translator::new(Arc::new(backend));
+        let translator = Translator::new(Arc::new(backend), test_decider());
         let server = tokio::spawn(translator.serve_vsock_raw(listener));
 
         // ── Client (guest) side ─────────────────────────────────────────
@@ -2084,7 +2100,7 @@ mod tests {
         let _ = std::fs::remove_file(&sock);
 
         let listener = UnixListener::bind(&sock).unwrap();
-        let translator = Translator::new(Arc::new(MemoryBackend::default()));
+        let translator = Translator::new(Arc::new(MemoryBackend::default()), test_decider());
         let server = tokio::spawn(translator.serve_vsock(listener));
 
         // First client sends garbage; server should drop it and keep listening.
@@ -2142,7 +2158,11 @@ mod tests {
         let root = SyntheticNode::dir()
             .with_child("hello.txt", SyntheticNode::file(b"hi alice".to_vec()));
         let mount: Arc<dyn hyprstream_vfs::Mount> = Arc::new(SyntheticMount::new(root));
-        Arc::new(Translator::from_mount_authorized(mount, Arc::new(FakeTicketAuth)))
+        Arc::new(Translator::from_mount_authorized(
+            mount,
+            Arc::new(FakeTicketAuth),
+            test_decider(),
+        ))
     }
 
     /// A valid ticket in `Tattach.uname` binds the session Subject and the

--- a/crates/hyprstream-9p/src/translator.rs
+++ b/crates/hyprstream-9p/src/translator.rs
@@ -48,6 +48,7 @@ use std::sync::Arc;
 use anyhow::{Context, Result};
 use async_trait::async_trait;
 use dashmap::DashMap;
+use hyprstream_rpc::auth::mac::ObjectRef;
 use hyprstream_rpc::Subject;
 use hyprstream_vfs::Mount;
 use tokio::io::{split, AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt};
@@ -56,7 +57,9 @@ use tokio::sync::OnceCell;
 use tracing::{debug, error, info, warn};
 
 use crate::backend::Backend;
-use crate::mac_seam::{Action, ReferenceMonitor, SessionContext};
+use crate::mac_seam::{
+    anonymous_floor, AccessDecider, Action, ReferenceMonitor, SessionContext,
+};
 use crate::mount_backend::MountBackend;
 use crate::msg::{
     self, encode_response, parse_request, rflush, Request, Response,
@@ -144,25 +147,23 @@ pub struct Translator {
     backend_factory: Arc<dyn Fn() -> Arc<dyn Backend> + Send + Sync>,
     fids: Arc<FidTable>,
     attach_session: OnceCell<SessionContext>,
-    /// The S2 reference monitor (#568). `None` is the dormant default: the
-    /// translator then performs no MAC enforcement at all, exactly matching
-    /// pre-#568 behavior. Activation (installing a monitor on the production
-    /// serve paths) is blocked on #698 — see the `mac_seam` module docs.
+    /// Mandatory resolver-backed, audited policy-enforcement point.
+    decider: Arc<dyn AccessDecider>,
+    /// Optional S2 token/IFC composition. The mandatory decider remains active
+    /// when this richer attach-time monitor is not installed.
     monitor: Option<Arc<ReferenceMonitor>>,
 }
 
 impl Translator {
-    /// Build a translator over the given backend. The fid table starts empty.
-    /// No reference monitor is installed: per-op behavior is unchanged from
-    /// before #568 until the application opts in via
-    /// [`Translator::with_reference_monitor`].
-    pub fn new(backend: Arc<dyn Backend>) -> Self {
+    /// Build a translator over the given backend and mandatory audited PEP.
+    pub fn new(backend: Arc<dyn Backend>, decider: Arc<dyn AccessDecider>) -> Self {
         let backend_factory_backend = Arc::clone(&backend);
         Self {
             backend,
             backend_factory: Arc::new(move || Arc::clone(&backend_factory_backend)),
             fids: Arc::new(FidTable::default()),
             attach_session: OnceCell::new(),
+            decider,
             monitor: None,
         }
     }
@@ -186,7 +187,11 @@ impl Translator {
     /// mount in a [`MountBackend`] — the same [`Backend`] seam the capnp-RPC
     /// `ModelBackend` uses on the TCP path — so no new attachment mechanism is
     /// introduced; only the export root differs.
-    pub fn from_mount(mount: Arc<dyn Mount>, subject: Subject) -> Self {
+    pub fn from_mount(
+        mount: Arc<dyn Mount>,
+        subject: Subject,
+        decider: Arc<dyn AccessDecider>,
+    ) -> Self {
         let backend: Arc<dyn Backend> =
             Arc::new(MountBackend::new(Arc::clone(&mount), subject.clone()));
         Self {
@@ -197,6 +202,7 @@ impl Translator {
             }),
             fids: Arc::new(FidTable::default()),
             attach_session: OnceCell::new(),
+            decider,
             monitor: None,
         }
     }
@@ -216,6 +222,7 @@ impl Translator {
     pub fn from_mount_authorized(
         mount: Arc<dyn Mount>,
         authorizer: Arc<dyn crate::mount_backend::AttachAuthorizer>,
+        decider: Arc<dyn AccessDecider>,
     ) -> Self {
         let backend: Arc<dyn Backend> = Arc::new(MountBackend::with_authorizer(
             Arc::clone(&mount),
@@ -231,6 +238,7 @@ impl Translator {
             }),
             fids: Arc::new(FidTable::default()),
             attach_session: OnceCell::new(),
+            decider,
             monitor: None,
         }
     }
@@ -246,6 +254,7 @@ impl Translator {
             backend_factory: Arc::clone(&self.backend_factory),
             fids: Arc::new(FidTable::default()),
             attach_session: OnceCell::new(),
+            decider: Arc::clone(&self.decider),
             monitor: self.monitor.clone(),
         }
     }
@@ -441,10 +450,9 @@ impl Translator {
     }
 
     async fn handle_attach(&self, fid: u32, uname: &str, aname: &str) -> Result<Response> {
-        // #568: MAC mediation happens only when a reference monitor is
-        // installed (never in production today — activation is blocked on
-        // #698). The credential is then verified exactly once at attach, and
-        // the derived session is cached on every fid walked from this one.
+        // A full S2 monitor verifies the attach credential and applies its
+        // token/IFC gates. Without one, the mandatory production decider still
+        // mediates the root against the anonymous-floor context.
         let session = match &self.monitor {
             Some(monitor) => {
                 let session = monitor.authenticate(uname, aname).await;
@@ -452,13 +460,22 @@ impl Translator {
                 // synthetic exemption: an unlabeled root or missing/expired
                 // token denies at attach, before any backend object handle
                 // is exposed.
-                if !monitor.authorize(&session, &[], Action::Walk) {
+                if !monitor.authorize(&session, &[], Action::Attach) {
                     return Ok(Response::Error { ecode: libc_eperm() });
                 }
                 self.ensure_attach_session_compatible(&session)?;
                 Some(session)
             }
-            None => None,
+            None => {
+                let root: [&str; 0] = [];
+                if !self
+                    .decider
+                    .check(&anonymous_floor(), ObjectRef::Path(&root), Action::Attach)
+                {
+                    return Ok(Response::Error { ecode: libc_eperm() });
+                }
+                None
+            }
         };
 
         // Only an attach that cleared monitor authorization may bind a backend
@@ -508,23 +525,13 @@ impl Translator {
         let session = self.fids.session(fid);
         let base = self.fids.path(fid).unwrap_or_default();
 
-        if let Some(monitor) = &self.monitor {
-            // Complete mediation: authorize *every* hop of the walk, not only
-            // the final destination. Content-truth labels need not be monotone
-            // with depth, so a parent directory can be more classified than a
-            // leaf — a subject must not traverse *through* a high-labeled
-            // directory to reach a lower-labeled object with the intermediate
-            // hops unmediated (F1). A fid outside a verified session denies
-            // outright.
-            let Some(session) = session.as_ref() else {
+        // Complete mediation: authorize every hop, not only the final
+        // destination. Labels need not be monotone with path depth.
+        let mut prefix = base.clone();
+        for component in &wnames {
+            prefix.push(component.clone());
+            if !self.authorize_path(session.as_ref(), &prefix, Action::Walk) {
                 return Ok(Response::Error { ecode: libc_eperm() });
-            };
-            let mut prefix = base.clone();
-            for component in &wnames {
-                prefix.push(component.clone());
-                if !monitor.authorize(session, &prefix, Action::Walk) {
-                    return Ok(Response::Error { ecode: libc_eperm() });
-                }
             }
         }
 
@@ -612,25 +619,35 @@ impl Translator {
         Ok(Response::Readdir { data })
     }
 
-    /// Mediate one op on `fid` through the installed [`ReferenceMonitor`].
-    /// Returns `Some(Response::Error)` (EPERM) when the op is denied, `None`
-    /// when it may proceed to the backend.
-    ///
-    /// With no monitor installed (the dormant pre-activation default) every
-    /// op proceeds — exactly the pre-#568 behavior. With a monitor, a fid
-    /// outside a verified attach session (unknown fid, or a fid created
-    /// before the monitor saw an attach) fails closed, and the session's
-    /// cached path is mediated as `label → token → IFC → decider`.
+    /// Mediate one op through the optional full S2 monitor or, when it is not
+    /// installed, directly through the mandatory audited decider.
     fn deny(&self, fid: u32, action: Action) -> Option<Response> {
-        let monitor = self.monitor.as_ref()?;
-        let (Some(session), Some(path)) = (self.fids.session(fid), self.fids.path(fid)) else {
+        let Some(path) = self.fids.path(fid) else {
             return Some(Response::Error { ecode: libc_eperm() });
         };
-        if monitor.authorize(&session, &path, action) {
+        let session = self.fids.session(fid);
+        if self.authorize_path(session.as_ref(), &path, action) {
             None
         } else {
             Some(Response::Error { ecode: libc_eperm() })
         }
+    }
+
+    fn authorize_path(
+        &self,
+        session: Option<&SessionContext>,
+        path: &[String],
+        action: Action,
+    ) -> bool {
+        if let Some(monitor) = &self.monitor {
+            return session.is_some_and(|session| monitor.authorize(session, path, action));
+        }
+        let components: Vec<&str> = path.iter().map(String::as_str).collect();
+        self.decider.check(
+            &anonymous_floor(),
+            ObjectRef::Path(&components),
+            action,
+        )
     }
 }
 
@@ -643,11 +660,14 @@ impl Translator {
 pub async fn serve_mount_uds(
     mount: Arc<dyn Mount>,
     subject: Subject,
+    decider: Arc<dyn AccessDecider>,
     path: impl AsRef<Path>,
 ) -> Result<()> {
     let listener = UnixListener::bind(path.as_ref())
         .with_context(|| format!("bind 9P UDS listener at {:?}", path.as_ref()))?;
-    Translator::from_mount(mount, subject).serve_uds(listener).await
+    Translator::from_mount(mount, subject, decider)
+        .serve_uds(listener)
+        .await
 }
 
 /// Bind a Cloud-Hypervisor **hybrid-vsock** host socket at `path` and serve
@@ -663,11 +683,14 @@ pub async fn serve_mount_uds(
 pub async fn serve_mount_vsock(
     mount: Arc<dyn Mount>,
     subject: Subject,
+    decider: Arc<dyn AccessDecider>,
     path: impl AsRef<Path>,
 ) -> Result<()> {
     let listener = UnixListener::bind(path.as_ref())
         .with_context(|| format!("bind 9P hybrid-vsock listener at {:?}", path.as_ref()))?;
-    Translator::from_mount(mount, subject).serve_vsock(listener).await
+    Translator::from_mount(mount, subject, decider)
+        .serve_vsock(listener)
+        .await
 }
 
 /// Bind a **raw** (no-handshake) hybrid-vsock **per-port** host socket at `path`
@@ -686,12 +709,15 @@ pub async fn serve_mount_vsock(
 pub async fn serve_mount_vsock_raw(
     mount: Arc<dyn Mount>,
     subject: Subject,
+    decider: Arc<dyn AccessDecider>,
     path: impl AsRef<Path>,
 ) -> Result<()> {
     let listener = UnixListener::bind(path.as_ref()).with_context(|| {
         format!("bind 9P raw hybrid-vsock per-port listener at {:?}", path.as_ref())
     })?;
-    Translator::from_mount(mount, subject).serve_vsock_raw(listener).await
+    Translator::from_mount(mount, subject, decider)
+        .serve_vsock_raw(listener)
+        .await
 }
 
 /// Transport-agnostic accept surface, implemented for [`TcpListener`] and

--- a/crates/hyprstream-9p/tests/socket_roundtrip.rs
+++ b/crates/hyprstream-9p/tests/socket_roundtrip.rs
@@ -13,9 +13,17 @@
 use std::sync::Arc;
 use std::time::Duration;
 
-use hyprstream_9p::{serve_mount_uds, Remote9pMount};
+use hyprstream_9p::{serve_mount_uds, AccessDecider, Action, Remote9pMount};
+use hyprstream_rpc::auth::mac::{ObjectRef, SecurityContext};
 use hyprstream_rpc::Subject;
 use hyprstream_vfs::{Mount, SyntheticMount, SyntheticNode};
+
+struct TestDecider;
+impl AccessDecider for TestDecider {
+    fn check(&self, _: &SecurityContext, _: ObjectRef<'_>, _: Action) -> bool {
+        true
+    }
+}
 
 #[tokio::test]
 async fn socket_client_mount_round_trips_against_translator() {
@@ -40,7 +48,7 @@ async fn socket_client_mount_round_trips_against_translator() {
         let sock = sock.clone();
         async move {
             // Returns only on listener error / shutdown; we abort it at the end.
-            let _ = serve_mount_uds(mount, subject, sock).await;
+            let _ = serve_mount_uds(mount, subject, Arc::new(TestDecider), sock).await;
         }
     });
 

--- a/crates/hyprstream-9p/tests/tcp_translator.rs
+++ b/crates/hyprstream-9p/tests/tcp_translator.rs
@@ -10,9 +10,17 @@ use std::time::Duration;
 
 use hyprstream_9p::memory::MemoryBackend;
 use hyprstream_9p::msg::{self, Response};
-use hyprstream_9p::Translator;
+use hyprstream_9p::{AccessDecider, Action, Translator};
+use hyprstream_rpc::auth::mac::{ObjectRef, SecurityContext};
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::net::{TcpListener, TcpStream};
+
+struct TestDecider;
+impl AccessDecider for TestDecider {
+    fn check(&self, _: &SecurityContext, _: ObjectRef<'_>, _: Action) -> bool {
+        true
+    }
+}
 
 /// Read one complete 9P message (length-prefixed) from `stream`.
 async fn recv_message(stream: &mut TcpStream) -> Vec<u8> {
@@ -39,7 +47,7 @@ async fn tcp_full_session() {
 
     let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
     let addr = listener.local_addr().unwrap();
-    let translator = Translator::new(Arc::new(backend));
+    let translator = Translator::new(Arc::new(backend), Arc::new(TestDecider));
     // Spawn the accept loop; it returns on listener close, which we never
     // trigger, so unwrap it onto a background task.
     let server = tokio::spawn(async move {
@@ -104,7 +112,7 @@ async fn tcp_write_then_read() {
     backend.add_file("/pipe", b"");
     let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
     let addr = listener.local_addr().unwrap();
-    let translator = Translator::new(Arc::new(backend));
+    let translator = Translator::new(Arc::new(backend), Arc::new(TestDecider));
     let server = tokio::spawn(async move {
         let _ = translator.serve(listener).await;
     });

--- a/crates/hyprstream-9p/tests/uds_translator.rs
+++ b/crates/hyprstream-9p/tests/uds_translator.rs
@@ -14,11 +14,19 @@ use std::time::Duration;
 
 use async_trait::async_trait;
 use hyprstream_9p::msg::{self, Response};
-use hyprstream_9p::Translator;
+use hyprstream_9p::{AccessDecider, Action, Translator};
+use hyprstream_rpc::auth::mac::{ObjectRef, SecurityContext};
 use hyprstream_rpc::Subject;
 use hyprstream_vfs::{DirEntry, Fid, Mount, MountError, Stat};
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::net::{UnixListener, UnixStream};
+
+struct TestDecider;
+impl AccessDecider for TestDecider {
+    fn check(&self, _: &SecurityContext, _: ObjectRef<'_>, _: Action) -> bool {
+        true
+    }
+}
 
 /// Opaque per-fid state for `TestMount`: the absolute path it resolves to.
 struct TestFid {
@@ -121,7 +129,7 @@ async fn uds_full_session() {
     let listener = UnixListener::bind(&sock).unwrap();
 
     let subject = Subject::new("tenant-a");
-    let translator = Translator::from_mount(mount, subject);
+    let translator = Translator::from_mount(mount, subject, Arc::new(TestDecider));
     let server = tokio::spawn(async move {
         let _ = translator.serve_uds(listener).await;
     });

--- a/crates/hyprstream-workers/src/runtime/kata_backend.rs
+++ b/crates/hyprstream-workers/src/runtime/kata_backend.rs
@@ -73,7 +73,10 @@ fn rootless_kata_runtime_dir(
     let base = match xdg_runtime_dir.map(str::trim).filter(|s| !s.is_empty()) {
         Some(xdg) => PathBuf::from(xdg).join("kata"),
         None => {
-            let tmp = tmpdir.map(str::trim).filter(|s| !s.is_empty()).unwrap_or("/tmp");
+            let tmp = tmpdir
+                .map(str::trim)
+                .filter(|s| !s.is_empty())
+                .unwrap_or("/tmp");
             PathBuf::from(tmp).join(format!("kata-{euid}"))
         }
     };
@@ -164,8 +167,14 @@ impl std::fmt::Debug for KataHandle {
         f.debug_struct("KataHandle")
             .field("api_socket", &self.api_socket)
             .field("virtiofs_socket", &self.virtiofs_socket)
-            .field("vfs_socket", &self.vfs_server.as_ref().map(SandboxFsServer::socket_path))
-            .field("vfs_9p_socket", &self.vfs_9p.as_ref().map(Vfs9pVsockServer::socket_path))
+            .field(
+                "vfs_socket",
+                &self.vfs_server.as_ref().map(SandboxFsServer::socket_path),
+            )
+            .field(
+                "vfs_9p_socket",
+                &self.vfs_9p.as_ref().map(Vfs9pVsockServer::socket_path),
+            )
             .field("rootfs_mount_tag", &self.rootfs_mount_tag())
             .finish_non_exhaustive()
     }
@@ -283,14 +292,12 @@ impl KataBackend {
 
         config.path = if pool_config.hypervisor_path.as_os_str().is_empty() {
             match pool_config.hypervisor {
-                HypervisorType::CloudHypervisor => {
-                    which::which("cloud-hypervisor")
-                        .map(|p| p.to_string_lossy().to_string())
-                        .unwrap_or_else(|e| {
-                            tracing::warn!("Failed to find cloud-hypervisor in PATH: {}", e);
-                            "cloud-hypervisor".to_owned()
-                        })
-                }
+                HypervisorType::CloudHypervisor => which::which("cloud-hypervisor")
+                    .map(|p| p.to_string_lossy().to_string())
+                    .unwrap_or_else(|e| {
+                        tracing::warn!("Failed to find cloud-hypervisor in PATH: {}", e);
+                        "cloud-hypervisor".to_owned()
+                    }),
                 #[cfg(feature = "dragonball")]
                 HypervisorType::Dragonball => String::new(),
             }
@@ -518,20 +525,26 @@ impl KataBackend {
         let meta_data_path = sandbox_runtime_dir.join("meta-data");
         tokio::fs::write(&meta_data_path, meta_data).await?;
 
-        let iso_path_str = iso_path
-            .to_str()
-            .ok_or_else(|| WorkerError::CloudInitFailed("ISO path contains invalid UTF-8".into()))?;
-        let user_data_str = user_data_path
-            .to_str()
-            .ok_or_else(|| WorkerError::CloudInitFailed("User data path contains invalid UTF-8".into()))?;
-        let meta_data_str = meta_data_path
-            .to_str()
-            .ok_or_else(|| WorkerError::CloudInitFailed("Meta data path contains invalid UTF-8".into()))?;
+        let iso_path_str = iso_path.to_str().ok_or_else(|| {
+            WorkerError::CloudInitFailed("ISO path contains invalid UTF-8".into())
+        })?;
+        let user_data_str = user_data_path.to_str().ok_or_else(|| {
+            WorkerError::CloudInitFailed("User data path contains invalid UTF-8".into())
+        })?;
+        let meta_data_str = meta_data_path.to_str().ok_or_else(|| {
+            WorkerError::CloudInitFailed("Meta data path contains invalid UTF-8".into())
+        })?;
 
         let status = tokio::process::Command::new("genisoimage")
             .args([
-                "-output", iso_path_str, "-volid", "cidata", "-joliet", "-rock",
-                user_data_str, meta_data_str,
+                "-output",
+                iso_path_str,
+                "-volid",
+                "cidata",
+                "-joliet",
+                "-rock",
+                user_data_str,
+                meta_data_str,
             ])
             .status()
             .await
@@ -827,7 +840,10 @@ impl SandboxBackend for KataBackend {
         use super::backend::{NamespaceDelivery, NamespaceTransport};
 
         let (socket_path, mount_tag) = match transport {
-            NamespaceTransport::VirtioFs { socket_path, mount_tag } => (socket_path, mount_tag),
+            NamespaceTransport::VirtioFs {
+                socket_path,
+                mount_tag,
+            } => (socket_path, mount_tag),
             other => {
                 return Err(WorkerError::Unsupported(format!(
                     "kata backend only supports the VirtioFs namespace transport, got {other:?}"
@@ -844,7 +860,9 @@ impl SandboxBackend for KataBackend {
         let socket_for_serve = socket_path.clone();
         let server = tokio::task::spawn_blocking(move || sandbox_fs.serve_on(socket_for_serve, rt))
             .await
-            .map_err(|e| WorkerError::SandboxCreationFailed(format!("VFS serve task join: {e}")))??;
+            .map_err(|e| {
+                WorkerError::SandboxCreationFailed(format!("VFS serve task join: {e}"))
+            })??;
 
         // Hot-attach when a hypervisor handle already exists for this sandbox
         // (VM already prepared/running). If the sandbox hasn't started yet,
@@ -853,8 +871,13 @@ impl SandboxBackend for KataBackend {
         // own compose-then-attach ordering).
         if let Some(handle) = sandbox.backend_handle.as_ref() {
             if let Some(kata) = handle.as_any().downcast_ref::<KataHandle>() {
-                Self::attach_share_fs(&kata.hypervisor, &sandbox.id, server.socket_path(), &mount_tag)
-                    .await?;
+                Self::attach_share_fs(
+                    &kata.hypervisor,
+                    &sandbox.id,
+                    server.socket_path(),
+                    &mount_tag,
+                )
+                .await?;
                 // #742: record the delivered share's tag as the container
                 // rootfs tag on the (already-`Arc`-shared) `KataHandle` via
                 // interior mutability. The delivered namespace is the fully
@@ -951,11 +974,17 @@ impl SandboxBackend for KataBackend {
                     // concurrent exec on another task may already have swapped
                     // in a fresh client, and clearing that one would discard a
                     // good connection.
-                    if guard.as_ref().map(|c| Arc::ptr_eq(c, &client)).unwrap_or(false) {
+                    if guard
+                        .as_ref()
+                        .map(|c| Arc::ptr_eq(c, &client))
+                        .unwrap_or(false)
+                    {
                         *guard = None;
                     }
                 }
-                Err(WorkerError::ExecFailed(format!("kata-agent exec failed: {e:#}")))
+                Err(WorkerError::ExecFailed(format!(
+                    "kata-agent exec failed: {e:#}"
+                )))
             }
         }
     }
@@ -979,9 +1008,12 @@ impl SandboxBackend for KataBackend {
         let handle = sandbox.backend_handle.as_ref().ok_or_else(|| {
             WorkerError::Internal("update_resources: sandbox has no backend handle".into())
         })?;
-        let kata = handle.as_any().downcast_ref::<KataHandle>().ok_or_else(|| {
-            WorkerError::Internal("update_resources: backend handle is not a KataHandle".into())
-        })?;
+        let kata = handle
+            .as_any()
+            .downcast_ref::<KataHandle>()
+            .ok_or_else(|| {
+                WorkerError::Internal("update_resources: backend handle is not a KataHandle".into())
+            })?;
 
         let client = self.guest_agent_client(kata).await?;
         let container_id = sandbox.id.clone();
@@ -1149,12 +1181,13 @@ impl KataBackend {
             .get_agent_socket()
             .await
             .map_err(|e| WorkerError::ExecFailed(format!("get_agent_socket failed: {e}")))?;
-        let address = AgentAddress::parse(&address)
-            .map_err(|e| WorkerError::ExecFailed(format!("unparseable agent socket address: {e}")))?;
+        let address = AgentAddress::parse(&address).map_err(|e| {
+            WorkerError::ExecFailed(format!("unparseable agent socket address: {e}"))
+        })?;
 
-        let client = KataAgentClient::connect(&address)
-            .await
-            .map_err(|e| WorkerError::ExecFailed(format!("failed to connect to kata-agent: {e:#}")))?;
+        let client = KataAgentClient::connect(&address).await.map_err(|e| {
+            WorkerError::ExecFailed(format!("failed to connect to kata-agent: {e:#}"))
+        })?;
         let client = Arc::new(client);
         *guard = Some(Arc::clone(&client));
         Ok(client)
@@ -1226,8 +1259,13 @@ impl KataBackend {
         // initiated, CH-multiplexer) direction; using it here would consume the
         // guest's first 9P `Tversion` bytes and break the handshake.
         let task = tokio::spawn(async move {
-            if let Err(e) =
-                hyprstream_9p::serve_mount_vsock_raw(mount, subject, &sock_for_task).await
+            if let Err(e) = hyprstream_9p::serve_mount_vsock_raw(
+                mount,
+                subject,
+                Arc::new(hyprstream_9p::DenyAllDecider),
+                &sock_for_task,
+            )
+            .await
             {
                 tracing::warn!(
                     sandbox_id = %sandbox_id,
@@ -1458,7 +1496,11 @@ mod tests {
             .expect("deliver_namespace should serve the namespace");
 
         match result {
-            NamespaceDelivery::VirtioFs { socket_path: served, mount_tag, guard } => {
+            NamespaceDelivery::VirtioFs {
+                socket_path: served,
+                mount_tag,
+                guard,
+            } => {
                 assert_eq!(served, socket_path);
                 assert_eq!(mount_tag, "hyprstream-vfs");
                 assert!(guard.is_some(), "kata should return a serving-thread guard");
@@ -1493,7 +1535,10 @@ mod tests {
 
         // Re-delivery re-roots the container: last write wins.
         handle.record_rootfs_mount_tag("re-delivered-tag".to_owned());
-        assert_eq!(handle.rootfs_mount_tag().as_deref(), Some("re-delivered-tag"));
+        assert_eq!(
+            handle.rootfs_mount_tag().as_deref(),
+            Some("re-delivered-tag")
+        );
     }
 
     #[tokio::test]
@@ -1544,7 +1589,10 @@ mod tests {
             .exec_sync(&sandbox, &["echo".into(), "hello".into()], 1)
             .await;
 
-        assert!(result.is_err(), "exec against an unprepared VM must fail, not hang");
+        assert!(
+            result.is_err(),
+            "exec against an unprepared VM must fail, not hang"
+        );
     }
 
     #[tokio::test]
@@ -1589,7 +1637,10 @@ mod tests {
             backend.exec_sync(&sandbox, &["echo".into(), "hi".into()], 1),
         )
         .await;
-        assert!(result.is_ok(), "exec_sync against a dead cached client must not hang");
+        assert!(
+            result.is_ok(),
+            "exec_sync against a dead cached client must not hang"
+        );
         assert!(
             result.unwrap().is_err(),
             "exec against a dead cached client must fail, not silently succeed"
@@ -1602,7 +1653,6 @@ mod tests {
             "cached dead agent client must be cleared on exec failure"
         );
     }
-
 
     #[test]
     fn test_is_available() {
@@ -1828,7 +1878,10 @@ mod tests {
 
         // virtiofs socket should be cleared on reset (the composed VFS server
         // is not reused; a recycled sandbox composes a fresh one on next start).
-        assert!(kata.virtiofs_socket.is_none(), "virtiofs_socket should be cleared");
+        assert!(
+            kata.virtiofs_socket.is_none(),
+            "virtiofs_socket should be cleared"
+        );
 
         // api_socket should be preserved
         assert_eq!(kata.api_socket, sandbox_path.join("test.sock"));
@@ -1842,8 +1895,14 @@ mod tests {
     fn test_debug_impl() {
         let (backend, _, _temp) = create_test_backend();
         let debug = format!("{backend:?}");
-        assert!(debug.contains("KataBackend"), "debug should contain struct name");
-        assert!(debug.contains("image_config"), "debug should contain image_config field");
+        assert!(
+            debug.contains("KataBackend"),
+            "debug should contain struct name"
+        );
+        assert!(
+            debug.contains("image_config"),
+            "debug should contain image_config field"
+        );
     }
 
     // ─────────────────────────────────────────────────────────────────────
@@ -1905,7 +1964,9 @@ mod tests {
         mem_data.limit = 4000;
         let mut mem_stats = agent::MemoryStats::new();
         mem_stats.usage = protobuf::MessageField::some(mem_data);
-        mem_stats.stats.insert("total_inactive_file".to_owned(), 200);
+        mem_stats
+            .stats
+            .insert("total_inactive_file".to_owned(), 200);
         mem_stats.stats.insert("total_rss".to_owned(), 700);
         mem_stats.stats.insert("total_pgfault".to_owned(), 42);
         mem_stats.stats.insert("total_pgmajfault".to_owned(), 7);

--- a/crates/hyprstream-workers/src/runtime/kata_backend.rs
+++ b/crates/hyprstream-workers/src/runtime/kata_backend.rs
@@ -269,13 +269,19 @@ impl std::fmt::Debug for Vfs9pVsockServer {
 pub struct KataBackend {
     image_config: ImageConfig,
     rafs_store: Arc<RafsStore>,
+    ninep_decider: Arc<dyn hyprstream_9p::AccessDecider>,
 }
 
 impl KataBackend {
-    pub fn new(image_config: ImageConfig, rafs_store: Arc<RafsStore>) -> Self {
+    pub fn new(
+        image_config: ImageConfig,
+        rafs_store: Arc<RafsStore>,
+        ninep_decider: Arc<dyn hyprstream_9p::AccessDecider>,
+    ) -> Self {
         Self {
             image_config,
             rafs_store,
+            ninep_decider,
         }
     }
 
@@ -699,7 +705,15 @@ impl SandboxBackend for KataBackend {
         // boots from is unaffected).
         let mut vfs_9p: Option<Vfs9pVsockServer> = None;
         if let Some((tenant_mount, subject)) = tenant_vfs {
-            match Self::serve_tenant_vfs_9p(&hypervisor, &sandbox.id, tenant_mount, subject).await {
+            match Self::serve_tenant_vfs_9p(
+                &hypervisor,
+                &sandbox.id,
+                tenant_mount,
+                subject,
+                Arc::clone(&self.ninep_decider),
+            )
+            .await
+            {
                 Ok(server) => vfs_9p = Some(server),
                 Err(e) => tracing::warn!(
                     sandbox_id = %sandbox.id,
@@ -1210,6 +1224,7 @@ impl KataBackend {
         sandbox_id: &str,
         mount: Arc<dyn Mount>,
         subject: Subject,
+        decider: Arc<dyn hyprstream_9p::AccessDecider>,
     ) -> Result<Vfs9pVsockServer> {
         // The CH hybrid-vsock base UDS (`hvsock://<base>`), same source the
         // kata-agent client uses — keeps CH/Dragonball working without a branch.
@@ -1262,7 +1277,7 @@ impl KataBackend {
             if let Err(e) = hyprstream_9p::serve_mount_vsock_raw(
                 mount,
                 subject,
-                Arc::new(hyprstream_9p::DenyAllDecider),
+                decider,
                 &sock_for_task,
             )
             .await
@@ -1317,6 +1332,7 @@ inventory::submit! {
             Ok(Arc::new(KataBackend::new(
                 ctx.image_config.clone(),
                 Arc::clone(&ctx.rafs_store),
+                Arc::clone(&ctx.ninep_decider),
             )) as Arc<dyn crate::runtime::SandboxBackend>)
         },
     }
@@ -1329,7 +1345,21 @@ mod tests {
     use crate::config::{ImageConfig, PoolConfig};
     use crate::error::WorkerError;
     use crate::image::RafsStore;
+    use hyprstream_rpc::auth::mac::{ObjectRef, SecurityContext};
     use tempfile::TempDir;
+
+    struct FixtureAccessDecider;
+
+    impl hyprstream_9p::AccessDecider for FixtureAccessDecider {
+        fn check(
+            &self,
+            _ctx: &SecurityContext,
+            _object: ObjectRef<'_>,
+            _action: hyprstream_9p::Action,
+        ) -> bool {
+            true
+        }
+    }
 
     #[test]
     fn vfs_9p_vsock_port_distinct_from_agent() {
@@ -1379,7 +1409,11 @@ mod tests {
         std::fs::create_dir_all(&image_config.cache_dir).unwrap();
 
         let rafs_store = Arc::new(RafsStore::new(image_config.clone()).unwrap());
-        let backend = KataBackend::new(image_config, Arc::clone(&rafs_store));
+        let backend = KataBackend::new(
+            image_config,
+            Arc::clone(&rafs_store),
+            Arc::new(FixtureAccessDecider),
+        );
         (backend, rafs_store, temp_dir)
     }
 

--- a/crates/hyprstream-workers/src/runtime/pool.rs
+++ b/crates/hyprstream-workers/src/runtime/pool.rs
@@ -519,7 +519,21 @@ mod tests {
     use crate::config::{ImageConfig, PoolConfig};
     use crate::image::RafsStore;
     use crate::runtime::kata_backend::KataBackend;
+    use hyprstream_rpc::auth::mac::{ObjectRef, SecurityContext};
     use tempfile::TempDir;
+
+    struct FixtureAccessDecider;
+
+    impl hyprstream_9p::AccessDecider for FixtureAccessDecider {
+        fn check(
+            &self,
+            _ctx: &SecurityContext,
+            _object: ObjectRef<'_>,
+            _action: hyprstream_9p::Action,
+        ) -> bool {
+            true
+        }
+    }
 
     /// Create a test pool with Kata backend and minimal configuration
     async fn create_test_pool(
@@ -553,8 +567,11 @@ mod tests {
         std::fs::create_dir_all(&pool_config.runtime_dir)?;
 
         let rafs_store = Arc::new(RafsStore::new(image_config.clone())?);
-        let backend: Arc<dyn SandboxBackend> =
-            Arc::new(KataBackend::new(image_config, rafs_store));
+        let backend: Arc<dyn SandboxBackend> = Arc::new(KataBackend::new(
+            image_config,
+            rafs_store,
+            Arc::new(FixtureAccessDecider),
+        ));
         let pool = Arc::new(SandboxPool::new(pool_config, backend));
 
         Ok((pool, temp_dir))

--- a/crates/hyprstream-workers/src/runtime/selection.rs
+++ b/crates/hyprstream-workers/src/runtime/selection.rs
@@ -71,6 +71,11 @@ pub struct BackendCtx {
     /// Sandbox pool configuration (paths, hypervisor, limits).
     pub pool_config: PoolConfig,
 
+    /// Mandatory resolver-backed, audited policy-enforcement point for every
+    /// 9P export constructed by a backend.
+    #[cfg(not(target_arch = "wasm32"))]
+    pub ninep_decider: Arc<dyn hyprstream_9p::AccessDecider>,
+
     /// Image storage configuration. Any backend that composes the RAFS image
     /// filesystem (kata over virtio-fs, or nspawn over FUSE — Model B #715)
     /// consumes it, so it exists on the `oci-image` build, not just `kata-vm`.

--- a/crates/hyprstream-workers/src/runtime/service.rs
+++ b/crates/hyprstream-workers/src/runtime/service.rs
@@ -1467,9 +1467,23 @@ mod tests {
     use crate::config::ImageConfig;
     use crate::image::RafsStore;
     use crate::runtime::{PodSandboxConfig, PodSandboxState, ContainerConfig};
+    use hyprstream_rpc::auth::mac::{ObjectRef, SecurityContext};
     use hyprstream_rpc::crypto::generate_signing_keypair;
     use hyprstream_rpc::transport::TransportConfig;
     use tempfile::TempDir;
+
+    struct FixtureAccessDecider;
+
+    impl hyprstream_9p::AccessDecider for FixtureAccessDecider {
+        fn check(
+            &self,
+            _ctx: &SecurityContext,
+            _object: ObjectRef<'_>,
+            _action: hyprstream_9p::Action,
+        ) -> bool {
+            true
+        }
+    }
 
     /// Create a test WorkerService with temporary directories
     async fn create_test_service() -> std::result::Result<(WorkerService, TempDir), Box<dyn std::error::Error>> {
@@ -1512,7 +1526,11 @@ mod tests {
         let (signing_key, _verifying_key) = generate_signing_keypair();
 
         let backend: Arc<dyn crate::runtime::backend::SandboxBackend> = Arc::new(
-            crate::runtime::kata_backend::KataBackend::new(image_config, Arc::clone(&rafs_store)),
+            crate::runtime::kata_backend::KataBackend::new(
+                image_config,
+                Arc::clone(&rafs_store),
+                Arc::new(FixtureAccessDecider),
+            ),
         );
         let service = WorkerService::new(pool_config, backend, Some(rafs_store), transport, signing_key)?;
         Ok((service, temp_dir))

--- a/crates/hyprstream-workers/src/runtime/wanix_workload.rs
+++ b/crates/hyprstream-workers/src/runtime/wanix_workload.rs
@@ -288,6 +288,7 @@ impl WanixInjection {
 pub async fn inject_9p_socket(
     mount: Arc<dyn Mount>,
     subject: Subject,
+    decider: Arc<dyn hyprstream_9p::AccessDecider>,
     workload_dir: &Path,
     guest_cfg: &WanixGuestConfig,
 ) -> Result<WanixInjection> {
@@ -315,13 +316,9 @@ pub async fn inject_9p_socket(
     let task = tokio::spawn(async move {
         // `serve_uds` is PR-A's wire-faithful 9P2000.L server; it runs until the
         // socket errors/closes (or the task is aborted on teardown).
-        if let Err(e) = hyprstream_9p::Translator::from_mount(
-            mount,
-            subject,
-            Arc::new(hyprstream_9p::DenyAllDecider),
-        )
-        .serve_uds(listener)
-        .await
+        if let Err(e) = hyprstream_9p::Translator::from_mount(mount, subject, decider)
+            .serve_uds(listener)
+            .await
         {
             warn!(socket = %sock_for_log.display(), error = %e, "9P workload server exited with error");
         }
@@ -537,11 +534,12 @@ pub async fn prepare_wanix_workload(
     backend_type: &str,
     mount: Arc<dyn Mount>,
     subject: Subject,
+    decider: Arc<dyn hyprstream_9p::AccessDecider>,
     workload_dir: &Path,
     guest_cfg: &WanixGuestConfig,
 ) -> Result<WanixInjection> {
     super::require_9p_socket_capability(backend_type)?;
-    inject_9p_socket(mount, subject, workload_dir, guest_cfg).await
+    inject_9p_socket(mount, subject, decider, workload_dir, guest_cfg).await
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -558,9 +556,8 @@ mod tests {
 
     /// Explicitly test-only policy for the loopback guest-export fixture.
     ///
-    /// Production worker-hosted translators remain fail-closed until the
-    /// concrete resolver-backed decider can be injected across this crate
-    /// boundary.
+    /// Production callers must inject the resolver-backed, audited decider;
+    /// this permit policy exists only to exercise the transport fixture.
     struct FixtureAccessDecider;
 
     impl hyprstream_9p::AccessDecider for FixtureAccessDecider {
@@ -605,9 +602,15 @@ mod tests {
         let cfg = WanixGuestConfig {
             guest_bin: PathBuf::from("/host/build/wanix-guest"),
         };
-        let inj = inject_9p_socket(tenant_mount(), Subject::anonymous(), dir.path(), &cfg)
-            .await
-            .unwrap();
+        let inj = inject_9p_socket(
+            tenant_mount(),
+            Subject::anonymous(),
+            Arc::new(FixtureAccessDecider),
+            dir.path(),
+            &cfg,
+        )
+        .await
+        .unwrap();
 
         // (a) socket exists on return (bound synchronously) — the bind-mount
         // source is ready before any sandbox start.
@@ -742,13 +745,15 @@ mod tests {
 
     #[tokio::test]
     async fn injected_socket_is_a_live_9p_server() {
-        // The spawned task actually serves 9P: a client that connects and sends
-        // a Tversion gets a well-formed Rversion back. Proves (b) wired the real
-        // PR-A server to the tenant Mount, not just created an empty socket.
+        // The spawned task actually serves 9P through attach, the first
+        // policy-controlled operation. Stopping at Rversion would miss a
+        // deny-all policy outage because negotiation is intentionally
+        // unauthenticated.
         let dir = tempfile::tempdir().unwrap();
         let inj = inject_9p_socket(
             tenant_mount(),
             Subject::anonymous(),
+            Arc::new(FixtureAccessDecider),
             dir.path(),
             &WanixGuestConfig::default(),
         )
@@ -756,31 +761,48 @@ mod tests {
         .unwrap();
 
         let sock = inj.server.socket_path().to_path_buf();
-        // Connect + do a minimal 9P2000.L version handshake.
+        // Connect, negotiate 9P2000.L, then attach to the exported root.
         let reply = tokio::task::spawn_blocking(move || {
             use std::io::{Read, Write};
-            let mut c = StdUnixStream::connect(&sock).unwrap();
-            // Tversion: size[4] type[1]=100 tag[2]=0xFFFF msize[4] version[s]
-            let version = b"9P2000.L";
-            let mut msg = Vec::new();
-            let body_len = 4 + 1 + 2 + 4 + 2 + version.len();
-            msg.extend_from_slice(&(body_len as u32).to_le_bytes());
-            msg.push(100); // Tversion
-            msg.extend_from_slice(&0xFFFFu16.to_le_bytes());
-            msg.extend_from_slice(&8192u32.to_le_bytes());
-            msg.extend_from_slice(&(version.len() as u16).to_le_bytes());
-            msg.extend_from_slice(version);
-            c.write_all(&msg).unwrap();
 
-            let mut hdr = [0u8; 5];
-            c.read_exact(&mut hdr).unwrap();
-            hdr[4] // message type byte
+            fn read_frame(stream: &mut StdUnixStream) -> Vec<u8> {
+                let mut len = [0u8; 4];
+                stream.read_exact(&mut len).unwrap();
+                let total = u32::from_le_bytes(len) as usize;
+                let mut frame = vec![0u8; total];
+                frame[..4].copy_from_slice(&len);
+                stream.read_exact(&mut frame[4..]).unwrap();
+                frame
+            }
+
+            let mut c = StdUnixStream::connect(&sock).unwrap();
+            c.write_all(&hyprstream_9p::msg::tversion(1, 8192, "9P2000.L"))
+                .unwrap();
+            let version = read_frame(&mut c);
+            assert_eq!(
+                version[4],
+                hyprstream_9p::msg::RVERSION,
+                "expected Rversion from the injected 9P server"
+            );
+
+            c.write_all(&hyprstream_9p::msg::tattach(
+                2,
+                0,
+                u32::MAX,
+                "wanix",
+                "",
+            ))
+            .unwrap();
+            read_frame(&mut c)[4]
         })
         .await
         .unwrap();
 
-        // Rversion == 101 (Tversion 100 + 1).
-        assert_eq!(reply, 101, "expected Rversion from the injected 9P server");
+        assert_eq!(
+            reply,
+            hyprstream_9p::msg::RATTACH,
+            "expected Rattach from the injected 9P server"
+        );
     }
 
     #[tokio::test]
@@ -789,6 +811,7 @@ mod tests {
         let inj = inject_9p_socket(
             tenant_mount(),
             Subject::anonymous(),
+            Arc::new(FixtureAccessDecider),
             dir.path(),
             &WanixGuestConfig::default(),
         )
@@ -811,6 +834,7 @@ mod tests {
             "kata",
             tenant_mount(),
             Subject::anonymous(),
+            Arc::new(FixtureAccessDecider),
             dir.path(),
             &WanixGuestConfig::default(),
         )
@@ -833,6 +857,7 @@ mod tests {
             "nspawn",
             tenant_mount(),
             Subject::anonymous(),
+            Arc::new(FixtureAccessDecider),
             dir.path(),
             &WanixGuestConfig::default(),
         )

--- a/crates/hyprstream-workers/src/runtime/wanix_workload.rs
+++ b/crates/hyprstream-workers/src/runtime/wanix_workload.rs
@@ -309,18 +309,19 @@ pub async fn inject_9p_socket(
     // (b) Bind the listener *now* (socket file exists on return), then spawn the
     // 9P serve loop in the background over that tenant's Subject-scoped Mount.
     let listener = UnixListener::bind(&socket_path).map_err(|e| {
-        WorkerError::SandboxCreationFailed(format!(
-            "bind 9P UDS at {}: {e}",
-            socket_path.display()
-        ))
+        WorkerError::SandboxCreationFailed(format!("bind 9P UDS at {}: {e}", socket_path.display()))
     })?;
     let sock_for_log = socket_path.clone();
     let task = tokio::spawn(async move {
         // `serve_uds` is PR-A's wire-faithful 9P2000.L server; it runs until the
         // socket errors/closes (or the task is aborted on teardown).
-        if let Err(e) = hyprstream_9p::Translator::from_mount(mount, subject)
-            .serve_uds(listener)
-            .await
+        if let Err(e) = hyprstream_9p::Translator::from_mount(
+            mount,
+            subject,
+            Arc::new(hyprstream_9p::DenyAllDecider),
+        )
+        .serve_uds(listener)
+        .await
         {
             warn!(socket = %sock_for_log.display(), error = %e, "9P workload server exited with error");
         }
@@ -358,12 +359,14 @@ pub async fn inject_9p_socket(
     // container, that socket appears on the host at `export_socket_path`, which
     // the host later dials via [`import_guest_namespace`].
     let host_export_dir = workload_dir.join(GUEST_EXPORT_DIR_NAME);
-    tokio::fs::create_dir_all(&host_export_dir).await.map_err(|e| {
-        WorkerError::SandboxCreationFailed(format!(
-            "create guest export dir {}: {e}",
-            host_export_dir.display()
-        ))
-    })?;
+    tokio::fs::create_dir_all(&host_export_dir)
+        .await
+        .map_err(|e| {
+            WorkerError::SandboxCreationFailed(format!(
+                "create guest export dir {}: {e}",
+                host_export_dir.display()
+            ))
+        })?;
     let export_socket_path = host_export_dir.join(GUEST_EXPORT_SOCKET_NAME);
     // Remove any stale export socket left by a crashed predecessor guest.
     if let Err(e) = tokio::fs::remove_file(&export_socket_path).await {
@@ -566,7 +569,10 @@ mod tests {
         std::env::remove_var(ENV_GUEST_BIN);
         let cfg = WanixGuestConfig::default();
         assert_eq!(cfg.guest_bin, PathBuf::from(DEFAULT_GUEST_BIN));
-        assert!(cfg.guest_bin.is_relative(), "default must not be an absolute hardcode");
+        assert!(
+            cfg.guest_bin.is_relative(),
+            "default must not be an absolute hardcode"
+        );
 
         std::env::set_var(ENV_GUEST_BIN, "/opt/custom/wanix-guest");
         let cfg = WanixGuestConfig::default();
@@ -580,24 +586,24 @@ mod tests {
         let cfg = WanixGuestConfig {
             guest_bin: PathBuf::from("/host/build/wanix-guest"),
         };
-        let inj = inject_9p_socket(
-            tenant_mount(),
-            Subject::anonymous(),
-            dir.path(),
-            &cfg,
-        )
-        .await
-        .unwrap();
+        let inj = inject_9p_socket(tenant_mount(), Subject::anonymous(), dir.path(), &cfg)
+            .await
+            .unwrap();
 
         // (a) socket exists on return (bound synchronously) — the bind-mount
         // source is ready before any sandbox start.
         let sock = dir.path().join(NINEP_SOCKET_NAME);
-        assert!(sock.exists(), "9P socket must exist immediately after inject");
+        assert!(
+            sock.exists(),
+            "9P socket must exist immediately after inject"
+        );
         assert_eq!(inj.server.socket_path(), sock.as_path());
 
         // (c) env points the guest at the in-container socket.
         assert_eq!(
-            inj.annotations.get(&format!("{ANN_ENV_PREFIX}{ENV_9P_SOCK}")).map(String::as_str),
+            inj.annotations
+                .get(&format!("{ANN_ENV_PREFIX}{ENV_9P_SOCK}"))
+                .map(String::as_str),
             Some(CTR_SOCK_PATH)
         );
         // socket bind: host abs path → container path, rw.
@@ -611,7 +617,9 @@ mod tests {
         );
         // guest binary bind uses the CONFIGURED host path (read-only).
         assert_eq!(
-            inj.annotations.get(&format!("{ANN_MOUNT_PREFIX}wanix-guest")).map(String::as_str),
+            inj.annotations
+                .get(&format!("{ANN_MOUNT_PREFIX}wanix-guest"))
+                .map(String::as_str),
             Some(format!("/host/build/wanix-guest:{CTR_GUEST_BIN_PATH}:ro").as_str())
         );
         // command runs the guest.
@@ -623,9 +631,13 @@ mod tests {
         // Direction B (#708 phase 2): shared export dir bound rw, export env set,
         // and the host-side export socket path exposed under the shared dir.
         let export_dir = dir.path().join(GUEST_EXPORT_DIR_NAME);
-        assert!(export_dir.is_dir(), "shared export dir must be created on inject");
+        assert!(
+            export_dir.is_dir(),
+            "shared export dir must be created on inject"
+        );
         assert_eq!(
-            inj.annotations.get(&format!("{ANN_MOUNT_PREFIX}wanix-export-dir")),
+            inj.annotations
+                .get(&format!("{ANN_MOUNT_PREFIX}wanix-export-dir")),
             Some(&format!("{}:{CTR_EXPORT_DIR}:rw", export_dir.display()))
         );
         assert_eq!(
@@ -651,9 +663,13 @@ mod tests {
         let sock = dir.path().join("guest-export.sock");
         let listener = UnixListener::bind(&sock).unwrap();
         let server = tokio::spawn(async move {
-            let _ = hyprstream_9p::Translator::from_mount(tenant_mount(), Subject::anonymous())
-                .serve_uds(listener)
-                .await;
+            let _ = hyprstream_9p::Translator::from_mount(
+                tenant_mount(),
+                Subject::anonymous(),
+                Arc::new(hyprstream_9p::DenyAllDecider),
+            )
+            .serve_uds(listener)
+            .await;
         });
 
         let mut host_ns = Namespace::new();
@@ -666,7 +682,10 @@ mod tests {
             .cat("/workers/t1/wanix/hello", &Subject::anonymous())
             .await
             .unwrap();
-        assert_eq!(data, b"hi\n", "host must read the guest's file over the imported 9P mount");
+        assert_eq!(
+            data, b"hi\n",
+            "host must read the guest's file over the imported 9P mount"
+        );
 
         imported.unmount(&mut host_ns);
         assert!(
@@ -692,8 +711,14 @@ mod tests {
         )
         .await
         .unwrap_err();
-        assert!(err.to_string().contains("could not import guest namespace"), "got: {err}");
-        assert!(host_ns.mount_prefixes().is_empty(), "nothing must be bound on failure");
+        assert!(
+            err.to_string().contains("could not import guest namespace"),
+            "got: {err}"
+        );
+        assert!(
+            host_ns.mount_prefixes().is_empty(),
+            "nothing must be bound on failure"
+        );
     }
 
     #[tokio::test]
@@ -753,7 +778,10 @@ mod tests {
         let sock = inj.server.socket_path().to_path_buf();
         assert!(sock.exists());
         drop(inj);
-        assert!(!sock.exists(), "socket must be removed when the server is dropped");
+        assert!(
+            !sock.exists(),
+            "socket must be removed when the server is dropped"
+        );
     }
 
     #[tokio::test]
@@ -769,7 +797,10 @@ mod tests {
         )
         .await
         .unwrap_err();
-        assert!(err.to_string().contains("cannot inject a 9P socket"), "got: {err}");
+        assert!(
+            err.to_string().contains("cannot inject a 9P socket"),
+            "got: {err}"
+        );
         // And no socket was created (fail-closed BEFORE any side effect).
         assert!(!dir.path().join(NINEP_SOCKET_NAME).exists());
     }

--- a/crates/hyprstream-workers/src/runtime/wanix_workload.rs
+++ b/crates/hyprstream-workers/src/runtime/wanix_workload.rs
@@ -552,8 +552,27 @@ pub async fn prepare_wanix_workload(
 #[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {
     use super::*;
+    use hyprstream_rpc::auth::mac::{ObjectRef, SecurityContext};
     use hyprstream_vfs::injected::{SyntheticMount, SyntheticNode};
     use std::os::unix::net::UnixStream as StdUnixStream;
+
+    /// Explicitly test-only policy for the loopback guest-export fixture.
+    ///
+    /// Production worker-hosted translators remain fail-closed until the
+    /// concrete resolver-backed decider can be injected across this crate
+    /// boundary.
+    struct FixtureAccessDecider;
+
+    impl hyprstream_9p::AccessDecider for FixtureAccessDecider {
+        fn check(
+            &self,
+            _ctx: &SecurityContext,
+            _object: ObjectRef<'_>,
+            _action: hyprstream_9p::Action,
+        ) -> bool {
+            true
+        }
+    }
 
     fn tenant_mount() -> Arc<dyn Mount> {
         // A trivial Subject-scoped tree stands in for a composed tenant namespace.
@@ -666,7 +685,7 @@ mod tests {
             let _ = hyprstream_9p::Translator::from_mount(
                 tenant_mount(),
                 Subject::anonymous(),
-                Arc::new(hyprstream_9p::DenyAllDecider),
+                Arc::new(FixtureAccessDecider),
             )
             .serve_uds(listener)
             .await;

--- a/crates/hyprstream-workers/tests/kata_9p_vsock_e2e.rs
+++ b/crates/hyprstream-workers/tests/kata_9p_vsock_e2e.rs
@@ -66,10 +66,20 @@ use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
+use hyprstream_9p::{AccessDecider, Action};
+use hyprstream_rpc::auth::mac::{ObjectRef, SecurityContext};
 use hyprstream_workers::runtime::{KataBackend, PodSandbox, PodSandboxConfig, SandboxBackend};
 use hyprstream_workers::{HypervisorType, ImageConfig, PoolConfig, RafsStore};
 
 type TestResult = Result<(), Box<dyn std::error::Error>>;
+
+struct FixtureAccessDecider;
+
+impl AccessDecider for FixtureAccessDecider {
+    fn check(&self, _ctx: &SecurityContext, _object: ObjectRef<'_>, _action: Action) -> bool {
+        true
+    }
+}
 
 /// In-guest path to the staged `hypr9p-guest` binary, overridable so the
 /// operator can stage it wherever the rootfs puts it.
@@ -204,7 +214,11 @@ async fn kata_9p_vsock_e2e() -> TestResult {
     // on VFS_9P_VSOCK_PORT (564).
     // ─────────────────────────────────────────────────────────────────────
     let pool_config = pool_config_for(&pre, runtime_dir.clone());
-    let backend = KataBackend::new(image_config, Arc::clone(&rafs_store));
+    let backend = KataBackend::new(
+        image_config,
+        Arc::clone(&rafs_store),
+        Arc::new(FixtureAccessDecider),
+    );
 
     assert!(
         backend.is_available(),
@@ -377,7 +391,11 @@ async fn kata_9p_fuse_mount_e2e() -> TestResult {
     let (image_config, rafs_store) = image_store(scratch.path())?;
 
     let pool_config = pool_config_for(&pre, runtime_dir.clone());
-    let backend = KataBackend::new(image_config, Arc::clone(&rafs_store));
+    let backend = KataBackend::new(
+        image_config,
+        Arc::clone(&rafs_store),
+        Arc::new(FixtureAccessDecider),
+    );
     assert!(
         backend.is_available(),
         "cloud-hypervisor was on PATH at preflight but backend reports unavailable"

--- a/crates/hyprstream-workers/tests/kata_spawn_e2e.rs
+++ b/crates/hyprstream-workers/tests/kata_spawn_e2e.rs
@@ -70,10 +70,20 @@ use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
+use hyprstream_9p::{AccessDecider, Action};
+use hyprstream_rpc::auth::mac::{ObjectRef, SecurityContext};
 use hyprstream_workers::runtime::{KataBackend, PodSandbox, PodSandboxConfig, SandboxBackend};
 use hyprstream_workers::{HypervisorType, ImageConfig, PoolConfig, RafsStore};
 
 type TestResult = Result<(), Box<dyn std::error::Error>>;
+
+struct FixtureAccessDecider;
+
+impl AccessDecider for FixtureAccessDecider {
+    fn check(&self, _ctx: &SecurityContext, _object: ObjectRef<'_>, _action: Action) -> bool {
+        true
+    }
+}
 
 /// Resolved preflight inputs for a real spawn.
 struct Preflight {
@@ -241,7 +251,11 @@ async fn kata_spawn_e2e() -> TestResult {
     // Boot the microVM via the real backend path.
     // ─────────────────────────────────────────────────────────────────────
     let pool_config = pool_config_for(&pre, runtime_dir.clone());
-    let backend = KataBackend::new(image_config, Arc::clone(&rafs_store));
+    let backend = KataBackend::new(
+        image_config,
+        Arc::clone(&rafs_store),
+        Arc::new(FixtureAccessDecider),
+    );
 
     assert!(
         backend.is_available(),

--- a/crates/hyprstream/src/bin/main.rs
+++ b/crates/hyprstream/src/bin/main.rs
@@ -1166,8 +1166,17 @@ fn handle_quick_command(
                             .as_ref()
                             .map(|w| w.backend.clone())
                             .unwrap_or_else(|| "auto".to_owned());
+                        let ninep_decider =
+                            hyprstream_core::mac::production_ninep_decider(
+                                signing_key.clone(),
+                                &ctx.config().oauth,
+                                "ninep-worker",
+                            )
+                            .await
+                            .context("construct worker 9P MAC PEP")?;
                         let backend_ctx = BackendCtx {
                             pool_config: pool_config.clone(),
+                            ninep_decider,
                             #[cfg(feature = "oci-image")]
                             image_config,
                             #[cfg(feature = "oci-image")]

--- a/crates/hyprstream/src/bin/main.rs
+++ b/crates/hyprstream/src/bin/main.rs
@@ -1993,9 +1993,8 @@ fn main() -> Result<()> {
                     // foreground (the mode that actually hosts services, incl.
                     // systemd ExecStart and standalone-spawned children),
                     // standalone, and the systemd/spawner dispatch below.
-                    // DORMANT — this only emits the activation coverage-gate
-                    // evidence (which nodes are labeled / would deny); it flips
-                    // no decider to enforcing (see `mac::genesis`).
+                    // Emit the coverage-gate evidence consumed by the active
+                    // 9P translator PEP (see `mac::genesis`).
                     hyprstream_core::mac::GenesisGate::production().log_report();
 
                     if foreground || standalone {
@@ -2406,10 +2405,8 @@ fn main() -> Result<()> {
                                     // `DenyUnlabeledResolver` to the real (#698)
                                     // `EnrollmentSubjectContextResolver`.
                                     //
-                                    // DORMANT: installing a compiled policy does NOT
-                                    // enable enforcement — the per-op deciders stay
-                                    // AllowAll (no PEP consults this PDP yet). It only
-                                    // makes the PDP inputs real.
+                                    // The 9P PEP is active and records the
+                                    // bootloaded policy as audit provenance.
                                     //
                                     // Fail-closed: the baseline is hybrid-signed
                                     // (EdDSA + ML-DSA-65) and verified with
@@ -2428,7 +2425,7 @@ fn main() -> Result<()> {
                                         ) {
                                             Ok((policy, true)) => tracing::info!(
                                                 "MAC S4: baseline compiled policy installed \
-                                                 (generation {}, DORMANT — enforcement not enabled)",
+                                                 (generation {}, 9P enforcement active)",
                                                 policy.generation
                                             ),
                                             // The seam is write-once: a policy was

--- a/crates/hyprstream/src/mac/audit.rs
+++ b/crates/hyprstream/src/mac/audit.rs
@@ -98,11 +98,11 @@
 use crate::mac::avc::{Avc, TokenScope};
 use crate::mac::lattice::SecurityLabel;
 use crate::mac::te::{Action, Decision, ObjectCtx, ObjectType, SubjectCtx, SubjectType};
+use parking_lot::Mutex;
 use serde::{Deserialize, Serialize};
 use std::fs::{File, OpenOptions};
 use std::io::Write;
 use std::path::{Path, PathBuf};
-use parking_lot::Mutex;
 use std::sync::Arc;
 use thiserror::Error;
 
@@ -218,6 +218,11 @@ pub enum DecisionReason {
     Permit,
     /// The MAC lattice floor denied (clearance does not dominate label).
     FloorDeny,
+    /// The PEP could not resolve a content-bound label for the object.
+    UnlabeledObject,
+    /// A write was denied because the system's IFC write direction is not yet
+    /// ratified. Writes fail closed until that policy decision is made.
+    WriteDirectionUndecided,
     /// The TE matrix had no allow (and no escalate) entry for the triple.
     TeMiss,
     /// The decision was `Escalate` (floor held, TE escalate-band hit).
@@ -261,6 +266,8 @@ impl DecisionReason {
         match self {
             DecisionReason::Permit => "permit",
             DecisionReason::FloorDeny => "floor_deny",
+            DecisionReason::UnlabeledObject => "unlabeled_object",
+            DecisionReason::WriteDirectionUndecided => "write_direction_undecided",
             DecisionReason::TeMiss => "te_miss",
             DecisionReason::Escalate => "escalate",
             DecisionReason::TokenGate => "token_gate",
@@ -335,7 +342,9 @@ pub enum AuditError {
     /// The signed checkpoint is ahead of the journal head: the journal tail was
     /// truncated since the last durable write. `journal_seq` is the journal's
     /// current head seq (`None` if the journal is empty/absent).
-    #[error("audit journal truncated: checkpoint at seq {checkpoint_seq}, journal head {journal_seq:?}")]
+    #[error(
+        "audit journal truncated: checkpoint at seq {checkpoint_seq}, journal head {journal_seq:?}"
+    )]
     Truncation {
         checkpoint_seq: u64,
         journal_seq: Option<u64>,
@@ -1552,8 +1561,7 @@ mod tests {
         let hash = rec.content_hash().expect("canonical encode + hash");
         let hex = hex::encode(hash);
         assert_eq!(
-            hex,
-            "e3ca6519bde2ebb9a60273bd30a8acfa13a299280aafeca6c438ea21f8282b30",
+            hex, "e3ca6519bde2ebb9a60273bd30a8acfa13a299280aafeca6c438ea21f8282b30",
             "Fu6 golden hash drifted — was the canonical CBOR encoding changed intentionally?"
         );
     }
@@ -1670,7 +1678,11 @@ mod tests {
         let met = subj(1, high());
         let delegator = subj(2, low());
         let d = audited.decide_delegated(met, Some(delegator), obj(1, low()), Action(1));
-        assert_eq!(d, Decision::Permit, "decision rests on the met subject alone");
+        assert_eq!(
+            d,
+            Decision::Permit,
+            "decision rests on the met subject alone"
+        );
 
         // A non-delegated decision on the same triple records no delegator.
         let d2 = audited.decide(subj(1, high()), obj(1, low()), Action(1));
@@ -1842,7 +1854,10 @@ mod tests {
                 }
             }
         }
-        assert!(cbor_start < last_line.len(), "journal line has a cbor field");
+        assert!(
+            cbor_start < last_line.len(),
+            "journal line has a cbor field"
+        );
         let orig = last_line[cbor_start];
         last_line[cbor_start] = if orig == b'A' { b'B' } else { b'A' };
         let tampered: Vec<u8> = lines
@@ -1871,7 +1886,7 @@ mod tests {
         let dir = tmp_dir("gap");
         let store = WalAuditStore::open(&dir, StubSigner { key: [4; 32] }).unwrap();
         let base = AuditRecord {
-            seq: 0, // ignored — the store assigns seq.
+            seq: 0,               // ignored — the store assigns seq.
             prev_hash: [0u8; 32], // ignored — the store assigns the chain link.
             ts_unix_nanos: 1,
             decision: Decision::Permit,
@@ -1990,7 +2005,13 @@ mod tests {
             .verify_journal(&StubVerifier { key: [8; 32] })
             .unwrap_err();
         assert!(
-            matches!(err, AuditError::Truncation { checkpoint_seq: 2, .. }),
+            matches!(
+                err,
+                AuditError::Truncation {
+                    checkpoint_seq: 2,
+                    ..
+                }
+            ),
             "verify_journal must detect the truncated tail, got {err:?}"
         );
     }

--- a/crates/hyprstream/src/mac/bootload.rs
+++ b/crates/hyprstream/src/mac/bootload.rs
@@ -14,15 +14,10 @@
 //! [`EnrollmentSubjectContextResolver`](crate::mac::EnrollmentSubjectContextResolver)
 //! inert. This module is the one missing wire.
 //!
-//! ## DORMANT — this does NOT enable enforcement
-//!
-//! Installing a compiled policy only makes the PDP *inputs* real: it flips
+//! Installing a compiled policy makes the PDP inputs real: it flips
 //! [`crate::mac::compiled_policy`] to `Some`, so the enrollment resolver
-//! resolves genuine clearances instead of denying every DID. The per-op
-//! deciders remain AllowAll — no PEP consults this PDP yet (see the "Current
-//! status" note in `CLAUDE.md` / the epic). Turning enforcement *on* is a
-//! separate, deliberate step; this keeps the framework fail-closed and correct
-//! while wiring the last dormant input.
+//! resolves genuine clearances instead of denying every DID. The active 9P PEP
+//! records the loaded generation and policy hash on every audited decision.
 //!
 //! ## Fail-closed
 //!
@@ -187,7 +182,7 @@ fn install_self_approved_empty_baseline(
     sign_load_install(policy, approval, ed_sk, pq_sk)
 }
 
-/// Install the node's **dormant baseline** compiled policy at daemon boot.
+/// Install the node's baseline compiled policy at daemon boot.
 ///
 /// The baseline is intentionally minimal: a self-issued empty grant over an
 /// empty lattice generation and an empty object registry, so the compiled TE
@@ -195,8 +190,7 @@ fn install_self_approved_empty_baseline(
 /// is to make [`crate::mac::compiled_policy`] return `Some`, which switches the
 /// grant path's subject resolver from deny-all to the real
 /// [`EnrollmentSubjectContextResolver`](crate::mac::EnrollmentSubjectContextResolver).
-/// Enforcement stays AllowAll — this is the dormant activation prerequisite, not
-/// the enforcement flip.
+/// The active 9P PEP uses this policy as decision provenance.
 ///
 /// Unlike [`compile_sign_load_install`], this path locally derives an approval;
 /// that exception is confined to a private helper which constructs the empty

--- a/crates/hyprstream/src/mac/genesis.rs
+++ b/crates/hyprstream/src/mac/genesis.rs
@@ -25,23 +25,14 @@
 //! 3. [`CompositeObjectLabelResolver`] — the production [`ObjectLabelResolver`]:
 //!    genesis static nodes → bind-time D2 descendant inheritance → CAS
 //!    [`BlobManifest`](crate::storage::cas::manifest::BlobManifest)-carried
-//!    labels; a manifest present but unlabeled clamps to the D2 floor; anything
+//!    labels; a manifest present but unlabeled is denied; anything
 //!    unresolvable returns `None` ⇒ deny.
 //! 4. [`GenesisGate`] — constructed at boot: it runs the enumerator, materialize,
 //!    and report, and holds the resolver, so the startup path can log/emit the
 //!    [`GenesisReport`] and a status surface can render coverage evidence.
 //!
-//! ## Stage 0: dormant, zero behavior change
-//!
-//! Nothing here flips a decider to enforcing. The composite resolver is
-//! constructed and testable, but the 9P PEP (`hyprstream-9p::mac_seam`) stays
-//! dormant: no production [`Translator`](hyprstream_9p::Translator) has a
-//! [`ReferenceMonitor`](hyprstream_9p::mac_seam::ReferenceMonitor) installed,
-//! so no request is allowed or denied differently than before this module
-//! existed (activation is blocked on #698). The value delivered now is the
-//! **coverage-gate evidence**: proof that a complete, well-formed genesis
-//! exists (or an explicit list of the gaps) so the activation decision has
-//! something to gate on.
+//! The production resolver is consumed by the authoritative 9P translator PEP.
+//! Missing and unlabeled objects deny; there is no permissive fallback.
 
 use std::collections::BTreeSet;
 use std::sync::Arc;
@@ -55,7 +46,7 @@ use hyprstream_rpc::auth::mac::{
 /// `server::routes::ninep::build_export_mount` + the `#730` host VFS layout).
 /// These are structural container directories, always present regardless of which
 /// services are running.
-pub const EXPORT_ROOTS: &[&str] = &["/srv", "/worktree", "/stream"];
+pub const EXPORT_ROOTS: &[&str] = &["/", "/srv", "/worktree", "/stream"];
 
 /// Non-service mount points the standard namespace binds (see
 /// `services::namespace_builder::build_standard_namespace` and
@@ -170,8 +161,7 @@ impl NamespaceEnumerator {
 }
 
 /// Normalize a node path to a canonical absolute form: leading slash, no trailing
-/// slash, no empty components. `""`/`"/"` normalize to `""` (dropped — the root is
-/// not itself an addressable node in this inventory).
+/// slash, no empty components. `""`/`"/"` normalize to the addressable root.
 fn normalize_node_path(path: &str) -> String {
     let mut out = String::new();
     for component in path.split('/') {
@@ -181,7 +171,11 @@ fn normalize_node_path(path: &str) -> String {
         out.push('/');
         out.push_str(component);
     }
-    out
+    if out.is_empty() {
+        "/".to_owned()
+    } else {
+        out
+    }
 }
 
 // ────────────────────────────────────────────────────────────────────────────
@@ -319,9 +313,7 @@ impl SitePolicy {
 /// The outer `Option` is "does a manifest exist for this CID?" and the inner is
 /// the manifest's `security_label` carrier field:
 /// - `Some(Some(label))` — manifest present and labeled ⇒ use the label.
-/// - `Some(None)` — manifest present but the carrier is empty ⇒ **missing
-///   carrier**: the composite clamps to the D2 floor (not deny — a real object
-///   exists, it just isn't labeled yet).
+/// - `Some(None)` — manifest present but unlabeled ⇒ deny.
 /// - `None` — no manifest for this CID ⇒ unresolvable ⇒ deny.
 pub trait ManifestLabelSource: Send + Sync {
     /// The label carried by the manifest for `cid`, per the semantics above.
@@ -352,7 +344,7 @@ impl ManifestLabelSource for NoManifests {
 /// 3. Neither ⇒ `None` ⇒ deny.
 ///
 /// For a **CID** reference: the CAS [`ManifestLabelSource`] — a present-but-
-/// unlabeled manifest clamps to the D2 floor, an absent manifest denies.
+/// unlabeled manifest denies, and an absent manifest denies.
 ///
 /// Every arm honors the S1 invariant: an unresolvable reference returns `None`
 /// (deny), never a manufactured permissive default.
@@ -379,6 +371,9 @@ impl CompositeObjectLabelResolver {
 
     /// Resolve a walked path (already split into components) to a label.
     fn resolve_path(&self, components: &[&str]) -> Option<SecurityLabel> {
+        if components.is_empty() {
+            return self.genesis.resolve("/").copied();
+        }
         // Walk from the full path up its ancestors. The first genesis assignment
         // found is either the exact node (arm 1) or the nearest labeled ancestor
         // (arm 2 — bind-time D2 descendant inheritance).
@@ -417,12 +412,9 @@ impl CompositeObjectLabelResolver {
             // `Internal` (D2 — object labels clamp to the importing boundary's
             // floor, never returned unrestricted).
             Some(Some(label)) => Some(import_label(self.floor, label)),
-            // Manifest present, carrier empty ⇒ D2 join-to-floor. `import_label`
-            // is the restrict-only clamp: join(floor, ⊥) == floor, and it can
-            // only ever raise, never lower, the effective label.
-            Some(None) => Some(import_label(self.floor, SecurityLabel::bottom())),
-            // No manifest ⇒ unresolvable ⇒ deny.
-            None => None,
+            // Present-but-unlabeled and absent manifests both deny. Never
+            // manufacture a label or join either case to a floor.
+            Some(None) | None => None,
         }
     }
 }
@@ -509,6 +501,11 @@ impl GenesisGate {
     /// The production object-label resolver (for wiring a real decider later).
     pub fn resolver(&self) -> &CompositeObjectLabelResolver {
         &self.resolver
+    }
+
+    /// Consume the gate and transfer its production resolver to the live PEP.
+    pub fn into_resolver(self) -> CompositeObjectLabelResolver {
+        self.resolver
     }
 
     /// The enumerated node set the report covers.
@@ -646,8 +643,8 @@ mod tests {
     fn enumerator_normalizes_paths() {
         assert_eq!(normalize_node_path("/srv//model/"), "/srv/model");
         assert_eq!(normalize_node_path("srv/model"), "/srv/model");
-        assert_eq!(normalize_node_path("/"), "");
-        assert_eq!(normalize_node_path(""), "");
+        assert_eq!(normalize_node_path("/"), "/");
+        assert_eq!(normalize_node_path(""), "/");
     }
 
     #[test]
@@ -693,9 +690,11 @@ mod tests {
 
     #[test]
     fn materialize_assigns_every_node_no_catch_all() {
-        let nodes = ["/srv/policy".to_owned(),
+        let nodes = [
+            "/srv/policy".to_owned(),
             "/srv/model".to_owned(),
-            "/srv".to_owned()];
+            "/srv".to_owned(),
+        ];
         let p = SitePolicy::conservative();
         let map = p.materialize(nodes.iter().map(String::as_str));
         // Every node resolves to a concrete label (materialized, not a default).
@@ -784,12 +783,9 @@ mod tests {
     }
 
     #[test]
-    fn resolver_cid_unlabeled_manifest_clamps_to_floor() {
-        // Manifest present but carrier empty ⇒ D2 join-to-floor (NOT deny).
+    fn resolver_cid_unlabeled_manifest_is_denied() {
         let r = resolver_over(&["/srv/policy"], Arc::new(FixedManifests(Some(None))));
-        let label = r.resolve(ObjectRef::Cid(&[1, 2, 3])).unwrap();
-        assert_eq!(label, SitePolicy::conservative().floor());
-        assert_eq!(label.assurance, Assurance::Unverified);
+        assert!(r.resolve(ObjectRef::Cid(&[1, 2, 3])).is_none());
     }
 
     #[test]

--- a/crates/hyprstream/src/mac/genesis.rs
+++ b/crates/hyprstream/src/mac/genesis.rs
@@ -846,7 +846,10 @@ mod tests {
         let gate = GenesisGate::production();
         let policy = SitePolicy::conservative();
         for node in &gate.report().labeled {
-            let components: Vec<&str> = node.trim_start_matches('/').split('/').collect();
+            let components: Vec<&str> = node
+                .split('/')
+                .filter(|component| !component.is_empty())
+                .collect();
             let expected = policy.label_for(node);
             assert_eq!(
                 gate.resolver().resolve(ObjectRef::Path(&components)),

--- a/crates/hyprstream/src/mac/mod.rs
+++ b/crates/hyprstream/src/mac/mod.rs
@@ -57,7 +57,7 @@
 pub mod audit;
 pub mod avc;
 // S4 (#570): the daemon-boot compile → sign → verify-load → install path that
-// finally populates `COMPILED_POLICY`. Dormant (no enforcement flip).
+// finally populates `COMPILED_POLICY`.
 pub mod bootload;
 pub mod compiled;
 pub mod compiler;
@@ -66,12 +66,12 @@ pub mod compiler;
 // sender-binding, consuming S1/S5/the compiler rather than re-implementing.
 pub mod exchange;
 // S1 activation (#567): production genesis CONTENT + enumerator + composite
-// ObjectLabelResolver + boot-time coverage gate. Dormant (Stage 0): builds the
-// coverage-gate evidence, flips no decider to enforcing.
+// ObjectLabelResolver + boot-time coverage gate consumed by the active 9P PEP.
 pub mod genesis;
 pub mod lattice;
 // #676: the production S3-scope ↔ S5-TE-rule vocabulary (injective + exact;
 // wildcards expand at compile time over a closed registry).
+pub mod pep;
 pub mod permission_map;
 pub mod te;
 
@@ -110,6 +110,7 @@ pub use genesis::{
     floor_label, genesis_lattice, CompositeObjectLabelResolver, GenesisGate, ManifestLabelSource,
     NamespaceEnumerator, NoManifests, SitePolicy,
 };
+pub use pep::NinePAccessDecider;
 // S4 (#570): the boot path that installs the verified `CompiledPolicy` at daemon
 // startup (dormant — makes the PDP inputs real without enabling enforcement).
 pub use bootload::{compile_sign_load_install, install_baseline_boot_policy, BootPolicyError};
@@ -305,7 +306,8 @@ mod enrollment_resolver_tests {
         // Enrollment table asserts PqHybrid for this DID; the resolver must
         // still floor the resulting SecurityContext at Classical (#698 Decision
         // D) — the table's own assurance component is not authoritative here.
-        let clearance = SecurityLabel::new(Level::Secret, Assurance::PqHybrid, CompartmentSet::EMPTY);
+        let clearance =
+            SecurityLabel::new(Level::Secret, Assurance::PqHybrid, CompartmentSet::EMPTY);
         let resolver =
             EnrollmentSubjectContextResolver::new(policy_with("did:key:actor", clearance));
 

--- a/crates/hyprstream/src/mac/mod.rs
+++ b/crates/hyprstream/src/mac/mod.rs
@@ -110,7 +110,7 @@ pub use genesis::{
     floor_label, genesis_lattice, CompositeObjectLabelResolver, GenesisGate, ManifestLabelSource,
     NamespaceEnumerator, NoManifests, SitePolicy,
 };
-pub use pep::NinePAccessDecider;
+pub use pep::{production_ninep_decider, NinePAccessDecider};
 // S4 (#570): the boot path that installs the verified `CompiledPolicy` at daemon
 // startup (dormant — makes the PDP inputs real without enabling enforcement).
 pub use bootload::{compile_sign_load_install, install_baseline_boot_policy, BootPolicyError};

--- a/crates/hyprstream/src/mac/pep.rs
+++ b/crates/hyprstream/src/mac/pep.rs
@@ -9,8 +9,10 @@
 use std::sync::Arc;
 use std::time::{SystemTime, UNIX_EPOCH};
 
+use anyhow::Context;
 use hyprstream_9p::{AccessDecider, Action as NinePAction};
 use hyprstream_rpc::auth::mac::{ObjectLabelResolver, ObjectRef, SecurityContext, SecurityLabel};
+use hyprstream_rpc::SigningKey;
 
 use crate::mac::audit::{AuditRecord, AuditSink, DecisionReason};
 use crate::mac::te::{Action, Decision, ObjectType, ScopeAction, SubjectType};
@@ -86,6 +88,51 @@ impl NinePAccessDecider {
             }
         }
     }
+}
+
+/// Build the production resolver-backed 9P PEP and its tamper-evident WAL.
+///
+/// The audit signer is mandatory under the active crypto policy. Callers must
+/// propagate an error from this function and refuse to construct a 9P-serving
+/// component; substituting [`hyprstream_9p::DenyAllDecider`] would both outage
+/// legitimate attaches and bypass the hash-chained MAC audit trail.
+pub async fn production_ninep_decider(
+    signing_key: SigningKey,
+    oauth: &crate::config::OAuthConfig,
+    audit_stream: &str,
+) -> anyhow::Result<Arc<dyn AccessDecider>> {
+    anyhow::ensure!(
+        !audit_stream.is_empty()
+            && audit_stream
+                .bytes()
+                .all(|byte| byte.is_ascii_alphanumeric() || byte == b'-' || byte == b'_'),
+        "invalid 9P MAC audit stream name"
+    );
+
+    let secrets_dir = crate::config::HyprConfig::resolve_secrets_dir()?;
+    let ml_dsa_store =
+        crate::auth::key_rotation::global_ml_dsa_key_store(&secrets_dir, oauth);
+    let signer = crate::mac::audit::cose::OwnedCoseAuditSigner::new(
+        Arc::new(signing_key),
+        ml_dsa_store.active_key().await,
+        hyprstream_rpc::envelope::mandatory_envelope_policy(),
+    );
+    anyhow::ensure!(
+        signer.can_sign(),
+        "9P MAC PEP audit signer unavailable under mandatory Hybrid policy"
+    );
+
+    let audit_store = crate::mac::audit::WalAuditStore::open(
+        secrets_dir.join("mac-audit").join(audit_stream),
+        signer,
+    )
+    .context("open 9P MAC audit store")?;
+    let resolver = crate::mac::GenesisGate::production().into_resolver();
+
+    Ok(Arc::new(NinePAccessDecider::new(
+        Arc::new(resolver),
+        Arc::new(audit_store),
+    )))
 }
 
 impl AccessDecider for NinePAccessDecider {

--- a/crates/hyprstream/src/mac/pep.rs
+++ b/crates/hyprstream/src/mac/pep.rs
@@ -1,0 +1,250 @@
+//! Authoritative 9P policy-enforcement point.
+//!
+//! The translator supplies the verified caller context and walked object
+//! reference. This decider resolves the content-truth label, applies the
+//! intrinsic lattice dominance rule for read-class operations, fails every
+//! write closed pending the IFC write-direction decision, and records every
+//! outcome through the existing tamper-evident MAC audit sink.
+
+use std::sync::Arc;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use hyprstream_9p::{AccessDecider, Action as NinePAction};
+use hyprstream_rpc::auth::mac::{ObjectLabelResolver, ObjectRef, SecurityContext, SecurityLabel};
+
+use crate::mac::audit::{AuditRecord, AuditSink, DecisionReason};
+use crate::mac::te::{Action, Decision, ObjectType, ScopeAction, SubjectType};
+
+/// Reserved audit identities for 9P PEP decisions. Real compiled-policy type
+/// ids grow upward from zero; these sentinels live below the grant-path
+/// `u32::MAX` sentinels and cannot collide.
+const NINEP_SUBJECT_TYPE: SubjectType = SubjectType(u32::MAX - 1);
+const NINEP_OBJECT_TYPE: ObjectType = ObjectType(u32::MAX - 1);
+
+/// Resolver-backed, audited 9P access decider.
+pub struct NinePAccessDecider {
+    resolver: Arc<dyn ObjectLabelResolver + Send + Sync>,
+    sink: Arc<dyn AuditSink>,
+}
+
+impl NinePAccessDecider {
+    pub fn new(
+        resolver: Arc<dyn ObjectLabelResolver + Send + Sync>,
+        sink: Arc<dyn AuditSink>,
+    ) -> Self {
+        Self { resolver, sink }
+    }
+
+    fn audit(
+        &self,
+        ctx: &SecurityContext,
+        label: Option<SecurityLabel>,
+        action: NinePAction,
+        decision: Decision,
+        reason: DecisionReason,
+    ) -> bool {
+        let policy = crate::mac::compiled_policy();
+        let generation = policy.as_ref().map_or(0, |p| p.generation);
+        let policy_hash = policy.as_ref().and_then(|p| p.policy_hash().ok());
+        let record = AuditRecord {
+            seq: 0,
+            prev_hash: [0; 32],
+            ts_unix_nanos: SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .map_or(0, |d| d.as_nanos()),
+            decision,
+            generation,
+            policy_hash,
+            subject_type: NINEP_SUBJECT_TYPE,
+            subject_clearance: *ctx.clearance(),
+            on_behalf_of: None,
+            object_type: NINEP_OBJECT_TYPE,
+            // No label exists on an unresolved decision. The bottom value is
+            // an audit-schema placeholder only; `UnlabeledObject` is the
+            // authoritative reason and the value never enters authorization.
+            object_label: label.unwrap_or_else(SecurityLabel::bottom),
+            action: audit_action(action),
+            reason,
+        };
+
+        match self.sink.record(&record) {
+            Ok(()) => decision.is_permit(),
+            Err(error) => {
+                let deny_record = AuditRecord {
+                    decision: Decision::Deny,
+                    reason: DecisionReason::AuditFailClosed,
+                    ..record
+                };
+                let _ = self.sink.record(&deny_record);
+                tracing::error!(
+                    target: "hyprstream.mac.audit",
+                    %error,
+                    reason = DecisionReason::AuditFailClosed.as_str(),
+                    "9P decision could not be durably audited; enforcing deny"
+                );
+                false
+            }
+        }
+    }
+}
+
+impl AccessDecider for NinePAccessDecider {
+    fn check(&self, ctx: &SecurityContext, object: ObjectRef<'_>, action: NinePAction) -> bool {
+        let Some(label) = self.resolver.resolve(object) else {
+            return self.audit(
+                ctx,
+                None,
+                action,
+                Decision::Deny,
+                DecisionReason::UnlabeledObject,
+            );
+        };
+
+        if matches!(action, NinePAction::Write) {
+            return self.audit(
+                ctx,
+                Some(label),
+                action,
+                Decision::Deny,
+                DecisionReason::WriteDirectionUndecided,
+            );
+        }
+
+        let permitted = ctx.can_access(&label);
+        self.audit(
+            ctx,
+            Some(label),
+            action,
+            if permitted {
+                Decision::Permit
+            } else {
+                Decision::Deny
+            },
+            if permitted {
+                DecisionReason::Permit
+            } else {
+                DecisionReason::FloorDeny
+            },
+        )
+    }
+}
+
+const fn audit_action(action: NinePAction) -> Action {
+    match action {
+        NinePAction::Write => Action::from_scope_action(ScopeAction::Write),
+        NinePAction::Attach
+        | NinePAction::Walk
+        | NinePAction::Open
+        | NinePAction::Read
+        | NinePAction::Getattr
+        | NinePAction::Readdir => Action::from_scope_action(ScopeAction::Query),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use parking_lot::Mutex;
+
+    use hyprstream_rpc::auth::mac::{Assurance, CompartmentSet, Level, VerifiedKeyMaterial};
+
+    use super::*;
+    use crate::mac::audit::{AuditError, AuditRecord};
+
+    struct FixtureResolver {
+        public: SecurityLabel,
+        secret: SecurityLabel,
+    }
+
+    impl ObjectLabelResolver for FixtureResolver {
+        fn resolve(&self, object: ObjectRef<'_>) -> Option<SecurityLabel> {
+            match object {
+                ObjectRef::Path(["public"]) => Some(self.public),
+                ObjectRef::Path(["secret"]) => Some(self.secret),
+                // Existing-but-unlabeled CIDs and unknown paths both resolve
+                // to absence, which is denial at the PEP boundary.
+                _ => None,
+            }
+        }
+    }
+
+    #[derive(Default)]
+    struct SpySink {
+        records: Mutex<Vec<AuditRecord>>,
+    }
+
+    impl AuditSink for SpySink {
+        fn record(&self, record: &AuditRecord) -> Result<(), AuditError> {
+            self.records.lock().push(record.clone());
+            Ok(())
+        }
+    }
+
+    fn label(level: Level) -> SecurityLabel {
+        SecurityLabel::new(level, Assurance::Classical, CompartmentSet::EMPTY)
+    }
+
+    fn context(level: Level) -> SecurityContext {
+        SecurityContext::from_clearance(label(level), VerifiedKeyMaterial::Classical)
+    }
+
+    #[test]
+    fn reads_fail_closed_and_every_decision_is_audited() {
+        let sink = Arc::new(SpySink::default());
+        let decider = NinePAccessDecider::new(
+            Arc::new(FixtureResolver {
+                public: label(Level::Public),
+                secret: label(Level::Secret),
+            }),
+            sink.clone(),
+        );
+
+        assert!(decider.check(
+            &context(Level::Secret),
+            ObjectRef::Path(&["public"]),
+            NinePAction::Read,
+        ));
+        assert!(!decider.check(
+            &context(Level::Public),
+            ObjectRef::Path(&["secret"]),
+            NinePAction::Read,
+        ));
+        assert!(!decider.check(
+            &context(Level::Secret),
+            ObjectRef::Cid(b"unlabeled"),
+            NinePAction::Read,
+        ));
+        assert!(!decider.check(
+            &context(Level::Secret),
+            ObjectRef::Path(&["does-not-exist"]),
+            NinePAction::Read,
+        ));
+
+        let records = sink.records.lock();
+        assert_eq!(records.len(), 4);
+        assert_eq!(records[0].decision, Decision::Permit);
+        assert_eq!(records[1].reason, DecisionReason::FloorDeny);
+        assert_eq!(records[2].reason, DecisionReason::UnlabeledObject);
+        assert_eq!(records[3].reason, DecisionReason::UnlabeledObject);
+    }
+
+    #[test]
+    fn writes_fail_closed_and_are_audited() {
+        let sink = Arc::new(SpySink::default());
+        let decider = NinePAccessDecider::new(
+            Arc::new(FixtureResolver {
+                public: label(Level::Public),
+                secret: label(Level::Secret),
+            }),
+            sink.clone(),
+        );
+
+        assert!(!decider.check(
+            &context(Level::Secret),
+            ObjectRef::Path(&["public"]),
+            NinePAction::Write,
+        ));
+        let records = sink.records.lock();
+        assert_eq!(records.len(), 1);
+        assert_eq!(records[0].reason, DecisionReason::WriteDirectionUndecided);
+    }
+}

--- a/crates/hyprstream/src/server/routes/ninep.rs
+++ b/crates/hyprstream/src/server/routes/ninep.rs
@@ -49,6 +49,7 @@ use std::collections::BTreeMap;
 use std::sync::Arc;
 use std::time::Duration;
 
+use async_trait::async_trait;
 use axum::{
     extract::{
         ws::{Message, WebSocket, WebSocketUpgrade},
@@ -58,7 +59,6 @@ use axum::{
     response::{IntoResponse, Response},
     Json,
 };
-use async_trait::async_trait;
 use futures::{SinkExt, StreamExt};
 use hyprstream_9p::{AttachAuthorizer, Translator};
 use hyprstream_rpc::transport::quinn_transport::{NinePWtHandler, NinePWtStream};
@@ -285,7 +285,11 @@ pub async fn ninep_ws(
     let mount = build_export_mount(&state, &subject);
     // `from_mount` wraps the Subject-scoped mount in a `MountBackend` and threads
     // `subject` onto every backend op — the same seam UDS/vsock use.
-    let translator = Arc::new(Translator::from_mount(mount, subject));
+    let translator = Arc::new(Translator::from_mount(
+        mount,
+        subject,
+        Arc::clone(&state.ninep_decider),
+    ));
 
     // No subprotocol negotiation: stock wanix connects with none.
     ws.on_upgrade(move |socket| serve_9p_websocket(socket, translator, PING_INTERVAL))
@@ -329,7 +333,9 @@ async fn verify_mount_ticket(
     }
     let local_issuers: &[&str] = &[&*state.oauth_issuer_url];
     let subject = claims.subject(local_issuers);
-    subject.validate().map_err(|_| "subject validation failed")?;
+    subject
+        .validate()
+        .map_err(|_| "subject validation failed")?;
     match subject.name() {
         Some(n) if !n.is_empty() => {}
         _ => return Err("empty subject"),
@@ -514,7 +520,9 @@ struct TicketAttachAuthorizer {
 impl AttachAuthorizer for TicketAttachAuthorizer {
     async fn authorize(&self, uname: &str) -> Result<Subject, MountError> {
         if uname.is_empty() {
-            return Err(MountError::PermissionDenied("missing mount ticket".to_owned()));
+            return Err(MountError::PermissionDenied(
+                "missing mount ticket".to_owned(),
+            ));
         }
         match verify_mount_ticket(&self.state, uname, PLANE_WEBTRANSPORT, ROOT_NAMESPACE_PATH).await
         {
@@ -557,9 +565,14 @@ impl NinePWtHandler for NinePWtExport {
         // current placeholder root — see its docs; the real #730 namespace is
         // scoped by the bound Subject once it lands).
         let mount = build_export_mount(&self.state, &Subject::anonymous());
-        let authorizer: Arc<dyn AttachAuthorizer> =
-            Arc::new(TicketAttachAuthorizer { state: self.state.clone() });
-        let translator = Arc::new(Translator::from_mount_authorized(mount, authorizer));
+        let authorizer: Arc<dyn AttachAuthorizer> = Arc::new(TicketAttachAuthorizer {
+            state: self.state.clone(),
+        });
+        let translator = Arc::new(Translator::from_mount_authorized(
+            mount,
+            authorizer,
+            Arc::clone(&self.state.ninep_decider),
+        ));
         if let Err(e) = translator.serve_connection(stream).await {
             debug!(error = %e, "9P WT serve loop ended with error");
         }
@@ -571,9 +584,9 @@ impl NinePWtHandler for NinePWtExport {
 /// call once at server startup where [`ServerState`] exists (see
 /// [`crate::server::create_app`]).
 pub fn register_ninep_wt_handler(state: ServerState) {
-    let installed = hyprstream_rpc::transport::quinn_transport::set_global_ninep_handler(
-        Arc::new(NinePWtExport::new(state)),
-    );
+    let installed = hyprstream_rpc::transport::quinn_transport::set_global_ninep_handler(Arc::new(
+        NinePWtExport::new(state),
+    ));
     if installed {
         info!("registered 9P-over-WebTransport handler (/9p QUIC path-mux, H1b)");
     }
@@ -586,6 +599,19 @@ mod tests {
     use axum::{routing::get, Router};
     use hyprstream_9p::msg::{self, Response as P9Response};
     use tokio_tungstenite::tungstenite::Message as WsMessage;
+
+    struct TransportTestDecider;
+
+    impl hyprstream_9p::AccessDecider for TransportTestDecider {
+        fn check(
+            &self,
+            _ctx: &hyprstream_rpc::auth::mac::SecurityContext,
+            _object: hyprstream_rpc::auth::mac::ObjectRef<'_>,
+            _action: hyprstream_9p::Action,
+        ) -> bool {
+            true
+        }
+    }
 
     /// Discovery doc round-trips and advertises the H1a contract.
     #[test]
@@ -614,14 +640,20 @@ mod tests {
         assert_eq!(ninep.protocol.as_deref(), Some("9P2000.L"));
 
         // The moq plane is advertised at its existing selector.
-        let moq = table.planes.get("moq").expect("moq plane must be advertised");
+        let moq = table
+            .planes
+            .get("moq")
+            .expect("moq plane must be advertised");
         assert_eq!(moq.path, hyprstream_rpc::dial::MOQ_PATH);
         assert_eq!(moq.transports, vec!["webtransport"]);
 
         // The document is valid JSON with the expected `planes` shape and
         // round-trips losslessly.
         let json = serde_json::to_value(&table).expect("table serializes to JSON");
-        assert!(json.get("planes").is_some(), "top-level `planes` key present");
+        assert!(
+            json.get("planes").is_some(),
+            "top-level `planes` key present"
+        );
         assert_eq!(json["planes"]["9p"]["path"], "/9p");
         assert_eq!(json["planes"]["9p"]["transports"][0], "ws");
         let round: WirePlaneTable =
@@ -632,7 +664,10 @@ mod tests {
         // export9p document's fields — deriving the entry guarantees no drift.
         let export9p = Export9pDiscovery::default();
         assert_eq!(ninep.path, export9p.endpoint);
-        assert_eq!(ninep.ticket_param.as_deref(), Some(export9p.ticket_param.as_str()));
+        assert_eq!(
+            ninep.ticket_param.as_deref(),
+            Some(export9p.ticket_param.as_str())
+        );
         assert_eq!(ninep.protocol.as_deref(), Some(export9p.protocol.as_str()));
 
         // The export9p contract itself is unchanged (still serializes with its
@@ -661,7 +696,11 @@ mod tests {
             let root = SyntheticNode::dir()
                 .with_child("hello.txt", SyntheticNode::file(b"hello ws".to_vec()));
             let mount: Arc<dyn Mount> = Arc::new(SyntheticMount::new(root));
-            let translator = Arc::new(Translator::from_mount(mount, Subject::new("test")));
+            let translator = Arc::new(Translator::from_mount(
+                mount,
+                Subject::new("test"),
+                Arc::new(TransportTestDecider),
+            ));
             ws.on_upgrade(move |s| serve_9p_websocket(s, translator, Duration::from_secs(10)))
         }
 

--- a/crates/hyprstream/src/server/state.rs
+++ b/crates/hyprstream/src/server/state.rs
@@ -1,7 +1,7 @@
 //! Server state management
 
-use crate::services::{RegistryClient, PolicyClient};
-use crate::services::generated::model_client::{ModelClient, LoadModelRequest};
+use crate::services::generated::model_client::{LoadModelRequest, ModelClient};
+use crate::services::{PolicyClient, RegistryClient};
 use ed25519_dalek::{SigningKey, VerifyingKey};
 use hyprstream_util::TtlCache;
 use std::collections::HashMap;
@@ -51,7 +51,8 @@ pub struct ServerState {
     pub published_jwt_verifying_keys: crate::auth::key_rotation::PublishedEd25519Keys,
 
     /// Context store for RAG/CAG (optional)
-    pub context_store: Option<Arc<ContextStore<hyprstream_metrics::storage::duckdb::DuckDbBackend>>>,
+    pub context_store:
+        Option<Arc<ContextStore<hyprstream_metrics::storage::duckdb::DuckDbBackend>>>,
 
     /// Cached resource URL for WWW-Authenticate headers (avoids per-request config reload)
     pub resource_url: String,
@@ -78,6 +79,9 @@ pub struct ServerState {
     /// Dedicated global limiter for public browser provisioning. This executes
     /// before checkpoint resolution and hybrid projection signing.
     pub browser_provisioning_rate_limiter: Arc<crate::server::middleware::RateLimiter>,
+
+    /// Mandatory resolver-backed, audited PEP shared by every 9P transport.
+    pub ninep_decider: Arc<dyn hyprstream_9p::AccessDecider>,
 }
 
 /// Security state shared by every authenticated HTTP resource face.
@@ -108,7 +112,8 @@ impl ResourceAuthState {
     ) -> Self {
         Self {
             verifying_key: Arc::new(verifying_key),
-            published_jwt_verifying_keys: crate::auth::key_rotation::global_ed25519_verifying_keys(),
+            published_jwt_verifying_keys: crate::auth::key_rotation::global_ed25519_verifying_keys(
+            ),
             composite_key_set: hyprstream_rpc::auth::global_composite_key_set(),
             resource_url,
             oauth_issuer_url,
@@ -178,6 +183,7 @@ impl ServerState {
         oauth_issuer_url: String,
         trusted_issuers: &HashMap<String, crate::config::TrustedIssuerConfig>,
         jti_blocklist: Arc<hyprstream_rpc::auth::InMemoryJtiBlocklist>,
+        ninep_decider: Arc<dyn hyprstream_9p::AccessDecider>,
     ) -> Result<Self, anyhow::Error> {
         let signing_key = Arc::new(signing_key);
         // Use the CA JWT verifying key (not the service's own key) so HTTP Bearer tokens
@@ -195,11 +201,14 @@ impl ServerState {
             tracing::info!("Preloading {} models", config.preload_models.len());
             for model_name in &config.preload_models {
                 tracing::info!("Preloading model: {}", model_name);
-                match model_client.load(&LoadModelRequest {
-                    model_ref: model_name.to_owned(),
-                    max_context: None,
-                    kv_quant: None,
-                }).await {
+                match model_client
+                    .load(&LoadModelRequest {
+                        model_ref: model_name.to_owned(),
+                        max_context: None,
+                        kv_quant: None,
+                    })
+                    .await
+                {
                     Ok(_) => tracing::info!("Preloaded: {}", model_name),
                     Err(e) => tracing::warn!("Failed to preload model '{}': {}", model_name, e),
                 }
@@ -214,7 +223,7 @@ impl ServerState {
         // trust decision applies to both clients and peers.
         let federation_resolver = Arc::new(
             crate::auth::FederationKeyResolver::new(trusted_issuers)
-                .with_policy_client(Arc::new(policy_client.clone()))
+                .with_policy_client(Arc::new(policy_client.clone())),
         );
 
         Ok(Self {
@@ -236,6 +245,7 @@ impl ServerState {
             browser_provisioning_rate_limiter: Arc::new(
                 crate::server::middleware::RateLimiter::new(60, 60),
             ),
+            ninep_decider,
         })
     }
 
@@ -269,9 +279,18 @@ impl ServerState {
         use hyprstream_metrics::storage::duckdb::DuckDbBackend;
         use hyprstream_metrics::StorageBackend;
 
-        let backend = Arc::new(DuckDbBackend::new(db_path.to_owned(), std::collections::HashMap::new(), None)?);
-        backend.init().await.map_err(|e| anyhow::anyhow!("Failed to init DuckDB: {}", e))?;
-        backend.create_table("context", &context_schema(embedding_dim)).await
+        let backend = Arc::new(DuckDbBackend::new(
+            db_path.to_owned(),
+            std::collections::HashMap::new(),
+            None,
+        )?);
+        backend
+            .init()
+            .await
+            .map_err(|e| anyhow::anyhow!("Failed to init DuckDB: {}", e))?;
+        backend
+            .create_table("context", &context_schema(embedding_dim))
+            .await
             .map_err(|e| anyhow::anyhow!("Failed to create context table: {}", e))?;
 
         let store = ContextStore::new(backend, "context", embedding_dim);
@@ -287,7 +306,9 @@ impl ServerState {
     }
 
     /// Get the context store if initialized
-    pub fn get_context_store(&self) -> Option<&Arc<ContextStore<hyprstream_metrics::storage::duckdb::DuckDbBackend>>> {
+    pub fn get_context_store(
+        &self,
+    ) -> Option<&Arc<ContextStore<hyprstream_metrics::storage::duckdb::DuckDbBackend>>> {
         self.context_store.as_ref()
     }
 }

--- a/crates/hyprstream/src/services/factories.rs
+++ b/crates/hyprstream/src/services/factories.rs
@@ -1152,23 +1152,49 @@ fn create_oai_service(ctx: &ServiceContext) -> anyhow::Result<Box<dyn Spawnable>
     let oauth_issuer_url = config.oauth.issuer_url();
     let server_state = tokio::task::block_in_place(|| {
         let rt = tokio::runtime::Handle::current();
-        rt.block_on(ServerState::new(
-            config.server.clone(),
-            model_client,
-            policy_client,
-            registry_client,
-            sk.clone(),
-            ctx.jwt_verifying_key(),
-            resource_url,
-            oauth_issuer_url,
-            &config.oauth.trusted_issuers,
-            // Share the PolicyService-owned JTI blocklist so POST /oauth/revoke
-            // immediately invalidates tokens at the OAI resource server.
-            SHARED_JTI_BLOCKLIST
-                .get()
-                .map(Arc::clone)
-                .unwrap_or_else(|| Arc::new(hyprstream_rpc::auth::InMemoryJtiBlocklist::new())),
-        ))
+        rt.block_on(async {
+            let secrets_dir = crate::config::HyprConfig::resolve_secrets_dir()?;
+            let ml_dsa_store =
+                crate::auth::key_rotation::global_ml_dsa_key_store(&secrets_dir, &config.oauth);
+            let signer = crate::mac::audit::cose::OwnedCoseAuditSigner::new(
+                Arc::new(sk.clone()),
+                ml_dsa_store.active_key().await,
+                hyprstream_rpc::envelope::mandatory_envelope_policy(),
+            );
+            anyhow::ensure!(
+                signer.can_sign(),
+                "9P MAC PEP audit signer unavailable under mandatory Hybrid policy"
+            );
+            let audit_store = crate::mac::audit::WalAuditStore::open(
+                secrets_dir.join("mac-audit").join("ninep"),
+                signer,
+            )
+            .map_err(|error| anyhow::anyhow!("open 9P MAC audit store: {error}"))?;
+            let resolver = crate::mac::GenesisGate::production().into_resolver();
+            let ninep_decider: Arc<dyn hyprstream_9p::AccessDecider> = Arc::new(
+                crate::mac::NinePAccessDecider::new(Arc::new(resolver), Arc::new(audit_store)),
+            );
+
+            ServerState::new(
+                config.server.clone(),
+                model_client,
+                policy_client,
+                registry_client,
+                sk.clone(),
+                ctx.jwt_verifying_key(),
+                resource_url,
+                oauth_issuer_url,
+                &config.oauth.trusted_issuers,
+                // Share the PolicyService-owned JTI blocklist so POST /oauth/revoke
+                // immediately invalidates tokens at the OAI resource server.
+                SHARED_JTI_BLOCKLIST
+                    .get()
+                    .map(Arc::clone)
+                    .unwrap_or_else(|| Arc::new(hyprstream_rpc::auth::InMemoryJtiBlocklist::new())),
+                ninep_decider,
+            )
+            .await
+        })
     })
     .context("Failed to create server state")?;
 

--- a/crates/hyprstream/src/services/factories.rs
+++ b/crates/hyprstream/src/services/factories.rs
@@ -1012,6 +1012,7 @@ fn create_worker_service(ctx: &ServiceContext) -> anyhow::Result<Box<dyn Spawnab
     use hyprstream_workers::{BackendCtx, SandboxBackend, WorkerService, resolve_backend};
 
     let config = load_config();
+    let sk = ctx.service_signing_key("worker");
     let worker_quic_port = config.worker.as_ref().and_then(|w| w.quic_port);
     // Operator-selected backend name ("auto" or a registered backend); resolved
     // fail-closed against the inventory registry below.
@@ -1060,6 +1061,15 @@ fn create_worker_service(ctx: &ServiceContext) -> anyhow::Result<Box<dyn Spawnab
     #[cfg(feature = "oci-image")]
     let rafs_store = Arc::new(RafsStore::new(image_config.clone())?);
 
+    let ninep_decider = tokio::task::block_in_place(|| {
+        tokio::runtime::Handle::current().block_on(crate::mac::production_ninep_decider(
+            sk.clone(),
+            &config.oauth,
+            "ninep-worker",
+        ))
+    })
+    .context("construct worker 9P MAC PEP")?;
+
     // Resolve + construct the backend fail-closed against the inventory registry
     // (config-driven by name; explicit requests are authoritative, missing
     // prerequisites error out rather than silently downgrading isolation; "auto"
@@ -1067,14 +1077,13 @@ fn create_worker_service(ctx: &ServiceContext) -> anyhow::Result<Box<dyn Spawnab
     // `_ => nspawn` fallback (#507 / #518).
     let backend_ctx = BackendCtx {
         pool_config: pool_config.clone(),
+        ninep_decider,
         #[cfg(feature = "oci-image")]
         image_config,
         #[cfg(feature = "oci-image")]
         rafs_store: Arc::clone(&rafs_store),
     };
     let backend: Arc<dyn SandboxBackend> = resolve_backend(&backend_name, &backend_ctx)?;
-
-    let sk = ctx.service_signing_key("worker");
 
     // Register this service's verifying key with PolicyService
     register_service_key(ctx, "worker", &sk)?;


### PR DESCRIPTION
## Summary

- activate a mandatory resolver-backed MAC decider on the shared 9P translator path
- retain each fid's absolute walked path so every attach, walk, open, read, getattr, readdir, and write reaches the PEP with the exact object reference
- deny unlabeled/unresolvable objects, apply SecurityContext::can_access dominance to read-class actions, and fail every write closed
- record every decision through the existing hash-chained MAC audit sink; audit failure downgrades permits to denial
- remove the permissive translator default; lower layers without the concrete Hyprstream resolver explicitly deny

Refs #699
Refs #547

## Authoritative PEP placement

The 9P translator seam is the single authoritative PEP. Every supported carrier (TCP, UDS, hybrid/raw vsock, WebSocket, and WebTransport) converges on the same translator dispatch before either MountBackend or an RPC Backend sees an object operation. Placing the check here covers both backend families and preserves the walked fid path needed by ObjectLabelResolver.

The VFS Mount trait is deliberately not a second PEP. Duplicating enforcement at Mount would create two independently evolving decisions, and the more permissive one would eventually become a bypass. Mount continues to thread Subject for its existing policy responsibilities, while the translator owns MAC mediation.

## Write direction

Writes fail closed because the IFC direction has not been ratified. Recommendation: adopt Bell-LaPadula for confidentiality-bearing labels (no write down: the target must dominate the subject's effective label), while treating integrity/Biba as a separate lattice or explicitly composed policy rather than reversing the same confidentiality order. Until that decision is approved, no 9P write is permitted.

## Validation

- buildq -- cargo test -p hyprstream mac::pep::tests --lib
- buildq -- cargo test -p hyprstream-9p --lib --tests
- buildq -- cargo build
- buildq -- cargo clippy --all-targets -- -D warnings
- foreground pre-commit release Clippy gate

Mutation check: replaced the intrinsic dominance result with unconditional permit; the insufficient-clearance assertion failed. Restored SecurityContext::can_access and reran the focused test successfully.
