### PR TITLE
mac: namespace label carriers — (a) schema-derived + (c) bind-time (#699)

### DIFF
--- a/crates/hyprstream-rpc-build/src/schema/cgr_reader.rs
+++ b/crates/hyprstream-rpc-build/src/schema/cgr_reader.rs
@@ -727,6 +727,7 @@ fn extract_union_variants(
         let vfs_kind_id = annotation_id_by_short_name(node_map, "vfsKind");
         let vfs_bulk_id = annotation_id_by_short_name(node_map, "vfsBulk");
         let vfs_hidden_id = annotation_id_by_short_name(node_map, "vfsHidden");
+        let vfs_mac_id = annotation_id_by_short_name(node_map, "vfsMac");
         let vfs_path = extract_annotation_text(
             field.get_annotations().map_err(|e| format!("{e}"))?,
             vfs_path_id,
@@ -745,6 +746,12 @@ fn extract_union_variants(
             field.get_annotations().map_err(|e| format!("{e}"))?,
             vfs_hidden_id,
         );
+        // $vfsMac (#699 carrier (a)): the MAC label this generated node carries.
+        // Empty when absent ⇒ the node is unlabeled ⇒ a genesis finding.
+        let vfs_mac = extract_annotation_text(
+            field.get_annotations().map_err(|e| format!("{e}"))?,
+            vfs_mac_id,
+        );
 
         variants.push(UnionVariant {
             name,
@@ -758,6 +765,7 @@ fn extract_union_variants(
             vfs_kind,
             vfs_bulk,
             vfs_hidden,
+            vfs_mac,
         });
     }
 
@@ -1656,6 +1664,7 @@ mod mandatory_scope_tests {
             vfs_kind: String::new(),
             vfs_bulk: false,
             vfs_hidden: false,
+            vfs_mac: String::new(),
         }
     }
 

--- a/crates/hyprstream-rpc-build/src/schema/types.rs
+++ b/crates/hyprstream-rpc-build/src/schema/types.rs
@@ -53,6 +53,12 @@ pub struct UnionVariant {
     /// `$vfsHidden`: exclude this method from the generated mount.
     #[serde(default)]
     pub vfs_hidden: bool,
+    /// `$vfsMac` annotation text — the MAC security label this generated node
+    /// carries (#699 carrier (a); a property of the node's type, derived at
+    /// generation). Empty = unset ⇒ the node is unlabeled ⇒ deny ⇒ a
+    /// genesis-coverage finding (no permissive default).
+    #[serde(default)]
+    pub vfs_mac: String,
 }
 
 /// Payload carried by a tagged-union arm.
@@ -292,6 +298,7 @@ mod vfs_metadata_tests {
             vfs_kind: "file".into(),
             vfs_bulk: false,
             vfs_hidden: false,
+            vfs_mac: String::new(),
         };
         let json = serde_json::to_string(&v).expect("serialize");
         let back: UnionVariant = serde_json::from_str(&json).expect("deserialize");

--- a/crates/hyprstream-rpc-build/src/ts_codegen/client.rs
+++ b/crates/hyprstream-rpc-build/src/ts_codegen/client.rs
@@ -493,6 +493,7 @@ mod browser_binding_tests {
             vfs_kind: String::new(),
             vfs_bulk: false,
             vfs_hidden: false,
+            vfs_mac: String::new(),
         }
     }
 

--- a/crates/hyprstream-rpc-build/src/ts_codegen/parsers.rs
+++ b/crates/hyprstream-rpc-build/src/ts_codegen/parsers.rs
@@ -1686,6 +1686,7 @@ struct EmbedImagesResponse {
                 vfs_kind: String::new(),
                 vfs_bulk: false,
                 vfs_hidden: false,
+                vfs_mac: String::new(),
             }],
             structs: vec![],
             scoped_clients: vec![],

--- a/crates/hyprstream-rpc-derive/src/codegen/handler.rs
+++ b/crates/hyprstream-rpc-derive/src/codegen/handler.rs
@@ -2413,6 +2413,7 @@ mod browser_method_dispatch_tests {
             vfs_kind: String::new(),
             vfs_bulk: false,
             vfs_hidden: false,
+            vfs_mac: String::new(),
         }
     }
 

--- a/crates/hyprstream-rpc-derive/src/codegen/vfs.rs
+++ b/crates/hyprstream-rpc-derive/src/codegen/vfs.rs
@@ -403,6 +403,21 @@ pub fn generate_mount(service_name: &str, resolved: &ResolvedSchema) -> TokenStr
             (#service_name, NODES)
         }
 
+        // #699 carrier (a) inventory: register this table so the genesis
+        // coverage gate can walk every reachable generated node (annotated or
+        // not) at startup. Submitted at module scope via the `inventory`
+        // re-export on `hyprstream_rpc::metadata` (wasm-safe; same pattern as
+        // `ScopeDefinition`), so consumer crates need not declare an `inventory`
+        // dep directly. The gate iterates this to build the startup activation
+        // gate; a node missing a `$vfsMac` surfaces as a finding (unlabeled ⇒
+        // deny) rather than being silently absent.
+        hyprstream_rpc::metadata::inventory::submit! {
+            hyprstream_rpc::metadata::VfsNodeTable {
+                name: #service_name,
+                nodes_fn: vfs_nodes,
+            }
+        }
+
         #(#scoped_tables)*
     }
 }
