### PR TITLE
fix(inference): scrub prompt/token text from process logs (#1253)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -95,9 +95,9 @@ tracing-opentelemetry = { version = "0.31" }
 # OpenTelemetry
 opentelemetry = { version = "0.30" }
 opentelemetry_sdk = { version = "0.30", features = ["rt-tokio"] }
-opentelemetry-otlp = { version = "0.30", features = ["grpc-tonic", "trace"] }
+opentelemetry-otlp = { version = "0.30", features = ["grpc-tonic", "trace", "metrics"] }
 opentelemetry-semantic-conventions = { version = "0.30" }
-opentelemetry-stdout = { version = "0.30", features = ["trace"] }
+opentelemetry-stdout = { version = "0.30", features = ["trace", "metrics"] }
 
 # Utilities
 uuid = { version = "1.0", features = ["v4", "v5", "serde"] }

--- a/crates/hyprstream/Cargo.toml
+++ b/crates/hyprstream/Cargo.toml
@@ -156,6 +156,18 @@ ratatui = { version = "0.30", default-features = false }  # TUI framework for pa
 critical-section = { version = "1", features = ["std"] }
 vte = "0.13"  # VT100/ANSI escape sequence parser for TUI pane ingestion
 
+# OpenTelemetry (0.30 + OTLP/stdout exporters + tokio) is not wasm32-compatible.
+# The `otel` feature stays in the default set, but the dependency family only
+# resolves for non-wasm targets; the OTel code paths are cfg-gated to match and
+# fall back to a no-op on wasm32 (#1253/#1261, browser client).
+[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
+tracing-opentelemetry = { workspace = true, optional = true }
+opentelemetry = { workspace = true, optional = true }
+opentelemetry_sdk = { workspace = true, optional = true }
+opentelemetry-otlp = { workspace = true, optional = true }
+opentelemetry-semantic-conventions = { workspace = true, optional = true }
+opentelemetry-stdout = { workspace = true, optional = true }
+
 [target.'cfg(target_os = "linux")'.dependencies]
 lru.workspace = true  # LRU cache for model caching and Git repository handles
 dashmap.workspace = true  # Concurrent HashMap for thread-safe repository caching
@@ -275,7 +287,9 @@ tokio-tungstenite = "0.24"
 # Test-only: the `testing` feature exposes `InMemoryMetricExporter` for the
 # token-burn meter tests. The SDK compiles it under cfg(test) or this feature;
 # dependencies are not built with cfg(test), so the feature is required here.
-# Dev-only, so production builds are unaffected.
+# Dev-only and non-wasm-only (the OTel family is target-gated off wasm32), so
+# production and wasm builds are unaffected.
+[target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
 opentelemetry_sdk = { workspace = true, features = ["testing"] }
 
 [lints]

--- a/crates/hyprstream/Cargo.toml
+++ b/crates/hyprstream/Cargo.toml
@@ -156,18 +156,6 @@ ratatui = { version = "0.30", default-features = false }  # TUI framework for pa
 critical-section = { version = "1", features = ["std"] }
 vte = "0.13"  # VT100/ANSI escape sequence parser for TUI pane ingestion
 
-# OpenTelemetry (0.30 + OTLP/stdout exporters + tokio) is not wasm32-compatible.
-# The `otel` feature stays in the default set, but the dependency family only
-# resolves for non-wasm targets; the OTel code paths are cfg-gated to match and
-# fall back to a no-op on wasm32 (#1253/#1261, browser client).
-[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-tracing-opentelemetry = { workspace = true, optional = true }
-opentelemetry = { workspace = true, optional = true }
-opentelemetry_sdk = { workspace = true, optional = true }
-opentelemetry-otlp = { workspace = true, optional = true }
-opentelemetry-semantic-conventions = { workspace = true, optional = true }
-opentelemetry-stdout = { workspace = true, optional = true }
-
 [target.'cfg(target_os = "linux")'.dependencies]
 lru.workspace = true  # LRU cache for model caching and Git repository handles
 dashmap.workspace = true  # Concurrent HashMap for thread-safe repository caching

--- a/crates/hyprstream/Cargo.toml
+++ b/crates/hyprstream/Cargo.toml
@@ -272,6 +272,11 @@ rand.workspace = true
 tower = { version = "0.5", features = ["util"] }
 # Test-only: WebSocket client for the 9P-over-WS attach round-trip (H1a / #764).
 tokio-tungstenite = "0.24"
+# Test-only: the `testing` feature exposes `InMemoryMetricExporter` for the
+# token-burn meter tests. The SDK compiles it under cfg(test) or this feature;
+# dependencies are not built with cfg(test), so the feature is required here.
+# Dev-only, so production builds are unaffected.
+opentelemetry_sdk = { workspace = true, features = ["testing"] }
 
 [lints]
 workspace = true

--- a/crates/hyprstream/src/bin/main.rs
+++ b/crates/hyprstream/src/bin/main.rs
@@ -391,16 +391,16 @@ fn init_telemetry(provider: TelemetryProvider) -> Result<()> {
         .with_attribute(KeyValue::new("service.version", env!("CARGO_PKG_VERSION")))
         .build();
 
+    let endpoint = std::env::var("OTEL_EXPORTER_OTLP_ENDPOINT")
+        .unwrap_or_else(|_| "http://localhost:4317".to_owned());
+
     let tracer_provider = match provider {
         TelemetryProvider::Otlp => {
-            let endpoint = std::env::var("OTEL_EXPORTER_OTLP_ENDPOINT")
-                .unwrap_or_else(|_| "http://localhost:4317".to_owned());
-
             info!("Using OTLP exporter for OpenTelemetry at {}", endpoint);
 
             let exporter = SpanExporter::builder()
                 .with_tonic()
-                .with_endpoint(endpoint)
+                .with_endpoint(endpoint.clone())
                 .build()
                 .context("Failed to create OTLP exporter")?;
 
@@ -413,11 +413,41 @@ fn init_telemetry(provider: TelemetryProvider) -> Result<()> {
             info!("Using stdout exporter for OpenTelemetry (debug)");
 
             opentelemetry_sdk::trace::SdkTracerProvider::builder()
-                .with_resource(resource)
+                .with_resource(resource.clone())
                 .with_simple_exporter(opentelemetry_stdout::SpanExporter::default())
                 .build()
         }
     };
+
+    // Token-burn + other OTel metrics (#1261) only flow to a collector when a
+    // meter provider is registered; otherwise the global meter is a no-op. Build
+    // a periodic-exporting provider mirroring the tracer provider's transport.
+    let meter_provider = match provider {
+        TelemetryProvider::Otlp => {
+            let exporter = opentelemetry_otlp::MetricExporter::builder()
+                .with_tonic()
+                .with_endpoint(endpoint)
+                .build()
+                .context("Failed to create OTLP metric exporter")?;
+
+            opentelemetry_sdk::metrics::SdkMeterProvider::builder()
+                .with_resource(resource.clone())
+                .with_reader(
+                    opentelemetry_sdk::metrics::PeriodicReader::builder(exporter).build(),
+                )
+                .build()
+        }
+        TelemetryProvider::Stdout => opentelemetry_sdk::metrics::SdkMeterProvider::builder()
+            .with_resource(resource)
+            .with_reader(
+                opentelemetry_sdk::metrics::PeriodicReader::builder(
+                    opentelemetry_stdout::MetricExporter::default(),
+                )
+                .build(),
+            )
+            .build(),
+    };
+    opentelemetry::global::set_meter_provider(meter_provider);
 
     let tracer = tracer_provider.tracer("hyprstream");
     let otel_layer = OpenTelemetryLayer::new(tracer);

--- a/crates/hyprstream/src/runtime/kv_cache.rs
+++ b/crates/hyprstream/src/runtime/kv_cache.rs
@@ -449,10 +449,15 @@ impl KVCacheRegistry {
         }
 
         if invalidated > 0 {
+            // Never log the raw tenant subject (#1253/#1261 review): emit the
+            // same opaque keyed-hash id used for metric attributes.
+            let opaque = crate::runtime::token_metrics::opaque_tenant_id(&Some(
+                tenant_id.to_owned(),
+            ));
             tracing::info!(
-                "Invalidated {} KV caches dependent on subject delta '{}'",
+                "Invalidated {} KV caches dependent on subject delta (tenant {})",
                 invalidated,
-                tenant_id
+                opaque.map_or_else(|| "anonymous".to_owned(), |h| format!("tenant:{h:016x}"))
             );
         }
 

--- a/crates/hyprstream/src/runtime/mod.rs
+++ b/crates/hyprstream/src/runtime/mod.rs
@@ -30,6 +30,7 @@ pub mod ttn_profile;  // TTN analysis pipeline: adaptive layer profiling + embed
 pub mod batched_lora; // Batched multi-tenant LoRA forward pass
 // REMOVED: pub mod conversation_router; // Dead code - VDB TemporalStreamingLayer removed
 pub mod generation_metrics; // Quality metrics for self-supervised training
+pub mod token_metrics; // OpenTelemetry token-burn metering (prompt + generated tokens per request)
 // KV cache quantization — re-export the generated Cap'n Proto enum as canonical type
 pub use crate::services::generated::model_client::KVQuantType;
 pub mod tensor_sampling; // Device-agnostic tensor-based sampling

--- a/crates/hyprstream/src/runtime/token_metrics.rs
+++ b/crates/hyprstream/src/runtime/token_metrics.rs
@@ -1,0 +1,281 @@
+//! OpenTelemetry token-burn metering for inference.
+//!
+//! Token burn — prompt tokens consumed plus generated tokens produced per
+//! request — is accounting- and ops-relevant, so it is emitted as OpenTelemetry
+//! **metrics** rather than process logs (#1253, #1261). The authoritative spend
+//! ledger lives in #1264; the instruments here are the metering/ops signal.
+//!
+//! # Instruments
+//!
+//! - `inference_tokens_total` — `Counter<u64>` (unit "tokens"), cumulative tokens
+//!   consumed, with attributes `kind` = `prompt` | `generated`, `model`, and an
+//!   **opaque hashed** tenant id.
+//! - `inference_request_tokens` — `Histogram<u64>` (unit "tokens"), total tokens
+//!   (prompt + generated) per request, same `model` / `tenant` attributes.
+//!
+//! # Security
+//!
+//! The raw request subject is **never** used as a metric attribute: metrics are
+//! aggregatable across tenants and must not carry tenant-identifying content. The
+//! tenant is reduced to an opaque 64-bit hash via [`opaque_tenant_id`] before it
+//! becomes an attribute. Prompt text, token text, and generated text are likewise
+//! never in metrics — only integer counts. See the no-leak canary test in
+//! [`crate::runtime::torch_engine`] which guards the same property for logs.
+
+#[cfg(feature = "otel")]
+mod metered {
+    use opentelemetry::{KeyValue, metrics::Meter};
+
+    /// OTel meter scope name for inference token-burn instruments.
+    const METER_NAME: &str = "hyprstream.inference";
+    const METRIC_TOKENS_TOTAL: &str = "inference_tokens_total";
+    const METRIC_REQUEST_TOKENS: &str = "inference_request_tokens";
+    const UNIT: &str = "tokens";
+
+    const KIND_PROMPT: &str = "prompt";
+    const KIND_GENERATED: &str = "generated";
+    const KIND_TOTAL: &str = "total";
+
+    /// Build the (kind, model, opaque-tenant) attribute set for a metric point.
+    fn attrs(kind: &str, model: &str, tenant: Option<u64>) -> [KeyValue; 3] {
+        let tenant_attr = match tenant {
+            // Opaque hashed id; never the raw subject.
+            Some(h) => KeyValue::new("tenant", format!("tenant:{h:016x}")),
+            None => KeyValue::new("tenant", "anonymous"),
+        };
+        [
+            KeyValue::new("kind", kind.to_owned()),
+            KeyValue::new("model", model.to_owned()),
+            tenant_attr,
+        ]
+    }
+
+    /// Token-burn instruments built from an OTel [`Meter`].
+    ///
+    /// When constructed via [`TokenBurnMeter::global`] the process-global OTel
+    /// meter is used, which is a no-op meter unless an SDK meter provider has been
+    /// registered (e.g. by `init_telemetry`). Recording is therefore always safe:
+    /// it never blocks or panics, and silently does nothing when no exporter is
+    /// configured or the `otel` feature is off.
+    pub struct TokenBurnMeter {
+        tokens_total: opentelemetry::metrics::Counter<u64>,
+        request_tokens: opentelemetry::metrics::Histogram<u64>,
+    }
+
+    impl TokenBurnMeter {
+        /// Build from the process-global OTel meter (no-op when no provider set).
+        pub fn global() -> Self {
+            Self::from_meter(opentelemetry::global::meter(METER_NAME))
+        }
+
+        /// Build from an explicit meter — used in tests with a local SDK meter
+        /// provider so recording can be asserted hermetically.
+        pub fn from_meter(meter: Meter) -> Self {
+            Self {
+                tokens_total: meter
+                    .u64_counter(METRIC_TOKENS_TOTAL)
+                    .with_unit(UNIT)
+                    .with_description(
+                        "Inference tokens consumed (prompt + generated), by kind/model/tenant",
+                    )
+                    .build(),
+                request_tokens: meter
+                    .u64_histogram(METRIC_REQUEST_TOKENS)
+                    .with_unit(UNIT)
+                    .with_description("Total tokens per inference request (prompt + generated)")
+                    .build(),
+            }
+        }
+
+        /// Record prompt tokens consumed by tokenizing a request.
+        pub fn record_prompt(&self, model: &str, tenant: Option<u64>, count: u64) {
+            if count == 0 {
+                return;
+            }
+            self.tokens_total
+                .add(count, &attrs(KIND_PROMPT, model, tenant));
+        }
+
+        /// Record generated tokens produced by a completed request.
+        pub fn record_generated(&self, model: &str, tenant: Option<u64>, count: u64) {
+            if count == 0 {
+                return;
+            }
+            self.tokens_total
+                .add(count, &attrs(KIND_GENERATED, model, tenant));
+        }
+
+        /// Record the per-request token total (prompt + generated) on the histogram.
+        pub fn record_request_total(&self, model: &str, tenant: Option<u64>, total: u64) {
+            // Record even when total == 0 so an empty-generation request is still
+            // observable as a sample; the counter carries the non-zero breakdown.
+            self.request_tokens
+                .record(total, &attrs(KIND_TOTAL, model, tenant));
+        }
+    }
+}
+
+#[cfg(feature = "otel")]
+pub use metered::TokenBurnMeter;
+
+/// No-op instruments when the `otel` feature is disabled.
+///
+/// Keeps the recording call sites compiling without an OTel SDK so non-`otel`
+/// builds still meter nothing without conditionalizing every call site.
+#[cfg(not(feature = "otel"))]
+pub struct TokenBurnMeter;
+
+#[cfg(not(feature = "otel"))]
+impl TokenBurnMeter {
+    pub fn global() -> Self {
+        Self
+    }
+    pub fn record_prompt(&self, _model: &str, _tenant: Option<u64>, _count: u64) {}
+    pub fn record_generated(&self, _model: &str, _tenant: Option<u64>, _count: u64) {}
+    pub fn record_request_total(&self, _model: &str, _tenant: Option<u64>, _total: u64) {}
+}
+
+/// Reduce a raw tenant subject to an opaque, stable 64-bit id for metric attrs.
+///
+/// The tenant subject is never carried verbatim in metrics (it is aggregatable
+/// across tenants and must not leak identity). A deterministic hash is emitted so
+/// the same tenant maps to the same opaque id across process restarts, enabling
+/// continuity in dashboards without ever revealing the subject. Returns `None`
+/// when no tenant is in scope.
+///
+/// This is pure std and available regardless of the `otel` feature so it can be
+/// unit-tested hermetically.
+pub fn opaque_tenant_id(tenant: &Option<String>) -> Option<u64> {
+    use std::hash::{Hash, Hasher};
+    let subject = tenant.as_ref()?;
+    // DefaultHasher is deterministic (fixed SipHash keys), not the per-process
+    // randomized RandomState — chosen deliberately for cross-restart stability.
+    let mut hasher = std::collections::hash_map::DefaultHasher::new();
+    subject.hash(&mut hasher);
+    Some(hasher.finish())
+}
+
+#[cfg(all(test, feature = "otel"))]
+mod tests {
+    use super::*;
+    use opentelemetry::metrics::MeterProvider;
+    use opentelemetry_sdk::metrics::data::{AggregatedMetrics, MetricData};
+    use opentelemetry_sdk::metrics::{InMemoryMetricExporter, PeriodicReader, SdkMeterProvider};
+
+    /// Drive the meter through a real SDK pipeline (in-memory exporter) and assert
+    /// token burn lands on the right instruments with opaque, never-raw tenant attrs.
+    #[test]
+    fn token_burn_meter_records_prompt_and_generated() {
+        let exporter = InMemoryMetricExporter::default();
+        let provider = SdkMeterProvider::builder()
+            .with_reader(PeriodicReader::builder(exporter.clone()).build())
+            .build();
+        let meter = provider.meter("hyprstream.inference");
+        let m = TokenBurnMeter::from_meter(meter);
+
+        let tenant_hash = opaque_tenant_id(&Some("did:web:acme.example".to_owned()));
+        assert!(tenant_hash.is_some(), "tenant hashes to an opaque id");
+        m.record_prompt("test-model", tenant_hash, 10);
+        m.record_generated("test-model", tenant_hash, 7);
+        m.record_request_total("test-model", tenant_hash, 17);
+
+        provider.force_flush().unwrap();
+        let collected = exporter.get_finished_metrics().unwrap();
+
+        // Flatten (name, sum-or-count, serialized-attrs) across scopes/instruments.
+        let mut counter_sum: u64 = 0;
+        let mut histogram_count: u64 = 0;
+        let mut histogram_sum: u64 = 0;
+        let mut any_attrs = String::new();
+        for rm in collected {
+            for sm in rm.scope_metrics() {
+                for metric in sm.metrics() {
+                    let name = metric.name();
+                    match metric.data() {
+                        AggregatedMetrics::U64(MetricData::Sum(s)) => {
+                            for dp in s.data_points() {
+                                if name == "inference_tokens_total" {
+                                    counter_sum += dp.value();
+                                }
+                                for kv in dp.attributes() {
+                                    any_attrs.push_str(&format!("{kv:?}"));
+                                }
+                            }
+                        }
+                        AggregatedMetrics::U64(MetricData::Histogram(h)) => {
+                            for dp in h.data_points() {
+                                if name == "inference_request_tokens" {
+                                    histogram_count += dp.count();
+                                    histogram_sum += dp.sum();
+                                }
+                                for kv in dp.attributes() {
+                                    any_attrs.push_str(&format!("{kv:?}"));
+                                }
+                            }
+                        }
+                        _ => {}
+                    }
+                }
+            }
+        }
+
+        // Counter: 10 (prompt) + 7 (generated) = 17 cumulative tokens.
+        assert_eq!(counter_sum, 17, "inference_tokens_total should sum to 17");
+        // Histogram: one request totaling 17 tokens.
+        assert_eq!(histogram_count, 1, "one request recorded on the histogram");
+        assert_eq!(histogram_sum, 17, "histogram total should be 17");
+
+        // The raw tenant subject must never appear in metric attributes; only the
+        // opaque hash form does.
+        assert!(
+            !any_attrs.contains("acme.example"),
+            "raw tenant subject leaked into metric attrs: {any_attrs}"
+        );
+        assert!(
+            any_attrs.contains("tenant:"),
+            "opaque tenant attr missing: {any_attrs}"
+        );
+    }
+
+    #[test]
+    fn opaque_tenant_id_is_stable_and_anonymous_when_absent() {
+        let a = opaque_tenant_id(&Some("did:web:acme.example".to_owned()));
+        let b = opaque_tenant_id(&Some("did:web:acme.example".to_owned()));
+        assert_eq!(a, b, "same subject must hash to the same opaque id");
+
+        let other = opaque_tenant_id(&Some("did:web:other.example".to_owned()));
+        assert_ne!(a, other, "different subjects must hash differently");
+
+        assert_eq!(
+            opaque_tenant_id(&None),
+            None,
+            "absent tenant yields no opaque id"
+        );
+    }
+
+    #[test]
+    fn zero_prompt_is_a_noop() {
+        // A zero count should not add a data point to the counter.
+        let exporter = InMemoryMetricExporter::default();
+        let provider = SdkMeterProvider::builder()
+            .with_reader(PeriodicReader::builder(exporter.clone()).build())
+            .build();
+        let meter = provider.meter("hyprstream.inference");
+        let m = TokenBurnMeter::from_meter(meter);
+        m.record_prompt("test-model", None, 0);
+        m.record_generated("test-model", None, 0);
+        provider.force_flush().unwrap();
+
+        let mut any_counter: u64 = 0;
+        for rm in exporter.get_finished_metrics().unwrap() {
+            for sm in rm.scope_metrics() {
+                for metric in sm.metrics() {
+                    if let AggregatedMetrics::U64(MetricData::Sum(s)) = metric.data() {
+                        any_counter += s.data_points().map(|dp| dp.value()).sum::<u64>();
+                    }
+                }
+            }
+        }
+        assert_eq!(any_counter, 0, "zero-count records must not land on the counter");
+    }
+}

--- a/crates/hyprstream/src/runtime/token_metrics.rs
+++ b/crates/hyprstream/src/runtime/token_metrics.rs
@@ -165,7 +165,7 @@ mod tests {
     /// Drive the meter through a real SDK pipeline (in-memory exporter) and assert
     /// token burn lands on the right instruments with opaque, never-raw tenant attrs.
     #[test]
-    fn token_burn_meter_records_prompt_and_generated() {
+    fn token_burn_meter_records_prompt_and_generated() -> Result<(), Box<dyn std::error::Error>> {
         let exporter = InMemoryMetricExporter::default();
         let provider = SdkMeterProvider::builder()
             .with_reader(PeriodicReader::builder(exporter.clone()).build())
@@ -179,8 +179,8 @@ mod tests {
         m.record_generated("test-model", tenant_hash, 7);
         m.record_request_total("test-model", tenant_hash, 17);
 
-        provider.force_flush().unwrap();
-        let collected = exporter.get_finished_metrics().unwrap();
+        provider.force_flush()?;
+        let collected = exporter.get_finished_metrics()?;
 
         // Flatten (name, sum-or-count, serialized-attrs) across scopes/instruments.
         let mut counter_sum: u64 = 0;
@@ -235,6 +235,7 @@ mod tests {
             any_attrs.contains("tenant:"),
             "opaque tenant attr missing: {any_attrs}"
         );
+        Ok(())
     }
 
     #[test]
@@ -254,7 +255,7 @@ mod tests {
     }
 
     #[test]
-    fn zero_prompt_is_a_noop() {
+    fn zero_prompt_is_a_noop() -> Result<(), Box<dyn std::error::Error>> {
         // A zero count should not add a data point to the counter.
         let exporter = InMemoryMetricExporter::default();
         let provider = SdkMeterProvider::builder()
@@ -264,18 +265,21 @@ mod tests {
         let m = TokenBurnMeter::from_meter(meter);
         m.record_prompt("test-model", None, 0);
         m.record_generated("test-model", None, 0);
-        provider.force_flush().unwrap();
+        provider.force_flush()?;
 
         let mut any_counter: u64 = 0;
-        for rm in exporter.get_finished_metrics().unwrap() {
+        for rm in exporter.get_finished_metrics()? {
             for sm in rm.scope_metrics() {
                 for metric in sm.metrics() {
                     if let AggregatedMetrics::U64(MetricData::Sum(s)) = metric.data() {
-                        any_counter += s.data_points().map(|dp| dp.value()).sum::<u64>();
+                        for dp in s.data_points() {
+                            any_counter += dp.value();
+                        }
                     }
                 }
             }
         }
         assert_eq!(any_counter, 0, "zero-count records must not land on the counter");
+        Ok(())
     }
 }

--- a/crates/hyprstream/src/runtime/token_metrics.rs
+++ b/crates/hyprstream/src/runtime/token_metrics.rs
@@ -7,47 +7,65 @@
 //!
 //! # Instruments
 //!
-//! - `inference_tokens_total` — `Counter<u64>` (unit "tokens"), cumulative tokens
-//!   consumed, with attributes `kind` = `prompt` | `generated`, `model`, and an
-//!   **opaque hashed** tenant id.
-//! - `inference_request_tokens` — `Histogram<u64>` (unit "tokens"), total tokens
-//!   (prompt + generated) per request, same `model` / `tenant` attributes.
+//! - `inference_tokens_total` — `Counter<u64>` (unit `{token}`, UCUM custom-unit
+//!   form), cumulative tokens consumed, with attributes `kind` =
+//!   `prompt` | `generated`, `model`, and an **opaque keyed-hash** tenant id.
+//! - `inference_request_tokens` — `Histogram<u64>` (unit `{token}`), total tokens
+//!   (prompt + generated) per request, with `model` / `tenant` attributes only.
 //!
 //! # Security
 //!
 //! The raw request subject is **never** used as a metric attribute: metrics are
 //! aggregatable across tenants and must not carry tenant-identifying content. The
-//! tenant is reduced to an opaque 64-bit hash via [`opaque_tenant_id`] before it
-//! becomes an attribute. Prompt text, token text, and generated text are likewise
-//! never in metrics — only integer counts. See the no-leak canary test in
-//! [`crate::runtime::torch_engine`] which guards the same property for logs.
+//! tenant is reduced to an opaque keyed hash via [`opaque_tenant_id`] before it
+//! becomes an attribute. Prompt text, token text, generated text, and token IDs
+//! are likewise never in metrics — only integer counts. See the no-leak canary
+//! test in [`crate::runtime::torch_engine`] which guards the same property for
+//! logs.
+//!
+//! # Platform gating
+//!
+//! The opentelemetry dependency family is not wasm32-compatible, so the crates
+//! are target-gated in `Cargo.toml` and the instruments here compile only for
+//! `all(feature = "otel", not(target_arch = "wasm32"))`. Everywhere else a no-op
+//! [`TokenBurnMeter`] keeps the call sites compiling — the wasm/browser client
+//! pays no metric cost and non-`otel` builds meter nothing.
 
-#[cfg(feature = "otel")]
+#[cfg(all(feature = "otel", not(target_arch = "wasm32")))]
 mod metered {
+    use once_cell::sync::Lazy;
     use opentelemetry::{KeyValue, metrics::Meter};
 
     /// OTel meter scope name for inference token-burn instruments.
     const METER_NAME: &str = "hyprstream.inference";
     const METRIC_TOKENS_TOTAL: &str = "inference_tokens_total";
     const METRIC_REQUEST_TOKENS: &str = "inference_request_tokens";
-    const UNIT: &str = "tokens";
+    /// UCUM custom-unit form for token counts (OTel convention: `{unit}`).
+    const UNIT: &str = "{token}";
 
     const KIND_PROMPT: &str = "prompt";
     const KIND_GENERATED: &str = "generated";
-    const KIND_TOTAL: &str = "total";
 
-    /// Build the (kind, model, opaque-tenant) attribute set for a metric point.
-    fn attrs(kind: &str, model: &str, tenant: Option<u64>) -> [KeyValue; 3] {
-        let tenant_attr = match tenant {
-            // Opaque hashed id; never the raw subject.
+    /// The tenant attribute: opaque keyed-hash id, never the raw subject.
+    fn tenant_attr(tenant: Option<u64>) -> KeyValue {
+        match tenant {
             Some(h) => KeyValue::new("tenant", format!("tenant:{h:016x}")),
             None => KeyValue::new("tenant", "anonymous"),
-        };
+        }
+    }
+
+    /// (kind, model, opaque-tenant) attribute set for the counter.
+    fn counter_attrs(kind: &str, model: &str, tenant: Option<u64>) -> [KeyValue; 3] {
         [
             KeyValue::new("kind", kind.to_owned()),
             KeyValue::new("model", model.to_owned()),
-            tenant_attr,
+            tenant_attr(tenant),
         ]
+    }
+
+    /// (model, opaque-tenant) attribute set for the per-request histogram.
+    fn request_attrs(model: &str, tenant: Option<u64>) -> [KeyValue; 2] {
+        [KeyValue::new("model", model.to_owned()), tenant_attr(tenant)]
     }
 
     /// Token-burn instruments built from an OTel [`Meter`].
@@ -68,8 +86,8 @@ mod metered {
             Self::from_meter(opentelemetry::global::meter(METER_NAME))
         }
 
-        /// Build from an explicit meter — used in tests with a local SDK meter
-        /// provider so recording can be asserted hermetically.
+        /// Build from an explicit meter — the test seam, used with a local SDK
+        /// meter provider so recording can be asserted hermetically.
         pub fn from_meter(meter: Meter) -> Self {
             Self {
                 tokens_total: meter
@@ -93,7 +111,7 @@ mod metered {
                 return;
             }
             self.tokens_total
-                .add(count, &attrs(KIND_PROMPT, model, tenant));
+                .add(count, &counter_attrs(KIND_PROMPT, model, tenant));
         }
 
         /// Record generated tokens produced by a completed request.
@@ -102,30 +120,43 @@ mod metered {
                 return;
             }
             self.tokens_total
-                .add(count, &attrs(KIND_GENERATED, model, tenant));
+                .add(count, &counter_attrs(KIND_GENERATED, model, tenant));
         }
 
         /// Record the per-request token total (prompt + generated) on the histogram.
         pub fn record_request_total(&self, model: &str, tenant: Option<u64>, total: u64) {
             // Record even when total == 0 so an empty-generation request is still
             // observable as a sample; the counter carries the non-zero breakdown.
-            self.request_tokens
-                .record(total, &attrs(KIND_TOTAL, model, tenant));
+            self.request_tokens.record(total, &request_attrs(model, tenant));
         }
+    }
+
+    /// Process-global instrument bundle, built **once** on first recording — not
+    /// per request (#1261 review: instrument construction must not be hot-path
+    /// work). Built lazily so a provider installed at startup (`init_telemetry`)
+    /// is already in place; if recording ever raced ahead of provider install,
+    /// the global meter defers and connects the instruments once the provider is
+    /// set, so no points are lost.
+    static GLOBAL_METER: Lazy<TokenBurnMeter> = Lazy::new(TokenBurnMeter::global);
+
+    /// Shared process-global token-burn instruments.
+    pub fn global_meter() -> &'static TokenBurnMeter {
+        &GLOBAL_METER
     }
 }
 
-#[cfg(feature = "otel")]
-pub use metered::TokenBurnMeter;
+#[cfg(all(feature = "otel", not(target_arch = "wasm32")))]
+pub use metered::{TokenBurnMeter, global_meter};
 
-/// No-op instruments when the `otel` feature is disabled.
+/// No-op instruments when the `otel` feature is disabled or the target is wasm32
+/// (the opentelemetry crates are not wasm-compatible and are target-gated out).
 ///
 /// Keeps the recording call sites compiling without an OTel SDK so non-`otel`
-/// builds still meter nothing without conditionalizing every call site.
-#[cfg(not(feature = "otel"))]
+/// and wasm builds meter nothing without conditionalizing every call site.
+#[cfg(not(all(feature = "otel", not(target_arch = "wasm32"))))]
 pub struct TokenBurnMeter;
 
-#[cfg(not(feature = "otel"))]
+#[cfg(not(all(feature = "otel", not(target_arch = "wasm32"))))]
 impl TokenBurnMeter {
     pub fn global() -> Self {
         Self
@@ -135,35 +166,56 @@ impl TokenBurnMeter {
     pub fn record_request_total(&self, _model: &str, _tenant: Option<u64>, _total: u64) {}
 }
 
-/// Reduce a raw tenant subject to an opaque, stable 64-bit id for metric attrs.
-///
-/// The tenant subject is never carried verbatim in metrics (it is aggregatable
-/// across tenants and must not leak identity). A deterministic hash is emitted so
-/// the same tenant maps to the same opaque id across process restarts, enabling
-/// continuity in dashboards without ever revealing the subject. Returns `None`
-/// when no tenant is in scope.
-///
-/// This is pure std and available regardless of the `otel` feature so it can be
-/// unit-tested hermetically.
-pub fn opaque_tenant_id(tenant: &Option<String>) -> Option<u64> {
-    use std::hash::{Hash, Hasher};
-    let subject = tenant.as_ref()?;
-    // DefaultHasher is deterministic (fixed SipHash keys), not the per-process
-    // randomized RandomState — chosen deliberately for cross-restart stability.
-    let mut hasher = std::collections::hash_map::DefaultHasher::new();
-    subject.hash(&mut hasher);
-    Some(hasher.finish())
+/// Shared no-op instruments for non-`otel` / wasm32 builds.
+#[cfg(not(all(feature = "otel", not(target_arch = "wasm32"))))]
+pub fn global_meter() -> &'static TokenBurnMeter {
+    static NOOP_METER: TokenBurnMeter = TokenBurnMeter;
+    &NOOP_METER
 }
 
-#[cfg(all(test, feature = "otel"))]
+/// Reduce a raw tenant subject to an opaque 64-bit id for metric attrs and
+/// tenant-safe logs.
+///
+/// The tenant subject is never carried verbatim in metrics or logs (metrics are
+/// aggregatable across tenants and must not leak identity). The hash is a
+/// SipHash keyed with **process-random** keys (`RandomState`, drawn from the OS
+/// RNG): an unkeyed hash such as `DefaultHasher::new()` is offline-enumerable —
+/// anyone can precompute the ids of guessed low-entropy subjects (#1261 review).
+/// With a random key the id is stable within the process but cannot be
+/// precomputed or correlated across deployments. Returns `None` when no tenant
+/// is in scope.
+///
+/// This is pure std and available regardless of the `otel` feature or target so
+/// it can be unit-tested hermetically and reused by tenant-safe logging.
+pub fn opaque_tenant_id(tenant: &Option<String>) -> Option<u64> {
+    use std::collections::hash_map::RandomState;
+    use std::hash::BuildHasher;
+    use std::sync::OnceLock;
+
+    static TENANT_HASH_KEY: OnceLock<RandomState> = OnceLock::new();
+
+    let subject = tenant.as_ref()?;
+    Some(TENANT_HASH_KEY.get_or_init(RandomState::new).hash_one(subject))
+}
+
+#[cfg(all(test, feature = "otel", not(target_arch = "wasm32")))]
 mod tests {
     use super::*;
     use opentelemetry::metrics::MeterProvider;
     use opentelemetry_sdk::metrics::data::{AggregatedMetrics, MetricData};
     use opentelemetry_sdk::metrics::{InMemoryMetricExporter, PeriodicReader, SdkMeterProvider};
 
+    /// Render a data point's attributes as a sorted `k=v` list for exact
+    /// set comparisons.
+    fn attr_set<'a, I: Iterator<Item = &'a opentelemetry::KeyValue>>(attrs: I) -> Vec<String> {
+        let mut v: Vec<String> = attrs.map(|kv| format!("{}={}", kv.key, kv.value)).collect();
+        v.sort();
+        v
+    }
+
     /// Drive the meter through a real SDK pipeline (in-memory exporter) and assert
-    /// token burn lands on the right instruments with opaque, never-raw tenant attrs.
+    /// token burn lands on the right instruments with the exact attribute contract
+    /// and opaque, never-raw tenant attrs.
     #[test]
     fn token_burn_meter_records_prompt_and_generated() -> Result<(), Box<dyn std::error::Error>> {
         let exporter = InMemoryMetricExporter::default();
@@ -175,6 +227,7 @@ mod tests {
 
         let tenant_hash = opaque_tenant_id(&Some("did:web:acme.example".to_owned()));
         assert!(tenant_hash.is_some(), "tenant hashes to an opaque id");
+        let expected_tenant = format!("tenant=tenant:{:016x}", tenant_hash.unwrap_or(0));
         m.record_prompt("test-model", tenant_hash, 10);
         m.record_generated("test-model", tenant_hash, 7);
         m.record_request_total("test-model", tenant_hash, 17);
@@ -182,35 +235,31 @@ mod tests {
         provider.force_flush()?;
         let collected = exporter.get_finished_metrics()?;
 
-        // Flatten (name, sum-or-count, serialized-attrs) across scopes/instruments.
-        let mut counter_sum: u64 = 0;
-        let mut histogram_count: u64 = 0;
-        let mut histogram_sum: u64 = 0;
+        let mut counter_points: Vec<(Vec<String>, u64)> = Vec::new();
+        let mut counter_unit = String::new();
+        let mut histogram_points: Vec<(Vec<String>, u64, u64)> = Vec::new();
+        let mut histogram_unit = String::new();
         let mut any_attrs = String::new();
         for rm in collected {
             for sm in rm.scope_metrics() {
                 for metric in sm.metrics() {
-                    let name = metric.name();
                     match metric.data() {
                         AggregatedMetrics::U64(MetricData::Sum(s)) => {
+                            assert_eq!(metric.name(), "inference_tokens_total");
+                            counter_unit = metric.unit().to_owned();
                             for dp in s.data_points() {
-                                if name == "inference_tokens_total" {
-                                    counter_sum += dp.value();
-                                }
-                                for kv in dp.attributes() {
-                                    any_attrs.push_str(&format!("{kv:?}"));
-                                }
+                                let attrs = attr_set(dp.attributes());
+                                any_attrs.push_str(&attrs.join(","));
+                                counter_points.push((attrs, dp.value()));
                             }
                         }
                         AggregatedMetrics::U64(MetricData::Histogram(h)) => {
+                            assert_eq!(metric.name(), "inference_request_tokens");
+                            histogram_unit = metric.unit().to_owned();
                             for dp in h.data_points() {
-                                if name == "inference_request_tokens" {
-                                    histogram_count += dp.count();
-                                    histogram_sum += dp.sum();
-                                }
-                                for kv in dp.attributes() {
-                                    any_attrs.push_str(&format!("{kv:?}"));
-                                }
+                                let attrs = attr_set(dp.attributes());
+                                any_attrs.push_str(&attrs.join(","));
+                                histogram_points.push((attrs, dp.count(), dp.sum()));
                             }
                         }
                         _ => {}
@@ -219,21 +268,46 @@ mod tests {
             }
         }
 
-        // Counter: 10 (prompt) + 7 (generated) = 17 cumulative tokens.
-        assert_eq!(counter_sum, 17, "inference_tokens_total should sum to 17");
-        // Histogram: one request totaling 17 tokens.
-        assert_eq!(histogram_count, 1, "one request recorded on the histogram");
-        assert_eq!(histogram_sum, 17, "histogram total should be 17");
+        // Units use the UCUM custom-unit form.
+        assert_eq!(counter_unit, "{token}", "counter unit");
+        assert_eq!(histogram_unit, "{token}", "histogram unit");
 
-        // The raw tenant subject must never appear in metric attributes; only the
-        // opaque hash form does.
+        // Counter: exactly two points — kind=prompt (10) and kind=generated (7) —
+        // each with the exact (kind, model, tenant) attribute set. The SDK does
+        // not guarantee data-point order, so sort before comparing.
+        counter_points.sort();
+        let expected_prompt_attrs = vec![
+            "kind=prompt".to_owned(),
+            "model=test-model".to_owned(),
+            expected_tenant.clone(),
+        ];
+        let expected_generated_attrs = vec![
+            "kind=generated".to_owned(),
+            "model=test-model".to_owned(),
+            expected_tenant.clone(),
+        ];
+        assert_eq!(
+            counter_points,
+            vec![
+                (expected_generated_attrs, 7),
+                (expected_prompt_attrs, 10),
+            ],
+            "counter points must be exactly prompt=10 and generated=7 with exact attrs"
+        );
+
+        // Histogram: exactly one point (count 1, sum 17) with ONLY the
+        // (model, tenant) attribute set — no kind.
+        let expected_histogram_attrs = vec!["model=test-model".to_owned(), expected_tenant];
+        assert_eq!(
+            histogram_points,
+            vec![(expected_histogram_attrs, 1, 17)],
+            "histogram must carry one request of 17 tokens with (model, tenant) attrs only"
+        );
+
+        // The raw tenant subject must never appear in metric attributes.
         assert!(
             !any_attrs.contains("acme.example"),
             "raw tenant subject leaked into metric attrs: {any_attrs}"
-        );
-        assert!(
-            any_attrs.contains("tenant:"),
-            "opaque tenant attr missing: {any_attrs}"
         );
         Ok(())
     }

--- a/crates/hyprstream/src/runtime/torch_engine.rs
+++ b/crates/hyprstream/src/runtime/torch_engine.rs
@@ -2342,11 +2342,12 @@ mod tests {
     /// regardless of tokenization outcome — success, empty-token failure, or
     /// roundtrip mismatch.
     ///
-    /// (Cancellation and stream-error paths were audited: after this change they
-    /// log only token IDs and error objects, never prompt or generated text.
-    /// They require a full model to drive, so the content-bearing tokenization
-    /// outcomes — which are exactly where the prompt is handled — are covered
-    /// hermetically here.)
+    /// (Generation, stop, cancellation, and stream-error paths were audited:
+    /// after the #1261 redaction they log only positions/counts and error
+    /// objects — never prompt text, generated text, or token IDs, which are
+    /// reversible to text via the loaded tokenizer. Those paths require a full
+    /// model to drive, so the content-bearing tokenization outcomes — which are
+    /// exactly where the prompt is handled — are covered hermetically here.)
     #[test]
     fn tokenize_redacted_never_logs_prompt_content() {
         let tokenizer = redact_test_tokenizer();
@@ -2706,7 +2707,7 @@ impl<'a> TextStream<'a> {
         // authoritative spend ledger is #1264.
         let tenant_hash = crate::runtime::token_metrics::opaque_tenant_id(&tenant_id);
         let model_label = engine.model_label();
-        crate::runtime::token_metrics::TokenBurnMeter::global()
+        crate::runtime::token_metrics::global_meter()
             .record_prompt(&model_label, tenant_hash, prompt_len as u64);
 
         let tokenizer = engine.get_tokenizer()?;
@@ -3071,9 +3072,11 @@ impl<'a> TextStream<'a> {
             })?;
 
             if self.tokens_generated.is_multiple_of(50) {
+                // Counts/positions only — token IDs are reversible to text via the
+                // loaded tokenizer and must never hit process logs (#1253/#1261).
                 tracing::debug!(
-                    "🔵 KV cache position: {}, tokens_generated: {}, last_token: {}",
-                    self.kv_cache_position, self.tokens_generated, last_token
+                    "🔵 KV cache position: {}, tokens_generated: {}",
+                    self.kv_cache_position, self.tokens_generated
                 );
             }
 
@@ -3294,7 +3297,10 @@ impl<'a> Stream for TextStream<'a> {
 
             // Check EOS
             if self.engine.is_eos_token(next_token as usize) {
-                tracing::debug!("EOS token detected: {}", next_token);
+                tracing::debug!(
+                    "EOS token detected at generated position {}",
+                    self.tokens_generated
+                );
                 self.finished = true;
                 self.finish_reason = Some(FinishReason::EndOfSequence);
                 return Poll::Ready(None);
@@ -3302,7 +3308,12 @@ impl<'a> Stream for TextStream<'a> {
 
             // Check stop tokens
             if self.stop_token_ids.contains(&next_token) {
-                tracing::debug!("Stop token ID {} detected", next_token);
+                // Never log the matched stop-token ID: it identifies a
+                // caller-supplied stop string (#1253/#1261). Position only.
+                tracing::debug!(
+                    "Stop token matched at generated position {}",
+                    self.tokens_generated
+                );
                 self.finished = true;
                 self.finish_reason = Some(FinishReason::StopToken(format!("{next_token}")));
                 return Poll::Ready(None);
@@ -3344,14 +3355,23 @@ impl<'a> Stream for TextStream<'a> {
                         self.recent_tokens.pop_front();
                     }
 
-                    // Simple trace without expensive tokenizer lock or decode
-                    tracing::trace!("Token {} -> buffering (incomplete UTF-8)", next_token);
+                    // Simple trace without expensive tokenizer lock or decode.
+                    // Counts/positions only — token IDs are reversible to text
+                    // and must never hit process logs (#1253/#1261).
+                    tracing::trace!(
+                        "Token at generated position {} buffering (incomplete UTF-8)",
+                        self.tokens_generated
+                    );
                     continue;
                 }
                 Err(e) => {
                     // CRITICAL: Do NOT update state on decode_stream error
                     // This prevents state corruption and keeps generation consistent
-                    tracing::error!("DecodeStream error on token {}: {}", next_token, e);
+                    tracing::error!(
+                        "DecodeStream error at generated position {}: {}",
+                        self.tokens_generated,
+                        e
+                    );
                     self.finished = true;
                     self.finish_reason = Some(FinishReason::Error(e.to_string()));
                     return Poll::Ready(Some(Err(anyhow::anyhow!("Decode error: {}", e))));
@@ -3372,7 +3392,7 @@ impl<'a> Drop for TextStream<'a> {
         // covers normal EOS, stop-token, max-tokens, timeout, and error finishes.
         // Only integer counts and the opaque tenant hash are metric attributes (#1253).
         let generated = self.tokens_generated as u64;
-        let meter = crate::runtime::token_metrics::TokenBurnMeter::global();
+        let meter = crate::runtime::token_metrics::global_meter();
         meter.record_generated(&self.model_label, self.tenant_hash, generated);
         meter.record_request_total(
             &self.model_label,

--- a/crates/hyprstream/src/runtime/torch_engine.rs
+++ b/crates/hyprstream/src/runtime/torch_engine.rs
@@ -142,6 +142,54 @@ pub struct TorchEngine {
     // Note: Pre-training not supported (persistent_model doesn't expose VarStore), LoRA only
 }
 
+/// Tokenize `text` with `tokenizer`, emitting only bounded, content-redacted
+/// metadata to the process log (byte/char length, token count).
+///
+/// #1253: the prompt and its decoded token text are tenant-private and must
+/// never reach process-wide logs — a shared inference process exposes them
+/// outside the caller's request boundary. This helper is split out from
+/// [`TorchEngine::tokenize`] so its no-leak behavior is unit-testable without
+/// a full engine/model.
+fn tokenize_redacted(tokenizer: &Tokenizer, text: &str) -> Result<Vec<i64>> {
+    let bytes = text.len();
+    let chars = text.chars().count();
+
+    let encoding = tokenizer
+        .encode(text, false)
+        .map_err(|e| anyhow!("Tokenization failed: {}", e))?;
+    let token_ids: Vec<i64> = encoding.get_ids().iter().map(|&id| id as i64).collect();
+
+    if token_ids.is_empty() {
+        tracing::warn!(bytes, chars, "Tokenization produced empty token sequence");
+        return Err(anyhow!(
+            "Tokenization produced empty token sequence ({} bytes, {} chars)",
+            bytes,
+            chars
+        ));
+    }
+
+    tracing::info!(bytes, chars, tokens = token_ids.len(), "Tokenized prompt");
+
+    // Surface roundtrip mismatches for diagnosis, but never the original or
+    // decoded text — only that they diverged and the bounded lengths.
+    if let Ok(decoded) = tokenizer.decode(
+        &token_ids.iter().map(|&id| id as u32).collect::<Vec<_>>(),
+        false,
+    ) {
+        if decoded != text {
+            tracing::warn!(
+                bytes,
+                chars,
+                tokens = token_ids.len(),
+                decoded_bytes = decoded.len(),
+                "Tokenization roundtrip mismatch (content redacted)"
+            );
+        }
+    }
+
+    Ok(token_ids)
+}
+
 /// Helper functions for tensor operations
 impl TorchEngine {
     /// Set the random seed for deterministic generation
@@ -933,45 +981,17 @@ impl TorchEngine {
     }
 
     /// Tokenize text to input IDs - thread safe
+    ///
+    /// Only bounded, content-redacted metadata (byte/char length, token count)
+    /// is written to the process log. The prompt itself and its token text are
+    /// tenant-private and never logged (#1253).
     fn tokenize(&self, text: &str) -> Result<Vec<i64>> {
         let tokenizer_guard = self.tokenizer.lock();
         let tokenizer = tokenizer_guard
             .as_ref()
             .ok_or_else(|| anyhow!("Tokenizer not loaded. Call load_tokenizer() first."))?;
 
-        // Log the raw input for debugging prompt issues
-        tracing::info!("📝 Raw prompt before tokenization:\n{}", text);
-
-        let encoding = tokenizer
-            .encode(text, false)
-            .map_err(|e| anyhow!("Tokenization failed: {}", e))?;
-        let token_ids: Vec<i64> = encoding.get_ids().iter().map(|&id| id as i64).collect();
-
-        if token_ids.is_empty() {
-            return Err(anyhow!(
-                "Tokenization produced empty token sequence for text: '{}'",
-                text
-            ));
-        }
-
-        // Show tokenization details
-        tracing::debug!("Tokenized '{}' -> {} tokens: {:?}",
-            text.chars().take(100).collect::<String>(),
-            token_ids.len(),
-            token_ids
-        );
-
-        // Decode back to verify tokenization is correct
-        if let Ok(decoded) = tokenizer.decode(&token_ids.iter().map(|&id| id as u32).collect::<Vec<_>>(), false) {
-            if decoded != text {
-                tracing::warn!("⚠️  Tokenization roundtrip mismatch!\nOriginal: {}\nDecoded:  {}",
-                    text.chars().take(200).collect::<String>(),
-                    decoded.chars().take(200).collect::<String>()
-                );
-            }
-        }
-
-        Ok(token_ids)
+        tokenize_redacted(tokenizer, text)
     }
 
     /// Format text with dynamic chat template
@@ -2237,6 +2257,126 @@ impl Drop for TorchEngine {
 #[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {
     use super::*;
+    use parking_lot::Mutex;
+    use std::io::Write;
+    use std::sync::Arc;
+
+    // ===== #1253: prompt/token text must never reach process logs =====
+
+    /// Distinctive canary planted in prompt inputs; the assertions below prove
+    /// it never appears in captured process logs.
+    const LEAK_CANARY: &str = "PROMPTLEAKCANARY7q3z";
+
+    /// Minimal in-memory WordLevel tokenizer (no model files needed). The canary
+    /// is a known vocab entry so it tokenizes cleanly on the success path; any
+    /// other word maps to `[UNK]`, exercising the roundtrip-mismatch path.
+    fn redact_test_tokenizer() -> Tokenizer {
+        const TOK_JSON: &str = r#"{"version":"1.0","truncation":null,"padding":null,"added_tokens":[],"normalizer":null,"pre_tokenizer":{"type":"Whitespace"},"post_processor":null,"decoder":null,"model":{"type":"WordLevel","vocab":{"hello":0,"world":1,"[UNK]":3,"PROMPTLEAKCANARY7q3z":7},"unk_token":"[UNK]"}}"#;
+        Tokenizer::from_bytes(TOK_JSON.as_bytes()).expect("valid in-memory tokenizer")
+    }
+
+    /// `tracing_subscriber` writer that buffers all output into a shared Vec.
+    struct CapturingWriter(Arc<Mutex<Vec<u8>>>);
+    impl Write for CapturingWriter {
+        fn write(&mut self, b: &[u8]) -> std::io::Result<usize> {
+            self.0.lock().extend_from_slice(b);
+            Ok(b.len())
+        }
+        fn flush(&mut self) -> std::io::Result<()> {
+            Ok(())
+        }
+    }
+
+    /// Newtype wrapper so we can implement the foreign `MakeWriter` trait for a
+    /// local type (orphan rule).
+    #[derive(Clone)]
+    struct CaptureSink(Arc<Mutex<Vec<u8>>>);
+
+    impl<'a> tracing_subscriber::fmt::MakeWriter<'a> for CaptureSink {
+        type Writer = CapturingWriter;
+        fn make_writer(&'a self) -> Self::Writer {
+            CapturingWriter(self.0.clone())
+        }
+    }
+
+    /// Run `f` under a thread-local TRACE subscriber whose output is captured.
+    /// TRACE is deliberate: #1253 forbids relocating prompt text to DEBUG, so
+    /// the canary must be absent even at the lowest log level.
+    fn capture_logs<F: FnOnce()>(f: F) -> String {
+        let sink = CaptureSink(Arc::new(Mutex::new(Vec::new())));
+        let subscriber = tracing_subscriber::fmt()
+            .with_max_level(tracing::Level::TRACE)
+            .with_ansi(false)
+            .with_writer(sink.clone())
+            .finish();
+        let _guard = tracing::subscriber::set_default(subscriber);
+        f();
+        // Drain the captured bytes into a local so the MutexGuard drops before
+        // `sink` itself (block-end drop order).
+        let cells = std::mem::take(&mut *sink.0.lock());
+        String::from_utf8(cells).unwrap()
+    }
+
+    /// #1253: a distinctive prompt secret must never appear in process logs,
+    /// regardless of tokenization outcome — success, empty-token failure, or
+    /// roundtrip mismatch.
+    ///
+    /// (Cancellation and stream-error paths were audited: after this change they
+    /// log only token IDs and error objects, never prompt or generated text.
+    /// They require a full model to drive, so the content-bearing tokenization
+    /// outcomes — which are exactly where the prompt is handled — are covered
+    /// hermetically here.)
+    #[test]
+    fn tokenize_redacted_never_logs_prompt_content() {
+        let tokenizer = redact_test_tokenizer();
+
+        // --- success: every word is a known token ---
+        let logs = capture_logs(|| {
+            let ids = tokenize_redacted(&tokenizer, &format!("hello {LEAK_CANARY} world"));
+            assert_eq!(ids.unwrap().len(), 3);
+        });
+        assert!(
+            logs.contains("Tokenized prompt"),
+            "success path must still emit bounded metadata: {logs}"
+        );
+        assert!(
+            !logs.contains(LEAK_CANARY),
+            "prompt secret leaked into logs on success: {logs}"
+        );
+
+        // --- roundtrip mismatch: unknown word decodes to [UNK] ---
+        let logs = capture_logs(|| {
+            let ids = tokenize_redacted(&tokenizer, &format!("{LEAK_CANARY} zzz_unknown"));
+            // non-empty -> Ok, but the decode diverges -> mismatch warning
+            assert_eq!(ids.unwrap().len(), 2);
+        });
+        assert!(
+            logs.contains("roundtrip mismatch"),
+            "mismatch path must still emit bounded metadata: {logs}"
+        );
+        assert!(
+            !logs.contains(LEAK_CANARY),
+            "prompt secret leaked into logs on mismatch: {logs}"
+        );
+        assert!(
+            !logs.contains("zzz_unknown"),
+            "decoded token text leaked into logs on mismatch: {logs}"
+        );
+
+        // --- empty-token failure: 0 tokens (pure whitespace input) ---
+        // An input that carries the canary always yields >=1 token with this
+        // tokenizer, so the failure path is exercised with whitespace; we still
+        // assert it logs only bounded metadata ("empty token sequence") and no
+        // prompt content.
+        let logs = capture_logs(|| {
+            let res = tokenize_redacted(&tokenizer, "   ");
+            assert!(res.is_err(), "whitespace-only input must fail");
+        });
+        assert!(
+            logs.contains("empty token sequence"),
+            "failure path must still emit bounded metadata: {logs}"
+        );
+    }
 
     #[test]
     fn test_generation_config_in_engine_has_correct_max_tokens() {
@@ -2542,9 +2682,14 @@ impl<'a> TextStream<'a> {
                 if ids.len() == 1 {
                     Some(ids[0])
                 } else {
+                    // The stop sequence is caller-supplied content and is never
+                    // logged (#1253); only its byte length and resulting token
+                    // count are retained, plus the opaque tenant id.
                     tracing::warn!(
-                        "Stop token '{}' encodes to {} tokens, skipping (only single-token stops supported)",
-                        stop_str, ids.len()
+                        stop_bytes = stop_str.len(),
+                        encoded_tokens = ids.len(),
+                        tenant = ?tenant_id,
+                        "Stop token encodes to multiple tokens, skipping (only single-token stops supported; content redacted)"
                     );
                     None
                 }
@@ -3142,12 +3287,13 @@ impl<'a> Stream for TextStream<'a> {
                         self.recent_tokens.pop_front();
                     }
 
-                    // DecodeStream returned text - emit it
+                    // DecodeStream returned text - emit it. The chunk text is
+                    // generated content and is never logged (#1253); only the
+                    // token id and byte length are retained for observability.
                     tracing::debug!(
-                        "Token {} -> text chunk (len={}): {:?}",
-                        next_token,
-                        text.len(),
-                        text
+                        token = next_token,
+                        len = text.len(),
+                        "Generated text chunk (content redacted)"
                     );
                     return Poll::Ready(Some(Ok(text)));
                 }

--- a/crates/hyprstream/src/runtime/torch_engine.rs
+++ b/crates/hyprstream/src/runtime/torch_engine.rs
@@ -142,8 +142,15 @@ pub struct TorchEngine {
     // Note: Pre-training not supported (persistent_model doesn't expose VarStore), LoRA only
 }
 
-/// Tokenize `text` with `tokenizer`, emitting only bounded, content-redacted
-/// metadata to the process log (byte/char length, token count).
+/// Tokenize `text` with `tokenizer`, writing no caller content to the process
+/// log.
+///
+/// Token-burn counts (prompt token count) are now emitted as OTel metrics at the
+/// call site (`TextStream::new_with_delta`), not as log lines (#1261) — the log
+/// is no longer the metering source. This helper logs only on the two
+/// content-free diagnostic outcomes: an empty token sequence (failure) and a
+/// tokenize/decode roundtrip mismatch (a real tokenizer-bug signal), in both
+/// cases carrying only bounded lengths, never the text.
 ///
 /// #1253: the prompt and its decoded token text are tenant-private and must
 /// never reach process-wide logs — a shared inference process exposes them
@@ -167,8 +174,6 @@ fn tokenize_redacted(tokenizer: &Tokenizer, text: &str) -> Result<Vec<i64>> {
             chars
         ));
     }
-
-    tracing::info!(bytes, chars, tokens = token_ids.len(), "Tokenized prompt");
 
     // Surface roundtrip mismatches for diagnosis, but never the original or
     // decoded text — only that they diverged and the bounded lengths.
@@ -1337,6 +1342,22 @@ impl TorchEngine {
     }
 }
 
+impl TorchEngine {
+    /// Stable, content-free label identifying the loaded model for OTel metric
+    /// attributes (#1261). Prefers the model name (set on load); falls back to
+    /// architecture, then "unknown". Never the prompt or generated text.
+    fn model_label(&self) -> String {
+        let info = self.model_info.lock().clone();
+        if !info.name.is_empty() && info.name != "unloaded" {
+            info.name
+        } else if !info.architecture.is_empty() && info.architecture != "unknown" {
+            info.architecture
+        } else {
+            "unknown".to_owned()
+        }
+    }
+}
+
 #[async_trait]
 impl RuntimeEngine for TorchEngine {
     #[instrument(name = "torch_engine.load_model", skip(self), fields(path = %path.display()))]
@@ -2336,8 +2357,8 @@ mod tests {
             assert_eq!(ids.unwrap().len(), 3);
         });
         assert!(
-            logs.contains("Tokenized prompt"),
-            "success path must still emit bounded metadata: {logs}"
+            !logs.contains("Tokenized prompt"),
+            "success path must no longer emit a metering log line (token counts are OTel metrics now, #1261): {logs}"
         );
         assert!(
             !logs.contains(LEAK_CANARY),
@@ -2656,6 +2677,12 @@ pub struct TextStream<'a> {
     last_token_time: Option<std::time::Instant>,
     /// Exponential moving average of tokens per second
     ema_tokens_per_sec: f32,
+
+    /// Model label for OTel token-burn metric attributes (#1261).
+    model_label: String,
+    /// Opaque (hashed) tenant id for token-burn metric attributes — never the
+    /// raw request subject (#1253). `None` when no tenant is in scope.
+    tenant_hash: Option<u64>,
 }
 
 impl<'a> TextStream<'a> {
@@ -2673,6 +2700,15 @@ impl<'a> TextStream<'a> {
         let prompt_tokens = engine.tokenize(&request.prompt)?;
         let prompt_len = prompt_tokens.len();
 
+        // Token-burn metering (#1261): emit the prompt-token count at the
+        // tokenization boundary as an OTel metric. The raw tenant subject is never
+        // a metric attribute — it is reduced to an opaque hash (#1253); the
+        // authoritative spend ledger is #1264.
+        let tenant_hash = crate::runtime::token_metrics::opaque_tenant_id(&tenant_id);
+        let model_label = engine.model_label();
+        crate::runtime::token_metrics::TokenBurnMeter::global()
+            .record_prompt(&model_label, tenant_hash, prompt_len as u64);
+
         let tokenizer = engine.get_tokenizer()?;
         let stop_token_ids: Vec<u32> = request.stop_tokens.as_deref().unwrap_or(&[])
             .iter()
@@ -2684,11 +2720,12 @@ impl<'a> TextStream<'a> {
                 } else {
                     // The stop sequence is caller-supplied content and is never
                     // logged (#1253); only its byte length and resulting token
-                    // count are retained, plus the opaque tenant id.
+                    // count are retained. The tenant is referenced only by its
+                    // opaque hash — the raw subject is dropped from logs.
                     tracing::warn!(
                         stop_bytes = stop_str.len(),
                         encoded_tokens = ids.len(),
-                        tenant = ?tenant_id,
+                        tenant_hash = ?tenant_hash,
                         "Stop token encodes to multiple tokens, skipping (only single-token stops supported; content redacted)"
                     );
                     None
@@ -2837,6 +2874,8 @@ impl<'a> TextStream<'a> {
             first_token_time: None,
             last_token_time: None,
             ema_tokens_per_sec: 0.0,
+            model_label,
+            tenant_hash,
         })
     }
 
@@ -3288,13 +3327,9 @@ impl<'a> Stream for TextStream<'a> {
                     }
 
                     // DecodeStream returned text - emit it. The chunk text is
-                    // generated content and is never logged (#1253); only the
-                    // token id and byte length are retained for observability.
-                    tracing::debug!(
-                        token = next_token,
-                        len = text.len(),
-                        "Generated text chunk (content redacted)"
-                    );
+                    // generated content and is never logged (#1253); generated-
+                    // token counts are now emitted as OTel metrics at completion
+                    // (#1261), so the per-chunk count log is dropped.
                     return Poll::Ready(Some(Ok(text)));
                 }
                 Ok(None) => {
@@ -3331,5 +3366,18 @@ impl<'a> Drop for TextStream<'a> {
         // Save token IDs to the session cache for prefix matching on the next turn.
         // This runs on all exit paths (EOS, stop token, max tokens, timeout, error).
         self.save_cached_tokens();
+
+        // Token-burn metering (#1261): emit the generated-token count and the
+        // per-request total at completion. Drop runs on every exit path, so this
+        // covers normal EOS, stop-token, max-tokens, timeout, and error finishes.
+        // Only integer counts and the opaque tenant hash are metric attributes (#1253).
+        let generated = self.tokens_generated as u64;
+        let meter = crate::runtime::token_metrics::TokenBurnMeter::global();
+        meter.record_generated(&self.model_label, self.tenant_hash, generated);
+        meter.record_request_total(
+            &self.model_label,
+            self.tenant_hash,
+            self.prompt_len as u64 + generated,
+        );
     }
 }

--- a/crates/hyprstream/src/server/routes/openai.rs
+++ b/crates/hyprstream/src/server/routes/openai.rs
@@ -464,15 +464,7 @@ async fn chat_completions(
                 .into_response();
         }
     };
-    info!(
-        "Template applied, prompt length: {}, preview: {}",
-        templated_prompt.len(),
-        &templated_prompt
-            .as_str()
-            .chars()
-            .take(200)
-            .collect::<String>()
-    );
+    info!("Template applied, prompt length: {}", templated_prompt.len());
 
     // Build generation request with templated prompt
     let gen_params = crate::config::SamplingParams::from(&state.config.sampling_defaults)


### PR DESCRIPTION
> **Revision (OTel focus):** this PR is redirected from log-only redaction to emitting **token burn as OpenTelemetry metrics** + trimming the now-redundant count-bearing logs. The no-content security property and hermetic canary test from the first revision are preserved.

## Summary

Emit **token burn** (prompt + generated tokens per request) as **OpenTelemetry metrics**, and trim the now-redundant count-bearing logs (the counts live in metrics, not logs). This is accounting- and ops-relevant. The authoritative spend ledger is tracked in **#1264**; the metrics here are the metering/ops signal.

## Changes

### OTel metrics — new `runtime/token_metrics`
- **`inference_tokens_total`** — `Counter<u64>` (unit `tokens`), cumulative tokens consumed, attrs `kind` = `prompt` | `generated`, `model`, and an **opaque hashed** tenant id (never the raw subject).
- **`inference_request_tokens`** — `Histogram<u64>` (unit `tokens`), per-request prompt + generated total.
- Prompt tokens recorded at the tokenization boundary (`TextStream::new_with_delta`); generated tokens + per-request total recorded at `TextStream` completion — `Drop` runs on every exit path (EOS, stop, max, timeout, error).
- Instruments build from the global OTel meter, so recording is always safe (no-op without a provider, and compiled out entirely when the `otel` feature is off).

### Meter provider wiring — `bin/main.rs` `init_telemetry`
- Registers a `SdkMeterProvider` (OTLP or stdout, mirroring the tracer transport) via `set_meter_provider`, so the metrics actually export to a collector instead of being no-ops. Adds the `metrics` feature to `opentelemetry-otlp` / `opentelemetry-stdout`.

### Log trimming (counts now in metrics)
- Removed the `bytes/chars/tokens` "Tokenized prompt" INFO line.
- Removed the per-chunk generated-text DEBUG count.
- **Kept** the content-free diagnostics — empty-token-sequence warn + tokenize/decode roundtrip-mismatch warn (bounded lengths, never text) — real tokenizer-bug signals, not accounting.
- Dropped raw `tenant=?tenant_id` from the stop-sequence warning; tenant identity in metrics/logs is opaque/hashed only (#1253).

### Tests
- Preserved the no-leak canary (`tokenize_redacted_never_logs_prompt_content`); it now asserts the success path no longer emits a metering log line (counts moved to metrics) while still never leaking prompt content.
- Added hermetic meter tests (`InMemoryMetricExporter` + `PeriodicReader`) asserting token burn lands on the right instruments with opaque tenant attrs; plus `opaque_tenant_id` stability / anonymous tests.

## Build

`--no-default-features --features "gittorrent,xet,otel"` locally (no libsystemd devel headers on this box; CI validates defaults). Gate green: `cargo check --tests`, `cargo clippy --tests -- -D warnings`, and the new meter tests + canary pass (rocm71 backend).

Refs #1253. Complement: **#1264** (authoritative spend ledger).

---
Stacked on #1260 (`ewindsch/d8-kv-invalidation`) — GitHub auto-retargets to `main` when #1260 lands. Do not merge / self-approve.
