### PR TITLE
Fix assurance integrity joins

### DIFF
--- a/crates/hyprstream-rpc/src/auth/mac/label.rs
+++ b/crates/hyprstream-rpc/src/auth/mac/label.rs
@@ -52,9 +52,7 @@ pub const MAX_COMPARTMENTS: u32 = 64;
 ///
 /// Adding a level is a deliberate policy change (a new lattice version), not a
 /// runtime/config knob.
-#[derive(
-    Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize,
-)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
 #[serde(rename_all = "lowercase")]
 #[repr(u8)]
 pub enum Level {
@@ -105,9 +103,7 @@ impl fmt::Display for Level {
 /// - `PqHybrid`  — has a verified hybrid-PQC anchor (Ed25519 ↔ ML-DSA-65 bound
 ///   via `register_pq_trust`), i.e. the [`crate::crypto::CryptoPolicy::Hybrid`]
 ///   composite verified.
-#[derive(
-    Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize,
-)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
 #[serde(rename_all = "kebab-case")]
 #[repr(u8)]
 pub enum Assurance {
@@ -122,9 +118,9 @@ pub enum Assurance {
 }
 
 impl Assurance {
-    /// Floor / join identity of the assurance axis.
+    /// Floor of the assurance axis (fail-closed for unknown provenance).
     pub const BOTTOM: Assurance = Assurance::Unverified;
-    /// Top of the assurance axis.
+    /// Top of the assurance axis and identity for its `min` join.
     pub const TOP: Assurance = Assurance::PqHybrid;
 }
 
@@ -178,9 +174,7 @@ impl fmt::Display for Compartment {
 /// policy. Subset/union are bitwise `AND`/`OR`. The empty set (`0`) is the
 /// compartment-axis bottom. This is the representation that lets S4's AVC (#570)
 /// key on a label with no interning indirection.
-#[derive(
-    Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default, Serialize, Deserialize,
-)]
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default, Serialize, Deserialize)]
 #[serde(transparent)]
 pub struct CompartmentSet(pub u64);
 
@@ -339,15 +333,25 @@ impl SecurityLabel {
         }
     }
 
-    /// The lattice **bottom** ⊥ = `(Public, Unverified, {})`.
+    /// The fail-closed label `(Public, Unverified, {})`.
     ///
-    /// This is the *join identity*, NOT a default object label. An object is
-    /// only at ⊥ if policy explicitly labels it so. It is mainly useful as the
-    /// seed for folding a join over provenance inputs (IFC).
+    /// This is deliberately distinct from the identity for provenance joins:
+    /// the Biba assurance axis joins with `min`, whose identity is `PqHybrid`.
+    /// In particular, an empty provenance set must remain unverified rather
+    /// than acquire the join identity's top assurance.
     pub const fn bottom() -> Self {
         SecurityLabel {
             level: Level::BOTTOM,
             assurance: Assurance::BOTTOM,
+            compartments: CompartmentSet::EMPTY,
+        }
+    }
+
+    /// Per-axis identity for a non-empty provenance join.
+    const fn join_identity() -> Self {
+        SecurityLabel {
+            level: Level::BOTTOM,
+            assurance: Assurance::TOP,
             compartments: CompartmentSet::EMPTY,
         }
     }
