### PR TITLE
feat(inference): post token-spend to cell ledger on generation completion (#1264)

### DIFF
--- a/crates/hyprstream/src/services/inference.rs
+++ b/crates/hyprstream/src/services/inference.rs
@@ -57,9 +57,12 @@ use tokio::runtime::Handle;
 use tokenizers::Tokenizer;
 use tracing::{debug, error, info, trace, warn};
 
-// #1264: completion-time ledger spend (behind the `ledger` feature, default off).
+// #1264/#1265: completion-time ledger spend (behind the `ledger` feature,
+// default off).
 #[cfg(feature = "ledger")]
-use crate::services::ledger::{observe_spend_result, InferenceSpendEmitter, SpendInput};
+use crate::services::ledger::{
+    observe_spend_result, InferenceSpendEmitter, SpendInput, SpendResult,
+};
 
 
 /// Pending work to be executed after REP response is sent.
@@ -237,6 +240,146 @@ fn resolve_instance_domain(
 
 // Intermediate response structs (DeltaStatusInfo, SaveAdaptationResult, SnapshotDeltaResult,
 // ExportPeftResult) eliminated — handlers return generated types directly.
+
+// ────────────────────────────────────────────────────────────────────────────
+// #1265: generation-loop accounting primitives (module-level, testable).
+//
+// `drive_generation_loop` consumes a generation output stream to a terminal
+// outcome (normal exhaustion / cancellation / stream error / publish failure).
+// It is the seam that makes "account for the work actually done" testable
+// without a live engine: `execute_stream` reads `completion_stats()` on the
+// SINGLE common exit after it returns, so no terminal path — including cancel
+// and publish-failure, which previously returned before the stats copy — can
+// skip the spend (#1265 blocker).
+// ────────────────────────────────────────────────────────────────────────────
+
+/// The terminal outcome of one generation output loop (#1265).
+#[derive(Debug)]
+enum GenLoopOutcome {
+    /// The stream was exhausted normally.
+    Exhausted,
+    /// The client cancelled / disconnected mid-stream.
+    Cancelled,
+    /// The generation stream yielded an error.
+    StreamError(anyhow::Error),
+    /// Publishing a generated chunk failed.
+    PublishFailed(anyhow::Error),
+}
+
+/// Abstraction over the stream publisher the generation loop writes to (#1265).
+/// A trait — not the concrete `AnyStreamPublisher` — so the loop can be driven by
+/// a fake sink in tests for the cancel / publish-failure / stream-error
+/// accounting paths without a live engine.
+trait GenSink {
+    /// Forward one generated chunk; an `Err` is a terminal publish-failure.
+    fn publish_chunk(&mut self, data: &str, rate: f32)
+        -> impl std::future::Future<Output = Result<()>>;
+}
+
+impl GenSink for hyprstream_rpc::moq_stream::AnyStreamPublisher {
+    fn publish_chunk(&mut self, data: &str, rate: f32)
+        -> impl std::future::Future<Output = Result<()>> {
+        self.publish_data_with_rate(data.as_bytes(), rate)
+    }
+}
+
+/// Abstraction over a generation output stream the loop consumes (#1265).
+/// Decouples the loop (and its tests) from `TextStream` / the PyTorch engine.
+trait GenOutput: futures::Stream<Item = anyhow::Result<String>> + Unpin {
+    /// Current EMA token rate (the per-chunk publish rate hint).
+    fn ema_rate(&self) -> f32;
+    /// Final completion stats (prefill + generated) — read on the common exit.
+    fn completion_stats(&self) -> crate::runtime::GenerationStats;
+}
+
+impl<'a> GenOutput for crate::runtime::TextStream<'a> {
+    fn ema_rate(&self) -> f32 {
+        self.stats().inference_tokens_per_sec_ema
+    }
+    fn completion_stats(&self) -> crate::runtime::GenerationStats {
+        self.stats()
+    }
+}
+
+/// Drive a generation output stream to a terminal outcome. Does NOT capture
+/// stats — the caller snapshots `output.completion_stats()` after this returns
+/// on the single common exit, so cancel / stream-error / publish-failure all
+/// account for the work actually done (#1265). Publish failures are terminal
+/// (returned to the caller, which lets the framework emit the Error frame,
+/// matching the prior behavior).
+async fn drive_generation_loop<S: GenOutput>(
+    stream: &mut S,
+    cancel: &tokio_util::sync::CancellationToken,
+    sink: &mut impl GenSink,
+) -> GenLoopOutcome {
+    use futures::StreamExt;
+    loop {
+        let next = tokio::select! {
+            biased;
+            _ = cancel.cancelled() => return GenLoopOutcome::Cancelled,
+            n = stream.next() => n,
+        };
+        match next {
+            None => return GenLoopOutcome::Exhausted,
+            Some(Err(e)) => return GenLoopOutcome::StreamError(e),
+            Some(Ok(text)) => {
+                let rate = stream.ema_rate();
+                if let Err(e) = sink.publish_chunk(&text, rate).await {
+                    return GenLoopOutcome::PublishFailed(e);
+                }
+            }
+        }
+    }
+}
+
+/// The content-free error frame emitted when a generation is denied because the
+/// caller has no self-certifying billing identity while a spend emitter is
+/// attached (#1265). Carries no subject DID and no prompt material.
+#[cfg_attr(not(feature = "ledger"), allow(dead_code))]  // only read on the ledger gate path
+const LEDGER_DENY_NO_IDENTITY: &str =
+    "generation denied: no verified billing identity for token-spend accounting";
+
+/// #1265: decide whether a generation must fail CLOSED before it starts because
+/// a #1264 spend emitter is attached but the caller has no self-certifying
+/// pairwise DID — the account owner the spend would debit. When `true`, the
+/// service denies the request with NO model output (see the gate in
+/// `execute_stream`, which precedes `engine.generate_with_delta`).
+///
+/// With no emitter attached the subsystem is inert — anonymous callers are
+/// unaffected. An explicit fail-open / debt policy for anonymous callers is a
+/// separate decision and is intentionally NOT implemented here.
+#[cfg_attr(not(feature = "ledger"), allow(dead_code))]  // only read on the ledger gate path
+fn ledger_requires_identity(emitter_attached: bool, owner_did: Option<&str>) -> bool {
+    emitter_attached && owner_did.is_none()
+}
+
+/// #1265: post the completion token-spend for the generation work actually done.
+/// Pure decision over the captured completion stats and the verified owner DID,
+/// delegating the single-phase debit to `emitter`. Returns:
+/// - `Some(SpendResult)` when a spend was attempted (Posted / Declined / Failed)
+///   — observe it as a content-free signal;
+/// - `None` when there is nothing to account for (no stats — generation never
+///   began — or no verified owner). A DID-less caller cannot reach the stats arm
+///   here in production: `execute_stream` gates it closed pre-generation.
+#[cfg(feature = "ledger")]
+async fn post_completion_spend(
+    emitter: &InferenceSpendEmitter,
+    stats: Option<&crate::runtime::GenerationStats>,
+    owner_did: Option<&str>,
+    stream_id: &str,
+) -> Option<SpendResult> {
+    let stats = stats?;
+    let owner = owner_did?;
+    let res = emitter
+        .post_generation_spend(SpendInput {
+            owner_did: owner,
+            stream_id,
+            prompt_tokens: stats.prefill_tokens as u64,
+            generated_tokens: stats.tokens_generated as u64,
+        })
+        .await;
+    Some(res)
+}
 
 impl InferenceService {
     /// Drain-time export hook (#869): force-snapshot every resident per-tenant delta
@@ -758,8 +901,6 @@ impl InferenceService {
     /// to avoid blocking the ZMQ REQ/REP handler.
     #[allow(clippy::await_holding_lock)]  // engine read-lock must be held while stream borrows it
     async fn execute_stream(&self, pending: PendingWork) {
-        use futures::StreamExt;
-
         // SAFETY: parking_lot::Mutex is safe here because InferenceService runs on
         // current_thread runtime — no task migration, no .await while lock held.
         debug_assert!(
@@ -768,12 +909,25 @@ impl InferenceService {
             "InferenceService must run on current_thread runtime for parking_lot safety"
         );
 
-        let PendingWork::Generation { stream_ctx, request, subject, ttt_overrides, owner_did } = pending else {
+        // #1265: `owner_did` is read only on the ledger spend path (itself
+        // `#[cfg(ledger)]`); in the default-off build it is an unused binding,
+        // so scope an `allow(unused_variables)` to THIS statement (not the crate)
+        // to keep the `-D warnings` clippy gate green without masking anything else.
+        #[cfg_attr(not(feature = "ledger"), allow(unused_variables))]
+        let PendingWork::Generation {
+            stream_ctx,
+            request,
+            subject,
+            ttt_overrides,
+            owner_did,
+        } = pending else {
             error!("execute_stream called with non-Generation PendingWork");
             return;
         };
         let stream_ctx = &stream_ctx;
-        // #1264: the spend's correlation entropy + the completion log key.
+        // #1264/#1265: the spend's correlation entropy + completion log key.
+        // Only needed on the ledger path.
+        #[cfg(feature = "ledger")]
         let stream_id_str = stream_ctx.stream_id().to_owned();
 
         // Get StreamChannel
@@ -784,6 +938,38 @@ impl InferenceService {
                 return;
             }
         };
+
+        // #1265: fail CLOSED before generation begins when a #1264 completion-
+        // spend emitter is attached but the caller has no self-certifying
+        // pairwise DID — that DID is the account owner the spend debits, so an
+        // authenticated-but-DID-less (anonymous) caller must not receive a
+        // completed zero-cost generation. Deny with a content-free error frame
+        // and NO model output (the engine is not even asked to generate). If the
+        // owner later wants an explicit fail-open / debt policy for anonymous
+        // callers, that is a separate policy change — do not implement it here.
+        #[cfg(feature = "ledger")]
+        {
+            if ledger_requires_identity(self.ledger.read().is_some(), owner_did.as_deref()) {
+                warn!(
+                    stream_id = %stream_id_str,
+                    "ledger: spend emitter attached but caller has no verified pairwise DID \
+                     — denying generation before it starts (fail-closed, #1265)"
+                );
+                if let Err(e) = stream_channel
+                    .run_stream(stream_ctx, |publisher| async move {
+                        (publisher, Err::<(), _>(anyhow!(LEDGER_DENY_NO_IDENTITY)))
+                    })
+                    .await
+                {
+                    error!(
+                        stream_id = %stream_id_str,
+                        error = %e,
+                        "failed to publish ledger deny frame"
+                    );
+                }
+                return;
+            }
+        }
 
         // Snapshot LoRA generation before TTT — used to detect reconfiguration mid-stream
         let lora_gen_before = self.lora_generation.load(Ordering::Acquire);
@@ -863,8 +1049,10 @@ impl InferenceService {
         let engine = self.engine.read();
         let stream_result = engine.generate_with_delta(request, delta, tenant_id, weight_epoch);
 
-        // #1264: capture the completion stats out of the stream closure so the
-        // token-spend can be posted after the client-visible completion frame.
+        // #1264/#1265: capture the completion stats out of the stream closure so
+        // the token-spend can be posted after the client-visible completion frame
+        // — on EVERY terminal path (normal end, cancel, stream error, publish
+        // failure), not only normal exhaustion.
         #[cfg(feature = "ledger")]
         let completion_stats: Arc<parking_lot::Mutex<Option<crate::runtime::GenerationStats>>> =
             Arc::new(parking_lot::Mutex::new(None));
@@ -876,46 +1064,41 @@ impl InferenceService {
                 let result = match stream_result {
                     Ok(mut stream) => {
                         let cancel = stream_ctx.cancel_token();
-                        loop {
-                            let chunk_result = tokio::select! {
-                                biased;
-                                _ = cancel.cancelled() => {
-                                    let _ = publisher.publish_error("cancelled").await;
-                                    return (publisher, Ok(()));
-                                }
-                                next = stream.next() => match next {
-                                    Some(r) => r,
-                                    None => break,
-                                },
-                            };
-                            match chunk_result {
-                                Ok(text) => {
-                                    let rate = stream.stats().inference_tokens_per_sec_ema;
-                                    if let Err(e) = publisher.publish_data_with_rate(text.as_bytes(), rate).await {
-                                        return (publisher, Err(e));
-                                    }
-                                }
-                                Err(e) => {
-                                    let _ = publisher.publish_error(&e.to_string()).await;
-                                    return (publisher, Ok(()));
-                                }
-                            }
-                        }
+                        // Drive the generation loop to a terminal outcome. The
+                        // loop publishes each chunk; cancel / stream-error /
+                        // publish-failure are all terminal. Completion stats are
+                        // captured on the SINGLE common exit below, so no
+                        // terminal path can skip accounting for the work actually
+                        // done (#1265).
+                        let outcome =
+                            drive_generation_loop(&mut stream, cancel, &mut publisher).await;
 
-                        // Normal completion with stats
-                        let stats = stream.stats();
+                        // Common exit: ALWAYS snapshot the stats once generation
+                        // has begun, regardless of how it ended — so a cancelled,
+                        // errored, or publish-failed generation still accounts.
+                        let stats = stream.completion_stats();
                         #[cfg(feature = "ledger")]
                         {
                             *completion_stats.lock() = Some(stats.clone());
                         }
-                        let mut complete = crate::services::rpc_types::InferenceComplete::from(&stats);
 
-                        // Attach TTT metrics to completion (from deferred TTT in execute_stream)
-                        complete.ttt_metrics = ttt_result.map(std::convert::Into::into);
-
-                        match publisher.complete_ref(&complete.to_bytes()).await {
-                            Ok(()) => Ok(()),
-                            Err(e) => Err(e),
+                        match outcome {
+                            GenLoopOutcome::Exhausted => {
+                                let mut complete =
+                                    crate::services::rpc_types::InferenceComplete::from(&stats);
+                                // Attach TTT metrics to completion (deferred TTT).
+                                complete.ttt_metrics = ttt_result.map(std::convert::Into::into);
+                                publisher.complete_ref(&complete.to_bytes()).await
+                            }
+                            GenLoopOutcome::Cancelled => {
+                                let _ = publisher.publish_error("cancelled").await;
+                                Ok(())
+                            }
+                            GenLoopOutcome::StreamError(e) => {
+                                let _ = publisher.publish_error(&e.to_string()).await;
+                                Ok(())
+                            }
+                            GenLoopOutcome::PublishFailed(e) => Err(e),
                         }
                     }
                     Err(e) => Err(e),  // framework sends Error frame automatically
@@ -932,48 +1115,38 @@ impl InferenceService {
             );
         }
 
-        // #1264: post the token-spend to the cell ledger on generation completion
-        // (quota burn). Fail-safe: a ledger/accounting failure MUST NOT break a
+        // #1264/#1265: post the token-spend for the work actually done (quota
+        // burn). Fail-safe: a ledger/accounting failure MUST NOT break a
         // generation that already produced output — the spend is best-effort and
         // every non-posted outcome is a content-free signal, never a silent drop.
-        // Anonymous caller ⇒ fail closed (no spend, no leak). Posted *after* the
-        // client-visible completion frame. (The engine read-lock is held across
-        // this best-effort await; covered by the `await_holding_lock` allow above
-        // and consistent with the stream itself.)
+        // Posted *after* the client-visible completion frame. (The engine
+        // read-lock is held across this best-effort await; covered by the
+        // `await_holding_lock` allow above and consistent with the stream itself.)
         #[cfg(feature = "ledger")]
         {
-            let emitter_opt = self.ledger.read().clone();
-            if let Some(emitter) = emitter_opt {
+            if let Some(emitter) = self.ledger.read().clone() {
                 let stats_opt = completion_stats.lock().clone();
-                match (stats_opt, owner_did.as_ref()) {
-                    (Some(stats), Some(owner)) => {
-                        let res = emitter
-                            .post_generation_spend(SpendInput {
-                                owner_did: owner,
-                                stream_id: &stream_id_str,
-                                prompt_tokens: stats.prefill_tokens as u64,
-                                generated_tokens: stats.tokens_generated as u64,
-                            })
-                            .await;
+                match post_completion_spend(
+                    &emitter,
+                    stats_opt.as_ref(),
+                    owner_did.as_deref(),
+                    &stream_id_str,
+                )
+                .await
+                {
+                    Some(res) => {
                         observe_spend_result(&res, &stream_id_str, emitter.unit());
                     }
-                    (Some(_), None) => {
-                        // Verified anonymous caller (no self-certifying DID) ⇒
-                        // fail closed: no spend, but signal it (#1264).
-                        warn!(
-                            stream_id = %stream_id_str,
-                            "ledger: anonymous caller — completion spend skipped (fail-closed)"
-                        );
-                    }
-                    (None, _) => {
-                        // No completion stats (errored/cancelled before the stats
-                        // frame) — nothing to account for; no signal needed.
+                    None => {
+                        // Nothing to account for: generation never began
+                        // (`engine.generate_with_delta` returned Err before the
+                        // loop ran). A DID-less caller cannot reach the stats arm
+                        // — the gate above denied it before generation started
+                        // (#1265).
                     }
                 }
             }
         }
-        #[cfg(not(feature = "ledger"))]
-        drop(stream_id_str);
     }
 
     /// Execute streaming training step - called AFTER REP response is sent.
@@ -2929,5 +3102,336 @@ mod tenant_binding_tests {
             key(9).verifying_key(),
         );
         assert!(resolve_instance_domain("tenant-a", &controller, &impostor).is_err());
+    }
+
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+mod tests {
+    //! #1265 regression tests for the generation-loop accounting seam.
+    //!
+    //! These prove the three fixes without a live PyTorch engine:
+    //! - **#1 (blocker):** cancel / publish-failure / stream-error all capture
+    //!   the completion stats on the single common exit and a spend is posted
+    //!   for the work actually done.
+    //! - **#2 (major):** a missing verified billing DID fails closed before
+    //!   generation when an emitter is attached.
+    //!
+    //! `drive_generation_loop` is driven by a `FakeStream` (GenOutput) + a
+    //! recording/cancelling/failing `FakeSink` (GenSink); the spend is posted
+    //! through the real `InferenceSpendEmitter` against a `MemLedger` fixture.
+
+    use super::*;
+    use crate::runtime::GenerationStats;
+    use std::future::Future;
+    use std::pin::Pin;
+    use std::task::{Context, Poll};
+
+    /// Build a `GenerationStats` with only the fields the spend reads.
+    fn stats(prefill: usize, generated: usize) -> GenerationStats {
+        GenerationStats {
+            tokens_generated: generated,
+            generation_time_ms: 0,
+            tokens_per_second: 0.0,
+            finish_reason: None,
+            quality_metrics: None,
+            prefill_tokens: prefill,
+            prefill_time_ms: 0,
+            prefill_tokens_per_sec: 0.0,
+            inference_tokens: generated,
+            inference_time_ms: 0,
+            inference_tokens_per_sec: 0.0,
+            inference_tokens_per_sec_ema: 0.0,
+        }
+    }
+
+    /// A generation output stream that yields a fixed sequence of chunks. Counts
+    /// Ok chunks consumed so far as the generated-token count.
+    struct FakeStream {
+        // `anyhow::Error` is not `Clone`, so store the error as a `String` and
+        // wrap it at yield time.
+        chunks: Vec<Result<String, String>>,
+        pos: usize,
+        prefill: usize,
+    }
+
+    impl FakeStream {
+        fn new(chunks: Vec<Result<String, String>>, prefill: usize) -> Self {
+            FakeStream { chunks, pos: 0, prefill }
+        }
+        fn generated(&self) -> usize {
+            self.chunks[..self.pos].iter().filter(|c| c.is_ok()).count()
+        }
+    }
+
+    impl futures::Stream for FakeStream {
+        type Item = anyhow::Result<String>;
+        fn poll_next(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+            let this = self.get_mut();
+            if this.pos < this.chunks.len() {
+                let c = this.chunks[this.pos].clone();
+                this.pos += 1;
+                Poll::Ready(Some(c.map_err(anyhow::Error::msg)))
+            } else {
+                Poll::Ready(None)
+            }
+        }
+    }
+
+    impl GenOutput for FakeStream {
+        fn ema_rate(&self) -> f32 {
+            1.0
+        }
+        fn completion_stats(&self) -> GenerationStats {
+            stats(self.prefill, self.generated())
+        }
+    }
+
+    /// A sink that records every chunk it publishes.
+    #[derive(Default)]
+    struct RecordingSink {
+        published: Vec<String>,
+    }
+
+    impl GenSink for RecordingSink {
+        fn publish_chunk(&mut self, data: &str, _rate: f32) -> impl Future<Output = Result<()>> {
+            self.published.push(data.to_owned());
+            std::future::ready(Ok(()))
+        }
+    }
+
+    /// A sink that cancels the generation after the Nth published chunk, so the
+    /// loop's cancel branch is exercised after partial output.
+    struct CancelAfterSink {
+        published: Vec<String>,
+        cancel: tokio_util::sync::CancellationToken,
+        cancel_after: usize,
+    }
+
+    impl CancelAfterSink {
+        fn new(cancel: tokio_util::sync::CancellationToken, cancel_after: usize) -> Self {
+            CancelAfterSink { published: vec![], cancel, cancel_after }
+        }
+    }
+
+    impl GenSink for CancelAfterSink {
+        fn publish_chunk(&mut self, data: &str, _rate: f32) -> impl Future<Output = Result<()>> {
+            self.published.push(data.to_owned());
+            if self.published.len() >= self.cancel_after {
+                self.cancel.cancel();
+            }
+            std::future::ready(Ok(()))
+        }
+    }
+
+    /// A sink that fails the Nth publish, exercising the publish-failure path.
+    struct FailOnSink {
+        published: Vec<String>,
+        fail_on: usize,
+    }
+
+    impl FailOnSink {
+        fn new(fail_on: usize) -> Self {
+            FailOnSink { published: vec![], fail_on }
+        }
+    }
+
+    impl GenSink for FailOnSink {
+        fn publish_chunk(&mut self, data: &str, _rate: f32) -> impl Future<Output = Result<()>> {
+            let will_fail = self.published.len() + 1 == self.fail_on;
+            self.published.push(data.to_owned());
+            std::future::ready(if will_fail {
+                Err(anyhow!("publish failed"))
+            } else {
+                Ok(())
+            })
+        }
+    }
+
+    // ── #1: stats captured on EVERY terminal path (default build) ─────────────
+
+    #[tokio::test]
+    async fn cancel_after_one_token_captures_partial_stats() {
+        let cancel = tokio_util::sync::CancellationToken::new();
+        let mut stream =
+            FakeStream::new(vec![Ok("a".into()), Ok("b".into()), Ok("c".into())], 5);
+        let mut sink = CancelAfterSink::new(cancel.clone(), 1);
+        let outcome = drive_generation_loop(&mut stream, &cancel, &mut sink).await;
+        assert!(matches!(outcome, GenLoopOutcome::Cancelled), "{outcome:?}");
+        // One token made it to the subscriber before cancel.
+        assert_eq!(sink.published.len(), 1);
+        // Stats captured on the cancel exit reflect prefill + the one token.
+        let s = stream.completion_stats();
+        assert_eq!(s.prefill_tokens, 5);
+        assert_eq!(s.tokens_generated, 1);
+    }
+
+    #[tokio::test]
+    async fn publish_failure_after_partial_captures_stats() {
+        let cancel = tokio_util::sync::CancellationToken::new();
+        let mut stream =
+            FakeStream::new(vec![Ok("a".into()), Ok("b".into()), Ok("c".into())], 5);
+        let mut sink = FailOnSink::new(2);
+        let outcome = drive_generation_loop(&mut stream, &cancel, &mut sink).await;
+        assert!(matches!(outcome, GenLoopOutcome::PublishFailed(_)), "{outcome:?}");
+        // "a" published; "b" generated then its publish failed.
+        let s = stream.completion_stats();
+        assert_eq!(s.prefill_tokens, 5);
+        assert_eq!(s.tokens_generated, 2);
+    }
+
+    #[tokio::test]
+    async fn stream_error_after_partial_captures_stats() {
+        let cancel = tokio_util::sync::CancellationToken::new();
+        let mut stream =
+            FakeStream::new(vec![Ok("a".into()), Err("decode boom".to_owned())], 5);
+        let mut sink = RecordingSink::default();
+        let outcome = drive_generation_loop(&mut stream, &cancel, &mut sink).await;
+        assert!(matches!(outcome, GenLoopOutcome::StreamError(_)), "{outcome:?}");
+        // Only the one Ok token counts; the error chunk does not.
+        let s = stream.completion_stats();
+        assert_eq!(s.prefill_tokens, 5);
+        assert_eq!(s.tokens_generated, 1);
+    }
+
+    #[tokio::test]
+    async fn normal_completion_captures_full_stats() {
+        let cancel = tokio_util::sync::CancellationToken::new();
+        let mut stream = FakeStream::new(vec![Ok("a".into()), Ok("b".into())], 5);
+        let mut sink = RecordingSink::default();
+        let outcome = drive_generation_loop(&mut stream, &cancel, &mut sink).await;
+        assert!(matches!(outcome, GenLoopOutcome::Exhausted), "{outcome:?}");
+        let s = stream.completion_stats();
+        assert_eq!(s.prefill_tokens, 5);
+        assert_eq!(s.tokens_generated, 2);
+    }
+
+    // ── #2: missing billing identity fails closed (default build) ─────────────
+
+    #[test]
+    fn missing_identity_denies_only_when_emitter_attached() {
+        // Emitter attached + no DID ⇒ deny (fail-closed before generation).
+        assert!(ledger_requires_identity(true, None));
+        // Authenticated caller with a DID ⇒ never deny.
+        assert!(!ledger_requires_identity(true, Some("did:web:alice")));
+        // Subsystem inert (no emitter) ⇒ anonymous callers unaffected.
+        assert!(!ledger_requires_identity(false, None));
+        assert!(!ledger_requires_identity(false, Some("did:web:alice")));
+    }
+
+    #[test]
+    fn deny_frame_is_content_free() {
+        // The fail-closed frame must carry no subject DID and no prompt material.
+        assert!(LEDGER_DENY_NO_IDENTITY.contains("billing identity"));
+        assert!(!LEDGER_DENY_NO_IDENTITY.contains("did:"));
+    }
+
+    // ── #1 + #2 spend posting (ledger build) ─────────────────────────────────
+    #[cfg(feature = "ledger")]
+    mod spend {
+        use super::*;
+        use crate::services::ledger::inference_spend::tests::{available, fixture};
+
+        // Drive a generation to a terminal outcome, then post the spend for the
+        // stats captured on that exit. Asserts the ledger is debited for the
+        // work actually done (prefill + generated).
+        async fn drive_and_post(
+            stream: &mut FakeStream,
+            cancel: &tokio_util::sync::CancellationToken,
+            sink: &mut impl GenSink,
+            emitter: &InferenceSpendEmitter,
+            stream_id: &str,
+        ) -> Option<SpendResult> {
+            drive_generation_loop(stream, cancel, sink).await;
+            post_completion_spend(
+                emitter,
+                Some(&stream.completion_stats()),
+                Some("did:web:alice"),
+                stream_id,
+            )
+            .await
+        }
+
+        #[tokio::test]
+        async fn cancelled_after_one_token_posts_spend() {
+            let (emitter, handle) = fixture(&[("did:web:alice", 1000)]).await;
+            let cancel = tokio_util::sync::CancellationToken::new();
+            let mut stream =
+                FakeStream::new(vec![Ok("a".into()), Ok("b".into()), Ok("c".into())], 5);
+            let mut sink = CancelAfterSink::new(cancel.clone(), 1);
+            let res = drive_and_post(&mut stream, &cancel, &mut sink, &emitter, "stream-cancel").await;
+            assert!(
+                matches!(res, Some(SpendResult::Posted { amount: 6, .. })),
+                "{res:?}"
+            );
+            // prefill(5) + 1 generated token debited; the rest never ran.
+            assert_eq!(available(&handle, "did:web:alice").await, 994);
+        }
+
+        #[tokio::test]
+        async fn publish_failure_after_partial_posts_spend() {
+            let (emitter, handle) = fixture(&[("did:web:alice", 1000)]).await;
+            let cancel = tokio_util::sync::CancellationToken::new();
+            let mut stream =
+                FakeStream::new(vec![Ok("a".into()), Ok("b".into()), Ok("c".into())], 5);
+            let mut sink = FailOnSink::new(2);
+            let res = drive_and_post(&mut stream, &cancel, &mut sink, &emitter, "stream-pubfail").await;
+            assert!(
+                matches!(res, Some(SpendResult::Posted { amount: 7, .. })),
+                "{res:?}"
+            );
+            // prefill(5) + 2 generated tokens (a published, b's publish failed).
+            assert_eq!(available(&handle, "did:web:alice").await, 993);
+        }
+
+        #[tokio::test]
+        async fn stream_error_after_partial_posts_spend() {
+            let (emitter, handle) = fixture(&[("did:web:alice", 1000)]).await;
+            let cancel = tokio_util::sync::CancellationToken::new();
+            let mut stream = FakeStream::new(vec![Ok("a".into()), Err("boom".to_owned())], 5);
+            let mut sink = RecordingSink::default();
+            let res = drive_and_post(&mut stream, &cancel, &mut sink, &emitter, "stream-err").await;
+            assert!(
+                matches!(res, Some(SpendResult::Posted { amount: 6, .. })),
+                "{res:?}"
+            );
+            // prefill(5) + 1 generated token before the error.
+            assert_eq!(available(&handle, "did:web:alice").await, 994);
+        }
+
+        #[tokio::test]
+        async fn normal_completion_posts_spend() {
+            let (emitter, handle) = fixture(&[("did:web:alice", 1000)]).await;
+            let cancel = tokio_util::sync::CancellationToken::new();
+            let mut stream = FakeStream::new(vec![Ok("a".into()), Ok("b".into())], 5);
+            let mut sink = RecordingSink::default();
+            let res = drive_and_post(&mut stream, &cancel, &mut sink, &emitter, "stream-ok").await;
+            assert!(
+                matches!(res, Some(SpendResult::Posted { amount: 7, .. })),
+                "{res:?}"
+            );
+            assert_eq!(available(&handle, "did:web:alice").await, 993);
+        }
+
+        #[tokio::test]
+        async fn missing_identity_posts_no_spend() {
+            // A DID-less caller (which the execute_stream gate denies
+            // pre-generation) posts no spend and touches no account.
+            let (emitter, handle) = fixture(&[("did:web:alice", 1000)]).await;
+            let s = stats(5, 1);
+            let res = post_completion_spend(&emitter, Some(&s), None, "stream-anon").await;
+            assert!(res.is_none(), "{res:?}");
+            assert_eq!(available(&handle, "did:web:alice").await, 1000);
+        }
+
+        #[tokio::test]
+        async fn no_stats_means_nothing_to_account() {
+            // Generation never began (engine returned Err) ⇒ no spend attempted.
+            let (emitter, handle) = fixture(&[("did:web:alice", 1000)]).await;
+            let res = post_completion_spend(&emitter, None, Some("did:web:alice"), "stream-nostart").await;
+            assert!(res.is_none(), "{res:?}");
+            assert_eq!(available(&handle, "did:web:alice").await, 1000);
+        }
     }
 }

--- a/crates/hyprstream/src/services/inference.rs
+++ b/crates/hyprstream/src/services/inference.rs
@@ -57,6 +57,10 @@ use tokio::runtime::Handle;
 use tokenizers::Tokenizer;
 use tracing::{debug, error, info, trace, warn};
 
+// #1264: completion-time ledger spend (behind the `ledger` feature, default off).
+#[cfg(feature = "ledger")]
+use crate::services::ledger::{observe_spend_result, InferenceSpendEmitter, SpendInput};
+
 
 /// Pending work to be executed after REP response is sent.
 ///
@@ -76,6 +80,13 @@ enum PendingWork {
         subject: Subject,
         /// Per-request TTT overrides (deferred to execute_stream)
         ttt_overrides: crate::training::ttt::TTTOverrides,
+        /// The verified caller's self-certifying pairwise DID — the ledger
+        /// account owner for the #1264 completion spend. `None` ⇒ anonymous ⇒
+        /// fail closed (no spend, no leak). Captured at admission from the
+        /// verified envelope and spent at completion. Read only under the
+        /// `ledger` feature.
+        #[cfg_attr(not(feature = "ledger"), allow(dead_code))]
+        owner_did: Option<String>,
     },
     /// Streaming training step (avoids REQ/REP timeout on backward pass compilation)
     Training {
@@ -172,6 +183,13 @@ pub struct InferenceServiceInner {
     /// Verified key of the ModelService controller allowed to bridge a local
     /// request into this tenant-bound instance.
     controller_pubkey: VerifyingKey,
+    /// Optional #1264 completion-spend emitter. `None` (default) ⇒ inert: the
+    /// completion path posts no spend. Behind a `RwLock` so an operator can
+    /// attach it after the service thread constructs the inner (the emitter's
+    /// `LedgerHandle` comes from a sibling ledger service whose startup ordering
+    /// is itself a follow-up). Gated behind the `ledger` feature.
+    #[cfg(feature = "ledger")]
+    ledger: parking_lot::RwLock<Option<Arc<InferenceSpendEmitter>>>,
 }
 
 /// ZMQ-based inference service
@@ -244,6 +262,19 @@ impl InferenceService {
             exported.len()
         );
         Ok(persisted)
+    }
+
+    /// Attach the #1264 completion-spend emitter. Once attached, every completed
+    /// generation posts a single-phase token spend to the cell ledger for the
+    /// verified caller's account (best-effort, fail-safe). When the emitter is
+    /// absent (`None`, the default), the completion path posts no spend — the
+    /// accounting subsystem is inert until an operator opts in.
+    ///
+    /// Behind the `ledger` feature. The emitter's [`LedgerHandle`] is cheap to
+    /// clone; attaching shares it with the service thread.
+    #[cfg(feature = "ledger")]
+    pub fn attach_ledger_spend(&self, emitter: Arc<InferenceSpendEmitter>) {
+        *self.ledger.write() = Some(emitter);
     }
 
     /// Run invariant checks before any TTT-scoped operation.
@@ -427,6 +458,8 @@ impl InferenceService {
                 lora_generation: Arc::new(AtomicU64::new(0)),
                 tenant_domain,
                 controller_pubkey,
+                #[cfg(feature = "ledger")]
+                ledger: parking_lot::RwLock::new(None),
             }),
         })
     }
@@ -653,6 +686,7 @@ impl InferenceService {
         expiry_secs: i64,
         subject: &Subject,
         ttt_overrides: crate::training::ttt::TTTOverrides,
+        owner_did: Option<String>,
     ) -> Result<(
         String,
         [u8; 32],
@@ -697,6 +731,7 @@ impl InferenceService {
             request,
             subject: subject.clone(),
             ttt_overrides,
+            owner_did,
         };
 
         Ok((stream_id, server_pubkey, broadcast_path, reach, pending))
@@ -733,11 +768,13 @@ impl InferenceService {
             "InferenceService must run on current_thread runtime for parking_lot safety"
         );
 
-        let PendingWork::Generation { stream_ctx, request, subject, ttt_overrides } = pending else {
+        let PendingWork::Generation { stream_ctx, request, subject, ttt_overrides, owner_did } = pending else {
             error!("execute_stream called with non-Generation PendingWork");
             return;
         };
         let stream_ctx = &stream_ctx;
+        // #1264: the spend's correlation entropy + the completion log key.
+        let stream_id_str = stream_ctx.stream_id().to_owned();
 
         // Get StreamChannel
         let stream_channel = match &self.stream_channel {
@@ -826,51 +863,65 @@ impl InferenceService {
         let engine = self.engine.read();
         let stream_result = engine.generate_with_delta(request, delta, tenant_id, weight_epoch);
 
-        let result = stream_channel.run_stream(stream_ctx, |mut publisher| async move {
-            let result = match stream_result {
-                Ok(mut stream) => {
-                    let cancel = stream_ctx.cancel_token();
-                    loop {
-                        let chunk_result = tokio::select! {
-                            biased;
-                            _ = cancel.cancelled() => {
-                                let _ = publisher.publish_error("cancelled").await;
-                                return (publisher, Ok(()));
-                            }
-                            next = stream.next() => match next {
-                                Some(r) => r,
-                                None => break,
-                            },
-                        };
-                        match chunk_result {
-                            Ok(text) => {
-                                let rate = stream.stats().inference_tokens_per_sec_ema;
-                                if let Err(e) = publisher.publish_data_with_rate(text.as_bytes(), rate).await {
-                                    return (publisher, Err(e));
+        // #1264: capture the completion stats out of the stream closure so the
+        // token-spend can be posted after the client-visible completion frame.
+        #[cfg(feature = "ledger")]
+        let completion_stats: Arc<parking_lot::Mutex<Option<crate::runtime::GenerationStats>>> =
+            Arc::new(parking_lot::Mutex::new(None));
+
+        let result = stream_channel.run_stream(stream_ctx, |mut publisher| {
+            #[cfg(feature = "ledger")]
+            let completion_stats = completion_stats.clone();
+            async move {
+                let result = match stream_result {
+                    Ok(mut stream) => {
+                        let cancel = stream_ctx.cancel_token();
+                        loop {
+                            let chunk_result = tokio::select! {
+                                biased;
+                                _ = cancel.cancelled() => {
+                                    let _ = publisher.publish_error("cancelled").await;
+                                    return (publisher, Ok(()));
+                                }
+                                next = stream.next() => match next {
+                                    Some(r) => r,
+                                    None => break,
+                                },
+                            };
+                            match chunk_result {
+                                Ok(text) => {
+                                    let rate = stream.stats().inference_tokens_per_sec_ema;
+                                    if let Err(e) = publisher.publish_data_with_rate(text.as_bytes(), rate).await {
+                                        return (publisher, Err(e));
+                                    }
+                                }
+                                Err(e) => {
+                                    let _ = publisher.publish_error(&e.to_string()).await;
+                                    return (publisher, Ok(()));
                                 }
                             }
-                            Err(e) => {
-                                let _ = publisher.publish_error(&e.to_string()).await;
-                                return (publisher, Ok(()));
-                            }
+                        }
+
+                        // Normal completion with stats
+                        let stats = stream.stats();
+                        #[cfg(feature = "ledger")]
+                        {
+                            *completion_stats.lock() = Some(stats.clone());
+                        }
+                        let mut complete = crate::services::rpc_types::InferenceComplete::from(&stats);
+
+                        // Attach TTT metrics to completion (from deferred TTT in execute_stream)
+                        complete.ttt_metrics = ttt_result.map(std::convert::Into::into);
+
+                        match publisher.complete_ref(&complete.to_bytes()).await {
+                            Ok(()) => Ok(()),
+                            Err(e) => Err(e),
                         }
                     }
-
-                    // Normal completion with stats
-                    let stats = stream.stats();
-                    let mut complete = crate::services::rpc_types::InferenceComplete::from(&stats);
-
-                    // Attach TTT metrics to completion (from deferred TTT in execute_stream)
-                    complete.ttt_metrics = ttt_result.map(std::convert::Into::into);
-
-                    match publisher.complete_ref(&complete.to_bytes()).await {
-                        Ok(()) => Ok(()),
-                        Err(e) => Err(e),
-                    }
-                }
-                Err(e) => Err(e),  // framework sends Error frame automatically
-            };
-            (publisher, result)
+                    Err(e) => Err(e),  // framework sends Error frame automatically
+                };
+                (publisher, result)
+            }
         }).await;
 
         if let Err(e) = result {
@@ -880,6 +931,49 @@ impl InferenceService {
                 "Stream execution failed"
             );
         }
+
+        // #1264: post the token-spend to the cell ledger on generation completion
+        // (quota burn). Fail-safe: a ledger/accounting failure MUST NOT break a
+        // generation that already produced output — the spend is best-effort and
+        // every non-posted outcome is a content-free signal, never a silent drop.
+        // Anonymous caller ⇒ fail closed (no spend, no leak). Posted *after* the
+        // client-visible completion frame. (The engine read-lock is held across
+        // this best-effort await; covered by the `await_holding_lock` allow above
+        // and consistent with the stream itself.)
+        #[cfg(feature = "ledger")]
+        {
+            let emitter_opt = self.ledger.read().clone();
+            if let Some(emitter) = emitter_opt {
+                let stats_opt = completion_stats.lock().clone();
+                match (stats_opt, owner_did.as_ref()) {
+                    (Some(stats), Some(owner)) => {
+                        let res = emitter
+                            .post_generation_spend(SpendInput {
+                                owner_did: owner,
+                                stream_id: &stream_id_str,
+                                prompt_tokens: stats.prefill_tokens as u64,
+                                generated_tokens: stats.tokens_generated as u64,
+                            })
+                            .await;
+                        observe_spend_result(&res, &stream_id_str, emitter.unit());
+                    }
+                    (Some(_), None) => {
+                        // Verified anonymous caller (no self-certifying DID) ⇒
+                        // fail closed: no spend, but signal it (#1264).
+                        warn!(
+                            stream_id = %stream_id_str,
+                            "ledger: anonymous caller — completion spend skipped (fail-closed)"
+                        );
+                    }
+                    (None, _) => {
+                        // No completion stats (errored/cancelled before the stats
+                        // frame) — nothing to account for; no signal needed.
+                    }
+                }
+            }
+        }
+        #[cfg(not(feature = "ledger"))]
+        drop(stream_id_str);
     }
 
     /// Execute streaming training step - called AFTER REP response is sent.
@@ -1991,8 +2085,17 @@ impl InferenceHandler for InferenceService {
 
         let client_ephemeral_pubkey = ctx.ephemeral_pubkey();
         let claims = ctx.claims().cloned();
+        // #1264: the verified caller's self-certifying pairwise DID — the ledger
+        // account owner spent at completion. `ctx.subject()` is the Casbin-facing
+        // authorization label (e.g. "alice"), not a DID and never a ledger
+        // principal; the self-certifying DID is derived from the same verified
+        // envelope (svc.rs / the enforcer's S1 model). Anonymous ⇒ `None`.
+        #[cfg(feature = "ledger")]
+        let owner_did = ctx.authenticated_pairwise_did().map(|d| d.as_str().to_owned());
+        #[cfg(not(feature = "ledger"))]
+        let owner_did: Option<String> = None;
         let (stream_id, server_pubkey, broadcast_path, reach, pending) =
-            self.prepare_stream(request, client_ephemeral_pubkey.as_ref().map(<[u8; 32]>::as_slice), claims, expiry_secs, &subject, ttt_overrides).await?;
+            self.prepare_stream(request, client_ephemeral_pubkey.as_ref().map(<[u8; 32]>::as_slice), claims, expiry_secs, &subject, ttt_overrides, owner_did).await?;
 
         let stream_info = crate::services::generated::inference_client::StreamInfo {
             stream_id,

--- a/crates/hyprstream/src/services/ledger/inference_spend.rs
+++ b/crates/hyprstream/src/services/ledger/inference_spend.rs
@@ -1,0 +1,623 @@
+//! Inference completion → single-phase ledger spend (issue #1264, epic #1064).
+//!
+//! At generation completion the inference service posts a **single-phase spend**
+//! to the cell ledger: it debits the verified caller's `Available` account for
+//! `prompt_tokens + generated_tokens` of the model's token unit, crediting the
+//! cell-owned usage account, bound to a `transfer_id`. This is the accounting
+//! *emit* — the durable accounting event the inference path previously never
+//! produced, so inference had no quota-burn accounting.
+//!
+//! ## Native spend API
+//!
+//! The emit uses [`LedgerHandle::debit`] — the ledger crate's native single-phase
+//! spend ([`hyprstream_ledger::LedgerBackend::debit`], overdraft-checked on the
+//! debit side). It does **not** depend on `ResourceIntent` (#1065, not merged);
+//! [`SpendInput`] is the minimal, completion-shaped record this seam needs and is
+//! left for #1065 to generalize.
+//!
+//! ## `transfer_id` (#985)
+//!
+//! `Transfer.id` is **client-supplied** — it *is* the ledger's idempotency key
+//! (the backend never mints one; the [`Outcome`](hyprstream_ledger::Outcome) for a
+//! replayed id is returned verbatim). The admission path
+//! ([`super::enforcer::LocalEnforcer::admit`]) mints it *at admission* via
+//! `mint_transfer_id(grant_cid, nonce)` so the #985 spend-authorization can bind
+//! to it. There is **no admission on the inference completion path yet** — the
+//! two-phase reserve/post enforcer is gated off and not wired into inference
+//! (see [`super`]'s module docs). So this emit mints the transfer id **at
+//! completion** ([`completion_transfer_id`]), under a distinct domain tag so it
+//! cannot collide with the admission path's id space. Cross-replay idempotency
+//! (a retried request reproducing the same id) is a documented follow-up: it
+//! requires threading the envelope `request_nonce` to completion; today the
+//! per-stream `stream_id` is the entropy, so a retried generation mints a fresh
+//! id and posts a fresh (idempotent-in-itself) spend.
+//!
+//! ## Fail-safe (#1264)
+//!
+//! A ledger/accounting failure MUST NOT break a generation that already produced
+//! output. [`InferenceSpendEmitter::post_generation_spend`] therefore **never
+//! returns a `Result`** the caller propagates as a stream failure: every outcome
+//! maps to an observable [`SpendResult`] the caller only *records* (log / metric).
+//! A declined spend (overdraft / unknown account) and a failed spend (actor down /
+//! encoding) are both surfaced as a **content-free signal** and then the
+//! generation proceeds — there is never a silent drop. The debit is best-effort
+//! accounting; the generation already completed.
+//!
+//! "Per the local enforcer's policy": the completion single-phase spend has no
+//! admission, so the in-memory [`super::CreditGate`] optimistic hold is not on
+//! this path. The floor that declines an overdraft here is the ledger engine's
+//! own overdraft check (`InsufficientBalance`) — the durable floor INV-1 upholds.
+
+use hyprstream_ledger::{
+    AccountId, Did, LedgerError, Outcome, Purpose, Transfer, TransferId, TransferResult, UnitId,
+};
+
+use super::handle::LedgerHandle;
+
+/// The observable result of a completion spend. Never an error the caller raises
+/// — the caller records it and continues (fail-safe, #1264).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum SpendResult {
+    /// The spend posted (or a replay returned the same applied outcome).
+    Posted {
+        /// The transfer id the spend is bound to (the idempotency key).
+        transfer_id: TransferId,
+        /// Tokens debited (prompt + generated).
+        amount: u128,
+    },
+    /// No spend was attempted: zero tokens to account, or not configured.
+    Skipped(&'static str),
+    /// The ledger floor declined the spend (overdraft / unknown account).
+    /// Recorded; the generation is unaffected.
+    Declined {
+        /// The transfer id the (failed) spend was bound to.
+        transfer_id: TransferId,
+        /// The deterministic reason (content-free category).
+        reason: SpendDecline,
+    },
+    /// The spend could not be posted (actor unavailable / encoding / misconfig).
+    /// Fail-safe: the caller signals and continues.
+    Failed {
+        /// The transfer id, if one was minted before the failure.
+        transfer_id: Option<TransferId>,
+        /// The content-free reason category.
+        reason: SpendFailure,
+    },
+}
+
+/// The deterministic, content-free category of a *declined* completion spend.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SpendDecline {
+    /// The caller's account cannot cover the token amount (overdraft floor).
+    InsufficientBalance,
+    /// The caller's account (or the cell usage account) does not exist.
+    UnknownAccount,
+}
+
+/// The content-free category of a *failed* completion spend.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SpendFailure {
+    /// The unit on the spend does not match an account's unit (misconfiguration).
+    UnitMismatch,
+    /// The holder and cell usage accounts resolve to the same id (misconfiguration).
+    AccountsMustDiffer,
+    /// The ledger actor is unavailable or reported an internal/encoding error.
+    Internal,
+}
+
+impl SpendResult {
+    /// A short, content-free label for logging/metrics (no subject, no prompt).
+    pub fn category(&self) -> &'static str {
+        match self {
+            SpendResult::Posted { .. } => "posted",
+            SpendResult::Skipped(_) => "skipped",
+            SpendResult::Declined { .. } => "declined",
+            SpendResult::Failed { .. } => "failed",
+        }
+    }
+}
+
+/// The minimal, completion-shaped record the emit consumes. Intentionally narrow:
+/// the general `ResourceIntent` (#1065) is left to that issue.
+#[derive(Debug, Clone)]
+pub struct SpendInput<'a> {
+    /// The verified caller's self-certifying pairwise DID (the account owner).
+    pub owner_did: &'a str,
+    /// Per-stream entropy → the deterministic transfer id (idempotency key).
+    pub stream_id: &'a str,
+    /// Prompt (prefill) tokens — from tokenization.
+    pub prompt_tokens: u64,
+    /// Generated (decode) tokens — from the stream completion count.
+    pub generated_tokens: u64,
+}
+
+/// The single-phase completion spend emitter, bound to one cell ledger and one
+/// inference token [`UnitId`] (the model-scoped token class; its `issuer` is the
+/// cell identity). Cheap to clone (an [`LedgerHandle`] is an `mpsc::Sender`).
+#[derive(Clone)]
+pub struct InferenceSpendEmitter {
+    handle: LedgerHandle,
+    cell: Did,
+    unit: UnitId,
+}
+
+impl std::fmt::Debug for InferenceSpendEmitter {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("InferenceSpendEmitter")
+            .field("cell", &self.cell)
+            .field("unit", &self.unit)
+            .finish_non_exhaustive()
+    }
+}
+
+impl InferenceSpendEmitter {
+    /// Construct against a cell ledger handle, the cell identity (unit issuer),
+    /// and the inference token unit (e.g. `resource_class = "inference.tokens"`).
+    pub fn new(handle: LedgerHandle, cell: Did, unit: UnitId) -> Self {
+        InferenceSpendEmitter { handle, cell, unit }
+    }
+
+    /// The cell ledger's service identity.
+    pub fn cell(&self) -> &Did {
+        &self.cell
+    }
+
+    /// The inference token unit spends are denominated in.
+    pub fn unit(&self) -> &UnitId {
+        &self.unit
+    }
+
+    /// Post the single-phase completion spend. Never errors: every outcome is an
+    /// observable [`SpendResult`] (fail-safe, #1264).
+    ///
+    /// The caller's `Available` account is debited `prompt_tokens +
+    /// generated_tokens`; the cell usage account is credited. The spend is bound
+    /// to a completion-minted [`TransferId`] (see the module docs on #985).
+    pub async fn post_generation_spend(&self, input: SpendInput<'_>) -> SpendResult {
+        // Token counts are `u64`; the ledger denominates amounts in `u128` minor
+        // units (token quanta). Widening is lossless; saturating add guards the
+        // (unreachable) sum-overflow on a single generation.
+        let amount: u128 =
+            (input.prompt_tokens as u128).saturating_add(input.generated_tokens as u128);
+        if amount == 0 {
+            return SpendResult::Skipped("zero tokens");
+        }
+
+        let owner = Did(input.owner_did.to_owned());
+        let debit = match holder_account(&self.cell, &owner, &self.unit) {
+            Ok(id) => id,
+            Err(_) => {
+                // `AccountId::derive` only fails on an (unreachable) CBOR encode.
+                return SpendResult::Failed {
+                    transfer_id: None,
+                    reason: SpendFailure::Internal,
+                };
+            }
+        };
+        let credit = match usage_account(&self.cell, &self.unit) {
+            Ok(id) => id,
+            Err(_) => {
+                return SpendResult::Failed {
+                    transfer_id: None,
+                    reason: SpendFailure::Internal,
+                };
+            }
+        };
+
+        let transfer_id = completion_transfer_id(&self.cell, &owner, &self.unit, input.stream_id);
+        let transfer = build_transfer(
+            transfer_id,
+            debit,
+            credit,
+            self.unit.clone(),
+            amount,
+            &owner,
+            input.stream_id,
+        );
+        let outcome = self.handle.debit(transfer).await;
+        classify(transfer_id, amount, outcome)
+    }
+}
+
+// ────────────────────────────────────────────────────────────────────────────
+// Pure helpers (no I/O) — unit-testable in isolation.
+// ────────────────────────────────────────────────────────────────────────────
+
+/// Derive the verified caller's spendable (`Available`) account id for `unit`.
+fn holder_account(cell: &Did, owner: &Did, unit: &UnitId) -> Result<AccountId, LedgerError> {
+    AccountId::derive(cell, owner, unit, &Purpose::Available)
+}
+
+/// Derive the cell-owned usage (credit) account id — the sink a spend credits.
+fn usage_account(cell: &Did, unit: &UnitId) -> Result<AccountId, LedgerError> {
+    AccountId::derive(cell, cell, unit, &Purpose::Available)
+}
+
+/// Deterministic completion transfer id: `blake3_128` over a domain-separated
+/// encoding of `(cell, owner, unit, stream_id)`. Distinct domain tag from the
+/// admission path's `mint_transfer_id` ⇒ the two id spaces never collide (#985).
+fn completion_transfer_id(cell: &Did, owner: &Did, unit: &UnitId, stream_id: &str) -> TransferId {
+    let mut h = blake3::Hasher::new();
+    h.update(b"hs-ledger-inference-xfer-v1");
+    h.update(cell.as_str().as_bytes());
+    h.update(owner.as_str().as_bytes());
+    h.update(unit.issuer.as_str().as_bytes());
+    h.update(unit.resource_class.as_bytes());
+    h.update(stream_id.as_bytes());
+    let mut out = [0u8; 16];
+    h.finalize_xof().fill(&mut out);
+    TransferId(u128::from_be_bytes(out))
+}
+
+/// Build the single-phase spend [`Transfer`] for one completion. `user_data` is a
+/// content address over `(owner, stream_id)` — opaque receipt correlation that
+/// carries no prompt material.
+fn build_transfer(
+    id: TransferId,
+    debit_account: AccountId,
+    credit_account: AccountId,
+    unit: UnitId,
+    amount: u128,
+    owner: &Did,
+    stream_id: &str,
+) -> Transfer {
+    let mut ud = blake3::Hasher::new();
+    ud.update(b"hs-ledger-inference-userdata-v1");
+    ud.update(owner.as_str().as_bytes());
+    ud.update(stream_id.as_bytes());
+    let mut user_data = [0u8; 32];
+    ud.finalize_xof().fill(&mut user_data);
+    Transfer {
+        id,
+        debit_account,
+        credit_account,
+        unit,
+        amount,
+        // No grant on the completion path (no admission/authorization yet, #985
+        // follow-up); the spend is an internal accounting emit.
+        grant_cid: None,
+        user_data,
+    }
+}
+
+/// Map a backend [`Outcome`] to the fail-safe [`SpendResult`] the caller records.
+fn classify(transfer_id: TransferId, amount: u128, outcome: Outcome) -> SpendResult {
+    match outcome.result {
+        Ok(TransferResult::Applied { posted, .. }) => {
+            // Single-phase debit posts the full amount; `posted` is authoritative.
+            SpendResult::Posted {
+                transfer_id,
+                amount: posted,
+            }
+        }
+        // A debit never yields the other `Ok` variants, but treat any success as
+        // posted rather than drop it (fail-loud, not fail-silent).
+        Ok(_) => SpendResult::Posted {
+            transfer_id,
+            amount,
+        },
+        Err(LedgerError::InsufficientBalance { .. }) => SpendResult::Declined {
+            transfer_id,
+            reason: SpendDecline::InsufficientBalance,
+        },
+        Err(LedgerError::UnknownAccount(_)) => SpendResult::Declined {
+            transfer_id,
+            reason: SpendDecline::UnknownAccount,
+        },
+        Err(LedgerError::UnitMismatch { .. }) => SpendResult::Failed {
+            transfer_id: Some(transfer_id),
+            reason: SpendFailure::UnitMismatch,
+        },
+        Err(LedgerError::AccountsMustDiffer(_)) => SpendResult::Failed {
+            transfer_id: Some(transfer_id),
+            reason: SpendFailure::AccountsMustDiffer,
+        },
+        Err(LedgerError::ZeroAmount) => SpendResult::Skipped("zero amount at floor"),
+        // Internal (actor down / encoding) and anything unexpected.
+        Err(_) => SpendResult::Failed {
+            transfer_id: Some(transfer_id),
+            reason: SpendFailure::Internal,
+        },
+    }
+}
+
+/// Record a completion spend outcome as a content-free signal (log only). Called
+/// by the inference completion path; never raises. "Content-free": the signal
+/// carries no subject DID and no prompt material — only `stream_id`, the unit,
+/// and the outcome category (#1264: never silently drop a spend).
+pub fn observe_spend_result(result: &SpendResult, stream_id: &str, unit: &UnitId) {
+    match result {
+        SpendResult::Posted { amount, .. } => {
+            tracing::debug!(
+                stream_id,
+                unit = unit.resource_class.as_str(),
+                amount,
+                category = result.category(),
+                "ledger: posted inference token spend",
+            );
+        }
+        SpendResult::Skipped(reason) => {
+            tracing::debug!(
+                stream_id,
+                unit = unit.resource_class.as_str(),
+                reason,
+                category = result.category(),
+                "ledger: inference spend skipped",
+            );
+        }
+        SpendResult::Declined { reason, .. } => {
+            tracing::warn!(
+                stream_id,
+                unit = unit.resource_class.as_str(),
+                decline = ?reason,
+                category = result.category(),
+                "ledger: inference spend declined by floor (generation unaffected)",
+            );
+        }
+        SpendResult::Failed { reason, .. } => {
+            tracing::error!(
+                stream_id,
+                unit = unit.resource_class.as_str(),
+                failure = ?reason,
+                category = result.category(),
+                "ledger: inference spend failed (fail-safe; generation unaffected)",
+            );
+        }
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+mod tests {
+    use super::*;
+    use crate::services::ledger::CoseCheckpointSigner;
+    use std::sync::Arc;
+    use hyprstream_ledger::{AccountSpec, IssueTransfer, LedgerBackend, MemLedger};
+
+    fn unit() -> UnitId {
+        UnitId {
+            issuer: Did("did:web:cell.test".to_owned()),
+            resource_class: "inference.tokens".to_owned(),
+        }
+    }
+
+    fn did(s: &str) -> Did {
+        Did(s.to_owned())
+    }
+
+    /// Open the issuer-liability + cell-usage accounts, plus one `Available`
+    /// account per named holder, and issue `credit` to each holder. Returns the
+    /// emitter and the spawned handle (for balance inspection).
+    async fn fixture(holders: &[(&str, u128)]) -> (InferenceSpendEmitter, LedgerHandle) {
+        let cell = did("did:web:cell.test");
+        let mut backend = MemLedger::new(cell.clone());
+        let issuer_liab =
+            AccountId::derive(&cell, &unit().issuer, &unit(), &Purpose::IssuerLiability).unwrap();
+        backend
+            .open_account(AccountSpec::new(
+                cell.clone(),
+                unit().issuer.clone(),
+                unit(),
+                Purpose::IssuerLiability,
+            ))
+            .unwrap();
+        backend
+            .open_account(AccountSpec::new(
+                cell.clone(),
+                cell.clone(),
+                unit(),
+                Purpose::Available,
+            ))
+            .unwrap();
+
+        for (idx, (h, credit)) in holders.iter().enumerate() {
+            let holder = did(h);
+            let acct = holder_account(&cell, &holder, &unit()).unwrap();
+            backend
+                .open_account(AccountSpec::new(
+                    cell.clone(),
+                    holder.clone(),
+                    unit(),
+                    Purpose::Available,
+                ))
+                .unwrap();
+            backend
+                .credit(IssueTransfer {
+                    // Monotonic, holder-distinct idempotency id per issuance.
+                    id: TransferId(1_000 + idx as u128),
+                    issuer_liability: issuer_liab,
+                    destination: acct,
+                    unit: unit(),
+                    amount: *credit,
+                    grant_cid: None,
+                    user_data: [0u8; 32],
+                })
+                .result
+                .unwrap();
+        }
+
+        let signer = Arc::new(CoseCheckpointSigner::classical(
+            cell.clone(),
+            ed25519_dalek::SigningKey::from_bytes(&[1u8; 32]),
+        ));
+        let handle = LedgerHandle::spawn(Box::new(backend), signer);
+        let emitter = InferenceSpendEmitter::new(handle.clone(), cell, unit());
+        (emitter, handle)
+    }
+
+    async fn available(handle: &LedgerHandle, owner: &str) -> u128 {
+        let cell = did("did:web:cell.test");
+        let acct = holder_account(&cell, &did(owner), &unit()).unwrap();
+        handle.balance(acct).await.unwrap().available
+    }
+
+    #[tokio::test]
+    async fn two_subjects_post_to_own_accounts_only() {
+        // Each holder starts with 1000 tokens; each spends 300. Only that
+        // holder's account is debited; the other is untouched.
+        let (emitter, handle) = fixture(&[("did:web:alice", 1000), ("did:web:bob", 1000)]).await;
+
+        let a = emitter
+            .post_generation_spend(SpendInput {
+                owner_did: "did:web:alice",
+                stream_id: "stream-a",
+                prompt_tokens: 100,
+                generated_tokens: 200,
+            })
+            .await;
+        let b = emitter
+            .post_generation_spend(SpendInput {
+                owner_did: "did:web:bob",
+                stream_id: "stream-b",
+                prompt_tokens: 50,
+                generated_tokens: 250,
+            })
+            .await;
+
+        assert!(
+            matches!(a, SpendResult::Posted { amount: 300, .. }),
+            "{a:?}"
+        );
+        assert!(
+            matches!(b, SpendResult::Posted { amount: 300, .. }),
+            "{b:?}"
+        );
+        // Each debited exactly its own 300; the other untouched.
+        assert_eq!(available(&handle, "did:web:alice").await, 700);
+        assert_eq!(available(&handle, "did:web:bob").await, 700);
+    }
+
+    #[tokio::test]
+    async fn overdraft_declined_per_local_enforcer_floor() {
+        // The completion spend has no admission/CreditGate hold; the floor that
+        // declines an overdraft is the ledger engine's own check
+        // (`InsufficientBalance`) — the durable floor INV-1 upholds. Alice has
+        // 10; she spends 100 → declined, balance untouched.
+        let (emitter, handle) = fixture(&[("did:web:alice", 10)]).await;
+
+        let res = emitter
+            .post_generation_spend(SpendInput {
+                owner_did: "did:web:alice",
+                stream_id: "stream-over",
+                prompt_tokens: 40,
+                generated_tokens: 60,
+            })
+            .await;
+
+        assert_eq!(
+            res,
+            SpendResult::Declined {
+                transfer_id: completion_transfer_id(
+                    &did("did:web:cell.test"),
+                    &did("did:web:alice"),
+                    &unit(),
+                    "stream-over",
+                ),
+                reason: SpendDecline::InsufficientBalance,
+            }
+        );
+        // No partial debit on a decline.
+        assert_eq!(available(&handle, "did:web:alice").await, 10);
+    }
+
+    #[tokio::test]
+    async fn missing_subject_account_fails_closed_no_spend_no_leak() {
+        // Carol calls but has no account (no entitlement issued). The spend must
+        // fail closed: no debit lands anywhere, and the outcome is a signal, not
+        // a propagated error.
+        let (emitter, handle) = fixture(&[("did:web:alice", 1000)]).await;
+
+        let res = emitter
+            .post_generation_spend(SpendInput {
+                owner_did: "did:web:carol",
+                stream_id: "stream-carol",
+                prompt_tokens: 10,
+                generated_tokens: 20,
+            })
+            .await;
+
+        assert_eq!(
+            res,
+            SpendResult::Declined {
+                transfer_id: completion_transfer_id(
+                    &did("did:web:cell.test"),
+                    &did("did:web:carol"),
+                    &unit(),
+                    "stream-carol",
+                ),
+                reason: SpendDecline::UnknownAccount,
+            }
+        );
+        // Alice (the only funded account) is untouched — no leak to/from her.
+        assert_eq!(available(&handle, "did:web:alice").await, 1000);
+    }
+
+    #[tokio::test]
+    async fn zero_tokens_is_a_skip_not_a_spend() {
+        let (emitter, handle) = fixture(&[("did:web:alice", 1000)]).await;
+        let res = emitter
+            .post_generation_spend(SpendInput {
+                owner_did: "did:web:alice",
+                stream_id: "stream-empty",
+                prompt_tokens: 0,
+                generated_tokens: 0,
+            })
+            .await;
+        assert!(matches!(res, SpendResult::Skipped(_)));
+        assert_eq!(available(&handle, "did:web:alice").await, 1000);
+    }
+
+    #[tokio::test]
+    async fn same_stream_replays_to_same_outcome() {
+        // The transfer id is deterministic in the stream id; a second post for
+        // the same stream is a replay → the ledger returns the original applied
+        // outcome verbatim (idempotency), and the holder is debited only once.
+        let (emitter, handle) = fixture(&[("did:web:alice", 1000)]).await;
+        let mk = || SpendInput {
+            owner_did: "did:web:alice",
+            stream_id: "stream-once",
+            prompt_tokens: 100,
+            generated_tokens: 100,
+        };
+        let first = emitter.post_generation_spend(mk()).await;
+        let second = emitter.post_generation_spend(mk()).await;
+        assert_eq!(first, second, "replay must yield the same SpendResult");
+        assert!(matches!(first, SpendResult::Posted { amount: 200, .. }));
+        assert_eq!(available(&handle, "did:web:alice").await, 800);
+    }
+
+    #[test]
+    fn transfer_id_is_deterministic_and_stream_distinct() {
+        let cell = did("did:web:cell.test");
+        let alice = did("did:web:alice");
+        let a = completion_transfer_id(&cell, &alice, &unit(), "s1");
+        let a2 = completion_transfer_id(&cell, &alice, &unit(), "s1");
+        let b = completion_transfer_id(&cell, &alice, &unit(), "s2");
+        assert_eq!(a, a2, "same inputs ⇒ same id");
+        assert_ne!(a, b, "different stream ⇒ different id");
+        // Distinct from a different subject even on the same stream.
+        let bob = did("did:web:bob");
+        let c = completion_transfer_id(&cell, &bob, &unit(), "s1");
+        assert_ne!(a, c, "different subject ⇒ different id");
+    }
+
+    #[test]
+    fn build_transfer_carries_amount_and_no_grant() {
+        let cell = did("did:web:cell.test");
+        let owner = did("did:web:alice");
+        let id = TransferId(7);
+        let debit = holder_account(&cell, &owner, &unit()).unwrap();
+        let credit = usage_account(&cell, &unit()).unwrap();
+        let t = build_transfer(id, debit, credit, unit(), 250, &owner, "stream-x");
+        assert_eq!(t.id, id);
+        assert_eq!(t.amount, 250);
+        assert!(
+            t.grant_cid.is_none(),
+            "completion spend carries no grant (#985)"
+        );
+        assert_ne!(
+            t.user_data, [0u8; 32],
+            "user_data is a real correlation hash"
+        );
+    }
+}

--- a/crates/hyprstream/src/services/ledger/inference_spend.rs
+++ b/crates/hyprstream/src/services/ledger/inference_spend.rs
@@ -368,27 +368,27 @@ pub fn observe_spend_result(result: &SpendResult, stream_id: &str, unit: &UnitId
 
 #[cfg(test)]
 #[allow(clippy::unwrap_used, clippy::expect_used)]
-mod tests {
+pub(crate) mod tests {
     use super::*;
     use crate::services::ledger::CoseCheckpointSigner;
     use std::sync::Arc;
     use hyprstream_ledger::{AccountSpec, IssueTransfer, LedgerBackend, MemLedger};
 
-    fn unit() -> UnitId {
+    pub(crate) fn unit() -> UnitId {
         UnitId {
             issuer: Did("did:web:cell.test".to_owned()),
             resource_class: "inference.tokens".to_owned(),
         }
     }
 
-    fn did(s: &str) -> Did {
+    pub(crate) fn did(s: &str) -> Did {
         Did(s.to_owned())
     }
 
     /// Open the issuer-liability + cell-usage accounts, plus one `Available`
     /// account per named holder, and issue `credit` to each holder. Returns the
     /// emitter and the spawned handle (for balance inspection).
-    async fn fixture(holders: &[(&str, u128)]) -> (InferenceSpendEmitter, LedgerHandle) {
+    pub(crate) async fn fixture(holders: &[(&str, u128)]) -> (InferenceSpendEmitter, LedgerHandle) {
         let cell = did("did:web:cell.test");
         let mut backend = MemLedger::new(cell.clone());
         let issuer_liab =
@@ -445,7 +445,7 @@ mod tests {
         (emitter, handle)
     }
 
-    async fn available(handle: &LedgerHandle, owner: &str) -> u128 {
+    pub(crate) async fn available(handle: &LedgerHandle, owner: &str) -> u128 {
         let cell = did("did:web:cell.test");
         let acct = holder_account(&cell, &did(owner), &unit()).unwrap();
         handle.balance(acct).await.unwrap().available

--- a/crates/hyprstream/src/services/ledger/mod.rs
+++ b/crates/hyprstream/src/services/ledger/mod.rs
@@ -36,6 +36,7 @@ pub mod actor;
 pub mod credit_gate;
 pub mod enforcer;
 pub mod handle;
+pub mod inference_spend;
 pub mod service;
 pub mod signer;
 pub mod sink;
@@ -49,6 +50,10 @@ pub use enforcer::{
     LocalEnforcer, Rejection,
 };
 pub use handle::LedgerHandle;
+pub use inference_spend::{
+    observe_spend_result, InferenceSpendEmitter, SpendDecline, SpendFailure, SpendInput,
+    SpendResult,
+};
 pub use service::LedgerService;
 pub use signer::CoseCheckpointSigner;
 pub use sink::{DebtBreaker, LoggingReceiptSink, ReceiptPayload, ReceiptSink};


### PR DESCRIPTION
Closes #1264 · Epic #1064 · refs #1246, #923, #985, #981

## What

At generation completion the inference service now posts a **single-phase
spend** to the cell ledger (`hyprstream-ledger`): it debits the verified
caller's account for `prompt_tokens + generated_tokens` of the model's token
unit, crediting the cell usage account, bound to a `transfer_id`. This is the
accounting emit inference previously never produced — so there was **no
quota-burn accounting for inference**.

## How

- **`services/ledger/inference_spend.rs` (new)** — `InferenceSpendEmitter`
  over a `LedgerHandle`. `post_generation_spend` mints a completion
  `transfer_id` and calls the ledger crate's **native single-phase spend**
  (`LedgerHandle::debit`, overdraft-checked on the debit side). Every backend
  `Outcome` is classified into a fail-safe `SpendResult`
  (`Posted` / `Skipped` / `Declined` / `Failed`); the method **never returns a
  `Result` the caller propagates** — a ledger/accounting failure can never
  break a generation that already produced output, and every non-posted outcome
  is a **content-free signal** (log), never a silent drop. Anonymous caller ⇒
  fail closed (no spend, no leak). Does **not** depend on `ResourceIntent`
  (#1065, not merged); `SpendInput` is the minimal completion-shaped record.
- **`services/inference.rs`** — thread the verified caller's self-certifying
  **pairwise DID** (`ctx.authenticated_pairwise_did()`, not the Casbin label
  `ctx.subject()`) through `PendingWork::Generation`; add a feature-gated,
  default-**inert** emitter field + an `attach_ledger_spend` seam; post the
  spend in `execute_stream` **after** the client-visible completion frame.
- **`services/ledger/mod.rs`** — export the emitter + result types.

## `transfer_id` (#985) — which path

`Transfer.id` is **client-supplied** (it *is* the ledger's idempotency key; the
backend never mints one — a replayed id returns the original `Outcome`
verbatim). The admission path (`LocalEnforcer::admit`) mints it **at admission**
via `mint_transfer_id(grant_cid, nonce)` so the #985 spend-authorization binds to
it. **There is no admission on the inference completion path yet** — the
two-phase reserve/post enforcer is gated off and not wired into inference (see
the `services::ledger` module docs). So this emit mints the transfer id **at
completion**, under a distinct domain tag so it cannot collide with the
admission path's id space. Cross-replay idempotency (a retried request
reproducing the same id) is a documented follow-up: it needs the envelope
`request_nonce` threaded to completion; today the per-stream `stream_id` is the
entropy.

## Fail-safe (decided)

Chosen failure mode: **best-effort, fire-and-forget, fail-open-for-the-stream /
fail-closed-for-accounting**. A ledger/accounting failure **must not** break a
generation that already produced output — the spend is posted *after* the
client-visible completion frame, and the emitter converts every outcome to an
observable `SpendResult` the caller only logs. There is no path by which a
ledger error propagates as a stream error or drops a spend silently. An
overdraft / unknown-account is `Declined` (the durable ledger floor INV-1
upholds; the in-memory `CreditGate` optimistic hold is not on this path since
there's no admission).

## Gating

Behind the `ledger` cargo feature (default off), and inert unless an operator
attaches an emitter (`attach_ledger_spend`). The ledger subsystem's full
factory wiring (obtaining the sibling `LedgerService` handle at inference
startup) is the documented follow-up — same status as the enforcer-not-yet-
wired-into-the-scheduler. Native spend API only; no `ResourceIntent` (#1065).

## Tests

`cargo test -p hyprstream --features ledger --lib inference_spend` → **7 pass**:
two-subject account isolation; overdraft declined by the ledger floor;
missing/unknown subject account fails closed (no spend, no leak); zero-token
skip; replay idempotency; transfer-id determinism/distinctness; `build_transfer`
shape. `cargo clippy --all-targets -D warnings` clean.

> Note: the two pre-existing enforcer happy-path tests
> (`admitted_then_post_and_void_roundtrip`,
> `insufficient_credit_rejects_retryable_not_queues`) fail when the `services::ledger`
> subset is run in isolation — they depend on a process-global PQ trust store
> (`install_verify_config`) populated by tests outside that module. They pass in
> the full `cargo test --workspace` run. This PR does not touch enforcer/PQ-store
> code.

## Merge note

Edits `services/inference.rs` (completion path / `execute_stream`). That region
overlaps the D8 (#1260) and D7 (#1261) edits to the same file → **serialize at
merge** (rebase whichever lands second; the conflict surface is the
`execute_stream` closure and `PendingWork::Generation`).