### PR TITLE
fix(inference): register TTT delta dependency on session KV cache (#1254)

### DIFF
--- a/crates/hyprstream/src/runtime/kv_cache.rs
+++ b/crates/hyprstream/src/runtime/kv_cache.rs
@@ -89,8 +89,6 @@ pub struct CacheConfig {
     pub max_seq_len: usize,
     /// Quantization type for memory efficiency
     pub quant_type: KVQuantType,
-    /// Whether this cache is exempt from eviction (e.g., for training)
-    pub eviction_exempt: bool,
     /// Use paged block storage (PagedAttention-style) instead of contiguous tensors.
     /// Requires a BlockPool to be initialized on the registry.
     pub paged: bool,
@@ -103,7 +101,6 @@ impl CacheConfig {
             num_layers,
             max_seq_len,
             quant_type: KVQuantType::None,
-            eviction_exempt: false,
             paged: false,
         }
     }
@@ -111,12 +108,6 @@ impl CacheConfig {
     /// Set quantization type
     pub fn with_quant_type(mut self, quant_type: KVQuantType) -> Self {
         self.quant_type = quant_type;
-        self
-    }
-
-    /// Mark as eviction exempt
-    pub fn with_eviction_exempt(mut self, exempt: bool) -> Self {
-        self.eviction_exempt = exempt;
         self
     }
 
@@ -260,13 +251,15 @@ impl KVCacheRegistry {
     pub fn release(&self, owner: &CacheOwner) {
         match owner {
             CacheOwner::Stateless(_) => {
-                // Stateless caches are removed immediately
+                // Stateless caches (and their delta dependency) are removed immediately.
                 self.caches.remove(owner);
+                self.delta_dependencies.remove(owner);
                 tracing::debug!("Released stateless cache: {:?}", owner);
             }
             CacheOwner::Session(_) | CacheOwner::Training { .. } => {
-                // Session and training caches are kept for reuse
-                // They will be evicted by LRU if memory pressure occurs
+                // Session and training caches are kept for reuse; their delta
+                // dependency is retained so a later tenant-delta eviction can
+                // still invalidate them. They fall to LRU eviction under memory pressure.
                 tracing::debug!("Marked session cache for potential reuse: {:?}", owner);
             }
         }
@@ -284,14 +277,17 @@ impl KVCacheRegistry {
             return;
         }
 
-        // Collect eviction candidates (skip eviction-exempt and training caches)
+        // Collect eviction candidates. `CacheOwner::Training` caches are exempt
+        // from eviction by rule — they hold validation/eval state for an active
+        // training run and must survive memory pressure (the run owns their
+        // lifecycle). All other owners (Stateless/Session) are evictable.
         let mut candidates: Vec<(CacheOwner, u64, usize)> = self
             .caches
             .iter()
             .filter_map(|entry| {
                 let owner = entry.key().clone();
 
-                // Skip training caches
+                // Skip training caches (exempt by rule — see comment above).
                 if matches!(owner, CacheOwner::Training { .. }) {
                     return None;
                 }
@@ -335,6 +331,7 @@ impl KVCacheRegistry {
                     if guard.location() == CacheLocation::Cpu {
                         drop(guard);
                         self.caches.remove(&owner);
+                        self.delta_dependencies.remove(&owner);
                         freed += size;
                         tracing::info!("Evicted CPU cache {:?}, freed {} bytes", owner, size);
                     }
@@ -363,13 +360,47 @@ impl KVCacheRegistry {
         tracing::info!("Cleared all KV caches from registry");
     }
 
-    /// Register a dependency between a cache owner and a subject's delta.
+    /// Register the tenant delta that produced a cache owner's KV.
     ///
-    /// When the subject's delta is later evicted or reset, all dependent caches
-    /// will be invalidated since they were computed with stale weights.
-    pub fn register_delta_dependency(&self, owner: &CacheOwner, tenant_id: Option<String>) {
-        self.delta_dependencies
-            .insert(owner.clone(), tenant_id);
+    /// Records `tenant_id` as the effective tenant whose delta contributed to
+    /// the cache's weights — pass `None` when no tenant delta contributes (bare
+    /// base model or base-delta-only inference). When that tenant's delta is
+    /// later evicted, reset, or removed, [`Self::invalidate_for_tenant`] clears
+    /// every cache recorded under it.
+    ///
+    /// **Stale-weight guard:** if the effective tenant differs from the value
+    /// recorded the last time this owner's cache was computed, the existing KV
+    /// was produced under different weights and is cleared in place (cached
+    /// token IDs + every layer cache) before the new dependency is recorded, so
+    /// generation can never reuse it. Returns `true` when such a stale cache was
+    /// cleared. This is the barrier that stops a session cache from crossing a
+    /// no-delta↔delta (or tenant-A↔tenant-B) weight boundary: the next request
+    /// re-`register`s with the now-effective tenant, the mismatch is detected,
+    /// and the stale KV is dropped, forcing a full recompute. A cache with no
+    /// prior record (fresh, or just invalidated) is never treated as stale.
+    pub fn register_delta_dependency(&self, owner: &CacheOwner, tenant_id: Option<String>) -> bool {
+        let stale = match self.delta_dependencies.get(owner) {
+            Some(prev) => *prev != tenant_id,
+            None => false,
+        };
+        self.delta_dependencies.insert(owner.clone(), tenant_id);
+
+        if stale {
+            if let Some(cache) = self.caches.get(owner) {
+                let mut guard = cache.lock();
+                // Mirror invalidate_for_tenant's cleanup: wipe both the prefix
+                // tokens and the layer caches so neither prefix-matching nor a
+                // retained tensor can resurrect the stale values.
+                guard.set_cached_tokens(Vec::new());
+                guard.clear_all();
+                tracing::info!(
+                    "Cleared stale KV cache for {:?}: effective tenant changed since last compute",
+                    owner
+                );
+            }
+        }
+
+        stale
     }
 
     /// Invalidate all KV caches that depend on a specific subject's delta.
@@ -2599,5 +2630,161 @@ mod tests {
         assert_eq!(pool.used_blocks(), 0);
         assert_eq!(pool.owner_of(block), None);
         Ok(())
+    }
+
+    // ========================================================================
+    // TTT → KV invalidation wiring (#1254, epic #1246)
+    // ========================================================================
+
+    /// Write 4 cached token IDs + a 4-token KV entry into layer 0 of a cache,
+    /// so "cleared" is observable as both empty token IDs (cached_token_count)
+    /// and an empty layer (seq_pos == 0).
+    fn populate_cache(cache: &Arc<Mutex<KVCacheManager>>) {
+        let mut g = cache.lock();
+        g.set_cached_tokens(vec![10, 20, 30, 40]);
+        g.with_layer_cache(0, |c| {
+            let k = Tensor::ones([1, 4, 2, 4], (DType::Float, Device::Cpu));
+            let v = Tensor::ones([1, 4, 2, 4], (DType::Float, Device::Cpu));
+            c.update(&k, &v, 0).expect("layer 0 update");
+        });
+    }
+
+    /// seq_pos of layer 0 (None when caching disabled / layer absent).
+    fn layer0_seq_pos(cache: &Arc<Mutex<KVCacheManager>>) -> Option<usize> {
+        cache.lock().with_layer_cache(0, |c| c.seq_pos)
+    }
+
+    /// Invalidating one tenant's delta clears that tenant's cache while every
+    /// other tenant's cache is left intact — the core cross-tenant isolation
+    /// invariant the missing `register_delta_dependency` call broke (#1254).
+    #[test]
+    fn test_invalidate_for_tenant_isolates_tenants() {
+        let registry = KVCacheRegistry::new(CacheConfig::new(2, 128), None);
+
+        let owner_a = CacheOwner::Session("session-a".into());
+        let owner_b = CacheOwner::Session("session-b".into());
+
+        let cache_a = registry.get_or_create(owner_a.clone());
+        let cache_b = registry.get_or_create(owner_b.clone());
+        populate_cache(&cache_a);
+        populate_cache(&cache_b);
+
+        // Register each cache under its own tenant delta.
+        registry.register_delta_dependency(&owner_a, Some("tenant-a".into()));
+        registry.register_delta_dependency(&owner_b, Some("tenant-b".into()));
+
+        assert_eq!(registry.cache_count(), 2);
+        assert_eq!(cache_a.lock().cached_token_count(), 4);
+        assert_eq!(cache_b.lock().cached_token_count(), 4);
+
+        // Evict tenant-a's delta: only A's cache is invalidated; B is untouched.
+        let invalidated = registry.invalidate_for_tenant("tenant-a");
+        assert_eq!(invalidated, 1);
+        assert_eq!(registry.cache_count(), 1, "only tenant-a's cache is removed");
+
+        // A's cache (Arc still held by the test) was cleared in place.
+        assert_eq!(cache_a.lock().cached_token_count(), 0, "tenant-a cache cleared");
+        assert_eq!(layer0_seq_pos(&cache_a), Some(0), "tenant-a layer KV cleared");
+
+        // B's cache survives with its KV intact.
+        assert_eq!(cache_b.lock().cached_token_count(), 4, "tenant-b cache intact");
+        assert_eq!(layer0_seq_pos(&cache_b), Some(4), "tenant-b layer KV intact");
+    }
+
+    /// A session cache must not survive a weight-version change: no-delta↔delta
+    /// and tenant-A↔tenant-B transitions all clear the stale KV; re-registering
+    /// the SAME tenant preserves it. This is the stale-cache-crossing-weight-
+    /// versions guard the serving path now enforces via register_delta_dependency.
+    #[test]
+    fn test_register_clears_stale_kv_on_tenant_transition() {
+        let registry = KVCacheRegistry::new(CacheConfig::new(2, 128), None);
+        let owner = CacheOwner::Session("session-x".into());
+        let cache = registry.get_or_create(owner.clone());
+        populate_cache(&cache);
+
+        // 1. First compute under NO tenant delta — fresh, nothing stale.
+        assert!(
+            !registry.register_delta_dependency(&owner, None),
+            "fresh cache is not stale"
+        );
+        assert_eq!(cache.lock().cached_token_count(), 4, "KV preserved on first register");
+
+        // 2. no-delta → tenant delta: weights changed, KV is stale and cleared.
+        assert!(
+            registry.register_delta_dependency(&owner, Some("tenant-1".into())),
+            "no-delta → delta must clear stale KV"
+        );
+        assert_eq!(cache.lock().cached_token_count(), 0, "KV cleared across weight version");
+        assert_eq!(layer0_seq_pos(&cache), Some(0));
+
+        // Repopulate to simulate a fresh compute under tenant-1.
+        populate_cache(&cache);
+        assert_eq!(cache.lock().cached_token_count(), 4);
+
+        // 3. Same tenant again — NOT stale, KV preserved.
+        assert!(
+            !registry.register_delta_dependency(&owner, Some("tenant-1".into())),
+            "same tenant is not stale"
+        );
+        assert_eq!(cache.lock().cached_token_count(), 4, "KV preserved for same tenant");
+
+        // 4. delta → no-delta: weights changed again, stale and cleared.
+        assert!(
+            registry.register_delta_dependency(&owner, None),
+            "delta → no-delta must clear stale KV"
+        );
+        assert_eq!(cache.lock().cached_token_count(), 0);
+
+        // 5. Repopulate, then switch tenants (tenant-1 effective → tenant-2): stale.
+        populate_cache(&cache);
+        assert!(
+            registry.register_delta_dependency(&owner, Some("tenant-2".into())),
+            "tenant change must clear stale KV"
+        );
+        assert_eq!(cache.lock().cached_token_count(), 0);
+
+        // 6. After a clear, the recorded tenant is tenant-2; invalidating
+        //    tenant-2 still finds (and removes) the owner entry.
+        assert_eq!(registry.invalidate_for_tenant("tenant-2"), 1);
+    }
+
+    /// Releasing or evicting a cache must drop its delta dependency so the map
+    /// has no orphan entries that a later invalidation would chase. Covers the
+    /// Stateless release path; evict_to_budget mirrors the same removal.
+    #[test]
+    fn test_release_clears_delta_dependency() {
+        let registry = KVCacheRegistry::new(CacheConfig::new(2, 128), None);
+
+        let owner = CacheOwner::Stateless(42);
+        let _cache = registry.get_or_create(owner.clone());
+        registry.register_delta_dependency(&owner, Some("tenant-s".into()));
+        assert!(registry.delta_dependencies.contains_key(&owner));
+
+        // Releasing a stateless cache removes both the cache and its dependency.
+        registry.release(&owner);
+        assert!(!registry.caches.contains_key(&owner), "stateless cache removed");
+        assert!(
+            !registry.delta_dependencies.contains_key(&owner),
+            "delta dependency removed on release"
+        );
+
+        // No orphan dependency → a later invalidation finds nothing.
+        assert_eq!(registry.invalidate_for_tenant("tenant-s"), 0);
+    }
+
+    /// A no-tenant cache (registered `None`) must NOT be cleared by any tenant's
+    /// invalidation — it carries no tenant dependency.
+    #[test]
+    fn test_no_tenant_cache_survives_any_invalidation() {
+        let registry = KVCacheRegistry::new(CacheConfig::new(2, 128), None);
+        let owner = CacheOwner::Session("base-only".into());
+        let cache = registry.get_or_create(owner.clone());
+        populate_cache(&cache);
+        registry.register_delta_dependency(&owner, None);
+
+        // Invalidating any tenant leaves the no-tenant cache untouched.
+        assert_eq!(registry.invalidate_for_tenant("anyone"), 0);
+        assert_eq!(registry.cache_count(), 1);
+        assert_eq!(cache.lock().cached_token_count(), 4, "no-tenant cache intact");
     }
 }

--- a/crates/hyprstream/src/runtime/kv_cache.rs
+++ b/crates/hyprstream/src/runtime/kv_cache.rs
@@ -141,8 +141,11 @@ pub struct KVCacheRegistry {
     /// Memory budget in bytes (None = unlimited)
     memory_budget_bytes: Option<usize>,
     /// Maps cache owners to the subject delta that was active when the cache was computed.
-    /// When a delta is evicted or reset, dependent caches must be invalidated.
-    delta_dependencies: DashMap<CacheOwner, Option<String>>,
+    /// The value is `(tenant_id, weight_epoch)`: the tenant whose delta contributed to
+    /// the KV, plus the delta's weight epoch at compute time. When a delta is evicted
+    /// or reset, dependent caches must be invalidated; when the epoch has advanced
+    /// (in-place re-adaptation under the same tenant), the cached KV is weight-stale.
+    delta_dependencies: DashMap<CacheOwner, Option<(String, u64)>>,
     /// Shared block pool for paged KV cache storage (None if paged mode not enabled)
     block_pool: Option<Arc<Mutex<BlockPool>>>,
 }
@@ -362,28 +365,39 @@ impl KVCacheRegistry {
 
     /// Register the tenant delta that produced a cache owner's KV.
     ///
-    /// Records `tenant_id` as the effective tenant whose delta contributed to
-    /// the cache's weights — pass `None` when no tenant delta contributes (bare
-    /// base model or base-delta-only inference). When that tenant's delta is
-    /// later evicted, reset, or removed, [`Self::invalidate_for_tenant`] clears
-    /// every cache recorded under it.
+    /// Records `(tenant_id, weight_epoch)` as the effective tenant whose delta
+    /// contributed to the cache's weights, along with that delta's weight epoch
+    /// at compute time — pass `None` when no tenant delta contributes (bare
+    /// base model or base-delta-only inference; the epoch is then irrelevant).
+    /// When that tenant's delta is later evicted, reset, or removed,
+    /// [`Self::invalidate_for_tenant`] clears every cache recorded under it.
     ///
-    /// **Stale-weight guard:** if the effective tenant differs from the value
-    /// recorded the last time this owner's cache was computed, the existing KV
-    /// was produced under different weights and is cleared in place (cached
-    /// token IDs + every layer cache) before the new dependency is recorded, so
-    /// generation can never reuse it. Returns `true` when such a stale cache was
-    /// cleared. This is the barrier that stops a session cache from crossing a
-    /// no-delta↔delta (or tenant-A↔tenant-B) weight boundary: the next request
-    /// re-`register`s with the now-effective tenant, the mismatch is detected,
-    /// and the stale KV is dropped, forcing a full recompute. A cache with no
+    /// **Stale-weight guard:** if the effective `(tenant_id, weight_epoch)`
+    /// differs from the value recorded the last time this owner's cache was
+    /// computed, the existing KV was produced under different weights and is
+    /// cleared in place (cached token IDs + every layer cache) before the new
+    /// dependency is recorded, so generation can never reuse it. Returns `true`
+    /// when such a stale cache was cleared. This is the barrier that stops a
+    /// session cache from crossing a weight boundary — no-delta↔delta,
+    /// tenant-A↔tenant-B, *and* same-tenant in-place re-adaptation (the epoch
+    /// advances while the tenant id stays the same): the next request
+    /// re-`register`s with the now-effective tenant and epoch, the mismatch is
+    /// detected, and the stale KV is dropped, forcing a full recompute. Both
+    /// the bump (at adapt/train/rollback/reset time) and this comparison are
+    /// O(1) — no per-adaptation scan of the dependency map. A cache with no
     /// prior record (fresh, or just invalidated) is never treated as stale.
-    pub fn register_delta_dependency(&self, owner: &CacheOwner, tenant_id: Option<String>) -> bool {
+    pub fn register_delta_dependency(
+        &self,
+        owner: &CacheOwner,
+        tenant_id: Option<String>,
+        weight_epoch: u64,
+    ) -> bool {
+        let dependency = tenant_id.map(|t| (t, weight_epoch));
         let stale = match self.delta_dependencies.get(owner) {
-            Some(prev) => *prev != tenant_id,
+            Some(prev) => *prev != dependency,
             None => false,
         };
-        self.delta_dependencies.insert(owner.clone(), tenant_id);
+        self.delta_dependencies.insert(owner.clone(), dependency);
 
         if stale {
             if let Some(cache) = self.caches.get(owner) {
@@ -394,7 +408,7 @@ impl KVCacheRegistry {
                 guard.set_cached_tokens(Vec::new());
                 guard.clear_all();
                 tracing::info!(
-                    "Cleared stale KV cache for {:?}: effective tenant changed since last compute",
+                    "Cleared stale KV cache for {:?}: effective tenant or weight epoch changed since last compute",
                     owner
                 );
             }
@@ -413,7 +427,7 @@ impl KVCacheRegistry {
             .delta_dependencies
             .iter()
             .filter_map(|entry| {
-                if entry.value().as_deref() == Some(tenant_id) {
+                if entry.value().as_ref().map(|(t, _)| t.as_str()) == Some(tenant_id) {
                     Some(entry.key().clone())
                 } else {
                     None
@@ -2670,8 +2684,8 @@ mod tests {
         populate_cache(&cache_b);
 
         // Register each cache under its own tenant delta.
-        registry.register_delta_dependency(&owner_a, Some("tenant-a".into()));
-        registry.register_delta_dependency(&owner_b, Some("tenant-b".into()));
+        registry.register_delta_dependency(&owner_a, Some("tenant-a".into()), 1);
+        registry.register_delta_dependency(&owner_b, Some("tenant-b".into()), 1);
 
         assert_eq!(registry.cache_count(), 2);
         assert_eq!(cache_a.lock().cached_token_count(), 4);
@@ -2704,14 +2718,14 @@ mod tests {
 
         // 1. First compute under NO tenant delta — fresh, nothing stale.
         assert!(
-            !registry.register_delta_dependency(&owner, None),
+            !registry.register_delta_dependency(&owner, None, 0),
             "fresh cache is not stale"
         );
         assert_eq!(cache.lock().cached_token_count(), 4, "KV preserved on first register");
 
         // 2. no-delta → tenant delta: weights changed, KV is stale and cleared.
         assert!(
-            registry.register_delta_dependency(&owner, Some("tenant-1".into())),
+            registry.register_delta_dependency(&owner, Some("tenant-1".into()), 1),
             "no-delta → delta must clear stale KV"
         );
         assert_eq!(cache.lock().cached_token_count(), 0, "KV cleared across weight version");
@@ -2721,16 +2735,16 @@ mod tests {
         populate_cache(&cache);
         assert_eq!(cache.lock().cached_token_count(), 4);
 
-        // 3. Same tenant again — NOT stale, KV preserved.
+        // 3. Same tenant, same weight epoch — NOT stale, KV preserved.
         assert!(
-            !registry.register_delta_dependency(&owner, Some("tenant-1".into())),
-            "same tenant is not stale"
+            !registry.register_delta_dependency(&owner, Some("tenant-1".into()), 1),
+            "same tenant at the same epoch is not stale"
         );
         assert_eq!(cache.lock().cached_token_count(), 4, "KV preserved for same tenant");
 
         // 4. delta → no-delta: weights changed again, stale and cleared.
         assert!(
-            registry.register_delta_dependency(&owner, None),
+            registry.register_delta_dependency(&owner, None, 0),
             "delta → no-delta must clear stale KV"
         );
         assert_eq!(cache.lock().cached_token_count(), 0);
@@ -2738,7 +2752,7 @@ mod tests {
         // 5. Repopulate, then switch tenants (tenant-1 effective → tenant-2): stale.
         populate_cache(&cache);
         assert!(
-            registry.register_delta_dependency(&owner, Some("tenant-2".into())),
+            registry.register_delta_dependency(&owner, Some("tenant-2".into()), 1),
             "tenant change must clear stale KV"
         );
         assert_eq!(cache.lock().cached_token_count(), 0);
@@ -2746,6 +2760,59 @@ mod tests {
         // 6. After a clear, the recorded tenant is tenant-2; invalidating
         //    tenant-2 still finds (and removes) the owner entry.
         assert_eq!(registry.invalidate_for_tenant("tenant-2"), 1);
+    }
+
+    /// Same-tenant in-place re-adaptation (adapt_tenant/train_step/rollback/reset
+    /// bumps the delta's weight epoch while the tenant id stays the same) must
+    /// clear the stale KV on the next reuse; reusing at the SAME epoch (no
+    /// re-adaptation) must preserve it. This is the F1 regression test: the
+    /// recorded `(tenant_id, weight_epoch)` pair detects weight staleness that a
+    /// tenant-id-only comparison cannot (#1254).
+    #[test]
+    fn test_register_clears_stale_kv_on_weight_epoch_advance() {
+        let registry = KVCacheRegistry::new(CacheConfig::new(2, 128), None);
+        let owner = CacheOwner::Session("session-ttt".into());
+        let cache = registry.get_or_create(owner.clone());
+        populate_cache(&cache);
+
+        // Compute under tenant-1 at weight epoch 1 — fresh, nothing stale.
+        assert!(
+            !registry.register_delta_dependency(&owner, Some("tenant-1".into()), 1),
+            "fresh cache is not stale"
+        );
+        assert_eq!(cache.lock().cached_token_count(), 4);
+
+        // No re-adaptation: same tenant, same epoch → KV preserved.
+        assert!(
+            !registry.register_delta_dependency(&owner, Some("tenant-1".into()), 1),
+            "same tenant at the same epoch must preserve KV"
+        );
+        assert_eq!(cache.lock().cached_token_count(), 4, "KV preserved within a weight epoch");
+        assert_eq!(layer0_seq_pos(&cache), Some(4));
+
+        // In-place re-adaptation: tenant id unchanged, epoch bumped 1 → 2.
+        // The cached KV was computed under the old weights → stale, cleared.
+        assert!(
+            registry.register_delta_dependency(&owner, Some("tenant-1".into()), 2),
+            "same tenant at an advanced epoch must clear stale KV"
+        );
+        assert_eq!(cache.lock().cached_token_count(), 0, "weight-stale KV cleared");
+        assert_eq!(layer0_seq_pos(&cache), Some(0));
+
+        // Repopulate under the new weights; the new epoch is now recorded.
+        populate_cache(&cache);
+        assert!(
+            !registry.register_delta_dependency(&owner, Some("tenant-1".into()), 2),
+            "post-clear reuse at the recorded epoch is not stale"
+        );
+        assert_eq!(cache.lock().cached_token_count(), 4, "KV preserved after recompute");
+
+        // A reset/rollback bumps the epoch again → stale again.
+        assert!(
+            registry.register_delta_dependency(&owner, Some("tenant-1".into()), 3),
+            "further epoch advance (reset/rollback) must clear stale KV"
+        );
+        assert_eq!(cache.lock().cached_token_count(), 0);
     }
 
     /// Releasing or evicting a cache must drop its delta dependency so the map
@@ -2757,7 +2824,7 @@ mod tests {
 
         let owner = CacheOwner::Stateless(42);
         let _cache = registry.get_or_create(owner.clone());
-        registry.register_delta_dependency(&owner, Some("tenant-s".into()));
+        registry.register_delta_dependency(&owner, Some("tenant-s".into()), 1);
         assert!(registry.delta_dependencies.contains_key(&owner));
 
         // Releasing a stateless cache removes both the cache and its dependency.
@@ -2780,7 +2847,7 @@ mod tests {
         let owner = CacheOwner::Session("base-only".into());
         let cache = registry.get_or_create(owner.clone());
         populate_cache(&cache);
-        registry.register_delta_dependency(&owner, None);
+        registry.register_delta_dependency(&owner, None, 0);
 
         // Invalidating any tenant leaves the no-tenant cache untouched.
         assert_eq!(registry.invalidate_for_tenant("anyone"), 0);

--- a/crates/hyprstream/src/runtime/torch_engine.rs
+++ b/crates/hyprstream/src/runtime/torch_engine.rs
@@ -342,7 +342,14 @@ impl TorchEngine {
     /// retrieves (or creates) the session's cache from the registry and
     /// installs it in the model via `set_kv_cache()`. Returns true if
     /// a session cache was swapped in.
-    pub fn swap_session_cache(&self) -> bool {
+    ///
+    /// `tenant_id` is the effective tenant whose delta contributed to this
+    /// request's weights (`None` when no tenant delta contributes). It is
+    /// registered against the owner cache *before* the cache is installed in the
+    /// model, so the cache is tracked for invalidation (and cleared if its
+    /// previously-computed KV is stale w.r.t. a different tenant) before
+    /// generation can read a single token from it.
+    pub fn swap_session_cache(&self, tenant_id: Option<String>) -> bool {
         let owner = match self.active_cache_owner.lock().clone() {
             Some(o) => o,
             None => return false,
@@ -356,10 +363,20 @@ impl TorchEngine {
             None => return false,
         };
 
-        let session_cache = registry.get_or_create(owner);
+        let session_cache = registry.get_or_create(owner.clone());
+        // Register the delta dependency BEFORE installing the cache. This both
+        // records the owner for tenant-delta invalidation and, if the effective
+        // tenant changed since this cache was last computed, clears the stale KV
+        // in place. Ordering matters: registration/staleness-clear precede
+        // set_kv_cache, so the model can never publish output from an untracked
+        // or weight-stale cache.
+        let cleared_stale = registry.register_delta_dependency(&owner, tenant_id);
         let mut model = model_arc.lock();
         model.set_kv_cache(session_cache);
-        tracing::debug!("Swapped session KV cache into model");
+        tracing::debug!(
+            "Swapped session KV cache into model (stale_cleared={})",
+            cleared_stale
+        );
         true
     }
 
@@ -1646,10 +1663,18 @@ impl TorchEngine {
     /// When `delta` is Some, LoRA corrections are injected at each attention layer
     /// during generation. The delta is locked per-token (not held across the entire
     /// generation) to allow concurrent training updates.
+    ///
+    /// `tenant_id` is the effective tenant whose delta contributed to the weights
+    /// (`Some` only when a per-tenant delta is in play, `None` otherwise). It is
+    /// threaded to the session-cache swap so the resulting KV is registered for
+    /// tenant-delta invalidation and cleared if the weights changed under a
+    /// different tenant. The caller must derive it from the verified request
+    /// subject, not invent a new identity source.
     pub fn generate_with_delta(
         &self,
         mut request: GenerationRequest,
         delta: Option<std::sync::Arc<parking_lot::Mutex<crate::training::TenantDelta>>>,
+        tenant_id: Option<String>,
     ) -> Result<TextStream<'_>> {
         if let Some(seed) = request.seed {
             self.set_seed(seed as u64);
@@ -1659,7 +1684,7 @@ impl TorchEngine {
             request.timeout_ms = Some(self.config.default_generation_timeout_ms);
         }
 
-        TextStream::new_with_delta(self, request, delta)
+        TextStream::new_with_delta(self, request, delta, tenant_id)
     }
 
     /// Non-streaming generation with optional delta (convenience wrapper)
@@ -1667,6 +1692,7 @@ impl TorchEngine {
         &self,
         request: GenerationRequest,
         delta: Option<std::sync::Arc<parking_lot::Mutex<crate::training::TenantDelta>>>,
+        tenant_id: Option<String>,
     ) -> Result<crate::config::GenerationResult> {
         use futures::StreamExt;
 
@@ -1676,7 +1702,7 @@ impl TorchEngine {
             ));
         }
 
-        let mut stream = self.generate_with_delta(request, delta)?;
+        let mut stream = self.generate_with_delta(request, delta, tenant_id)?;
         let mut accumulated_text = String::new();
 
         while let Some(text_chunk) = stream.next().await {
@@ -2478,13 +2504,14 @@ pub struct TextStream<'a> {
 
 impl<'a> TextStream<'a> {
     fn new(engine: &'a TorchEngine, request: GenerationRequest) -> Result<Self> {
-        Self::new_with_delta(engine, request, None)
+        Self::new_with_delta(engine, request, None, None)
     }
 
     fn new_with_delta(
         engine: &'a TorchEngine,
         request: GenerationRequest,
         delta: Option<std::sync::Arc<parking_lot::Mutex<crate::training::TenantDelta>>>,
+        tenant_id: Option<String>,
     ) -> Result<Self> {
         let prompt_tokens = engine.tokenize(&request.prompt)?;
         let prompt_len = prompt_tokens.len();
@@ -2515,7 +2542,7 @@ impl<'a> TextStream<'a> {
         // If an active session exists, swap its KV cache into the model and check
         // if the new prompt shares a prefix with the cached tokens. This avoids
         // re-computing attention for unchanged conversation history.
-        let prefill_start_pos = if engine.swap_session_cache() {
+        let prefill_start_pos = if engine.swap_session_cache(tenant_id) {
             // Session cache swapped in — check for prefix match
             let prefix_len = if let Some(model_arc) = &engine.persistent_model {
                 let model = model_arc.lock();

--- a/crates/hyprstream/src/runtime/torch_engine.rs
+++ b/crates/hyprstream/src/runtime/torch_engine.rs
@@ -344,12 +344,24 @@ impl TorchEngine {
     /// a session cache was swapped in.
     ///
     /// `tenant_id` is the effective tenant whose delta contributed to this
-    /// request's weights (`None` when no tenant delta contributes). It is
-    /// registered against the owner cache *before* the cache is installed in the
-    /// model, so the cache is tracked for invalidation (and cleared if its
-    /// previously-computed KV is stale w.r.t. a different tenant) before
-    /// generation can read a single token from it.
-    pub fn swap_session_cache(&self, tenant_id: Option<String>) -> bool {
+    /// request's weights (`None` when no tenant delta contributes), and
+    /// `weight_epoch` is that delta's current weight epoch (ignored when
+    /// `tenant_id` is `None`). The pair is registered against the owner cache
+    /// *before* the cache is installed in the model, so the cache is tracked
+    /// for invalidation (and cleared if its previously-computed KV is stale
+    /// w.r.t. a different tenant or an older weight epoch) before generation
+    /// can read a single token from it.
+    ///
+    /// **Atomicity invariant (F2):** the register→install sequence below is
+    /// *not* guarded by a lock spanning both operations. It is race-free today
+    /// because `InferenceService` runs on a single-threaded `current_thread`
+    /// Tokio runtime inside a `LocalSet`, and this function is await-free — no
+    /// other request task can interleave between `register_delta_dependency`
+    /// and `set_kv_cache`, so the pair executes atomically with respect to
+    /// other requests. If `InferenceService` ever moves to a multi-threaded
+    /// runtime (or an `.await` is introduced here), this invariant breaks and a
+    /// spanning lock or an epoch handshake would be required.
+    pub fn swap_session_cache(&self, tenant_id: Option<String>, weight_epoch: u64) -> bool {
         let owner = match self.active_cache_owner.lock().clone() {
             Some(o) => o,
             None => return false,
@@ -370,7 +382,7 @@ impl TorchEngine {
         // in place. Ordering matters: registration/staleness-clear precede
         // set_kv_cache, so the model can never publish output from an untracked
         // or weight-stale cache.
-        let cleared_stale = registry.register_delta_dependency(&owner, tenant_id);
+        let cleared_stale = registry.register_delta_dependency(&owner, tenant_id, weight_epoch);
         let mut model = model_arc.lock();
         model.set_kv_cache(session_cache);
         tracing::debug!(
@@ -1665,16 +1677,19 @@ impl TorchEngine {
     /// generation) to allow concurrent training updates.
     ///
     /// `tenant_id` is the effective tenant whose delta contributed to the weights
-    /// (`Some` only when a per-tenant delta is in play, `None` otherwise). It is
-    /// threaded to the session-cache swap so the resulting KV is registered for
+    /// (`Some` only when a per-tenant delta is in play, `None` otherwise), and
+    /// `weight_epoch` is that delta's current weight epoch. The pair is threaded
+    /// to the session-cache swap so the resulting KV is registered for
     /// tenant-delta invalidation and cleared if the weights changed under a
-    /// different tenant. The caller must derive it from the verified request
-    /// subject, not invent a new identity source.
+    /// different tenant or an older weight epoch (same-tenant in-place
+    /// re-adaptation). The caller must derive the tenant id from the verified
+    /// request subject, not invent a new identity source.
     pub fn generate_with_delta(
         &self,
         mut request: GenerationRequest,
         delta: Option<std::sync::Arc<parking_lot::Mutex<crate::training::TenantDelta>>>,
         tenant_id: Option<String>,
+        weight_epoch: u64,
     ) -> Result<TextStream<'_>> {
         if let Some(seed) = request.seed {
             self.set_seed(seed as u64);
@@ -1684,7 +1699,7 @@ impl TorchEngine {
             request.timeout_ms = Some(self.config.default_generation_timeout_ms);
         }
 
-        TextStream::new_with_delta(self, request, delta, tenant_id)
+        TextStream::new_with_delta(self, request, delta, tenant_id, weight_epoch)
     }
 
     /// Non-streaming generation with optional delta (convenience wrapper)
@@ -1693,6 +1708,7 @@ impl TorchEngine {
         request: GenerationRequest,
         delta: Option<std::sync::Arc<parking_lot::Mutex<crate::training::TenantDelta>>>,
         tenant_id: Option<String>,
+        weight_epoch: u64,
     ) -> Result<crate::config::GenerationResult> {
         use futures::StreamExt;
 
@@ -1702,7 +1718,7 @@ impl TorchEngine {
             ));
         }
 
-        let mut stream = self.generate_with_delta(request, delta, tenant_id)?;
+        let mut stream = self.generate_with_delta(request, delta, tenant_id, weight_epoch)?;
         let mut accumulated_text = String::new();
 
         while let Some(text_chunk) = stream.next().await {
@@ -2504,7 +2520,7 @@ pub struct TextStream<'a> {
 
 impl<'a> TextStream<'a> {
     fn new(engine: &'a TorchEngine, request: GenerationRequest) -> Result<Self> {
-        Self::new_with_delta(engine, request, None, None)
+        Self::new_with_delta(engine, request, None, None, 0)
     }
 
     fn new_with_delta(
@@ -2512,6 +2528,7 @@ impl<'a> TextStream<'a> {
         request: GenerationRequest,
         delta: Option<std::sync::Arc<parking_lot::Mutex<crate::training::TenantDelta>>>,
         tenant_id: Option<String>,
+        weight_epoch: u64,
     ) -> Result<Self> {
         let prompt_tokens = engine.tokenize(&request.prompt)?;
         let prompt_len = prompt_tokens.len();
@@ -2542,7 +2559,7 @@ impl<'a> TextStream<'a> {
         // If an active session exists, swap its KV cache into the model and check
         // if the new prompt shares a prefix with the cached tokens. This avoids
         // re-computing attention for unchanged conversation history.
-        let prefill_start_pos = if engine.swap_session_cache(tenant_id) {
+        let prefill_start_pos = if engine.swap_session_cache(tenant_id, weight_epoch) {
             // Session cache swapped in — check for prefix match
             let prefix_len = if let Some(model_arc) = &engine.persistent_model {
                 let model = model_arc.lock();

--- a/crates/hyprstream/src/services/inference.rs
+++ b/crates/hyprstream/src/services/inference.rs
@@ -446,18 +446,22 @@ impl InferenceService {
     /// Returns None if no deltas exist (base model only), which is the common case
     /// and incurs zero overhead.
     ///
-    /// Returns `(delta, tenant_id)` where `tenant_id` is `Some(subject)` only when
-    /// a per-tenant delta contributed to the effective weights. The engine
-    /// registers that id against the session KV cache so a later tenant-delta
-    /// eviction/reset/removal invalidates it; base-delta-only and bare-base
-    /// requests carry no tenant dependency (`None`) and are never cleared by a
-    /// tenant eviction.
+    /// Returns `(delta, tenant_id, weight_epoch)` where `tenant_id` is
+    /// `Some(subject)` only when a per-tenant delta contributed to the effective
+    /// weights, and `weight_epoch` is that tenant delta's current weight epoch
+    /// (0 when no tenant delta is in play). The engine registers the pair
+    /// against the session KV cache so a later tenant-delta eviction/reset/removal
+    /// invalidates it, and so an epoch advance (in-place re-adaptation under the
+    /// same tenant) marks the cached KV weight-stale; base-delta-only and
+    /// bare-base requests carry no tenant dependency (`None`) and are never
+    /// cleared by a tenant eviction.
     fn resolve_delta(
         &self,
         subject: &hyprstream_rpc::Subject,
     ) -> (
         Option<Arc<Mutex<crate::training::TenantDelta>>>,
         Option<String>,
+        u64,
     ) {
         let base = self.base_delta.lock().clone();
         let tenant = self.delta_pool.as_ref().and_then(|pool| pool.get(subject));
@@ -465,6 +469,13 @@ impl InferenceService {
         // The id is the verified request subject — the existing RPC tenant
         // identity — not a new identity source.
         let tenant_id = tenant.as_ref().map(|_| subject.to_string());
+        // Read the epoch AFTER any adaptation for this request has completed
+        // (resolve_delta runs after apply_ttt_adaptation on the serving path),
+        // so a re-adapted tenant's new epoch is what gets registered.
+        let weight_epoch = tenant
+            .as_ref()
+            .map(|d| d.lock().weight_epoch())
+            .unwrap_or(0);
 
         let delta = match (base, tenant) {
             (Some(base), Some(tenant)) => {
@@ -476,7 +487,7 @@ impl InferenceService {
             (None, None) => None,
         };
 
-        (delta, tenant_id)
+        (delta, tenant_id, weight_epoch)
     }
 
     /// Apply TTT adaptation if enabled (adapts model to input BEFORE generation)
@@ -783,7 +794,7 @@ impl InferenceService {
         };
 
         // Re-resolve delta after TTT (may have been updated by adaptation)
-        let (delta, tenant_id) = self.resolve_delta(&subject);
+        let (delta, tenant_id, weight_epoch) = self.resolve_delta(&subject);
 
         trace!(
             stream_id = %stream_ctx.stream_id(),
@@ -813,7 +824,7 @@ impl InferenceService {
         // Run the stream with StreamChannel's async publisher callback.
         // Engine read-lock held across await: generate_with_delta returns a stream borrowing engine.
         let engine = self.engine.read();
-        let stream_result = engine.generate_with_delta(request, delta, tenant_id);
+        let stream_result = engine.generate_with_delta(request, delta, tenant_id, weight_epoch);
 
         let result = stream_channel.run_stream(stream_ctx, |mut publisher| async move {
             let result = match stream_result {

--- a/crates/hyprstream/src/services/inference.rs
+++ b/crates/hyprstream/src/services/inference.rs
@@ -445,14 +445,28 @@ impl InferenceService {
     ///
     /// Returns None if no deltas exist (base model only), which is the common case
     /// and incurs zero overhead.
+    ///
+    /// Returns `(delta, tenant_id)` where `tenant_id` is `Some(subject)` only when
+    /// a per-tenant delta contributed to the effective weights. The engine
+    /// registers that id against the session KV cache so a later tenant-delta
+    /// eviction/reset/removal invalidates it; base-delta-only and bare-base
+    /// requests carry no tenant dependency (`None`) and are never cleared by a
+    /// tenant eviction.
     fn resolve_delta(
         &self,
         subject: &hyprstream_rpc::Subject,
-    ) -> Option<Arc<Mutex<crate::training::TenantDelta>>> {
+    ) -> (
+        Option<Arc<Mutex<crate::training::TenantDelta>>>,
+        Option<String>,
+    ) {
         let base = self.base_delta.lock().clone();
         let tenant = self.delta_pool.as_ref().and_then(|pool| pool.get(subject));
 
-        match (base, tenant) {
+        // The id is the verified request subject — the existing RPC tenant
+        // identity — not a new identity source.
+        let tenant_id = tenant.as_ref().map(|_| subject.to_string());
+
+        let delta = match (base, tenant) {
             (Some(base), Some(tenant)) => {
                 // Compose: base + tenant corrections
                 Some(crate::training::TenantDelta::compose(&base, &tenant))
@@ -460,7 +474,9 @@ impl InferenceService {
             (Some(base), None) => Some(base),
             (None, Some(tenant)) => Some(tenant),
             (None, None) => None,
-        }
+        };
+
+        (delta, tenant_id)
     }
 
     /// Apply TTT adaptation if enabled (adapts model to input BEFORE generation)
@@ -767,7 +783,7 @@ impl InferenceService {
         };
 
         // Re-resolve delta after TTT (may have been updated by adaptation)
-        let delta = self.resolve_delta(&subject);
+        let (delta, tenant_id) = self.resolve_delta(&subject);
 
         trace!(
             stream_id = %stream_ctx.stream_id(),
@@ -797,7 +813,7 @@ impl InferenceService {
         // Run the stream with StreamChannel's async publisher callback.
         // Engine read-lock held across await: generate_with_delta returns a stream borrowing engine.
         let engine = self.engine.read();
-        let stream_result = engine.generate_with_delta(request, delta);
+        let stream_result = engine.generate_with_delta(request, delta, tenant_id);
 
         let result = stream_channel.run_stream(stream_ctx, |mut publisher| async move {
             let result = match stream_result {

--- a/crates/hyprstream/src/training/tenant_delta.rs
+++ b/crates/hyprstream/src/training/tenant_delta.rs
@@ -260,6 +260,11 @@ pub struct TenantDelta {
     pub rank_oracle: Option<super::ttt::RankOracle>,
     /// Lifecycle state of any pending adaptation (Idle or Pending with snapshot).
     pub adaptation_state: crate::training::adaptation_state::DeltaAdaptationState,
+    /// Weight epoch: a version counter bumped on every in-place weight mutation
+    /// (adaptation, train step, rollback/restore, reset). Session KV caches record
+    /// the epoch they were computed under; a mismatch on reuse means the cached
+    /// KV is weight-stale and must be cleared (#1254 F1 fix).
+    weight_epoch: u64,
 }
 
 impl TenantDelta {
@@ -409,6 +414,7 @@ impl TenantDelta {
             alpha: config.alpha,
             rank_oracle: None,
             adaptation_state: crate::training::adaptation_state::DeltaAdaptationState::Idle,
+            weight_epoch: 0,
         })
     }
 
@@ -617,12 +623,30 @@ impl TenantDelta {
             }
         }
 
+        // Restoring a state dict changes the effective weights in place
+        // (rollback / snapshot rehydrate) — bump the weight epoch so session
+        // KV computed under the previous weights is treated as stale.
+        self.bump_weight_epoch();
+
         Ok(())
     }
 
     /// Update last access time
     pub fn touch(&mut self) {
         self.last_access = Instant::now();
+    }
+
+    /// Current weight epoch (version counter for KV-cache staleness detection).
+    pub fn weight_epoch(&self) -> u64 {
+        self.weight_epoch
+    }
+
+    /// Bump the weight epoch. Must be called on every in-place mutation of the
+    /// effective weights that happens without a remove/re-add of the delta —
+    /// adaptations, train steps, rollback restores, resets. O(1); the session
+    /// KV layer compares epochs on reuse and clears weight-stale caches.
+    pub fn bump_weight_epoch(&mut self) {
+        self.weight_epoch = self.weight_epoch.wrapping_add(1);
     }
 
     /// Estimate memory usage in bytes
@@ -655,6 +679,9 @@ impl TenantDelta {
         self.request_count = 0;
         self.avg_loss_improvement = 0.0;
         self.adaptation_state = crate::training::adaptation_state::DeltaAdaptationState::Idle;
+        // Zeroing the LoRA weights is the largest possible in-place weight
+        // change — bump the epoch so dependent session KV is invalidated.
+        self.bump_weight_epoch();
     }
 
     /// Zero all gradients on trainable variables.
@@ -845,6 +872,7 @@ impl TenantDelta {
             alpha: 1.0, // Already pre-scaled during composition
             rank_oracle: None,
             adaptation_state: crate::training::adaptation_state::DeltaAdaptationState::Idle,
+            weight_epoch: 0,
         }))
     }
 }
@@ -1042,6 +1070,7 @@ impl TenantDelta {
             alpha,
             rank_oracle: None,
             adaptation_state: crate::training::adaptation_state::DeltaAdaptationState::Idle,
+            weight_epoch: 0,
         })
     }
 }
@@ -1225,6 +1254,27 @@ mod tests {
             .sum(Kind::Float)
             .double_value(&[]);
         assert!(diff1 < 1e-6, "State dict roundtrip should preserve layer 1 values");
+    }
+
+    /// The weight epoch starts at 0 and advances on every in-place weight
+    /// mutation that bypasses remove/re-add — reset() and load_state_dict()
+    /// (rollback / snapshot rehydrate) here; adapt_tenant/train_step bump it in
+    /// the trainer. The KV layer keys staleness on this counter (#1254 F1 fix).
+    #[test]
+    fn test_weight_epoch_bumps_on_in_place_mutation() {
+        let config = TenantDeltaConfig::default();
+        let dims = test_module_dims();
+        let mut delta = TenantDelta::new(&config, &dims, Device::Cpu, TEST_NUM_LAYERS).unwrap();
+        assert_eq!(delta.weight_epoch(), 0, "fresh delta starts at epoch 0");
+
+        // reset() zeroes the LoRA B weights in place → epoch advances.
+        delta.reset();
+        assert_eq!(delta.weight_epoch(), 1, "reset bumps the weight epoch");
+
+        // load_state_dict() restores weights in place (rollback path) → epoch advances.
+        let state = delta.extract_state_dict();
+        delta.load_state_dict(&state).unwrap();
+        assert_eq!(delta.weight_epoch(), 2, "state restore bumps the weight epoch");
     }
 
     #[test]

--- a/crates/hyprstream/src/training/ttt.rs
+++ b/crates/hyprstream/src/training/ttt.rs
@@ -871,6 +871,14 @@ impl TestTimeTrainer {
                 // Restore SSM states so TTT training data does not pollute inference recurrent state.
                 engine.restore_ssm_states(ssm_snapshot);
 
+                // The LoRA weights were mutated in place (same tenant key, new
+                // effective weights) — bump the weight epoch so session KV
+                // computed under the pre-adaptation weights is cleared as stale
+                // on the next reuse (#1254 F1 fix).
+                if actual_steps > 0 {
+                    delta.bump_weight_epoch();
+                }
+
                 Ok((
                     TTTResult {
                         avg_loss,
@@ -1202,6 +1210,13 @@ impl TestTimeTrainer {
 
                 // Restore SSM states so training data does not pollute inference recurrent state.
                 engine.restore_ssm_states(ssm_snapshot);
+
+                // The LoRA weights were mutated in place — bump the weight epoch
+                // so session KV computed under the pre-training weights is
+                // cleared as stale on the next reuse (#1254 F1 fix).
+                if actual_steps > 0 {
+                    delta.bump_weight_epoch();
+                }
 
                 Ok(TTTResult {
                     avg_loss,


### PR DESCRIPTION
## Summary

Fixes #1254 (Epic #1246 — Inference multi-tenant hardening).

The serving cache-selection path (`TorchEngine::swap_session_cache`) obtained/installed the owner KV cache but **never called `KVCacheRegistry::register_delta_dependency`** between those steps. `invalidate_for_tenant` only evicts owners found in the dependency map, so it could not discover those caches — meaning stale KV survived a TTT delta change once session reuse was active.

## Changes

- **`runtime/torch_engine.rs`** — `swap_session_cache` now takes the effective tenant id (`None` when no tenant delta contributes) and registers it via `register_delta_dependency` **before** `set_kv_cache`, so a cache is tracked for invalidation before generation can read a token from it. `tenant_id` is threaded from the verified RPC subject through `generate_with_delta` → `TextStream::new_with_delta` → `swap_session_cache`.
- **`runtime/kv_cache.rs`**
  - `register_delta_dependency` now also clears the cache **in place when the effective tenant changed since its last compute** (no-delta↔delta, tenant-A↔tenant-B), so stale KV cannot cross a weight boundary. Returns whether it cleared.
  - `release()` (Stateless) and `evict_to_budget()` (tier-2) drop the delta dependency alongside the cache — no orphan dependency entries.
  - Removed the dead `CacheConfig.eviction_exempt` field + `with_eviction_exempt` builder and documented the explicit `CacheOwner::Training` exemption rule in `evict_to_budget` (the field was configurable but never consulted).
- **`services/inference.rs`** — `resolve_delta` now also returns the tenant id (`Some(subject)` only when a per-tenant delta contributed), derived from the existing verified request subject — no new identity source.

## Tests (`runtime::kv_cache`)

- Cross-tenant isolation: invalidate tenant-a clears only A's cache; B's stays intact (token IDs + layer KV).
- no-delta↔delta and tenant-A↔tenant-B transitions clear the stale KV; re-registering the same tenant preserves it.
- `release` drops the delta dependency (no orphan).
- A no-tenant cache survives any tenant invalidation.

## Build notes

Local gate green: `cargo check` / `cargo test runtime::kv_cache` (19 passed, 0 failed) / `cargo clippy --tests` for `hyprstream`, built with `--no-default-features --features gittorrent,xet,otel` (the box has no `libsystemd` devel headers, so the default `systemd` feature can't link locally). The changed code is feature-agnostic; CI validates the default-feature build.

## Merge coordination

Touches `runtime/torch_engine.rs` + `runtime/kv_cache.rs` — file overlap with **D7 (#1253)**, which also edits `torch_engine.rs`. Stack/serialize at merge to avoid conflicts.

Closes #1254
Epic #1246