@@ -368,6 +372,10 @@ impl SecurityLabel {
     /// - `self.assurance >= object.assurance`        (#548 crypto-assurance axis)
     /// - `object.compartments ⊆ self.compartments`   (cleared into all categories)
     ///
+    /// The assurance field is currently overloaded: here it is an authentication-
+    /// strength gate, while provenance joining treats it as Biba integrity. Keep
+    /// this gate unchanged pending the field-separation/proof follow-up in #1232.
+    ///
     /// The per-op MAC floor (design §3, §10): the *fixed* product-lattice order,
     /// content truth, never overridable by a token/UCAN/grant.
     #[inline]
@@ -378,13 +386,11 @@ impl SecurityLabel {
             && object.compartments.is_subset(self.compartments)
     }
 
-    /// **Join** (least upper bound) — the IFC combinator (design §3).
+    /// IFC provenance join over confidentiality, integrity, and compartments.
     ///
-    /// `a ⊔ b` = `(max(level), max(assurance), union(compartments))`. A derived
-    /// object's label is the join of its inputs' labels, so a rollup of secret
-    /// inputs is automatically secret and aggregation cannot launder
-    /// classification. Associative, commutative, idempotent; `⊥` is the
-    /// identity — hence [`SecurityLabel::join_all`] can fold from `bottom()`.
+    /// `a ⊔ b` = `(max(level), min(assurance), union(compartments))`: secrecy
+    /// rises to the most restrictive input, while provenance integrity degrades
+    /// to its weakest link. Associative, commutative, and idempotent.
     #[inline]
     #[must_use]
     pub fn join(&self, other: &SecurityLabel) -> SecurityLabel {
@@ -394,7 +400,7 @@ impl SecurityLabel {
             } else {
                 other.level
             },
-            assurance: if self.assurance >= other.assurance {
+            assurance: if self.assurance <= other.assurance {
                 self.assurance
             } else {
                 other.assurance
@@ -405,16 +411,19 @@ impl SecurityLabel {
 
     /// Fold the IFC join over a set of input labels (provenance-DAG join).
     ///
-    /// Returns `⊥` for an empty input set (the identity), which the caller
-    /// MUST treat carefully: a derived object with *no* recorded inputs is
-    /// suspicious and should generally be rejected rather than labeled ⊥. This
-    /// helper computes the algebra only; the seal/rollup policy (when an empty
-    /// provenance is allowed) is S2's (#568).
+    /// Non-empty inputs fold from the per-axis identity `(Public, PqHybrid, {})`.
+    /// Empty provenance instead returns the fail-closed `bottom()` label, never
+    /// the top-assurance identity.
     #[must_use]
     pub fn join_all<'a>(labels: impl IntoIterator<Item = &'a SecurityLabel>) -> SecurityLabel {
-        labels
-            .into_iter()
-            .fold(SecurityLabel::bottom(), |acc, l| acc.join(l))
+        let mut labels = labels.into_iter();
+        let Some(first) = labels.next() else {
+            return SecurityLabel::bottom();
+        };
+
+        labels.fold(SecurityLabel::join_identity().join(first), |acc, label| {
+            acc.join(label)
+        })
     }
 }
 
@@ -509,23 +518,25 @@ mod tests {
     }
 
     #[test]
-    fn join_takes_max_and_union() {
+    fn join_takes_confidentiality_max_integrity_min_and_union() {
         let a = label(Level::Internal, Assurance::Classical, &[0]); // pii
         let b = label(Level::Secret, Assurance::PqHybrid, &[5]); // finance
         let j = a.join(&b);
         assert_eq!(j.level, Level::Secret);
-        assert_eq!(j.assurance, Assurance::PqHybrid);
+        assert_eq!(j.assurance, Assurance::Classical);
         assert!(j.compartments.contains(0));
         assert!(j.compartments.contains(5));
     }
 
     #[test]
-    fn join_is_least_upper_bound() {
+    fn join_preserves_each_axis_bound() {
         let a = label(Level::Internal, Assurance::Classical, &[0]);
         let b = label(Level::Confidential, Assurance::Unverified, &[5]);
         let j = a.join(&b);
-        assert!(j.can_access(&a));
-        assert!(j.can_access(&b));
+        assert!(j.level >= a.level && j.level >= b.level);
+        assert!(j.assurance <= a.assurance && j.assurance <= b.assurance);
+        assert!(a.compartments.is_subset(j.compartments));
+        assert!(b.compartments.is_subset(j.compartments));
     }
 
     #[test]
@@ -539,13 +550,13 @@ mod tests {
         assert_eq!(a.join(&b).join(&c), a.join(&b.join(&c)));
         // idempotent
         assert_eq!(a.join(&a), a);
-        // bottom identity
-        assert_eq!(a.join(&SecurityLabel::bottom()), a);
+        // per-axis identity
+        assert_eq!(a.join(&SecurityLabel::join_identity()), a);
     }
 
     #[test]
     fn join_all_secret_input_propagates() {
-        // IFC: aggregating a secret input yields a secret result.
+        // Confidentiality rises, integrity falls, and compartments accumulate.
         let inputs = vec![
             label(Level::Public, Assurance::Classical, &[0]),
             label(Level::Secret, Assurance::PqHybrid, &[1]),
@@ -553,14 +564,30 @@ mod tests {
         ];
         let j = SecurityLabel::join_all(&inputs);
         assert_eq!(j.level, Level::Secret);
-        assert_eq!(j.assurance, Assurance::PqHybrid);
+        assert_eq!(j.assurance, Assurance::Classical);
         assert_eq!(j.compartments.len(), 3);
     }
 
     #[test]
-    fn join_all_empty_is_bottom() {
+    fn join_all_mixed_classical_and_pq_hybrid_yields_classical() {
+        let inputs = vec![
+            label(Level::Public, Assurance::PqHybrid, &[]),
+            label(Level::Public, Assurance::Classical, &[]),
+        ];
+
+        assert_eq!(
+            SecurityLabel::join_all(&inputs).assurance,
+            Assurance::Classical
+        );
+    }
+
+    #[test]
+    fn join_all_empty_is_fail_closed_unverified() {
         let none: Vec<&SecurityLabel> = vec![];
-        assert!(SecurityLabel::join_all(none).is_bottom());
+        let joined = SecurityLabel::join_all(none);
+        assert_eq!(joined.assurance, Assurance::Unverified);
+        assert!(joined.is_bottom());
+        assert_ne!(joined, SecurityLabel::join_identity());
     }
 
     #[test]

--- a/crates/hyprstream/src/mac/genesis.rs
+++ b/crates/hyprstream/src/mac/genesis.rs
@@ -765,11 +765,20 @@ mod tests {
     #[test]
     fn resolver_cid_labeled_manifest() {
         let labeled = SecurityLabel::new(Level::Secret, Assurance::PqHybrid, Default::default());
-        let r = resolver_over(
-            &["/srv/policy"],
+        let import_floor =
+            SecurityLabel::new(Level::Internal, Assurance::Classical, Default::default());
+        let genesis = SitePolicy::floor_only(import_floor).materialize(["/srv/policy"]);
+        let r = CompositeObjectLabelResolver::new(
+            genesis,
+            import_floor,
             Arc::new(FixedManifests(Some(Some(labeled)))),
         );
-        assert_eq!(r.resolve(ObjectRef::Cid(&[1, 2, 3])), Some(labeled));
+        let expected = SecurityLabel::new(Level::Secret, Assurance::Classical, Default::default());
+        assert_eq!(
+            r.resolve(ObjectRef::Cid(&[1, 2, 3])),
+            Some(expected),
+            "PqHybrid provenance imported through a Classical floor must degrade to Classical"
+        );
     }
 
     #[test]
@@ -778,6 +787,7 @@ mod tests {
         let r = resolver_over(&["/srv/policy"], Arc::new(FixedManifests(Some(None))));
         let label = r.resolve(ObjectRef::Cid(&[1, 2, 3])).unwrap();
         assert_eq!(label, SitePolicy::conservative().floor());
+        assert_eq!(label.assurance, Assurance::Unverified);
     }
 
     #[test]
@@ -832,17 +842,20 @@ mod tests {
 
     #[test]
     fn gate_resolver_matches_report_coverage() {
-        // Every labeled node in the report must resolve through the gate's
-        // resolver (the report and the resolver agree on coverage).
+        // Every labeled node in the report must resolve to the exact site-policy
+        // label. Genesis carries no provenance evidence, so assurance remains at
+        // the fail-closed Unverified floor rather than acquiring a join identity.
         let gate = GenesisGate::production();
+        let policy = SitePolicy::conservative();
         for node in &gate.report().labeled {
             let components: Vec<&str> = node.trim_start_matches('/').split('/').collect();
-            assert!(
-                gate.resolver()
-                    .resolve(ObjectRef::Path(&components))
-                    .is_some(),
-                "labeled node {node} must resolve through the resolver"
+            let expected = policy.label_for(node);
+            assert_eq!(
+                gate.resolver().resolve(ObjectRef::Path(&components)),
+                Some(expected),
+                "labeled node {node} must resolve to its reported site-policy label"
             );
+            assert_eq!(expected.assurance, Assurance::Unverified);
         }
     }
 }

--- a/crates/hyprstream/src/mac/lattice.rs
+++ b/crates/hyprstream/src/mac/lattice.rs
@@ -123,9 +123,10 @@ mod tests {
             SecurityLabel::new(Level::Public, Assurance::PqHybrid, CompartmentSet::EMPTY);
         assert_eq!(ifc_join(&[algebraic_identity, secret]), secret);
         let empty = ifc_join(&[]);
+        assert_eq!(empty.level, Level::Public);
         assert_eq!(empty.assurance, Assurance::Unverified);
+        assert!(empty.compartments.is_empty());
         assert_ne!(empty, algebraic_identity);
-        assert!(empty.is_bottom());
     }
 
     #[test]

--- a/crates/hyprstream/src/mac/lattice.rs
+++ b/crates/hyprstream/src/mac/lattice.rs
@@ -46,10 +46,11 @@ pub use hyprstream_rpc::auth::mac::{
 
 /// IFC convenience: join a slice of input labels into the derived label (design
 /// §3 — sealed at rollup). Thin forwarder over S1's intrinsic
-/// [`SecurityLabel::join_all`]; an empty input yields the lattice bottom ⊥ (the
-/// join identity), which the seal/rollup policy (S2) must treat as suspicious. This
-/// is the function S6/seal-time labeling calls; it lives here so PDP callers have a
-/// single entry-point without reaching across crates.
+/// [`SecurityLabel::join_all`]. Non-empty joins use the per-axis algebraic identity
+/// `(Public, PqHybrid, {})`; empty input instead yields the fail-closed
+/// `(Public, Unverified, {})`, which the seal/rollup policy (S2) must treat as
+/// suspicious. This is the function S6/seal-time labeling calls; it lives here so
+/// PDP callers have a single entry-point without reaching across crates.
 #[inline]
 #[must_use]
 pub fn ifc_join(inputs: &[SecurityLabel]) -> SecurityLabel {
@@ -83,7 +84,11 @@ mod tests {
             )
             .unwrap();
         let needs_pii = l
-            .label(Level::Confidential, Assurance::Classical, [Compartment::new("pii")])
+            .label(
+                Level::Confidential,
+                Assurance::Classical,
+                [Compartment::new("pii")],
+            )
             .unwrap();
         // dominates on every axis (level ≥, assurance ≥, compartments ⊇).
         assert!(cleared.can_access(&needs_pii));
@@ -91,21 +96,36 @@ mod tests {
     }
 
     #[test]
-    fn ifc_join_raises_to_lub() {
+    fn ifc_join_combines_blp_confidentiality_and_biba_integrity() {
         let l = lattice();
         let secret = l
-            .label(Level::Secret, Assurance::PqHybrid, [Compartment::new("pii")])
+            .label(
+                Level::Secret,
+                Assurance::PqHybrid,
+                [Compartment::new("pii")],
+            )
             .unwrap();
-        let public = l
-            .label(Level::Public, Assurance::Classical, [])
-            .unwrap();
+        let public = l.label(Level::Public, Assurance::Classical, []).unwrap();
         let derived = ifc_join(&[secret, public]);
-        assert_eq!(derived.level, Level::Secret);
-        assert_eq!(derived.assurance, Assurance::PqHybrid);
-        assert!(derived.can_access(&secret));
-        assert!(derived.can_access(&public));
-        // empty input folds to the join identity ⊥.
-        assert!(ifc_join(&[]).is_bottom());
+
+        // Confidentiality and compartments take their upper bounds.
+        assert!(derived.level >= secret.level && derived.level >= public.level);
+        assert!(secret.compartments.is_subset(derived.compartments));
+        assert!(public.compartments.is_subset(derived.compartments));
+        // Biba provenance integrity takes the floor (weakest input).
+        assert!(derived.assurance <= secret.assurance);
+        assert!(derived.assurance <= public.assurance);
+        assert_eq!(derived.assurance, Assurance::Classical);
+
+        // The algebraic identity is (Public, PqHybrid, {}), but an empty input
+        // is deliberately fail-closed rather than returning that identity.
+        let algebraic_identity =
+            SecurityLabel::new(Level::Public, Assurance::PqHybrid, CompartmentSet::EMPTY);
+        assert_eq!(ifc_join(&[algebraic_identity, secret]), secret);
+        let empty = ifc_join(&[]);
+        assert_eq!(empty.assurance, Assurance::Unverified);
+        assert_ne!(empty, algebraic_identity);
+        assert!(empty.is_bottom());
     }
 
     #[test]
@@ -116,7 +136,11 @@ mod tests {
         let restored = Lattice::from_bytes(&l.to_bytes()).unwrap();
         assert_eq!(restored.compartment_names(), l.compartment_names());
         let label = l
-            .label(Level::Internal, Assurance::Classical, [Compartment::new("tenant:acme")])
+            .label(
+                Level::Internal,
+                Assurance::Classical,
+                [Compartment::new("tenant:acme")],
+            )
             .unwrap();
         assert!(restored.validate(&label).is_ok());
         assert_eq!(restored.bit_of(&Compartment::new("tenant:acme")), Some(2));


### PR DESCRIPTION
Fixes #1232.

- treat assurance as a Biba integrity axis and take the floor in provenance joins
- fold non-empty joins from the per-axis identity `(Public, PqHybrid, {})`
- keep empty provenance fail-closed at `Unverified`
- document the overloaded `can_access` auth-strength gate without changing it
- cover mixed Classical + PqHybrid `join_all` yielding Classical

#1224 must rebase onto this PR before sealing joined labels.

Test: `buildq -- cargo test -p hyprstream-rpc auth::mac` (61 passed, 0 failed).