### PR TITLE
fix(auth): bind JWT kid during JWKS rotation

### DIFF
--- a/crates/hyprstream-rpc/src/auth/federation.rs
+++ b/crates/hyprstream-rpc/src/auth/federation.rs
@@ -7,6 +7,17 @@
 use anyhow::Result;
 use ed25519_dalek::VerifyingKey;
 
+/// One named Ed25519 key published in a federation JWKS.
+///
+/// `kid` stays attached to its key until verification.  Collapsing this to a
+/// bare `VerifyingKey` would let a token that names one key verify with a
+/// different, merely co-published key.
+#[derive(Clone, Debug)]
+pub struct FederationKey {
+    pub kid: Option<String>,
+    pub verifying_key: VerifyingKey,
+}
+
 /// Resolves external JWT issuer URLs to Ed25519 verifying keys.
 ///
 /// Implemented by `hyprstream::auth::FederationKeyResolver`. Services that
@@ -17,12 +28,10 @@ use ed25519_dalek::VerifyingKey;
 /// # Key-set semantics (rotation-aware, #1185)
 ///
 /// A published JWKS is a **named set**, never an ordered singleton. `get_keys`
-/// returns every usable Ed25519 entry from the issuer's current JWKS so the
-/// caller can try each candidate — this is what makes overlap rotation (old +
-/// new keys published simultaneously) and future PQ-hybrid publication
-/// possible. When the JWT carries a `kid`, the matching candidate is ordered
-/// first; the rest follow so a verifier that prefers the kid still benefits
-/// from overlap fallback if the named key has been retired mid-window.
+/// returns every usable named Ed25519 entry from the issuer's current JWKS so
+/// a token without a `kid` can try each candidate. When the JWT carries a
+/// `kid`, it returns only entries with that exact `kid`; a named token must
+/// never verify with another co-published key.
 ///
 /// The resolver MUST NOT collapse the set to a positional singleton: returning
 /// the "first" Ed25519 key forecloses rotation (#1183). An empty result is an
@@ -50,11 +59,9 @@ pub trait FederationKeySource: Send + Sync + 'static {
     /// Fetch (or return from cache) the Ed25519 candidate verifying keys for
     /// `issuer`.
     ///
-    /// Returns every usable Ed25519 key from the issuer's JWKS, ordered so
-    /// that when `kid` is `Some` the matching candidate comes first and the
-    /// remaining overlap candidates follow. The caller SHOULD try each
-    /// candidate against the JWT and accept the first that verifies — this is
-    /// the rotation/pQ-hybrid publication model (#1183).
+    /// Returns every usable named Ed25519 key from the issuer's JWKS. When
+    /// `kid` is `Some`, every returned entry has that exact `kid`; when it is
+    /// `None`, the caller may try each candidate against the JWT.
     ///
     /// On a cache miss for the requested `kid`, the resolver refetches the
     /// JWKS once and re-checks. A `kid` that is still absent after a fresh
@@ -67,7 +74,7 @@ pub trait FederationKeySource: Send + Sync + 'static {
     /// - the issuer is not in the trusted list (`is_trusted` returns `false`), or
     /// - the JWKS endpoint is unreachable or returns no usable Ed25519 key, or
     /// - `kid` is `Some` and no candidate with that `kid` exists after refetch.
-    async fn get_keys(&self, issuer: &str, kid: Option<&str>) -> Result<Vec<VerifyingKey>>;
+    async fn get_keys(&self, issuer: &str, kid: Option<&str>) -> Result<Vec<FederationKey>>;
 }
 
 #[cfg(test)]
@@ -85,11 +92,7 @@ mod tests {
             false
         }
 
-        async fn get_keys(
-            &self,
-            issuer: &str,
-            _kid: Option<&str>,
-        ) -> Result<Vec<VerifyingKey>> {
+        async fn get_keys(&self, issuer: &str, _kid: Option<&str>) -> Result<Vec<FederationKey>> {
             let _ = issuer;
             anyhow::bail!("Issuer not trusted: {}", issuer)
         }
@@ -99,6 +102,10 @@ mod tests {
     async fn trait_object_compiles_and_rejects() {
         let src: Arc<dyn FederationKeySource> = Arc::new(AlwaysReject);
         assert!(!src.is_trusted("https://evil.example.com"));
-        assert!(src.get_keys("https://evil.example.com", None).await.is_err());
+        assert!(
+            src.get_keys("https://evil.example.com", None)
+                .await
+                .is_err()
+        );
     }
 }

--- a/crates/hyprstream-rpc/src/auth/federation.rs
+++ b/crates/hyprstream-rpc/src/auth/federation.rs
@@ -14,9 +14,23 @@ use ed25519_dalek::VerifyingKey;
 /// `RequestService::federation_key_source()` so the default `verify_claims()`
 /// can perform real key resolution instead of rejecting federated JWTs.
 ///
+/// # Key-set semantics (rotation-aware, #1185)
+///
+/// A published JWKS is a **named set**, never an ordered singleton. `get_keys`
+/// returns every usable Ed25519 entry from the issuer's current JWKS so the
+/// caller can try each candidate — this is what makes overlap rotation (old +
+/// new keys published simultaneously) and future PQ-hybrid publication
+/// possible. When the JWT carries a `kid`, the matching candidate is ordered
+/// first; the rest follow so a verifier that prefers the kid still benefits
+/// from overlap fallback if the named key has been retired mid-window.
+///
+/// The resolver MUST NOT collapse the set to a positional singleton: returning
+/// the "first" Ed25519 key forecloses rotation (#1183). An empty result is an
+/// `Err`.
+///
 /// # Note on `Send` bounds
 ///
-/// `get_key` uses the default (`Send`) flavour of `#[async_trait]` because
+/// `get_keys` uses the default (`Send`) flavour of `#[async_trait]` because
 /// `FederationKeyResolver` performs real async I/O (HTTPS JWKS fetch) whose
 /// future must be `Send`. Call sites inside `#[async_trait(?Send)]` contexts
 /// (e.g. `RequestService::verify_claims`) may `.await` this future directly:
@@ -28,23 +42,32 @@ use ed25519_dalek::VerifyingKey;
 pub trait FederationKeySource: Send + Sync + 'static {
     /// Return `true` if `issuer` is in the configured trusted-issuer list.
     ///
-    /// Callers should check this before calling `get_key` to distinguish an
+    /// Callers should check this before calling `get_keys` to distinguish an
     /// untrusted issuer (policy reject → 401) from a transient fetch error
     /// (retry eligible → 503).
     fn is_trusted(&self, issuer: &str) -> bool;
 
-    /// Fetch (or return from cache) the Ed25519 verifying key for `issuer`.
+    /// Fetch (or return from cache) the Ed25519 candidate verifying keys for
+    /// `issuer`.
+    ///
+    /// Returns every usable Ed25519 key from the issuer's JWKS, ordered so
+    /// that when `kid` is `Some` the matching candidate comes first and the
+    /// remaining overlap candidates follow. The caller SHOULD try each
+    /// candidate against the JWT and accept the first that verifies — this is
+    /// the rotation/pQ-hybrid publication model (#1183).
+    ///
+    /// On a cache miss for the requested `kid`, the resolver refetches the
+    /// JWKS once and re-checks. A `kid` that is still absent after a fresh
+    /// fetch fails closed (`Err`); the resolver MUST NOT silently substitute
+    /// another key for a named `kid`.
     ///
     /// # Errors
     ///
     /// Returns `Err` if:
     /// - the issuer is not in the trusted list (`is_trusted` returns `false`), or
-    /// - the JWKS endpoint is unreachable or returns an invalid key.
-    ///
-    /// Callers that need to distinguish these cases should call `is_trusted`
-    /// first; a subsequent `Err` from `get_key` then indicates a fetch/parse
-    /// failure rather than a policy rejection.
-    async fn get_key(&self, issuer: &str) -> Result<VerifyingKey>;
+    /// - the JWKS endpoint is unreachable or returns no usable Ed25519 key, or
+    /// - `kid` is `Some` and no candidate with that `kid` exists after refetch.
+    async fn get_keys(&self, issuer: &str, kid: Option<&str>) -> Result<Vec<VerifyingKey>>;
 }
 
 #[cfg(test)]
@@ -62,7 +85,12 @@ mod tests {
             false
         }
 
-        async fn get_key(&self, issuer: &str) -> Result<VerifyingKey> {
+        async fn get_keys(
+            &self,
+            issuer: &str,
+            _kid: Option<&str>,
+        ) -> Result<Vec<VerifyingKey>> {
+            let _ = issuer;
             anyhow::bail!("Issuer not trusted: {}", issuer)
         }
     }
@@ -71,6 +99,6 @@ mod tests {
     async fn trait_object_compiles_and_rejects() {
         let src: Arc<dyn FederationKeySource> = Arc::new(AlwaysReject);
         assert!(!src.is_trusted("https://evil.example.com"));
-        assert!(src.get_key("https://evil.example.com").await.is_err());
+        assert!(src.get_keys("https://evil.example.com", None).await.is_err());
     }
 }

--- a/crates/hyprstream-rpc/src/auth/jwt.rs
+++ b/crates/hyprstream-rpc/src/auth/jwt.rs
@@ -10,7 +10,7 @@
 //! - Payload: Claims (sub, exp, iat)
 //! - Signature: Ed25519 over `base64url(header).base64url(payload)`
 
-use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine};
+use base64::{Engine, engine::general_purpose::URL_SAFE_NO_PAD};
 use chrono::Utc;
 use ed25519_dalek::{Signature, Signer, SigningKey, Verifier, VerifyingKey};
 use thiserror::Error;
@@ -109,7 +109,7 @@ impl<'de> serde::Deserialize<'de> for ProtectedHeader {
                             return Err(A::Error::unknown_field(
                                 &key,
                                 &["alg", "typ", "kid", "crit"],
-                            ))
+                            ));
                         }
                     }
                 }
@@ -411,6 +411,28 @@ pub fn decode_with_candidates(
         }
     }
     Err(last_err)
+}
+
+/// Decode a federation JWT while retaining the JWKS `kid` binding.
+///
+/// A token that names a key may only be verified by entries carrying that
+/// exact name. A token without a selector may try every compatible published
+/// key, which is the overlap-rotation case.
+pub fn decode_with_federation_candidates(
+    token: &str,
+    candidates: &[super::FederationKey],
+    expected_aud: Option<&str>,
+) -> Result<Claims, JwtError> {
+    let kid = header_kid(token)?;
+    let keys: Vec<VerifyingKey> = candidates
+        .iter()
+        .filter(|candidate| match kid.as_deref() {
+            Some(named_kid) => candidate.kid.as_deref() == Some(named_kid),
+            None => true,
+        })
+        .map(|candidate| candidate.verifying_key)
+        .collect();
+    decode_with_candidates(token, &keys, expected_aud)
 }
 
 /// Internal decode implementation shared by `decode` and `decode_with_key`.
@@ -736,7 +758,10 @@ mod tests {
             "JWT",
             "wit+jwt",
         ] {
-            assert!(!is_rfc9068_access_token_type(rejected), "accepted {rejected:?}");
+            assert!(
+                !is_rfc9068_access_token_type(rejected),
+                "accepted {rejected:?}"
+            );
         }
     }
 
@@ -917,11 +942,12 @@ mod tests {
         let claims = Claims::new("overlap-test".to_owned(), 0, 9_999_999_999);
         let token = encode(&claims, &key_b); // signed by the second key
 
-        // Candidate set published kid-first as [old, new]; the token is
+        // Candidate set published in overlap order as [old, new]; the token is
         // signed by `new` (the second entry). The old code resolved only
         // the first key and this token would have failed.
         let candidates = vec![key_a.verifying_key(), key_b.verifying_key()];
-        let decoded = decode_with_candidates(&token, &candidates, None).expect("second key verifies");
+        let decoded =
+            decode_with_candidates(&token, &candidates, None).expect("second key verifies");
         assert_eq!(decoded.sub, "overlap-test");
     }
 
@@ -941,5 +967,31 @@ mod tests {
         let claims = Claims::new("empty".to_owned(), 0, 9_999_999_999);
         let token = encode(&claims, &make_key(0x22));
         assert!(decode_with_candidates(&token, &[], None).is_err());
+    }
+
+    #[test]
+    fn federation_candidates_reject_mismatched_named_key() {
+        use crate::auth::FederationKey;
+
+        let old = make_key(0xA1);
+        let new = make_key(0xB2);
+        let claims = Claims::new("kid-binding".to_owned(), 0, 9_999_999_999);
+        let token = encode(&claims, &old);
+        let old_kid = kid_for_key(&old);
+
+        // The token names `old_kid`, but only a different co-published key is
+        // attached to that name. The bare-key candidate loop would accept the
+        // `old` entry below; the federation path must reject it.
+        let candidates = vec![
+            FederationKey {
+                kid: Some(old_kid),
+                verifying_key: new.verifying_key(),
+            },
+            FederationKey {
+                kid: Some(kid_for_key(&new)),
+                verifying_key: old.verifying_key(),
+            },
+        ];
+        assert!(decode_with_federation_candidates(&token, &candidates, None).is_err());
     }
 }

--- a/crates/hyprstream-rpc/src/auth/jwt.rs
+++ b/crates/hyprstream-rpc/src/auth/jwt.rs
@@ -387,6 +387,62 @@ pub fn decode_with_key(
     decode_inner(token, verifying_key, expected_aud, true)
 }
 
+/// Try verifying a JWT against each candidate key, returning the first
+/// successful decode. Mirrors [`decode`] (strict audience: an absent `aud`
+/// is rejected when `expected_aud` is `Some`).
+///
+/// This is the safe verifier shape for a kid-less JWT: when the JOSE header
+/// carries no `kid`, the verifier cannot know which published key signed the
+/// token, so it MUST try every algorithm-compatible candidate rather than
+/// collapse the published set to a positional singleton (#1183 / #1184).
+/// Per-candidate failures are expected in the happy path (a JWKS with several
+/// keys has exactly one real verifier), so they are logged at `debug!`; the
+/// final failure surfaces `InvalidSignature`.
+///
+/// `candidates` MUST be non-empty; an empty slice is an `InvalidSignature`
+/// error rather than a panic.
+pub fn decode_with_any_key(
+    token: &str,
+    candidates: &[VerifyingKey],
+    expected_aud: Option<&str>,
+) -> Result<Claims, JwtError> {
+    decode_with_any_key_inner(token, candidates, expected_aud, false)
+}
+
+/// Lenient-audience twin of [`decode_with_any_key`], mirroring
+/// [`decode_with_key`]: a wrong `aud` is still rejected, but an absent `aud`
+/// is accepted when `expected_aud` is `Some`. Use this for federated tokens
+/// from issuers that do not set `aud`.
+pub fn decode_with_any_key_lenient(
+    token: &str,
+    candidates: &[VerifyingKey],
+    expected_aud: Option<&str>,
+) -> Result<Claims, JwtError> {
+    decode_with_any_key_inner(token, candidates, expected_aud, true)
+}
+
+fn decode_with_any_key_inner(
+    token: &str,
+    candidates: &[VerifyingKey],
+    expected_aud: Option<&str>,
+    lenient_aud: bool,
+) -> Result<Claims, JwtError> {
+    if candidates.is_empty() {
+        return Err(JwtError::InvalidSignature);
+    }
+    let mut last_err = JwtError::InvalidSignature;
+    for vk in candidates {
+        match decode_inner(token, vk, expected_aud, lenient_aud) {
+            Ok(claims) => return Ok(claims),
+            Err(e) => {
+                tracing::debug!(error = %e, "JWT candidate key did not verify; trying next");
+                last_err = e;
+            }
+        }
+    }
+    Err(last_err)
+}
+
 /// Internal decode implementation shared by `decode` and `decode_with_key`.
 ///
 /// `lenient_aud`: when true, accepts tokens with no `aud` claim even when

--- a/crates/hyprstream-rpc/src/auth/jwt.rs
+++ b/crates/hyprstream-rpc/src/auth/jwt.rs
@@ -387,6 +387,32 @@ pub fn decode_with_key(
     decode_inner(token, verifying_key, expected_aud, true)
 }
 
+/// Decode a JWT by trying each candidate key in order, accepting the first
+/// that verifies. This is the rotation-aware federation verifier: a caller
+/// passes the candidate set returned by a key-set resolver (e.g.
+/// `FederationKeySource::get_keys`) and the token verifies if ANY published
+/// key validates it — the overlap-rotation and PQ-hybrid publication model
+/// (#1183/#1185). `candidates` SHOULD be ordered kid-first by the resolver
+/// so the preferred key is tried before overlap fallbacks.
+///
+/// Returns the last error if no candidate verifies (so a caller can surface
+/// a representative failure); `InvalidFormat` when the candidate set is empty
+/// (the resolver is contractually non-empty, so this is a fail-closed guard).
+pub fn decode_with_candidates(
+    token: &str,
+    candidates: &[VerifyingKey],
+    expected_aud: Option<&str>,
+) -> Result<Claims, JwtError> {
+    let mut last_err = JwtError::InvalidFormat;
+    for key in candidates {
+        match decode_with_key(token, key, expected_aud) {
+            Ok(claims) => return Ok(claims),
+            Err(e) => last_err = e,
+        }
+    }
+    Err(last_err)
+}
+
 /// Internal decode implementation shared by `decode` and `decode_with_key`.
 ///
 /// `lenient_aud`: when true, accepts tokens with no `aud` claim even when
@@ -879,5 +905,41 @@ mod tests {
 
         let kid = header_kid(&token).unwrap();
         assert!(kid.is_none());
+    }
+
+    // #1185 — decode_with_candidates is the rotation-aware federation
+    // verifier: it MUST accept a token signed by ANY published candidate,
+    // including a non-first key, and reject when none verify.
+    #[test]
+    fn decode_with_candidates_accepts_non_first_published_key() {
+        let key_a = make_key(0xA1);
+        let key_b = make_key(0xB2); // the "second" / rotated key
+        let claims = Claims::new("overlap-test".to_owned(), 0, 9_999_999_999);
+        let token = encode(&claims, &key_b); // signed by the second key
+
+        // Candidate set published kid-first as [old, new]; the token is
+        // signed by `new` (the second entry). The old code resolved only
+        // the first key and this token would have failed.
+        let candidates = vec![key_a.verifying_key(), key_b.verifying_key()];
+        let decoded = decode_with_candidates(&token, &candidates, None).expect("second key verifies");
+        assert_eq!(decoded.sub, "overlap-test");
+    }
+
+    #[test]
+    fn decode_with_candidates_rejects_when_no_candidate_verifies() {
+        let key_unrelated = make_key(0x99);
+        let claims = Claims::new("no-match".to_owned(), 0, 9_999_999_999);
+        let token = encode(&claims, &make_key(0x11));
+        let candidates = vec![key_unrelated.verifying_key()];
+        assert!(decode_with_candidates(&token, &candidates, None).is_err());
+    }
+
+    #[test]
+    fn decode_with_candidates_empty_set_fails_closed() {
+        // An empty candidate set is a fail-closed guard (the resolver is
+        // contractually non-empty); never silently accept.
+        let claims = Claims::new("empty".to_owned(), 0, 9_999_999_999);
+        let token = encode(&claims, &make_key(0x22));
+        assert!(decode_with_candidates(&token, &[], None).is_err());
     }
 }

