### PR TITLE
B1: seal user-controlled hosted-account genesis

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7160,6 +7160,7 @@ dependencies = [
  "parking_lot 0.12.4",
  "proptest",
  "rand 0.8.5",
+ "rustix 1.1.4",
  "serde_json",
  "sha2 0.10.9",
  "tempfile",

--- a/crates/hyprstream-pds/Cargo.toml
+++ b/crates/hyprstream-pds/Cargo.toml
@@ -24,6 +24,7 @@ hyprstream-rpc = { path = "../hyprstream-rpc" }
 hyprstream-crypto = { path = "../hyprstream-crypto" }
 # Ed25519 signing/verifying keys for the at9p composite signature path.
 ed25519-dalek = { workspace = true }
+rustix = { version = "1.1.4", features = ["fs"] }
 blake3 = { workspace = true }
 # Non-poisoning Mutex for the in-memory duplicity watermark store (#886).
 parking_lot = { workspace = true }

--- a/crates/hyprstream-pds/Cargo.toml
+++ b/crates/hyprstream-pds/Cargo.toml
@@ -9,6 +9,8 @@ description = "atproto PDS record store — DAG-CBOR records, MST, signed commit
 [dependencies]
 # P-256 ES256 signing for atproto commits (#atproto verification method).
 p256 = { workspace = true }
+# OS-backed entropy for per-account #atproto key generation.
+rand = { workspace = true }
 # SHA-256 — signing digest + CIDv1 dag-cbor multihash for all repo blocks.
 sha2 = { workspace = true }
 # Error handling.
@@ -33,8 +35,7 @@ tracing = { workspace = true }
 # tag-42 links) that serde-driven CBOR cannot guarantee. No CBOR/CID crate dep.
 
 [dev-dependencies]
-# Random signing keys for round-trip / tamper tests.
-rand = { workspace = true }
+# Property tests for deterministic codecs.
 proptest = { workspace = true }
 # at9p_resolver tests exercise the admission arm (admit_key_against_did) which is
 # generic over DidDocResolve — an async trait — against a never-call test double.

--- a/crates/hyprstream-pds/src/did_op.rs
+++ b/crates/hyprstream-pds/src/did_op.rs
@@ -1013,6 +1013,26 @@ mod tests {
     }
 
     #[test]
+    fn tampered_mldsa_component_cannot_downgrade_genesis_to_classical_only() {
+        let user = signer();
+        let unsigned = unsigned(
+            &user,
+            RecoveryKeyEnrollment::Declined,
+            HostKeyEnrollment::Absent,
+        );
+        let signature = sign_genesis(&unsigned, &user.ed, &user.pq).unwrap();
+        let mut tampered_pq = signature.mldsa65().to_vec();
+        tampered_pq[0] ^= 1;
+        let tampered =
+            DidOpSignature::from_components(signature.ed25519().to_vec(), tampered_pq).unwrap();
+
+        assert!(
+            GenesisDidOp::seal(unsigned, tampered).is_err(),
+            "genesis sealing must require a valid ML-DSA-65 signature as well as Ed25519"
+        );
+    }
+
+    #[test]
     fn duplicate_custody_keys_are_rejected() {
         let user = signer();
         let error = GenesisRotationKeys::new(

--- a/crates/hyprstream-pds/src/did_op.rs
+++ b/crates/hyprstream-pds/src/did_op.rs
@@ -1,0 +1,1075 @@
+//! The permanent genesis operation for a hyprstream-hosted `did:web` account.
+//!
+//! This module deliberately implements only operation zero. Successor-chain
+//! validation, fork selection, and historical key-validity queries belong to
+//! C1 (#1167). The bytes emitted here are nevertheless the first record in that
+//! future log, so their grammar is a one-way door for every minted account.
+//!
+//! # Rotation custody is structural
+//!
+//! [`GenesisRotationKeys`] is not a `Vec`. It has exactly three ordered slots:
+//!
+//! 0. a required [`UserRotationKey`];
+//! 1. an enrolled recovery key or an explicit
+//!    [`RecoveryKeyEnrollment::Declined`];
+//! 2. an enrolled host key or an explicit [`HostKeyEnrollment::Absent`].
+//!
+//! A [`HostRotationKey`] therefore cannot be passed as priority zero:
+//!
+//! ```compile_fail
+//! use hyprstream_pds::{
+//!     GenesisRotationKeys, HostKeyEnrollment, HostRotationKey,
+//!     RecoveryKeyEnrollment,
+//! };
+//! # fn example(host: HostRotationKey) {
+//! let _ = GenesisRotationKeys::new(
+//!     host,
+//!     RecoveryKeyEnrollment::Declined,
+//!     HostKeyEnrollment::Absent,
+//! );
+//! # }
+//! ```
+//!
+//! The wire form preserves those slots as a fixed three-element
+//! `rotation_keys` array. A declined/absent slot is encoded as a role-bearing
+//! map whose `key` is `null`, so recovery absence is a signed decision rather
+//! than an omitted field or decoder default.
+//!
+//! # Hybrid pin
+//!
+//! Rotation is not an atproto interoperability surface. Every rotation key and
+//! the genesis signature therefore consists of Ed25519 + ML-DSA-65, with both
+//! components required. There is no classical constructor or verification
+//! mode.
+
+use std::collections::BTreeSet;
+
+use anyhow::{bail, ensure, Context, Result};
+use ed25519_dalek::{SigningKey, VerifyingKey};
+use hyprstream_crypto::cose_sign::{
+    assemble_composite_nested, sign_composite, split_composite, verify_composite,
+};
+use hyprstream_crypto::pq::{
+    ml_dsa_sk_to_vk_bytes, ml_dsa_vk_bytes, ml_dsa_vk_from_bytes, MlDsaSigningKey,
+};
+
+use crate::cid::Cid;
+use crate::dag_cbor::DagCbor;
+
+/// Version sealed into operation number zero.
+pub const DID_OP_VERSION: u16 = 1;
+/// Domain-separation context bound into both signature components.
+pub const DID_OP_SIGNATURE_CONTEXT: &str = "hyprstream-did-op/1";
+
+const COMPOSITE_ALGORITHM: &str = "id-MLDSA65-Ed25519";
+const ED25519_PUBLIC_KEY_LEN: usize = 32;
+const ED25519_SIGNATURE_LEN: usize = 64;
+const ML_DSA65_PUBLIC_KEY_LEN: usize = 1952;
+const ML_DSA65_SIGNATURE_LEN: usize = 3309;
+const GENESIS_ROTATION_SLOT_COUNT: usize = 3;
+
+/// A pinned-Hybrid public key authorized to control a hosted account.
+///
+/// The fields are private so malformed component lengths cannot be represented.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct HybridRotationKey {
+    ed25519: Vec<u8>,
+    mldsa65: Vec<u8>,
+}
+
+impl HybridRotationKey {
+    /// Construct a rotation key from its mandatory classical and PQ components.
+    pub fn new(ed25519: impl Into<Vec<u8>>, mldsa65: impl Into<Vec<u8>>) -> Result<Self> {
+        let key = Self {
+            ed25519: ed25519.into(),
+            mldsa65: mldsa65.into(),
+        };
+        key.validate()?;
+        Ok(key)
+    }
+
+    /// The Ed25519 verifying-key bytes.
+    pub fn ed25519(&self) -> &[u8] {
+        &self.ed25519
+    }
+
+    /// The ML-DSA-65 verifying-key bytes.
+    pub fn mldsa65(&self) -> &[u8] {
+        &self.mldsa65
+    }
+
+    fn validate(&self) -> Result<()> {
+        ensure!(
+            self.ed25519.len() == ED25519_PUBLIC_KEY_LEN,
+            "rotation Ed25519 key must be {ED25519_PUBLIC_KEY_LEN} bytes"
+        );
+        ensure!(
+            self.mldsa65.len() == ML_DSA65_PUBLIC_KEY_LEN,
+            "rotation ML-DSA-65 key must be {ML_DSA65_PUBLIC_KEY_LEN} bytes"
+        );
+        let ed: [u8; ED25519_PUBLIC_KEY_LEN] = self
+            .ed25519
+            .as_slice()
+            .try_into()
+            .context("rotation Ed25519 key has an invalid length")?;
+        VerifyingKey::from_bytes(&ed).context("rotation Ed25519 key is not a valid point")?;
+        ml_dsa_vk_from_bytes(&self.mldsa65).context("rotation ML-DSA-65 key is invalid")?;
+        Ok(())
+    }
+
+    fn identity(&self) -> Vec<u8> {
+        let mut identity = Vec::with_capacity(self.ed25519.len() + self.mldsa65.len());
+        identity.extend_from_slice(&self.ed25519);
+        identity.extend_from_slice(&self.mldsa65);
+        identity
+    }
+
+    fn to_value(&self) -> DagCbor {
+        DagCbor::str_map([
+            ("ed25519", DagCbor::Bytes(self.ed25519.clone())),
+            ("mldsa65", DagCbor::Bytes(self.mldsa65.clone())),
+        ])
+    }
+
+    fn from_value(value: &DagCbor) -> Result<Self> {
+        reject_unknown(value, &["ed25519", "mldsa65"], "rotation key")?;
+        Self::new(
+            required(value, "ed25519", "rotation key")?
+                .as_bytes()?
+                .to_vec(),
+            required(value, "mldsa65", "rotation key")?
+                .as_bytes()?
+                .to_vec(),
+        )
+    }
+}
+
+macro_rules! custody_key {
+    ($name:ident, $description:literal) => {
+        #[doc = $description]
+        #[derive(Clone, Debug, Eq, PartialEq)]
+        pub struct $name(HybridRotationKey);
+
+        impl $name {
+            /// Bind valid pinned-Hybrid public material to this custody role.
+            pub fn new(key: HybridRotationKey) -> Self {
+                Self(key)
+            }
+
+            /// The role-bound public key.
+            pub fn key(&self) -> &HybridRotationKey {
+                &self.0
+            }
+        }
+    };
+}
+
+custody_key!(
+    UserRotationKey,
+    "The required user-held key occupying genesis priority zero."
+);
+custody_key!(
+    RecoveryRotationKey,
+    "A user-held recovery key kept on a device distinct from the primary key."
+);
+custody_key!(
+    HostRotationKey,
+    "An optional host-held rotation key, representable only at priority two."
+);
+
+/// The deliberate outcome of the recovery-key enrollment offer.
+///
+/// There is intentionally no `Default`: the mint caller must record either a
+/// concrete recovery key or an explicit decline.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum RecoveryKeyEnrollment {
+    Enrolled(RecoveryRotationKey),
+    Declined,
+}
+
+/// Whether the deployment is enrolled as the lowest-priority rotation actor.
+///
+/// There is intentionally no `Default`; absence is sealed explicitly.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum HostKeyEnrollment {
+    Enrolled(HostRotationKey),
+    Absent,
+}
+
+/// A reference to one ordered genesis rotation slot.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct RotationSlotRef<'a> {
+    pub priority: u8,
+    pub role: &'static str,
+    pub key: Option<&'a HybridRotationKey>,
+}
+
+/// The only representable genesis rotation-key ordering.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct GenesisRotationKeys {
+    user: UserRotationKey,
+    recovery: RecoveryKeyEnrollment,
+    host: HostKeyEnrollment,
+}
+
+impl GenesisRotationKeys {
+    /// Establish the permanent priority order.
+    ///
+    /// Equal key material in two custody slots is rejected: a "recovery" key
+    /// that is the primary key is not recovery, and a host key equal to either
+    /// user-held key would blur the custody boundary.
+    pub fn new(
+        user: UserRotationKey,
+        recovery: RecoveryKeyEnrollment,
+        host: HostKeyEnrollment,
+    ) -> Result<Self> {
+        let keys = Self {
+            user,
+            recovery,
+            host,
+        };
+        keys.validate()?;
+        Ok(keys)
+    }
+
+    pub fn user(&self) -> &UserRotationKey {
+        &self.user
+    }
+
+    pub fn recovery(&self) -> &RecoveryKeyEnrollment {
+        &self.recovery
+    }
+
+    pub fn host(&self) -> &HostKeyEnrollment {
+        &self.host
+    }
+
+    /// Return all three priority slots, including deliberate empty slots.
+    pub fn ordered_slots(&self) -> [RotationSlotRef<'_>; GENESIS_ROTATION_SLOT_COUNT] {
+        let recovery = match &self.recovery {
+            RecoveryKeyEnrollment::Enrolled(key) => Some(key.key()),
+            RecoveryKeyEnrollment::Declined => None,
+        };
+        let host = match &self.host {
+            HostKeyEnrollment::Enrolled(key) => Some(key.key()),
+            HostKeyEnrollment::Absent => None,
+        };
+        [
+            RotationSlotRef {
+                priority: 0,
+                role: "user",
+                key: Some(self.user.key()),
+            },
+            RotationSlotRef {
+                priority: 1,
+                role: "recovery",
+                key: recovery,
+            },
+            RotationSlotRef {
+                priority: 2,
+                role: "host",
+                key: host,
+            },
+        ]
+    }
+
+    fn validate(&self) -> Result<()> {
+        self.user.key().validate()?;
+        let mut identities = BTreeSet::new();
+        ensure!(
+            identities.insert(self.user.key().identity()),
+            "duplicate primary user rotation key"
+        );
+        if let RecoveryKeyEnrollment::Enrolled(key) = &self.recovery {
+            key.key().validate()?;
+            ensure!(
+                identities.insert(key.key().identity()),
+                "recovery rotation key must differ from the primary user key"
+            );
+        }
+        if let HostKeyEnrollment::Enrolled(key) = &self.host {
+            key.key().validate()?;
+            ensure!(
+                identities.insert(key.key().identity()),
+                "host rotation key must differ from every user-held key"
+            );
+        }
+        Ok(())
+    }
+
+    fn to_value(&self) -> DagCbor {
+        DagCbor::list(self.ordered_slots().into_iter().map(|slot| {
+            DagCbor::str_map([
+                (
+                    "key",
+                    slot.key.map_or(DagCbor::Null, HybridRotationKey::to_value),
+                ),
+                ("role", DagCbor::Text(slot.role.to_owned())),
+            ])
+        }))
+    }
+
+    fn from_value(value: &DagCbor) -> Result<Self> {
+        let slots = value.as_list()?;
+        ensure!(
+            slots.len() == GENESIS_ROTATION_SLOT_COUNT,
+            "genesis rotation_keys must contain exactly {GENESIS_ROTATION_SLOT_COUNT} explicit slots"
+        );
+
+        let user = parse_slot(&slots[0], "user")?
+            .map(UserRotationKey::new)
+            .ok_or_else(|| anyhow::anyhow!("priority-zero user rotation key is required"))?;
+        let recovery = match parse_slot(&slots[1], "recovery")? {
+            Some(key) => RecoveryKeyEnrollment::Enrolled(RecoveryRotationKey::new(key)),
+            None => RecoveryKeyEnrollment::Declined,
+        };
+        let host = match parse_slot(&slots[2], "host")? {
+            Some(key) => HostKeyEnrollment::Enrolled(HostRotationKey::new(key)),
+            None => HostKeyEnrollment::Absent,
+        };
+        Self::new(user, recovery, host)
+    }
+}
+
+fn parse_slot(value: &DagCbor, expected_role: &str) -> Result<Option<HybridRotationKey>> {
+    reject_unknown(value, &["key", "role"], "rotation slot")?;
+    let role = required(value, "role", "rotation slot")?.as_str()?;
+    ensure!(
+        role == expected_role,
+        "genesis priority slot for {expected_role:?} cannot contain role {role:?}"
+    );
+    let key = required(value, "key", "rotation slot")?;
+    if key.is_null() {
+        Ok(None)
+    } else {
+        HybridRotationKey::from_value(key).map(Some)
+    }
+}
+
+/// The repo state deliberately recorded at genesis.
+///
+/// `EmptyRepo` encodes as `null`; it means the account has no repo head yet,
+/// not "skip head validation".
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum GenesisRepoHead {
+    EmptyRepo,
+    Existing(Cid),
+}
+
+impl GenesisRepoHead {
+    fn to_value(self) -> DagCbor {
+        match self {
+            Self::EmptyRepo => DagCbor::Null,
+            Self::Existing(cid) => DagCbor::Link(cid),
+        }
+    }
+
+    fn from_value(value: &DagCbor) -> Result<Self> {
+        if value.is_null() {
+            Ok(Self::EmptyRepo)
+        } else {
+            Ok(Self::Existing(*value.as_link()?))
+        }
+    }
+}
+
+/// Operation zero without its signature.
+///
+/// All fields are private so operation zero cannot accidentally acquire a
+/// predecessor, a non-zero sequence, or omit its version.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct UnsignedGenesisDidOp {
+    did: String,
+    doc_cid: Cid,
+    rotation_keys: GenesisRotationKeys,
+    head_at_op: GenesisRepoHead,
+}
+
+impl UnsignedGenesisDidOp {
+    pub fn new(
+        did: impl Into<String>,
+        doc_cid: Cid,
+        rotation_keys: GenesisRotationKeys,
+        head_at_op: GenesisRepoHead,
+    ) -> Result<Self> {
+        let op = Self {
+            did: did.into(),
+            doc_cid,
+            rotation_keys,
+            head_at_op,
+        };
+        op.validate()?;
+        Ok(op)
+    }
+
+    pub fn version(&self) -> u16 {
+        DID_OP_VERSION
+    }
+
+    pub fn sequence(&self) -> u64 {
+        0
+    }
+
+    pub fn did(&self) -> &str {
+        &self.did
+    }
+
+    pub fn doc_cid(&self) -> Cid {
+        self.doc_cid
+    }
+
+    pub fn rotation_keys(&self) -> &GenesisRotationKeys {
+        &self.rotation_keys
+    }
+
+    pub fn head_at_op(&self) -> GenesisRepoHead {
+        self.head_at_op
+    }
+
+    pub fn to_dag_cbor(&self) -> Result<Vec<u8>> {
+        self.validate()?;
+        Ok(self.to_value().encode())
+    }
+
+    pub fn from_dag_cbor(bytes: &[u8]) -> Result<Self> {
+        let value = DagCbor::decode(bytes)?;
+        let op = Self::from_value(&value)?;
+        ensure!(
+            op.to_dag_cbor()? == bytes,
+            "genesis DidOp is not canonical DAG-CBOR"
+        );
+        Ok(op)
+    }
+
+    fn validate(&self) -> Result<()> {
+        validate_host_form_did_web(&self.did)?;
+        self.rotation_keys.validate()
+    }
+
+    fn to_value(&self) -> DagCbor {
+        DagCbor::str_map([
+            ("did", DagCbor::Text(self.did.clone())),
+            ("doc_cid", DagCbor::Link(self.doc_cid)),
+            ("head_at_op", self.head_at_op.to_value()),
+            ("prev", DagCbor::Null),
+            ("rotation_keys", self.rotation_keys.to_value()),
+            ("seq", DagCbor::Unsigned(0)),
+            ("version", DagCbor::Unsigned(u64::from(DID_OP_VERSION))),
+        ])
+    }
+
+    fn from_value(value: &DagCbor) -> Result<Self> {
+        reject_unknown(
+            value,
+            &[
+                "version",
+                "prev",
+                "seq",
+                "did",
+                "doc_cid",
+                "rotation_keys",
+                "head_at_op",
+            ],
+            "unsigned genesis DidOp",
+        )?;
+        let version = required(value, "version", "unsigned genesis DidOp")?.as_unsigned()?;
+        ensure!(
+            version == u64::from(DID_OP_VERSION),
+            "unsupported genesis DidOp version {version}"
+        );
+        ensure!(
+            required(value, "prev", "unsigned genesis DidOp")?.is_null(),
+            "genesis DidOp prev must be null"
+        );
+        ensure!(
+            required(value, "seq", "unsigned genesis DidOp")?.as_unsigned()? == 0,
+            "genesis DidOp seq must be zero"
+        );
+        Self::new(
+            required(value, "did", "unsigned genesis DidOp")?
+                .as_str()?
+                .to_owned(),
+            *required(value, "doc_cid", "unsigned genesis DidOp")?.as_link()?,
+            GenesisRotationKeys::from_value(required(
+                value,
+                "rotation_keys",
+                "unsigned genesis DidOp",
+            )?)?,
+            GenesisRepoHead::from_value(required(value, "head_at_op", "unsigned genesis DidOp")?)?,
+        )
+    }
+}
+
+/// The decomposed, context-bound composite signature stored in a `DidOp`.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct DidOpSignature {
+    protected: Vec<u8>,
+    ed25519: Vec<u8>,
+    mldsa65: Vec<u8>,
+}
+
+impl DidOpSignature {
+    /// Construct the canonical v1 signature wrapper from raw component
+    /// signatures returned by a user-side composite signer.
+    pub fn from_components(
+        ed25519: impl Into<Vec<u8>>,
+        mldsa65: impl Into<Vec<u8>>,
+    ) -> Result<Self> {
+        Self::new(signature_protected_header(), ed25519, mldsa65)
+    }
+
+    /// Construct from all wire components.
+    ///
+    /// Prefer [`Self::from_components`] for v1 signing. This form exists for
+    /// strict wire decoding and rejects any non-canonical protected header.
+    pub fn new(
+        protected: impl Into<Vec<u8>>,
+        ed25519: impl Into<Vec<u8>>,
+        mldsa65: impl Into<Vec<u8>>,
+    ) -> Result<Self> {
+        let signature = Self {
+            protected: protected.into(),
+            ed25519: ed25519.into(),
+            mldsa65: mldsa65.into(),
+        };
+        signature.validate()?;
+        Ok(signature)
+    }
+
+    pub fn protected(&self) -> &[u8] {
+        &self.protected
+    }
+
+    pub fn ed25519(&self) -> &[u8] {
+        &self.ed25519
+    }
+
+    pub fn mldsa65(&self) -> &[u8] {
+        &self.mldsa65
+    }
+
+    fn validate(&self) -> Result<()> {
+        ensure!(
+            self.protected == signature_protected_header(),
+            "DidOp signature protected header is not the canonical v1 binding"
+        );
+        ensure!(
+            self.ed25519.len() == ED25519_SIGNATURE_LEN,
+            "DidOp Ed25519 signature must be {ED25519_SIGNATURE_LEN} bytes"
+        );
+        ensure!(
+            self.mldsa65.len() == ML_DSA65_SIGNATURE_LEN,
+            "DidOp ML-DSA-65 signature must be {ML_DSA65_SIGNATURE_LEN} bytes"
+        );
+        Ok(())
+    }
+
+    fn to_value(&self) -> DagCbor {
+        DagCbor::str_map([
+            (
+                "context",
+                DagCbor::Text(DID_OP_SIGNATURE_CONTEXT.to_owned()),
+            ),
+            ("ed25519", DagCbor::Bytes(self.ed25519.clone())),
+            ("mldsa65", DagCbor::Bytes(self.mldsa65.clone())),
+            ("protected", DagCbor::Bytes(self.protected.clone())),
+        ])
+    }
+
+    fn from_value(value: &DagCbor) -> Result<Self> {
+        reject_unknown(
+            value,
+            &["context", "protected", "ed25519", "mldsa65"],
+            "DidOp signature",
+        )?;
+        ensure!(
+            required(value, "context", "DidOp signature")?.as_str()? == DID_OP_SIGNATURE_CONTEXT,
+            "DidOp signature context mismatch"
+        );
+        Self::new(
+            required(value, "protected", "DidOp signature")?
+                .as_bytes()?
+                .to_vec(),
+            required(value, "ed25519", "DidOp signature")?
+                .as_bytes()?
+                .to_vec(),
+            required(value, "mldsa65", "DidOp signature")?
+                .as_bytes()?
+                .to_vec(),
+        )
+    }
+}
+
+/// A sealed, self-signed genesis operation.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct GenesisDidOp {
+    unsigned: UnsignedGenesisDidOp,
+    signature: DidOpSignature,
+}
+
+impl GenesisDidOp {
+    /// Verify a user-produced signature and seal operation zero.
+    ///
+    /// Only the required priority-zero user key is accepted. Recovery and host
+    /// keys authorize future operations according to the ordered fork rules;
+    /// neither can self-sign genesis.
+    pub fn seal(unsigned: UnsignedGenesisDidOp, signature: DidOpSignature) -> Result<Self> {
+        unsigned.validate()?;
+        signature.validate()?;
+        verify_signature(
+            &unsigned.to_dag_cbor()?,
+            &signature,
+            unsigned.rotation_keys.user.key(),
+        )?;
+        Ok(Self {
+            unsigned,
+            signature,
+        })
+    }
+
+    pub fn unsigned(&self) -> &UnsignedGenesisDidOp {
+        &self.unsigned
+    }
+
+    pub fn signature(&self) -> &DidOpSignature {
+        &self.signature
+    }
+
+    pub fn to_dag_cbor(&self) -> Result<Vec<u8>> {
+        self.unsigned.validate()?;
+        self.signature.validate()?;
+        Ok(self.to_value().encode())
+    }
+
+    pub fn from_dag_cbor(bytes: &[u8]) -> Result<Self> {
+        let value = DagCbor::decode(bytes)?;
+        reject_unknown(
+            &value,
+            &[
+                "version",
+                "prev",
+                "seq",
+                "did",
+                "doc_cid",
+                "rotation_keys",
+                "head_at_op",
+                "sig",
+            ],
+            "genesis DidOp",
+        )?;
+        let unsigned_value = DagCbor::str_map([
+            ("did", required(&value, "did", "genesis DidOp")?.clone()),
+            (
+                "doc_cid",
+                required(&value, "doc_cid", "genesis DidOp")?.clone(),
+            ),
+            (
+                "head_at_op",
+                required(&value, "head_at_op", "genesis DidOp")?.clone(),
+            ),
+            ("prev", required(&value, "prev", "genesis DidOp")?.clone()),
+            (
+                "rotation_keys",
+                required(&value, "rotation_keys", "genesis DidOp")?.clone(),
+            ),
+            ("seq", required(&value, "seq", "genesis DidOp")?.clone()),
+            (
+                "version",
+                required(&value, "version", "genesis DidOp")?.clone(),
+            ),
+        ]);
+        let unsigned = UnsignedGenesisDidOp::from_value(&unsigned_value)?;
+        let signature = DidOpSignature::from_value(required(&value, "sig", "genesis DidOp")?)?;
+        let op = Self::seal(unsigned, signature)?;
+        ensure!(
+            op.to_dag_cbor()? == bytes,
+            "genesis DidOp is not canonical DAG-CBOR"
+        );
+        Ok(op)
+    }
+
+    pub fn cid(&self) -> Result<Cid> {
+        Ok(Cid::from_dag_cbor(&self.to_dag_cbor()?))
+    }
+
+    fn to_value(&self) -> DagCbor {
+        DagCbor::str_map([
+            ("did", DagCbor::Text(self.unsigned.did.clone())),
+            ("doc_cid", DagCbor::Link(self.unsigned.doc_cid)),
+            ("head_at_op", self.unsigned.head_at_op.to_value()),
+            ("prev", DagCbor::Null),
+            ("rotation_keys", self.unsigned.rotation_keys.to_value()),
+            ("seq", DagCbor::Unsigned(0)),
+            ("sig", self.signature.to_value()),
+            ("version", DagCbor::Unsigned(u64::from(DID_OP_VERSION))),
+        ])
+    }
+}
+
+/// Sign operation zero with the user-held priority-zero key.
+///
+/// This helper is suitable for a user-side signer. The host mint path consumes
+/// the returned signature but never needs either private key.
+pub fn sign_genesis(
+    unsigned: &UnsignedGenesisDidOp,
+    ed25519: &SigningKey,
+    mldsa65: &MlDsaSigningKey,
+) -> Result<DidOpSignature> {
+    unsigned.validate()?;
+    let user_key = unsigned.rotation_keys.user.key();
+    ensure!(
+        user_key.ed25519 == ed25519.verifying_key().to_bytes(),
+        "genesis Ed25519 signer does not match priority-zero user key"
+    );
+    ensure!(
+        user_key.mldsa65 == ml_dsa_sk_to_vk_bytes(mldsa65),
+        "genesis ML-DSA-65 signer does not match priority-zero user key"
+    );
+
+    let protected = signature_protected_header();
+    let composite = sign_composite(ed25519, Some(mldsa65), &unsigned.to_dag_cbor()?, &protected)
+        .context("genesis DidOp composite signing failed")?;
+    let (ed_signature, pq_signature) = split_composite(&composite)?;
+    let pq_signature = pq_signature
+        .ok_or_else(|| anyhow::anyhow!("genesis DidOp signing produced no ML-DSA-65 component"))?;
+    DidOpSignature::new(protected, ed_signature, pq_signature)
+}
+
+fn verify_signature(
+    payload: &[u8],
+    signature: &DidOpSignature,
+    key: &HybridRotationKey,
+) -> Result<()> {
+    signature.validate()?;
+    key.validate()?;
+    let ed_bytes: [u8; ED25519_PUBLIC_KEY_LEN] = key
+        .ed25519
+        .as_slice()
+        .try_into()
+        .context("rotation Ed25519 key has an invalid length")?;
+    let ed_vk = VerifyingKey::from_bytes(&ed_bytes).context("rotation Ed25519 key is invalid")?;
+    let pq_vk = ml_dsa_vk_from_bytes(&key.mldsa65).context("rotation ML-DSA-65 key is invalid")?;
+    let composite = assemble_composite_nested(
+        (ed_vk.to_bytes().to_vec(), signature.ed25519.clone()),
+        Some((ml_dsa_vk_bytes(&pq_vk), signature.mldsa65.clone())),
+    )
+    .context("failed to reassemble genesis DidOp composite signature")?;
+    let verified = verify_composite(
+        &composite,
+        &ed_vk,
+        Some(&pq_vk),
+        payload,
+        &signature_protected_header(),
+        true,
+    )
+    .context("genesis DidOp priority-zero signature verification failed")?;
+    ensure!(
+        verified.eddsa && verified.ml_dsa,
+        "genesis DidOp did not verify both pinned-Hybrid components"
+    );
+    Ok(())
+}
+
+fn signature_protected_header() -> Vec<u8> {
+    DagCbor::str_map([
+        ("alg", DagCbor::Text(COMPOSITE_ALGORITHM.to_owned())),
+        (
+            "context",
+            DagCbor::Text(DID_OP_SIGNATURE_CONTEXT.to_owned()),
+        ),
+    ])
+    .encode()
+}
+
+/// Validate the host-only `did:web` form used for accounts.
+///
+/// The future A2/A3 mint seam supplies an allocated label and deployment zone;
+/// this check independently refuses path-form, port-bearing, uppercase, or
+/// non-LDH DIDs before their value is permanently signed.
+pub(crate) fn validate_host_form_did_web(did: &str) -> Result<()> {
+    let host = did
+        .strip_prefix("did:web:")
+        .ok_or_else(|| anyhow::anyhow!("hosted account DID must use did:web"))?;
+    ensure!(!host.is_empty(), "hosted account did:web host is empty");
+    ensure!(
+        !host.contains(':') && !host.contains('/') && !host.contains('%'),
+        "hosted account DID must be host-form did:web without path, port, or percent encoding"
+    );
+    ensure!(
+        host == host.to_ascii_lowercase(),
+        "hosted account DID must already be lowercase"
+    );
+    let labels = host.split('.').collect::<Vec<_>>();
+    ensure!(
+        labels.len() >= 2,
+        "hosted account DID must contain a deployment-qualified DNS host"
+    );
+    ensure!(
+        host.len() <= 253,
+        "hosted account DID host exceeds DNS limit"
+    );
+    for label in labels {
+        ensure!(
+            !label.is_empty() && label.len() <= 63,
+            "hosted account DID contains an empty or oversized DNS label"
+        );
+        ensure!(
+            label
+                .bytes()
+                .all(|byte| { byte.is_ascii_lowercase() || byte.is_ascii_digit() || byte == b'-' }),
+            "hosted account DID labels must be lowercase LDH"
+        );
+        ensure!(
+            !label.starts_with('-') && !label.ends_with('-'),
+            "hosted account DID labels must not start or end with a hyphen"
+        );
+    }
+    Ok(())
+}
+
+fn required<'a>(value: &'a DagCbor, key: &str, what: &str) -> Result<&'a DagCbor> {
+    value
+        .get(key)
+        .ok_or_else(|| anyhow::anyhow!("{what} missing required field {key:?}"))
+}
+
+fn reject_unknown(value: &DagCbor, allowed: &[&str], what: &str) -> Result<()> {
+    let allowed = allowed.iter().copied().collect::<BTreeSet<_>>();
+    for (key, _) in value.as_map()? {
+        let key = key.as_str()?;
+        if !allowed.contains(key) {
+            bail!("{what} contains unknown field {key:?}");
+        }
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    #![allow(clippy::unwrap_used, clippy::expect_used, clippy::indexing_slicing)]
+
+    use super::*;
+    use hyprstream_crypto::pq::{
+        ml_dsa_generate_keypair, ml_dsa_sk_from_seed, ml_dsa_sk_to_vk_bytes, ml_dsa_vk_bytes,
+        MlDsaSigningKey,
+    };
+    use rand::rngs::OsRng;
+    use sha2::{Digest as _, Sha256};
+
+    struct Signer {
+        ed: SigningKey,
+        pq: MlDsaSigningKey,
+        public: HybridRotationKey,
+    }
+
+    fn signer() -> Signer {
+        let ed = SigningKey::generate(&mut OsRng);
+        let (pq, pq_vk) = ml_dsa_generate_keypair();
+        let public =
+            HybridRotationKey::new(ed.verifying_key().to_bytes(), ml_dsa_vk_bytes(&pq_vk)).unwrap();
+        Signer { ed, pq, public }
+    }
+
+    fn unsigned(
+        user: &Signer,
+        recovery: RecoveryKeyEnrollment,
+        host: HostKeyEnrollment,
+    ) -> UnsignedGenesisDidOp {
+        UnsignedGenesisDidOp::new(
+            "did:web:alice.acct.example.com",
+            Cid::from_raw(b"sealed did document"),
+            GenesisRotationKeys::new(UserRotationKey::new(user.public.clone()), recovery, host)
+                .unwrap(),
+            GenesisRepoHead::EmptyRepo,
+        )
+        .unwrap()
+    }
+
+    #[test]
+    fn host_role_at_priority_zero_is_rejected_on_decode() {
+        let user = signer();
+        let rotations = GenesisRotationKeys::new(
+            UserRotationKey::new(user.public),
+            RecoveryKeyEnrollment::Declined,
+            HostKeyEnrollment::Absent,
+        )
+        .unwrap();
+        let mut slots = rotations.to_value().as_list().unwrap().to_vec();
+        slots[0] = DagCbor::str_map([
+            ("key", slots[0].get("key").expect("slot key").clone()),
+            ("role", DagCbor::Text("host".to_owned())),
+        ]);
+        let error = GenesisRotationKeys::from_value(&DagCbor::List(slots)).unwrap_err();
+        assert!(error.to_string().contains("cannot contain role"));
+    }
+
+    #[test]
+    fn missing_priority_zero_user_key_is_rejected() {
+        let rotations = DagCbor::list([
+            DagCbor::str_map([
+                ("key", DagCbor::Null),
+                ("role", DagCbor::Text("user".to_owned())),
+            ]),
+            DagCbor::str_map([
+                ("key", DagCbor::Null),
+                ("role", DagCbor::Text("recovery".to_owned())),
+            ]),
+            DagCbor::str_map([
+                ("key", DagCbor::Null),
+                ("role", DagCbor::Text("host".to_owned())),
+            ]),
+        ]);
+        let error = GenesisRotationKeys::from_value(&rotations).unwrap_err();
+        assert!(error.to_string().contains("priority-zero user"));
+    }
+
+    #[test]
+    fn declined_recovery_is_explicit_in_signed_bytes() {
+        let user = signer();
+        let unsigned = unsigned(
+            &user,
+            RecoveryKeyEnrollment::Declined,
+            HostKeyEnrollment::Absent,
+        );
+        let value = DagCbor::decode(&unsigned.to_dag_cbor().unwrap()).unwrap();
+        let slots = value.get("rotation_keys").unwrap().as_list().unwrap();
+        assert_eq!(slots.len(), 3);
+        assert_eq!(slots[1].get("role").unwrap().as_str().unwrap(), "recovery");
+        assert!(slots[1].get("key").unwrap().is_null());
+
+        let roundtrip =
+            UnsignedGenesisDidOp::from_dag_cbor(&unsigned.to_dag_cbor().unwrap()).unwrap();
+        assert_eq!(
+            roundtrip.rotation_keys().recovery(),
+            &RecoveryKeyEnrollment::Declined
+        );
+    }
+
+    #[test]
+    fn sealed_ordering_roundtrips_byte_exactly() {
+        let user = signer();
+        let recovery = signer();
+        let host = signer();
+        let unsigned = unsigned(
+            &user,
+            RecoveryKeyEnrollment::Enrolled(RecoveryRotationKey::new(recovery.public.clone())),
+            HostKeyEnrollment::Enrolled(HostRotationKey::new(host.public.clone())),
+        );
+        let signature = sign_genesis(&unsigned, &user.ed, &user.pq).unwrap();
+        let sealed = GenesisDidOp::seal(unsigned, signature).unwrap();
+        let bytes = sealed.to_dag_cbor().unwrap();
+        let decoded = GenesisDidOp::from_dag_cbor(&bytes).unwrap();
+        assert_eq!(decoded.to_dag_cbor().unwrap(), bytes);
+
+        let slots = decoded.unsigned().rotation_keys().ordered_slots();
+        assert_eq!(
+            slots.map(|slot| (slot.priority, slot.role)),
+            [(0, "user"), (1, "recovery"), (2, "host")]
+        );
+        assert_eq!(slots[0].key, Some(&user.public));
+        assert_eq!(slots[1].key, Some(&recovery.public));
+        assert_eq!(slots[2].key, Some(&host.public));
+    }
+
+    #[test]
+    fn operation_zero_contains_version_from_first_signed_bytes() {
+        let user = signer();
+        let unsigned = unsigned(
+            &user,
+            RecoveryKeyEnrollment::Declined,
+            HostKeyEnrollment::Absent,
+        );
+        let signature = sign_genesis(&unsigned, &user.ed, &user.pq).unwrap();
+        let bytes = GenesisDidOp::seal(unsigned, signature)
+            .unwrap()
+            .to_dag_cbor()
+            .unwrap();
+        let value = DagCbor::decode(&bytes).unwrap();
+        assert_eq!(
+            value.get("version").unwrap().as_unsigned().unwrap(),
+            u64::from(DID_OP_VERSION)
+        );
+        assert_eq!(value.get("seq").unwrap().as_unsigned().unwrap(), 0);
+        assert!(value.get("prev").unwrap().is_null());
+    }
+
+    #[test]
+    fn tampering_a_signed_field_fails_closed() {
+        let user = signer();
+        let unsigned = unsigned(
+            &user,
+            RecoveryKeyEnrollment::Declined,
+            HostKeyEnrollment::Absent,
+        );
+        let signature = sign_genesis(&unsigned, &user.ed, &user.pq).unwrap();
+        let tampered = UnsignedGenesisDidOp::new(
+            unsigned.did().to_owned(),
+            Cid::from_raw(b"different document"),
+            unsigned.rotation_keys().clone(),
+            unsigned.head_at_op(),
+        )
+        .unwrap();
+        assert!(GenesisDidOp::seal(tampered, signature).is_err());
+    }
+
+    #[test]
+    fn duplicate_custody_keys_are_rejected() {
+        let user = signer();
+        let error = GenesisRotationKeys::new(
+            UserRotationKey::new(user.public.clone()),
+            RecoveryKeyEnrollment::Enrolled(RecoveryRotationKey::new(user.public.clone())),
+            HostKeyEnrollment::Absent,
+        )
+        .unwrap_err();
+        assert!(error
+            .to_string()
+            .contains("recovery rotation key must differ"));
+    }
+
+    #[test]
+    fn path_form_did_is_never_sealable() {
+        let user = signer();
+        let rotations = GenesisRotationKeys::new(
+            UserRotationKey::new(user.public),
+            RecoveryKeyEnrollment::Declined,
+            HostKeyEnrollment::Absent,
+        )
+        .unwrap();
+        assert!(UnsignedGenesisDidOp::new(
+            "did:web:example.com:users:alice",
+            Cid::from_raw(b"doc"),
+            rotations,
+            GenesisRepoHead::EmptyRepo,
+        )
+        .is_err());
+    }
+
+    #[test]
+    fn genesis_v1_unsigned_wire_digest_is_frozen() {
+        let ed = SigningKey::from_bytes(&[7_u8; 32]);
+        let pq = ml_dsa_sk_from_seed(&[8_u8; 32]);
+        let user =
+            HybridRotationKey::new(ed.verifying_key().to_bytes(), ml_dsa_sk_to_vk_bytes(&pq))
+                .unwrap();
+        let op = UnsignedGenesisDidOp::new(
+            "did:web:alice.acct.example.com",
+            Cid::from_raw(b"canonical did document fixture"),
+            GenesisRotationKeys::new(
+                UserRotationKey::new(user),
+                RecoveryKeyEnrollment::Declined,
+                HostKeyEnrollment::Absent,
+            )
+            .unwrap(),
+            GenesisRepoHead::EmptyRepo,
+        )
+        .unwrap();
+        let digest: [u8; 32] = Sha256::digest(op.to_dag_cbor().unwrap()).into();
+        assert_eq!(
+            digest,
+            [
+                203, 83, 224, 124, 141, 189, 39, 233, 164, 155, 250, 243, 220, 177, 180, 209, 123,
+                118, 237, 64, 150, 190, 19, 13, 216, 118, 245, 117, 206, 73, 156, 47,
+            ]
+        );
+    }
+}

--- a/crates/hyprstream-pds/src/hosted_account.rs
+++ b/crates/hyprstream-pds/src/hosted_account.rs
@@ -1,0 +1,761 @@
+//! Hosted-account record and mint state machine.
+//!
+//! The mint path is intentionally split around the user signature:
+//!
+//! 1. [`HostedAccountMint::begin`] consumes an already-allocated account name
+//!    and generates a fresh per-account ES256 `#atproto` key.
+//! 2. The caller uses [`HostedAccountMint::atproto_verifying_key`] to build and
+//!    seal the canonical DID document (B2/#1164), then supplies that document's
+//!    CID to [`HostedAccountMint::prepare_genesis`].
+//! 3. The user signs [`PendingHostedAccountMint::signing_bytes`] with the
+//!    required priority-zero Hybrid rotation key.
+//! 4. [`PendingHostedAccountMint::seal`] verifies that signature before it can
+//!    produce an [`AccountRecord`].
+//!
+//! A host never receives the user's rotation private key. The generated ES256
+//! private key is returned separately from the public account record so a
+//! caller can place it in the deployment's secret store; it is never serialized
+//! into the record or genesis operation.
+//!
+//! A2 (#1160) owns label allocation and never-reuse. A3 (#1162) owns deriving
+//! the host from the configured deployment zone. This module consumes the
+//! narrow seam between them as [`AllocatedAccountName`] and independently
+//! revalidates the permanent host-form DID before signing anything.
+
+use std::collections::BTreeSet;
+use std::fs::{File, OpenOptions};
+use std::io::Write as _;
+use std::path::{Path, PathBuf};
+
+use anyhow::{bail, ensure, Context, Result};
+use p256::ecdsa::{SigningKey as AtprotoSigningKey, VerifyingKey as AtprotoVerifyingKey};
+use rand::rngs::OsRng;
+
+use crate::cid::Cid;
+use crate::dag_cbor::DagCbor;
+use crate::did_op::{
+    validate_host_form_did_web, DidOpSignature, GenesisDidOp, GenesisRepoHead, GenesisRotationKeys,
+    UnsignedGenesisDidOp,
+};
+
+/// Version of the durable hosted-account record.
+pub const ACCOUNT_RECORD_VERSION: u16 = 1;
+const COMPRESSED_P256_PUBLIC_KEY_LEN: usize = 33;
+const ACCOUNT_RECORD_FILE: &str = "account-record.cbor";
+const GENESIS_DID_OP_FILE: &str = "genesis.didop.cbor";
+const ATPROTO_SIGNING_KEY_FILE: &str = "atproto-signing-key";
+
+/// The output of the A2 allocation + A3 configured-zone seam.
+///
+/// Construction is strict but cannot itself prove never-reuse; the A2 allocator
+/// must only produce this value after atomically reserving the label forever.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct AllocatedAccountName {
+    label: String,
+    did: String,
+}
+
+impl AllocatedAccountName {
+    pub fn new(label: impl Into<String>, did: impl Into<String>) -> Result<Self> {
+        let name = Self {
+            label: label.into(),
+            did: did.into(),
+        };
+        name.validate()?;
+        Ok(name)
+    }
+
+    pub fn label(&self) -> &str {
+        &self.label
+    }
+
+    pub fn did(&self) -> &str {
+        &self.did
+    }
+
+    fn validate(&self) -> Result<()> {
+        ensure!(!self.label.is_empty(), "allocated account label is empty");
+        ensure!(
+            self.label.len() <= 63,
+            "allocated account label exceeds 63 octets"
+        );
+        ensure!(
+            self.label == self.label.to_ascii_lowercase(),
+            "allocated account label must already be lowercase"
+        );
+        ensure!(
+            self.label
+                .bytes()
+                .all(|byte| { byte.is_ascii_lowercase() || byte.is_ascii_digit() || byte == b'-' }),
+            "allocated account label must be a single LDH label"
+        );
+        ensure!(
+            !self.label.starts_with('-') && !self.label.ends_with('-'),
+            "allocated account label must not start or end with a hyphen"
+        );
+        validate_host_form_did_web(&self.did)?;
+        let host = self
+            .did
+            .strip_prefix("did:web:")
+            .ok_or_else(|| anyhow::anyhow!("hosted account DID must use did:web"))?;
+        ensure!(
+            host.split('.').next() == Some(self.label.as_str()),
+            "allocated account label does not match the first label of its did:web host"
+        );
+        Ok(())
+    }
+}
+
+/// The public durable record locating a hosted account's permanent genesis.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct AccountRecord {
+    name: AllocatedAccountName,
+    atproto_key: Vec<u8>,
+    genesis_op: Cid,
+    current_op: Cid,
+    doc_cid: Cid,
+}
+
+impl AccountRecord {
+    fn new(
+        name: AllocatedAccountName,
+        atproto_key: Vec<u8>,
+        genesis_op: Cid,
+        doc_cid: Cid,
+    ) -> Result<Self> {
+        let record = Self {
+            name,
+            atproto_key,
+            genesis_op,
+            current_op: genesis_op,
+            doc_cid,
+        };
+        record.validate()?;
+        Ok(record)
+    }
+
+    pub fn version(&self) -> u16 {
+        ACCOUNT_RECORD_VERSION
+    }
+
+    pub fn name(&self) -> &AllocatedAccountName {
+        &self.name
+    }
+
+    pub fn atproto_key_bytes(&self) -> &[u8] {
+        &self.atproto_key
+    }
+
+    pub fn genesis_op(&self) -> Cid {
+        self.genesis_op
+    }
+
+    pub fn current_op(&self) -> Cid {
+        self.current_op
+    }
+
+    pub fn doc_cid(&self) -> Cid {
+        self.doc_cid
+    }
+
+    pub fn atproto_verifying_key(&self) -> Result<AtprotoVerifyingKey> {
+        AtprotoVerifyingKey::from_sec1_bytes(&self.atproto_key)
+            .context("account record contains an invalid #atproto P-256 key")
+    }
+
+    pub fn to_dag_cbor(&self) -> Result<Vec<u8>> {
+        self.validate()?;
+        Ok(self.to_value().encode())
+    }
+
+    pub fn from_dag_cbor(bytes: &[u8]) -> Result<Self> {
+        let value = DagCbor::decode(bytes)?;
+        reject_unknown(
+            &value,
+            &[
+                "version",
+                "label",
+                "did",
+                "atproto_key",
+                "genesis_op",
+                "current_op",
+                "doc_cid",
+            ],
+            "account record",
+        )?;
+        let version = required(&value, "version", "account record")?.as_unsigned()?;
+        ensure!(
+            version == u64::from(ACCOUNT_RECORD_VERSION),
+            "unsupported account record version {version}"
+        );
+        let record = Self {
+            name: AllocatedAccountName::new(
+                required(&value, "label", "account record")?
+                    .as_str()?
+                    .to_owned(),
+                required(&value, "did", "account record")?
+                    .as_str()?
+                    .to_owned(),
+            )?,
+            atproto_key: required(&value, "atproto_key", "account record")?
+                .as_bytes()?
+                .to_vec(),
+            genesis_op: *required(&value, "genesis_op", "account record")?.as_link()?,
+            current_op: *required(&value, "current_op", "account record")?.as_link()?,
+            doc_cid: *required(&value, "doc_cid", "account record")?.as_link()?,
+        };
+        record.validate()?;
+        ensure!(
+            record.to_dag_cbor()? == bytes,
+            "account record is not canonical DAG-CBOR"
+        );
+        Ok(record)
+    }
+
+    fn validate(&self) -> Result<()> {
+        self.name.validate()?;
+        ensure!(
+            self.atproto_key.len() == COMPRESSED_P256_PUBLIC_KEY_LEN,
+            "account #atproto key must be a {COMPRESSED_P256_PUBLIC_KEY_LEN}-byte compressed P-256 point"
+        );
+        self.atproto_verifying_key()?;
+        Ok(())
+    }
+
+    fn to_value(&self) -> DagCbor {
+        DagCbor::str_map([
+            ("atproto_key", DagCbor::Bytes(self.atproto_key.clone())),
+            ("current_op", DagCbor::Link(self.current_op)),
+            ("did", DagCbor::Text(self.name.did.clone())),
+            ("doc_cid", DagCbor::Link(self.doc_cid)),
+            ("genesis_op", DagCbor::Link(self.genesis_op)),
+            ("label", DagCbor::Text(self.name.label.clone())),
+            (
+                "version",
+                DagCbor::Unsigned(u64::from(ACCOUNT_RECORD_VERSION)),
+            ),
+        ])
+    }
+}
+
+/// Mint state after label allocation and per-account ES256 generation.
+///
+/// This type is deliberately neither `Clone` nor `Debug`: it owns secret key
+/// material.
+pub struct HostedAccountMint {
+    name: AllocatedAccountName,
+    rotations: GenesisRotationKeys,
+    atproto_signing_key: AtprotoSigningKey,
+}
+
+impl HostedAccountMint {
+    /// Begin minting. A user-held priority-zero key is mandatory in
+    /// `rotations`; there is no overload that omits it.
+    pub fn begin(name: AllocatedAccountName, rotations: GenesisRotationKeys) -> Result<Self> {
+        name.validate()?;
+        // Reconstructing from canonical bytes re-applies every slot invariant
+        // even if this crate later gains internal mutation helpers.
+        let rotations = GenesisRotationKeys::new(
+            rotations.user().clone(),
+            rotations.recovery().clone(),
+            rotations.host().clone(),
+        )?;
+        Ok(Self {
+            name,
+            rotations,
+            atproto_signing_key: AtprotoSigningKey::random(&mut OsRng),
+        })
+    }
+
+    /// The generated account-specific `#atproto` key used by B2 to build the
+    /// canonical DID document before genesis is signed.
+    pub fn atproto_verifying_key(&self) -> AtprotoVerifyingKey {
+        *self.atproto_signing_key.verifying_key()
+    }
+
+    /// Bind the sealed DID document and deliberate genesis repo-head state.
+    pub fn prepare_genesis(
+        self,
+        doc_cid: Cid,
+        head_at_op: GenesisRepoHead,
+    ) -> Result<PendingHostedAccountMint> {
+        let unsigned =
+            UnsignedGenesisDidOp::new(self.name.did.clone(), doc_cid, self.rotations, head_at_op)?;
+        Ok(PendingHostedAccountMint {
+            name: self.name,
+            atproto_signing_key: self.atproto_signing_key,
+            unsigned,
+        })
+    }
+}
+
+/// Mint state waiting for the user-held priority-zero signature.
+///
+/// No [`AccountRecord`] exists yet.
+pub struct PendingHostedAccountMint {
+    name: AllocatedAccountName,
+    atproto_signing_key: AtprotoSigningKey,
+    unsigned: UnsignedGenesisDidOp,
+}
+
+impl PendingHostedAccountMint {
+    pub fn unsigned_genesis(&self) -> &UnsignedGenesisDidOp {
+        &self.unsigned
+    }
+
+    /// Exact canonical bytes the user's Hybrid signer must sign.
+    pub fn signing_bytes(&self) -> Result<Vec<u8>> {
+        self.unsigned.to_dag_cbor()
+    }
+
+    /// Verify the user signature and produce the sealed account artifacts.
+    ///
+    /// Invalid, host-signed, classical-only, or tampered signatures fail before
+    /// an account record is constructed.
+    pub fn seal(self, signature: DidOpSignature) -> Result<SealedHostedAccount> {
+        let genesis = GenesisDidOp::seal(self.unsigned, signature)?;
+        let genesis_bytes = genesis.to_dag_cbor()?;
+        let genesis_cid = Cid::from_dag_cbor(&genesis_bytes);
+        let atproto_key = self
+            .atproto_signing_key
+            .verifying_key()
+            .to_encoded_point(true)
+            .as_bytes()
+            .to_vec();
+        let record = AccountRecord::new(
+            self.name,
+            atproto_key,
+            genesis_cid,
+            genesis.unsigned().doc_cid(),
+        )?;
+        let record_bytes = record.to_dag_cbor()?;
+        Ok(SealedHostedAccount {
+            record,
+            record_bytes,
+            genesis,
+            genesis_bytes,
+            atproto_signing_key: self.atproto_signing_key,
+        })
+    }
+}
+
+/// Fully sealed account artifacts ready for an atomic persistence boundary.
+///
+/// The secret ES256 key is separate from both byte vectors. Persistence is a
+/// caller-owned seam because the deployment decides its secret store and B2
+/// decides its CAS; this type ensures those writers receive one coherent,
+/// already-verified generation.
+pub struct SealedHostedAccount {
+    record: AccountRecord,
+    record_bytes: Vec<u8>,
+    genesis: GenesisDidOp,
+    genesis_bytes: Vec<u8>,
+    atproto_signing_key: AtprotoSigningKey,
+}
+
+impl SealedHostedAccount {
+    pub fn record(&self) -> &AccountRecord {
+        &self.record
+    }
+
+    pub fn record_bytes(&self) -> &[u8] {
+        &self.record_bytes
+    }
+
+    pub fn genesis(&self) -> &GenesisDidOp {
+        &self.genesis
+    }
+
+    pub fn genesis_bytes(&self) -> &[u8] {
+        &self.genesis_bytes
+    }
+
+    pub fn atproto_signing_key(&self) -> &AtprotoSigningKey {
+        &self.atproto_signing_key
+    }
+
+    /// Consume the bundle for a persistence implementation.
+    pub fn into_parts(
+        self,
+    ) -> (
+        AccountRecord,
+        Vec<u8>,
+        GenesisDidOp,
+        Vec<u8>,
+        AtprotoSigningKey,
+    ) {
+        (
+            self.record,
+            self.record_bytes,
+            self.genesis,
+            self.genesis_bytes,
+            self.atproto_signing_key,
+        )
+    }
+
+    /// Persist this mint generation and return its public account record.
+    ///
+    /// The bundle is consumed so callers cannot accidentally try to publish
+    /// the same secret-bearing generation to two account locations.
+    pub fn write_to(self, store: &DirectoryHostedAccountStore) -> Result<AccountRecord> {
+        store.write_new(&self)?;
+        Ok(self.record)
+    }
+}
+
+/// Fail-closed filesystem persistence for newly minted hosted accounts.
+///
+/// Each allocated label gets one directory beneath `root`. The directory is
+/// created exclusively and is never reused. Files are written in this order:
+///
+/// 1. the generated `#atproto` private key;
+/// 2. the sealed genesis operation;
+/// 3. the public account record, **last**, as the publication marker.
+///
+/// A crash before step 3 leaves no visible account record and the label
+/// directory remains reserved. A retry or duplicate mint cannot overwrite it.
+/// C2 (#1168) owns later crash-atomic *rotation*; this writer only establishes
+/// the immutable first generation.
+#[derive(Clone, Debug)]
+pub struct DirectoryHostedAccountStore {
+    root: PathBuf,
+}
+
+impl DirectoryHostedAccountStore {
+    /// Configure the caller-selected durable account root.
+    ///
+    /// There is intentionally no default path.
+    pub fn new(root: impl Into<PathBuf>) -> Self {
+        Self { root: root.into() }
+    }
+
+    pub fn root(&self) -> &Path {
+        &self.root
+    }
+
+    /// Location of an account record after a successful mint.
+    pub fn account_record_path(&self, label: &str) -> PathBuf {
+        self.root.join(label).join(ACCOUNT_RECORD_FILE)
+    }
+
+    fn write_new(&self, account: &SealedHostedAccount) -> Result<()> {
+        validate_sealed_bundle(account)?;
+        ensure_private_directory(&self.root)?;
+        let account_dir = self.root.join(account.record.name().label());
+        std::fs::create_dir(&account_dir).with_context(|| {
+            format!(
+                "failed to reserve hosted-account label directory {:?}",
+                account_dir
+            )
+        })?;
+        set_private_directory_permissions(&account_dir)?;
+
+        write_new_file(
+            &account_dir.join(ATPROTO_SIGNING_KEY_FILE),
+            account.atproto_signing_key.to_bytes().as_slice(),
+        )?;
+        write_new_file(
+            &account_dir.join(GENESIS_DID_OP_FILE),
+            &account.genesis_bytes,
+        )?;
+        // Publication marker: always last.
+        write_new_file(
+            &account_dir.join(ACCOUNT_RECORD_FILE),
+            &account.record_bytes,
+        )?;
+        sync_directory(&account_dir)?;
+        sync_directory(&self.root)?;
+        Ok(())
+    }
+}
+
+fn validate_sealed_bundle(account: &SealedHostedAccount) -> Result<()> {
+    ensure!(
+        AccountRecord::from_dag_cbor(&account.record_bytes)? == account.record,
+        "sealed account record bytes do not match the in-memory record"
+    );
+    ensure!(
+        GenesisDidOp::from_dag_cbor(&account.genesis_bytes)? == account.genesis,
+        "sealed genesis bytes do not match the in-memory operation"
+    );
+    ensure!(
+        account.record.genesis_op() == account.genesis.cid()?,
+        "account record does not name its sealed genesis operation"
+    );
+    ensure!(
+        account.record.doc_cid() == account.genesis.unsigned().doc_cid(),
+        "account record and genesis operation disagree on the DID document CID"
+    );
+    ensure!(
+        account
+            .record
+            .atproto_verifying_key()?
+            .to_encoded_point(true)
+            == account
+                .atproto_signing_key
+                .verifying_key()
+                .to_encoded_point(true),
+        "account record #atproto public key does not match the generated private key"
+    );
+    Ok(())
+}
+
+fn ensure_private_directory(path: &Path) -> Result<()> {
+    std::fs::create_dir_all(path)
+        .with_context(|| format!("failed to create hosted-account root {path:?}"))?;
+    ensure!(
+        std::fs::symlink_metadata(path)?.file_type().is_dir(),
+        "hosted-account root is not a directory"
+    );
+    set_private_directory_permissions(path)
+}
+
+#[cfg(unix)]
+fn set_private_directory_permissions(path: &Path) -> Result<()> {
+    use std::os::unix::fs::PermissionsExt as _;
+    std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o700))
+        .with_context(|| format!("failed to secure hosted-account directory {path:?}"))
+}
+
+#[cfg(not(unix))]
+fn set_private_directory_permissions(_path: &Path) -> Result<()> {
+    Ok(())
+}
+
+fn write_new_file(path: &Path, bytes: &[u8]) -> Result<()> {
+    let mut options = OpenOptions::new();
+    options.write(true).create_new(true);
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::OpenOptionsExt as _;
+        options.mode(0o600);
+    }
+    let mut file = options
+        .open(path)
+        .with_context(|| format!("failed to create hosted-account file {path:?}"))?;
+    file.write_all(bytes)
+        .with_context(|| format!("failed to write hosted-account file {path:?}"))?;
+    file.sync_all()
+        .with_context(|| format!("failed to sync hosted-account file {path:?}"))
+}
+
+fn sync_directory(path: &Path) -> Result<()> {
+    File::open(path)
+        .with_context(|| format!("failed to open hosted-account directory {path:?} for sync"))?
+        .sync_all()
+        .with_context(|| format!("failed to sync hosted-account directory {path:?}"))
+}
+
+fn required<'a>(value: &'a DagCbor, key: &str, what: &str) -> Result<&'a DagCbor> {
+    value
+        .get(key)
+        .ok_or_else(|| anyhow::anyhow!("{what} missing required field {key:?}"))
+}
+
+fn reject_unknown(value: &DagCbor, allowed: &[&str], what: &str) -> Result<()> {
+    let allowed = allowed.iter().copied().collect::<BTreeSet<_>>();
+    for (key, _) in value.as_map()? {
+        let key = key.as_str()?;
+        if !allowed.contains(key) {
+            bail!("{what} contains unknown field {key:?}");
+        }
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    #![allow(clippy::unwrap_used, clippy::expect_used, clippy::indexing_slicing)]
+
+    use super::*;
+    use crate::did_op::{
+        sign_genesis, HostKeyEnrollment, HybridRotationKey, RecoveryKeyEnrollment, UserRotationKey,
+    };
+    use ed25519_dalek::SigningKey;
+    use hyprstream_crypto::pq::{ml_dsa_generate_keypair, ml_dsa_vk_bytes, MlDsaSigningKey};
+
+    struct UserSigner {
+        ed: SigningKey,
+        pq: MlDsaSigningKey,
+        public: HybridRotationKey,
+    }
+
+    fn user_signer() -> UserSigner {
+        let ed = SigningKey::generate(&mut OsRng);
+        let (pq, pq_vk) = ml_dsa_generate_keypair();
+        let public =
+            HybridRotationKey::new(ed.verifying_key().to_bytes(), ml_dsa_vk_bytes(&pq_vk)).unwrap();
+        UserSigner { ed, pq, public }
+    }
+
+    fn begin(user: &UserSigner) -> HostedAccountMint {
+        HostedAccountMint::begin(
+            AllocatedAccountName::new("alice", "did:web:alice.acct.example.com").unwrap(),
+            GenesisRotationKeys::new(
+                UserRotationKey::new(user.public.clone()),
+                RecoveryKeyEnrollment::Declined,
+                HostKeyEnrollment::Absent,
+            )
+            .unwrap(),
+        )
+        .unwrap()
+    }
+
+    #[test]
+    fn mint_generates_account_specific_atproto_key_and_never_serializes_secret() {
+        let user = user_signer();
+        let first = begin(&user);
+        let first_public = first.atproto_verifying_key();
+        let second = begin(&user);
+        assert_ne!(
+            first_public.to_encoded_point(true),
+            second.atproto_verifying_key().to_encoded_point(true)
+        );
+
+        let pending = first
+            .prepare_genesis(Cid::from_raw(b"did document"), GenesisRepoHead::EmptyRepo)
+            .unwrap();
+        let signature = sign_genesis(pending.unsigned_genesis(), &user.ed, &user.pq).unwrap();
+        let sealed = pending.seal(signature).unwrap();
+        assert_eq!(
+            sealed
+                .record()
+                .atproto_verifying_key()
+                .unwrap()
+                .to_encoded_point(true),
+            first_public.to_encoded_point(true)
+        );
+        let secret = sealed.atproto_signing_key().to_bytes();
+        assert!(
+            !sealed
+                .record_bytes()
+                .windows(secret.len())
+                .any(|window| window == secret.as_slice()),
+            "account record must never contain the #atproto private key"
+        );
+        assert!(
+            !sealed
+                .genesis_bytes()
+                .windows(secret.len())
+                .any(|window| window == secret.as_slice()),
+            "genesis operation must never contain the #atproto private key"
+        );
+    }
+
+    #[test]
+    fn account_record_is_not_produced_before_valid_user_signature() {
+        let user = user_signer();
+        let attacker = user_signer();
+        let pending = begin(&user)
+            .prepare_genesis(Cid::from_raw(b"did document"), GenesisRepoHead::EmptyRepo)
+            .unwrap();
+        assert!(sign_genesis(pending.unsigned_genesis(), &attacker.ed, &attacker.pq).is_err());
+    }
+
+    #[test]
+    fn account_and_genesis_roundtrip_byte_exactly() {
+        let user = user_signer();
+        let pending = begin(&user)
+            .prepare_genesis(Cid::from_raw(b"did document"), GenesisRepoHead::EmptyRepo)
+            .unwrap();
+        let signature = sign_genesis(pending.unsigned_genesis(), &user.ed, &user.pq).unwrap();
+        let sealed = pending.seal(signature).unwrap();
+        let account = AccountRecord::from_dag_cbor(sealed.record_bytes()).unwrap();
+        assert_eq!(account.to_dag_cbor().unwrap(), sealed.record_bytes());
+        let genesis = GenesisDidOp::from_dag_cbor(sealed.genesis_bytes()).unwrap();
+        assert_eq!(genesis.to_dag_cbor().unwrap(), sealed.genesis_bytes());
+        assert_eq!(account.genesis_op(), genesis.cid().unwrap());
+        assert_eq!(account.current_op(), account.genesis_op());
+        assert_eq!(account.doc_cid(), genesis.unsigned().doc_cid());
+    }
+
+    #[test]
+    fn allocated_name_rejects_path_form_and_label_mismatch() {
+        assert!(AllocatedAccountName::new("alice", "did:web:example.com:users:alice").is_err());
+        assert!(AllocatedAccountName::new("alice", "did:web:bob.acct.example.com").is_err());
+        assert!(AllocatedAccountName::new(
+            "alice.example",
+            "did:web:alice.example.acct.example.com"
+        )
+        .is_err());
+    }
+
+    #[test]
+    fn operation_one_version_is_sealed_before_account_record() {
+        let user = user_signer();
+        let pending = begin(&user)
+            .prepare_genesis(Cid::from_raw(b"did document"), GenesisRepoHead::EmptyRepo)
+            .unwrap();
+        let signing_value = DagCbor::decode(&pending.signing_bytes().unwrap()).unwrap();
+        assert_eq!(
+            signing_value.get("version").unwrap().as_unsigned().unwrap(),
+            1
+        );
+        let signature = sign_genesis(pending.unsigned_genesis(), &user.ed, &user.pq).unwrap();
+        assert!(pending.seal(signature).is_ok());
+    }
+
+    #[test]
+    fn durable_writer_publishes_record_last_and_never_overwrites() {
+        let user = user_signer();
+        let pending = begin(&user)
+            .prepare_genesis(Cid::from_raw(b"did document"), GenesisRepoHead::EmptyRepo)
+            .unwrap();
+        let signature = sign_genesis(pending.unsigned_genesis(), &user.ed, &user.pq).unwrap();
+        let sealed = pending.seal(signature).unwrap();
+        let expected_record = sealed.record().clone();
+        let expected_record_bytes = sealed.record_bytes().to_vec();
+        let expected_genesis_bytes = sealed.genesis_bytes().to_vec();
+        let expected_secret = sealed.atproto_signing_key().to_bytes();
+
+        let temporary = tempfile::tempdir().unwrap();
+        let store = DirectoryHostedAccountStore::new(temporary.path().join("accounts"));
+        let stored_record = sealed.write_to(&store).unwrap();
+        assert_eq!(stored_record, expected_record);
+
+        let account_dir = store.root().join("alice");
+        assert_eq!(
+            std::fs::read(account_dir.join(ACCOUNT_RECORD_FILE)).unwrap(),
+            expected_record_bytes
+        );
+        assert_eq!(
+            std::fs::read(account_dir.join(GENESIS_DID_OP_FILE)).unwrap(),
+            expected_genesis_bytes
+        );
+        assert_eq!(
+            std::fs::read(account_dir.join(ATPROTO_SIGNING_KEY_FILE)).unwrap(),
+            expected_secret.as_slice()
+        );
+
+        // The label directory is the exclusive never-overwrite boundary.
+        let second = begin(&user)
+            .prepare_genesis(
+                Cid::from_raw(b"other did document"),
+                GenesisRepoHead::EmptyRepo,
+            )
+            .unwrap();
+        let second_signature = sign_genesis(second.unsigned_genesis(), &user.ed, &user.pq).unwrap();
+        assert!(second
+            .seal(second_signature)
+            .unwrap()
+            .write_to(&store)
+            .is_err());
+        assert_eq!(
+            std::fs::read(account_dir.join(ACCOUNT_RECORD_FILE)).unwrap(),
+            expected_record_bytes
+        );
+
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt as _;
+            assert_eq!(
+                std::fs::metadata(account_dir.join(ATPROTO_SIGNING_KEY_FILE))
+                    .unwrap()
+                    .permissions()
+                    .mode()
+                    & 0o777,
+                0o600
+            );
+        }
+    }
+}

