### PR TITLE
fix(runtime): production multi-GPU pipeline forward — move activations across device boundaries (#314)

### DIFF
--- a/crates/hyprstream/src/runtime/architectures/llama.rs
+++ b/crates/hyprstream/src/runtime/architectures/llama.rs
@@ -2292,11 +2292,29 @@ impl LlamaModel {
                 (tch::Kind::Int64, hidden_states.device()),
             )
         };
+        let mut position_ids = position_ids;
 
         // PERF: Lock KV cache ONCE before the layer loop (not 28 times inside!)
         let cache_guard = self.kv_cache.as_ref().map(|cache_ref| cache_ref.lock());
 
         for (idx, layer) in self.layers.iter().enumerate() {
+            // Production cached forwards own the full mapped layer range, so
+            // carry both device-bound inputs across each real layer boundary.
+            // This mirrors `forward_layers_inner`; the unsplit fast path never
+            // enters this branch.
+            let global_idx = self.layer_offset + idx;
+            let target = self.device_map.device_for(global_idx);
+            if hidden_states.device() != target {
+                tracing::debug!(
+                    layer = global_idx,
+                    from = ?hidden_states.device(),
+                    to = ?target,
+                    "Llama cached forward crossing device boundary"
+                );
+                hidden_states = hidden_states.to_device(target);
+                position_ids = position_ids.to_device(target);
+            }
+
             let residual = hidden_states.shallow_clone();
 
             // Self-attention block with optional KV cache and delta injection
@@ -2336,6 +2354,19 @@ impl LlamaModel {
             hidden_states = layer.post_attention_layernorm.forward(&hidden_states)?;
             let ffn_output = layer.mlp.forward(&hidden_states, delta)?;
             hidden_states = residual + ffn_output;
+        }
+
+        // Non-layer weights live on the engine's primary device. A split model
+        // finishes its decoder stack on the final layer's device, so return the
+        // activation once before final norm / lm_head. This is also a no-op for
+        // the single-device path.
+        if hidden_states.device() != self.device {
+            tracing::debug!(
+                from = ?hidden_states.device(),
+                to = ?self.device,
+                "Llama cached forward returning activation to output device"
+            );
+            hidden_states = hidden_states.to_device(self.device);
         }
 
         // Final layer norm
@@ -2537,9 +2568,29 @@ impl LlamaModel {
         // each, mirroring the single-sequence path's lock-once strategy).
         let guards: Vec<_> = sequences.iter().map(|(_, _, c)| c.lock()).collect();
 
-        let position_refs: Vec<Tensor> = position_ids; // already per-row [q]
+        let mut position_refs: Vec<Tensor> = position_ids; // already per-row [q]
+        let mut mask = mask;
 
         for (idx, layer) in self.layers.iter().enumerate() {
+            // Continuous batching traverses the same mapped layer range as the
+            // single-sequence cached path. Move every attention input exactly
+            // once at a real device change.
+            let global_idx = self.layer_offset + idx;
+            let target = self.device_map.device_for(global_idx);
+            if hidden_states.device() != target {
+                tracing::debug!(
+                    layer = global_idx,
+                    from = ?hidden_states.device(),
+                    to = ?target,
+                    "Llama batched forward crossing device boundary"
+                );
+                hidden_states = hidden_states.to_device(target);
+                for positions in &mut position_refs {
+                    *positions = positions.to_device(target);
+                }
+                mask = mask.to_device(target);
+            }
+
             let residual = hidden_states.shallow_clone();
             hidden_states = layer.input_layernorm.forward(&hidden_states)?;
 
@@ -2575,6 +2626,15 @@ impl LlamaModel {
             hidden_states = residual + ffn_output;
         }
         drop(guards);
+
+        if hidden_states.device() != self.device {
+            tracing::debug!(
+                from = ?hidden_states.device(),
+                to = ?self.device,
+                "Llama batched forward returning activation to output device"
+            );
+            hidden_states = hidden_states.to_device(self.device);
+        }
 
         hidden_states = self.apply_final_norm(&hidden_states)?;
         let logits = self.lm_head(&hidden_states)?;

--- a/crates/hyprstream/tests/e2e_inference.rs
+++ b/crates/hyprstream/tests/e2e_inference.rs
@@ -713,6 +713,14 @@ async fn e6_gpu_load_and_stream_tokens() {
     use hyprstream_core::config::RuntimeConfig;
     use hyprstream_core::inference::{InferenceClient, LocalInferenceService};
 
+    // Hardware validation needs the production boundary and sampled-token
+    // traces. Tests do not otherwise install a tracing subscriber, so honor
+    // RUST_LOG here and write through libtest's captured output.
+    let _ = tracing_subscriber::fmt()
+        .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
+        .with_test_writer()
+        .try_init();
+
     let model = match gpu_and_model_ready() {
         Some(m) => m,
         None => return, // auto-skip on hosts without the prerequisites
@@ -766,6 +774,7 @@ async fn e6_gpu_load_and_stream_tokens() {
         ..Default::default()
     };
 
+    let generation_started = Instant::now();
     let mut handle = client
         .generate_stream(request)
         .await
@@ -773,9 +782,11 @@ async fn e6_gpu_load_and_stream_tokens() {
 
     let mut full = String::new();
     let mut chunks = 0usize;
+    let mut ttft = None;
     while let Some(chunk) = handle.next().await {
         match chunk {
             Ok(piece) => {
+                ttft.get_or_insert_with(|| generation_started.elapsed());
                 chunks += 1;
                 full.push_str(&piece);
             }
@@ -785,8 +796,11 @@ async fn e6_gpu_load_and_stream_tokens() {
     let stats = handle.stats().await.expect("final stream stats");
 
     eprintln!(
-        "[e2e_inference] produced {chunks} chunks, {} tokens, {:.1} tok/s: {:?}",
-        stats.tokens_generated, stats.tokens_per_second, full
+        "[e2e_inference] TTFT {:.2}ms; produced {chunks} chunks, {} tokens, {:.1} tok/s: {:?}",
+        ttft.unwrap_or_default().as_secs_f64() * 1000.0,
+        stats.tokens_generated,
+        stats.tokens_per_second,
+        full
     );
 
     // The load-bearing assertions: generation actually produced tokens over the


### PR DESCRIPTION
Refs #314.
Validates the dual-MI210 parity acceptance criterion in #317.

## What changed

- Move `hidden_states` and `position_ids` to each mapped decoder layer's device in the production Llama cached-forward loop, exactly at real device changes.
- Return the final decoder activation to the primary/output device before the primary-resident final norm and tied LM head.
- Apply the same boundary handling to continuous batching, including per-row position tensors and the attention mask.
- Keep the single-device path copy-free.
- Initialize tracing in the ignored GPU E2E test and report user-visible TTFT so boundary and sampled-token evidence is reproducible.

## Build and validation

Built on a 2x AMD Instinct MI210 host with ROCm 7.1 libtorch:

```text
CARGO_BUILD_JOBS=6
nice -n19 ionice -c3
cargo test -p hyprstream --release --no-default-features \
  --test e2e_inference --no-run
```

The release build passed. The CPU-only two-device layer-map assertion also passed.

Both GPU runs used:

- checkpoint: `HuggingFaceTB/SmolLM2-360M-Instruct`, pinned local 32-layer BF16 checkpoint
- weight SHA-256: `e6bffe7435d7ddc10fd3b9a9efd429dafbacb1cb17015fb5562664e7532bf86e`
- prompt: `The capital of France is`
- greedy sampling: temperature `0.0`, top-p `1.0`
- production path: cached prefill followed by repeated one-token cached decode

### Greedy-token parity

```text
single GPU (HYPRSTREAM_GPU_DEVICES=0):
[7042, 30, 198, 198, 38634, 314, 260, 3575, 282, 4649, 30, 2]

dual GPU (HYPRSTREAM_GPU_DEVICES=0,1):
[7042, 30, 198, 198, 38634, 314, 260, 3575, 282, 4649, 30, 2]
```

Token `2` is EOS. Both runs streamed the identical text:

```text
 Paris.

Paris is the capital of France.
```

### Real boundary trace

The dual run logged 12 decoder boundary copies (one cached prefill plus 11 cached decode/EOS forwards), always at the actual 32-layer split:

```text
Llama cached forward crossing device boundary layer=16 from=Cuda(0) to=Cuda(1)
Llama cached forward returning activation to output device from=Cuda(1) to=Cuda(0)
```

The single-GPU run logged zero boundary copies.

### Metrics

| Run | TTFT | Decode tok/s | Peak HBM card 0 | Peak HBM card 1 | Layer-boundary copies |
|---|---:|---:|---:|---:|---:|
| single GPU | 952.54 ms | 11.28 | 1,465.25 MiB | 10.86 MiB (baseline) | 0 |
| dual GPU | 1,018.20 ms | 12.55 | 1,523.05 MiB | 968.30 MiB | 12 |

Decode throughput is generated tokens divided by elapsed time from the post-prefill sampling timestamp through EOS. Both hardware tests passed and exited 0; the dual run had no device-mismatch panic.