--- a/crates/hyprstream-rpc/src/auth/jwt.rs
+++ b/crates/hyprstream-rpc/src/auth/jwt.rs
@@ -714,7 +714,7 @@ pub fn decode_composite(
 #[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {
     use super::*;
-    use crate::auth::Claims;
+    use crate::auth::{Claims, IssuerResolver, JwksFetcher, JwksKeySource, JwksMode, JwtKeySource};
     use ed25519_dalek::SigningKey;
 
     fn make_key(seed: u8) -> SigningKey {
@@ -820,6 +820,146 @@ mod tests {
             matches!(result, Err(JwtError::InvalidSignature)),
             "wrong key must yield InvalidSignature"
         );
+    }
+
+    /// I2b / #1234: every JWKS-derived lookup is issuer-scoped. In
+    /// particular, preloading issuer A must not make an issuer-B token signed
+    /// by A acceptable merely because both JWKS documents reuse a `kid`.
+    #[tokio::test]
+    async fn cross_issuer_shared_kid_rejects_issuer_a_signature() -> anyhow::Result<()> {
+        use std::sync::{
+            atomic::{AtomicU32, Ordering},
+            Arc,
+        };
+
+        const ISSUER_A: &str = "https://issuer-a.example";
+        const ISSUER_B: &str = "https://issuer-b.example";
+        const SHARED_KID: &str = "shared-kid";
+        const METADATA_KID: &str = "shared-metadata-kid";
+
+        struct TestResolver;
+
+        #[async_trait::async_trait]
+        impl IssuerResolver for TestResolver {
+            async fn resolve(&self, issuer: &str) -> anyhow::Result<String> {
+                Ok(format!("{issuer}/jwks"))
+            }
+        }
+
+        fn ed25519_jwk(signing_key: &SigningKey, kid: &str) -> serde_json::Value {
+            serde_json::json!({
+                "kty": "OKP",
+                "crv": "Ed25519",
+                "use": "sig",
+                "alg": "EdDSA",
+                "kid": kid,
+                "x": URL_SAFE_NO_PAD.encode(signing_key.verifying_key().as_bytes()),
+            })
+        }
+
+        let issuer_a_key = make_key(0xA1);
+        let issuer_b_key = make_key(0xB2);
+        let issuer_a_jwks = serde_json::json!({
+            "keys": [
+                ed25519_jwk(&issuer_a_key, SHARED_KID),
+                {
+                    "kty": "AKP",
+                    "use": "sig",
+                    "alg": "ML-DSA-65-Ed25519",
+                    "kid": METADATA_KID,
+                    "pub": URL_SAFE_NO_PAD.encode([0u8; 16]),
+                },
+            ]
+        });
+        let issuer_b_jwks = serde_json::json!({
+            "keys": [
+                ed25519_jwk(&issuer_b_key, SHARED_KID),
+                {
+                    "kty": "AKP",
+                    "use": "sig",
+                    "alg": "ML-DSA-65",
+                    "kid": METADATA_KID,
+                    "pub": URL_SAFE_NO_PAD.encode([1u8; 16]),
+                },
+            ]
+        });
+
+        let issuer_a_fetches = Arc::new(AtomicU32::new(0));
+        let issuer_b_fetches = Arc::new(AtomicU32::new(0));
+        let fetcher: JwksFetcher = {
+            let issuer_a_fetches = issuer_a_fetches.clone();
+            let issuer_b_fetches = issuer_b_fetches.clone();
+            Arc::new(move |url| {
+                let jwks = if url == format!("{ISSUER_A}/jwks") {
+                    issuer_a_fetches.fetch_add(1, Ordering::Relaxed);
+                    issuer_a_jwks.clone()
+                } else if url == format!("{ISSUER_B}/jwks") {
+                    issuer_b_fetches.fetch_add(1, Ordering::Relaxed);
+                    issuer_b_jwks.clone()
+                } else {
+                    return Box::pin(async move { anyhow::bail!("unexpected JWKS URL: {url}") });
+                };
+                Box::pin(async move { Ok(jwks) })
+            })
+        };
+
+        let key_source = JwksKeySource::new(
+            JwksMode::Federated {
+                local_jwks_url: "https://local.example/jwks".to_owned(),
+                resolver: Arc::new(TestResolver),
+            },
+            "https://local.example".to_owned(),
+            fetcher,
+        );
+
+        // Prime issuer A's positive cache under the deliberately shared kid.
+        let selected_a = key_source.get_key(ISSUER_A, Some(SHARED_KID)).await?;
+        assert_eq!(selected_a, issuer_a_key.verifying_key());
+
+        let claims = Claims::new("issuer-b-subject".to_owned(), 0, 9_999_999_999)
+            .with_issuer(ISSUER_B.to_owned());
+        let header = format!(r#"{{"alg":"EdDSA","typ":"JWT","kid":"{SHARED_KID}"}}"#);
+        let forged = encode_with_header(&claims, &issuer_a_key, &header);
+
+        // Issuer B must resolve only B's key, so A's signature is rejected.
+        let selected_b = key_source.get_key(ISSUER_B, Some(SHARED_KID)).await?;
+        assert_eq!(selected_b, issuer_b_key.verifying_key());
+        assert!(matches!(
+            decode_with_key(&forged, &selected_b, None),
+            Err(JwtError::InvalidSignature)
+        ));
+
+        // Kid-less candidates and kid→alg metadata are issuer-scoped too.
+        assert_eq!(
+            key_source.get_keys(ISSUER_B, None).await?,
+            vec![issuer_b_key.verifying_key()]
+        );
+        assert_eq!(
+            key_source.kid_algs(ISSUER_A, METADATA_KID),
+            vec!["ML-DSA-65-Ed25519".to_owned()]
+        );
+        assert_eq!(
+            key_source.kid_algs(ISSUER_B, METADATA_KID),
+            vec!["ML-DSA-65".to_owned()]
+        );
+
+        // A negative hit for issuer A must not suppress issuer B's fetch.
+        assert!(key_source
+            .get_key(ISSUER_A, Some("missing-kid"))
+            .await
+            .is_err());
+        assert!(key_source
+            .get_key(ISSUER_A, Some("missing-kid"))
+            .await
+            .is_err());
+        assert_eq!(issuer_a_fetches.load(Ordering::Relaxed), 2);
+        assert!(key_source
+            .get_key(ISSUER_B, Some("missing-kid"))
+            .await
+            .is_err());
+        assert_eq!(issuer_b_fetches.load(Ordering::Relaxed), 2);
+
+        Ok(())
     }
 
     #[test]

--- a/crates/hyprstream-rpc/src/auth/key_source.rs
+++ b/crates/hyprstream-rpc/src/auth/key_source.rs
@@ -30,7 +30,7 @@
 #![allow(clippy::disallowed_types)]
 
 use anyhow::Result;
-use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine};
+use base64::{Engine, engine::general_purpose::URL_SAFE_NO_PAD};
 use ed25519_dalek::VerifyingKey;
 use std::collections::HashMap;
 use std::sync::Arc;
@@ -148,7 +148,10 @@ impl ClusterKeySource {
     /// Set the shared ML-DSA-65 verifying key list for PQ-hybrid JWT verification.
     ///
     /// The Arc is shared with the rotation task so keys stay current.
-    pub fn with_ml_dsa_verifying_keys(mut self, vks: Arc<std::sync::RwLock<Vec<crate::crypto::pq::MlDsaVerifyingKey>>>) -> Self {
+    pub fn with_ml_dsa_verifying_keys(
+        mut self,
+        vks: Arc<std::sync::RwLock<Vec<crate::crypto::pq::MlDsaVerifyingKey>>>,
+    ) -> Self {
         self.ml_dsa_vks = vks;
         self
     }
@@ -193,7 +196,10 @@ impl JwtKeySource for ClusterKeySource {
     }
 
     fn ml_dsa_verifying_keys(&self) -> Vec<crate::crypto::pq::MlDsaVerifyingKey> {
-        self.ml_dsa_vks.read().unwrap_or_else(std::sync::PoisonError::into_inner).clone()
+        self.ml_dsa_vks
+            .read()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .clone()
     }
 
     fn composite_key_set(&self) -> Arc<super::CompositeKeySet> {
@@ -235,16 +241,18 @@ impl JwtKeySource for FederatedKeySource {
         if self.local.is_trusted(issuer) {
             return self.local.get_key(issuer, kid).await;
         }
-        // Fall back to federation. The resolver returns the full candidate
-        // set ordered kid-first; we return the preferred (kid-matching, or
-        // first published) key for the single-key JwtKeySource contract.
-        // Rotation overlap is preserved because the resolver surfaces every
-        // published key and orders the requested kid first (#1185).
+        // Fall back to federation. A named token may use only the exact named
+        // key; a kid-less legacy caller retains the single-key fallback this
+        // trait requires.
         if self.federation.is_trusted(issuer) {
             let candidates = self.federation.get_keys(issuer, kid).await?;
             return candidates
-                .first()
-                .copied()
+                .iter()
+                .find(|candidate| match kid {
+                    Some(named_kid) => candidate.kid.as_deref() == Some(named_kid),
+                    None => true,
+                })
+                .map(|candidate| candidate.verifying_key)
                 .ok_or_else(|| anyhow::anyhow!("No Ed25519 key for issuer {}", issuer));
         }
         anyhow::bail!("Untrusted issuer: {}", issuer)
@@ -272,7 +280,14 @@ impl JwtKeySource for FederatedKeySource {
 }
 
 /// Async function that fetches raw JWKS JSON from a URL.
-pub type JwksFetcher = Arc<dyn Fn(String) -> std::pin::Pin<Box<dyn std::future::Future<Output = Result<serde_json::Value>> + Send>> + Send + Sync>;
+pub type JwksFetcher = Arc<
+    dyn Fn(
+            String,
+        )
+            -> std::pin::Pin<Box<dyn std::future::Future<Output = Result<serde_json::Value>> + Send>>
+        + Send
+        + Sync,
+>;
 
 /// Deployment mode for JWKS-backed key resolution.
 #[derive(Clone)]
@@ -280,14 +295,23 @@ pub enum JwksMode {
     /// Single-node: fetches JWKS from local `/oauth/jwks` endpoint.
     Isolated { jwks_url: String },
     /// Multi-node / cross-org: resolves issuer → JWKS URL via `IssuerResolver`.
-    Federated { local_jwks_url: String, resolver: Arc<dyn IssuerResolver> },
+    Federated {
+        local_jwks_url: String,
+        resolver: Arc<dyn IssuerResolver>,
+    },
 }
 
 impl std::fmt::Debug for JwksMode {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            Self::Isolated { jwks_url } => f.debug_struct("Isolated").field("jwks_url", jwks_url).finish(),
-            Self::Federated { local_jwks_url, .. } => f.debug_struct("Federated").field("local_jwks_url", local_jwks_url).finish(),
+            Self::Isolated { jwks_url } => f
+                .debug_struct("Isolated")
+                .field("jwks_url", jwks_url)
+                .finish(),
+            Self::Federated { local_jwks_url, .. } => f
+                .debug_struct("Federated")
+                .field("local_jwks_url", local_jwks_url)
+                .finish(),
         }
     }
 }
@@ -370,7 +394,10 @@ impl JwksKeySource {
     }
 
     /// Set the shared ML-DSA-65 verifying key list for PQ-hybrid JWT verification.
-    pub fn with_ml_dsa_verifying_keys(mut self, vks: Arc<std::sync::RwLock<Vec<crate::crypto::pq::MlDsaVerifyingKey>>>) -> Self {
+    pub fn with_ml_dsa_verifying_keys(
+        mut self,
+        vks: Arc<std::sync::RwLock<Vec<crate::crypto::pq::MlDsaVerifyingKey>>>,
+    ) -> Self {
         self.ml_dsa_vks = vks;
         self
     }
@@ -379,7 +406,9 @@ impl JwksKeySource {
     /// of local-issuer (service) JWTs. See the `local_ca_key` field docs.
     pub fn with_local_ca_key(mut self, ca_vk: VerifyingKey) -> Self {
         self.local_ca_kid = Some(crate::auth::jwt::jwk_thumbprint(
-            &crate::auth::jwt::JwkThumbprintInput::Ed25519 { x: ca_vk.as_bytes() },
+            &crate::auth::jwt::JwkThumbprintInput::Ed25519 {
+                x: ca_vk.as_bytes(),
+            },
         ));
         self.local_ca_key = Some(ca_vk);
         self
@@ -414,18 +443,24 @@ impl JwksKeySource {
         }
         match &self.mode {
             JwksMode::Federated { resolver, .. } => resolver.resolve(issuer).await,
-            JwksMode::Isolated { .. } => anyhow::bail!("Untrusted issuer in isolated mode: {}", issuer),
+            JwksMode::Isolated { .. } => {
+                anyhow::bail!("Untrusted issuer in isolated mode: {}", issuer)
+            }
         }
     }
 
     async fn fetch_and_cache(&self, issuer: &str) -> Result<()> {
-        let _permit = self.fetch_semaphore.acquire().await
+        let _permit = self
+            .fetch_semaphore
+            .acquire()
+            .await
             .map_err(|_| anyhow::anyhow!("JWKS fetch semaphore closed"))?;
 
         let url = self.resolve_jwks_url(issuer).await?;
         let jwks = (self.fetcher)(url).await?;
 
-        let keys = jwks.get("keys")
+        let keys = jwks
+            .get("keys")
             .and_then(|v| v.as_array())
             .ok_or_else(|| anyhow::anyhow!("JWKS response missing 'keys' array"))?;
 
@@ -460,10 +495,13 @@ impl JwksKeySource {
                                 let mut arr = [0u8; 32];
                                 arr.copy_from_slice(&x_bytes);
                                 if let Ok(vk) = VerifyingKey::from_bytes(&arr) {
-                                    cache.insert(kid, CachedKey {
-                                        verifying_key: vk,
-                                        fetched_at: now,
-                                    });
+                                    cache.insert(
+                                        kid,
+                                        CachedKey {
+                                            verifying_key: vk,
+                                            fetched_at: now,
+                                        },
+                                    );
                                 }
                             }
                         }
@@ -500,7 +538,9 @@ impl JwtKeySource for JwksKeySource {
             // resolution must not depend on it. Never overrides a JWKS-published
             // (rotated) key because it's keyed on the exact CA thumbprint.
             if self.is_local(issuer) {
-                if let (Some(ca_kid), Some(ca_key)) = (self.local_ca_kid.as_deref(), self.local_ca_key) {
+                if let (Some(ca_kid), Some(ca_key)) =
+                    (self.local_ca_kid.as_deref(), self.local_ca_key)
+                {
                     if ca_kid == kid_str {
                         return Ok(ca_key);
                     }
@@ -550,7 +590,8 @@ impl JwtKeySource for JwksKeySource {
             }
 
             let cache = self.cache.read().await;
-            cache.values()
+            cache
+                .values()
                 .next()
                 .map(|e| e.verifying_key)
                 .ok_or_else(|| anyhow::anyhow!("No Ed25519 keys in JWKS"))
@@ -574,11 +615,18 @@ impl JwtKeySource for JwksKeySource {
     }
 
     fn ml_dsa_verifying_keys(&self) -> Vec<crate::crypto::pq::MlDsaVerifyingKey> {
-        self.ml_dsa_vks.read().unwrap_or_else(std::sync::PoisonError::into_inner).clone()
+        self.ml_dsa_vks
+            .read()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .clone()
     }
 
     fn kid_algs(&self, kid: &str) -> Vec<String> {
-        self.kid_alg_map.read().get(kid).cloned().unwrap_or_default()
+        self.kid_alg_map
+            .read()
+            .get(kid)
+            .cloned()
+            .unwrap_or_default()
     }
 }
 
@@ -613,14 +661,18 @@ mod tests {
     async fn jwks_source_resolves_local_ca_key_offline() -> anyhow::Result<()> {
         // A fetcher that always fails — proves resolution does NOT touch it.
         let fetcher: JwksFetcher = std::sync::Arc::new(|_url: String| {
-            Box::pin(async move { anyhow::bail!("network must not be used for local CA resolution") })
+            Box::pin(
+                async move { anyhow::bail!("network must not be used for local CA resolution") },
+            )
         });
         let ca_sk = SigningKey::from_bytes(&[7u8; 32]);
         let ca_vk = ca_sk.verifying_key();
         let ca_kid = crate::auth::jwt::kid_for_key(&ca_sk);
 
         let ks = JwksKeySource::new(
-            JwksMode::Isolated { jwks_url: "http://127.0.0.1:1/oauth/jwks".to_owned() },
+            JwksMode::Isolated {
+                jwks_url: "http://127.0.0.1:1/oauth/jwks".to_owned(),
+            },
             "http://localhost:9080".to_owned(),
             fetcher,
         )
@@ -647,7 +699,9 @@ mod tests {
         });
         let ca_vk = SigningKey::from_bytes(&[7u8; 32]).verifying_key();
         let ks = JwksKeySource::new(
-            JwksMode::Isolated { jwks_url: "http://127.0.0.1:1/oauth/jwks".to_owned() },
+            JwksMode::Isolated {
+                jwks_url: "http://127.0.0.1:1/oauth/jwks".to_owned(),
+            },
             "http://localhost:9080".to_owned(),
             fetcher,
         )
@@ -655,10 +709,18 @@ mod tests {
 
         // Local issuer but a different kid -> CA fallback does NOT fire; the
         // JWKS fetch is attempted and fails -> error (not the CA key).
-        assert!(ks.get_key("http://localhost:9080", Some("some-other-kid")).await.is_err());
+        assert!(
+            ks.get_key("http://localhost:9080", Some("some-other-kid"))
+                .await
+                .is_err()
+        );
 
         // Non-local issuer is untrusted in isolated mode regardless of kid.
-        assert!(ks.get_key("https://evil.example.com", Some("some-other-kid")).await.is_err());
+        assert!(
+            ks.get_key("https://evil.example.com", Some("some-other-kid"))
+                .await
+                .is_err()
+        );
     }
 
     #[tokio::test]
@@ -687,19 +749,22 @@ mod tests {
     }
 
     fn mock_jwks_json(keys: &[&SigningKey]) -> serde_json::Value {
-        let jwk_entries: Vec<serde_json::Value> = keys.iter().map(|sk| {
-            let vk = sk.verifying_key();
-            let x = base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(vk.as_bytes());
-            let kid = crate::auth::jwt::kid_for_key(sk);
-            serde_json::json!({
-                "kty": "OKP",
-                "crv": "Ed25519",
-                "use": "sig",
-                "alg": "EdDSA",
-                "kid": kid,
-                "x": x,
+        let jwk_entries: Vec<serde_json::Value> = keys
+            .iter()
+            .map(|sk| {
+                let vk = sk.verifying_key();
+                let x = base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(vk.as_bytes());
+                let kid = crate::auth::jwt::kid_for_key(sk);
+                serde_json::json!({
+                    "kty": "OKP",
+                    "crv": "Ed25519",
+                    "use": "sig",
+                    "alg": "EdDSA",
+                    "kid": kid,
+                    "x": x,
+                })
             })
-        }).collect();
+            .collect();
         serde_json::json!({ "keys": jwk_entries })
     }
 
@@ -719,7 +784,9 @@ mod tests {
 
         let jwks = mock_jwks_json(&[&sk_a, &sk_b]);
         let ks = JwksKeySource::new(
-            JwksMode::Isolated { jwks_url: "http://localhost/oauth/jwks".to_owned() },
+            JwksMode::Isolated {
+                jwks_url: "http://localhost/oauth/jwks".to_owned(),
+            },
             "http://localhost".to_owned(),
             mock_fetcher(jwks),
         );
@@ -737,12 +804,16 @@ mod tests {
         let sk = SigningKey::from_bytes(&[0xCC; 32]);
         let jwks = mock_jwks_json(&[&sk]);
         let ks = JwksKeySource::new(
-            JwksMode::Isolated { jwks_url: "http://localhost/oauth/jwks".to_owned() },
+            JwksMode::Isolated {
+                jwks_url: "http://localhost/oauth/jwks".to_owned(),
+            },
             "http://localhost".to_owned(),
             mock_fetcher(jwks),
         );
 
-        let result = ks.get_key("http://localhost", Some("nonexistent-kid")).await;
+        let result = ks
+            .get_key("http://localhost", Some("nonexistent-kid"))
+            .await;
         assert!(result.is_err());
     }
 
@@ -751,7 +822,9 @@ mod tests {
         let sk = SigningKey::from_bytes(&[0xDD; 32]);
         let jwks = mock_jwks_json(&[&sk]);
         let ks = JwksKeySource::new(
-            JwksMode::Isolated { jwks_url: "http://localhost/oauth/jwks".to_owned() },
+            JwksMode::Isolated {
+                jwks_url: "http://localhost/oauth/jwks".to_owned(),
+            },
             "http://localhost".to_owned(),
             mock_fetcher(jwks),
         );
@@ -777,7 +850,9 @@ mod tests {
         });
 
         let ks = JwksKeySource::new(
-            JwksMode::Isolated { jwks_url: "http://localhost/oauth/jwks".to_owned() },
+            JwksMode::Isolated {
+                jwks_url: "http://localhost/oauth/jwks".to_owned(),
+            },
             "http://localhost".to_owned(),
             fetcher,
         );
@@ -800,7 +875,9 @@ mod tests {
         let sk = SigningKey::from_bytes(&[0xFF; 32]);
         let jwks = mock_jwks_json(&[&sk]);
         let ks = JwksKeySource::new(
-            JwksMode::Isolated { jwks_url: "http://localhost/oauth/jwks".to_owned() },
+            JwksMode::Isolated {
+                jwks_url: "http://localhost/oauth/jwks".to_owned(),
+            },
             "http://localhost".to_owned(),
             mock_fetcher(jwks),
         );
@@ -828,7 +905,9 @@ mod tests {
             ]
         });
         let ks = JwksKeySource::new(
-            JwksMode::Isolated { jwks_url: "http://localhost/oauth/jwks".to_owned() },
+            JwksMode::Isolated {
+                jwks_url: "http://localhost/oauth/jwks".to_owned(),
+            },
             "http://localhost".to_owned(),
             mock_fetcher(jwks),
         );
@@ -848,7 +927,8 @@ mod tests {
     async fn dpop_stripping_jwks_multi_alg_per_kid() -> anyhow::Result<()> {
         let sk = SigningKey::from_bytes(&[0x77; 32]);
         let kid = crate::auth::jwt::kid_for_key(&sk);
-        let x = base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(sk.verifying_key().as_bytes());
+        let x =
+            base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(sk.verifying_key().as_bytes());
         let jwks = serde_json::json!({
             "keys": [
                 {"kty": "OKP", "crv": "Ed25519", "use": "sig", "alg": "EdDSA", "kid": kid.clone(), "x": x},
@@ -857,7 +937,9 @@ mod tests {
             ]
         });
         let ks = JwksKeySource::new(
-            JwksMode::Isolated { jwks_url: "http://localhost/oauth/jwks".to_owned() },
+            JwksMode::Isolated {
+                jwks_url: "http://localhost/oauth/jwks".to_owned(),
+            },
             "http://localhost".to_owned(),
             mock_fetcher(jwks),
         );
@@ -882,7 +964,9 @@ mod tests {
         let sk = SigningKey::from_bytes(&[0x11; 32]);
         let jwks = mock_jwks_json(&[&sk]);
         let ks = JwksKeySource::new(
-            JwksMode::Isolated { jwks_url: "http://localhost/oauth/jwks".to_owned() },
+            JwksMode::Isolated {
+                jwks_url: "http://localhost/oauth/jwks".to_owned(),
+            },
             "http://localhost".to_owned(),
             mock_fetcher(jwks),
         );

--- a/crates/hyprstream-rpc/src/auth/key_source.rs
+++ b/crates/hyprstream-rpc/src/auth/key_source.rs
@@ -55,6 +55,24 @@ pub trait JwtKeySource: Send + Sync + 'static {
     /// Returns error if the issuer is untrusted or key resolution fails.
     async fn get_key(&self, issuer: &str, kid: Option<&str>) -> Result<VerifyingKey>;
 
+    /// Resolve **all** algorithm-compatible candidates for an issuer/kid pair.
+    ///
+    /// This is the safe default for verifying a kid-less JWT: when no `kid`
+    /// selector is present the verifier cannot know which published key signed
+    /// the token, so it MUST retain every compatible candidate and try each
+    /// until one verifies — never collapse the published set to a positional
+    /// singleton (`first`/`next`/`values().next()`). See #1183 / #1184.
+    ///
+    /// Single-key sources return a one-element vec. JWKS-backed sources
+    /// override this to return every Ed25519 entry when `kid` is `None`.
+    ///
+    /// Callers pair this with [`crate::auth::jwt::decode_with_any_key`] to
+    /// try each candidate against the JWT signature.
+    async fn get_keys(&self, issuer: &str, kid: Option<&str>) -> Result<Vec<VerifyingKey>> {
+        let key = self.get_key(issuer, kid).await?;
+        Ok(vec![key])
+    }
+
     /// Check if an issuer is trusted (before attempting key fetch).
     ///
     /// Returns `true` for local issuers and configured federated issuers.
@@ -473,6 +491,74 @@ impl JwksKeySource {
 
         Ok(())
     }
+
+    /// Resolve a single key by `kid`, consulting the offline local-CA path,
+    /// the JWKS cache, the negative cache, and (on miss) a refetch. The
+    /// `kid` selector makes the choice unambiguous — contrast with the
+    /// kid-less path in [`JwtKeySource::get_keys`] which must return every
+    /// candidate.
+    async fn resolve_by_kid(&self, issuer: &str, kid_str: &str) -> Result<VerifyingKey> {
+        // Authoritative local CA key (offline): for a LOCAL issuer whose
+        // `kid` matches the on-disk CA key thumbprint, resolve without any
+        // network fetch. This is the service-to-service WIT JWT path; the
+        // HTTP /oauth/jwks endpoint may not be up yet during startup, and
+        // #441 makes service-key registration a hard precondition, so this
+        // resolution must not depend on it. Never overrides a JWKS-published
+        // (rotated) key because it's keyed on the exact CA thumbprint.
+        if self.is_local(issuer) {
+            if let (Some(ca_kid), Some(ca_key)) = (self.local_ca_kid.as_deref(), self.local_ca_key) {
+                if ca_kid == kid_str {
+                    return Ok(ca_key);
+                }
+            }
+        }
+        {
+            let cache = self.cache.read().await;
+            if let Some(entry) = cache.get(kid_str) {
+                return Ok(entry.verifying_key);
+            }
+        }
+
+        // Check negative cache
+        {
+            let neg = self.negative_cache.read().await;
+            if let Some(&ts) = neg.get(kid_str) {
+                if ts.elapsed() < self.negative_ttl {
+                    anyhow::bail!("Key not found for kid={} (negative cached)", kid_str);
+                }
+            }
+        }
+
+        // On-miss refetch
+        if let Err(e) = self.fetch_and_cache(issuer).await {
+            tracing::warn!("JWKS fetch failed for issuer={}: {}", issuer, e);
+        }
+
+        // Retry from cache
+        let cache = self.cache.read().await;
+        if let Some(entry) = cache.get(kid_str) {
+            return Ok(entry.verifying_key);
+        }
+
+        // Add to negative cache
+        {
+            let mut neg = self.negative_cache.write().await;
+            neg.insert(kid_str.to_owned(), std::time::Instant::now());
+        }
+
+        anyhow::bail!("Key not found in JWKS for kid={}", kid_str)
+    }
+
+    /// Ensure the JWKS cache has been populated for `issuer` (refetch on
+    /// empty). Used by the kid-less resolution paths before they read every
+    /// candidate out of the cache.
+    async fn ensure_cached(&self, issuer: &str) {
+        if self.cache.read().await.is_empty() {
+            if let Err(e) = self.fetch_and_cache(issuer).await {
+                tracing::warn!("JWKS fetch failed for issuer={}: {}", issuer, e);
+            }
+        }
+    }
 }
 
 #[async_trait::async_trait]
@@ -482,71 +568,52 @@ impl JwtKeySource for JwksKeySource {
             anyhow::bail!("Untrusted issuer: {}", issuer);
         }
 
-        // Try cache first
+        // A presented `kid` is unambiguous: resolve that exact slot.
         if let Some(kid_str) = kid {
-            // Authoritative local CA key (offline): for a LOCAL issuer whose
-            // `kid` matches the on-disk CA key thumbprint, resolve without any
-            // network fetch. This is the service-to-service WIT JWT path; the
-            // HTTP /oauth/jwks endpoint may not be up yet during startup, and
-            // #441 makes service-key registration a hard precondition, so this
-            // resolution must not depend on it. Never overrides a JWKS-published
-            // (rotated) key because it's keyed on the exact CA thumbprint.
-            if self.is_local(issuer) {
-                if let (Some(ca_kid), Some(ca_key)) = (self.local_ca_kid.as_deref(), self.local_ca_key) {
-                    if ca_kid == kid_str {
-                        return Ok(ca_key);
-                    }
-                }
-            }
-            {
-                let cache = self.cache.read().await;
-                if let Some(entry) = cache.get(kid_str) {
-                    return Ok(entry.verifying_key);
-                }
-            }
-
-            // Check negative cache
-            {
-                let neg = self.negative_cache.read().await;
-                if let Some(&ts) = neg.get(kid_str) {
-                    if ts.elapsed() < self.negative_ttl {
-                        anyhow::bail!("Key not found for kid={} (negative cached)", kid_str);
-                    }
-                }
-            }
-
-            // On-miss refetch
-            if let Err(e) = self.fetch_and_cache(issuer).await {
-                tracing::warn!("JWKS fetch failed for issuer={}: {}", issuer, e);
-            }
-
-            // Retry from cache
-            let cache = self.cache.read().await;
-            if let Some(entry) = cache.get(kid_str) {
-                return Ok(entry.verifying_key);
-            }
-
-            // Add to negative cache
-            {
-                let mut neg = self.negative_cache.write().await;
-                neg.insert(kid_str.to_owned(), std::time::Instant::now());
-            }
-
-            anyhow::bail!("Key not found in JWKS for kid={}", kid_str)
-        } else {
-            // No kid: fetch JWKS and return the first Ed25519 key (fallback)
-            if self.cache.read().await.is_empty() {
-                if let Err(e) = self.fetch_and_cache(issuer).await {
-                    tracing::warn!("JWKS fetch failed for issuer={}: {}", issuer, e);
-                }
-            }
-
-            let cache = self.cache.read().await;
-            cache.values()
-                .next()
-                .map(|e| e.verifying_key)
-                .ok_or_else(|| anyhow::anyhow!("No Ed25519 keys in JWKS"))
+            return self.resolve_by_kid(issuer, kid_str).await;
         }
+
+        // No kid: refuse to collapse a multi-key published set to a positional
+        // singleton. `get_keys` is the safe API for kid-less tokens — it
+        // returns every Ed25519 candidate so the caller can try each. Here we
+        // only succeed when the JWKS publishes exactly one key, which is the
+        // unambiguous case. Two or more published keys is overlap rotation /
+        // PQ-hybrid rollout territory and MUST NOT be resolved to "the first
+        // one" (#1183 / #1184).
+        self.ensure_cached(issuer).await;
+        let cache = self.cache.read().await;
+        let mut iter = cache.values();
+        match (iter.next(), iter.next()) {
+            (Some(first), None) => Ok(first.verifying_key),
+            (None, _) => anyhow::bail!("No Ed25519 keys in JWKS for issuer {}", issuer),
+            (Some(_), Some(_)) => anyhow::bail!(
+                "Issuer {} publishes multiple Ed25519 keys and the JWT carries no kid; \
+                 use get_keys() and try each candidate (overlap rotation / hybrid rollout)",
+                issuer
+            ),
+        }
+    }
+
+    async fn get_keys(&self, issuer: &str, kid: Option<&str>) -> Result<Vec<VerifyingKey>> {
+        if !self.is_trusted(issuer) {
+            anyhow::bail!("Untrusted issuer: {}", issuer);
+        }
+
+        // A presented `kid` selects one slot.
+        if let Some(kid_str) = kid {
+            let vk = self.resolve_by_kid(issuer, kid_str).await?;
+            return Ok(vec![vk]);
+        }
+
+        // No kid: return EVERY Ed25519 candidate so the caller can try each
+        // until one verifies. Never positional selection (#1183 / #1184).
+        self.ensure_cached(issuer).await;
+        let cache = self.cache.read().await;
+        let v: Vec<VerifyingKey> = cache.values().map(|e| e.verifying_key).collect();
+        if v.is_empty() {
+            anyhow::bail!("No Ed25519 keys in JWKS for issuer {}", issuer);
+        }
+        Ok(v)
     }
 
     fn is_trusted(&self, issuer: &str) -> bool {
@@ -738,8 +805,11 @@ mod tests {
         assert!(result.is_err());
     }
 
+    /// #1184: with exactly one published key, `get_key(None)` is unambiguous
+    /// and resolves to that key. (Two or more published keys is the overlap
+    /// case, covered by `jwks_key_source_no_kid_multi_key_get_keys_tries_all`.)
     #[tokio::test]
-    async fn jwks_key_source_no_kid_returns_first() -> anyhow::Result<()> {
+    async fn jwks_key_source_no_kid_single_key_resolves() -> anyhow::Result<()> {
         let sk = SigningKey::from_bytes(&[0xDD; 32]);
         let jwks = mock_jwks_json(&[&sk]);
         let ks = JwksKeySource::new(
@@ -750,6 +820,85 @@ mod tests {
 
         let key = ks.get_key("http://localhost", None).await?;
         assert_eq!(key, sk.verifying_key());
+        Ok(())
+    }
+
+    /// #1184: `get_key(None)` MUST refuse to collapse a multi-key published
+    /// set to a positional singleton — that forecloses overlap rotation and
+    /// PQ-hybrid rollout. The previous implementation returned
+    /// `HashMap::values().next()` (nondeterministic); reverting this hunk to
+    /// "return the first candidate" makes the assertion below fail.
+    #[tokio::test]
+    async fn jwks_key_source_no_kid_multi_key_get_key_refuses_arbitrary() {
+        let sk_a = SigningKey::from_bytes(&[0x11; 32]);
+        let sk_b = SigningKey::from_bytes(&[0x22; 32]);
+        let jwks = mock_jwks_json(&[&sk_a, &sk_b]);
+        let ks = JwksKeySource::new(
+            JwksMode::Isolated { jwks_url: "http://localhost/oauth/jwks".to_owned() },
+            "http://localhost".to_owned(),
+            mock_fetcher(jwks),
+        );
+
+        let result = ks.get_key("http://localhost", None).await;
+        assert!(result.is_err(), "multi-key no-kid get_key must refuse arbitrary selection");
+        let msg = result.err().map(|e| e.to_string()).unwrap_or_default();
+        assert!(
+            msg.contains("multiple Ed25519 keys") && msg.contains("no kid"),
+            "expected a refusal to pick arbitrarily, got: {msg}"
+        );
+    }
+
+    /// #1184 overlap: two Ed25519 keys published simultaneously. `get_keys`
+    /// MUST return BOTH so a kid-less verifier can try each — overlap
+    /// rotation and PQ-hybrid rollout depend on this. A token signed by the
+    /// non-first key still verifies because both candidates are tried.
+    #[tokio::test]
+    async fn jwks_key_source_no_kid_multi_key_get_keys_tries_all() -> anyhow::Result<()> {
+        let sk_a = SigningKey::from_bytes(&[0x11; 32]); // "first" in JWKS order
+        let sk_b = SigningKey::from_bytes(&[0x22; 32]); // "second"
+        let vk_a = sk_a.verifying_key();
+        let vk_b = sk_b.verifying_key();
+
+        let jwks = mock_jwks_json(&[&sk_a, &sk_b]);
+        let ks = JwksKeySource::new(
+            JwksMode::Isolated { jwks_url: "http://localhost/oauth/jwks".to_owned() },
+            "http://localhost".to_owned(),
+            mock_fetcher(jwks),
+        );
+
+        let candidates = ks.get_keys("http://localhost", None).await?;
+        assert_eq!(candidates.len(), 2, "both published keys must be returned");
+        assert!(candidates.contains(&vk_a));
+        assert!(candidates.contains(&vk_b));
+        Ok(())
+    }
+
+    /// #1184 overlap: a token signed by the non-first published key verifies
+    /// when the caller uses `get_keys` + `decode_with_any_key`. Reverting
+    /// `JwksKeySource` to return a single arbitrary candidate makes this fail
+    /// (the wrong candidate is returned roughly half the time).
+    #[tokio::test]
+    async fn jwks_key_source_overlap_non_first_signer_verifies() -> anyhow::Result<()> {
+        use crate::auth::jwt::{decode_with_any_key_lenient, encode};
+
+        let sk_a = SigningKey::from_bytes(&[0x11; 32]);
+        let sk_b = SigningKey::from_bytes(&[0x22; 32]);
+
+        let jwks = mock_jwks_json(&[&sk_a, &sk_b]);
+        let ks = JwksKeySource::new(
+            JwksMode::Isolated { jwks_url: "http://localhost/oauth/jwks".to_owned() },
+            "http://localhost".to_owned(),
+            mock_fetcher(jwks),
+        );
+
+        // Sign with the SECOND key — no kid in the header, so the verifier
+        // must try both candidates.
+        let now = chrono::Utc::now().timestamp();
+        let claims = crate::auth::Claims::new("user-1".to_owned(), now, now + 300);
+        let token = encode(&claims, &sk_b);
+        let candidates = ks.get_keys("http://localhost", None).await?;
+        let verified = decode_with_any_key_lenient(&token, &candidates, None)?;
+        assert_eq!(verified.sub, "user-1");
         Ok(())
     }
 

--- a/crates/hyprstream-rpc/src/auth/key_source.rs
+++ b/crates/hyprstream-rpc/src/auth/key_source.rs
@@ -235,9 +235,17 @@ impl JwtKeySource for FederatedKeySource {
         if self.local.is_trusted(issuer) {
             return self.local.get_key(issuer, kid).await;
         }
-        // Fall back to federation
+        // Fall back to federation. The resolver returns the full candidate
+        // set ordered kid-first; we return the preferred (kid-matching, or
+        // first published) key for the single-key JwtKeySource contract.
+        // Rotation overlap is preserved because the resolver surfaces every
+        // published key and orders the requested kid first (#1185).
         if self.federation.is_trusted(issuer) {
-            return self.federation.get_key(issuer).await;
+            let candidates = self.federation.get_keys(issuer, kid).await?;
+            return candidates
+                .first()
+                .copied()
+                .ok_or_else(|| anyhow::anyhow!("No Ed25519 key for issuer {}", issuer));
         }
         anyhow::bail!("Untrusted issuer: {}", issuer)
     }

--- a/crates/hyprstream-rpc/src/auth/key_source.rs
+++ b/crates/hyprstream-rpc/src/auth/key_source.rs
@@ -32,7 +32,7 @@
 use anyhow::Result;
 use base64::{Engine, engine::general_purpose::URL_SAFE_NO_PAD};
 use ed25519_dalek::VerifyingKey;
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 use tokio::sync::{RwLock, Semaphore};
 
@@ -108,7 +108,7 @@ pub trait JwtKeySource: Send + Sync + 'static {
     /// Default implementation returns an empty vec, which means "no policy
     /// constraint" (legacy behavior). Implementations backed by JWKS should
     /// override to surface the algs they observed.
-    fn kid_algs(&self, _kid: &str) -> Vec<String> {
+    fn kid_algs(&self, _issuer: &str, _kid: &str) -> Vec<String> {
         Vec::new()
     }
 }
@@ -315,8 +315,8 @@ impl JwtKeySource for FederatedKeySource {
         self.local.composite_key_set()
     }
 
-    fn kid_algs(&self, kid: &str) -> Vec<String> {
-        self.local.kid_algs(kid)
+    fn kid_algs(&self, issuer: &str, kid: &str) -> Vec<String> {
+        self.local.kid_algs(issuer, kid)
     }
 }
 
@@ -370,25 +370,24 @@ struct CachedKey {
     fetched_at: std::time::Instant,
 }
 
-/// JWKS-backed key source with kid-based resolution.
+/// JWKS-backed key source with issuer-and-kid-based resolution.
 ///
 /// Replaces `ClusterKeySource` with standards-aligned JWKS key lookup:
-/// - Caches keys by kid after fetching from the JWKS endpoint
+/// - Caches keys by `(issuer, kid)` after fetching from the JWKS endpoint
 /// - On cache miss, refetches JWKS (primary invalidation mechanism)
-/// - Negative cache prevents DoS from random kid spam (5s TTL)
+/// - Issuer-scoped negative cache prevents DoS from random kid spam (5s TTL)
 /// - Semaphore bounds concurrent JWKS fetches
 pub struct JwksKeySource {
     mode: JwksMode,
     local_issuer_url: String,
     local_issuers_vec: Vec<String>,
     fetcher: JwksFetcher,
-    cache: RwLock<HashMap<String, CachedKey>>,
-    negative_cache: RwLock<HashMap<String, std::time::Instant>>,
-    /// Multi-alg map: kid → all `alg` values present in the JWKS for that kid.
-    /// Populated alongside `cache` during `fetch_and_cache`. Used by `kid_algs`
-    /// to implement the stripping-defense policy (verifier must require all
-    /// listed algs for a composite-signed kid).
-    kid_alg_map: parking_lot::RwLock<HashMap<String, Vec<String>>>,
+    cache: RwLock<HashMap<String, HashMap<String, CachedKey>>>,
+    negative_cache: RwLock<HashMap<String, HashMap<String, std::time::Instant>>>,
+    /// Multi-alg map: issuer → kid → all `alg` values in that issuer's JWKS.
+    /// Populated alongside `cache` during `fetch_and_cache`. Both dimensions
+    /// are security boundaries: two issuers may legitimately reuse a kid.
+    kid_alg_map: parking_lot::RwLock<HashMap<String, HashMap<String, Vec<String>>>>,
     fetch_semaphore: Semaphore,
     /// Soft TTL for cache refresh (keys older than this trigger background refresh)
     #[allow(dead_code)]
@@ -506,10 +505,8 @@ impl JwksKeySource {
             .ok_or_else(|| anyhow::anyhow!("JWKS response missing 'keys' array"))?;
 
         let now = std::time::Instant::now();
-        let mut cache = self.cache.write().await;
-
-        // Rebuild kid → algs map from this JWKS snapshot.
-        let mut new_kid_algs: HashMap<String, Vec<String>> = HashMap::new();
+        let mut issuer_cache: HashMap<String, CachedKey> = HashMap::new();
+        let mut issuer_kid_algs: HashMap<String, Vec<String>> = HashMap::new();
 
         for key in keys {
             let kty = key.get("kty").and_then(|v| v.as_str()).unwrap_or_default();
@@ -522,7 +519,7 @@ impl JwksKeySource {
             // need to record those algs even though we can't verify-decode them
             // here.
             if let (Some(kid_str), Some(alg)) = (kid.as_ref(), alg) {
-                let entry = new_kid_algs.entry(kid_str.clone()).or_default();
+                let entry = issuer_kid_algs.entry(kid_str.clone()).or_default();
                 if !entry.contains(&alg) {
                     entry.push(alg);
                 }
@@ -536,7 +533,7 @@ impl JwksKeySource {
                                 let mut arr = [0u8; 32];
                                 arr.copy_from_slice(&x_bytes);
                                 if let Ok(vk) = VerifyingKey::from_bytes(&arr) {
-                                    cache.insert(
+                                    issuer_cache.insert(
                                         kid,
                                         CachedKey {
                                             verifying_key: vk,
@@ -551,12 +548,24 @@ impl JwksKeySource {
             }
         }
 
-        // Publish the new kid→algs view atomically.
-        *self.kid_alg_map.write() = new_kid_algs;
+        let cached_kids: HashSet<String> = issuer_cache.keys().cloned().collect();
 
-        // Clear negative cache entries for keys we now have
+        // Replace only this issuer's snapshot. A kid is not globally unique:
+        // publishing issuer B must neither overwrite nor expose issuer A's
+        // keys or algorithm metadata.
+        self.cache
+            .write()
+            .await
+            .insert(issuer.to_owned(), issuer_cache);
+        self.kid_alg_map
+            .write()
+            .insert(issuer.to_owned(), issuer_kid_algs);
+
+        // Clear negative-cache entries only for keys this issuer now has.
         let mut neg = self.negative_cache.write().await;
-        neg.retain(|kid, _| !cache.contains_key(kid));
+        if let Some(issuer_neg) = neg.get_mut(issuer) {
+            issuer_neg.retain(|kid, _| !cached_kids.contains(kid));
+        }
 
         Ok(())
     }
@@ -583,7 +592,10 @@ impl JwksKeySource {
         }
         {
             let cache = self.cache.read().await;
-            if let Some(entry) = cache.get(kid_str) {
+            if let Some(entry) = cache
+                .get(issuer)
+                .and_then(|issuer_cache| issuer_cache.get(kid_str))
+            {
                 return Ok(entry.verifying_key);
             }
         }
@@ -591,7 +603,10 @@ impl JwksKeySource {
         // Check negative cache
         {
             let neg = self.negative_cache.read().await;
-            if let Some(&ts) = neg.get(kid_str) {
+            if let Some(&ts) = neg
+                .get(issuer)
+                .and_then(|issuer_cache| issuer_cache.get(kid_str))
+            {
                 if ts.elapsed() < self.negative_ttl {
                     anyhow::bail!("Key not found for kid={} (negative cached)", kid_str);
                 }
@@ -605,14 +620,20 @@ impl JwksKeySource {
 
         // Retry from cache
         let cache = self.cache.read().await;
-        if let Some(entry) = cache.get(kid_str) {
+        if let Some(entry) = cache
+            .get(issuer)
+            .and_then(|issuer_cache| issuer_cache.get(kid_str))
+        {
             return Ok(entry.verifying_key);
         }
+        drop(cache);
 
         // Add to negative cache
         {
             let mut neg = self.negative_cache.write().await;
-            neg.insert(kid_str.to_owned(), std::time::Instant::now());
+            neg.entry(issuer.to_owned())
+                .or_default()
+                .insert(kid_str.to_owned(), std::time::Instant::now());
         }
 
         anyhow::bail!("Key not found in JWKS for kid={}", kid_str)
@@ -622,7 +643,7 @@ impl JwksKeySource {
     /// empty). Used by the kid-less resolution paths before they read every
     /// candidate out of the cache.
     async fn ensure_cached(&self, issuer: &str) {
-        if self.cache.read().await.is_empty() {
+        if !self.cache.read().await.contains_key(issuer) {
             if let Err(e) = self.fetch_and_cache(issuer).await {
                 tracing::warn!("JWKS fetch failed for issuer={}: {}", issuer, e);
             }
@@ -651,7 +672,10 @@ impl JwtKeySource for JwksKeySource {
         // one" (#1183 / #1184).
         self.ensure_cached(issuer).await;
         let cache = self.cache.read().await;
-        let mut iter = cache.values();
+        let mut iter = cache
+            .get(issuer)
+            .into_iter()
+            .flat_map(|issuer_cache| issuer_cache.values());
         match (iter.next(), iter.next()) {
             (Some(first), None) => Ok(first.verifying_key),
             (None, _) => anyhow::bail!("No Ed25519 keys in JWKS for issuer {}", issuer),
@@ -678,7 +702,12 @@ impl JwtKeySource for JwksKeySource {
         // until one verifies. Never positional selection (#1183 / #1184).
         self.ensure_cached(issuer).await;
         let cache = self.cache.read().await;
-        let v: Vec<VerifyingKey> = cache.values().map(|e| e.verifying_key).collect();
+        let v: Vec<VerifyingKey> = cache
+            .get(issuer)
+            .into_iter()
+            .flat_map(|issuer_cache| issuer_cache.values())
+            .map(|e| e.verifying_key)
+            .collect();
         if v.is_empty() {
             anyhow::bail!("No Ed25519 keys in JWKS for issuer {}", issuer);
         }
@@ -708,10 +737,11 @@ impl JwtKeySource for JwksKeySource {
             .clone()
     }
 
-    fn kid_algs(&self, kid: &str) -> Vec<String> {
+    fn kid_algs(&self, issuer: &str, kid: &str) -> Vec<String> {
         self.kid_alg_map
             .read()
-            .get(kid)
+            .get(issuer)
+            .and_then(|issuer_algs| issuer_algs.get(kid))
             .cloned()
             .unwrap_or_default()
     }
@@ -1020,7 +1050,8 @@ mod tests {
     /// (the wrong candidate is returned roughly half the time).
     #[tokio::test]
     async fn jwks_key_source_overlap_non_first_signer_verifies() -> anyhow::Result<()> {
-        use crate::auth::jwt::{decode_with_any_key_lenient, encode};
+        use crate::auth::jwt::decode_with_any_key_lenient;
+        use ed25519_dalek::Signer as _;
 
         let sk_a = SigningKey::from_bytes(&[0x11; 32]);
         let sk_b = SigningKey::from_bytes(&[0x22; 32]);
@@ -1036,7 +1067,13 @@ mod tests {
         // must try both candidates.
         let now = chrono::Utc::now().timestamp();
         let claims = crate::auth::Claims::new("user-1".to_owned(), now, now + 300);
-        let token = encode(&claims, &sk_b);
+        let header = URL_SAFE_NO_PAD.encode(r#"{"alg":"EdDSA","typ":"at+jwt"}"#);
+        let payload = URL_SAFE_NO_PAD.encode(serde_json::to_vec(&claims)?);
+        let signing_input = format!("{header}.{payload}");
+        let token = format!(
+            "{signing_input}.{}",
+            URL_SAFE_NO_PAD.encode(sk_b.sign(signing_input.as_bytes()).to_bytes())
+        );
         let candidates = ks.get_keys("http://localhost", None).await?;
         let verified = decode_with_any_key_lenient(&token, &candidates, None)?;
         assert_eq!(verified.sub, "user-1");
@@ -1122,7 +1159,7 @@ mod tests {
         );
         // Trigger cache fill (looking up an unknown Ed25519 kid still pulls JWKS).
         let _ = ks.get_key("http://localhost", Some("unknown")).await;
-        let algs = ks.kid_algs(kid);
+        let algs = ks.kid_algs("http://localhost", kid);
         assert_eq!(algs, vec!["ML-DSA-65-Ed25519".to_owned()]);
         Ok(())
     }
@@ -1153,7 +1190,7 @@ mod tests {
             mock_fetcher(jwks),
         );
         let _ = ks.get_key("http://localhost", Some(&kid)).await?;
-        let mut algs = ks.kid_algs(&kid);
+        let mut algs = ks.kid_algs("http://localhost", &kid);
         algs.sort();
         assert_eq!(algs, vec!["EdDSA".to_owned(), "ML-DSA-65".to_owned()]);
         Ok(())
@@ -1165,7 +1202,7 @@ mod tests {
     #[test]
     fn dpop_stripping_default_impl_empty() {
         let ks = ClusterKeySource::new(test_ca_key(), "http://localhost:9080".to_owned());
-        assert!(ks.kid_algs("anything").is_empty());
+        assert!(ks.kid_algs("http://localhost:9080", "anything").is_empty());
     }
 
     #[test]

--- a/crates/hyprstream-rpc/src/auth/mod.rs
+++ b/crates/hyprstream-rpc/src/auth/mod.rs
@@ -54,7 +54,8 @@ pub use mac::{
 #[cfg(not(target_arch = "wasm32"))]
 pub use federation::FederationKeySource;
 pub use jwt::{
-    composite_kid, decode, decode_unverified, decode_with_key, encode, encode_service_jwt,
+    composite_kid, decode, decode_unverified, decode_with_any_key, decode_with_any_key_lenient,
+    decode_with_key, encode, encode_service_jwt,
     header_alg, header_kid, is_rfc9068_access_token_type, jwk_thumbprint,
     parse_composite_dispatch, parse_protected_header, CompositeJwtDispatch, JwkThumbprintInput,
     JwtError, ProtectedHeader, RFC9068_ACCESS_TOKEN_TYPES,

--- a/crates/hyprstream-rpc/src/auth/mod.rs
+++ b/crates/hyprstream-rpc/src/auth/mod.rs
@@ -18,13 +18,13 @@ pub mod composite;
 pub mod federation;
 pub mod jti_blocklist;
 pub mod jwt;
-/// Native MAC: security labels, lattice, subject contexts, genesis labeling
-/// (S1, #567). Platform-independent (no std-only deps) so it compiles for wasm.
-pub mod mac;
 #[cfg(not(target_arch = "wasm32"))]
 pub mod key_source;
 #[cfg(not(target_arch = "wasm32"))]
 pub mod key_subject_resolver;
+/// Native MAC: security labels, lattice, subject contexts, genesis labeling
+/// (S1, #567). Platform-independent (no std-only deps) so it compiles for wasm.
+pub mod mac;
 pub mod scope;
 #[cfg(not(target_arch = "wasm32"))]
 pub mod scope_registry;
@@ -38,35 +38,41 @@ pub use atproto_perimeter::{AtprotoPerimeterGateway, EnrolledPeer, EnrollmentSto
 // The identity-resolution contract (#579) lives canonically in `crate::identity`;
 // re-exported here so existing `crate::auth::{IdentityResolver, ...}` paths keep working.
 pub use crate::identity::{Ed25519Vk, IdentityKeys, IdentityResolver, MlDsaVk};
-pub use claims::{ActClaim, Claims, Cnf, CnfJwk, IdTokenClaims, OneOrMany, compute_jkt, is_local_iss};
+pub use claims::{
+    ActClaim, Claims, Cnf, CnfJwk, IdTokenClaims, OneOrMany, compute_jkt, is_local_iss,
+};
 #[cfg(not(target_arch = "wasm32"))]
 pub use composite::{
-    global_composite_key_set, CompositeKeyPair, CompositeKeySet, CompositeKeySetSnapshot,
-    CompositePairRole, CompositePairState,
+    CompositeKeyPair, CompositeKeySet, CompositeKeySetSnapshot, CompositePairRole,
+    CompositePairState, global_composite_key_set,
 };
+#[cfg(not(target_arch = "wasm32"))]
+pub use federation::{FederationKey, FederationKeySource};
 pub use jti_blocklist::{InMemoryJtiBlocklist, JtiBlocklist};
-pub use mac::{
-    bind_time_label, import_label, Assurance, Compartment, CompartmentSet, ContentBoundLabel,
-    GenesisMap, GenesisReport, LabelError, LabeledObject, Lattice, LatticeCodecError,
-    LatticeDecodeError, LatticeVersion, Level, ObjectLabelResolver, ObjectRef, SecurityContext,
-    SecurityLabel, StaticNodeLabel, SubjectContextClaims, VerifiedKeyMaterial, MAX_COMPARTMENTS,
-};
-#[cfg(not(target_arch = "wasm32"))]
-pub use federation::FederationKeySource;
 pub use jwt::{
-    composite_kid, decode, decode_unverified, decode_with_candidates, decode_with_key, encode,
-    encode_service_jwt, header_alg, header_kid, is_rfc9068_access_token_type, jwk_thumbprint,
-    parse_composite_dispatch, parse_protected_header, CompositeJwtDispatch, JwkThumbprintInput,
-    JwtError, ProtectedHeader, RFC9068_ACCESS_TOKEN_TYPES,
+    CompositeJwtDispatch, JwkThumbprintInput, JwtError, ProtectedHeader,
+    RFC9068_ACCESS_TOKEN_TYPES, composite_kid, decode, decode_unverified, decode_with_candidates,
+    decode_with_federation_candidates, decode_with_key, encode, encode_service_jwt, header_alg,
+    header_kid, is_rfc9068_access_token_type, jwk_thumbprint, parse_composite_dispatch,
+    parse_protected_header,
 };
 #[cfg(not(target_arch = "wasm32"))]
-pub use key_source::{ClusterKeySource, FederatedKeySource, IssuerResolver, JwksFetcher, JwksKeySource, JwksMode, JwtKeySource};
+pub use key_source::{
+    ClusterKeySource, FederatedKeySource, IssuerResolver, JwksFetcher, JwksKeySource, JwksMode,
+    JwtKeySource,
+};
 #[cfg(not(target_arch = "wasm32"))]
 pub use key_subject_resolver::{KeySubjectResolver, set_global as set_global_key_subject_resolver};
+pub use mac::{
+    Assurance, Compartment, CompartmentSet, ContentBoundLabel, GenesisMap, GenesisReport,
+    LabelError, LabeledObject, Lattice, LatticeCodecError, LatticeDecodeError, LatticeVersion,
+    Level, MAX_COMPARTMENTS, ObjectLabelResolver, ObjectRef, SecurityContext, SecurityLabel,
+    StaticNodeLabel, SubjectContextClaims, VerifiedKeyMaterial, bind_time_label, import_label,
+};
 pub use scope::Scope;
 #[cfg(not(target_arch = "wasm32"))]
 pub use scope_registry::ScopeDefinition;
 pub use ucan::{
-    set_attenuates, Ability, ApprovalBinding, ApprovalError, Capability, CaveatValue, Caveats,
-    ChainError, Did, Resource, SignedApproval, Ucan, UcanError, UcanPayload, UcanVerifier,
+    Ability, ApprovalBinding, ApprovalError, Capability, CaveatValue, Caveats, ChainError, Did,
+    Resource, SignedApproval, Ucan, UcanError, UcanPayload, UcanVerifier, set_attenuates,
 };

--- a/crates/hyprstream-rpc/src/auth/mod.rs
+++ b/crates/hyprstream-rpc/src/auth/mod.rs
@@ -54,8 +54,8 @@ pub use mac::{
 #[cfg(not(target_arch = "wasm32"))]
 pub use federation::FederationKeySource;
 pub use jwt::{
-    composite_kid, decode, decode_unverified, decode_with_key, encode, encode_service_jwt,
-    header_alg, header_kid, is_rfc9068_access_token_type, jwk_thumbprint,
+    composite_kid, decode, decode_unverified, decode_with_candidates, decode_with_key, encode,
+    encode_service_jwt, header_alg, header_kid, is_rfc9068_access_token_type, jwk_thumbprint,
     parse_composite_dispatch, parse_protected_header, CompositeJwtDispatch, JwkThumbprintInput,
     JwtError, ProtectedHeader, RFC9068_ACCESS_TOKEN_TYPES,
 };

--- a/crates/hyprstream-rpc/src/federated_identity.rs
+++ b/crates/hyprstream-rpc/src/federated_identity.rs
@@ -9,10 +9,10 @@ use anyhow::Result;
 use async_trait::async_trait;
 use std::sync::Arc;
 
+use crate::Subject;
 use crate::auth::FederationKeySource;
 use crate::identity::{IdentityProvider, SigningIdentity};
 use crate::node_identity::NodeIdentityProvider;
-use crate::Subject;
 
 /// Identity provider with cross-node trust via federation.
 ///
@@ -76,7 +76,7 @@ mod tests {
             &self,
             _issuer: &str,
             _kid: Option<&str>,
-        ) -> Result<Vec<ed25519_dalek::VerifyingKey>> {
+        ) -> Result<Vec<crate::auth::FederationKey>> {
             anyhow::bail!("mock: no key")
         }
     }

--- a/crates/hyprstream-rpc/src/federated_identity.rs
+++ b/crates/hyprstream-rpc/src/federated_identity.rs
@@ -72,7 +72,11 @@ mod tests {
         fn is_trusted(&self, _issuer: &str) -> bool {
             true
         }
-        async fn get_key(&self, _issuer: &str) -> Result<ed25519_dalek::VerifyingKey> {
+        async fn get_keys(
+            &self,
+            _issuer: &str,
+            _kid: Option<&str>,
+        ) -> Result<Vec<ed25519_dalek::VerifyingKey>> {
             anyhow::bail!("mock: no key")
         }
     }

--- a/crates/hyprstream-rpc/src/service/svc.rs
+++ b/crates/hyprstream-rpc/src/service/svc.rs
@@ -764,7 +764,7 @@ pub trait RequestService: 'static {
         // post-quantum half of a composite signature and presenting only the
         // classical EdDSA half under the composite kid.
         if let Some(ref kid_str) = kid {
-            let listed_algs = key_source.kid_algs(kid_str);
+            let listed_algs = key_source.kid_algs(&unverified.iss, kid_str);
             if !listed_algs.is_empty() {
                 if !listed_algs.iter().any(|a| a == &alg) {
                     tracing::warn!(

--- a/crates/hyprstream-rpc/src/service/svc.rs
+++ b/crates/hyprstream-rpc/src/service/svc.rs
@@ -872,8 +872,13 @@ pub trait RequestService: 'static {
                 })?
             }
             "EdDSA" => {
-                let verifying_key = key_source
-                    .get_key(&unverified.iss, kid.as_deref())
+                // A kid-less JWT may have been signed by any of the issuer's
+                // simultaneously-published keys (overlap rotation / PQ-hybrid
+                // rollout). Resolve every candidate and try each rather than
+                // collapsing the published set to a positional singleton
+                // (#1183 / #1184).
+                let candidates = key_source
+                    .get_keys(&unverified.iss, kid.as_deref())
                     .await
                     .map_err(|e| {
                         tracing::warn!(
@@ -883,11 +888,15 @@ pub trait RequestService: 'static {
                         );
                         anyhow::anyhow!("JWT key resolution failed")
                     })?;
-                crate::auth::decode_with_key(&token, &verifying_key, self.expected_audience())
-                    .map_err(|e| {
-                        tracing::warn!("JWT verification failed: {}", e);
-                        anyhow::anyhow!("JWT verification failed")
-                    })?
+                crate::auth::decode_with_any_key_lenient(
+                    &token,
+                    &candidates,
+                    self.expected_audience(),
+                )
+                .map_err(|e| {
+                    tracing::warn!("JWT verification failed: {}", e);
+                    anyhow::anyhow!("JWT verification failed")
+                })?
             }
             _ => anyhow::bail!("unsupported JWT algorithm"),
         };

--- a/crates/hyprstream/src/auth/federation.rs
+++ b/crates/hyprstream/src/auth/federation.rs
@@ -12,16 +12,16 @@
 //! positional singleton — that anti-pattern forecloses both overlap rotation
 //! and PQ-hybrid publication (#1183).
 
+use anyhow::{Result, anyhow};
+use base64::{Engine, engine::general_purpose::URL_SAFE_NO_PAD};
+use ed25519_dalek::VerifyingKey;
+use hyprstream_discovery::DiscoveryClient;
+use hyprstream_rpc::auth::{FederationKey, FederationKeySource};
 use std::collections::HashMap;
 use std::pin::Pin;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
-use tokio::sync::Mutex;
-use anyhow::{anyhow, Result};
-use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine};
-use ed25519_dalek::VerifyingKey;
-use hyprstream_rpc::auth::FederationKeySource;
-use hyprstream_discovery::DiscoveryClient;
+use tokio::sync::{Mutex, RwLock};
 
 /// Async function that fetches raw JWKS JSON from a URL. Defaults to a
 /// reqwest GET; injectable for tests.
@@ -63,11 +63,13 @@ impl CachedJwks {
 pub struct FederationKeyResolver {
     /// issuer_url → cached JWKS key set.
     ///
-    /// A single `Mutex` (not `RwLock`) serialises both reads and writes so
-    /// that concurrent cache-miss events for the same issuer do not race:
-    /// the first waiter fetches, writes the result, and the second waiter
-    /// then finds a valid entry on re-check.
-    cache: Mutex<HashMap<String, CachedJwks>>,
+    cache: RwLock<HashMap<String, CachedJwks>>,
+    /// Short-lived cache of named keys that were absent after a refresh.
+    /// This bounds attacker-controlled repeated unknown-`kid` requests.
+    negative_cache: Mutex<HashMap<(String, String), Instant>>,
+    /// Per-issuer single-flight guards. Different trusted issuers never block
+    /// each other while one issuer refreshes its JWKS.
+    fetch_locks: Mutex<HashMap<String, Arc<Mutex<()>>>>,
     /// issuer_url → (optional jwks_uri_override, ttl, allow_http)
     config: HashMap<String, (Option<String>, Duration, bool)>,
     http: reqwest::Client,
@@ -97,9 +99,7 @@ pub struct FederationKeyResolver {
 }
 
 impl FederationKeyResolver {
-    pub fn new(
-        trusted_issuers: &HashMap<String, crate::config::TrustedIssuerConfig>,
-    ) -> Self {
+    pub fn new(trusted_issuers: &HashMap<String, crate::config::TrustedIssuerConfig>) -> Self {
         let config = trusted_issuers
             .iter()
             .map(|(iss, cfg)| {
@@ -113,15 +113,18 @@ impl FederationKeyResolver {
                 )
             })
             .collect();
+        let http = reqwest::Client::builder()
+            .timeout(Duration::from_secs(10))
+            .build()
+            .unwrap_or_default();
         Self {
-            cache: Mutex::new(HashMap::new()),
+            cache: RwLock::new(HashMap::new()),
+            negative_cache: Mutex::new(HashMap::new()),
+            fetch_locks: Mutex::new(HashMap::new()),
             config,
             // TLS certificate verification is enabled by default (reqwest default).
-            http: reqwest::Client::builder()
-                .timeout(Duration::from_secs(10))
-                .build()
-                .unwrap_or_default(),
-            jwks_fetcher: default_jwks_fetcher(),
+            jwks_fetcher: default_jwks_fetcher(http.clone()),
+            http,
             discovery_client: None,
             policy_client: None,
         }
@@ -174,11 +177,7 @@ impl FederationKeyResolver {
     /// requests for the same issuer serialise: the second waiter re-checks the
     /// cache after the first finishes, finding a fresh entry rather than issuing
     /// a redundant JWKS fetch.
-    pub async fn get_keys(
-        &self,
-        issuer: &str,
-        kid: Option<&str>,
-    ) -> Result<Vec<VerifyingKey>> {
+    pub async fn get_keys(&self, issuer: &str, kid: Option<&str>) -> Result<Vec<FederationKey>> {
         // Look up config before acquiring cache lock (config is immutable after new())
         let (jwks_uri_override, ttl, allow_http) = self
             .config
@@ -231,27 +230,30 @@ impl FederationKeyResolver {
             }
         }
 
-        // Acquire the cache lock once. Check first; fetch only if
-        // expired/absent OR if the requested kid is not present in a
-        // fresh entry (rotation: a newly-published kid must trigger one
-        // refetch before we fail closed).
-        let mut cache = self.cache.lock().await;
-
-        // Helper: does a fresh cached entry satisfy `kid`?
-        fn has_fresh_kid(entry: &CachedJwks, kid: Option<&str>) -> bool {
-            match kid {
-                None => {
-                    // No selector: any non-empty fresh set suffices.
-                    !entry.entries.is_empty()
-                }
-                Some(k) => entry.entries.iter().any(|e| e.kid.as_deref() == Some(k)),
-            }
+        if let Some(candidates) = self.fresh_candidates(issuer, kid).await {
+            return Ok(candidates);
+        }
+        if self.is_negative_cached(issuer, kid).await {
+            anyhow::bail!("JWKS has no Ed25519 key with requested kid (negative cached)");
         }
 
-        if let Some(entry) = cache.get(issuer) {
-            if !entry.is_expired() && has_fresh_kid(entry, kid) {
-                return Ok(order_candidates(&entry.entries, kid));
-            }
+        // Recheck cache and the negative cache after acquiring this issuer's
+        // single-flight guard. This makes one refresh serve all same-issuer
+        // waiters without globally head-of-line blocking unrelated issuers.
+        let fetch_lock = {
+            let mut locks = self.fetch_locks.lock().await;
+            Arc::clone(
+                locks
+                    .entry(issuer.to_owned())
+                    .or_insert_with(|| Arc::new(Mutex::new(()))),
+            )
+        };
+        let _fetch_guard = fetch_lock.lock().await;
+        if let Some(candidates) = self.fresh_candidates(issuer, kid).await {
+            return Ok(candidates);
+        }
+        if self.is_negative_cached(issuer, kid).await {
+            anyhow::bail!("JWKS has no Ed25519 key with requested kid (negative cached)");
         }
 
         // Phase 0.5 Stage D — try DiscoveryService first if configured.
@@ -262,16 +264,19 @@ impl FederationKeyResolver {
         if let Some(ref dc) = self.discovery_client {
             match self.try_get_keys_from_discovery(dc, issuer).await {
                 Ok(entries) if !entries.is_empty() => {
-                    let ordered = order_candidates(&entries, kid);
-                    cache.insert(
-                        issuer.to_owned(),
-                        CachedJwks {
-                            entries,
-                            fetched_at: Instant::now(),
-                            ttl,
-                        },
-                    );
-                    return Ok(ordered);
+                    if has_requested_kid(&entries, kid) {
+                        self.cache_entries(issuer, entries, ttl).await;
+                        self.clear_negative_cache(issuer, kid).await;
+                        // A selector exists only to select: do not return
+                        // unrelated co-published keys as signature fallbacks.
+                        return self.fresh_candidates(issuer, kid).await.ok_or_else(|| {
+                            anyhow!("fresh Discovery JWKS unexpectedly missing requested key")
+                        });
+                    }
+                    // A stale Discovery statement cannot hide an HTTPS JWKS
+                    // rotation. Preserve it for kid-less callers only if the
+                    // authoritative HTTPS lookup below fails.
+                    self.cache_entries(issuer, entries, ttl).await;
                 }
                 Ok(_) => {
                     tracing::debug!(
@@ -305,32 +310,37 @@ impl FederationKeyResolver {
             anyhow::bail!("No Ed25519 key found in JWKS at {}", jwks_uri);
         }
 
-        // If a kid was requested, a fresh fetch that does not carry it
-        // fails closed — never substitute another key for a named kid
-        // (anti-pattern: positional singleton, #1183).
-        if let Some(k) = kid {
-            let found = entries.iter().any(|e| e.kid.as_deref() == Some(k));
-            if !found {
-                // Cache the fresh set anyway so a concurrent request for
-                // a kid that *is* present benefits, then fail closed.
-                cache.insert(
-                    issuer.to_owned(),
-                    CachedJwks {
-                        entries,
-                        fetched_at: Instant::now(),
-                        ttl,
-                    },
-                );
-                anyhow::bail!(
-                    "JWKS at {} has no Ed25519 key with kid={}",
-                    jwks_uri,
-                    k
-                );
-            }
+        let found = has_requested_kid(&entries, kid);
+        self.cache_entries(issuer, entries, ttl).await;
+        if !found {
+            self.record_negative_cache(issuer, kid).await;
+            let Some(requested_kid) = kid else {
+                anyhow::bail!("JWKS unexpectedly contained no usable Ed25519 key");
+            };
+            anyhow::bail!(
+                "JWKS at {} has no Ed25519 key with kid={}",
+                jwks_uri,
+                requested_kid
+            );
         }
+        self.clear_negative_cache(issuer, kid).await;
+        let cache = self.cache.read().await;
+        Ok(select_candidates(&cache[issuer].entries, kid))
+    }
 
-        let ordered = order_candidates(&entries, kid);
-        cache.insert(
+    async fn fresh_candidates(
+        &self,
+        issuer: &str,
+        kid: Option<&str>,
+    ) -> Option<Vec<FederationKey>> {
+        let cache = self.cache.read().await;
+        let entry = cache.get(issuer)?;
+        (!entry.is_expired() && has_requested_kid(&entry.entries, kid))
+            .then(|| select_candidates(&entry.entries, kid))
+    }
+
+    async fn cache_entries(&self, issuer: &str, entries: Vec<JwksEntry>, ttl: Duration) {
+        self.cache.write().await.insert(
             issuer.to_owned(),
             CachedJwks {
                 entries,
@@ -338,8 +348,48 @@ impl FederationKeyResolver {
                 ttl,
             },
         );
+    }
 
-        Ok(ordered)
+    async fn is_negative_cached(&self, issuer: &str, kid: Option<&str>) -> bool {
+        const NEGATIVE_TTL: Duration = Duration::from_secs(5);
+        let Some(kid) = kid else {
+            return false;
+        };
+        let key = (issuer.to_owned(), kid.to_owned());
+        let mut misses = self.negative_cache.lock().await;
+        match misses.get(&key) {
+            Some(seen) if seen.elapsed() < NEGATIVE_TTL => true,
+            Some(_) => {
+                misses.remove(&key);
+                false
+            }
+            None => false,
+        }
+    }
+
+    async fn record_negative_cache(&self, issuer: &str, kid: Option<&str>) {
+        const NEGATIVE_TTL: Duration = Duration::from_secs(5);
+        const MAX_NEGATIVE_ENTRIES: usize = 1024;
+        let Some(kid) = kid else {
+            return;
+        };
+        let mut misses = self.negative_cache.lock().await;
+        misses.retain(|_, seen| seen.elapsed() < NEGATIVE_TTL);
+        if misses.len() >= MAX_NEGATIVE_ENTRIES {
+            if let Some(key) = misses.keys().next().cloned() {
+                misses.remove(&key);
+            }
+        }
+        misses.insert((issuer.to_owned(), kid.to_owned()), Instant::now());
+    }
+
+    async fn clear_negative_cache(&self, issuer: &str, kid: Option<&str>) {
+        if let Some(kid) = kid {
+            self.negative_cache
+                .lock()
+                .await
+                .remove(&(issuer.to_owned(), kid.to_owned()));
+        }
     }
 
     /// Try fetching the Ed25519 verifying keys for `issuer` via DiscoveryService.
@@ -415,10 +465,7 @@ impl FederationKeyResolver {
             )
         } else {
             // Non-HTTP(S) scheme (ftp://, file://, javascript:, etc.)
-            anyhow::bail!(
-                "JWKS URI must use HTTPS or HTTP scheme (got '{}').",
-                url
-            )
+            anyhow::bail!("JWKS URI must use HTTPS or HTTP scheme (got '{}').", url)
         }
     }
 
@@ -426,13 +473,7 @@ impl FederationKeyResolver {
         // Validate the issuer URL scheme before fetching AS metadata
         self.check_scheme(issuer, allow_http)?;
         let meta_url = format!("{}/.well-known/oauth-authorization-server", issuer);
-        let meta: serde_json::Value = self
-            .http
-            .get(&meta_url)
-            .send()
-            .await?
-            .json()
-            .await?;
+        let meta: serde_json::Value = self.http.get(&meta_url).send().await?.json().await?;
         let jwks_uri = meta["jwks_uri"]
             .as_str()
             .map(str::to_owned)
@@ -454,19 +495,12 @@ impl FederationKeyResolver {
 /// The default JWKS fetcher: a reqwest GET returning the parsed JSON body.
 /// Captured as a `JwksFetcher` so the production path and the test seam
 /// share one shape (#1185).
-fn default_jwks_fetcher() -> JwksFetcher {
-    // The client is rebuilt per-call here only as a closure capture; the
-    // resolver also holds `http` for AS-metadata discovery, so this is a
-    // thin wrapper. A dedicated client is used so a future reqwest tuning
-    // (timeouts, TLS) applies uniformly.
-    Arc::new(|url: &str| {
+fn default_jwks_fetcher(http: reqwest::Client) -> JwksFetcher {
+    Arc::new(move |url: &str| {
         let url = url.to_owned();
+        let http = http.clone();
         Box::pin(async move {
-            let client = reqwest::Client::builder()
-                .timeout(Duration::from_secs(10))
-                .build()
-                .unwrap_or_default();
-            let jwks: serde_json::Value = client.get(&url).send().await?.json().await?;
+            let jwks: serde_json::Value = http.get(&url).send().await?.json().await?;
             Ok(jwks)
         })
     })
@@ -510,23 +544,29 @@ fn parse_jwks_ed25519(jwks: &serde_json::Value, jwks_uri: &str) -> Vec<JwksEntry
     out
 }
 
-/// Order `entries` so the `kid`-matching entry (if any) comes first, followed
-/// by every remaining usable key. A verifier that prefers the named kid thus
-/// still gets overlap candidates as a fallback, and a kid-less caller simply
-/// receives the full published set in JWKS order. This is the
-/// select-by-id-or-try-each rule from the #1183 key-set audit.
-fn order_candidates(entries: &[JwksEntry], kid: Option<&str>) -> Vec<VerifyingKey> {
-    let mut ordered: Vec<VerifyingKey> = Vec::with_capacity(entries.len());
-    if let Some(k) = kid {
-        ordered.extend(entries.iter().filter(|e| e.kid.as_deref() == Some(k)).map(|e| e.key));
+/// A named token selects only its exact entry. A kid-less token can try every
+/// compatible published key, preserving the overlap-rotation case.
+fn select_candidates(entries: &[JwksEntry], kid: Option<&str>) -> Vec<FederationKey> {
+    entries
+        .iter()
+        .filter(|entry| match kid {
+            Some(requested_kid) => entry.kid.as_deref() == Some(requested_kid),
+            None => true,
+        })
+        .map(|entry| FederationKey {
+            kid: entry.kid.clone(),
+            verifying_key: entry.key,
+        })
+        .collect()
+}
+
+fn has_requested_kid(entries: &[JwksEntry], kid: Option<&str>) -> bool {
+    match kid {
+        Some(requested_kid) => entries
+            .iter()
+            .any(|entry| entry.kid.as_deref() == Some(requested_kid)),
+        None => !entries.is_empty(),
     }
-    for e in entries {
-        if kid.is_some() && e.kid.as_deref() == kid {
-            continue;
-        }
-        ordered.push(e.key);
-    }
-    ordered
 }
 
 /// Phase 0.5 Stage D — self-validating signature verification of an
@@ -571,10 +611,7 @@ pub(crate) fn verify_self_issued_entity_statement(
 /// set is retained — not collapsed to the signer — so overlap rotation and
 /// PQ-hybrid publication work through the Discovery path as they do through
 /// HTTPS JWKS (#1185).
-fn extract_self_issued_jwks(
-    jwt: &str,
-    expected_issuer: &str,
-) -> Result<Vec<JwksEntry>> {
+fn extract_self_issued_jwks(jwt: &str, expected_issuer: &str) -> Result<Vec<JwksEntry>> {
     let (entries, _signer) = parse_self_issued_entity_statement(jwt, expected_issuer)?;
     Ok(entries)
 }
@@ -604,7 +641,10 @@ fn parse_self_issued_entity_statement(
         .map_err(|e| anyhow!("entity statement JWT header not JSON: {}", e))?;
     let alg = header.get("alg").and_then(|v| v.as_str()).unwrap_or("");
     if alg != "EdDSA" {
-        anyhow::bail!("entity statement JWT alg is '{}', only EdDSA supported", alg);
+        anyhow::bail!(
+            "entity statement JWT alg is '{}', only EdDSA supported",
+            alg
+        );
     }
 
     // Payload — iss/sub bind to expected issuer; exp not expired.
@@ -617,10 +657,17 @@ fn parse_self_issued_entity_statement(
     let iss = claims.get("iss").and_then(|v| v.as_str()).unwrap_or("");
     let sub = claims.get("sub").and_then(|v| v.as_str()).unwrap_or("");
     if iss != expected_issuer {
-        anyhow::bail!("entity statement iss '{}' != expected issuer '{}'", iss, expected_issuer);
+        anyhow::bail!(
+            "entity statement iss '{}' != expected issuer '{}'",
+            iss,
+            expected_issuer
+        );
     }
     if sub != expected_issuer {
-        anyhow::bail!("entity statement sub '{}' != iss (must be self-issued)", sub);
+        anyhow::bail!(
+            "entity statement sub '{}' != iss (must be self-issued)",
+            sub
+        );
     }
 
     if let Some(exp) = claims.get("exp").and_then(serde_json::Value::as_i64) {
@@ -647,7 +694,10 @@ fn parse_self_issued_entity_statement(
         .decode(parts[2])
         .map_err(|e| anyhow!("entity statement signature not base64url: {}", e))?;
     if sig_bytes.len() != 64 {
-        anyhow::bail!("Ed25519 signature must be 64 bytes, got {}", sig_bytes.len());
+        anyhow::bail!(
+            "Ed25519 signature must be 64 bytes, got {}",
+            sig_bytes.len()
+        );
     }
     let mut sig_arr = [0u8; 64];
     sig_arr.copy_from_slice(&sig_bytes);
@@ -682,7 +732,11 @@ fn parse_self_issued_entity_statement(
             .and_then(|v| v.as_str())
             .filter(|s| !s.is_empty())
             .map(str::to_owned);
-        if signer.is_none() && vk.verify_strict(signing_input.as_bytes(), &signature).is_ok() {
+        if signer.is_none()
+            && vk
+                .verify_strict(signing_input.as_bytes(), &signature)
+                .is_ok()
+        {
             signer = Some(vk);
         }
         entries.push(JwksEntry { kid, key: vk });
@@ -709,7 +763,7 @@ impl FederationKeySource for FederationKeyResolver {
         &self,
         issuer: &str,
         kid: Option<&str>,
-    ) -> anyhow::Result<Vec<ed25519_dalek::VerifyingKey>> {
+    ) -> anyhow::Result<Vec<FederationKey>> {
         FederationKeyResolver::get_keys(self, issuer, kid).await
     }
 }
@@ -747,6 +801,7 @@ mod tests {
     // ──────────────────────────────────────────────────────────────────
 
     use ed25519_dalek::{Signer, SigningKey};
+    use hyprstream_rpc::auth::{Claims, jwt};
     use rand::rngs::OsRng;
 
     fn b64u(bytes: &[u8]) -> String {
@@ -1011,6 +1066,20 @@ mod tests {
         })
     }
 
+    fn federation_token(signing_key: &SigningKey, kid: &str, sub: &str) -> String {
+        let exp = future_exp();
+        let claims = Claims::new(sub.to_owned(), exp - 3600, exp)
+            .with_issuer("https://fed.example".to_owned());
+        let header = serde_json::json!({"alg": "EdDSA", "typ": "at+jwt", "kid": kid});
+        let signing_input = format!(
+            "{}.{}",
+            b64u_json(&header),
+            b64u(&serde_json::to_vec(&claims).expect("claims json"))
+        );
+        let signature = signing_key.sign(signing_input.as_bytes());
+        format!("{}.{}", signing_input, b64u(&signature.to_bytes()))
+    }
+
     fn trusted_issuer(jwks_uri: &str) -> HashMap<String, crate::config::TrustedIssuerConfig> {
         let mut issuers = HashMap::new();
         issuers.insert(
@@ -1043,10 +1112,9 @@ mod tests {
         assert!(kids.contains(&Some("kid-new")));
     }
 
-    /// The anti-pattern this ticket fixes: with two keys published and the
-    /// token signed by the SECOND key, `get_keys` must surface that key. The
-    /// old `fetch_ed25519_key` returned only the first key, so a verifier
-    /// had no candidate that could verify a second-key signature.
+    /// Production-boundary overlap acceptance: two published keys each verify
+    /// their own named token. A named token is never allowed to fall back to a
+    /// different co-published key.
     #[tokio::test]
     async fn get_keys_overlap_returns_both_and_resolves_second_by_kid() {
         let sk_old = SigningKey::generate(&mut OsRng);
@@ -1063,28 +1131,44 @@ mod tests {
             let jwks = jwks.clone();
             Box::pin(async move { Ok(jwks) })
         });
-        let resolver =
-            FederationKeyResolver::new(&trusted_issuer("https://fed.example/jwks"))
-                .with_jwks_fetcher(fetcher);
+        let resolver = FederationKeyResolver::new(&trusted_issuer("https://fed.example/jwks"))
+            .with_jwks_fetcher(fetcher);
 
-        // No kid → ALL candidates returned so the verifier can try each.
-        let all = resolver.get_keys("https://fed.example", None).await.expect("both keys");
+        let old_token = federation_token(&sk_old, "kid-old", "old-subject");
+        let new_token = federation_token(&sk_new, "kid-new", "new-subject");
+
+        // No kid → all candidates are available to a genuinely kid-less token.
+        let all = resolver
+            .get_keys("https://fed.example", None)
+            .await
+            .expect("both keys");
         assert_eq!(all.len(), 2, "overlap: both keys must be returned");
 
-        // kid-new must resolve to the new (second-published) key, ordered first.
-        let ordered = resolver
+        let new_candidates = resolver
             .get_keys("https://fed.example", Some("kid-new"))
             .await
             .expect("kid-new resolves");
-        assert_eq!(ordered.first().copied(), Some(vk_new), "kid-new is first");
-        assert!(ordered.contains(&vk_old), "old key retained as overlap candidate");
+        assert_eq!(new_candidates.len(), 1, "named lookup must not fall back");
+        assert_eq!(new_candidates[0].verifying_key, vk_new);
+        assert_eq!(
+            jwt::decode_with_federation_candidates(&new_token, &new_candidates, None)
+                .expect("new overlap token verifies")
+                .sub,
+            "new-subject"
+        );
 
-        // kid-old still resolves during the overlap window.
-        let ordered_old = resolver
+        let old_candidates = resolver
             .get_keys("https://fed.example", Some("kid-old"))
             .await
             .expect("kid-old resolves");
-        assert_eq!(ordered_old.first().copied(), Some(vk_old));
+        assert_eq!(old_candidates.len(), 1, "named lookup must not fall back");
+        assert_eq!(old_candidates[0].verifying_key, vk_old);
+        assert_eq!(
+            jwt::decode_with_federation_candidates(&old_token, &old_candidates, None)
+                .expect("old overlap token verifies")
+                .sub,
+            "old-subject"
+        );
     }
 
     /// A named `kid` that is not in the published set after a fresh fetch
@@ -1093,15 +1177,13 @@ mod tests {
     #[tokio::test]
     async fn get_keys_unknown_kid_fails_closed_without_substitution() {
         let sk = SigningKey::generate(&mut OsRng);
-        let jwks =
-            serde_json::json!({"keys": [jwk_with_kid(&sk.verifying_key(), "kid-real")]});
+        let jwks = serde_json::json!({"keys": [jwk_with_kid(&sk.verifying_key(), "kid-real")]});
         let fetcher: JwksFetcher = Arc::new(move |_url| {
             let jwks = jwks.clone();
             Box::pin(async move { Ok(jwks) })
         });
-        let resolver =
-            FederationKeyResolver::new(&trusted_issuer("https://fed.example/jwks"))
-                .with_jwks_fetcher(fetcher);
+        let resolver = FederationKeyResolver::new(&trusted_issuer("https://fed.example/jwks"))
+            .with_jwks_fetcher(fetcher);
 
         let err = resolver
             .get_keys("https://fed.example", Some("kid-ghost"))
@@ -1110,6 +1192,38 @@ mod tests {
         assert!(
             format!("{err}").contains("kid-ghost"),
             "error must name the missing kid: {err}"
+        );
+    }
+
+    #[tokio::test]
+    async fn repeated_unknown_kid_uses_one_refresh_within_negative_ttl() {
+        let sk = SigningKey::generate(&mut OsRng);
+        let jwks = serde_json::json!({"keys": [jwk_with_kid(&sk.verifying_key(), "kid-real")]});
+        let fetch_count = Arc::new(AtomicU32::new(0));
+        let count = Arc::clone(&fetch_count);
+        let fetcher: JwksFetcher = Arc::new(move |_url| {
+            let jwks = jwks.clone();
+            let count = Arc::clone(&count);
+            Box::pin(async move {
+                count.fetch_add(1, Ordering::SeqCst);
+                Ok(jwks)
+            })
+        });
+        let resolver = FederationKeyResolver::new(&trusted_issuer("https://fed.example/jwks"))
+            .with_jwks_fetcher(fetcher);
+
+        for _ in 0..3 {
+            assert!(
+                resolver
+                    .get_keys("https://fed.example", Some("kid-ghost"))
+                    .await
+                    .is_err()
+            );
+        }
+        assert_eq!(
+            fetch_count.load(Ordering::SeqCst),
+            1,
+            "one miss → one refresh per negative TTL"
         );
     }
 
@@ -1146,11 +1260,7 @@ mod tests {
             let rotated = rotated.clone();
             Box::pin(async move {
                 let n = cc.fetch_add(1, Ordering::SeqCst);
-                if n == 0 {
-                    Ok(overlap)
-                } else {
-                    Ok(rotated)
-                }
+                if n == 0 { Ok(overlap) } else { Ok(rotated) }
             })
         });
 
@@ -1164,15 +1274,25 @@ mod tests {
                 allow_http: true,
             },
         );
-        let resolver =
-            FederationKeyResolver::new(&issuers).with_jwks_fetcher(fetcher);
+        let resolver = FederationKeyResolver::new(&issuers).with_jwks_fetcher(fetcher);
 
-        // Overlap: old key still honoured.
+        let old_token = federation_token(&sk_old, "kid-old", "old-subject");
+        let new_token = federation_token(&sk_new, "kid-new", "new-subject");
+
+        // During overlap both signed tokens verify at the resolver/verifier
+        // boundary, not merely by inspecting returned vectors.
         let during_overlap = resolver
             .get_keys("https://fed.example", Some("kid-old"))
             .await
             .expect("old key honoured during overlap");
-        assert!(during_overlap.contains(&vk_old));
+        assert!(jwt::decode_with_federation_candidates(&old_token, &during_overlap, None).is_ok());
+        let new_during_overlap = resolver
+            .get_keys("https://fed.example", Some("kid-new"))
+            .await
+            .expect("new key honoured during overlap");
+        assert!(
+            jwt::decode_with_federation_candidates(&new_token, &new_during_overlap, None).is_ok()
+        );
 
         // After rotation drains, the old kid is gone — refetch, fail closed.
         let err = resolver
@@ -1189,6 +1309,6 @@ mod tests {
             .get_keys("https://fed.example", Some("kid-new"))
             .await
             .expect("new key still resolves");
-        assert!(after.contains(&vk_new));
+        assert!(jwt::decode_with_federation_candidates(&new_token, &after, None).is_ok());
     }
 }

--- a/crates/hyprstream/src/auth/federation.rs
+++ b/crates/hyprstream/src/auth/federation.rs
@@ -2,8 +2,18 @@
 //!
 //! `FederationKeyResolver` resolves external issuer URLs to Ed25519 verifying
 //! keys by fetching and caching JWKS (RFC 7517) documents.
+//!
+//! # Rotation-aware key set (#1185)
+//!
+//! The cache retains **every** usable Ed25519 key an issuer publishes, keyed by
+//! `kid`, so two keys published simultaneously during an overlap rotation both
+//! verify. A `kid` hint selects the preferred candidate; without one, the
+//! caller tries each. The resolver never collapses the published set to a
+//! positional singleton — that anti-pattern forecloses both overlap rotation
+//! and PQ-hybrid publication (#1183).
 
 use std::collections::HashMap;
+use std::pin::Pin;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 use tokio::sync::Mutex;
@@ -13,13 +23,29 @@ use ed25519_dalek::VerifyingKey;
 use hyprstream_rpc::auth::FederationKeySource;
 use hyprstream_discovery::DiscoveryClient;
 
-struct CachedKey {
+/// Async function that fetches raw JWKS JSON from a URL. Defaults to a
+/// reqwest GET; injectable for tests.
+type JwksFetcher = Arc<
+    dyn Fn(&str) -> Pin<Box<dyn std::future::Future<Output = Result<serde_json::Value>> + Send>>
+        + Send
+        + Sync,
+>;
+
+/// One Ed25519 entry from a published JWKS, with its optional `kid`.
+#[derive(Clone)]
+struct JwksEntry {
+    kid: Option<String>,
     key: VerifyingKey,
+}
+
+/// All Ed25519 keys currently published by one issuer, plus cache bookkeeping.
+struct CachedJwks {
+    entries: Vec<JwksEntry>,
     fetched_at: Instant,
     ttl: Duration,
 }
 
-impl CachedKey {
+impl CachedJwks {
     fn is_expired(&self) -> bool {
         self.fetched_at.elapsed() > self.ttl
     }
@@ -35,19 +61,23 @@ impl CachedKey {
 /// Set `allow_http: true` in `TrustedIssuerConfig` on a per-issuer basis to
 /// permit plain HTTP (development / internal use only).
 pub struct FederationKeyResolver {
-    /// issuer_url → cached key.
+    /// issuer_url → cached JWKS key set.
     ///
     /// A single `Mutex` (not `RwLock`) serialises both reads and writes so
     /// that concurrent cache-miss events for the same issuer do not race:
     /// the first waiter fetches, writes the result, and the second waiter
     /// then finds a valid entry on re-check.
-    cache: Mutex<HashMap<String, CachedKey>>,
+    cache: Mutex<HashMap<String, CachedJwks>>,
     /// issuer_url → (optional jwks_uri_override, ttl, allow_http)
     config: HashMap<String, (Option<String>, Duration, bool)>,
     http: reqwest::Client,
+    /// Injectable JWKS fetcher (url → raw JWKS JSON). Defaults to a reqwest
+    /// GET; overridable in tests so the rotation/overlap behaviour of
+    /// `get_keys` can be exercised end-to-end without a network mock.
+    jwks_fetcher: JwksFetcher,
     /// Phase 0.5 Stage D — optional DiscoveryService client.
     ///
-    /// When configured, `get_key` consults DiscoveryService for a cached
+    /// When configured, `get_keys` consults DiscoveryService for a cached
     /// signed entity statement before falling back to HTTPS JWKS fetch.
     /// This avoids the HTTPS round-trip for local-issuer verification and
     /// the 300s TTL becomes irrelevant for cluster-internal traffic.
@@ -55,7 +85,7 @@ pub struct FederationKeyResolver {
     /// trust on missing data).
     discovery_client: Option<Arc<DiscoveryClient>>,
     /// Unified federation trust gate (atproto-style). When set, every
-    /// `get_key` call additionally verifies the issuer's origin is
+    /// `get_keys` call additionally verifies the issuer's origin is
     /// permitted by PolicyService `federation:register` — same gate as
     /// CIMD client registration. The `trusted_issuers` config carries
     /// operational metadata (jwks_uri override, scheme, TTL); this
@@ -91,14 +121,24 @@ impl FederationKeyResolver {
                 .timeout(Duration::from_secs(10))
                 .build()
                 .unwrap_or_default(),
+            jwks_fetcher: default_jwks_fetcher(),
             discovery_client: None,
             policy_client: None,
         }
     }
 
-    /// Wire the PolicyService client so [`get_key`] enforces the
+    /// Override the JWKS fetcher (url → raw JWKS JSON). Test-only seam that
+    /// lets the rotation/overlap behaviour of [`get_keys`] be exercised
+    /// end-to-end without standing up an HTTPS server.
+    #[cfg(test)]
+    pub(crate) fn with_jwks_fetcher(mut self, fetcher: JwksFetcher) -> Self {
+        self.jwks_fetcher = fetcher;
+        self
+    }
+
+    /// Wire the PolicyService client so [`get_keys`] enforces the
     /// `federation:register` trust gate before any HTTPS fetch. When
-    /// set, calls to `get_key` for issuers that aren't currently
+    /// set, calls to `get_keys` for issuers that aren't currently
     /// permitted by PolicyService policy return Err — fail-closed,
     /// matching the CIMD client path.
     pub fn with_policy_client(mut self, client: Arc<crate::services::PolicyClient>) -> Self {
@@ -107,7 +147,7 @@ impl FederationKeyResolver {
     }
 
     /// Phase 0.5 Stage D — wire a DiscoveryService client for federation
-    /// directory consultation. When set, [`get_key`] will try fetching the
+    /// directory consultation. When set, [`get_keys`] will try fetching the
     /// issuer's signed entity statement via DiscoveryService before falling
     /// back to HTTPS JWKS fetch.
     ///
@@ -126,13 +166,19 @@ impl FederationKeyResolver {
         self.config.contains_key(issuer)
     }
 
-    /// Get the verifying key for an issuer, fetching/refreshing JWKS as needed.
+    /// Get the Ed25519 candidate verifying keys for an issuer, fetching /
+    /// refreshing JWKS as needed. See the trait docs for the rotation-aware
+    /// key-set contract (#1185).
     ///
     /// Uses a single `Mutex` for both cache reads and writes so that concurrent
     /// requests for the same issuer serialise: the second waiter re-checks the
     /// cache after the first finishes, finding a fresh entry rather than issuing
     /// a redundant JWKS fetch.
-    pub async fn get_key(&self, issuer: &str) -> Result<VerifyingKey> {
+    pub async fn get_keys(
+        &self,
+        issuer: &str,
+        kid: Option<&str>,
+    ) -> Result<Vec<VerifyingKey>> {
         // Look up config before acquiring cache lock (config is immutable after new())
         let (jwks_uri_override, ttl, allow_http) = self
             .config
@@ -185,11 +231,26 @@ impl FederationKeyResolver {
             }
         }
 
-        // Acquire the cache lock once. Check first; only fetch if expired/absent.
+        // Acquire the cache lock once. Check first; fetch only if
+        // expired/absent OR if the requested kid is not present in a
+        // fresh entry (rotation: a newly-published kid must trigger one
+        // refetch before we fail closed).
         let mut cache = self.cache.lock().await;
+
+        // Helper: does a fresh cached entry satisfy `kid`?
+        fn has_fresh_kid(entry: &CachedJwks, kid: Option<&str>) -> bool {
+            match kid {
+                None => {
+                    // No selector: any non-empty fresh set suffices.
+                    !entry.entries.is_empty()
+                }
+                Some(k) => entry.entries.iter().any(|e| e.kid.as_deref() == Some(k)),
+            }
+        }
+
         if let Some(entry) = cache.get(issuer) {
-            if !entry.is_expired() {
-                return Ok(entry.key);
+            if !entry.is_expired() && has_fresh_kid(entry, kid) {
+                return Ok(order_candidates(&entry.entries, kid));
             }
         }
 
@@ -199,17 +260,25 @@ impl FederationKeyResolver {
         // round-trip. Conservative on errors: any failure falls through
         // to the existing HTTPS path. Never downgrades trust.
         if let Some(ref dc) = self.discovery_client {
-            match self.try_get_key_from_discovery(dc, issuer).await {
-                Ok(key) => {
+            match self.try_get_keys_from_discovery(dc, issuer).await {
+                Ok(entries) if !entries.is_empty() => {
+                    let ordered = order_candidates(&entries, kid);
                     cache.insert(
                         issuer.to_owned(),
-                        CachedKey {
-                            key,
+                        CachedJwks {
+                            entries,
                             fetched_at: Instant::now(),
                             ttl,
                         },
                     );
-                    return Ok(key);
+                    return Ok(ordered);
+                }
+                Ok(_) => {
+                    tracing::debug!(
+                        issuer = %issuer,
+                        "DiscoveryService federation lookup returned no Ed25519 keys; \
+                         falling through to HTTPS"
+                    );
                 }
                 Err(e) => {
                     tracing::debug!(
@@ -221,8 +290,9 @@ impl FederationKeyResolver {
             }
         }
 
-        // Cache miss or expired — fetch while holding the lock so concurrent
-        // callers for the same issuer block here and reuse the result.
+        // Cache miss, expired, or unknown kid — fetch while holding the
+        // lock so concurrent callers for the same issuer block here and
+        // reuse the result.
         let jwks_uri = if let Some(uri) = jwks_uri_override {
             self.check_scheme(&uri, allow_http)?;
             uri
@@ -230,21 +300,49 @@ impl FederationKeyResolver {
             self.discover_jwks_uri(issuer, allow_http).await?
         };
 
-        let key = self.fetch_ed25519_key(&jwks_uri).await?;
+        let entries = self.fetch_ed25519_keys(&jwks_uri).await?;
+        if entries.is_empty() {
+            anyhow::bail!("No Ed25519 key found in JWKS at {}", jwks_uri);
+        }
 
+        // If a kid was requested, a fresh fetch that does not carry it
+        // fails closed — never substitute another key for a named kid
+        // (anti-pattern: positional singleton, #1183).
+        if let Some(k) = kid {
+            let found = entries.iter().any(|e| e.kid.as_deref() == Some(k));
+            if !found {
+                // Cache the fresh set anyway so a concurrent request for
+                // a kid that *is* present benefits, then fail closed.
+                cache.insert(
+                    issuer.to_owned(),
+                    CachedJwks {
+                        entries,
+                        fetched_at: Instant::now(),
+                        ttl,
+                    },
+                );
+                anyhow::bail!(
+                    "JWKS at {} has no Ed25519 key with kid={}",
+                    jwks_uri,
+                    k
+                );
+            }
+        }
+
+        let ordered = order_candidates(&entries, kid);
         cache.insert(
             issuer.to_owned(),
-            CachedKey {
-                key,
+            CachedJwks {
+                entries,
                 fetched_at: Instant::now(),
                 ttl,
             },
         );
 
-        Ok(key)
+        Ok(ordered)
     }
 
-    /// Try fetching the Ed25519 verifying key for `issuer` via DiscoveryService.
+    /// Try fetching the Ed25519 verifying keys for `issuer` via DiscoveryService.
     ///
     /// Calls `DiscoveryClient::get_entity_statement(issuer)` to retrieve a
     /// cached signed OIDF entity statement, then performs self-validating
@@ -254,7 +352,7 @@ impl FederationKeyResolver {
     /// 2. Parse JWT payload → require `iss == sub == issuer` (self-issued check)
     /// 3. Parse JWT payload → extract `jwks.keys`
     /// 4. For each Ed25519 key in the JWKS: try verifying the JWT signature
-    /// 5. Return the FIRST key that successfully verifies the JWT
+    /// 5. Return the full candidate set once SOME embedded key verifies
     ///
     /// This self-validation establishes that the JWT was signed by a key
     /// listed in its own embedded JWKS — defeats tampering during delivery
@@ -279,11 +377,11 @@ impl FederationKeyResolver {
     /// Self-validation is the strongest check we can do without trust anchors;
     /// the existing per-issuer `trusted_issuers` config provides the trust root
     /// for the *result* (since only configured issuers reach this path at all).
-    async fn try_get_key_from_discovery(
+    async fn try_get_keys_from_discovery(
         &self,
         dc: &DiscoveryClient,
         issuer: &str,
-    ) -> Result<VerifyingKey> {
+    ) -> Result<Vec<JwksEntry>> {
         let stmt = dc
             .get_entity_statement(issuer)
             .await
@@ -293,7 +391,11 @@ impl FederationKeyResolver {
             anyhow::bail!("DiscoveryService returned empty entity statement JWT");
         }
 
-        verify_self_issued_entity_statement(&stmt.jwt, issuer)
+        // Self-validation establishes which embedded key signed the statement.
+        // The full published JWKS is retained (all Ed25519 entries with their
+        // kids) so overlap candidates survive a Discovery lookup, matching the
+        // HTTPS JWKS path's rotation semantics (#1185).
+        extract_self_issued_jwks(&stmt.jwt, issuer)
     }
 
     /// Validate that `url` uses HTTPS (or HTTP when explicitly permitted).
@@ -340,31 +442,91 @@ impl FederationKeyResolver {
         Ok(jwks_uri)
     }
 
-    async fn fetch_ed25519_key(&self, jwks_uri: &str) -> Result<VerifyingKey> {
-        let jwks: serde_json::Value = self
-            .http
-            .get(jwks_uri)
-            .send()
-            .await?
-            .json()
-            .await?;
-        let keys = jwks["keys"]
-            .as_array()
-            .ok_or_else(|| anyhow!("JWKS missing 'keys' array at {}", jwks_uri))?;
-        for key in keys {
-            if key["kty"].as_str() == Some("OKP") && key["crv"].as_str() == Some("Ed25519") {
-                let x = key["x"]
-                    .as_str()
-                    .ok_or_else(|| anyhow!("OKP key missing 'x' field"))?;
-                let raw = URL_SAFE_NO_PAD.decode(x)?;
-                let bytes: [u8; 32] = raw
-                    .try_into()
-                    .map_err(|_| anyhow!("Ed25519 key must be 32 bytes"))?;
-                return VerifyingKey::from_bytes(&bytes).map_err(|e| anyhow!("{}", e));
-            }
-        }
-        Err(anyhow!("No Ed25519 key found in JWKS at {}", jwks_uri))
+    /// Fetch every Ed25519 key in the JWKS at `jwks_uri`, each with its
+    /// optional `kid`. All usable entries are retained — callers select by
+    /// `kid` and/or try each candidate (rotation overlap, PQ-hybrid).
+    async fn fetch_ed25519_keys(&self, jwks_uri: &str) -> Result<Vec<JwksEntry>> {
+        let jwks = (self.jwks_fetcher)(jwks_uri).await?;
+        Ok(parse_jwks_ed25519(&jwks, jwks_uri))
     }
+}
+
+/// The default JWKS fetcher: a reqwest GET returning the parsed JSON body.
+/// Captured as a `JwksFetcher` so the production path and the test seam
+/// share one shape (#1185).
+fn default_jwks_fetcher() -> JwksFetcher {
+    // The client is rebuilt per-call here only as a closure capture; the
+    // resolver also holds `http` for AS-metadata discovery, so this is a
+    // thin wrapper. A dedicated client is used so a future reqwest tuning
+    // (timeouts, TLS) applies uniformly.
+    Arc::new(|url: &str| {
+        let url = url.to_owned();
+        Box::pin(async move {
+            let client = reqwest::Client::builder()
+                .timeout(Duration::from_secs(10))
+                .build()
+                .unwrap_or_default();
+            let jwks: serde_json::Value = client.get(&url).send().await?.json().await?;
+            Ok(jwks)
+        })
+    })
+}
+
+/// Parse every Ed25519 entry (with its `kid`) out of a JWKS document. All
+/// usable entries are retained — callers select by `kid` and/or try each
+/// candidate. Pure (no I/O) so rotation/overlap behaviour is unit-testable.
+fn parse_jwks_ed25519(jwks: &serde_json::Value, jwks_uri: &str) -> Vec<JwksEntry> {
+    let mut out = Vec::new();
+    let Some(keys) = jwks["keys"].as_array() else {
+        return out;
+    };
+    for key in keys {
+        if key["kty"].as_str() != Some("OKP") || key["crv"].as_str() != Some("Ed25519") {
+            continue;
+        }
+        let x = match key["x"].as_str() {
+            Some(s) => s,
+            None => continue,
+        };
+        let raw = match URL_SAFE_NO_PAD.decode(x) {
+            Ok(r) => r,
+            Err(_) => continue,
+        };
+        let bytes: [u8; 32] = match raw.try_into() {
+            Ok(b) => b,
+            Err(_) => continue,
+        };
+        let vk = match VerifyingKey::from_bytes(&bytes) {
+            Ok(v) => v,
+            Err(_) => continue,
+        };
+        let kid = key["kid"]
+            .as_str()
+            .filter(|s| !s.is_empty())
+            .map(str::to_owned);
+        out.push(JwksEntry { kid, key: vk });
+    }
+    let _ = jwks_uri; // context only (error reporting is at call sites)
+    out
+}
+
+/// Order `entries` so the `kid`-matching entry (if any) comes first, followed
+/// by every remaining usable key. A verifier that prefers the named kid thus
+/// still gets overlap candidates as a fallback, and a kid-less caller simply
+/// receives the full published set in JWKS order. This is the
+/// select-by-id-or-try-each rule from the #1183 key-set audit.
+fn order_candidates(entries: &[JwksEntry], kid: Option<&str>) -> Vec<VerifyingKey> {
+    let mut ordered: Vec<VerifyingKey> = Vec::with_capacity(entries.len());
+    if let Some(k) = kid {
+        ordered.extend(entries.iter().filter(|e| e.kid.as_deref() == Some(k)).map(|e| e.key));
+    }
+    for e in entries {
+        if kid.is_some() && e.kid.as_deref() == kid {
+            continue;
+        }
+        ordered.push(e.key);
+    }
+    ordered
 }
 
 /// Phase 0.5 Stage D — self-validating signature verification of an
@@ -380,7 +542,8 @@ impl FederationKeyResolver {
 /// 4. `exp` (if present) is in the future
 /// 5. SOME Ed25519 key in the embedded JWKS verifies the JWT signature
 ///
-/// Returns the verifying key that produced the signature.
+/// Returns the verifying key that produced the signature. For the full
+/// published key set (rotation-aware), use [`extract_self_issued_jwks`].
 ///
 /// This defeats tampering during delivery: a man-in-the-middle (or a
 /// compromised intermediary like DiscoveryService) cannot substitute
@@ -391,10 +554,43 @@ impl FederationKeyResolver {
 /// caller is expected to have already established that `expected_issuer`
 /// is in the trusted-issuer config; self-validation defeats tampering of
 /// the delivered statement, not initial trust establishment.
+#[cfg(test)]
 pub(crate) fn verify_self_issued_entity_statement(
     jwt: &str,
     expected_issuer: &str,
 ) -> Result<VerifyingKey> {
+    let (_entries, signer) = parse_self_issued_entity_statement(jwt, expected_issuer)?;
+    Ok(signer)
+}
+
+/// Phase 0.5 Stage D — self-validating signature verification of an
+/// OpenID Federation 1.0 entity statement received from DiscoveryService.
+///
+/// Returns the full published Ed25519 key set (each with its `kid`) after
+/// confirming at least one of them produced the statement's signature. The
+/// set is retained — not collapsed to the signer — so overlap rotation and
+/// PQ-hybrid publication work through the Discovery path as they do through
+/// HTTPS JWKS (#1185).
+fn extract_self_issued_jwks(
+    jwt: &str,
+    expected_issuer: &str,
+) -> Result<Vec<JwksEntry>> {
+    let (entries, _signer) = parse_self_issued_entity_statement(jwt, expected_issuer)?;
+    Ok(entries)
+}
+
+/// Shared parse + self-validation for a self-issued entity statement.
+///
+/// Performs the full structural/claim/exp checks and self-validates the
+/// signature against the embedded JWKS, returning both the complete
+/// Ed25519 candidate list (with kids) and the key that produced the
+/// signature. Both entry points (`verify_self_issued_entity_statement`
+/// for the single signer key, `extract_self_issued_jwks` for the rotation
+/// set) run this identical check.
+fn parse_self_issued_entity_statement(
+    jwt: &str,
+    expected_issuer: &str,
+) -> Result<(Vec<JwksEntry>, VerifyingKey)> {
     let parts: Vec<&str> = jwt.split('.').collect();
     if parts.len() != 3 {
         anyhow::bail!("entity statement JWT not in 3-part compact form");
@@ -437,7 +633,8 @@ pub(crate) fn verify_self_issued_entity_statement(
         }
     }
 
-    // JWKS — extract Ed25519 candidates.
+    // JWKS — extract every Ed25519 candidate, retaining each `kid` so the
+    // caller can select by id and keep overlap candidates (#1185).
     let keys = claims
         .get("jwks")
         .and_then(|j| j.get("keys"))
@@ -456,6 +653,8 @@ pub(crate) fn verify_self_issued_entity_statement(
     sig_arr.copy_from_slice(&sig_bytes);
     let signature = ed25519_dalek::Signature::from_bytes(&sig_arr);
 
+    let mut entries: Vec<JwksEntry> = Vec::new();
+    let mut signer: Option<VerifyingKey> = None;
     for key in keys {
         if key.get("kty").and_then(|v| v.as_str()) != Some("OKP")
             || key.get("crv").and_then(|v| v.as_str()) != Some("Ed25519")
@@ -478,15 +677,23 @@ pub(crate) fn verify_self_issued_entity_statement(
             Ok(v) => v,
             Err(_) => continue,
         };
-
-        if vk.verify_strict(signing_input.as_bytes(), &signature).is_ok() {
-            return Ok(vk);
+        let kid = key
+            .get("kid")
+            .and_then(|v| v.as_str())
+            .filter(|s| !s.is_empty())
+            .map(str::to_owned);
+        if signer.is_none() && vk.verify_strict(signing_input.as_bytes(), &signature).is_ok() {
+            signer = Some(vk);
         }
+        entries.push(JwksEntry { kid, key: vk });
     }
 
-    anyhow::bail!(
-        "entity statement self-validation failed: no Ed25519 key in jwks verifies the signature"
-    )
+    match signer {
+        Some(vk) => Ok((entries, vk)),
+        None => anyhow::bail!(
+            "entity statement self-validation failed: no Ed25519 key in jwks verifies the signature"
+        ),
+    }
 }
 
 // Adapter: delegates to the inherent methods. Using fully-qualified paths
@@ -498,8 +705,12 @@ impl FederationKeySource for FederationKeyResolver {
         FederationKeyResolver::is_trusted(self, issuer)
     }
 
-    async fn get_key(&self, issuer: &str) -> anyhow::Result<ed25519_dalek::VerifyingKey> {
-        FederationKeyResolver::get_key(self, issuer).await
+    async fn get_keys(
+        &self,
+        issuer: &str,
+        kid: Option<&str>,
+    ) -> anyhow::Result<Vec<ed25519_dalek::VerifyingKey>> {
+        FederationKeyResolver::get_keys(self, issuer, kid).await
     }
 }
 
@@ -781,5 +992,203 @@ mod tests {
         let err = verify_self_issued_entity_statement("not.a.jwt.with.too.many.parts", "x")
             .expect_err("malformed JWT must reject");
         assert!(format!("{err}").contains("3-part"), "got: {err}");
+    }
+
+    // ──────────────────────────────────────────────────────────────────
+    // #1185 — rotation-aware JWKS key set (overlap + kid selection)
+    // ──────────────────────────────────────────────────────────────────
+
+    use std::sync::atomic::{AtomicU32, Ordering};
+
+    fn jwk_with_kid(vk: &VerifyingKey, kid: &str) -> serde_json::Value {
+        serde_json::json!({
+            "kty": "OKP",
+            "crv": "Ed25519",
+            "x": b64u(vk.as_bytes()),
+            "use": "sig",
+            "alg": "EdDSA",
+            "kid": kid,
+        })
+    }
+
+    fn trusted_issuer(jwks_uri: &str) -> HashMap<String, crate::config::TrustedIssuerConfig> {
+        let mut issuers = HashMap::new();
+        issuers.insert(
+            "https://fed.example".to_owned(),
+            crate::config::TrustedIssuerConfig {
+                jwks_uri: Some(jwks_uri.to_owned()),
+                jwks_cache_ttl_secs: 300,
+                allow_http: true,
+            },
+        );
+        issuers
+    }
+
+    /// `parse_jwks_ed25519` retains EVERY published Ed25519 key with its kid,
+    /// not just the first — the core anti-singleton invariant from #1183.
+    #[test]
+    fn parse_jwks_retains_all_ed25519_entries_with_kids() {
+        let sk_a = SigningKey::generate(&mut OsRng);
+        let sk_b = SigningKey::generate(&mut OsRng);
+        let jwks = serde_json::json!({
+            "keys": [
+                jwk_with_kid(&sk_a.verifying_key(), "kid-old"),
+                jwk_with_kid(&sk_b.verifying_key(), "kid-new"),
+            ]
+        });
+        let entries = parse_jwks_ed25519(&jwks, "https://fed.example/jwks");
+        assert_eq!(entries.len(), 2, "both published keys must be retained");
+        let kids: Vec<Option<&str>> = entries.iter().map(|e| e.kid.as_deref()).collect();
+        assert!(kids.contains(&Some("kid-old")));
+        assert!(kids.contains(&Some("kid-new")));
+    }
+
+    /// The anti-pattern this ticket fixes: with two keys published and the
+    /// token signed by the SECOND key, `get_keys` must surface that key. The
+    /// old `fetch_ed25519_key` returned only the first key, so a verifier
+    /// had no candidate that could verify a second-key signature.
+    #[tokio::test]
+    async fn get_keys_overlap_returns_both_and_resolves_second_by_kid() {
+        let sk_old = SigningKey::generate(&mut OsRng);
+        let sk_new = SigningKey::generate(&mut OsRng);
+        let vk_old = sk_old.verifying_key();
+        let vk_new = sk_new.verifying_key();
+        let jwks = serde_json::json!({
+            "keys": [
+                jwk_with_kid(&vk_old, "kid-old"),
+                jwk_with_kid(&vk_new, "kid-new"),
+            ]
+        });
+        let fetcher: JwksFetcher = Arc::new(move |_url| {
+            let jwks = jwks.clone();
+            Box::pin(async move { Ok(jwks) })
+        });
+        let resolver =
+            FederationKeyResolver::new(&trusted_issuer("https://fed.example/jwks"))
+                .with_jwks_fetcher(fetcher);
+
+        // No kid → ALL candidates returned so the verifier can try each.
+        let all = resolver.get_keys("https://fed.example", None).await.expect("both keys");
+        assert_eq!(all.len(), 2, "overlap: both keys must be returned");
+
+        // kid-new must resolve to the new (second-published) key, ordered first.
+        let ordered = resolver
+            .get_keys("https://fed.example", Some("kid-new"))
+            .await
+            .expect("kid-new resolves");
+        assert_eq!(ordered.first().copied(), Some(vk_new), "kid-new is first");
+        assert!(ordered.contains(&vk_old), "old key retained as overlap candidate");
+
+        // kid-old still resolves during the overlap window.
+        let ordered_old = resolver
+            .get_keys("https://fed.example", Some("kid-old"))
+            .await
+            .expect("kid-old resolves");
+        assert_eq!(ordered_old.first().copied(), Some(vk_old));
+    }
+
+    /// A named `kid` that is not in the published set after a fresh fetch
+    /// MUST fail closed — never silently substitute another published key
+    /// (the positional-singleton anti-pattern, #1183).
+    #[tokio::test]
+    async fn get_keys_unknown_kid_fails_closed_without_substitution() {
+        let sk = SigningKey::generate(&mut OsRng);
+        let jwks =
+            serde_json::json!({"keys": [jwk_with_kid(&sk.verifying_key(), "kid-real")]});
+        let fetcher: JwksFetcher = Arc::new(move |_url| {
+            let jwks = jwks.clone();
+            Box::pin(async move { Ok(jwks) })
+        });
+        let resolver =
+            FederationKeyResolver::new(&trusted_issuer("https://fed.example/jwks"))
+                .with_jwks_fetcher(fetcher);
+
+        let err = resolver
+            .get_keys("https://fed.example", Some("kid-ghost"))
+            .await
+            .expect_err("unknown kid must fail closed");
+        assert!(
+            format!("{err}").contains("kid-ghost"),
+            "error must name the missing kid: {err}"
+        );
+    }
+
+    /// Overlap rotation lifecycle: publish [old,new] (both accepted), then
+    /// publish [new] only — the rotation completed and `old` is now retired
+    /// past its bounded observation window. A subsequent request for `old`
+    /// refetches and finds it gone, so it fails closed. This is the
+    /// "retired one rejected after bounded window" overlap test.
+    #[tokio::test]
+    async fn get_keys_retired_key_rejected_after_rotation_completes() {
+        let sk_old = SigningKey::generate(&mut OsRng);
+        let sk_new = SigningKey::generate(&mut OsRng);
+        let vk_old = sk_old.verifying_key();
+        let vk_new = sk_new.verifying_key();
+
+        // Overlap window: both keys published.
+        let overlap = serde_json::json!({
+            "keys": [
+                jwk_with_kid(&vk_old, "kid-old"),
+                jwk_with_kid(&vk_new, "kid-new"),
+            ]
+        });
+        // Post-rotation: only the new key remains (old retired).
+        let rotated = serde_json::json!({"keys": [jwk_with_kid(&vk_new, "kid-new")]});
+
+        // The fetcher returns `overlap` for the first call and `rotated`
+        // thereafter — modelling a JWKS that drops the old key between
+        // the two observations (the bounded drain window elapsing).
+        let call_count = Arc::new(AtomicU32::new(0));
+        let cc = call_count.clone();
+        let fetcher: JwksFetcher = Arc::new(move |_url| {
+            let cc = cc.clone();
+            let overlap = overlap.clone();
+            let rotated = rotated.clone();
+            Box::pin(async move {
+                let n = cc.fetch_add(1, Ordering::SeqCst);
+                if n == 0 {
+                    Ok(overlap)
+                } else {
+                    Ok(rotated)
+                }
+            })
+        });
+
+        // Use a zero TTL so the second lookup forces a fresh refetch.
+        let mut issuers = HashMap::new();
+        issuers.insert(
+            "https://fed.example".to_owned(),
+            crate::config::TrustedIssuerConfig {
+                jwks_uri: Some("https://fed.example/jwks".to_owned()),
+                jwks_cache_ttl_secs: 0,
+                allow_http: true,
+            },
+        );
+        let resolver =
+            FederationKeyResolver::new(&issuers).with_jwks_fetcher(fetcher);
+
+        // Overlap: old key still honoured.
+        let during_overlap = resolver
+            .get_keys("https://fed.example", Some("kid-old"))
+            .await
+            .expect("old key honoured during overlap");
+        assert!(during_overlap.contains(&vk_old));
+
+        // After rotation drains, the old kid is gone — refetch, fail closed.
+        let err = resolver
+            .get_keys("https://fed.example", Some("kid-old"))
+            .await
+            .expect_err("retired key must be rejected after drain");
+        assert!(
+            format!("{err}").contains("kid-old"),
+            "retired-key error must name the kid: {err}"
+        );
+
+        // The new key is unaffected.
+        let after = resolver
+            .get_keys("https://fed.example", Some("kid-new"))
+            .await
+            .expect("new key still resolves");
+        assert!(after.contains(&vk_new));
     }
 }

--- a/crates/hyprstream/src/auth/id_token_verify.rs
+++ b/crates/hyprstream/src/auth/id_token_verify.rs
@@ -67,32 +67,85 @@ pub async fn verify_id_token(
         .as_array()
         .ok_or_else(|| anyhow!("JWKS missing 'keys' array at {}", jwks_uri))?;
 
+    verify_id_token_with_keys(token, keys, expected_issuer, expected_audience)
+}
+
+/// Pure (HTTP-free) verification core: given the parsed JWKS `keys` array,
+/// verify an id_token's signature and claims. Exposed for tests so the
+/// overlap-rotation behaviour can be exercised without a mock server.
+///
+/// Selects every algorithm-compatible candidate and tries each until one
+/// verifies — never collapsing the published set to a positional singleton
+/// (#1183 / #1184).
+pub(crate) fn verify_id_token_with_keys(
+    token: &str,
+    keys: &[Value],
+    expected_issuer: &str,
+    expected_audience: &str,
+) -> Result<VerifiedIdToken> {
     // Extract the JWT header to get the `kid` for key selection
     let header = decode_jwt_header(token)?;
 
     let kid = header.get("kid").and_then(|v| v.as_str());
 
-    // Find the matching key from JWKS
-    let matching_key = find_matching_key(keys, kid, &header)?;
+    // Collect every algorithm-compatible candidate. When the JWT carries a
+    // `kid` the set is the kid-matched entries; when it does not, the set is
+    // every key whose `kty`/`crv` matches the header `alg`. The verifier then
+    // tries each until one verifies — never collapsing a published key SET to
+    // a positional singleton, which would foreclose overlap rotation and
+    // PQ-hybrid rollout (#1183 / #1184).
+    let candidates = candidate_keys(keys, kid, &header);
+    if candidates.is_empty() {
+        return Err(anyhow!(
+            "No JWKS key matches {} (kid={:?})",
+            header.get("alg").and_then(|v| v.as_str()).unwrap_or(""),
+            kid,
+        ));
+    }
 
-    // Build a jsonwebtoken::Validation with the correct algorithm
-    let alg = determine_algorithm(matching_key, &header)?;
+    // Build a jsonwebtoken::Validation. Algorithm is taken from the JWT header
+    // (each candidate shares the header `alg` because candidate_keys filtered
+    // on kty/crv consistency).
+    let alg = algorithm_from_header(&header)?;
     let mut validation = Validation::new(alg);
     validation.set_issuer(&[expected_issuer]);
     validation.set_audience(&[expected_audience]);
     // Allow 60 seconds of clock skew (same as provider.clock_skew_seconds default)
     validation.leeway = 60;
 
-    // Build the DecodingKey from the JWKS key
-    let decoding_key = build_decoding_key(matching_key)?;
+    // Try each candidate until one verifies. A JWKS may publish several keys
+    // simultaneously (overlap rotation / PQ-hybrid); only one is the real
+    // verifier and the rest are expected misses, logged at `debug`. An unknown
+    // or unsupported entry is skipped rather than failing the whole set.
+    let mut last_err: Option<anyhow::Error> = None;
+    for jwk in &candidates {
+        let decoding_key = match build_decoding_key(jwk) {
+            Ok(k) => k,
+            Err(e) => {
+                tracing::debug!(error = %e, "id_token: skipping JWKS key (invalid key material)");
+                last_err = Some(e);
+                continue;
+            }
+        };
+        match jsonwebtoken::decode::<Value>(token, &decoding_key, &validation) {
+            Ok(decoded) => {
+                return Ok(VerifiedIdToken {
+                    claims: decoded.claims,
+                });
+            }
+            Err(e) => {
+                tracing::debug!(error = %e, "id_token: candidate key did not verify; trying next");
+                last_err = Some(anyhow!("id_token signature verification failed: {}", e));
+            }
+        }
+    }
 
-    // Decode and verify
-    let decoded = jsonwebtoken::decode::<Value>(token, &decoding_key, &validation)
-        .map_err(|e| anyhow!("id_token signature verification failed: {}", e))?;
-
-    Ok(VerifiedIdToken {
-        claims: decoded.claims,
-    })
+    Err(last_err.unwrap_or_else(|| {
+        anyhow!(
+            "id_token verification failed: no candidate verified ({} candidates)",
+            candidates.len()
+        )
+    }))
 }
 
 /// Decode only the JWT header (without verification) for key selection.
@@ -108,71 +161,51 @@ fn decode_jwt_header(token: &str) -> Result<Value> {
         .map_err(|e| anyhow!("Invalid JSON in JWT header: {e}"))
 }
 
-/// Find the matching JWKS key by `kid` (if present) or by algorithm.
-fn find_matching_key<'a>(keys: &'a [Value], kid: Option<&str>, header: &Value) -> Result<&'a Value> {
-    // If kid is present, match by kid first
-    if let Some(kid) = kid {
-        for key in keys {
-            if key.get("kid").and_then(|v| v.as_str()) == Some(kid) {
-                return Ok(key);
-            }
-        }
-        return Err(anyhow!("No JWKS key found with kid='{}'", kid));
-    }
-
-    // No kid — try to match by algorithm from the header
+/// Collect every algorithm-compatible JWKS candidate for a JWT header.
+///
+/// When the JWT carries a `kid`, only entries with that exact `kid` are
+/// returned (there may be several — e.g. an Ed25519 entry and a composite
+/// entry published side-by-side under the same kid). When it carries no
+/// `kid`, every entry whose `kty`/`crv` matches the header `alg` is
+/// returned. Unknown / unsupported algorithms are skipped: the caller tries
+/// each candidate and a published set is never collapsed to a positional
+/// singleton (#1183 / #1184).
+fn candidate_keys<'a>(keys: &'a [Value], kid: Option<&str>, header: &Value) -> Vec<&'a Value> {
     let header_alg = header.get("alg").and_then(|v| v.as_str()).unwrap_or("");
-    for key in keys {
-        let key_kty = key.get("kty").and_then(|v| v.as_str()).unwrap_or("");
-        let matches = match header_alg {
-            "RS256" => key_kty == "RSA",
-            "ES256" => key_kty == "EC",
-            "EdDSA" => key_kty == "OKP",
-            _ => false,
-        };
-        if matches {
-            return Ok(key);
-        }
-    }
 
-    // Fallback: return first key
-    keys.first()
-        .ok_or_else(|| anyhow!("JWKS keys array is empty"))
+    keys.iter()
+        .filter(|key| {
+            // If a kid is presented, select by it; otherwise keep every
+            // algorithm-compatible entry.
+            if let Some(want) = kid {
+                let k = key.get("kid").and_then(|v| v.as_str());
+                return k == Some(want);
+            }
+            let key_kty = key.get("kty").and_then(|v| v.as_str()).unwrap_or("");
+            match header_alg {
+                "RS256" => key_kty == "RSA",
+                "ES256" => key_kty == "EC",
+                "EdDSA" => key_kty == "OKP",
+                _ => false,
+            }
+        })
+        .collect()
 }
 
-/// Determine the Algorithm from the JWKS key and JWT header.
-fn determine_algorithm(jwks_key: &Value, header: &Value) -> Result<Algorithm> {
-    let header_alg = header.get("alg").and_then(|v| v.as_str());
-
-    // Trust the JWT header's alg if it's one we support
-    if let Some(alg_str) = header_alg {
-        let alg = match alg_str {
-            "RS256" => Algorithm::RS256,
-            "ES256" => Algorithm::ES256,
-            "EdDSA" => Algorithm::EdDSA,
-            other => return Err(anyhow!("Unsupported JWT algorithm: {}", other)),
-        };
-        // Verify the JWKS key type is consistent
-        let kty = jwks_key.get("kty").and_then(|v| v.as_str()).unwrap_or("");
-        let expected_kty = match alg {
-            Algorithm::RS256 => "RSA",
-            Algorithm::ES256 => "EC",
-            Algorithm::EdDSA => "OKP",
-            _ => unreachable!(),
-        };
-        if kty != expected_kty {
-            return Err(anyhow!(
-                "JWT algorithm {} expects kty='{}' but JWKS key has kty='{}'",
-                alg_str,
-                expected_kty,
-                kty
-            ));
-        }
-        return Ok(alg);
+/// Resolve the jsonwebtoken `Algorithm` from the JWT header `alg`, after
+/// [`candidate_keys`] has already filtered the JWKS to kty/crv-consistent
+/// entries.
+fn algorithm_from_header(header: &Value) -> Result<Algorithm> {
+    let alg_str = header
+        .get("alg")
+        .and_then(|v| v.as_str())
+        .ok_or_else(|| anyhow!("JWT header missing 'alg'"))?;
+    match alg_str {
+        "RS256" => Ok(Algorithm::RS256),
+        "ES256" => Ok(Algorithm::ES256),
+        "EdDSA" => Ok(Algorithm::EdDSA),
+        other => Err(anyhow!("Unsupported JWT algorithm: {}", other)),
     }
-
-    // Infer from JWKS key type
-    algorithm_for_key_pub(jwks_key)
 }
 
 /// Public alias for the algorithm-from-JWK helper. Used by client_auth.
@@ -287,48 +320,214 @@ mod tests {
     }
 
     #[test]
-    fn test_determine_algorithm_from_header() {
-        let key = serde_json::json!({"kty": "RSA", "n": "abc", "e": "AQAB"});
+    fn test_algorithm_from_header_rs256() {
         let header = serde_json::json!({"alg": "RS256"});
-        assert_eq!(determine_algorithm(&key, &header).unwrap(), Algorithm::RS256);
+        assert_eq!(algorithm_from_header(&header).unwrap(), Algorithm::RS256);
     }
 
     #[test]
-    fn test_determine_algorithm_kty_mismatch() {
-        let key = serde_json::json!({"kty": "EC", "x": "abc", "y": "def"});
-        let header = serde_json::json!({"alg": "RS256"});
-        assert!(determine_algorithm(&key, &header).is_err());
+    fn test_algorithm_from_header_missing() {
+        let header = serde_json::json!({});
+        assert!(algorithm_from_header(&header).is_err());
     }
 
     #[test]
-    fn test_determine_algorithm_infer_from_kty() {
-        let rsa_key = serde_json::json!({"kty": "RSA"});
-        let empty_header = serde_json::json!({});
-        assert_eq!(
-            determine_algorithm(&rsa_key, &empty_header).unwrap(),
-            Algorithm::RS256
-        );
+    fn test_algorithm_from_header_unsupported() {
+        let header = serde_json::json!({"alg": "RS512"});
+        assert!(algorithm_from_header(&header).is_err());
     }
 
     #[test]
-    fn test_find_matching_key_by_kid() {
+    fn test_candidate_keys_by_kid() {
         let keys = vec![
             serde_json::json!({"kty": "RSA", "kid": "key-1", "n": "abc", "e": "AQAB"}),
             serde_json::json!({"kty": "RSA", "kid": "key-2", "n": "def", "e": "AQAB"}),
         ];
         let header = serde_json::json!({"alg": "RS256", "kid": "key-2"});
-        let found = find_matching_key(&keys, Some("key-2"), &header).unwrap();
-        assert_eq!(found["kid"], "key-2");
+        let found = candidate_keys(&keys, Some("key-2"), &header);
+        assert_eq!(found.len(), 1);
+        assert_eq!(found[0]["kid"], "key-2");
     }
 
     #[test]
-    fn test_find_matching_key_no_kid_matches_alg() {
+    fn test_candidate_keys_no_kid_returns_all_alg_compatible() {
+        // Two simultaneously published RSA keys (overlap rotation). Without a
+        // `kid`, the verifier MUST retain BOTH candidates so it can try each —
+        // collapsing to "the first one" forecloses overlap rotation and
+        // PQ-hybrid rollout (#1183 / #1184).
         let keys = vec![
-            serde_json::json!({"kty": "RSA", "n": "abc", "e": "AQAB"}),
+            serde_json::json!({"kty": "RSA", "kid": "key-1", "n": "abc", "e": "AQAB"}),
+            serde_json::json!({"kty": "RSA", "kid": "key-2", "n": "def", "e": "AQAB"}),
         ];
         let header = serde_json::json!({"alg": "RS256"});
-        let found = find_matching_key(&keys, None, &header).unwrap();
-        assert_eq!(found["kty"], "RSA");
+        let found = candidate_keys(&keys, None, &header);
+        assert_eq!(found.len(), 2);
+    }
+
+    #[test]
+    fn test_candidate_keys_skips_unknown_alg() {
+        // An unsupported/unknown algorithm entry MUST be skipped rather than
+        // fail the whole set — a PQ-capable verifier ignores what it does not
+        // recognize while a classical verifier keeps working against the
+        // classical entry.
+        let keys = vec![
+            serde_json::json!({"kty": "AKP", "alg": "ML-DSA-65-Ed25519", "kid": "pq"}),
+            serde_json::json!({"kty": "RSA", "kid": "classic", "n": "abc", "e": "AQAB"}),
+        ];
+        let header = serde_json::json!({"alg": "RS256"});
+        let found = candidate_keys(&keys, None, &header);
+        assert_eq!(found.len(), 1);
+        assert_eq!(found[0]["kid"], "classic");
+    }
+
+    #[test]
+    fn test_candidate_keys_no_kid_no_match() {
+        let keys = vec![
+            serde_json::json!({"kty": "EC", "kid": "ec-1", "x": "a", "y": "b"}),
+        ];
+        let header = serde_json::json!({"alg": "RS256"});
+        let found = candidate_keys(&keys, None, &header);
+        assert!(found.is_empty());
+    }
+
+    /// Build an EdDSA JWT signed with `signing_key`. The header carries the
+    /// given optional `kid`. Used by the overlap-rotation tests so they can
+    /// sign with arbitrary Ed25519 keys without a PEM/DER round-trip.
+    fn sign_eddsa_jwt(
+        signing_key: &ed25519_dalek::SigningKey,
+        claims: &serde_json::Value,
+        kid: Option<&str>,
+    ) -> String {
+        use ed25519_dalek::Signer;
+        let mut header = serde_json::json!({"alg": "EdDSA", "typ": "JWT"});
+        if let Some(k) = kid {
+            header["kid"] = serde_json::Value::String(k.to_owned());
+        }
+        let header_b64 = URL_SAFE_NO_PAD.encode(serde_json::to_vec(&header).unwrap());
+        let payload_b64 = URL_SAFE_NO_PAD.encode(serde_json::to_vec(claims).unwrap());
+        let signing_input = format!("{header_b64}.{payload_b64}");
+        let sig = signing_key.sign(signing_input.as_bytes());
+        let sig_b64 = URL_SAFE_NO_PAD.encode(sig.to_bytes());
+        format!("{signing_input}.{sig_b64}")
+    }
+
+    fn jwks_ed25519(entries: &[(&str, &ed25519_dalek::VerifyingKey)]) -> Vec<Value> {
+        entries
+            .iter()
+            .map(|(kid, vk)| {
+                serde_json::json!({
+                    "kty": "OKP", "crv": "Ed25519", "alg": "EdDSA",
+                    "kid": kid,
+                    "x": URL_SAFE_NO_PAD.encode(vk.as_bytes()),
+                })
+            })
+            .collect()
+    }
+
+    /// #1184: a kid-less id_token signed by the SECOND of two simultaneously
+    /// published Ed25519 keys must verify against the JWKS set. The previous
+    /// implementation returned `keys.first()` and would fail for the non-first
+    /// signer; reverting this hunk to "try only the first candidate" makes
+    /// this test fail.
+    #[test]
+    fn id_token_kid_less_signer_is_non_first_published_key() -> anyhow::Result<()> {
+        let sk_a = ed25519_dalek::SigningKey::from_bytes(&[0xA0; 32]);
+        let sk_b = ed25519_dalek::SigningKey::from_bytes(&[0xB0; 32]);
+
+        // Publish BOTH keys (overlap window): lead first, drain second.
+        let keys = jwks_ed25519(&[("lead", &sk_a.verifying_key()), ("drain", &sk_b.verifying_key())]);
+
+        // Sign with the SECOND (drain) key — no `kid` in the header.
+        let claims = serde_json::json!({
+            "iss": "https://idp.example.com",
+            "aud": "client-42",
+            "sub": "user-1",
+            "exp": (jsonwebtoken::get_current_timestamp() + 300),
+        });
+        let token = sign_eddsa_jwt(&sk_b, &claims, None);
+
+        let verified = verify_id_token_with_keys(
+            &token,
+            &keys,
+            "https://idp.example.com",
+            "client-42",
+        )?;
+        assert_eq!(verified.claims["sub"], "user-1");
+        Ok(())
+    }
+
+    /// #1184 overlap: while both keys are published, a token signed by either
+    /// verifies (first AND non-first), and a token signed by an UNKNOWN key
+    /// that is not in the set is rejected.
+    #[test]
+    fn id_token_overlap_both_signers_accepted_unknown_rejected() -> anyhow::Result<()> {
+        let sk_lead = ed25519_dalek::SigningKey::from_bytes(&[0x11; 32]);
+        let sk_drain = ed25519_dalek::SigningKey::from_bytes(&[0x22; 32]);
+        let sk_unknown = ed25519_dalek::SigningKey::from_bytes(&[0x99; 32]);
+
+        let keys = jwks_ed25519(&[
+            ("lead", &sk_lead.verifying_key()),
+            ("drain", &sk_drain.verifying_key()),
+        ]);
+
+        let claims = serde_json::json!({
+            "iss": "https://idp.example.com",
+            "aud": "client-42",
+            "sub": "user-1",
+            "exp": (jsonwebtoken::get_current_timestamp() + 300),
+        });
+
+        // First (lead) signer — accepted.
+        let token_lead = sign_eddsa_jwt(&sk_lead, &claims, None);
+        let v = verify_id_token_with_keys(&token_lead, &keys, "https://idp.example.com", "client-42")?;
+        assert_eq!(v.claims["sub"], "user-1");
+
+        // Non-first (drain) signer — accepted.
+        let token_drain = sign_eddsa_jwt(&sk_drain, &claims, None);
+        let v = verify_id_token_with_keys(&token_drain, &keys, "https://idp.example.com", "client-42")?;
+        assert_eq!(v.claims["sub"], "user-1");
+
+        // Unknown signer (not in the published set) — rejected.
+        let token_bad = sign_eddsa_jwt(&sk_unknown, &claims, None);
+        let err = verify_id_token_with_keys(&token_bad, &keys, "https://idp.example.com", "client-42")
+            .unwrap_err();
+        assert!(
+            err.to_string().contains("signature verification failed")
+                || err.to_string().contains("no candidate verified"),
+            "unexpected error: {err}"
+        );
+        Ok(())
+    }
+
+    /// #1184: an unsupported/unknown algorithm entry in the JWKS MUST be
+    /// skipped rather than fail the whole set — a PQ-capable verifier ignores
+    /// what it does not recognize while a classical verifier keeps working
+    /// against the classical entry.
+    #[test]
+    fn id_token_skips_unsupported_alg_and_accepts_classical() -> anyhow::Result<()> {
+        let sk = ed25519_dalek::SigningKey::from_bytes(&[0x33; 32]);
+        let vk = sk.verifying_key();
+
+        let keys = vec![
+            // Unknown composite_alg entry — must be skipped, not fatal.
+            serde_json::json!({"kty": "AKP", "alg": "ML-DSA-65-Ed25519", "kid": "pq"}),
+            // Classical Ed25519 entry — the real verifier.
+            serde_json::json!({
+                "kty": "OKP", "crv": "Ed25519", "alg": "EdDSA", "kid": "classic",
+                "x": URL_SAFE_NO_PAD.encode(vk.as_bytes()),
+            }),
+        ];
+
+        let claims = serde_json::json!({
+            "iss": "https://idp.example.com",
+            "aud": "client-42",
+            "sub": "user-1",
+            "exp": (jsonwebtoken::get_current_timestamp() + 300),
+        });
+        let token = sign_eddsa_jwt(&sk, &claims, None);
+        let v = verify_id_token_with_keys(&token, &keys, "https://idp.example.com", "client-42")?;
+        assert_eq!(v.claims["sub"], "user-1");
+        Ok(())
     }
 
     #[test]

--- a/crates/hyprstream/src/auth/jwt.rs
+++ b/crates/hyprstream/src/auth/jwt.rs
@@ -3,7 +3,8 @@
 //! Re-exports EdDSA signing from hyprstream-rpc and adds ES256 (P-256) signing.
 
 pub use hyprstream_rpc::auth::{
-    decode, decode_with_candidates, decode_with_key, encode, encode_service_jwt, Claims, JwtError,
+    decode, decode_with_candidates, decode_with_federation_candidates, decode_with_key, encode,
+    encode_service_jwt, Claims, JwtError,
 };
 
 use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine as _};

--- a/crates/hyprstream/src/auth/jwt.rs
+++ b/crates/hyprstream/src/auth/jwt.rs
@@ -3,7 +3,7 @@
 //! Re-exports EdDSA signing from hyprstream-rpc and adds ES256 (P-256) signing.
 
 pub use hyprstream_rpc::auth::{
-    decode, decode_with_key, encode, encode_service_jwt, Claims, JwtError,
+    decode, decode_with_candidates, decode_with_key, encode, encode_service_jwt, Claims, JwtError,
 };
 
 use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine as _};

--- a/crates/hyprstream/src/auth/jwt.rs
+++ b/crates/hyprstream/src/auth/jwt.rs
@@ -3,7 +3,8 @@
 //! Re-exports EdDSA signing from hyprstream-rpc and adds ES256 (P-256) signing.
 
 pub use hyprstream_rpc::auth::{
-    decode, decode_with_key, encode, encode_service_jwt, Claims, JwtError,
+    decode, decode_with_any_key, decode_with_any_key_lenient, decode_with_key, encode,
+    encode_service_jwt, Claims, JwtError,
 };
 
 use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine as _};

--- a/crates/hyprstream/src/server/middleware.rs
+++ b/crates/hyprstream/src/server/middleware.rs
@@ -444,10 +444,33 @@ pub(crate) async fn verify_token_claims(
         if !state.federation_resolver.is_trusted(&iss) {
             return Err("untrusted federation issuer");
         }
-        match state.federation_resolver.get_key(&iss).await {
-            Ok(key) => jwt::decode_with_key(token, &key, Some(&state.resource_url))
-                .map_err(|_| "JWT validation failed")?,
-            Err(_) => return Err("federation key resolution failed"),
+        // Rotation-aware federation verification (#1185): the resolver
+        // returns every Ed25519 key the issuer currently publishes
+        // (ordered kid-first), and we accept the token if ANY candidate
+        // verifies it. This is what makes overlap rotation safe — a
+        // token signed by a non-first key succeeds when its kid is
+        // published — and mirrors `decode_local_multi_key` for external
+        // issuers. The token's own `kid`, when present, is passed to
+        // the resolver so it can refetch on an unknown kid.
+        let kid = extract_kid_from_token(token);
+        match state.federation_resolver.get_keys(&iss, kid.as_deref()).await {
+            Ok(candidates) if !candidates.is_empty() => {
+                let mut verified: Option<jwt::Claims> = None;
+                for key in &candidates {
+                    if let Ok(claims) =
+                        jwt::decode_with_key(token, key, Some(&state.resource_url))
+                    {
+                        verified = Some(claims);
+                        break;
+                    }
+                }
+                match verified {
+                    Some(claims) => claims,
+                    None => return Err("JWT validation failed"),
+                }
+            }
+            // Empty candidate set or fetch failure: fail closed either way.
+            Ok(_) | Err(_) => return Err("federation key resolution failed"),
         }
     };
 

--- a/crates/hyprstream/src/server/middleware.rs
+++ b/crates/hyprstream/src/server/middleware.rs
@@ -4,7 +4,7 @@ use crate::auth::jwt;
 use crate::server::state::ServerState;
 use axum::{
     extract::{Request, State},
-    http::{header, HeaderValue, StatusCode},
+    http::{HeaderValue, StatusCode, header},
     middleware::Next,
     response::{IntoResponse, Response},
 };
@@ -379,7 +379,9 @@ fn decode_composite_multi(
         hyprstream_rpc::auth::RFC9068_ACCESS_TOKEN_TYPES,
     )
     .map_err(|_| "JWT validation failed")?;
-    if dispatch.kid() != header.kid { return Err("JWT validation failed"); }
+    if dispatch.kid() != header.kid {
+        return Err("JWT validation failed");
+    }
     let pair = published_composite
         .iter()
         .find(|pair| pair.kid() == header.kid)
@@ -453,11 +455,17 @@ pub(crate) async fn verify_token_claims(
         // issuers. The token's own `kid`, when present, is passed to
         // the resolver so it can refetch on an unknown kid.
         let kid = extract_kid_from_token(token);
-        match state.federation_resolver.get_keys(&iss, kid.as_deref()).await {
-            Ok(candidates) if !candidates.is_empty() => {
-                jwt::decode_with_candidates(token, &candidates, Some(&state.resource_url))
-                    .map_err(|_| "JWT validation failed")?
-            }
+        match state
+            .federation_resolver
+            .get_keys(&iss, kid.as_deref())
+            .await
+        {
+            Ok(candidates) if !candidates.is_empty() => jwt::decode_with_federation_candidates(
+                token,
+                &candidates,
+                Some(&state.resource_url),
+            )
+            .map_err(|_| "JWT validation failed")?,
             // Empty candidate set or fetch failure: fail closed either way.
             Ok(_) | Err(_) => return Err("federation key resolution failed"),
         }
@@ -496,7 +504,7 @@ fn unauthorized_response(message: &str, www_authenticate: &str) -> Response {
 /// Exported for use in other middleware-like contexts (e.g. MCP inline auth).
 /// Returns an empty string on any parse failure.
 pub fn extract_iss_from_token(token: &str) -> String {
-    use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine};
+    use base64::{Engine, engine::general_purpose::URL_SAFE_NO_PAD};
     let parts: Vec<&str> = token.splitn(3, '.').collect();
     if parts.len() < 2 {
         return String::new();
@@ -522,7 +530,7 @@ pub fn extract_iss_from_token(token: &str) -> String {
 
 /// Extract `kid` from a JWT header without full validation.
 pub fn extract_kid_from_token(token: &str) -> Option<String> {
-    use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine};
+    use base64::{Engine, engine::general_purpose::URL_SAFE_NO_PAD};
     let header_b64 = token.split('.').next()?;
     if header_b64.len() > 4096 {
         return None;
@@ -655,7 +663,7 @@ mod tests {
 
     #[test]
     fn test_extract_iss_from_token() {
-        use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine};
+        use base64::{Engine, engine::general_purpose::URL_SAFE_NO_PAD};
 
         // Craft a JWT with iss in payload: header.payload.sig
         // payload = base64url({"iss":"https://node-a","sub":"alice","exp":9999999999,"iat":0})
@@ -684,7 +692,7 @@ mod tests {
 #[allow(clippy::unwrap_used, clippy::expect_used)]
 mod rotation_aware_tests {
     use super::*;
-    use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine as _};
+    use base64::{Engine as _, engine::general_purpose::URL_SAFE_NO_PAD};
     use ed25519_dalek::{Signer as _, SigningKey};
 
     const AUD: &str = "https://node-a/resource";
@@ -703,12 +711,7 @@ mod rotation_aware_tests {
         signed_token_with_type(key, aud, jti, "at+jwt")
     }
 
-    fn signed_token_with_type(
-        key: &SigningKey,
-        aud: &str,
-        jti: Option<&str>,
-        typ: &str,
-    ) -> String {
+    fn signed_token_with_type(key: &SigningKey, aud: &str, jti: Option<&str>, typ: &str) -> String {
         let n = now();
         let mut claims =
             jwt::Claims::new("alice".to_owned(), n, n + 3600).with_audience(Some(aud.to_owned()));
@@ -829,7 +832,7 @@ mod rotation_aware_tests {
             Some(AUD),
             true,
         )
-            .unwrap_err();
+        .unwrap_err();
         assert_eq!(err, "JWT validation failed");
     }
 
@@ -850,7 +853,7 @@ mod rotation_aware_tests {
             Some(AUD),
             true,
         )
-            .unwrap_err();
+        .unwrap_err();
         assert_eq!(err, "JWT validation failed");
     }
 
@@ -921,7 +924,7 @@ mod rotation_aware_tests {
 mod composite_aware_tests {
     use super::*;
     use crate::auth::jwt::encode_composite_ml_dsa_65_ed25519;
-    use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine};
+    use base64::{Engine, engine::general_purpose::URL_SAFE_NO_PAD};
     use ed25519_dalek::SigningKey;
 
     const AUD: &str = "https://node-a/resource";
@@ -1098,15 +1101,17 @@ mod composite_aware_tests {
             published_pair(pq_b_vk, ed_b.verifying_key()),
         ];
 
-        assert!(decode_local_multi_key(
-            &cross_token,
-            &ca.verifying_key(),
-            &[ed_a.verifying_key(), ed_b.verifying_key()],
-            &published,
-            Some(AUD),
-            false,
-        )
-        .is_err());
+        assert!(
+            decode_local_multi_key(
+                &cross_token,
+                &ca.verifying_key(),
+                &[ed_a.verifying_key(), ed_b.verifying_key()],
+                &published,
+                Some(AUD),
+                false,
+            )
+            .is_err()
+        );
     }
 
     #[test]
@@ -1159,7 +1164,7 @@ mod composite_aware_tests {
             (
                 "future",
                 jwt::Claims::new("future".to_owned(), now() + 120, now() + 3600)
-                .with_audience(Some(AUD.to_owned())),
+                    .with_audience(Some(AUD.to_owned())),
             ),
             (
                 "no-aud",
@@ -1177,13 +1182,13 @@ mod composite_aware_tests {
             );
             assert!(
                 decode_local_multi_key(
-                &token,
-                &ca.verifying_key(),
-                &[ed.verifying_key()],
-                std::slice::from_ref(&pair),
-                Some(AUD),
-                false,
-            )
+                    &token,
+                    &ca.verifying_key(),
+                    &[ed.verifying_key()],
+                    std::slice::from_ref(&pair),
+                    Some(AUD),
+                    false,
+                )
                 .is_err(),
                 "accepted invalid {case} claims"
             );
@@ -1244,15 +1249,17 @@ mod composite_aware_tests {
         let sig_bytes = URL_SAFE_NO_PAD.decode(sig_b64).unwrap();
         for stripped in [&sig_bytes[..3309], &sig_bytes[3309..]] {
             let tampered = format!("{}.{}", &token[..dot2], URL_SAFE_NO_PAD.encode(stripped));
-            assert!(decode_local_multi_key(
-                &tampered,
-                &ca.verifying_key(),
-                &published_ed,
-                &pairs,
-                Some(AUD),
-                false,
-            )
-            .is_err());
+            assert!(
+                decode_local_multi_key(
+                    &tampered,
+                    &ca.verifying_key(),
+                    &published_ed,
+                    &pairs,
+                    Some(AUD),
+                    false,
+                )
+                .is_err()
+            );
         }
     }
 
@@ -1281,15 +1288,17 @@ mod composite_aware_tests {
         .unwrap();
         assert_eq!(claims.sub, "alice");
 
-        assert!(decode_local_multi_key(
-            &token,
-            &ca.verifying_key(),
-            &published_ed,
-            &pairs,
-            Some(AUD),
-            false,
-        )
-        .is_err());
+        assert!(
+            decode_local_multi_key(
+                &token,
+                &ca.verifying_key(),
+                &published_ed,
+                &pairs,
+                Some(AUD),
+                false,
+            )
+            .is_err()
+        );
     }
 
     #[test]
@@ -1380,7 +1389,7 @@ mod composite_aware_tests {
 #[allow(clippy::expect_used)]
 mod browser_provisioning_rate_limit_tests {
     use super::*;
-    use axum::{body::Body, http::Request as HttpRequest, middleware, routing::get, Router};
+    use axum::{Router, body::Body, http::Request as HttpRequest, middleware, routing::get};
     use std::sync::atomic::{AtomicUsize, Ordering};
     use tower::ServiceExt;
 
@@ -1407,11 +1416,19 @@ mod browser_provisioning_rate_limit_tests {
 
         let first = app
             .clone()
-            .oneshot(HttpRequest::get("/provision").body(Body::empty()).expect("request"))
+            .oneshot(
+                HttpRequest::get("/provision")
+                    .body(Body::empty())
+                    .expect("request"),
+            )
             .await
             .expect("first response");
         let rejected = app
-            .oneshot(HttpRequest::get("/provision").body(Body::empty()).expect("request"))
+            .oneshot(
+                HttpRequest::get("/provision")
+                    .body(Body::empty())
+                    .expect("request"),
+            )
             .await
             .expect("limited response");
 

--- a/crates/hyprstream/src/server/middleware.rs
+++ b/crates/hyprstream/src/server/middleware.rs
@@ -455,19 +455,8 @@ pub(crate) async fn verify_token_claims(
         let kid = extract_kid_from_token(token);
         match state.federation_resolver.get_keys(&iss, kid.as_deref()).await {
             Ok(candidates) if !candidates.is_empty() => {
-                let mut verified: Option<jwt::Claims> = None;
-                for key in &candidates {
-                    if let Ok(claims) =
-                        jwt::decode_with_key(token, key, Some(&state.resource_url))
-                    {
-                        verified = Some(claims);
-                        break;
-                    }
-                }
-                match verified {
-                    Some(claims) => claims,
-                    None => return Err("JWT validation failed"),
-                }
+                jwt::decode_with_candidates(token, &candidates, Some(&state.resource_url))
+                    .map_err(|_| "JWT validation failed")?
             }
             // Empty candidate set or fetch failure: fail closed either way.
             Ok(_) | Err(_) => return Err("federation key resolution failed"),

--- a/crates/hyprstream/src/services/factories.rs
+++ b/crates/hyprstream/src/services/factories.rs
@@ -1477,8 +1477,12 @@ fn create_mcp_service(ctx: &ServiceContext) -> anyhow::Result<Box<dyn Spawnable>
                             let iss = crate::server::middleware::extract_iss_from_token(&t);
                             let kid = crate::server::middleware::extract_kid_from_token(&t);
                             let result = if let Some(ref key_source) = jwt_key_source {
-                                match key_source.get_key(&iss, kid.as_deref()).await {
-                                    Ok(key) => crate::auth::jwt::decode(&t, &key, Some(mcp_resource_url.as_str())),
+                                match key_source.get_keys(&iss, kid.as_deref()).await {
+                                    Ok(candidates) => crate::auth::jwt::decode_with_any_key(
+                                        &t,
+                                        &candidates,
+                                        Some(mcp_resource_url.as_str()),
+                                    ),
                                     Err(e) => {
                                         tracing::debug!(%method, %uri, issuer = %iss, error = %e, "MCP JWT key resolution failed");
                                         let mut res = (StatusCode::UNAUTHORIZED, "Authentication failed").into_response();

--- a/crates/hyprstream/src/services/factories.rs
+++ b/crates/hyprstream/src/services/factories.rs
@@ -1495,26 +1495,11 @@ fn create_mcp_service(ctx: &ServiceContext) -> anyhow::Result<Box<dyn Spawnable>
                                 // verifies during overlap rotation.
                                 match federation_resolver.get_keys(&iss, kid.as_deref()).await {
                                     Ok(candidates) if !candidates.is_empty() => {
-                                        let mut decoded: Option<crate::auth::jwt::Claims> = None;
-                                        let mut last_err: Option<crate::auth::jwt::JwtError> = None;
-                                        for key in &candidates {
-                                            match crate::auth::jwt::decode_with_key(
-                                                &t,
-                                                key,
-                                                Some(mcp_resource_url.as_str()),
-                                            ) {
-                                                Ok(c) => {
-                                                    decoded = Some(c);
-                                                    break;
-                                                }
-                                                Err(e) => last_err = Some(e),
-                                            }
-                                        }
-                                        match (decoded, last_err) {
-                                            (Some(c), _) => Ok(c),
-                                            (None, Some(e)) => Err(e),
-                                            (None, None) => Err(crate::auth::jwt::JwtError::InvalidFormat),
-                                        }
+                                        crate::auth::jwt::decode_with_candidates(
+                                            &t,
+                                            &candidates,
+                                            Some(mcp_resource_url.as_str()),
+                                        )
                                     }
                                     Ok(_) => Err(crate::auth::jwt::JwtError::InvalidFormat),
                                     Err(e) => {

--- a/crates/hyprstream/src/services/factories.rs
+++ b/crates/hyprstream/src/services/factories.rs
@@ -1489,8 +1489,34 @@ fn create_mcp_service(ctx: &ServiceContext) -> anyhow::Result<Box<dyn Spawnable>
                                     }
                                 }
                             } else {
-                                match federation_resolver.get_key(&iss).await {
-                                    Ok(key) => crate::auth::jwt::decode_with_key(&t, &key, Some(mcp_resource_url.as_str())),
+                                // Rotation-aware federation verification (#1185):
+                                // try each published candidate (kid-first) so a
+                                // token signed by a non-first published key
+                                // verifies during overlap rotation.
+                                match federation_resolver.get_keys(&iss, kid.as_deref()).await {
+                                    Ok(candidates) if !candidates.is_empty() => {
+                                        let mut decoded: Option<crate::auth::jwt::Claims> = None;
+                                        let mut last_err: Option<crate::auth::jwt::JwtError> = None;
+                                        for key in &candidates {
+                                            match crate::auth::jwt::decode_with_key(
+                                                &t,
+                                                key,
+                                                Some(mcp_resource_url.as_str()),
+                                            ) {
+                                                Ok(c) => {
+                                                    decoded = Some(c);
+                                                    break;
+                                                }
+                                                Err(e) => last_err = Some(e),
+                                            }
+                                        }
+                                        match (decoded, last_err) {
+                                            (Some(c), _) => Ok(c),
+                                            (None, Some(e)) => Err(e),
+                                            (None, None) => Err(crate::auth::jwt::JwtError::InvalidFormat),
+                                        }
+                                    }
+                                    Ok(_) => Err(crate::auth::jwt::JwtError::InvalidFormat),
                                     Err(e) => {
                                         tracing::debug!(%method, %uri, issuer = %iss, error = %e, "MCP federation key resolution failed");
                                         let mut res = (StatusCode::UNAUTHORIZED, "Authentication failed").into_response();

--- a/crates/hyprstream/src/services/factories.rs
+++ b/crates/hyprstream/src/services/factories.rs
@@ -32,8 +32,8 @@ use hyprstream_service::{ServiceContext, Spawnable};
 use tokio::sync::RwLock;
 use tracing::info;
 
-use crate::auth::identity_store::credentials_dir;
 use crate::auth::PolicyManager;
+use crate::auth::identity_store::credentials_dir;
 use crate::config::{HyprConfig, TokenConfig};
 use crate::services::generated::policy_client::{RefreshServiceTokenRequest, RegisterServiceKey};
 use crate::services::{
@@ -269,8 +269,8 @@ fn register_service_key(
 /// Used for local-disk JWTs that we issued ourselves — signature is verified
 /// by PolicyService; here we only need the expiry to decide whether to renew.
 fn decode_jwt_exp(jwt: &str) -> Option<i64> {
-    use base64::engine::general_purpose::URL_SAFE_NO_PAD;
     use base64::Engine as _;
+    use base64::engine::general_purpose::URL_SAFE_NO_PAD;
     let payload_b64 = jwt.split('.').nth(1)?;
     let payload = URL_SAFE_NO_PAD.decode(payload_b64).ok()?;
     let value: serde_json::Value = serde_json::from_slice(&payload).ok()?;
@@ -494,7 +494,9 @@ fn create_ledger_service(ctx: &ServiceContext) -> anyhow::Result<Box<dyn Spawnab
     let config = load_config();
     let lcfg = config.ledger.clone();
     if !lcfg.is_enabled() {
-        anyhow::bail!("ledger service requested but [ledger] enabled = false (the Phase-1 enforcer is opt-in)");
+        anyhow::bail!(
+            "ledger service requested but [ledger] enabled = false (the Phase-1 enforcer is opt-in)"
+        );
     }
 
     // Cell identity = did:key over the service Ed25519 key.
@@ -517,7 +519,11 @@ fn create_ledger_service(ctx: &ServiceContext) -> anyhow::Result<Box<dyn Spawnab
             tokio::runtime::Handle::current().block_on(async { store.active_key().await })
         });
         match pq_key {
-            Some(k) => Arc::new(CoseCheckpointSigner::hybrid(cell_identity.clone(), ed_sk, (*k).clone())),
+            Some(k) => Arc::new(CoseCheckpointSigner::hybrid(
+                cell_identity.clone(),
+                ed_sk,
+                (*k).clone(),
+            )),
             None => anyhow::bail!(
                 "ledger: require_pq_signatures is set but no ML-DSA-65 key is available (fail-closed)"
             ),
@@ -994,7 +1000,7 @@ fn create_worker_service(ctx: &ServiceContext) -> anyhow::Result<Box<dyn Spawnab
     use hyprstream_workers::config::PoolConfig;
     #[cfg(feature = "oci-image")]
     use hyprstream_workers::image::RafsStore;
-    use hyprstream_workers::{resolve_backend, BackendCtx, SandboxBackend, WorkerService};
+    use hyprstream_workers::{BackendCtx, SandboxBackend, WorkerService, resolve_backend};
 
     let config = load_config();
     let worker_quic_port = config.worker.as_ref().and_then(|w| w.quic_port);
@@ -1110,8 +1116,8 @@ fn create_oai_service(ctx: &ServiceContext) -> anyhow::Result<Box<dyn Spawnable>
     info!("Creating OAIService");
 
     use crate::server::state::ServerState;
-    use crate::services::generated::model_client::ModelClient;
     use crate::services::OAIService;
+    use crate::services::generated::model_client::ModelClient;
 
     // Load full config for OAI settings
     let config = load_config();
@@ -1291,7 +1297,9 @@ fn create_oauth_service(ctx: &ServiceContext) -> anyhow::Result<Box<dyn Spawnabl
     if let Some(bl) = SHARED_JTI_BLOCKLIST.get() {
         oauth_service = oauth_service.with_jti_blocklist(Arc::clone(bl));
     } else {
-        tracing::warn!("JTI blocklist not set by PolicyService factory — revoked access tokens will not be blocked at RPC layer");
+        tracing::warn!(
+            "JTI blocklist not set by PolicyService factory — revoked access tokens will not be blocked at RPC layer"
+        );
     }
 
     Ok(Box::new(oauth_service))
@@ -1495,7 +1503,7 @@ fn create_mcp_service(ctx: &ServiceContext) -> anyhow::Result<Box<dyn Spawnable>
                                 // verifies during overlap rotation.
                                 match federation_resolver.get_keys(&iss, kid.as_deref()).await {
                                     Ok(candidates) if !candidates.is_empty() => {
-                                        crate::auth::jwt::decode_with_candidates(
+                                        crate::auth::jwt::decode_with_federation_candidates(
                                             &t,
                                             &candidates,
                                             Some(mcp_resource_url.as_str()),
@@ -1701,7 +1709,7 @@ fn create_mcp_service(ctx: &ServiceContext) -> anyhow::Result<Box<dyn Spawnable>
 fn create_tui_service(ctx: &ServiceContext) -> anyhow::Result<Box<dyn Spawnable>> {
     info!("Creating TuiService");
 
-    use crate::tui::{service::TuiService, TuiState};
+    use crate::tui::{TuiState, service::TuiService};
 
     // TUI publishes terminal frames (stdin/stdout) over moq via
     // StreamChannel::publisher(), and returns its per-PID moq UDS path to the
@@ -1892,9 +1900,9 @@ fn create_metrics_service(ctx: &ServiceContext) -> anyhow::Result<Box<dyn Spawna
     init_local_moq_stream_plane("metrics");
 
     use crate::services::MetricsService;
+    use hyprstream_metrics::StorageBackend as _;
     use hyprstream_metrics::query::QueryOrchestrator;
     use hyprstream_metrics::storage::duckdb::DuckDbBackend;
-    use hyprstream_metrics::StorageBackend as _;
 
     let config = load_config();
     let mc = &config.metrics;


### PR DESCRIPTION
Consolidates #1213 and #1214 into one I2-compliant JWKS rotation fix.

- A JWT declaring `kid=X` resolves and verifies only key X; no co-published-key substitution.
- Only kid-less JWTs may try all compatible JWKS candidates.
- Each candidate receives complete verification with the algorithm pinned to the supported key type/curve.
- Adds regressions for the proven `kid-new` / signed-by-`kid-old` exploit and non-first kid-less overlap keys.

Validation:
- `buildq -- cargo test -p hyprstream-rpc auth::jwt` — 19 passed
- `buildq -- cargo test -p hyprstream auth` — 357 passed (with installed Python libtorch environment)
- pre-commit clippy — passed

Supersedes #1213 and #1214.