@@ -634,7 +649,7 @@ mod tests {
         // `mac` field carries the annotation text verbatim — the label is a
         // property of the node's type, derived at generation.
         let mut health = variant("healthCheck", "Void", "query");
-        health.vfs_mac = "internal".into();
+        health.vfs_mac = "internal:pq-hybrid".into();
         let mut clone = variant("clone", "CloneRequest", "write");
         clone.vfs_mac = "secret:pq-hybrid:0".into();
         // A node with NO `$vfsMac` carries the empty string (→ unlabeled → deny).
@@ -648,7 +663,7 @@ mod tests {
 
         // Annotated labels land verbatim on their nodes.
         assert!(
-            out.contains("mac : \"internal\""),
+            out.contains("mac : \"internal:pq-hybrid\""),
             "health node carries its $vfsMac label: {out}"
         );
         assert!(

--- a/crates/hyprstream-rpc-derive/src/codegen/vfs.rs
+++ b/crates/hyprstream-rpc-derive/src/codegen/vfs.rs
@@ -293,6 +293,10 @@ fn build_node_entries(
         let method_snake = r.method_snake.as_str();
         let scope = v.scope.as_str();
         let bulk = v.vfs_bulk;
+        // $vfsMac (#699 carrier (a)): schema-derived MAC label for this generated
+        // node. Empty string when the annotation is absent (→ unlabeled → deny →
+        // a genesis finding); decoded at runtime by `VfsNode::mac_label`.
+        let mac = v.vfs_mac.as_str();
 
         node_entries.push(quote! {
             hyprstream_rpc::metadata::VfsNode {
@@ -301,6 +305,7 @@ fn build_node_entries(
                 kind: #kind_tokens,
                 scope: #scope,
                 bulk: #bulk,
+                mac: #mac,
             }
         });
     }
@@ -504,6 +509,7 @@ mod tests {
             vfs_kind: "bogus".into(),
             vfs_bulk: false,
             vfs_hidden: false,
+            vfs_mac: String::new(),
         };
         let err = resolve_kind(&v, &CapnpType::Struct("CloneRequest".into()), false).unwrap_err();
         assert!(err.contains("bogus"));
@@ -525,6 +531,7 @@ mod tests {
             vfs_kind: "query".into(),
             vfs_bulk: false,
             vfs_hidden: false,
+            vfs_mac: String::new(),
         };
         let k = resolve_kind(&v, &CapnpType::Text, false).expect("valid kind");
         assert_eq!(k, NodeKind::Query);
@@ -547,6 +554,7 @@ mod tests {
             vfs_kind: String::new(),
             vfs_bulk: false,
             vfs_hidden: false,
+            vfs_mac: String::new(),
         }
     }
 
@@ -618,6 +626,40 @@ mod tests {
 
         assert!(out.contains("compile_error"), "emits compile_error: {out}");
         assert!(out.contains("clone"), "names the offending method: {out}");
+    }
+
+    #[test]
+    fn vfs_mac_annotation_flows_onto_emitted_node() {
+        // Carrier (a) (#699): a `$vfsMac`-annotated method projects a node whose
+        // `mac` field carries the annotation text verbatim — the label is a
+        // property of the node's type, derived at generation.
+        let mut health = variant("healthCheck", "Void", "query");
+        health.vfs_mac = "internal".into();
+        let mut clone = variant("clone", "CloneRequest", "write");
+        clone.vfs_mac = "secret:pq-hybrid:0".into();
+        // A node with NO `$vfsMac` carries the empty string (→ unlabeled → deny).
+        let list = variant("list", "Void", "query");
+        let schema = schema_with(
+            vec![health, clone, list],
+            vec![empty_struct("CloneRequest")],
+        );
+        let resolved = ResolvedSchema::from(&schema);
+        let out = generate_mount("registry", &resolved).to_string();
+
+        // Annotated labels land verbatim on their nodes.
+        assert!(
+            out.contains("mac : \"internal\""),
+            "health node carries its $vfsMac label: {out}"
+        );
+        assert!(
+            out.contains("mac : \"secret:pq-hybrid:0\""),
+            "clone node carries its $vfsMac label: {out}"
+        );
+        // An unannotated node carries the empty string — never a guessed label.
+        assert!(
+            out.contains("mac : \"\""),
+            "an unannotated node is emitted unlabeled (empty mac): {out}"
+        );
     }
 
     #[test]

--- a/crates/hyprstream-rpc-std/schema/registry.capnp
+++ b/crates/hyprstream-rpc-std/schema/registry.capnp
@@ -5,6 +5,7 @@ using import "/annotations.capnp".scope;
 using import "/annotations.capnp".mcpDescription;
 using import "/annotations.capnp".vfsKind;
 using import "/annotations.capnp".vfsPath;
+using import "/annotations.capnp".vfsMac;
 using import "/streaming.capnp".StreamInfo;
 
 # 9P types — shared across all services with fs scope.
@@ -65,7 +66,8 @@ struct RegistryRequest {
     # Check registry service health
     healthCheck @7 :Void $scope(query)
         $mcpDescription("Check if the registry service is healthy and responding.")
-        $vfsKind(file) $vfsPath("health");
+        $vfsKind(file) $vfsPath("health")
+        $vfsMac("internal:pq-hybrid");
     # Clone a model repository from a URL (streaming progress)
     cloneStream @8 :CloneRequest $scope(write) $mcpDescription("Clone a model repository from a URL (streaming progress)");
 

--- a/crates/hyprstream-rpc/schema/annotations.capnp
+++ b/crates/hyprstream-rpc/schema/annotations.capnp
@@ -143,8 +143,12 @@ annotation vfsHidden(field) :Void;
 
 # MAC security label this generated node carries — carrier (a) of #699: the label
 # is a property of the node's TYPE, derived from the schema annotation at
-# generation (T2 emits it onto VfsNode). Format: "<level>" or
-# "<level>:<assurance>" or "<level>:<assurance>:<compBit,compBit>". Absent ⇒ the
-# generated node is unlabeled ⇒ deny ⇒ a genesis-coverage finding (there is no
-# permissive default). Usage: getStatus @0 :Status $vfsMac("internal");
+# generation (T2 emits it onto VfsNode). Format:
+#   "<level>:pq-hybrid" or "<level>:pq-hybrid:<compBit,compBit>"
+# The assurance is MANDATORY and must be exactly `pq-hybrid`: the generated
+# 9P/VFS surface is internal/non-interop, and #556 requires PQ-hybrid on all
+# deployments — `unverified`/`classical`/omitted are rejected (⇒ unlabeled ⇒
+# deny), never silently downgraded. Absent ⇒ unlabeled ⇒ deny ⇒ a genesis-
+# coverage finding (there is no permissive default).
+# Usage: getStatus @0 :Status $vfsMac("internal:pq-hybrid");
 annotation vfsMac(field) :Text;

--- a/crates/hyprstream-rpc/schema/annotations.capnp
+++ b/crates/hyprstream-rpc/schema/annotations.capnp
@@ -140,3 +140,11 @@ annotation vfsBulk(field) :Void;
 
 # Exclude a method from the generated mount.
 annotation vfsHidden(field) :Void;
+
+# MAC security label this generated node carries — carrier (a) of #699: the label
+# is a property of the node's TYPE, derived from the schema annotation at
+# generation (T2 emits it onto VfsNode). Format: "<level>" or
+# "<level>:<assurance>" or "<level>:<assurance>:<compBit,compBit>". Absent ⇒ the
+# generated node is unlabeled ⇒ deny ⇒ a genesis-coverage finding (there is no
+# permissive default). Usage: getStatus @0 :Status $vfsMac("internal");
+annotation vfsMac(field) :Text;

--- a/crates/hyprstream-rpc/src/_metadata.rs
+++ b/crates/hyprstream-rpc/src/_metadata.rs
@@ -95,16 +95,18 @@ pub struct VfsNode {
 impl VfsNode {
     /// Decode this node's `$vfsMac` annotation into a [`SecurityLabel`].
     ///
-    /// Returns `None` when the annotation is empty or malformed — the node is
-    /// then **unlabeled**, which the MAC model treats as **deny** (there is no
-    /// permissive default; absence is denial). Such nodes surface as gaps in the
-    /// genesis coverage report rather than being silently defaulted.
+    /// Returns `None` when the annotation is empty, malformed, or carries a
+    /// non-`pq-hybrid` assurance — the node is then **unlabeled**, which the MAC
+    /// model treats as **deny** (there is no permissive default; absence is
+    /// denial). Such nodes surface as gaps in the genesis coverage report rather
+    /// than being silently defaulted.
     ///
-    /// Format: `"<level>"` | `"<level>:<assurance>"` |
-    /// `"<level>:<assurance>:<compBit>[,<compBit>...]"` where `level` is one of
-    /// `public`/`internal`/`confidential`/`secret`, `assurance` is one of
-    /// `unverified`/`classical`/`pq-hybrid`, and each `compBit` is a `u32`
-    /// compartment bit index (the lattice vocabulary is S3's job, #569).
+    /// Format: `"<level>:<assurance>[:<compBit>[,<compBit>...]]"` where `level`
+    /// is one of `public`/`internal`/`confidential`/`secret`, `assurance` is
+    /// **required** and must be exactly `pq-hybrid` (the internal non-interop
+    /// carrier rejects `unverified`/`classical`/omitted — #556), and each
+    /// `compBit` is a `u32` compartment bit index (the lattice vocabulary is S3's
+    /// job, #569).
     pub fn mac_label(&self) -> Option<crate::auth::mac::SecurityLabel> {
         parse_mac_annotation(self.mac)
     }
@@ -112,7 +114,16 @@ impl VfsNode {
 
 /// Parse a `$vfsMac` annotation string into a [`SecurityLabel`].
 ///
-/// `""` / unparseable ⇒ `None` (unlabeled ⇒ deny). See [`VfsNode::mac_label`].
+/// `""` / unparseable / non-`pq-hybrid` ⇒ `None` (unlabeled ⇒ deny). See
+/// [`VfsNode::mac_label`].
+///
+/// **Assurance is mandatory and MUST be `pq-hybrid`** (#556, #1228): the
+/// generated 9P/VFS surface is an *internal, non-interop* carrier, and the
+/// operator ruling is PQ-hybrid required on all deployments. A level-only
+/// annotation, `unverified`, or `classical` would produce a label a classical
+/// subject dominates — the non-PQ path #556 was enacted to remove, reappearing
+/// as a silent default. Those forms are therefore **rejected** (⇒ unlabeled ⇒
+/// deny ⇒ a genesis-coverage finding), never silently downgraded.
 fn parse_mac_annotation(s: &str) -> Option<crate::auth::mac::SecurityLabel> {
     use crate::auth::mac::{Assurance, CompartmentSet, Level, SecurityLabel};
 
@@ -128,11 +139,14 @@ fn parse_mac_annotation(s: &str) -> Option<crate::auth::mac::SecurityLabel> {
         "secret" => Level::Secret,
         _ => return None,
     };
+    // Assurance is MANDATORY and must be exactly `pq-hybrid`. Omitted,
+    // `unverified`, and `classical` are all rejected ⇒ None ⇒ unlabeled ⇒ deny
+    // (this is the internal non-interop surface; #556 removes the classical
+    // floor, and this carrier must not silently reintroduce it).
     let assurance = match parts.next().map(str::trim) {
-        None | Some("") | Some("unverified") => Assurance::Unverified,
-        Some("classical") => Assurance::Classical,
         Some("pq-hybrid") => Assurance::PqHybrid,
-        Some(_) => return None,
+        // Omitted, empty, unverified, classical, or unknown ⇒ reject.
+        None | Some("") | Some("unverified") | Some("classical") | Some(_) => return None,
     };
     let compartments = match parts.next().map(str::trim) {
         None | Some("") => CompartmentSet::EMPTY,
@@ -160,6 +174,28 @@ fn parse_mac_annotation(s: &str) -> Option<crate::auth::mac::SecurityLabel> {
 ///
 /// Returns `(service_name, nodes)`.
 pub type VfsNodesFn = fn() -> (&'static str, &'static [VfsNode]);
+
+/// Inventory-registered generated VFS node table (#699 carrier (a) inventory).
+///
+/// Submitted by `generate_rpc_service!` for every schema that has request
+/// variants (i.e. every service that projects a `/srv/{name}` mount with
+/// generated nodes). The genesis coverage gate collects the union of these
+/// tables via [`inventory::iter::<VfsNodeTable>()`] so the startup gate covers
+/// every reachable generated object class — not just the ones a hand-built
+/// fixture happened to include.
+///
+/// The `nodes_fn` indirection keeps the table lazy (zero-cost until the gate
+/// walks it) and lets this crate stay free of a `hyprstream-service`
+/// dependency: the macro emits the `inventory::submit!` in whatever crate owns
+/// the generated client module, and the gate (in the daemon crate) iterates it.
+pub struct VfsNodeTable {
+    /// The `/srv/{name}` service this table belongs to.
+    pub name: &'static str,
+    /// `fn() -> (service_name, &[VfsNode])` — the generated `vfs_nodes()`.
+    pub nodes_fn: VfsNodesFn,
+}
+
+inventory::collect!(VfsNodeTable);
 
 /// Function type for service schema metadata.
 ///
@@ -199,10 +235,11 @@ mod tests {
     }
 
     #[test]
-    fn mac_label_decodes_level_only() {
-        let l = node("confidential").mac_label().unwrap();
+    fn mac_label_decodes_level_and_pq_hybrid_assurance() {
+        // The only accepted form: <level>:pq-hybrid. Assurance is mandatory.
+        let l = node("confidential:pq-hybrid").mac_label().unwrap();
         assert_eq!(l.level, Level::Confidential);
-        assert_eq!(l.assurance, Assurance::Unverified);
+        assert_eq!(l.assurance, Assurance::PqHybrid);
         assert!(l.compartments.is_empty());
     }
 
@@ -215,9 +252,11 @@ mod tests {
 
     #[test]
     fn mac_label_decodes_compartments() {
-        let l = node("internal:classical:0,3").mac_label().unwrap();
+        // Compartments are the optional third field, after the mandatory
+        // `pq-hybrid` assurance.
+        let l = node("internal:pq-hybrid:0,3").mac_label().unwrap();
         assert_eq!(l.level, Level::Internal);
-        assert_eq!(l.assurance, Assurance::Classical);
+        assert_eq!(l.assurance, Assurance::PqHybrid);
         assert!(l.compartments.contains(0));
         assert!(l.compartments.contains(3));
         assert!(!l.compartments.contains(1));
@@ -228,6 +267,36 @@ mod tests {
         // No $vfsMac ⇒ unlabeled ⇒ None ⇒ deny. No permissive default.
         assert!(node("").mac_label().is_none());
         assert!(node("   ").mac_label().is_none());
+    }
+
+    #[test]
+    fn mac_label_level_only_is_denied_assurance_is_mandatory() {
+        // A level-only annotation (no assurance) is rejected ⇒ None ⇒ deny.
+        // Assurance is mandatory on this internal non-interop carrier; a
+        // level-only form would default to Unverified, the non-PQ path #556
+        // removed. Each level is rejected without an assurance.
+        for level in ["public", "internal", "confidential", "secret"] {
+            assert!(
+                node(level).mac_label().is_none(),
+                "level-only `{level}` must deny: assurance is mandatory"
+            );
+        }
+    }
+
+    #[test]
+    fn mac_label_unverified_assurance_is_denied() {
+        // `unverified` is the non-PQ floor ⇒ rejected on this internal carrier.
+        // Each form an operator might reach for that silently drops PQ is denied.
+        assert!(node("internal:unverified").mac_label().is_none());
+        assert!(node("public:unverified").mac_label().is_none());
+    }
+
+    #[test]
+    fn mac_label_classical_assurance_is_denied() {
+        // `classical` is the explicit non-PQ path #556 removes from internal VFS
+        // — a classical subject would dominate it. Rejected ⇒ None ⇒ deny.
+        assert!(node("internal:classical").mac_label().is_none());
+        assert!(node("secret:classical:0").mac_label().is_none());
     }
 
     #[test]

--- a/crates/hyprstream-rpc/src/_metadata.rs
+++ b/crates/hyprstream-rpc/src/_metadata.rs
@@ -85,6 +85,75 @@ pub struct VfsNode {
     pub scope: &'static str,
     /// `$vfsBulk`: `read` returns raw mmap bytes, bypassing capnp (DMA path).
     pub bulk: bool,
+    /// `$vfsMac` annotation text declaring this node's MAC security label
+    /// (#699 carrier (a)): the label is a property of the node's type, derived
+    /// at codegen. Decode with [`VfsNode::mac_label`]. Empty ⇒ the node is
+    /// unlabeled ⇒ deny ⇒ a genesis-coverage finding (no permissive default).
+    pub mac: &'static str,
+}
+
+impl VfsNode {
+    /// Decode this node's `$vfsMac` annotation into a [`SecurityLabel`].
+    ///
+    /// Returns `None` when the annotation is empty or malformed — the node is
+    /// then **unlabeled**, which the MAC model treats as **deny** (there is no
+    /// permissive default; absence is denial). Such nodes surface as gaps in the
+    /// genesis coverage report rather than being silently defaulted.
+    ///
+    /// Format: `"<level>"` | `"<level>:<assurance>"` |
+    /// `"<level>:<assurance>:<compBit>[,<compBit>...]"` where `level` is one of
+    /// `public`/`internal`/`confidential`/`secret`, `assurance` is one of
+    /// `unverified`/`classical`/`pq-hybrid`, and each `compBit` is a `u32`
+    /// compartment bit index (the lattice vocabulary is S3's job, #569).
+    pub fn mac_label(&self) -> Option<crate::auth::mac::SecurityLabel> {
+        parse_mac_annotation(self.mac)
+    }
+}
+
+/// Parse a `$vfsMac` annotation string into a [`SecurityLabel`].
+///
+/// `""` / unparseable ⇒ `None` (unlabeled ⇒ deny). See [`VfsNode::mac_label`].
+fn parse_mac_annotation(s: &str) -> Option<crate::auth::mac::SecurityLabel> {
+    use crate::auth::mac::{Assurance, CompartmentSet, Level, SecurityLabel};
+
+    let s = s.trim();
+    if s.is_empty() {
+        return None;
+    }
+    let mut parts = s.split(':');
+    let level = match parts.next()?.trim() {
+        "public" => Level::Public,
+        "internal" => Level::Internal,
+        "confidential" => Level::Confidential,
+        "secret" => Level::Secret,
+        _ => return None,
+    };
+    let assurance = match parts.next().map(str::trim) {
+        None | Some("") | Some("unverified") => Assurance::Unverified,
+        Some("classical") => Assurance::Classical,
+        Some("pq-hybrid") => Assurance::PqHybrid,
+        Some(_) => return None,
+    };
+    let compartments = match parts.next().map(str::trim) {
+        None | Some("") => CompartmentSet::EMPTY,
+        Some(bits) => {
+            let mut set = CompartmentSet::EMPTY;
+            for b in bits.split(',') {
+                let b = b.trim();
+                if b.is_empty() {
+                    continue;
+                }
+                let idx: u32 = b.parse().ok()?;
+                set = set.union(CompartmentSet::single(idx));
+            }
+            set
+        }
+    };
+    // A fourth field is not part of the grammar → malformed → deny.
+    if parts.next().is_some() {
+        return None;
+    }
+    Some(SecurityLabel::new(level, assurance, compartments))
 }
 
 /// Function type for a service's VFS node table.
@@ -110,4 +179,68 @@ pub struct ScopedClientTreeNode {
     pub scope_field: &'static str,
     pub metadata_fn: ScopedSchemaMetadataFn,
     pub nested: &'static [ScopedClientTreeNode],
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)]
+mod tests {
+    use super::*;
+    use crate::auth::mac::{Assurance, Level};
+
+    fn node(mac: &'static str) -> VfsNode {
+        VfsNode {
+            method: "m",
+            path: "p",
+            kind: VfsNodeKind::File,
+            scope: "query",
+            bulk: false,
+            mac,
+        }
+    }
+
+    #[test]
+    fn mac_label_decodes_level_only() {
+        let l = node("confidential").mac_label().unwrap();
+        assert_eq!(l.level, Level::Confidential);
+        assert_eq!(l.assurance, Assurance::Unverified);
+        assert!(l.compartments.is_empty());
+    }
+
+    #[test]
+    fn mac_label_decodes_level_and_assurance() {
+        let l = node("secret:pq-hybrid").mac_label().unwrap();
+        assert_eq!(l.level, Level::Secret);
+        assert_eq!(l.assurance, Assurance::PqHybrid);
+    }
+
+    #[test]
+    fn mac_label_decodes_compartments() {
+        let l = node("internal:classical:0,3").mac_label().unwrap();
+        assert_eq!(l.level, Level::Internal);
+        assert_eq!(l.assurance, Assurance::Classical);
+        assert!(l.compartments.contains(0));
+        assert!(l.compartments.contains(3));
+        assert!(!l.compartments.contains(1));
+    }
+
+    #[test]
+    fn mac_label_empty_is_unlabeled_deny() {
+        // No $vfsMac ⇒ unlabeled ⇒ None ⇒ deny. No permissive default.
+        assert!(node("").mac_label().is_none());
+        assert!(node("   ").mac_label().is_none());
+    }
+
+    #[test]
+    fn mac_label_malformed_is_unlabeled_deny() {
+        // An unknown level / assurance / a trailing field ⇒ None ⇒ deny
+        // (fail-closed, never a guessed label).
+        assert!(node("topsecret").mac_label().is_none());
+        assert!(node("secret:quantum").mac_label().is_none());
+        assert!(node("secret:pq-hybrid:0:extra").mac_label().is_none());
+    }
+
+    #[test]
+    fn mac_label_non_numeric_compartment_is_deny() {
+        assert!(node("secret:pq-hybrid:pii").mac_label().is_none());
+    }
 }

--- a/crates/hyprstream-rpc/src/auth/mac/bind.rs
+++ b/crates/hyprstream-rpc/src/auth/mac/bind.rs
@@ -1,0 +1,293 @@
+//! **Carrier (c) — bind-time labels for synthetic VFS mounts** (#699 scope item 1,
+//! epic #547).
+//!
+//! A synthetic mount (one a subject binds into its own namespace, the Plan 9
+//! composition model) carries a security label computed at bind time from two
+//! inputs the binder supplies:
+//!
+//! - **`binder_floor`** — the binding subject's own clearance floor. Not optional:
+//!   a mount must carry a label, and that label can never be *less* restrictive
+//!   than what the binder is itself cleared to read (otherwise a subject could
+//!   re-export high-clearance data through its own mount labeled low —
+//!   declassification by re-serving, the D2 amendment case).
+//! - **`declared`** — the label the mount asserts for what it serves.
+//!
+//! The effective label is [`bind_time_label`]`binder_floor.join(declared)` — the
+//! BLP least-upper-bound, a floor not a negotiation. Every node beneath the mount
+//! is clamped to *at least* this label ([`BindLabelMap::resolve`] returns it for a
+//! descendant), and a descendant's own carrier-(a) label is joined on top
+//! ([`clamp_descendant`]) — restrict-only, never less.
+//!
+//! ## No escape hatch
+//!
+//! There is **no label-less bind**. [`BindLabelMap::bind`] takes both inputs as
+//! `SecurityLabel` (not `Option`), so a mount cannot be constructed without a
+//! label at the type level — and a path under a prefix that was never bound
+//! resolves to `None` ⇒ **deny** (the MAC model has no default label; absence is
+//! denial — the same invariant `hyprstream::mac::exchange` states for grants).
+//! There is no `Default`, no
+//! `NotApplicable`, no flag that turns the clamp off.
+
+use std::collections::BTreeMap;
+
+use super::label::SecurityLabel;
+use super::manifest::bind_time_label;
+
+/// The effective bind-time label a synthetic mount carries: the restrict-only
+/// join of the binder's floor and the mount's declared label, via
+/// [`bind_time_label`].
+///
+/// Constructed only by [`BindLabelMap::bind`], which guarantees the label is
+/// `⊒ binder_floor` and `⊒ declared` (the join can only raise, never lower).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct BindLabel(SecurityLabel);
+
+impl BindLabel {
+    /// The effective label everything beneath this mount is clamped to.
+    pub fn effective(&self) -> SecurityLabel {
+        self.0
+    }
+}
+
+/// The set of synthetic-mount bind-time labels keyed by mount prefix.
+///
+/// This is the carrier-(c) companion to [`super::genesis::GenesisMap`] (carrier
+/// (a) static nodes): where genesis labels the *generated* `/srv/{name}` surface
+/// from schema annotations, this labels the *synthetic* mounts a subject composes
+/// into its own namespace, from the binder's floor × the mount's declared label.
+///
+/// Both carriers feed the same [`super::manifest::ObjectLabelResolver`] at
+/// enforcement time; this type is the pure-data source for the bind-time half.
+#[derive(Debug, Clone, Default)]
+pub struct BindLabelMap {
+    /// Normalized absolute prefix → effective bind-time label.
+    bindings: BTreeMap<String, BindLabel>,
+}
+
+impl BindLabelMap {
+    /// An empty bind-label map.
+    pub fn new() -> Self {
+        BindLabelMap::default()
+    }
+
+    /// Bind `binder_floor × declared` at `prefix`, storing the effective
+    /// [`bind_time_label`] and returning the stored label by value.
+    ///
+    /// **Both labels are mandatory** (`SecurityLabel`, not `Option`): there is no
+    /// label-less bind — a synthetic mount must carry a label, and this is the
+    /// only way to add one. The effective label is the restrict-only join, so it
+    /// is always `⊒ binder_floor` and `⊒ declared`.
+    pub fn bind(
+        &mut self,
+        prefix: &str,
+        binder_floor: SecurityLabel,
+        declared: SecurityLabel,
+    ) -> BindLabel {
+        let normalized = normalize_prefix(prefix);
+        let effective = bind_time_label(binder_floor, declared);
+        let entry = BindLabel(effective);
+        self.bindings.insert(normalized, entry);
+        entry
+    }
+
+    /// The effective label a mount bound at `prefix` carries, if any. A prefix
+    /// that was never bound ⇒ `None` ⇒ unlabeled ⇒ deny.
+    pub fn label_for(&self, prefix: &str) -> Option<SecurityLabel> {
+        self.bindings
+            .get(&normalize_prefix(prefix))
+            .map(BindLabel::effective)
+    }
+
+    /// Resolve a walked object (path components relative to the namespace root)
+    /// to the effective bind-time label of the **nearest enclosing** synthetic
+    /// mount — the floor every node beneath that mount is clamped to.
+    ///
+    /// Walks from the full path up its ancestors; the first bound prefix found is
+    /// the enclosing mount, and its label is the descendant floor (the clamp).
+    /// `None` ⇒ no enclosing labeled mount ⇒ unlabeled ⇒ deny.
+    pub fn resolve(&self, components: &[&str]) -> Option<SecurityLabel> {
+        let full = components.len();
+        let mut depth = full;
+        while depth > 0 {
+            let path = join_components(&components[..depth]);
+            if let Some(entry) = self.bindings.get(&path) {
+                return Some(entry.effective());
+            }
+            depth -= 1;
+        }
+        None
+    }
+
+    /// Whether any synthetic mount has been bound.
+    pub fn is_empty(&self) -> bool {
+        self.bindings.is_empty()
+    }
+
+    /// The number of bound synthetic mounts.
+    pub fn len(&self) -> usize {
+        self.bindings.len()
+    }
+
+    /// Iterate the bound `(prefix, effective-label)` pairs.
+    pub fn iter(&self) -> impl Iterator<Item = (&str, SecurityLabel)> {
+        self.bindings
+            .iter()
+            .map(|(p, b)| (p.as_str(), b.effective()))
+    }
+}
+
+/// Clamp a descendant node's own (carrier-a/manifest) label to at least its
+/// enclosing mount's bind-time floor.
+///
+/// `effective = mount_floor.join(node_label)` — restrict-only: the descendant's
+/// effective label is `⊒ mount_floor` and `⊒ node_label`. A node that *declares*
+/// a less-restrictive label than its mount cannot lower the effective label below
+/// the mount's floor (the declassification-by-declaration case the clamp closes).
+/// A node may always declare itself *more* restrictive.
+#[must_use]
+pub fn clamp_descendant(mount_floor: SecurityLabel, node_label: SecurityLabel) -> SecurityLabel {
+    mount_floor.join(&node_label)
+}
+
+/// Normalize a prefix to a canonical absolute form: leading slash, no trailing
+/// slash, no empty components (`"/srv/model/"`, `"srv/model"` → `"/srv/model"`).
+/// The empty/`"/"` prefix normalizes to `""` and is never stored (the namespace
+/// root is not itself an addressable mount here).
+fn normalize_prefix(prefix: &str) -> String {
+    join_components(&prefix.split('/').collect::<Vec<_>>())
+}
+
+/// Join path components into a normalized absolute path (`["srv","model"]` →
+/// `"/srv/model"`), skipping empty components.
+fn join_components(components: &[&str]) -> String {
+    let mut out = String::new();
+    for c in components {
+        if c.is_empty() {
+            continue;
+        }
+        out.push('/');
+        out.push_str(c);
+    }
+    out
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)]
+mod tests {
+    use super::super::label::{Assurance, CompartmentSet, Level};
+    use super::*;
+
+    fn label(level: Level) -> SecurityLabel {
+        SecurityLabel::new(level, Assurance::PqHybrid, CompartmentSet::EMPTY)
+    }
+
+    // ── Test (2): a mount without a label fails to construct ──────────────────
+    //
+    // `bind` takes both labels as `SecurityLabel` (not Option), so a label-less
+    // mount is unconstructible at the type level. Runtime mirror: a path under a
+    // prefix that was never bound resolves to None ⇒ deny (no default label).
+
+    #[test]
+    fn unbound_prefix_resolves_to_none_deny() {
+        // A namespace where /srv/model is bound but /srv/policy is not.
+        let mut map = BindLabelMap::new();
+        map.bind("/srv/model", label(Level::Internal), label(Level::Internal));
+        // /srv/policy carries no label → its descendants are denied.
+        assert!(
+            map.resolve(&["srv", "policy", "config"]).is_none(),
+            "a path under a mount that carries no label must deny, not fall back to a default"
+        );
+    }
+
+    #[test]
+    fn bind_requires_both_labels_type_level() {
+        // The only `bind` constructor takes (binder_floor, declared) as
+        // SecurityLabel. The effective label is the join of exactly those two —
+        // there is no third "no-label" path the caller can reach.
+        let mut map = BindLabelMap::new();
+        let b = map.bind("/srv/model", label(Level::Internal), label(Level::Confidential));
+        // effective = join(Internal, Confidential) = Confidential.
+        assert_eq!(b.effective().level, Level::Confidential);
+    }
+
+    // ── Test (3): a node beneath a mount is clamped to at least the floor ─────
+
+    #[test]
+    fn descendant_inherits_mount_effective_label() {
+        let mut map = BindLabelMap::new();
+        // A Secret-cleared binder declares Internal; effective = Secret (floor wins).
+        map.bind("/srv/policy", label(Level::Secret), label(Level::Internal));
+        let under = map.resolve(&["srv", "policy", "config", "current"]).unwrap();
+        assert_eq!(
+            under.level,
+            Level::Secret,
+            "a descendant is clamped to at least the mount's effective floor"
+        );
+    }
+
+    // ── Test (4): the clamp is restrict-only ──────────────────────────────────
+
+    #[test]
+    fn clamp_descendant_is_restrict_only() {
+        let mount_floor = label(Level::Secret);
+        // A node that declares itself LESS restrictive than its mount cannot
+        // lower the effective label below the mount floor.
+        let node_declared_low = label(Level::Public);
+        assert_eq!(
+            clamp_descendant(mount_floor, node_declared_low).level,
+            Level::Secret,
+            "a descendant declaring a lower label cannot lower below the mount floor"
+        );
+        // A node that declares itself MORE restrictive is honored as-is (still ⊒ mount).
+        let node_declared_higher = SecurityLabel::new(
+            Level::Secret,
+            Assurance::PqHybrid,
+            CompartmentSet::single(0),
+        );
+        let clamped = clamp_descendant(mount_floor, node_declared_higher);
+        assert!(clamped.compartments.contains(0));
+        assert!(clamped.level >= mount_floor.level);
+    }
+
+    #[test]
+    fn effective_label_never_below_binder_floor() {
+        // The D2 invariant: re-exporting Secret-read data as Public via a mount
+        // the binder labeled low still clamps back to (at least) Secret.
+        let mut map = BindLabelMap::new();
+        map.bind("/reexport", label(Level::Secret), label(Level::Public));
+        let effective = map.label_for("/reexport").unwrap();
+        assert_eq!(
+            effective.level,
+            Level::Secret,
+            "bind_time_label must not let a declared-low mount go below the binder floor"
+        );
+    }
+
+    #[test]
+    fn resolve_walks_to_nearest_enclosing_mount() {
+        let mut map = BindLabelMap::new();
+        map.bind("/srv", label(Level::Public), label(Level::Public));
+        map.bind(
+            "/srv/model",
+            label(Level::Internal),
+            label(Level::Internal),
+        );
+        // /srv/model/qwen/status → nearest is /srv/model (Internal), not /srv.
+        assert_eq!(
+            map.resolve(&["srv", "model", "qwen", "status"]).unwrap().level,
+            Level::Internal
+        );
+        // /srv/other → nearest is /srv (Public).
+        assert_eq!(
+            map.resolve(&["srv", "other"]).unwrap().level,
+            Level::Public
+        );
+    }
+
+    #[test]
+    fn empty_map_denies_everything() {
+        let map = BindLabelMap::new();
+        assert!(map.is_empty());
+        assert!(map.resolve(&["anything"]).is_none());
+    }
+}

--- a/crates/hyprstream-rpc/src/auth/mac/mod.rs
+++ b/crates/hyprstream-rpc/src/auth/mac/mod.rs
@@ -102,12 +102,14 @@
 //!    fail-closed, which is correct. No type change needed when #153 lands —
 //!    it's a new compartment/level value, not a new axis.
 
+pub mod bind;
 pub mod context;
 pub mod genesis;
 pub mod label;
 pub mod lattice;
 pub mod manifest;
 
+pub use bind::{clamp_descendant, BindLabel, BindLabelMap};
 pub use context::{SecurityContext, SubjectContextClaims, VerifiedKeyMaterial};
 pub use genesis::{GenesisMap, GenesisReport};
 pub use label::{

--- a/crates/hyprstream-rpc/src/lib.rs
+++ b/crates/hyprstream-rpc/src/lib.rs
@@ -130,6 +130,13 @@ pub mod zmtp_framing;
 
 /// Schema introspection metadata types — used by proc macro codegen on all targets.
 pub mod metadata {
+    /// Re-export of the `inventory` crate so generated code (`generate_rpc_service!`)
+    /// can submit `VfsNodeTable` entries without forcing every consumer crate to
+    /// declare an `inventory` dependency — `hyprstream_rpc::metadata::inventory`
+    /// resolves wherever `hyprstream-rpc` is a dependency (same pattern the crate
+    /// already uses internally for `ScopeDefinition`).
+    pub use inventory;
+
     pub use crate::_metadata::*;
 }
 mod _metadata;

--- a/crates/hyprstream/src/mac/genesis.rs
+++ b/crates/hyprstream/src/mac/genesis.rs
@@ -601,6 +601,69 @@ impl GenesisGate {
     }
 }
 
+// ────────────────────────────────────────────────────────────────────────────
+// 5. Carrier (a) — schema-derived labels on generated mount nodes (#699)
+// ────────────────────────────────────────────────────────────────────────────
+
+/// Per-node label coverage of a service's generated `vfs_nodes()` table
+/// (#699 carrier (a)): each generated `/srv/{service}/*` node carries its MAC
+/// label as a property of its type, derived from the `$vfsMac` schema annotation
+/// at codegen (see [`hyprstream_rpc::metadata::VfsNode::mac_label`]).
+///
+/// A node whose schema declared no `$vfsMac` decodes to `None` ⇒ **unlabeled** ⇒
+/// deny ⇒ a **finding** the operator must close (by annotating the schema) before
+/// enforcement is enabled. There is no permissive default and no catch-all: this
+/// type only partitions what the schemas declared.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct GeneratedNodeCoverage {
+    /// `(mount-relative path, label)` for every node that resolves to a label.
+    pub labeled: Vec<(String, SecurityLabel)>,
+    /// Mount-relative paths of nodes whose schema declared no `$vfsMac`
+    /// (unlabeled ⇒ deny ⇒ finding).
+    pub unlabeled: Vec<String>,
+}
+
+impl GeneratedNodeCoverage {
+    /// Coverage is complete iff every generated node resolves to a label.
+    pub fn is_complete(&self) -> bool {
+        self.unlabeled.is_empty()
+    }
+
+    /// Classify a service's generated node table by carrier (a).
+    ///
+    /// `service` is the `/srv/{service}` mount name (for reporting); `nodes` is
+    /// the table the codegen macro emitted (from `vfs_nodes()`).
+    pub fn for_service(service: &str, nodes: &[hyprstream_rpc::metadata::VfsNode]) -> Self {
+        let mut labeled = Vec::new();
+        let mut unlabeled = Vec::new();
+        for n in nodes {
+            let path = format!("/srv/{}{}", service, normalize_relative(n.path));
+            match n.mac_label() {
+                Some(label) => labeled.push((path, label)),
+                None => unlabeled.push(path),
+            }
+        }
+        // Deterministic order (tests + stable reports).
+        labeled.sort_by(|a, b| a.0.cmp(&b.0));
+        unlabeled.sort();
+        GeneratedNodeCoverage { labeled, unlabeled }
+    }
+}
+
+/// Normalize a mount-relative node path into an absolute `/srv/{service}/...`
+/// segment suffix: prepend `/` if the node path is non-empty, else "" (the
+/// service root itself). `{brace}` arg-segments are kept verbatim — they are
+/// part of the node's path identity, not resolved here.
+fn normalize_relative(path: &str) -> String {
+    if path.is_empty() {
+        String::new()
+    } else if path.starts_with('/') {
+        path.to_owned()
+    } else {
+        format!("/{path}")
+    }
+}
+
 #[cfg(test)]
 #[allow(clippy::unwrap_used)]
 mod tests {
@@ -858,5 +921,60 @@ mod tests {
             );
             assert_eq!(expected.assurance, Assurance::Unverified);
         }
+    }
+
+    // ── Carrier (a): generated-node label coverage (#699) ─────────────────────
+
+    use hyprstream_rpc::metadata::{VfsNode, VfsNodeKind};
+
+    fn vnode(path: &'static str, mac: &'static str) -> VfsNode {
+        VfsNode {
+            method: "m",
+            path,
+            kind: VfsNodeKind::File,
+            scope: "query",
+            bulk: false,
+            mac,
+        }
+    }
+
+    #[test]
+    fn every_annotated_generated_node_resolves_to_a_label() {
+        // Carrier (a): a fully-`$vfsMac`-annotated service's generated table has
+        // NO unlabeled nodes — every node resolves to a label.
+        let nodes = [
+            vnode("status", "internal"),
+            vnode("{name}", "confidential"),
+            vnode("ctl", "secret:pq-hybrid:0"),
+        ];
+        let cov = GeneratedNodeCoverage::for_service("model", &nodes);
+        assert!(cov.is_complete(), "unlabeled findings: {:?}", cov.unlabeled);
+        assert_eq!(cov.labeled.len(), 3);
+        assert_eq!(cov.unlabeled, Vec::<String>::new());
+        // Paths are /srv/{service}/{node}.
+        let paths: Vec<&str> = cov.labeled.iter().map(|(p, _)| p.as_str()).collect();
+        assert!(paths.contains(&"/srv/model/status"));
+        assert!(paths.contains(&"/srv/model/{name}"));
+        assert!(paths.contains(&"/srv/model/ctl"));
+    }
+
+    #[test]
+    fn unannotated_generated_node_is_a_finding_not_a_default() {
+        // A node whose schema declared no `$vfsMac` is unlabeled ⇒ deny ⇒ a
+        // finding. It is NOT defaulted to a permissive label.
+        let nodes = [vnode("status", "internal"), vnode("secret", "")];
+        let cov = GeneratedNodeCoverage::for_service("model", &nodes);
+        assert!(!cov.is_complete());
+        assert_eq!(cov.unlabeled, vec!["/srv/model/secret"]);
+        assert_eq!(cov.labeled.len(), 1);
+    }
+
+    #[test]
+    fn malformed_vfs_mac_is_a_finding() {
+        // A garbled `$vfsMac` decodes to None ⇒ finding (fail-closed).
+        let nodes = [vnode("status", "internal"), vnode("x", "not-a-level")];
+        let cov = GeneratedNodeCoverage::for_service("model", &nodes);
+        assert!(!cov.is_complete());
+        assert!(cov.unlabeled.contains(&"/srv/model/x".to_owned()));
     }
 }

--- a/crates/hyprstream/src/mac/genesis.rs
+++ b/crates/hyprstream/src/mac/genesis.rs
@@ -34,13 +34,14 @@
 //! The production resolver is consumed by the authoritative 9P translator PEP.
 //! Missing and unlabeled objects deny; there is no permissive fallback.
 
-use std::collections::BTreeSet;
+use std::collections::{BTreeMap, BTreeSet};
 use std::sync::Arc;
 
 use hyprstream_rpc::auth::mac::{
-    import_label, Assurance, GenesisMap, GenesisReport, Lattice, LatticeVersion, Level,
-    ObjectLabelResolver, ObjectRef, SecurityLabel,
+    clamp_descendant, import_label, Assurance, BindLabelMap, GenesisMap, GenesisReport, Lattice,
+    LatticeVersion, Level, ObjectLabelResolver, ObjectRef, SecurityLabel,
 };
+use hyprstream_rpc::metadata::VfsNodeTable;
 
 /// The export-root skeleton nodes the host VFS composes under (mirrors
 /// `server::routes::ninep::build_export_mount` + the `#730` host VFS layout).
@@ -332,16 +333,23 @@ impl ManifestLabelSource for NoManifests {
     }
 }
 
-/// The production [`ObjectLabelResolver`]: composes the three label sources the
+/// The production [`ObjectLabelResolver`]: composes the label sources the
 /// reference monitor needs, in priority order, and fails closed when none applies.
 ///
 /// For a **path** reference:
-/// 1. **Genesis static node** — an exact genesis assignment for the path.
-/// 2. **Bind-time D2 descendant inheritance** — a path *under* a genesis-labeled
-///    node inherits that ancestor's label (the mount's bind-time floor). This is
-///    the D2 clamp: a descendant is never *less* restrictive than the mount it
-///    lives in.
-/// 3. Neither ⇒ `None` ⇒ deny.
+/// 1. **Carrier (a) deny-set** — a *generated* node whose schema declared no
+///    `$vfsMac` is unlabeled ⇒ **deny**. It does NOT inherit an ancestor's label
+///    (that would be a permissive default on a known surface the operator
+///    explicitly left unannotated). Only the *exact* path of a known unlabeled
+///    generated node denies; a path the inventory never saw still walks its
+///    ancestors.
+/// 2. **Carrier (c) bind-time floor** — a path *under* a synthetic mount
+///    ([`BindLabelMap`]) inherits that mount's bind-time floor, D2-joined with
+///    any genesis/generated label found below (the mount can only raise, never
+///    lower).
+/// 3. **Genesis static node** (incl. materialized carrier-(a) labels) — an exact
+///    assignment, or the nearest labeled non-structural-root ancestor.
+/// 4. None ⇒ `None` ⇒ deny.
 ///
 /// For a **CID** reference: the CAS [`ManifestLabelSource`] — a present-but-
 /// unlabeled manifest denies, and an absent manifest denies.
@@ -352,20 +360,36 @@ pub struct CompositeObjectLabelResolver {
     genesis: GenesisMap,
     floor: SecurityLabel,
     manifests: Arc<dyn ManifestLabelSource>,
+    /// Carrier (a): exact paths of generated nodes whose schema declared no
+    /// `$vfsMac` (or a non-`pq-hybrid` one). These **deny** — they do not fall
+    /// through to ancestor inheritance, because the operator left a *known*
+    /// surface unannotated and a permissive default there is exactly the silent
+    /// hole #1228 closes.
+    generated_unlabeled: BTreeSet<String>,
+    /// Carrier (c): synthetic-mount bind-time labels. Empty at boot (Stage 0 —
+    /// no composed mounts yet); the bind operation (`BindLabelMap::bind`, which
+    /// takes both labels as `SecurityLabel` — no label-less construction) feeds
+    /// this. `Arc` so the future PEP bind path and this resolver share one map.
+    binds: Arc<BindLabelMap>,
 }
 
 impl CompositeObjectLabelResolver {
-    /// Construct from a materialized genesis map, the D2 clamp floor, and a CAS
-    /// manifest source.
+    /// Construct from a materialized genesis map, the D2 clamp floor, a CAS
+    /// manifest source, the carrier-(a) generated-node deny-set, and the
+    /// carrier-(c) bind-time label map.
     pub fn new(
         genesis: GenesisMap,
         floor: SecurityLabel,
         manifests: Arc<dyn ManifestLabelSource>,
+        generated_unlabeled: BTreeSet<String>,
+        binds: Arc<BindLabelMap>,
     ) -> Self {
         CompositeObjectLabelResolver {
             genesis,
             floor,
             manifests,
+            generated_unlabeled,
+            binds,
         }
     }
 
@@ -374,23 +398,45 @@ impl CompositeObjectLabelResolver {
         if components.is_empty() {
             return self.genesis.resolve("/").copied();
         }
-        // Walk from the full path up its ancestors. The first genesis assignment
-        // found is either the exact node (arm 1) or the nearest labeled ancestor
-        // (arm 2 — bind-time D2 descendant inheritance).
+        let full = join_components(components);
+
+        // Carrier (a): a generated node whose schema declared no $vfsMac (or a
+        // non-pq-hybrid one) ⇒ unlabeled ⇒ deny. Do NOT walk ancestors — a known
+        // unannotated surface must not inherit a permissive label from its
+        // service mount (#1228).
+        if self.generated_unlabeled.contains(&full) {
+            return None;
+        }
+
+        // Carrier (c): nearest enclosing synthetic mount's bind-time floor (the
+        // D2 clamp target for everything beneath it). `BindLabelMap::resolve`
+        // already walks ancestors internally.
+        let bind_floor = self.binds.resolve(components);
+
+        // Genesis (incl. materialized carrier-a labels): nearest labeled
+        // ancestor, with the structural-root inheritance carve-out.
+        let node_label = self.resolve_genesis_label(components);
+
+        // D2-join the bind floor with the node label (restrict-only). Either
+        // alone is enough to label the object; neither ⇒ deny.
+        match (bind_floor, node_label) {
+            (Some(f), Some(l)) => Some(clamp_descendant(f, l)),
+            (Some(f), None) => Some(f),
+            (None, Some(l)) => Some(l),
+            (None, None) => None,
+        }
+    }
+
+    /// Walk ancestors for the nearest genesis assignment, honoring the
+    /// structural-root inheritance carve-out (a `/srv`/`/worktree`/`/stream`
+    /// Public label does NOT flow to descendants — otherwise the structural root
+    /// acts as an implicit permissive wildcard).
+    fn resolve_genesis_label(&self, components: &[&str]) -> Option<SecurityLabel> {
         let full = components.len();
         let mut depth = full;
         while depth > 0 {
             let path = join_components(&components[..depth]);
             if let Some(label) = self.genesis.resolve(&path) {
-                // A structural export root (`/srv`, `/worktree`, `/stream`) is a
-                // container directory whose *own* Public label must NOT flow to
-                // its descendants — otherwise an unenumerated `/srv/unknown`
-                // would inherit Public and the structural root would act as an
-                // implicit permissive wildcard (fail-OPEN). Only honor a
-                // structural-root label on an EXACT hit; on an ancestor
-                // (inherited) hit, keep walking up so an unlabeled descendant
-                // falls through to `None` ⇒ deny (S1 fail-closed). Real service
-                // mounts (`/srv/model`, …) still inherit to their descendants.
                 let inherited = depth < full;
                 let structural_root = EXPORT_ROOTS.contains(&path.as_str());
                 if !inherited || !structural_root {
@@ -460,30 +506,81 @@ pub struct GenesisGate {
     lattice: Lattice,
     report: GenesisReport,
     resolver: CompositeObjectLabelResolver,
+    /// Carrier (a) coverage over the real generated-node inventory (#699). Kept
+    /// on the gate so an operator / status surface can see exactly which
+    /// generated nodes are annotated and which are findings.
+    generated: GeneratedNodeCoverage,
 }
 
 impl GenesisGate {
-    /// Build a gate from explicit parts.
+    /// Build a gate from explicit parts, folding in the **real** generated-node
+    /// inventory (carrier (a), collected from every registered `VfsNodeTable`).
+    ///
+    /// The generated inventory is part of the gate, not a manually-callable
+    /// helper: a generated node whose schema declared no `$vfsMac` (or a
+    /// non-`pq-hybrid` one) is an unlabeled **finding** that makes the report
+    /// incomplete, so enforcement cannot be enabled until every reachable
+    /// generated object class is annotated. Labeled generated nodes are
+    /// materialized into the genesis map (so the resolver resolves them);
+    /// unlabeled ones go into the resolver's deny-set (so they deny, never
+    /// inherit an ancestor's label).
     pub fn build(
         nodes: Vec<String>,
         lattice: Lattice,
         policy: &SitePolicy,
         manifests: Arc<dyn ManifestLabelSource>,
     ) -> Self {
-        let genesis = policy.materialize(nodes.iter().map(String::as_str));
-        let report = genesis.report(nodes.iter().map(String::as_str), &lattice);
-        let resolver = CompositeObjectLabelResolver::new(genesis, policy.floor(), manifests);
+        // Site-policy genesis over the enumerated MOUNT nodes only — generated
+        // node labels come exclusively from `$vfsMac` below, never from the
+        // site-policy floor (an unannotated generated node must deny, not pick
+        // up the floor).
+        let mut genesis = policy.materialize(nodes.iter().map(String::as_str));
+
+        // Carrier (a): the real generated-node inventory.
+        let generated = GeneratedNodeCoverage::for_all_services();
+        for (path, label) in &generated.labeled {
+            genesis = genesis.assign(path, *label);
+        }
+
+        // The report node set = mount nodes ∪ generated-node paths, so the
+        // completeness check covers every reachable object class.
+        let mut all_nodes: Vec<String> = nodes;
+        for (path, _) in &generated.labeled {
+            all_nodes.push(path.clone());
+        }
+        for path in &generated.unlabeled {
+            all_nodes.push(path.clone());
+        }
+        all_nodes.sort();
+        all_nodes.dedup();
+
+        let report = genesis.report(all_nodes.iter().map(String::as_str), &lattice);
+        let generated_unlabeled: BTreeSet<String> = generated.unlabeled.iter().cloned().collect();
+        // Carrier (c): Stage 0 — no synthetic mounts composed yet. The bind map
+        // is empty; the future bind operation (`BindLabelMap::bind`, which takes
+        // both labels as `SecurityLabel`) feeds the shared map the resolver
+        // consults. No label-less construction exists.
+        let binds = Arc::new(BindLabelMap::new());
+        let resolver = CompositeObjectLabelResolver::new(
+            genesis,
+            policy.floor(),
+            manifests,
+            generated_unlabeled,
+            binds,
+        );
         GenesisGate {
-            nodes,
+            nodes: all_nodes,
             lattice,
             report,
             resolver,
+            generated,
         }
     }
 
     /// Build the default production gate: the production node inventory, the
     /// conservative site policy, the genesis lattice, and no CAS manifest source
-    /// wired yet ([`NoManifests`], Stage 0).
+    /// wired yet ([`NoManifests`], Stage 0). The generated-node inventory is
+    /// collected from the real `VfsNodeTable` registry.
     pub fn production() -> Self {
         GenesisGate::build(
             NamespaceEnumerator::production().into_nodes(),
@@ -491,6 +588,14 @@ impl GenesisGate {
             &SitePolicy::conservative(),
             Arc::new(NoManifests),
         )
+    }
+
+    /// Carrier (a) coverage over the real generated-node inventory: the
+    /// `(path, label)` pairs that resolved, and the paths that are findings
+    /// (unlabeled ⇒ deny). This is the per-node evidence an operator annotates
+    /// against before activation.
+    pub fn generated_coverage(&self) -> &GeneratedNodeCoverage {
+        &self.generated
     }
 
     /// The completeness report over the enumerated node set.
@@ -627,6 +732,33 @@ impl GeneratedNodeCoverage {
     /// Coverage is complete iff every generated node resolves to a label.
     pub fn is_complete(&self) -> bool {
         self.unlabeled.is_empty()
+    }
+
+    /// Classify the **real** generated-node inventory — every `vfs_nodes()`
+    /// table registered at codegen via `inventory::submit! { VfsNodeTable }` —
+    /// into labeled / unlabeled. This is the source the startup gate walks: it
+    /// covers every reachable generated object class, not whatever a hand-built
+    /// fixture happened to include.
+    ///
+    /// Deterministic: tables are sorted by service name, and the output's
+    /// `labeled`/`unlabeled` are sorted (stable reports + tests).
+    pub fn for_all_services() -> Self {
+        let mut by_service: BTreeMap<&'static str, &'static [hyprstream_rpc::metadata::VfsNode]> =
+            BTreeMap::new();
+        for t in inventory::iter::<VfsNodeTable> {
+            let (name, nodes) = (t.nodes_fn)();
+            by_service.insert(name, nodes);
+        }
+        let mut labeled = Vec::new();
+        let mut unlabeled = Vec::new();
+        for (service, nodes) in &by_service {
+            let cov = GeneratedNodeCoverage::for_service(service, nodes);
+            labeled.extend(cov.labeled);
+            unlabeled.extend(cov.unlabeled);
+        }
+        labeled.sort_by(|a, b| a.0.cmp(&b.0));
+        unlabeled.sort();
+        GeneratedNodeCoverage { labeled, unlabeled }
     }
 
     /// Classify a service's generated node table by carrier (a).
@@ -789,7 +921,13 @@ mod tests {
     ) -> CompositeObjectLabelResolver {
         let p = SitePolicy::conservative();
         let map = p.materialize(nodes.iter().copied());
-        CompositeObjectLabelResolver::new(map, p.floor(), manifests)
+        CompositeObjectLabelResolver::new(
+            map,
+            p.floor(),
+            manifests,
+            BTreeSet::new(),
+            Arc::new(BindLabelMap::new()),
+        )
     }
 
     #[test]
@@ -836,6 +974,8 @@ mod tests {
             genesis,
             import_floor,
             Arc::new(FixedManifests(Some(Some(labeled)))),
+            BTreeSet::new(),
+            Arc::new(BindLabelMap::new()),
         );
         let expected = SecurityLabel::new(Level::Secret, Assurance::Classical, Default::default());
         assert_eq!(
@@ -867,22 +1007,73 @@ mod tests {
     // ── Gate ─────────────────────────────────────────────────────────────────
 
     #[test]
-    fn production_gate_reports_complete() {
+    fn production_gate_mount_coverage_is_complete() {
+        // The site-policy half: every enumerated MOUNT node (/srv/{service},
+        // structural roots, standard mounts) is labeled by the conservative
+        // policy. This is the pre-existing coverage; carrier (a) adds the
+        // generated-node dimension on top.
+        let gate = GenesisGate::production();
+        let mount_nodes = NamespaceEnumerator::production().into_nodes();
+        for node in &mount_nodes {
+            assert!(
+                gate.report().labeled.contains(node),
+                "mount node {node} must be labeled by the site-policy genesis"
+            );
+        }
+    }
+
+    #[test]
+    fn production_gate_generated_coverage_is_collected() {
+        // Carrier (a) wiring (#1228): the gate folds in the REAL generated-node
+        // inventory — not a hand-built fixture. The inventory is non-empty (the
+        // daemon's services project generated nodes), and the coverage is
+        // surfaced on the gate for operator visibility.
+        let gate = GenesisGate::production();
+        let cov = gate.generated_coverage();
+        let total = cov.labeled.len() + cov.unlabeled.len();
+        assert!(
+            total > 0,
+            "the real generated-node inventory must be collected into the gate"
+        );
+    }
+
+    #[test]
+    fn production_gate_is_incomplete_until_all_generated_nodes_annotated() {
+        // The startup activation gate (#1228): a generated node whose schema
+        // declared no `$vfsMac` is a finding, so the production gate is
+        // INCOMPLETE until every reachable generated object class is annotated.
+        // This is the honest Stage 0 state — enforcement MUST NOT be enabled
+        // while any generated node is unlabeled. (Schemas are not yet fully
+        // `$vfsMac`-annotated, so the unannotated majority are findings here.)
         let gate = GenesisGate::production();
         assert!(
-            gate.report().is_complete(),
-            "production gate should be complete; gaps: {:?}",
-            gate.report().unlabeled
+            !gate.generated_coverage().is_complete(),
+            "the production gate must surface the unannotated generated nodes as \
+             findings — a complete gate before schemas are annotated would mean \
+             the inventory is not really gating"
         );
-        assert!(!gate.nodes().is_empty());
+        // And the report itself is incomplete (the generated unlabeled paths are
+        // in the report's unlabeled list, not silently dropped).
+        assert!(
+            !gate.report().is_complete(),
+            "the report must reflect the generated-node findings"
+        );
     }
 
     #[test]
     fn gate_render_report_contains_summary_and_labels() {
+        // The rendered report carries the status line and each labeled node's
+        // assignment, whether the gate is COMPLETE or INCOMPLETE.
         let gate = GenesisGate::production();
         let rendered = gate.render_report();
-        assert!(rendered.contains("MAC genesis coverage: COMPLETE"));
-        assert!(rendered.contains("/srv/policy -> confidential"));
+        assert!(
+            rendered.contains("MAC genesis coverage:"),
+            "rendered report has a status line: {rendered}"
+        );
+        assert!(
+            rendered.contains("/srv/policy -> confidential"),
+            "labeled mount nodes appear in the report: {rendered}"
+        );
     }
 
     #[test]
@@ -903,9 +1094,9 @@ mod tests {
 
     #[test]
     fn gate_resolver_matches_report_coverage() {
-        // Every labeled node in the report must resolve to the exact site-policy
-        // label. Genesis carries no provenance evidence, so assurance remains at
-        // the fail-closed Unverified floor rather than acquiring a join identity.
+        // Every labeled node in the report must resolve to the label materialized
+        // into genesis: generated nodes use their schema carrier, while mount
+        // nodes use the site-policy label.
         let gate = GenesisGate::production();
         let policy = SitePolicy::conservative();
         for node in &gate.report().labeled {
@@ -913,14 +1104,128 @@ mod tests {
                 .split('/')
                 .filter(|component| !component.is_empty())
                 .collect();
-            let expected = policy.label_for(node);
+            let carrier_label = gate
+                .generated_coverage()
+                .labeled
+                .iter()
+                .find_map(|(path, label)| (path == node).then_some(*label));
+            let expected = carrier_label.unwrap_or_else(|| policy.label_for(node));
             assert_eq!(
                 gate.resolver().resolve(ObjectRef::Path(&components)),
                 Some(expected),
-                "labeled node {node} must resolve to its reported site-policy label"
+                "labeled node {node} must resolve to its materialized genesis label"
             );
-            assert_eq!(expected.assurance, Assurance::Unverified);
+            if carrier_label.is_none() {
+                assert_eq!(expected.assurance, Assurance::Unverified);
+            }
         }
+    }
+
+    // ── Carrier wiring (#1228): the carriers reach the resolver, end-to-end ──
+
+    #[test]
+    fn resolver_resolves_real_annotated_generated_node() {
+        // End-to-end over the REAL generated-node inventory (not a fixture):
+        // the production gate folds in every registered `VfsNodeTable`, so a
+        // `$vfsMac`-annotated real schema node resolves through the production
+        // resolver to its schema-declared label. `registry`'s `healthCheck` is
+        // annotated `internal:pq-hybrid` and projects to `/srv/registry/health`.
+        let gate = GenesisGate::production();
+        let cov = gate.generated_coverage();
+        let health_path = "/srv/registry/health";
+        assert!(
+            cov.labeled.iter().any(|(p, _)| p == health_path),
+            "the annotated registry health node must be in the generated coverage: {:?}",
+            cov.labeled
+        );
+        let label = gate
+            .resolver()
+            .resolve(ObjectRef::Path(&["srv", "registry", "health"]))
+            .unwrap(); // annotated node must resolve to its label
+        assert_eq!(label.level, Level::Internal);
+        assert_eq!(label.assurance, Assurance::PqHybrid);
+    }
+
+    #[test]
+    fn resolver_denies_real_unannotated_generated_node() {
+        // End-to-end over the REAL inventory: an unannotated generated node (one
+        // the schema left without a `$vfsMac`) denies — it does NOT inherit its
+        // service mount's label. `registry`'s `getByName` projects to
+        // `/srv/registry/{name}` and carries no `$vfsMac`, so it is a finding
+        // and resolves to None ⇒ deny (#1228: the silent hole is closed).
+        let gate = GenesisGate::production();
+        let cov = gate.generated_coverage();
+        let name_path = "/srv/registry/{name}";
+        assert!(
+            cov.unlabeled.iter().any(|p| p == name_path),
+            "the unannotated registry {{name}} node must be a finding: {:?}",
+            cov.unlabeled
+        );
+        assert!(
+            gate.resolver()
+                .resolve(ObjectRef::Path(&["srv", "registry", "{name}"]))
+                .is_none(),
+            "an unannotated real node must deny, not inherit the mount label"
+        );
+    }
+
+    #[test]
+    fn resolver_bind_time_floor_clamps_descendant_carrier_c() {
+        // Carrier (c) reaches the resolver: a synthetic mount bound with a
+        // floor clamps every descendant to at least that floor (D2 restrict-
+        // only). A descendant with its own label is joined; one without inherits
+        // the floor. A path under no bound and no genesis label denies.
+        let p = SitePolicy::conservative();
+        let map = p.materialize(["/srv/model"]);
+        let secret_floor =
+            SecurityLabel::new(Level::Secret, Assurance::PqHybrid, Default::default());
+        let mut binds = BindLabelMap::new();
+        // A Secret-cleared subject binds a synthetic mount at /synth.
+        binds.bind("/synth", secret_floor, secret_floor);
+        let resolver = CompositeObjectLabelResolver::new(
+            map,
+            p.floor(),
+            Arc::new(NoManifests),
+            std::collections::BTreeSet::new(),
+            Arc::new(binds),
+        );
+        // A descendant with no label of its own inherits the bind floor.
+        let under = resolver
+            .resolve(ObjectRef::Path(&["synth", "child"]))
+            .unwrap(); // descendant of a bound mount inherits the floor
+        assert_eq!(under.level, Level::Secret);
+        // A path under no bound prefix and no genesis assignment denies.
+        assert!(resolver
+            .resolve(ObjectRef::Path(&["nowhere", "at", "all"]))
+            .is_none());
+    }
+
+    #[test]
+    fn resolver_bind_floor_joins_genesis_label_restrict_only() {
+        // Carrier (c) × genesis: a descendant under a Secret bind floor whose
+        // genesis label is Internal resolves to Secret (the join — floor wins,
+        // D2 restrict-only, never less).
+        let p = SitePolicy::conservative();
+        let internal = SecurityLabel::new(Level::Internal, Assurance::PqHybrid, Default::default());
+        let secret = SecurityLabel::new(Level::Secret, Assurance::PqHybrid, Default::default());
+        let map = p.materialize(["/srv"]).assign("/synth/low", internal);
+        let mut binds = BindLabelMap::new();
+        binds.bind("/synth", secret, secret);
+        let resolver = CompositeObjectLabelResolver::new(
+            map,
+            p.floor(),
+            Arc::new(NoManifests),
+            std::collections::BTreeSet::new(),
+            Arc::new(binds),
+        );
+        let label = resolver
+            .resolve(ObjectRef::Path(&["synth", "low"]))
+            .unwrap(); // bind floor joined with genesis label resolves
+        assert_eq!(
+            label.level,
+            Level::Secret,
+            "join(Secret floor, Internal label) = Secret (restrict-only)"
+        );
     }
 
     // ── Carrier (a): generated-node label coverage (#699) ─────────────────────
@@ -941,10 +1246,11 @@ mod tests {
     #[test]
     fn every_annotated_generated_node_resolves_to_a_label() {
         // Carrier (a): a fully-`$vfsMac`-annotated service's generated table has
-        // NO unlabeled nodes — every node resolves to a label.
+        // NO unlabeled nodes — every node resolves to a label. Every annotation
+        // carries the mandatory `pq-hybrid` assurance.
         let nodes = [
-            vnode("status", "internal"),
-            vnode("{name}", "confidential"),
+            vnode("status", "internal:pq-hybrid"),
+            vnode("{name}", "confidential:pq-hybrid"),
             vnode("ctl", "secret:pq-hybrid:0"),
         ];
         let cov = GeneratedNodeCoverage::for_service("model", &nodes);
@@ -962,7 +1268,7 @@ mod tests {
     fn unannotated_generated_node_is_a_finding_not_a_default() {
         // A node whose schema declared no `$vfsMac` is unlabeled ⇒ deny ⇒ a
         // finding. It is NOT defaulted to a permissive label.
-        let nodes = [vnode("status", "internal"), vnode("secret", "")];
+        let nodes = [vnode("status", "internal:pq-hybrid"), vnode("secret", "")];
         let cov = GeneratedNodeCoverage::for_service("model", &nodes);
         assert!(!cov.is_complete());
         assert_eq!(cov.unlabeled, vec!["/srv/model/secret"]);
@@ -970,9 +1276,31 @@ mod tests {
     }
 
     #[test]
+    fn non_pq_hybrid_assurance_is_a_finding() {
+        // #556/#1228: the internal VFS carrier requires `pq-hybrid`. A
+        // level-only annotation, `unverified`, or `classical` all decode to
+        // None ⇒ unlabeled ⇒ finding (the non-PQ path must not silently land).
+        let nodes = [
+            vnode("a", "internal"), // level-only — assurance mandatory
+            vnode("b", "internal:unverified"),
+            vnode("c", "internal:classical"),
+            vnode("ok", "internal:pq-hybrid"), // the one accepted form
+        ];
+        let cov = GeneratedNodeCoverage::for_service("model", &nodes);
+        assert!(!cov.is_complete());
+        assert!(cov.unlabeled.contains(&"/srv/model/a".to_owned()));
+        assert!(cov.unlabeled.contains(&"/srv/model/b".to_owned()));
+        assert!(cov.unlabeled.contains(&"/srv/model/c".to_owned()));
+        assert_eq!(cov.labeled.len(), 1);
+    }
+
+    #[test]
     fn malformed_vfs_mac_is_a_finding() {
         // A garbled `$vfsMac` decodes to None ⇒ finding (fail-closed).
-        let nodes = [vnode("status", "internal"), vnode("x", "not-a-level")];
+        let nodes = [
+            vnode("status", "internal:pq-hybrid"),
+            vnode("x", "not-a-level"),
+        ];
         let cov = GeneratedNodeCoverage::for_service("model", &nodes);
         assert!(!cov.is_complete());
         assert!(cov.unlabeled.contains(&"/srv/model/x".to_owned()));

--- a/crates/hyprstream/src/mac/mod.rs
+++ b/crates/hyprstream/src/mac/mod.rs
@@ -107,8 +107,8 @@ pub use compiler::{
 };
 // S1 activation (#567): production genesis content/enumerator/resolver/gate.
 pub use genesis::{
-    floor_label, genesis_lattice, CompositeObjectLabelResolver, GenesisGate, ManifestLabelSource,
-    NamespaceEnumerator, NoManifests, SitePolicy,
+    floor_label, genesis_lattice, CompositeObjectLabelResolver, GeneratedNodeCoverage,
+    GenesisGate, ManifestLabelSource, NamespaceEnumerator, NoManifests, SitePolicy,
 };
 pub use pep::{production_ninep_decider, NinePAccessDecider};
 // S4 (#570): the boot path that installs the verified `CompiledPolicy` at daemon


### PR DESCRIPTION
## What

Two of the three object-label carriers the 9P/VFS namespace needs before MAC enforcement can turn on. Closes #699 scope item 1 · epic #547 · relates #569 (S3 baseline).

The third carrier (**b** — the `security_label` field on the content-addressed CAS manifest) is a sibling lane (`.worktrees/mac-ingest-label`); `storage/cas/` is **not touched** here. The three carriers meet at `ObjectLabelResolver`, keyed on the walked path/CID — the same `Tread` resolving differently per object is exactly why schema annotation alone (carrier a) cannot cover CAS (carrier b).

A sibling lane is turning enforcement ON; anything left unlabeled becomes inaccessible. **This PR delivers the label carriers and their resolution, not the 9P PEP** (`hyprstream-9p` `AccessDecider` still defaults to `AllowAll` — wiring the resolver into the decider is the enforcement lane).

## Carrier (a) — schema-derived labels on generated mount nodes (static `/srv/*`)

The label is a property of the node's TYPE, derived from a new `$vfsMac` schema annotation at codegen — the same path `$vfsKind`/`$vfsPath` already flow:

- `annotations.capnp`: `annotation vfsMac(field) :Text`
- `VfsNode.mac` + `VfsNode::mac_label() -> Option<SecurityLabel>` (decoder; format `level[:assurance[:compBits]]`)
- codegen (`cgr_reader` → `types::UnionVariant` → `vfs.rs`) captures and emits it onto the generated `VfsNode` table

A node whose schema declares no `$vfsMac` decodes to `None` ⇒ **unlabeled ⇒ deny ⇒ a genesis-coverage finding** (`GeneratedNodeCoverage`). No permissive default; absence is denial.

## Carrier (c) — bind-time labels for synthetic VFS mounts, via the previously-unused `bind_time_label`

New `BindLabelMap` (`hyprstream-rpc::auth::mac::bind`):

- `bind(binder_floor, declared)` — both labels are `SecurityLabel` (not `Option`); **there is no label-less bind** (a mount must carry a label). Effective label = `bind_time_label` = the restrict-only join, always `⊒ binder_floor` and `⊒ declared`.
- `resolve(components)` — nearest enclosing mount's effective label, the floor descendants clamp to. Unbound ⇒ `None` ⇒ deny.
- `clamp_descendant(mount_floor, node_label)` — restrict-only join; a node declaring a lower label cannot lower below the mount floor.

## No escape hatch

Neither carrier has one: no `Option` whose `None` means skip, no `NotApplicable`, no default that turns a check off, no feature flag. `None` always means **deny**, never skip.

## Tests — every behavior has one that FAILS without it (revert-verified)

| behavior | test | verified by reverting |
|---|---|---|
| clamp restrict-only | `clamp_descendant_is_restrict_only` | returning `node_label` (no join) → left Public / right Secret, fails ✅ |
| empty `$vfsMac` ⇒ deny | `mac_label_empty_is_unlabeled_deny` | defaulting empty to `Some(bottom())` → fails ✅ |
| codegen emits `mac` | `vfs_mac_annotation_flows_onto_emitted_node` | dropping the field from the literal → fails ✅ |
| generated-node coverage | `unannotated_generated_node_is_a_finding_not_a_default` | — |
| mount must carry a label | `unbound_prefix_resolves_to_none_deny` + type-level `bind` signature | — |
| descendant clamps to mount floor | `descendant_inherits_mount_effective_label` | — |
| effective never below binder floor | `effective_label_never_below_binder_floor` | — |

`VERIFY`: `buildq -- cargo build -p hyprstream`; carrier tests in `hyprstream-rpc` (`auth::mac::bind`, `_metadata`), `hyprstream-rpc-derive` (`codegen::vfs`), `hyprstream` (`mac::genesis`); `buildq clippy --all-targets -D warnings` on all four crates (and the pre-commit full-workspace release clippy passed). `cargo fmt --check` fails on a clean main (#1140) — not introduced here.

---

## Namespace inventory — every object class reachable through the 9P/VFS surface

| # | object class | examples | carrier | label source today | status |
|---|---|---|---|---|---|
| 1 | structural export-root container dirs | `/srv`, `/worktree`, `/stream` | (a) static | `SitePolicy::conservative` → **Public** (listing only; its label **does not** inherit to descendants — anti-laundering rule in `CompositeObjectLabelResolver`) | labeled |
| 2 | generated service mount nodes (schema-backed) | `/srv/policy`, `/srv/oauth`, `/srv/ledger`, `/srv/model`, `/srv/registry`, `/srv/mcp`, `/srv/tui`, `/srv/discovery`, `/srv/metrics`, `/srv/inference` | (a) schema-derived | `SitePolicy` table: control-plane (`policy`/`oauth`/`ledger`) → **Confidential**; data services → **Internal**. **Carrier (a) mechanism now lets the schema `$vfsMac` be the source instead of the site table.** | labeled (site table); schema-annotation content is the S3/#569 follow-up |
| 3 | generated method nodes under a service | `/srv/model/{name}/status`, `…/ctl`, `…/health` | (a) per-node `$vfsMac` on the service's `vfs_nodes()` table | none annotated yet → `mac=""` → `None` | ⚠️ **finding** (carrier delivered; annotation content TBD) |
| 4 | services with **no** schema / no generated VfsNode table | `/srv/event`, `/srv/worker`, `/srv/oai`, `/srv/xet`, `/srv/flight`, `/srv/streams` | (a) — none emitted | no table → no node → unlabeled | ⚠️ **finding** (needs a schema or an explicit site-policy rule) |
| 5 | standard non-service synthetic mounts | `/bin`, `/env`, `/lang/tcl` | **(c) bind-time** | `BindLabelMap.bind(binder_floor, declared)` — floor × declared | ⚠️ **finding** until bound through the labeled-bind surface |
| 6 | subject-composed synthetic mounts | any mount a subject binds into its namespace | **(c) bind-time** | `bind_time_label(binder_floor, declared)` | carrier delivered; enforcement lane wires it at bind |
| 7 | content-addressed data objects (CAS blobs/manifests) | `/worktree/...` blob content | **(b) CAS manifest `security_label`** | the manifest field | 🚫 **sibling lane** (`mac-ingest-label`); untouched here |
| 8 | stream pipes | `/stream/{...}` (MoQ plane) | TBD | — | ⚠️ **finding** (stream-plane labeling is a separate scope) |
| 9 | browser doc mounts | `/srv/{svc}/doc` | (a) structural | Public | labeled (structural) |

**Findings to close before enforcement turns on** (reported, not defaulted): rows 3, 4, 5, 8. None are defaulted to a permissive label — each is `None` ⇒ deny ⇒ surfaced by the genesis coverage gate.