--- a/crates/hyprstream-pds/src/hosted_account.rs
+++ b/crates/hyprstream-pds/src/hosted_account.rs
@@ -395,30 +395,36 @@ impl SealedHostedAccount {
 
     /// Persist this mint generation and return its public account record.
     ///
-    /// The bundle is consumed so callers cannot accidentally try to publish
-    /// the same secret-bearing generation to two account locations.
-    pub fn write_to(self, store: &DirectoryHostedAccountStore) -> Result<AccountRecord> {
-        store.write_new(&self)?;
-        Ok(self.record)
+    /// Retaining the bundle permits a retry after a crash or I/O error. The
+    /// sealed record fixes its label, so it cannot be redirected to another
+    /// account location.
+    pub fn write_to(&self, store: &DirectoryHostedAccountStore) -> Result<AccountRecord> {
+        store.write_new(self)?;
+        Ok(self.record.clone())
     }
 }
 
 /// Fail-closed filesystem persistence for newly minted hosted accounts.
 ///
-/// Each allocated label gets one directory beneath `root`. The directory is
-/// created exclusively and is never reused. Files are written in this order:
+/// Each allocated label gets one directory beneath `root`. Files are first
+/// written and synced in an unpublished private staging directory, then that
+/// complete directory is atomically published without replacement. Files are
+/// written in this order:
 ///
 /// 1. the generated `#atproto` private key;
 /// 2. the sealed genesis operation;
 /// 3. the public account record, **last**, as the publication marker.
 ///
-/// A crash before step 3 leaves no visible account record and the label
-/// directory remains reserved. A retry or duplicate mint cannot overwrite it.
+/// A crash before publication leaves no label directory. A crash after
+/// publication leaves the complete account. A retry removes only an invalid or
+/// incomplete legacy residue; it never replaces a complete account.
 /// C2 (#1168) owns later crash-atomic *rotation*; this writer only establishes
 /// the immutable first generation.
 #[derive(Clone, Debug)]
 pub struct DirectoryHostedAccountStore {
     root: PathBuf,
+    #[cfg(test)]
+    fault: Option<WriteFault>,
 }
 
 impl DirectoryHostedAccountStore {
@@ -426,7 +432,11 @@ impl DirectoryHostedAccountStore {
     ///
     /// There is intentionally no default path.
     pub fn new(root: impl Into<PathBuf>) -> Self {
-        Self { root: root.into() }
+        Self {
+            root: root.into(),
+            #[cfg(test)]
+            fault: None,
+        }
     }
 
     pub fn root(&self) -> &Path {
@@ -442,31 +452,272 @@ impl DirectoryHostedAccountStore {
         validate_sealed_bundle(account)?;
         ensure_private_directory(&self.root)?;
         let account_dir = self.root.join(account.record.name().label());
-        std::fs::create_dir(&account_dir).with_context(|| {
-            format!(
-                "failed to reserve hosted-account label directory {:?}",
-                account_dir
-            )
-        })?;
-        set_private_directory_permissions(&account_dir)?;
+        if complete_account_matches(&account_dir, account)? {
+            return Ok(());
+        }
+        remove_incomplete_account_directory(&account_dir)?;
 
-        write_new_file(
-            &account_dir.join(ATPROTO_SIGNING_KEY_FILE),
+        let staging_dir = self.new_staging_directory(account.record.name().label())?;
+        self.inject_fault(WriteFault::StagingDirectoryCreate)?;
+
+        self.write_new_file(
+            &staging_dir.join(ATPROTO_SIGNING_KEY_FILE),
             account.atproto_signing_key.to_bytes().as_slice(),
+            WriteFault::AtprotoFileCreate,
+            WriteFault::AtprotoFileWrite,
+            WriteFault::AtprotoFileSync,
         )?;
-        write_new_file(
-            &account_dir.join(GENESIS_DID_OP_FILE),
+        self.write_new_file(
+            &staging_dir.join(GENESIS_DID_OP_FILE),
             &account.genesis_bytes,
+            WriteFault::GenesisFileCreate,
+            WriteFault::GenesisFileWrite,
+            WriteFault::GenesisFileSync,
         )?;
-        // Publication marker: always last.
-        write_new_file(
-            &account_dir.join(ACCOUNT_RECORD_FILE),
+        self.write_new_file(
+            &staging_dir.join(ACCOUNT_RECORD_FILE),
             &account.record_bytes,
+            WriteFault::RecordFileCreate,
+            WriteFault::RecordFileWrite,
+            WriteFault::RecordFileSync,
         )?;
-        sync_directory(&account_dir)?;
+        sync_directory(&staging_dir)?;
+        self.inject_fault(WriteFault::StagingDirectorySync)?;
+
+        match rename_no_replace(&staging_dir, &account_dir) {
+            Ok(()) => {}
+            Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => {
+                if complete_account_matches(&account_dir, account)? {
+                    return Ok(());
+                }
+                bail!(
+                    "hosted-account label directory {:?} was concurrently claimed by an incomplete account",
+                    account_dir
+                );
+            }
+            Err(error) => {
+                return Err(error).with_context(|| {
+                    format!(
+                        "failed to atomically publish hosted-account label directory {:?}",
+                        account_dir
+                    )
+                });
+            }
+        }
+        self.inject_fault(WriteFault::Publish)?;
         sync_directory(&self.root)?;
+        self.inject_fault(WriteFault::RootDirectorySync)?;
         Ok(())
     }
+
+    fn new_staging_directory(&self, label: &str) -> Result<PathBuf> {
+        for attempt in 0_u32..128 {
+            let staging = self.root.join(format!(
+                ".{label}.mint-{}-{attempt}",
+                rand::random::<u128>()
+            ));
+            match std::fs::create_dir(&staging) {
+                Ok(()) => {
+                    set_private_directory_permissions(&staging)?;
+                    return Ok(staging);
+                }
+                Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => continue,
+                Err(error) => {
+                    return Err(error).with_context(|| {
+                        format!("failed to create hosted-account staging directory {staging:?}")
+                    });
+                }
+            }
+        }
+        bail!("could not allocate a unique hosted-account staging directory")
+    }
+
+    fn write_new_file(
+        &self,
+        path: &Path,
+        bytes: &[u8],
+        create_fault: WriteFault,
+        write_fault: WriteFault,
+        sync_fault: WriteFault,
+    ) -> Result<()> {
+        let mut options = OpenOptions::new();
+        options.write(true).create_new(true);
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::OpenOptionsExt as _;
+            options.mode(0o600);
+        }
+        let mut file = options
+            .open(path)
+            .with_context(|| format!("failed to create hosted-account file {path:?}"))?;
+        self.inject_fault(create_fault)?;
+        file.write_all(bytes)
+            .with_context(|| format!("failed to write hosted-account file {path:?}"))?;
+        self.inject_fault(write_fault)?;
+        file.sync_all()
+            .with_context(|| format!("failed to sync hosted-account file {path:?}"))?;
+        self.inject_fault(sync_fault)
+    }
+
+    #[cfg(test)]
+    fn with_fault(root: impl Into<PathBuf>, fault: WriteFault) -> Self {
+        Self {
+            root: root.into(),
+            fault: Some(fault),
+        }
+    }
+
+    #[cfg(test)]
+    fn inject_fault(&self, point: WriteFault) -> Result<()> {
+        if self.fault == Some(point) {
+            bail!("injected crash after {point:?}")
+        }
+        Ok(())
+    }
+
+    #[cfg(not(test))]
+    fn inject_fault(&self, _point: WriteFault) -> Result<()> {
+        Ok(())
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum WriteFault {
+    StagingDirectoryCreate,
+    AtprotoFileCreate,
+    AtprotoFileWrite,
+    AtprotoFileSync,
+    GenesisFileCreate,
+    GenesisFileWrite,
+    GenesisFileSync,
+    RecordFileCreate,
+    RecordFileWrite,
+    RecordFileSync,
+    StagingDirectorySync,
+    Publish,
+    RootDirectorySync,
+}
+
+#[cfg(test)]
+const WRITE_FAULTS: [WriteFault; 13] = [
+    WriteFault::StagingDirectoryCreate,
+    WriteFault::AtprotoFileCreate,
+    WriteFault::AtprotoFileWrite,
+    WriteFault::AtprotoFileSync,
+    WriteFault::GenesisFileCreate,
+    WriteFault::GenesisFileWrite,
+    WriteFault::GenesisFileSync,
+    WriteFault::RecordFileCreate,
+    WriteFault::RecordFileWrite,
+    WriteFault::RecordFileSync,
+    WriteFault::StagingDirectorySync,
+    WriteFault::Publish,
+    WriteFault::RootDirectorySync,
+];
+
+/// Return `true` only for a fully valid, byte-identical already-published
+/// account. Invalid or partial legacy directories are deliberately reported as
+/// incomplete so a mint retry can replace them through the no-replace publish
+/// transition; a valid different account is never removed or overwritten.
+fn complete_account_matches(path: &Path, expected: &SealedHostedAccount) -> Result<bool> {
+    let metadata = match std::fs::symlink_metadata(path) {
+        Ok(metadata) => metadata,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(false),
+        Err(error) => {
+            return Err(error)
+                .with_context(|| format!("failed to inspect hosted-account directory {path:?}"));
+        }
+    };
+    ensure!(
+        metadata.file_type().is_dir(),
+        "hosted-account label path {path:?} is not a directory"
+    );
+
+    let read = |name: &str| -> Result<Option<Vec<u8>>> {
+        let file = path.join(name);
+        match std::fs::read(&file) {
+            Ok(bytes) => Ok(Some(bytes)),
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(None),
+            Err(error) => {
+                Err(error).with_context(|| format!("failed to read hosted-account file {file:?}"))
+            }
+        }
+    };
+    let (Some(record_bytes), Some(genesis_bytes), Some(secret_bytes)) = (
+        read(ACCOUNT_RECORD_FILE)?,
+        read(GENESIS_DID_OP_FILE)?,
+        read(ATPROTO_SIGNING_KEY_FILE)?,
+    ) else {
+        return Ok(false);
+    };
+
+    let Ok(record) = AccountRecord::from_dag_cbor(&record_bytes) else {
+        return Ok(false);
+    };
+    let Ok(genesis) = GenesisDidOp::from_dag_cbor(&genesis_bytes) else {
+        return Ok(false);
+    };
+    let Ok(secret) = AtprotoSigningKey::from_slice(&secret_bytes) else {
+        return Ok(false);
+    };
+    if record.genesis_op() != genesis.cid()?
+        || record.current_op() != record.genesis_op()
+        || record.doc_cid() != genesis.unsigned().doc_cid()
+        || record.atproto_verifying_key()?.to_encoded_point(true)
+            != secret.verifying_key().to_encoded_point(true)
+    {
+        return Ok(false);
+    }
+
+    ensure!(
+        record_bytes == expected.record_bytes
+            && genesis_bytes == expected.genesis_bytes
+            && secret_bytes == expected.atproto_signing_key.to_bytes().as_slice(),
+        "hosted-account label directory {path:?} already contains a different complete account"
+    );
+    Ok(true)
+}
+
+fn remove_incomplete_account_directory(path: &Path) -> Result<()> {
+    match std::fs::symlink_metadata(path) {
+        Ok(metadata) => {
+            ensure!(
+                metadata.file_type().is_dir(),
+                "hosted-account label path {path:?} is not a directory"
+            );
+            std::fs::remove_dir_all(path).with_context(|| {
+                format!("failed to remove incomplete hosted-account directory {path:?}")
+            })?;
+            sync_directory(
+                path.parent()
+                    .ok_or_else(|| anyhow::anyhow!("hosted-account directory has no parent"))?,
+            )?;
+            Ok(())
+        }
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(()),
+        Err(error) => Err(error)
+            .with_context(|| format!("failed to inspect hosted-account directory {path:?}")),
+    }
+}
+
+#[cfg(target_os = "linux")]
+fn rename_no_replace(from: &Path, to: &Path) -> std::io::Result<()> {
+    rustix::fs::renameat_with(
+        rustix::fs::CWD,
+        from,
+        rustix::fs::CWD,
+        to,
+        rustix::fs::RenameFlags::NOREPLACE,
+    )?;
+    Ok(())
+}
+
+#[cfg(not(target_os = "linux"))]
+fn rename_no_replace(_from: &Path, _to: &Path) -> std::io::Result<()> {
+    Err(std::io::Error::new(
+        std::io::ErrorKind::Unsupported,
+        "atomic no-replace directory publication requires Linux renameat2",
+    ))
 }
 
 fn validate_sealed_bundle(account: &SealedHostedAccount) -> Result<()> {
@@ -520,23 +771,6 @@ fn set_private_directory_permissions(path: &Path) -> Result<()> {
 #[cfg(not(unix))]
 fn set_private_directory_permissions(_path: &Path) -> Result<()> {
     Ok(())
-}
-
-fn write_new_file(path: &Path, bytes: &[u8]) -> Result<()> {
-    let mut options = OpenOptions::new();
-    options.write(true).create_new(true);
-    #[cfg(unix)]
-    {
-        use std::os::unix::fs::OpenOptionsExt as _;
-        options.mode(0o600);
-    }
-    let mut file = options
-        .open(path)
-        .with_context(|| format!("failed to create hosted-account file {path:?}"))?;
-    file.write_all(bytes)
-        .with_context(|| format!("failed to write hosted-account file {path:?}"))?;
-    file.sync_all()
-        .with_context(|| format!("failed to sync hosted-account file {path:?}"))
 }
 
 fn sync_directory(path: &Path) -> Result<()> {
@@ -756,6 +990,38 @@ mod tests {
                     & 0o777,
                 0o600
             );
+        }
+    }
+
+    #[test]
+    fn durable_writer_recovers_from_every_interrupted_boundary() {
+        let user = user_signer();
+        let pending = begin(&user)
+            .prepare_genesis(Cid::from_raw(b"did document"), GenesisRepoHead::EmptyRepo)
+            .unwrap();
+        let signature = sign_genesis(pending.unsigned_genesis(), &user.ed, &user.pq).unwrap();
+        let sealed = pending.seal(signature).unwrap();
+
+        for fault in WRITE_FAULTS {
+            let temporary = tempfile::tempdir().unwrap();
+            let root = temporary.path().join("accounts");
+            let interrupted = DirectoryHostedAccountStore::with_fault(&root, fault);
+            assert!(
+                interrupted.write_new(&sealed).is_err(),
+                "fault injection at {fault:?} must interrupt mint publication"
+            );
+
+            let final_directory = root.join(sealed.record().name().label());
+            if final_directory.exists() {
+                assert!(
+                    complete_account_matches(&final_directory, &sealed).unwrap(),
+                    "a crash at {fault:?} may publish only a complete account"
+                );
+            }
+
+            let recovery = DirectoryHostedAccountStore::new(&root);
+            recovery.write_new(&sealed).unwrap();
+            assert!(complete_account_matches(&final_directory, &sealed).unwrap());
         }
     }
 }

--- a/crates/hyprstream-pds/src/lib.rs
+++ b/crates/hyprstream-pds/src/lib.rs
@@ -35,7 +35,9 @@
 //! - No libtorch / inference — this is a metadata/crypto layer.
 //! - No networking — proofs are produced and verified in-process; a transport
 //!   (HTTP/moq) wraps this separately.
-//! - No on-disk storage — the store is in-memory; persistence is a caller concern.
+//! - No general repo database — MST/CAR stores remain in-memory. The narrow
+//!   exception is [`DirectoryHostedAccountStore`], which durably establishes
+//!   an account's immutable genesis bundle and generated `#atproto` secret.
 //!
 //! # Reused infrastructure
 //!
@@ -59,7 +61,9 @@ pub mod car;
 pub mod cid;
 pub mod commit;
 pub mod dag_cbor;
+pub mod did_op;
 pub mod event_group;
+pub mod hosted_account;
 pub mod ledger;
 pub mod list_record;
 pub mod mst;
@@ -70,6 +74,16 @@ pub mod repo_authority;
 pub mod tid;
 
 pub use cid::Cid;
+pub use did_op::{
+    sign_genesis, DidOpSignature, GenesisDidOp, GenesisRepoHead, GenesisRotationKeys,
+    HostKeyEnrollment, HostRotationKey, HybridRotationKey, RecoveryKeyEnrollment,
+    RecoveryRotationKey, RotationSlotRef, UnsignedGenesisDidOp, UserRotationKey,
+    DID_OP_SIGNATURE_CONTEXT, DID_OP_VERSION,
+};
+pub use hosted_account::{
+    AccountRecord, AllocatedAccountName, DirectoryHostedAccountStore, HostedAccountMint,
+    PendingHostedAccountMint, SealedHostedAccount, ACCOUNT_RECORD_VERSION,
+};
 pub use ledger::{AllocationRecord, CheckpointRecord, GrantClass, ReceiptRecord, StateRoot, Unit};
 pub use name_record::NameRecord;
 pub use placement::{GroupItemRecord, GroupRecord, NodeRecord, WorkloadRecord};


### PR DESCRIPTION
## Summary

- seal genesis `DidOp` v1 from operation #1 with canonical DAG-CBOR and a frozen wire-format digest
- make the Q2 option-B ordering structural: required user key at priority 0, explicit recovery enrollment/decline at priority 1, optional host key only at priority 2
- require a pinned Ed25519 + ML-DSA-65 user signature before producing an account record
- generate a distinct per-account ES256 `#atproto` key and persist the secret, genesis bytes, and account record through an exclusive never-overwrite mint boundary

## Permanent genesis shape

`rotation_keys` is a fixed three-slot array. Every slot carries its role; declined recovery and absent host slots carry an explicit null key. The API has no constructor that accepts a host key in the user slot, and the doctest proves that misuse does not compile.

Genesis v1 seals `version`, `prev = null`, `seq = 0`, `did`, `doc_cid`, the ordered rotation slots, deliberate `head_at_op`, and the pinned-Hybrid signature. Unknown fields, reordered roles, missing PQ material, non-canonical bytes, and path-form did:web all fail closed.

## Dependency seams

- A2 #1160 supplies an atomically reserved, never-reusable account label.
- A3 #1162 / PR #1182 supplies the deployment-zone-derived host-form DID.
- B2 #1164 consumes the generated `#atproto` public key, seals the canonical DID document, and supplies its CID before the user signs genesis.
- A1 #1159 / PR #1181 remains the separate path-form freeze.

## Validation

- `buildq -- cargo test -p hyprstream-pds --lib --tests --no-fail-fast` (214 unit + 6 integration tests passed)
- `buildq -- cargo test -p hyprstream-pds --doc` (compile-fail custody test passed)
- `buildq -- cargo clippy -p hyprstream-pds --all-targets -- -D warnings`
- repository pre-commit release-profile Clippy gate

Closes #1163
Refs #1158