### PR TITLE
fix(test): stabilize composite_authority_production_paths_reject_semantic_rollback (unblocks merge queue)

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -12,3 +12,13 @@
 # KILLED after `terminate-after` periods, not merely flagged slow).
 [profile.ci]
 slow-timeout = { period = "60s", terminate-after = 3 }
+
+[test-groups]
+production-authority = { max-threads = 1 }
+
+[[profile.ci.overrides]]
+filter = 'test(=auth::key_rotation::tests::composite_authority_production_paths_reject_semantic_rollback)'
+test-group = 'production-authority'
+# This test re-execs the release test binary and runs several authority
+# processes concurrently. Reserve the runner while it owns that process tree.
+threads-required = "num-cpus"

--- a/crates/hyprstream/src/auth/key_rotation.rs
+++ b/crates/hyprstream/src/auth/key_rotation.rs
@@ -2964,10 +2964,8 @@ mod tests {
         const ORCHESTRATOR_DIR: &str = "HYPRSTREAM_COMPOSITE_ORCHESTRATOR_TEST_DIR";
         if std::env::var_os(ORCHESTRATOR_DIR).is_none() {
             // UDS socket paths are limited to ~108 bytes; keep the parent
-            // short even when the worktree has a long absolute path.
-            let test_tmp = std::env::temp_dir().join("hs-composite-tests");
-            std::fs::create_dir_all(&test_tmp).unwrap();
-            let dir = TempDir::new_in(test_tmp).unwrap();
+            // short and unique even when the worktree has a long absolute path.
+            let dir = TempDir::new().unwrap();
             let status = std::process::Command::new(std::env::current_exe().unwrap())
                 .args([
                     "--exact",


### PR DESCRIPTION
## Determination

This is a test-coordination/resource-contention flake, not a production key-publication race. `CompositeKeySet::publish()` validates a complete `CompositeKeySetSnapshot` while holding one `RwLock<Arc<CompositeKeySetSnapshot>>` write guard and replaces the single `Arc` publication point. JWKS and verification readers call `snapshot()`, while minting calls `mint_snapshot()` and receives one whole snapshot after checking the committed on-disk generation under the ledger lock. No reader observes separately published Ed25519 and ML-DSA components.

The failing test re-execs the release test binary and owns a tree of production-authority subprocesses with acknowledgement-barrier deadlines. In a saturated parallel release suite, that process tree competed with unrelated tests for runner resources. It also placed its per-run directory beneath the fixed `/tmp/hs-composite-tests` namespace.

## Fix

- Put the test in the `production-authority` nextest test group with `max-threads = 1`.
- Reserve `threads-required = "num-cpus"` for that CI-profile test, preventing unrelated suite tests from overlapping its subprocess tree.
- Use `TempDir::new()` for a short, unique temporary root instead of the fixed `hs-composite-tests` parent.
- Keep all rollback, barrier, mint, verify, and JWKS security assertions unchanged.

The spawned HTTP listener was already bound to `127.0.0.1:0`, IPC paths are scoped to the unique temporary root, and synchronization already uses bounded polling rather than blind fixed sleeps.

## Validation

Ran the complete surrounding module three consecutive times with the CI release profile:

`cargo nextest run --release --profile ci -p hyprstream auth::key_rotation::tests`

- Run 1: 30/30 passed; target test 6.312s
- Run 2: 30/30 passed; target test 6.305s
- Run 3: 30/30 passed; target test 6.334s

The pre-commit CI-equivalent release Clippy gate also passed.