### PR TITLE
kv-cache: define native compatibility fingerprint + rejection policy

### DIFF
--- a/crates/hyprstream/src/runtime/kv_cache.rs
+++ b/crates/hyprstream/src/runtime/kv_cache.rs
@@ -32,6 +32,7 @@ use tch::Device;
 use tch::{Kind as DType, Tensor};
 
 use super::KVQuantType;
+use super::kv_compat::KvCompatFingerprint;
 use super::torch_utils::{estimate_tensor_size_mb, safe_zeros};
 
 // ============================================================================
@@ -1930,6 +1931,11 @@ pub struct KVCacheManager {
     cached_token_ids: Vec<i64>,
     /// Where this cache's tensors currently reside
     location: CacheLocation,
+    /// Compatibility fingerprint under which this cache's KV was produced
+    /// (#1277). `None` until the cache is first populated; the engine stamps it
+    /// at reuse time and rejects (clears + recomputes) on mismatch against the
+    /// current expected fingerprint.
+    compat_fingerprint: Option<KvCompatFingerprint>,
 }
 
 impl KVCacheManager {
@@ -1956,6 +1962,7 @@ impl KVCacheManager {
             access_count: AtomicU64::new(0),
             cached_token_ids: Vec::new(),
             location: CacheLocation::Gpu,
+            compat_fingerprint: None,
         }
     }
 
@@ -1990,6 +1997,7 @@ impl KVCacheManager {
             access_count: AtomicU64::new(0),
             cached_token_ids: Vec::new(),
             location: CacheLocation::Gpu,
+            compat_fingerprint: None,
         }
     }
 
@@ -2033,6 +2041,20 @@ impl KVCacheManager {
         for mut cache_ref in self.layer_caches.iter_mut() {
             cache_ref.clear();
         }
+    }
+
+    /// The compatibility fingerprint stamped on this cache, or `None` until the
+    /// cache is first populated (#1277).
+    pub fn compat_fingerprint(&self) -> Option<KvCompatFingerprint> {
+        self.compat_fingerprint
+    }
+
+    /// Stamp (or re-stamp) the compatibility fingerprint under which this
+    /// cache's KV is being produced. Called by the engine at reuse time: a fresh
+    /// cache is stamped with the current config; an incompatible cache is
+    /// cleared and re-stamped after its stale KV is discarded.
+    pub fn set_compat_fingerprint(&mut self, fp: KvCompatFingerprint) {
+        self.compat_fingerprint = Some(fp);
     }
 
     /// Enable or disable caching

--- a/crates/hyprstream/src/runtime/kv_cache.rs
+++ b/crates/hyprstream/src/runtime/kv_cache.rs
@@ -2673,6 +2673,71 @@ mod tests {
         Ok(())
     }
 
+    /// The cache-level lifecycle the KV-compat reuse guard (#1277) relies on:
+    /// `cached_token_count() == 0` is the "provably empty" signal, and a populated
+    /// cache with no stamp must be rejected (DiscardAndRecompute), never adopted.
+    #[test]
+    fn test_kv_compat_fail_closed_lifecycle() {
+        use crate::runtime::kv_compat::{
+            decide_cache_reuse, CacheReuseDecision, KvCompatDescriptor, WeightIdentity,
+            KV_COMPAT_FORMAT_VERSION,
+        };
+
+        let expected = KvCompatDescriptor {
+            format_version: KV_COMPAT_FORMAT_VERSION,
+            weights: WeightIdentity::base_only("sha256:base"),
+            tokenizer_hash: Some("deadbeef".to_owned()),
+            ..Default::default()
+        }
+        .fingerprint();
+
+        let mut manager = KVCacheManager::new(2, 64, KVQuantType::None);
+
+        // (1) Fresh cache: empty, un-stamped. An authoritative identity is available
+        //     → stamp fresh and let prefill populate it.
+        assert_eq!(manager.cached_token_count(), 0);
+        assert!(manager.compat_fingerprint().is_none());
+        assert_eq!(
+            decide_cache_reuse(Some(&expected), manager.compat_fingerprint().as_ref(), true),
+            CacheReuseDecision::StampFresh
+        );
+        manager.set_compat_fingerprint(expected);
+
+        // (2) Cache now populated but its stamp matches → reuse.
+        manager.set_cached_tokens(vec![1, 2, 3, 4]);
+        assert_eq!(
+            decide_cache_reuse(
+                Some(&expected),
+                manager.compat_fingerprint().as_ref(),
+                manager.cached_token_count() == 0
+            ),
+            CacheReuseDecision::Reuse
+        );
+
+        // (3) A populated cache carrying NO stamp (e.g. produced before stamping
+        //     existed) must be rejected, never silently adopted.
+        let mut unstamped = KVCacheManager::new(2, 64, KVQuantType::None);
+        unstamped.set_cached_tokens(vec![9, 9, 9]);
+        assert_eq!(
+            decide_cache_reuse(
+                Some(&expected),
+                unstamped.compat_fingerprint().as_ref(),
+                unstamped.cached_token_count() == 0
+            ),
+            CacheReuseDecision::DiscardAndRecompute,
+            "an unstamped populated cache must fail-closed to discard"
+        );
+
+        // (4) Discard clears the emptiness signal so the cache is treated fresh again.
+        unstamped.set_cached_tokens(Vec::new());
+        unstamped.clear_all();
+        assert_eq!(unstamped.cached_token_count(), 0);
+        assert_eq!(
+            decide_cache_reuse(Some(&expected), unstamped.compat_fingerprint().as_ref(), true),
+            CacheReuseDecision::StampFresh
+        );
+    }
+
     // ========================================================================
     // TTT → KV invalidation wiring (#1254, epic #1246)
     // ========================================================================

--- a/crates/hyprstream/src/runtime/kv_cache.rs
+++ b/crates/hyprstream/src/runtime/kv_cache.rs
@@ -32,7 +32,9 @@ use tch::Device;
 use tch::{Kind as DType, Tensor};
 
 use super::KVQuantType;
-use super::kv_compat::KvCompatFingerprint;
+use super::kv_compat::{
+    decide_cache_reuse, CacheReuseDecision, KvCompatFingerprint,
+};
 use super::torch_utils::{estimate_tensor_size_mb, safe_zeros};
 
 // ============================================================================
@@ -2057,6 +2059,62 @@ impl KVCacheManager {
         self.compat_fingerprint = Some(fp);
     }
 
+    /// Apply the fail-closed KV compatibility policy to this real cache.
+    ///
+    /// This is the production state-transition boundary for #1277. A compatible
+    /// stamped cache is retained. A fresh empty cache is stamped before prefill.
+    /// Every incompatible or unproven cache has both its token IDs and layer
+    /// tensors discarded, then is re-stamped only when an authoritative expected
+    /// fingerprint is available.
+    pub fn apply_reuse_policy(
+        &mut self,
+        expected: Option<KvCompatFingerprint>,
+    ) -> CacheReuseDecision {
+        let stored = self.compat_fingerprint();
+        let cache_is_empty = self.cached_token_count() == 0;
+        let decision =
+            decide_cache_reuse(expected.as_ref(), stored.as_ref(), cache_is_empty);
+
+        match decision {
+            CacheReuseDecision::Reuse => {
+                tracing::debug!(target: "kv_compat", "KV cache reuse: compatible");
+            }
+            CacheReuseDecision::StampFresh => {
+                if let Some(expected) = expected {
+                    self.set_compat_fingerprint(expected);
+                }
+            }
+            CacheReuseDecision::DiscardAndRecompute => {
+                let reason = match stored {
+                    Some(stored) => format!(
+                        "stamp mismatch (stored={}, expected={})",
+                        stored.to_hex(),
+                        expected
+                            .map(|fingerprint| fingerprint.to_hex())
+                            .unwrap_or_else(|| "<none>".to_owned())
+                    ),
+                    None if !cache_is_empty => {
+                        "populated cache with no compatibility stamp".to_owned()
+                    }
+                    None => "no authoritative compatibility identity".to_owned(),
+                };
+                tracing::info!(
+                    target: "kv_compat",
+                    reason = %reason,
+                    "KV cache not reusable: discarding and recomputing (fail-closed)"
+                );
+
+                self.set_cached_tokens(Vec::new());
+                self.clear_all();
+                if let Some(expected) = expected {
+                    self.set_compat_fingerprint(expected);
+                }
+            }
+        }
+
+        decision
+    }
+
     /// Enable or disable caching
     pub fn set_enabled(&mut self, enabled: bool) {
         self.enabled = enabled;
@@ -2673,69 +2731,94 @@ mod tests {
         Ok(())
     }
 
-    /// The cache-level lifecycle the KV-compat reuse guard (#1277) relies on:
-    /// `cached_token_count() == 0` is the "provably empty" signal, and a populated
-    /// cache with no stamp must be rejected (DiscardAndRecompute), never adopted.
-    #[test]
-    fn test_kv_compat_fail_closed_lifecycle() {
+    fn compat_test_fingerprint(base_revision: &str) -> KvCompatFingerprint {
         use crate::runtime::kv_compat::{
-            decide_cache_reuse, CacheReuseDecision, KvCompatDescriptor, WeightIdentity,
-            KV_COMPAT_FORMAT_VERSION,
+            KvCompatDescriptor, WeightIdentity, KV_COMPAT_FORMAT_VERSION,
         };
 
-        let expected = KvCompatDescriptor {
+        KvCompatDescriptor {
             format_version: KV_COMPAT_FORMAT_VERSION,
-            weights: WeightIdentity::base_only("sha256:base"),
+            weights: WeightIdentity::base_only(base_revision),
             tokenizer_hash: Some("deadbeef".to_owned()),
             ..Default::default()
         }
-        .fingerprint();
+        .fingerprint()
+    }
 
+    /// Populate both reuse signals on a real manager: token IDs used by prefix
+    /// matching and layer tensors used by attention.
+    fn populate_compat_test_cache(manager: &mut KVCacheManager) {
+        manager.set_cached_tokens(vec![1, 2, 3, 4]);
+        let updated = manager.with_layer_cache(0, |cache| {
+            let keys = Tensor::ones([1, 4, 2, 4], (DType::Float, Device::Cpu));
+            let values = Tensor::ones([1, 4, 2, 4], (DType::Float, Device::Cpu));
+            cache.update(&keys, &values, 0).expect("populate layer cache");
+        });
+        assert_eq!(updated, Some(()));
+    }
+
+    fn compat_test_layer_seq_pos(manager: &KVCacheManager) -> usize {
+        manager
+            .with_layer_cache(0, |cache| cache.seq_pos)
+            .expect("layer 0 exists")
+    }
+
+    #[test]
+    fn apply_reuse_policy_retains_compatible_real_cache() {
+        let expected = compat_test_fingerprint("sha256:base");
         let mut manager = KVCacheManager::new(2, 64, KVQuantType::None);
 
-        // (1) Fresh cache: empty, un-stamped. An authoritative identity is available
-        //     → stamp fresh and let prefill populate it.
-        assert_eq!(manager.cached_token_count(), 0);
-        assert!(manager.compat_fingerprint().is_none());
         assert_eq!(
-            decide_cache_reuse(Some(&expected), manager.compat_fingerprint().as_ref(), true),
+            manager.apply_reuse_policy(Some(expected)),
             CacheReuseDecision::StampFresh
         );
-        manager.set_compat_fingerprint(expected);
+        assert_eq!(manager.compat_fingerprint(), Some(expected));
 
-        // (2) Cache now populated but its stamp matches → reuse.
-        manager.set_cached_tokens(vec![1, 2, 3, 4]);
+        populate_compat_test_cache(&mut manager);
         assert_eq!(
-            decide_cache_reuse(
-                Some(&expected),
-                manager.compat_fingerprint().as_ref(),
-                manager.cached_token_count() == 0
-            ),
+            manager.apply_reuse_policy(Some(expected)),
             CacheReuseDecision::Reuse
         );
+        assert_eq!(manager.cached_token_count(), 4);
+        assert_eq!(compat_test_layer_seq_pos(&manager), 4);
+        assert_eq!(manager.compat_fingerprint(), Some(expected));
+    }
 
-        // (3) A populated cache carrying NO stamp (e.g. produced before stamping
-        //     existed) must be rejected, never silently adopted.
-        let mut unstamped = KVCacheManager::new(2, 64, KVQuantType::None);
-        unstamped.set_cached_tokens(vec![9, 9, 9]);
-        assert_eq!(
-            decide_cache_reuse(
-                Some(&expected),
-                unstamped.compat_fingerprint().as_ref(),
-                unstamped.cached_token_count() == 0
-            ),
-            CacheReuseDecision::DiscardAndRecompute,
-            "an unstamped populated cache must fail-closed to discard"
-        );
+    #[test]
+    fn apply_reuse_policy_discards_and_restamps_incompatible_real_cache() {
+        let original = compat_test_fingerprint("sha256:old");
+        let expected = compat_test_fingerprint("sha256:new");
+        let mut manager = KVCacheManager::new(2, 64, KVQuantType::None);
 
-        // (4) Discard clears the emptiness signal so the cache is treated fresh again.
-        unstamped.set_cached_tokens(Vec::new());
-        unstamped.clear_all();
-        assert_eq!(unstamped.cached_token_count(), 0);
         assert_eq!(
-            decide_cache_reuse(Some(&expected), unstamped.compat_fingerprint().as_ref(), true),
+            manager.apply_reuse_policy(Some(original)),
             CacheReuseDecision::StampFresh
         );
+        populate_compat_test_cache(&mut manager);
+
+        assert_eq!(
+            manager.apply_reuse_policy(Some(expected)),
+            CacheReuseDecision::DiscardAndRecompute
+        );
+        assert_eq!(manager.cached_token_count(), 0);
+        assert_eq!(compat_test_layer_seq_pos(&manager), 0);
+        assert_eq!(manager.compat_fingerprint(), Some(expected));
+    }
+
+    #[test]
+    fn apply_reuse_policy_discards_populated_unstamped_real_cache() {
+        let expected = compat_test_fingerprint("sha256:base");
+        let mut manager = KVCacheManager::new(2, 64, KVQuantType::None);
+        populate_compat_test_cache(&mut manager);
+        assert!(manager.compat_fingerprint().is_none());
+
+        assert_eq!(
+            manager.apply_reuse_policy(Some(expected)),
+            CacheReuseDecision::DiscardAndRecompute
+        );
+        assert_eq!(manager.cached_token_count(), 0);
+        assert_eq!(compat_test_layer_seq_pos(&manager), 0);
+        assert_eq!(manager.compat_fingerprint(), Some(expected));
     }
 
     // ========================================================================

--- a/crates/hyprstream/src/runtime/kv_compat.rs
+++ b/crates/hyprstream/src/runtime/kv_compat.rs
@@ -72,10 +72,16 @@ use sha2::{Digest, Sha256};
 /// produced (or persisted) under an older format version is **never** reused —
 /// the rejection policy treats a format-version mismatch as a hard reject.
 ///
-/// v2 adds the behavior-affecting effective-config fields (`use_qk_norm`,
-/// partial rotary dimension, attention layer layout, and linear-attention
-/// dimensions) that change KV byte-content without changing coarse geometry.
-pub const KV_COMPAT_FORMAT_VERSION: u32 = 2;
+/// v3 adds the remaining behavior-affecting effective model configuration:
+/// RMS/LayerNorm epsilon, activation/embedding/attention scaling, MoE routing,
+/// and local-RoPE/sliding-window settings. Two runs with identical weight bytes
+/// and coarse geometry can still produce different KV when any of these differ,
+/// so they are authoritative for reuse.
+///
+/// v2 added `use_qk_norm`, partial rotary dimension, attention layer layout,
+/// and linear-attention dimensions (K/V-value-affecting fields below coarse
+/// geometry).
+pub const KV_COMPAT_FORMAT_VERSION: u32 = 3;
 
 /// Default tokens-per-block for paged KV storage.
 ///
@@ -127,6 +133,23 @@ impl WeightIdentity {
         self.adapter_generation = generation;
         self
     }
+}
+
+/// Mixture-of-experts routing configuration. Different routing changes which
+/// expert FFN each token traverses, and therefore the residual — and thus later
+/// K/V — feeding downstream attention. A dense model (the default) is all-zero.
+#[derive(Clone, Debug, PartialEq, Eq, Hash, Default)]
+pub struct MoeRouting {
+    /// Whether this is a MoE model (e.g. `model_type` contains `"moe"`).
+    pub is_moe: bool,
+    /// Total number of experts.
+    pub num_experts: usize,
+    /// Experts activated per token (top-k routing).
+    pub num_experts_per_tok: usize,
+    /// Per-expert FFN intermediate size.
+    pub moe_intermediate_size: usize,
+    /// Shared-expert intermediate size (Qwen3.5 MoE), if any.
+    pub shared_expert_intermediate_size: usize,
 }
 
 // ===========================================================================
@@ -312,6 +335,33 @@ pub struct KvCompatDescriptor {
     pub linear_num_value_heads: usize,
     pub linear_conv_kernel_dim: usize,
 
+    // --- effective model config (changes hidden states / downstream K/V) ---
+    /// `f32::to_bits` of `rms_norm_eps`. The RMS epsilon changes the normalized
+    /// inputs to Q/K and every layer's residual, so it changes all downstream
+    /// K/V. Stored as bits for byte-stable hashing (no `f32` equality pitfalls).
+    pub rms_norm_eps_bits: u32,
+    /// `f32::to_bits` of `layer_norm_eps` when the architecture uses LayerNorm
+    /// instead of RMSNorm. `None` when LayerNorm is not in effect.
+    pub layer_norm_eps_bits: Option<u32>,
+    /// Activation function (e.g. `"silu"`, `"gelu_pytorch_tanh"`). A different
+    /// activation changes every FFN output and thus the residual feeding later
+    /// K/V. Canonicalized (trimmed, lowercased) at construction.
+    pub hidden_activation: String,
+    /// Whether embeddings are scaled before entering the stack (changes all
+    /// layer inputs and therefore all K/V).
+    pub scale_embeddings: bool,
+    /// `f32::to_bits` of `query_pre_attn_scalar` (Gemma attention logit scale),
+    /// when set. Changes the attention scores and thus the per-layer output.
+    pub query_pre_attn_scalar_bits: Option<u32>,
+    /// MoE routing config. `is_moe == false` and all-zero for a dense model.
+    pub moe: MoeRouting,
+    /// Sliding-window size for local-attention layers (Gemma3), when set.
+    /// Changes which tokens each local layer attends to and thus its K/V.
+    pub sliding_window: Option<usize>,
+    /// `f32::to_bits` of `rope_local_base_freq` (the RoPE theta used in local
+    /// layers, Gemma3), when set. Changes local-layer post-RoPE key values.
+    pub rope_local_base_freq_bits: Option<u32>,
+
     // --- position encoding (determines K values post-RoPE) ---
     /// `f32::to_bits` of `rope_theta`.
     pub rope_theta_bits: u32,
@@ -355,6 +405,26 @@ impl KvCompatDescriptor {
     /// Set the partial-rotary factor from an `f32` (canonicalized to bits).
     pub fn set_partial_rotary_factor(&mut self, factor: Option<f32>) {
         self.partial_rotary_factor_bits = factor.map(f32::to_bits);
+    }
+
+    /// Set the RMS norm epsilon from an `f32` (canonicalized to bits).
+    pub fn set_rms_norm_eps(&mut self, eps: f32) {
+        self.rms_norm_eps_bits = eps.to_bits();
+    }
+
+    /// Set the LayerNorm epsilon from an `f32`, or `None`.
+    pub fn set_layer_norm_eps(&mut self, eps: Option<f32>) {
+        self.layer_norm_eps_bits = eps.map(f32::to_bits);
+    }
+
+    /// Set the query pre-attention scalar from an `f32`, or `None`.
+    pub fn set_query_pre_attn_scalar(&mut self, scalar: Option<f32>) {
+        self.query_pre_attn_scalar_bits = scalar.map(f32::to_bits);
+    }
+
+    /// Set the local-RoPE base frequency from an `f32`, or `None`.
+    pub fn set_rope_local_base_freq(&mut self, freq: Option<f32>) {
+        self.rope_local_base_freq_bits = freq.map(f32::to_bits);
     }
 
     /// True iff every authoritative identity axis is populated.
@@ -420,6 +490,20 @@ impl KvCompatDescriptor {
         put_usize(hash, self.linear_num_key_heads);
         put_usize(hash, self.linear_num_value_heads);
         put_usize(hash, self.linear_conv_kernel_dim);
+
+        // Effective model config (changes hidden states / downstream K/V).
+        put_u32(hash, self.rms_norm_eps_bits);
+        put_opt_u32(hash, self.layer_norm_eps_bits);
+        put_str(hash, &canon_str(&self.hidden_activation));
+        put_bool(hash, self.scale_embeddings);
+        put_opt_u32(hash, self.query_pre_attn_scalar_bits);
+        put_bool(hash, self.moe.is_moe);
+        put_usize(hash, self.moe.num_experts);
+        put_usize(hash, self.moe.num_experts_per_tok);
+        put_usize(hash, self.moe.moe_intermediate_size);
+        put_usize(hash, self.moe.shared_expert_intermediate_size);
+        put_opt_usize(hash, self.sliding_window);
+        put_opt_u32(hash, self.rope_local_base_freq_bits);
 
         put_u32(hash, self.rope_theta_bits);
         match &self.rope_scaling {
@@ -541,6 +625,39 @@ pub enum KvCompatMismatch {
         expected: Vec<String>,
         observed: Vec<String>,
     },
+    /// Effective model config (changes hidden states / downstream K/V).
+    RmsNormEps {
+        expected_bits: u32,
+        observed_bits: u32,
+    },
+    LayerNormEps {
+        expected_bits: Option<u32>,
+        observed_bits: Option<u32>,
+    },
+    HiddenActivation {
+        expected: String,
+        observed: String,
+    },
+    ScaleEmbeddings {
+        expected: bool,
+        observed: bool,
+    },
+    QueryPreAttnScalar {
+        expected_bits: Option<u32>,
+        observed_bits: Option<u32>,
+    },
+    MoeRouting {
+        expected: MoeRouting,
+        observed: MoeRouting,
+    },
+    SlidingWindow {
+        expected: Option<usize>,
+        observed: Option<usize>,
+    },
+    RopeLocalBaseFreq {
+        expected_bits: Option<u32>,
+        observed_bits: Option<u32>,
+    },
     RopeTheta {
         expected_bits: u32,
         observed_bits: u32,
@@ -624,6 +741,50 @@ impl std::fmt::Display for KvCompatMismatch {
             KvCompatMismatch::LayerTypes { expected, observed } => write!(
                 f,
                 "KV compat mismatch: layer_types (expected {expected:?}, observed {observed:?})"
+            ),
+            KvCompatMismatch::RmsNormEps {
+                expected_bits,
+                observed_bits,
+            } => write!(
+                f,
+                "KV compat mismatch: rms_norm_eps (expected bits {expected_bits:#x}, observed bits {observed_bits:#x})"
+            ),
+            KvCompatMismatch::LayerNormEps {
+                expected_bits,
+                observed_bits,
+            } => write!(
+                f,
+                "KV compat mismatch: layer_norm_eps (expected bits {expected_bits:?}, observed bits {observed_bits:?})"
+            ),
+            KvCompatMismatch::HiddenActivation { expected, observed } => write!(
+                f,
+                "KV compat mismatch: hidden_activation (expected {expected:?}, observed {observed:?})"
+            ),
+            KvCompatMismatch::ScaleEmbeddings { expected, observed } => write!(
+                f,
+                "KV compat mismatch: scale_embeddings (expected {expected}, observed {observed})"
+            ),
+            KvCompatMismatch::QueryPreAttnScalar {
+                expected_bits,
+                observed_bits,
+            } => write!(
+                f,
+                "KV compat mismatch: query_pre_attn_scalar (expected bits {expected_bits:?}, observed bits {observed_bits:?})"
+            ),
+            KvCompatMismatch::MoeRouting { expected, observed } => write!(
+                f,
+                "KV compat mismatch: moe routing (expected {expected:?}, observed {observed:?})"
+            ),
+            KvCompatMismatch::SlidingWindow { expected, observed } => write!(
+                f,
+                "KV compat mismatch: sliding_window (expected {expected:?}, observed {observed:?})"
+            ),
+            KvCompatMismatch::RopeLocalBaseFreq {
+                expected_bits,
+                observed_bits,
+            } => write!(
+                f,
+                "KV compat mismatch: rope_local_base_freq (expected bits {expected_bits:?}, observed bits {observed_bits:?})"
             ),
             KvCompatMismatch::RopeTheta {
                 expected_bits,
@@ -761,11 +922,19 @@ pub fn check_compatibility(
             observed_bits: observed.partial_rotary_factor_bits,
         });
     }
-    if expected.layer_types != observed.layer_types {
-        return Err(KvCompatMismatch::LayerTypes {
-            expected: expected.layer_types.clone(),
-            observed: observed.layer_types.clone(),
-        });
+    // `layer_types` is canonicalized (trimmed, lowercased) before hashing
+    // (`put_str_vec`), so compare the canonical forms here too — aliases like
+    // "GLOBAL"/"global" must be compatible in both the hot-path fingerprint and
+    // this structured policy (#1277 review, hot-path/policy equivalence).
+    {
+        let exp_lt = canonical_layer_types(&expected.layer_types);
+        let obs_lt = canonical_layer_types(&observed.layer_types);
+        if exp_lt != obs_lt {
+            return Err(KvCompatMismatch::LayerTypes {
+                expected: exp_lt,
+                observed: obs_lt,
+            });
+        }
     }
     if expected.linear_key_head_dim != observed.linear_key_head_dim {
         return Err(geometry(
@@ -801,6 +970,56 @@ pub fn check_compatibility(
             expected.linear_conv_kernel_dim,
             observed.linear_conv_kernel_dim,
         ));
+    }
+    // Effective model config — changes hidden states / downstream K/V even when
+    // coarse geometry is identical (#1277 review finding F3).
+    if expected.rms_norm_eps_bits != observed.rms_norm_eps_bits {
+        return Err(KvCompatMismatch::RmsNormEps {
+            expected_bits: expected.rms_norm_eps_bits,
+            observed_bits: observed.rms_norm_eps_bits,
+        });
+    }
+    if expected.layer_norm_eps_bits != observed.layer_norm_eps_bits {
+        return Err(KvCompatMismatch::LayerNormEps {
+            expected_bits: expected.layer_norm_eps_bits,
+            observed_bits: observed.layer_norm_eps_bits,
+        });
+    }
+    if canon_str(&expected.hidden_activation) != canon_str(&observed.hidden_activation) {
+        return Err(KvCompatMismatch::HiddenActivation {
+            expected: canon_str(&expected.hidden_activation),
+            observed: canon_str(&observed.hidden_activation),
+        });
+    }
+    if expected.scale_embeddings != observed.scale_embeddings {
+        return Err(KvCompatMismatch::ScaleEmbeddings {
+            expected: expected.scale_embeddings,
+            observed: observed.scale_embeddings,
+        });
+    }
+    if expected.query_pre_attn_scalar_bits != observed.query_pre_attn_scalar_bits {
+        return Err(KvCompatMismatch::QueryPreAttnScalar {
+            expected_bits: expected.query_pre_attn_scalar_bits,
+            observed_bits: observed.query_pre_attn_scalar_bits,
+        });
+    }
+    if expected.moe != observed.moe {
+        return Err(KvCompatMismatch::MoeRouting {
+            expected: expected.moe.clone(),
+            observed: observed.moe.clone(),
+        });
+    }
+    if expected.sliding_window != observed.sliding_window {
+        return Err(KvCompatMismatch::SlidingWindow {
+            expected: expected.sliding_window,
+            observed: observed.sliding_window,
+        });
+    }
+    if expected.rope_local_base_freq_bits != observed.rope_local_base_freq_bits {
+        return Err(KvCompatMismatch::RopeLocalBaseFreq {
+            expected_bits: expected.rope_local_base_freq_bits,
+            observed_bits: observed.rope_local_base_freq_bits,
+        });
     }
     if expected.rope_theta_bits != observed.rope_theta_bits {
         return Err(KvCompatMismatch::RopeTheta {
@@ -956,6 +1175,17 @@ fn put_usize(hash: &mut Sha256, v: usize) {
 }
 
 #[inline]
+fn put_opt_usize(hash: &mut Sha256, v: Option<usize>) {
+    match v {
+        Some(x) => {
+            hash.update([1u8]);
+            put_usize(hash, x);
+        }
+        None => hash.update([0u8]),
+    }
+}
+
+#[inline]
 fn put_str(hash: &mut Sha256, s: &str) {
     put_u64(hash, s.len() as u64);
     hash.update(s.as_bytes());
@@ -972,15 +1202,65 @@ fn put_opt_str(hash: &mut Sha256, s: Option<&str>) {
     }
 }
 
+/// Canonicalize a string identifier: trim and ASCII-lowercase. Used everywhere
+/// a string participates in the fingerprint or the structured comparison so
+/// aliases ("GLOBAL"/"global") cannot disagree between the two (#1277 review).
+#[inline]
+fn canon_str(s: &str) -> String {
+    s.trim().to_ascii_lowercase()
+}
+
+/// Canonicalized (trimmed, lowercased) copy of a `layer_types` sequence, in
+/// order. Used by both the hash ([`put_str_vec`]) and the structured comparison
+/// ([`check_compatibility`]) so they agree on casing/whitespace aliases.
+fn canonical_layer_types(v: &[String]) -> Vec<String> {
+    v.iter().map(|s| canon_str(s)).collect()
+}
+
 /// Hash a `Vec<String>` as a length-prefixed sequence of canonicalized
 /// (trimmed, lowercased) strings so layout casing/order changes are caught.
 #[inline]
 fn put_str_vec(hash: &mut Sha256, v: &[String]) {
     put_u64(hash, v.len() as u64);
     for s in v {
-        let canon: String = s.trim().to_ascii_lowercase();
-        put_str(hash, &canon);
+        put_str(hash, &canon_str(s));
     }
+}
+
+// ===========================================================================
+// Authoritative base-weight content digest (#1277, finding F1)
+// ===========================================================================
+//
+// The base-weight identity is a content digest over the *resolved* weight shards
+// the loader actually builds tensors from — never a directory listing or a path
+// label, and never a pointer stub. Two snapshots sharing a basename but
+// differing in content diverge here. These pure helpers own the canonical
+// framing; the engine seam (`TorchEngine::weights_content_digest`) resolves each
+// shard's bytes (transparently resolving LFS/XET pointers) and feeds them here.
+
+/// SHA-256 of a single shard's resolved content bytes.
+pub fn shard_content_digest(bytes: &[u8]) -> [u8; 32] {
+    let mut h = Sha256::new();
+    h.update(bytes);
+    let mut out = [0u8; 32];
+    out.copy_from_slice(h.finalize().as_slice());
+    out
+}
+
+/// Canonical base-weight digest over a shard set: the shard count, then for each
+/// shard a length-prefixed filename and that shard's content digest. Emitting
+/// the count and length-prefixing every name makes distinct shard segmentations
+/// collide-resistant (shard A+B split at byte N cannot masquerade as a single
+/// shard, nor can two shard sets of equal total bytes share a digest). Shards
+/// must be supplied sorted by name for determinism.
+pub(crate) fn base_weight_digest_from_shards(shards: &[(String, [u8; 32])]) -> String {
+    let mut h = Sha256::new();
+    put_u64(&mut h, shards.len() as u64);
+    for (name, digest) in shards {
+        put_str(&mut h, name);
+        h.update(digest);
+    }
+    hex::encode(h.finalize())
 }
 
 #[cfg(test)]
@@ -1011,6 +1291,16 @@ mod tests {
             linear_num_key_heads: 0,
             linear_num_value_heads: 0,
             linear_conv_kernel_dim: 0,
+            // Effective model config (plain-Llama defaults; non-default below
+            // diverge the fingerprint in every_authoritative_field_participates).
+            rms_norm_eps_bits: 1e-5f32.to_bits(),
+            layer_norm_eps_bits: None,
+            hidden_activation: "silu".to_owned(),
+            scale_embeddings: false,
+            query_pre_attn_scalar_bits: None,
+            moe: MoeRouting::default(),
+            sliding_window: None,
+            rope_local_base_freq_bits: None,
             rope_theta_bits: 10_000.0f32.to_bits(),
             rope_scaling: None,
             max_position_embeddings: 4096,
@@ -1166,7 +1456,8 @@ mod tests {
                 observed: Vec::new(),
             }),
         );
-        // layer_types must be compared case-insensitively (canonicalized).
+        // layer_types must be compared case-insensitively (canonicalized) — in
+        // BOTH the fingerprint hash and the structured policy (#1277 MINOR).
         {
             let mut d = baseline();
             let fp0 = d.fingerprint();
@@ -1177,6 +1468,12 @@ mod tests {
                 d.fingerprint(),
                 d2.fingerprint(),
                 "layer_types casing must canonicalize before hashing"
+            );
+            // Equal fingerprints must imply a compatible structured policy:
+            // casing/whitespace aliases must NOT report a LayerTypes mismatch.
+            assert!(
+                check_compatibility(&d, &d2).is_ok(),
+                "layer_types casing alias must be policy-compatible, not just hash-equal"
             );
             assert_ne!(fp0, d.fingerprint(), "non-empty layer layout must diverge");
         }
@@ -1201,6 +1498,125 @@ mod tests {
                 "{field}: mismatch variant"
             );
         }
+        // Effective model config — each demonstrably changes hidden states /
+        // downstream K/V without changing coarse geometry (#1277 F3).
+        assert_field_diverges(
+            "rms_norm_eps",
+            |d| d.set_rms_norm_eps(1e-6),
+            Some(KvCompatMismatch::RmsNormEps {
+                expected_bits: 1e-6f32.to_bits(),
+                observed_bits: 1e-5f32.to_bits(),
+            }),
+        );
+        assert_field_diverges(
+            "layer_norm_eps",
+            |d| d.set_layer_norm_eps(Some(1e-5)),
+            Some(KvCompatMismatch::LayerNormEps {
+                expected_bits: Some(1e-5f32.to_bits()),
+                observed_bits: None,
+            }),
+        );
+        assert_field_diverges(
+            "hidden_activation",
+            |d| d.hidden_activation = "gelu_pytorch_tanh".into(),
+            Some(KvCompatMismatch::HiddenActivation {
+                expected: "gelu_pytorch_tanh".into(),
+                observed: "silu".into(),
+            }),
+        );
+        // hidden_activation must canonicalize (casing/whitespace) in both the
+        // hash and the policy — an alias must be compatible, a real change must
+        // not.
+        {
+            let mut d = baseline();
+            d.hidden_activation = "  SiLU ".into();
+            assert_eq!(
+                d.fingerprint(),
+                baseline().fingerprint(),
+                "hidden_activation casing/whitespace must canonicalize"
+            );
+            assert!(check_compatibility(&d, &baseline()).is_ok());
+        }
+        assert_field_diverges(
+            "scale_embeddings",
+            |d| d.scale_embeddings = true,
+            Some(KvCompatMismatch::ScaleEmbeddings {
+                expected: true,
+                observed: false,
+            }),
+        );
+        assert_field_diverges(
+            "query_pre_attn_scalar",
+            |d| d.set_query_pre_attn_scalar(Some(256.0)),
+            Some(KvCompatMismatch::QueryPreAttnScalar {
+                expected_bits: Some(256.0f32.to_bits()),
+                observed_bits: None,
+            }),
+        );
+        // MoE routing — each field individually diverges. `is_moe` (bool) and the
+        // four usize routing fields are exercised separately.
+        {
+            let mut d = baseline();
+            d.moe.is_moe = true;
+            assert_ne!(
+                baseline().fingerprint(),
+                d.fingerprint(),
+                "moe.is_moe: setting MoE must change the fingerprint"
+            );
+            assert_eq!(
+                check_compatibility(&d, &baseline()).unwrap_err(),
+                KvCompatMismatch::MoeRouting {
+                    expected: d.moe.clone(),
+                    observed: baseline().moe,
+                },
+                "moe.is_moe: mismatch variant"
+            );
+        }
+        for (field, val) in [
+            ("num_experts", 64usize),
+            ("num_experts_per_tok", 8usize),
+            ("moe_intermediate_size", 2048usize),
+            ("shared_expert_intermediate_size", 1024usize),
+        ] {
+            let mut d = baseline();
+            match field {
+                "num_experts" => d.moe.num_experts = val,
+                "num_experts_per_tok" => d.moe.num_experts_per_tok = val,
+                "moe_intermediate_size" => d.moe.moe_intermediate_size = val,
+                "shared_expert_intermediate_size" => d.moe.shared_expert_intermediate_size = val,
+                _ => unreachable!(),
+            }
+            let divergent_fp = d.fingerprint();
+            assert_ne!(
+                baseline().fingerprint(),
+                divergent_fp,
+                "{field}: MoE routing change must change the fingerprint"
+            );
+            assert_eq!(
+                check_compatibility(&d, &baseline()).unwrap_err(),
+                KvCompatMismatch::MoeRouting {
+                    expected: d.moe.clone(),
+                    observed: baseline().moe,
+                },
+                "{field}: MoE mismatch variant"
+            );
+        }
+        assert_field_diverges(
+            "sliding_window",
+            |d| d.sliding_window = Some(1024),
+            Some(KvCompatMismatch::SlidingWindow {
+                expected: Some(1024),
+                observed: None,
+            }),
+        );
+        assert_field_diverges(
+            "rope_local_base_freq",
+            |d| d.set_rope_local_base_freq(Some(10_000.0)),
+            Some(KvCompatMismatch::RopeLocalBaseFreq {
+                expected_bits: Some(10_000.0f32.to_bits()),
+                observed_bits: None,
+            }),
+        );
         // Position encoding.
         assert_field_diverges(
             "rope_theta",
@@ -1424,7 +1840,7 @@ mod tests {
     fn golden_digest_is_pinned() {
         let fp = baseline().fingerprint();
         let hex = fp.to_hex();
-        let expected = "767058c0b3505492e27b5f477f7cec63344a5a78c9bafa7837d44deab5730170";
+        let expected = "2c1658e12b2935e6444e0503c35b9e36b3f2e941614d9078b445776eae5cc55c";
         assert_eq!(
             hex, expected,
             "KV-compat golden digest drifted; computed = {hex}. \
@@ -1450,6 +1866,104 @@ mod tests {
         let mut c = baseline();
         c.weights.base_revision = "sha256:snapshot-A".into();
         assert_eq!(a.fingerprint(), c.fingerprint());
+    }
+
+    // ---- base-weight content digest producer (#1277, finding F1) ----
+    //
+    // These exercise the pure framing/digest helpers that the engine seam feeds
+    // with the *resolved* shard bytes. The fail-closed enumeration + pointer
+    // resolution is covered by `torch_engine::tests::weights_content_digest_*`.
+
+    /// Helper: build a digested shard set (name + per-shard content digest) from
+    /// raw bytes, mirroring what `TorchEngine::weights_content_digest` produces.
+    fn digested(shards: &[(&str, &[u8])]) -> Vec<(String, [u8; 32])> {
+        shards
+            .iter()
+            .map(|(n, b)| ((*n).to_owned(), shard_content_digest(b)))
+            .collect()
+    }
+
+    #[test]
+    fn shard_content_digest_is_deterministic_and_distinct() {
+        let a = b"hello weights";
+        let b = b"hello weights!";
+        // Deterministic.
+        assert_eq!(shard_content_digest(a), shard_content_digest(a));
+        // Distinct content → distinct digest.
+        assert_ne!(shard_content_digest(a), shard_content_digest(b));
+        // 32 bytes.
+        assert_eq!(shard_content_digest(a).len(), 32);
+    }
+
+    #[test]
+    fn base_weight_digest_is_stable() {
+        let s = digested(&[("model-00001-of-00002.safetensors", b"AAA"), ("model-00002-of-00002.safetensors", b"BBB")]);
+        // Same sorted input → identical digest.
+        assert_eq!(
+            base_weight_digest_from_shards(&s),
+            base_weight_digest_from_shards(&s)
+        );
+    }
+
+    /// Same basenames, different content → different base-weight digest (the
+    /// "authoritative, not a label" rule; two snapshots sharing a path stem but
+    /// differing in bytes must diverge).
+    #[test]
+    fn base_weight_digest_same_basename_different_bytes_diverge() {
+        let names = ["model-00001-of-00002.safetensors", "model-00002-of-00002.safetensors"];
+        let a = digested(&[(names[0], b"content-A"), (names[1], b"content-B")]);
+        let b = digested(&[(names[0], b"content-A!"), (names[1], b"content-B")]);
+        assert_ne!(
+            base_weight_digest_from_shards(&a),
+            base_weight_digest_from_shards(&b),
+            "different shard content must produce a different digest"
+        );
+    }
+
+    /// Canonical framing must disambiguate shard boundaries: a single shard
+    /// whose bytes are the concatenation of two others must NOT collide with the
+    /// two-shard set, even though total bytes are equal.
+    #[test]
+    fn base_weight_digest_shard_boundary_disambiguates() {
+        let two = digested(&[
+            ("model-00001-of-00002.safetensors", b"PART-ONE-"),
+            ("model-00002-of-00002.safetensors", b"PART-TWO"),
+        ]);
+        let one = digested(&[("model.safetensors", b"PART-ONE-PART-TWO")]);
+        assert_ne!(
+            base_weight_digest_from_shards(&two),
+            base_weight_digest_from_shards(&one),
+            "shard segmentation must not be ambiguous in the digest"
+        );
+    }
+
+    /// A different shard count alone (same content, split differently) must
+    /// diverge — the count is part of the canonical frame.
+    #[test]
+    fn base_weight_digest_shard_count_participates() {
+        // Two shards each carrying the same bytes vs one shard carrying them.
+        let two = digested(&[
+            ("a-00001.safetensors", b"X"),
+            ("a-00002.safetensors", b"X"),
+        ]);
+        let one = digested(&[("a.safetensors", b"X")]);
+        assert_ne!(
+            base_weight_digest_from_shards(&two),
+            base_weight_digest_from_shards(&one)
+        );
+    }
+
+    /// Renaming a shard (same content, different filename) must diverge — the
+    /// length-prefixed name is part of the frame.
+    #[test]
+    fn base_weight_digest_filename_participates() {
+        let a = digested(&[("model-00001.safetensors", b"X")]);
+        let b = digested(&[("model-00002.safetensors", b"X")]);
+        assert_ne!(
+            base_weight_digest_from_shards(&a),
+            base_weight_digest_from_shards(&b),
+            "shard filename must participate in the digest"
+        );
     }
 
     #[test]

--- a/crates/hyprstream/src/runtime/kv_compat.rs
+++ b/crates/hyprstream/src/runtime/kv_compat.rs
@@ -162,26 +162,21 @@ pub struct MoeRouting {
 /// stability does not depend on the `tch` version, and so the module stays
 /// `tch`-free. Unrecognized dtypes fall through to [`KvDtype::Other`], keyed by
 /// a canonicalized name.
-#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+#[derive(Clone, Debug, Default, PartialEq, Eq, Hash)]
 pub enum KvDtype {
     Float64,
     Float32,
     Float16,
+    #[default]
     BFloat16,
     /// Any other dtype, identified by its canonicalized (trimmed, lowercased) name.
     Other(String),
 }
 
-impl Default for KvDtype {
-    fn default() -> Self {
-        KvDtype::BFloat16
-    }
-}
-
 impl KvDtype {
     /// Parse a dtype from a HuggingFace `dtype`/`torch_dtype` string, case- and
     /// alias-insensitive.
-    pub fn from_str(s: &str) -> Self {
+    pub fn from_name(s: &str) -> Self {
         let n = s.trim().to_ascii_lowercase();
         match n.as_str() {
             "float64" | "double" | "f64" => KvDtype::Float64,
@@ -216,9 +211,10 @@ impl std::fmt::Display for KvDtype {
 /// Mirrors the Cap'n Proto `KVQuantType` (`none`/`int8`/`nf4`/`fp4`) but is
 /// owned here so the fingerprint is independent of schema codegen. Convert at
 /// the engine boundary with a `match`.
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Hash)]
 pub enum KvQuantMode {
     /// Full precision (FP16/BF16).
+    #[default]
     None,
     /// 8-bit integer quantization.
     Int8,
@@ -226,12 +222,6 @@ pub enum KvQuantMode {
     Nf4,
     /// 4-bit FloatingPoint.
     Fp4,
-}
-
-impl Default for KvQuantMode {
-    fn default() -> Self {
-        KvQuantMode::None
-    }
 }
 
 impl KvQuantMode {
@@ -1274,8 +1264,8 @@ mod tests {
         KvCompatDescriptor {
             format_version: KV_COMPAT_FORMAT_VERSION,
             weights: WeightIdentity::base_only("sha256:my-model-weights"),
-            model_name: "my-model".to_string(),
-            architecture: "llama".to_string(),
+            model_name: "my-model".to_owned(),
+            architecture: "llama".to_owned(),
             model_version: 1,
             num_hidden_layers: 32,
             num_attention_heads: 32,
@@ -1309,7 +1299,7 @@ mod tests {
             block_size: KV_BLOCK_SIZE_DEFAULT,
             max_context: 4096,
             vocab_size: 32_000,
-            tokenizer_hash: Some("deadbeef".to_string()),
+            tokenizer_hash: Some("deadbeef".to_owned()),
         }
     }
 
@@ -1450,9 +1440,9 @@ mod tests {
         );
         assert_field_diverges(
             "layer_types",
-            |d| d.layer_types = vec!["global".to_string(), "local".to_string()],
+            |d| d.layer_types = vec!["global".to_owned(), "local".to_owned()],
             Some(KvCompatMismatch::LayerTypes {
-                expected: vec!["global".to_string(), "local".to_string()],
+                expected: vec!["global".to_owned(), "local".to_owned()],
                 observed: Vec::new(),
             }),
         );
@@ -1461,9 +1451,9 @@ mod tests {
         {
             let mut d = baseline();
             let fp0 = d.fingerprint();
-            d.layer_types = vec!["GLOBAL".to_string(), "Local".to_string()];
+            d.layer_types = vec!["GLOBAL".to_owned(), "Local".to_owned()];
             let mut d2 = baseline();
-            d2.layer_types = vec!["global".to_string(), "local".to_string()];
+            d2.layer_types = vec!["global".to_owned(), "local".to_owned()];
             assert_eq!(
                 d.fingerprint(),
                 d2.fingerprint(),
@@ -1732,16 +1722,16 @@ mod tests {
 
     #[test]
     fn kvdtype_is_case_and_alias_insensitive() {
-        assert_eq!(KvDtype::from_str("BFLOAT16"), KvDtype::BFloat16);
-        assert_eq!(KvDtype::from_str("  bf16 "), KvDtype::BFloat16);
-        assert_eq!(KvDtype::from_str("float16"), KvDtype::Float16);
-        assert_eq!(KvDtype::from_str("FP16"), KvDtype::Float16);
-        assert_eq!(KvDtype::from_str("float32"), KvDtype::Float32);
+        assert_eq!(KvDtype::from_name("BFLOAT16"), KvDtype::BFloat16);
+        assert_eq!(KvDtype::from_name("  bf16 "), KvDtype::BFloat16);
+        assert_eq!(KvDtype::from_name("float16"), KvDtype::Float16);
+        assert_eq!(KvDtype::from_name("FP16"), KvDtype::Float16);
+        assert_eq!(KvDtype::from_name("float32"), KvDtype::Float32);
         // Two descriptors differing only by dtype *spelling* must hash equally.
         let mut d1 = baseline();
         let mut d2 = baseline();
-        d1.dtype = KvDtype::from_str("BFLOAT16");
-        d2.dtype = KvDtype::from_str("bfloat16");
+        d1.dtype = KvDtype::from_name("BFLOAT16");
+        d2.dtype = KvDtype::from_name("bfloat16");
         assert_eq!(d1.fingerprint(), d2.fingerprint());
     }
 
@@ -1766,7 +1756,7 @@ mod tests {
             KvQuantMode::Nf4,
             KvQuantMode::Fp4,
         ];
-        let strs: Vec<&str> = modes.iter().map(|m| m.as_canonical_str()).collect();
+        let strs: Vec<&str> = modes.iter().map(KvQuantMode::as_canonical_str).collect();
         let unique: std::collections::HashSet<&str> = strs.iter().copied().collect();
         assert_eq!(unique.len(), modes.len(), "quant mode names must be unique");
     }

--- a/crates/hyprstream/src/runtime/kv_compat.rs
+++ b/crates/hyprstream/src/runtime/kv_compat.rs
@@ -1,0 +1,1097 @@
+//! KV-cache compatibility fingerprint and rejection policy.
+//!
+//! *Epic [#1276](https://github.com/hyprstream/hyprstream/issues/1276),
+//! issue [#1277](https://github.com/hyprstream/hyprstream/issues/1277).*
+//!
+//! KV states are a pure function of (a) the weights that produced them and
+//! (b) every model/runtime parameter that shapes the attention computation.
+//! Reusing KV produced under one configuration inside a request running under
+//! another is a silent correctness bug — the cached keys/values belong to a
+//! different function. This module defines the **authoritative identity** of
+//! that function as a versioned [`KvCompatDescriptor`], reduces it to a stable
+//! content-addressed [`KvCompatFingerprint`], and exposes a [`check_compatibility`]
+//! rejection policy: a cache whose descriptor differs in *any* authoritative
+//! field is rejected (its KV is discarded and recomputed).
+//!
+//! This is the foundational lane item — every later reusable/durable lookup
+//! (cross-session prefix index, snapshot codec, durable store) consumes the
+//! fingerprint defined here. The module deliberately owns **no** `tch`/Cap'n
+//! Proto dependency: it is pure data + hashing, so it is fully unit-testable
+//! without a loaded model. Boundary types (`KVQuantType`, `ModelConfig`) are
+//! converted into the self-contained enums below at the engine seam.
+//!
+//! ## What participates (authoritative inputs)
+//!
+//! Every field of [`KvCompatDescriptor`] is derived from the model/runtime state
+//! that actually produced the KV tensors — never from a human label:
+//!
+//! - **Effective weights** — base-weight revision + adapter/delta generation.
+//! - **Model identity** — name, architecture (`model_type`), config version.
+//! - **Attention geometry** — layers, KV heads, attention heads, head dim,
+//!   hidden size (determines K/V tensor *shape*).
+//! - **Position encoding** — RoPE theta, RoPE scaling, max position embeddings
+//!   (determines K *values* post-RoPE).
+//! - **Compute dtype** — the dtype the model computes/stores K/V in.
+//! - **KV storage encoding** — quantization mode in effect.
+//! - **Block geometry** — `BLOCK_SIZE` for paged caches.
+//! - **Context cap** — the effective max context actually bounding the cache.
+//! - **Tokenizer identity** — vocab size + a digest of the tokenizer bytes
+//!   (cached token ids are only meaningful relative to one tokenizer).
+//! - **Format version** — the wire/layout version of the fingerprint itself.
+//!
+//! ## Relation to TTT delta invalidation
+//!
+//! The registry's existing push-based [`invalidate_for_tenant`][crate::runtime::kv_cache::KVCacheRegistry::invalidate_for_tenant]
+//! clears a tenant's caches when that tenant's LoRA delta changes. The
+//! fingerprint is the complementary **pull-based** guard checked at reuse time;
+//! it does not replace the push path. The descriptor carries an
+//! `adapter_generation` slot that a live counter (issue #1260) will feed so the
+//! pull path also covers per-request delta changes; until then, delta staleness
+//! is handled by the push path, and the fingerprint covers every *other* axis.
+
+use sha2::{Digest, Sha256};
+
+/// Wire/layout format version of the compatibility fingerprint.
+///
+/// Bumped whenever the set of fields that participate in the fingerprint, or
+/// their canonical encoding, changes in a backward-incompatible way. A cache
+/// produced (or persisted) under an older format version is **never** reused —
+/// the rejection policy treats a format-version mismatch as a hard reject.
+pub const KV_COMPAT_FORMAT_VERSION: u32 = 1;
+
+/// Default tokens-per-block for paged KV storage.
+///
+/// This mirrors [`crate::runtime::kv_cache::BLOCK_SIZE`]; the two are asserted
+/// equal by a unit test so the const lives here without pulling the `tch`-backed
+/// `kv_cache` module into this module's dependency graph.
+pub const KV_BLOCK_SIZE_DEFAULT: usize = 256;
+
+// ===========================================================================
+// Effective-weights identity
+// ===========================================================================
+
+/// Authoritative identity of the effective weights (base + adapter/delta) that
+/// produced a cache's KV.
+///
+/// Two caches are reuse-compatible only if their KV was produced under the same
+/// effective weights. This is split from the structural descriptor so a weight
+/// change (e.g. loading/unloading an adapter) is a first-class mismatch reason
+/// distinct from a geometry or dtype change.
+#[derive(Clone, Debug, PartialEq, Eq, Hash, Default)]
+pub struct WeightIdentity {
+    /// Identity of the base model weights. Today this is the loaded model's
+    /// path/identity; future work feeds a git2db content oid (issue #1285) for
+    /// a true content address.
+    pub base_revision: String,
+    /// Adapter/delta generation active when the KV was produced. `0` means base
+    /// weights only (no adapter). The live `lora_generation` counter (issue
+    /// #1260) is the intended producer; until it is wired, per-tenant delta
+    /// staleness is handled by the registry's push-based
+    /// [`invalidate_for_tenant`][crate::runtime::kv_cache::KVCacheRegistry::invalidate_for_tenant].
+    pub adapter_generation: u64,
+}
+
+impl WeightIdentity {
+    /// Base weights only, no adapter (generation 0).
+    pub fn base_only(base_revision: impl Into<String>) -> Self {
+        Self {
+            base_revision: base_revision.into(),
+            adapter_generation: 0,
+        }
+    }
+
+    /// Effective weights = `base` plus an adapter/delta at `generation`.
+    pub fn with_adapter(mut self, generation: u64) -> Self {
+        self.adapter_generation = generation;
+        self
+    }
+}
+
+// ===========================================================================
+// Scalar identity enums (own types, decoupled from codegen/tch)
+// ===========================================================================
+
+/// Compute dtype the model stores K/V in.
+///
+/// Owned by this module (rather than reusing `tch::Kind`) so the fingerprint's
+/// stability does not depend on the `tch` version, and so the module stays
+/// `tch`-free. Unrecognized dtypes fall through to [`KvDtype::Other`], keyed by
+/// a canonicalized name.
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+pub enum KvDtype {
+    Float64,
+    Float32,
+    Float16,
+    BFloat16,
+    /// Any other dtype, identified by its canonicalized (trimmed, lowercased) name.
+    Other(String),
+}
+
+impl Default for KvDtype {
+    fn default() -> Self {
+        KvDtype::BFloat16
+    }
+}
+
+impl KvDtype {
+    /// Parse a dtype from a HuggingFace `dtype`/`torch_dtype` string, case- and
+    /// alias-insensitive.
+    pub fn from_str(s: &str) -> Self {
+        let n = s.trim().to_ascii_lowercase();
+        match n.as_str() {
+            "float64" | "double" | "f64" => KvDtype::Float64,
+            "float32" | "float" | "f32" => KvDtype::Float32,
+            "float16" | "half" | "fp16" | "f16" => KvDtype::Float16,
+            "bfloat16" | "bf16" => KvDtype::BFloat16,
+            other => KvDtype::Other(other.to_owned()),
+        }
+    }
+
+    /// Canonical lowercase name used both for [`Display`](std::fmt::Display) and
+    /// as the hashed representation.
+    pub fn as_canonical_str(&self) -> &str {
+        match self {
+            KvDtype::Float64 => "float64",
+            KvDtype::Float32 => "float32",
+            KvDtype::Float16 => "float16",
+            KvDtype::BFloat16 => "bfloat16",
+            KvDtype::Other(s) => s.as_str(),
+        }
+    }
+}
+
+impl std::fmt::Display for KvDtype {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.as_canonical_str())
+    }
+}
+
+/// KV-cache storage encoding / quantization mode.
+///
+/// Mirrors the Cap'n Proto `KVQuantType` (`none`/`int8`/`nf4`/`fp4`) but is
+/// owned here so the fingerprint is independent of schema codegen. Convert at
+/// the engine boundary with a `match`.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub enum KvQuantMode {
+    /// Full precision (FP16/BF16).
+    None,
+    /// 8-bit integer quantization.
+    Int8,
+    /// 4-bit NormalFloat.
+    Nf4,
+    /// 4-bit FloatingPoint.
+    Fp4,
+}
+
+impl Default for KvQuantMode {
+    fn default() -> Self {
+        KvQuantMode::None
+    }
+}
+
+impl KvQuantMode {
+    /// Canonical lowercase name used for display and hashing.
+    pub fn as_canonical_str(&self) -> &'static str {
+        match self {
+            KvQuantMode::None => "none",
+            KvQuantMode::Int8 => "int8",
+            KvQuantMode::Nf4 => "nf4",
+            KvQuantMode::Fp4 => "fp4",
+        }
+    }
+}
+
+impl std::fmt::Display for KvQuantMode {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.as_canonical_str())
+    }
+}
+
+/// RoPE scaling config, with the factor canonicalized to its IEEE-754 bit
+/// pattern so the descriptor is byte-stable (no `f32` equality pitfalls).
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+pub struct RopeScalingFp {
+    /// Canonicalized (trimmed, lowercased) RoPE type, e.g. `"linear"`.
+    pub rope_type: String,
+    /// `f32::to_bits` of the scaling factor.
+    pub factor_bits: u32,
+}
+
+impl RopeScalingFp {
+    /// Construct from a RoPE type string and a scaling factor.
+    pub fn new(rope_type: &str, factor: f32) -> Self {
+        Self {
+            rope_type: rope_type.trim().to_ascii_lowercase(),
+            factor_bits: factor.to_bits(),
+        }
+    }
+
+    /// The scaling factor, recovered from its bit pattern.
+    pub fn factor(&self) -> f32 {
+        f32::from_bits(self.factor_bits)
+    }
+}
+
+// ===========================================================================
+// Descriptor
+// ===========================================================================
+
+/// The complete set of authoritative inputs that determine whether KV states
+/// computed under one configuration can be reused under another.
+///
+/// Two caches are compatible **iff** their descriptors are equal in every
+/// field. [`KvCompatFingerprint`] is the content-addressed digest of a canonical
+/// serialization, so equality of fingerprints implies equality of descriptors
+/// (modulo the astronomically unlikely SHA-256 collision). The descriptor is
+/// `Clone + Eq + Hash` and small; the engine retains one (the "expected"
+/// identity of the loaded model) and caches store a [`KvCompatFingerprint`]
+/// stamped at first use.
+#[derive(Clone, Debug, PartialEq, Eq, Hash, Default)]
+pub struct KvCompatDescriptor {
+    /// Fingerprint format/layout version ([`KV_COMPAT_FORMAT_VERSION`]).
+    pub format_version: u32,
+
+    /// Effective weights (base + adapter/delta) identity.
+    pub weights: WeightIdentity,
+
+    /// Loaded model identity (path stem / name).
+    pub model_name: String,
+    /// HuggingFace `model_type` (e.g. `"llama"`, `"qwen2"`).
+    pub architecture: String,
+    /// Parsed config `version`.
+    pub model_version: u32,
+
+    // --- attention geometry (determines K/V tensor shape) ---
+    pub num_hidden_layers: usize,
+    pub num_attention_heads: usize,
+    pub num_key_value_heads: usize,
+    pub head_dim: usize,
+    pub hidden_size: usize,
+
+    // --- position encoding (determines K values post-RoPE) ---
+    /// `f32::to_bits` of `rope_theta`.
+    pub rope_theta_bits: u32,
+    /// RoPE scaling, if any.
+    pub rope_scaling: Option<RopeScalingFp>,
+    /// Model's `max_position_embeddings`.
+    pub max_position_embeddings: usize,
+
+    // --- dtype + KV storage encoding ---
+    /// Compute dtype the model stores K/V in.
+    pub dtype: KvDtype,
+    /// KV storage encoding/quantization mode.
+    pub kv_quant: KvQuantMode,
+    /// Tokens per paged block (must match for paged caches).
+    pub block_size: usize,
+    /// Effective runtime context cap actually bounding the cache.
+    pub max_context: usize,
+
+    // --- tokenizer identity (cached token ids are per-tokenizer) ---
+    pub vocab_size: usize,
+    /// Hex digest of the tokenizer bytes, when known.
+    pub tokenizer_hash: Option<String>,
+}
+
+impl KvCompatDescriptor {
+    /// The RoPE theta, recovered from its bit pattern.
+    pub fn rope_theta(&self) -> f32 {
+        f32::from_bits(self.rope_theta_bits)
+    }
+
+    /// Set the RoPE theta from an `f32` (canonicalized to bits).
+    pub fn set_rope_theta(&mut self, theta: f32) {
+        self.rope_theta_bits = theta.to_bits();
+    }
+
+    /// Record the tokenizer identity (vocab size + digest of its bytes).
+    ///
+    /// Called by the engine once the tokenizer is loaded; the descriptor is
+    /// finalized before any generation reads its fingerprint.
+    pub fn set_tokenizer(&mut self, vocab_size: usize, hash: impl Into<Option<String>>) {
+        self.vocab_size = vocab_size;
+        self.tokenizer_hash = hash.into();
+    }
+
+    /// Content-addressed fingerprint of this descriptor.
+    pub fn fingerprint(&self) -> KvCompatFingerprint {
+        KvCompatFingerprint::of(self)
+    }
+
+    /// Rejection policy against an observed (cache-side) descriptor.
+    ///
+    /// Returns the first differing field in a fixed order, or `Ok(())` if the
+    /// descriptors are fully compatible. See [`check_compatibility`].
+    pub fn check_against(&self, observed: &KvCompatDescriptor) -> Result<(), KvCompatMismatch> {
+        check_compatibility(self, observed)
+    }
+
+    /// Feed a canonical, byte-stable serialization of the descriptor into `hash`.
+    ///
+    /// Every variable-length field is length-prefixed and every `Option` is
+    /// tag-prefixed so distinct descriptors never collide (e.g. `"ab"+"c"` is
+    /// distinguishable from `"a"+"bc"`). Little-endian fixed widths for scalars.
+    /// This encoding is what makes persisted fingerprints portable across builds.
+    fn write_canonical(&self, hash: &mut Sha256) {
+        put_u32(hash, self.format_version);
+
+        put_str(hash, &self.weights.base_revision);
+        put_u64(hash, self.weights.adapter_generation);
+
+        put_str(hash, &self.model_name);
+        put_str(hash, &self.architecture);
+        put_u32(hash, self.model_version);
+
+        put_usize(hash, self.num_hidden_layers);
+        put_usize(hash, self.num_attention_heads);
+        put_usize(hash, self.num_key_value_heads);
+        put_usize(hash, self.head_dim);
+        put_usize(hash, self.hidden_size);
+
+        put_u32(hash, self.rope_theta_bits);
+        match &self.rope_scaling {
+            Some(rs) => {
+                hash.update([1u8]);
+                put_str(hash, &rs.rope_type);
+                put_u32(hash, rs.factor_bits);
+            }
+            None => hash.update([0u8]),
+        }
+        put_usize(hash, self.max_position_embeddings);
+
+        put_str(hash, self.dtype.as_canonical_str());
+        put_str(hash, self.kv_quant.as_canonical_str());
+        put_usize(hash, self.block_size);
+        put_usize(hash, self.max_context);
+
+        put_usize(hash, self.vocab_size);
+        put_opt_str(hash, self.tokenizer_hash.as_deref());
+    }
+}
+
+// ===========================================================================
+// Fingerprint
+// ===========================================================================
+
+/// Content-addressed digest (SHA-256) of a [`KvCompatDescriptor`].
+///
+/// This is what gets stamped on a cache and compared at reuse time — the hot
+/// path checks `cache_fp == expected_fp`, a 32-byte compare. Two caches are
+/// reuse-compatible iff their fingerprints are equal.
+#[derive(Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub struct KvCompatFingerprint([u8; 32]);
+
+impl KvCompatFingerprint {
+    /// Compute the fingerprint of a descriptor.
+    pub fn of(desc: &KvCompatDescriptor) -> Self {
+        let mut hash = Sha256::new();
+        desc.write_canonical(&mut hash);
+        let digest = hash.finalize();
+        // Copy rather than `.into()` so this is stable across generic-array
+        // versions (digest output is always exactly 32 bytes for SHA-256).
+        let mut out = [0u8; 32];
+        out.copy_from_slice(&digest);
+        Self(out)
+    }
+
+    /// The raw 32-byte digest.
+    pub fn as_bytes(&self) -> &[u8; 32] {
+        &self.0
+    }
+
+    /// Lowercase hex encoding of the digest.
+    pub fn to_hex(&self) -> String {
+        hex::encode(self.0)
+    }
+
+    /// True iff a cache carrying this fingerprint is reuse-compatible with a
+    /// request whose expected fingerprint is `expected`.
+    pub fn is_compatible_with(&self, expected: &KvCompatFingerprint) -> bool {
+        self.0 == expected.0
+    }
+}
+
+impl std::fmt::Display for KvCompatFingerprint {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&self.to_hex())
+    }
+}
+
+impl std::fmt::Debug for KvCompatFingerprint {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "KvCompatFingerprint({})", self.to_hex())
+    }
+}
+
+// ===========================================================================
+// Rejection policy
+// ===========================================================================
+
+/// Why a cache was rejected for reuse, naming the first differing authoritative
+/// field in a fixed comparison order. Produced by [`check_compatibility`].
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum KvCompatMismatch {
+    FormatVersion {
+        expected: u32,
+        observed: u32,
+    },
+    Weights {
+        expected: WeightIdentity,
+        observed: WeightIdentity,
+    },
+    ModelName {
+        expected: String,
+        observed: String,
+    },
+    Architecture {
+        expected: String,
+        observed: String,
+    },
+    ModelVersion {
+        expected: u32,
+        observed: u32,
+    },
+    Geometry {
+        field: &'static str,
+        expected: usize,
+        observed: usize,
+    },
+    RopeTheta {
+        expected_bits: u32,
+        observed_bits: u32,
+    },
+    RopeScaling {
+        expected: Option<RopeScalingFp>,
+        observed: Option<RopeScalingFp>,
+    },
+    MaxPositionEmbeddings {
+        expected: usize,
+        observed: usize,
+    },
+    Dtype {
+        expected: KvDtype,
+        observed: KvDtype,
+    },
+    KvQuant {
+        expected: KvQuantMode,
+        observed: KvQuantMode,
+    },
+    BlockSize {
+        expected: usize,
+        observed: usize,
+    },
+    MaxContext {
+        expected: usize,
+        observed: usize,
+    },
+    VocabSize {
+        expected: usize,
+        observed: usize,
+    },
+    TokenizerHash {
+        expected: Option<String>,
+        observed: Option<String>,
+    },
+}
+
+impl std::fmt::Display for KvCompatMismatch {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            KvCompatMismatch::FormatVersion { expected, observed } => write!(
+                f,
+                "KV compat mismatch: format_version (expected {expected}, observed {observed})"
+            ),
+            KvCompatMismatch::Weights { expected, observed } => write!(
+                f,
+                "KV compat mismatch: effective weights (expected {expected:?}, observed {observed:?})"
+            ),
+            KvCompatMismatch::ModelName { expected, observed } => write!(
+                f,
+                "KV compat mismatch: model name (expected {expected:?}, observed {observed:?})"
+            ),
+            KvCompatMismatch::Architecture { expected, observed } => write!(
+                f,
+                "KV compat mismatch: architecture (expected {expected:?}, observed {observed:?})"
+            ),
+            KvCompatMismatch::ModelVersion { expected, observed } => write!(
+                f,
+                "KV compat mismatch: model version (expected {expected}, observed {observed})"
+            ),
+            KvCompatMismatch::Geometry {
+                field,
+                expected,
+                observed,
+            } => write!(
+                f,
+                "KV compat mismatch: geometry field {field:?} (expected {expected}, observed {observed})"
+            ),
+            KvCompatMismatch::RopeTheta {
+                expected_bits,
+                observed_bits,
+            } => write!(
+                f,
+                "KV compat mismatch: rope_theta (expected bits {expected_bits:#x}, observed {observed_bits:#x})"
+            ),
+            KvCompatMismatch::RopeScaling { expected, observed } => write!(
+                f,
+                "KV compat mismatch: rope_scaling (expected {expected:?}, observed {observed:?})"
+            ),
+            KvCompatMismatch::MaxPositionEmbeddings { expected, observed } => write!(
+                f,
+                "KV compat mismatch: max_position_embeddings (expected {expected}, observed {observed})"
+            ),
+            KvCompatMismatch::Dtype { expected, observed } => write!(
+                f,
+                "KV compat mismatch: dtype (expected {expected}, observed {observed})"
+            ),
+            KvCompatMismatch::KvQuant { expected, observed } => write!(
+                f,
+                "KV compat mismatch: kv quant mode (expected {expected}, observed {observed})"
+            ),
+            KvCompatMismatch::BlockSize { expected, observed } => write!(
+                f,
+                "KV compat mismatch: block_size (expected {expected}, observed {observed})"
+            ),
+            KvCompatMismatch::MaxContext { expected, observed } => write!(
+                f,
+                "KV compat mismatch: max_context (expected {expected}, observed {observed})"
+            ),
+            KvCompatMismatch::VocabSize { expected, observed } => write!(
+                f,
+                "KV compat mismatch: vocab_size (expected {expected}, observed {observed})"
+            ),
+            KvCompatMismatch::TokenizerHash { expected, observed } => write!(
+                f,
+                "KV compat mismatch: tokenizer_hash (expected {expected:?}, observed {observed:?})"
+            ),
+        }
+    }
+}
+
+impl std::error::Error for KvCompatMismatch {}
+
+/// **Rejection policy**: a cache whose descriptor differs in *any* authoritative
+/// field is rejected.
+///
+/// Compares `expected` (the current model/runtime identity) against `observed`
+/// (the descriptor under which a cache's KV was produced), field by field in a
+/// fixed order, returning the first mismatch. Returns `Ok(())` only when the
+/// descriptors are fully compatible.
+///
+/// At runtime the engine usually compares [`KvCompatFingerprint`]s (a 32-byte
+/// equality) rather than calling this; this function exists to produce a
+/// structured, human-readable rejection reason (for logs, metrics, and tests)
+/// and to pin the exact comparison contract the fingerprint must honor.
+pub fn check_compatibility(
+    expected: &KvCompatDescriptor,
+    observed: &KvCompatDescriptor,
+) -> Result<(), KvCompatMismatch> {
+    if expected.format_version != observed.format_version {
+        return Err(KvCompatMismatch::FormatVersion {
+            expected: expected.format_version,
+            observed: observed.format_version,
+        });
+    }
+    if expected.weights != observed.weights {
+        return Err(KvCompatMismatch::Weights {
+            expected: expected.weights.clone(),
+            observed: observed.weights.clone(),
+        });
+    }
+    if expected.model_name != observed.model_name {
+        return Err(KvCompatMismatch::ModelName {
+            expected: expected.model_name.clone(),
+            observed: observed.model_name.clone(),
+        });
+    }
+    if expected.architecture != observed.architecture {
+        return Err(KvCompatMismatch::Architecture {
+            expected: expected.architecture.clone(),
+            observed: observed.architecture.clone(),
+        });
+    }
+    if expected.model_version != observed.model_version {
+        return Err(KvCompatMismatch::ModelVersion {
+            expected: expected.model_version,
+            observed: observed.model_version,
+        });
+    }
+    // Geometry: report the first diverging dimension.
+    if expected.num_hidden_layers != observed.num_hidden_layers {
+        return Err(geometry(
+            "num_hidden_layers",
+            expected.num_hidden_layers,
+            observed.num_hidden_layers,
+        ));
+    }
+    if expected.num_attention_heads != observed.num_attention_heads {
+        return Err(geometry(
+            "num_attention_heads",
+            expected.num_attention_heads,
+            observed.num_attention_heads,
+        ));
+    }
+    if expected.num_key_value_heads != observed.num_key_value_heads {
+        return Err(geometry(
+            "num_key_value_heads",
+            expected.num_key_value_heads,
+            observed.num_key_value_heads,
+        ));
+    }
+    if expected.head_dim != observed.head_dim {
+        return Err(geometry("head_dim", expected.head_dim, observed.head_dim));
+    }
+    if expected.hidden_size != observed.hidden_size {
+        return Err(geometry(
+            "hidden_size",
+            expected.hidden_size,
+            observed.hidden_size,
+        ));
+    }
+    if expected.rope_theta_bits != observed.rope_theta_bits {
+        return Err(KvCompatMismatch::RopeTheta {
+            expected_bits: expected.rope_theta_bits,
+            observed_bits: observed.rope_theta_bits,
+        });
+    }
+    if expected.rope_scaling != observed.rope_scaling {
+        return Err(KvCompatMismatch::RopeScaling {
+            expected: expected.rope_scaling.clone(),
+            observed: observed.rope_scaling.clone(),
+        });
+    }
+    if expected.max_position_embeddings != observed.max_position_embeddings {
+        return Err(KvCompatMismatch::MaxPositionEmbeddings {
+            expected: expected.max_position_embeddings,
+            observed: observed.max_position_embeddings,
+        });
+    }
+    if expected.dtype != observed.dtype {
+        return Err(KvCompatMismatch::Dtype {
+            expected: expected.dtype.clone(),
+            observed: observed.dtype.clone(),
+        });
+    }
+    if expected.kv_quant != observed.kv_quant {
+        return Err(KvCompatMismatch::KvQuant {
+            expected: expected.kv_quant,
+            observed: observed.kv_quant,
+        });
+    }
+    if expected.block_size != observed.block_size {
+        return Err(KvCompatMismatch::BlockSize {
+            expected: expected.block_size,
+            observed: observed.block_size,
+        });
+    }
+    if expected.max_context != observed.max_context {
+        return Err(KvCompatMismatch::MaxContext {
+            expected: expected.max_context,
+            observed: observed.max_context,
+        });
+    }
+    if expected.vocab_size != observed.vocab_size {
+        return Err(KvCompatMismatch::VocabSize {
+            expected: expected.vocab_size,
+            observed: observed.vocab_size,
+        });
+    }
+    if expected.tokenizer_hash != observed.tokenizer_hash {
+        return Err(KvCompatMismatch::TokenizerHash {
+            expected: expected.tokenizer_hash.clone(),
+            observed: observed.tokenizer_hash.clone(),
+        });
+    }
+    Ok(())
+}
+
+fn geometry(field: &'static str, expected: usize, observed: usize) -> KvCompatMismatch {
+    KvCompatMismatch::Geometry {
+        field,
+        expected,
+        observed,
+    }
+}
+
+// ===========================================================================
+// Canonical byte framing for stable hashing
+// ===========================================================================
+
+#[inline]
+fn put_u32(hash: &mut Sha256, v: u32) {
+    hash.update(v.to_le_bytes());
+}
+
+#[inline]
+fn put_u64(hash: &mut Sha256, v: u64) {
+    hash.update(v.to_le_bytes());
+}
+
+#[inline]
+fn put_usize(hash: &mut Sha256, v: usize) {
+    // usize width is platform-dependent; hash it as a fixed u64 so fingerprints
+    // are stable across 32-/64-bit builds.
+    hash.update((v as u64).to_le_bytes());
+}
+
+#[inline]
+fn put_str(hash: &mut Sha256, s: &str) {
+    put_u64(hash, s.len() as u64);
+    hash.update(s.as_bytes());
+}
+
+#[inline]
+fn put_opt_str(hash: &mut Sha256, s: Option<&str>) {
+    match s {
+        Some(s) => {
+            hash.update([1u8]);
+            put_str(hash, s);
+        }
+        None => hash.update([0u8]),
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)]
+mod tests {
+    use super::*;
+
+    /// A representative, fully-populated descriptor used as the compatibility
+    /// baseline in the tests below.
+    fn baseline() -> KvCompatDescriptor {
+        KvCompatDescriptor {
+            format_version: KV_COMPAT_FORMAT_VERSION,
+            weights: WeightIdentity::base_only("my-model"),
+            model_name: "my-model".to_string(),
+            architecture: "llama".to_string(),
+            model_version: 1,
+            num_hidden_layers: 32,
+            num_attention_heads: 32,
+            num_key_value_heads: 8,
+            head_dim: 128,
+            hidden_size: 4096,
+            rope_theta_bits: 10_000.0f32.to_bits(),
+            rope_scaling: None,
+            max_position_embeddings: 4096,
+            dtype: KvDtype::BFloat16,
+            kv_quant: KvQuantMode::None,
+            block_size: KV_BLOCK_SIZE_DEFAULT,
+            max_context: 4096,
+            vocab_size: 32_000,
+            tokenizer_hash: Some("deadbeef".to_string()),
+        }
+    }
+
+    #[test]
+    fn default_block_size_tracks_kv_cache_block_size() {
+        // Keeps this module's const in sync with the paged-KV block geometry
+        // without importing the tch-backed kv_cache module here.
+        assert_eq!(KV_BLOCK_SIZE_DEFAULT, crate::runtime::kv_cache::BLOCK_SIZE);
+    }
+
+    #[test]
+    fn fingerprint_is_deterministic() {
+        let a = baseline().fingerprint();
+        let b = baseline().fingerprint();
+        assert_eq!(a, b, "identical descriptors must hash identically");
+        assert_eq!(a.to_hex(), b.to_hex());
+        assert_eq!(a.as_bytes().len(), 32);
+    }
+
+    #[test]
+    fn fingerprint_is_clone_stable() {
+        let d = baseline();
+        assert_eq!(d.fingerprint(), d.clone().fingerprint());
+    }
+
+    /// Asserts that `mutator` produces a descriptor whose fingerprint differs
+    /// from the baseline, and (when given) the expected mismatch variant.
+    fn assert_field_diverges(
+        label: &str,
+        mutator: impl FnOnce(&mut KvCompatDescriptor),
+        expected_mismatch: Option<KvCompatMismatch>,
+    ) {
+        let base_fp = baseline().fingerprint();
+        let mut d = baseline();
+        mutator(&mut d);
+        let divergent_fp = d.fingerprint();
+        assert_ne!(
+            base_fp, divergent_fp,
+            "{label}: flipping the field must change the fingerprint"
+        );
+        if let Some(expected) = expected_mismatch {
+            let observed = baseline();
+            let reason = check_compatibility(&d, &observed).err().unwrap_or_else(|| {
+                panic!("{label}: expected a mismatch but descriptors compared equal")
+            });
+            assert_eq!(
+                reason, expected,
+                "{label}: mismatch variant/reason did not match expectation"
+            );
+        }
+    }
+
+    #[test]
+    fn every_authoritative_field_participates() {
+        // Weight identity.
+        assert_field_diverges(
+            "weights.base_revision",
+            |d| d.weights.base_revision = "other-model".into(),
+            Some(KvCompatMismatch::Weights {
+                expected: WeightIdentity::base_only("other-model"),
+                observed: WeightIdentity::base_only("my-model"),
+            }),
+        );
+        assert_field_diverges(
+            "weights.adapter_generation",
+            |d| d.weights.adapter_generation = 7,
+            Some(KvCompatMismatch::Weights {
+                expected: WeightIdentity::base_only("my-model").with_adapter(7),
+                observed: WeightIdentity::base_only("my-model"),
+            }),
+        );
+        // Model identity.
+        assert_field_diverges("model_name", |d| d.model_name = "other".into(), None);
+        assert_field_diverges("architecture", |d| d.architecture = "qwen2".into(), None);
+        assert_field_diverges("model_version", |d| d.model_version = 2, None);
+        // Geometry.
+        assert_field_diverges(
+            "num_hidden_layers",
+            |d| d.num_hidden_layers = 24,
+            Some(geometry("num_hidden_layers", 24, 32)),
+        );
+        assert_field_diverges(
+            "num_attention_heads",
+            |d| d.num_attention_heads = 16,
+            Some(geometry("num_attention_heads", 16, 32)),
+        );
+        assert_field_diverges(
+            "num_key_value_heads",
+            |d| d.num_key_value_heads = 4,
+            Some(geometry("num_key_value_heads", 4, 8)),
+        );
+        assert_field_diverges(
+            "head_dim",
+            |d| d.head_dim = 64,
+            Some(geometry("head_dim", 64, 128)),
+        );
+        assert_field_diverges(
+            "hidden_size",
+            |d| d.hidden_size = 2048,
+            Some(geometry("hidden_size", 2048, 4096)),
+        );
+        // Position encoding.
+        assert_field_diverges(
+            "rope_theta",
+            |d| d.set_rope_theta(1_000_000.0),
+            Some(KvCompatMismatch::RopeTheta {
+                expected_bits: 1_000_000.0f32.to_bits(),
+                observed_bits: 10_000.0f32.to_bits(),
+            }),
+        );
+        assert_field_diverges(
+            "rope_scaling presence",
+            |d| d.rope_scaling = Some(RopeScalingFp::new("linear", 2.0)),
+            None,
+        );
+        assert_field_diverges(
+            "rope_scaling factor",
+            |d| {
+                d.rope_scaling = Some(RopeScalingFp::new("linear", 2.0));
+                d.rope_scaling = Some(RopeScalingFp::new("linear", 4.0));
+            },
+            None,
+        );
+        assert_field_diverges(
+            "max_position_embeddings",
+            |d| d.max_position_embeddings = 8192,
+            None,
+        );
+        // Dtype + encoding.
+        assert_field_diverges(
+            "dtype",
+            |d| d.dtype = KvDtype::Float16,
+            Some(KvCompatMismatch::Dtype {
+                expected: KvDtype::Float16,
+                observed: KvDtype::BFloat16,
+            }),
+        );
+        assert_field_diverges(
+            "kv_quant",
+            |d| d.kv_quant = KvQuantMode::Int8,
+            Some(KvCompatMismatch::KvQuant {
+                expected: KvQuantMode::Int8,
+                observed: KvQuantMode::None,
+            }),
+        );
+        assert_field_diverges(
+            "block_size",
+            |d| d.block_size = 128,
+            Some(KvCompatMismatch::BlockSize {
+                expected: 128,
+                observed: 256,
+            }),
+        );
+        assert_field_diverges(
+            "max_context",
+            |d| d.max_context = 2048,
+            Some(KvCompatMismatch::MaxContext {
+                expected: 2048,
+                observed: 4096,
+            }),
+        );
+        // Tokenizer.
+        assert_field_diverges(
+            "vocab_size",
+            |d| d.vocab_size = 64_000,
+            Some(KvCompatMismatch::VocabSize {
+                expected: 64_000,
+                observed: 32_000,
+            }),
+        );
+        assert_field_diverges(
+            "tokenizer_hash",
+            |d| d.tokenizer_hash = Some("cafebabe".into()),
+            Some(KvCompatMismatch::TokenizerHash {
+                expected: Some("cafebabe".into()),
+                observed: Some("deadbeef".into()),
+            }),
+        );
+        assert_field_diverges("tokenizer_hash absent", |d| d.tokenizer_hash = None, None);
+    }
+
+    #[test]
+    fn format_version_bump_is_hard_reject() {
+        let mut observed = baseline();
+        observed.format_version = 0; // an older/persisted format
+        assert_eq!(
+            check_compatibility(&baseline(), &observed),
+            Err(KvCompatMismatch::FormatVersion {
+                expected: KV_COMPAT_FORMAT_VERSION,
+                observed: 0,
+            })
+        );
+    }
+
+    #[test]
+    fn equal_descriptors_are_compatible() {
+        assert!(check_compatibility(&baseline(), &baseline()).is_ok());
+        assert!(baseline().check_against(&baseline()).is_ok());
+    }
+
+    #[test]
+    fn fingerprint_equality_implies_descriptor_compatibility() {
+        // The hot path compares fingerprints; assert it agrees with the
+        // structured policy for both compatible and divergent cases.
+        let a = baseline();
+        let b = baseline();
+        assert!(a.fingerprint().is_compatible_with(&b.fingerprint()));
+
+        let mut c = baseline();
+        c.kv_quant = KvQuantMode::Nf4;
+        assert!(!a.fingerprint().is_compatible_with(&c.fingerprint()));
+        assert!(check_compatibility(&a, &c).is_err());
+    }
+
+    #[test]
+    fn kvdtype_is_case_and_alias_insensitive() {
+        assert_eq!(KvDtype::from_str("BFLOAT16"), KvDtype::BFloat16);
+        assert_eq!(KvDtype::from_str("  bf16 "), KvDtype::BFloat16);
+        assert_eq!(KvDtype::from_str("float16"), KvDtype::Float16);
+        assert_eq!(KvDtype::from_str("FP16"), KvDtype::Float16);
+        assert_eq!(KvDtype::from_str("float32"), KvDtype::Float32);
+        // Two descriptors differing only by dtype *spelling* must hash equally.
+        let mut d1 = baseline();
+        let mut d2 = baseline();
+        d1.dtype = KvDtype::from_str("BFLOAT16");
+        d2.dtype = KvDtype::from_str("bfloat16");
+        assert_eq!(d1.fingerprint(), d2.fingerprint());
+    }
+
+    #[test]
+    fn rope_scaling_canonicalizes_case() {
+        assert_eq!(
+            RopeScalingFp::new("Linear", 2.0),
+            RopeScalingFp::new("linear", 2.0)
+        );
+        // Different factor -> different identity.
+        assert_ne!(
+            RopeScalingFp::new("linear", 2.0),
+            RopeScalingFp::new("linear", 4.0)
+        );
+    }
+
+    #[test]
+    fn kvquant_canonical_strs_are_distinct() {
+        let modes = [
+            KvQuantMode::None,
+            KvQuantMode::Int8,
+            KvQuantMode::Nf4,
+            KvQuantMode::Fp4,
+        ];
+        let strs: Vec<&str> = modes.iter().map(|m| m.as_canonical_str()).collect();
+        let unique: std::collections::HashSet<&str> = strs.iter().copied().collect();
+        assert_eq!(unique.len(), modes.len(), "quant mode names must be unique");
+    }
+
+    #[test]
+    fn canonical_framing_disambiguates_concatenations() {
+        // Length-prefixing must keep "ab"+"c" distinct from "a"+"bc".
+        let mut h1 = Sha256::new();
+        put_str(&mut h1, "ab");
+        put_str(&mut h1, "c");
+        let mut h2 = Sha256::new();
+        put_str(&mut h2, "a");
+        put_str(&mut h2, "bc");
+        assert_ne!(
+            h1.finalize().as_slice(),
+            h2.finalize().as_slice(),
+            "framing must prevent concatenation collisions"
+        );
+    }
+
+    #[test]
+    fn mismatch_reasons_are_displayable() {
+        let cases = [
+            KvCompatMismatch::FormatVersion {
+                expected: 1,
+                observed: 0,
+            },
+            KvCompatMismatch::Weights {
+                expected: WeightIdentity::base_only("a"),
+                observed: WeightIdentity::base_only("b"),
+            },
+            KvCompatMismatch::Geometry {
+                field: "head_dim",
+                expected: 128,
+                observed: 64,
+            },
+            KvCompatMismatch::Dtype {
+                expected: KvDtype::BFloat16,
+                observed: KvDtype::Float16,
+            },
+            KvCompatMismatch::KvQuant {
+                expected: KvQuantMode::None,
+                observed: KvQuantMode::Int8,
+            },
+        ];
+        for c in cases {
+            let s = format!("{c}");
+            assert!(
+                s.contains("KV compat mismatch"),
+                "display missing prefix: {s}"
+            );
+        }
+    }
+
+    #[test]
+    fn weight_identity_with_adapter() {
+        let w = WeightIdentity::base_only("m").with_adapter(3);
+        assert_eq!(w.adapter_generation, 3);
+        assert_eq!(w.base_revision, "m");
+        // Adapter generation changes the fingerprint.
+        let mut d = baseline();
+        let fp0 = d.fingerprint();
+        d.weights = WeightIdentity::base_only("my-model").with_adapter(1);
+        assert_ne!(fp0, d.fingerprint());
+    }
+}

--- a/crates/hyprstream/src/runtime/kv_compat.rs
+++ b/crates/hyprstream/src/runtime/kv_compat.rs
@@ -25,10 +25,14 @@
 //! Every field of [`KvCompatDescriptor`] is derived from the model/runtime state
 //! that actually produced the KV tensors — never from a human label:
 //!
-//! - **Effective weights** — base-weight revision + adapter/delta generation.
+//! - **Effective weights** — base-weight **content digest** + adapter/delta
+//!   generation (the live `lora_generation` actually applied to the request).
 //! - **Model identity** — name, architecture (`model_type`), config version.
 //! - **Attention geometry** — layers, KV heads, attention heads, head dim,
 //!   hidden size (determines K/V tensor *shape*).
+//! - **Effective attention behavior** — QK-norm, partial-rotary dimension,
+//!   per-layer local/global layout (`layer_types`), and hybrid/linear-attention
+//!   dimensions (change K/V *values*, not just shape).
 //! - **Position encoding** — RoPE theta, RoPE scaling, max position embeddings
 //!   (determines K *values* post-RoPE).
 //! - **Compute dtype** — the dtype the model computes/stores K/V in.
@@ -38,6 +42,16 @@
 //! - **Tokenizer identity** — vocab size + a digest of the tokenizer bytes
 //!   (cached token ids are only meaningful relative to one tokenizer).
 //! - **Format version** — the wire/layout version of the fingerprint itself.
+//!
+//! ## Authority and fail-closed reuse
+//!
+//! A descriptor is only usable to bless a cache when every authoritative axis is
+//! populated ([`KvCompatDescriptor::is_authoritatively_complete`]): the
+//! base-weight content digest and the tokenizer hash. If the loader cannot
+//! obtain the base digest, or tokenizer hashing fails, the engine declines to
+//! mint an expected identity and the cache boundary **fails closed** — KV is
+//! recomputed rather than reused under a guess ([`decide_cache_reuse`]). An
+//! unstamped but populated cache is likewise discarded, never silently adopted.
 //!
 //! ## Relation to TTT delta invalidation
 //!
@@ -57,7 +71,11 @@ use sha2::{Digest, Sha256};
 /// their canonical encoding, changes in a backward-incompatible way. A cache
 /// produced (or persisted) under an older format version is **never** reused —
 /// the rejection policy treats a format-version mismatch as a hard reject.
-pub const KV_COMPAT_FORMAT_VERSION: u32 = 1;
+///
+/// v2 adds the behavior-affecting effective-config fields (`use_qk_norm`,
+/// partial rotary dimension, attention layer layout, and linear-attention
+/// dimensions) that change KV byte-content without changing coarse geometry.
+pub const KV_COMPAT_FORMAT_VERSION: u32 = 2;
 
 /// Default tokens-per-block for paged KV storage.
 ///
@@ -79,15 +97,19 @@ pub const KV_BLOCK_SIZE_DEFAULT: usize = 256;
 /// distinct from a geometry or dtype change.
 #[derive(Clone, Debug, PartialEq, Eq, Hash, Default)]
 pub struct WeightIdentity {
-    /// Identity of the base model weights. Today this is the loaded model's
-    /// path/identity; future work feeds a git2db content oid (issue #1285) for
-    /// a true content address.
+    /// Authoritative identity of the base model weights — a content digest of
+    /// the weight shards actually resolved by the loader (today a SHA-256 over
+    /// the sorted `.safetensors` shard bytes; a git2db content OID when one is
+    /// associated with the loaded worktree, issue #1285). This is **never** a
+    /// human/path label: two snapshots sharing a basename but differing in
+    /// content diverge here. Empty when no authoritative digest could be
+    /// obtained, in which case the descriptor is treated as non-authoritative
+    /// and reuse fails closed (see [`KvCompatDescriptor::is_authoritatively_complete`]).
     pub base_revision: String,
     /// Adapter/delta generation active when the KV was produced. `0` means base
-    /// weights only (no adapter). The live `lora_generation` counter (issue
-    /// #1260) is the intended producer; until it is wired, per-tenant delta
-    /// staleness is handled by the registry's push-based
-    /// [`invalidate_for_tenant`][crate::runtime::kv_cache::KVCacheRegistry::invalidate_for_tenant].
+    /// weights only (no adapter). Populated at the per-request reuse boundary
+    /// from the live `lora_generation` counter actually applied to the request,
+    /// so a re-adapted model is detected as incompatible (issue #1260).
     pub adapter_generation: u64,
 }
 
@@ -268,6 +290,28 @@ pub struct KvCompatDescriptor {
     pub head_dim: usize,
     pub hidden_size: usize,
 
+    // --- effective attention behavior (changes K/V *values*, not just shape) ---
+    /// QK-norm applied to queries/keys (Gemma3, Qwen3 families). Off vs. on
+    /// normalizes K and changes every downstream value.
+    pub use_qk_norm: bool,
+    /// `f32::to_bits` of the partial-rotary factor. Determines `rotary_dim`
+    /// (`head_dim * factor`), i.e. how much of each key is rotated by RoPE —
+    /// a different factor rotates a different slice of K. `None` = full rotary.
+    pub partial_rotary_factor_bits: Option<u32>,
+    /// Per-layer attention type in layer order (e.g. `"global"`/`"local"`,
+    /// `"full_attention"`/`"linear_attention"`). The local/global layout and any
+    /// local-RoPE behavior change which tokens each layer attends to and thus its
+    /// K/V. Stored lowercased; canonicalized at hash time.
+    pub layer_types: Vec<String>,
+    /// Linear/hybrid-attention state dimensions (Qwen3.5 GatedDeltaNet etc.).
+    /// Non-zero on hybrid models; a different dimension changes the per-layer
+    /// recurrent state that feeds later K/V.
+    pub linear_key_head_dim: usize,
+    pub linear_value_head_dim: usize,
+    pub linear_num_key_heads: usize,
+    pub linear_num_value_heads: usize,
+    pub linear_conv_kernel_dim: usize,
+
     // --- position encoding (determines K values post-RoPE) ---
     /// `f32::to_bits` of `rope_theta`.
     pub rope_theta_bits: u32,
@@ -301,6 +345,26 @@ impl KvCompatDescriptor {
     /// Set the RoPE theta from an `f32` (canonicalized to bits).
     pub fn set_rope_theta(&mut self, theta: f32) {
         self.rope_theta_bits = theta.to_bits();
+    }
+
+    /// The partial-rotary factor, recovered from its bit pattern (`None` = full rotary).
+    pub fn partial_rotary_factor(&self) -> Option<f32> {
+        self.partial_rotary_factor_bits.map(f32::from_bits)
+    }
+
+    /// Set the partial-rotary factor from an `f32` (canonicalized to bits).
+    pub fn set_partial_rotary_factor(&mut self, factor: Option<f32>) {
+        self.partial_rotary_factor_bits = factor.map(f32::to_bits);
+    }
+
+    /// True iff every authoritative identity axis is populated.
+    ///
+    /// A descriptor missing the base-weight digest or the tokenizer identity was
+    /// built from a non-authoritative source and must **not** be used to bless a
+    /// cache for reuse: the engine treats a non-authoritative expected identity
+    /// as fail-closed (discard + recompute) rather than stamping a guess.
+    pub fn is_authoritatively_complete(&self) -> bool {
+        !self.weights.base_revision.is_empty() && self.tokenizer_hash.is_some()
     }
 
     /// Record the tokenizer identity (vocab size + digest of its bytes).
@@ -346,6 +410,16 @@ impl KvCompatDescriptor {
         put_usize(hash, self.num_key_value_heads);
         put_usize(hash, self.head_dim);
         put_usize(hash, self.hidden_size);
+
+        // Effective attention behavior.
+        put_bool(hash, self.use_qk_norm);
+        put_opt_u32(hash, self.partial_rotary_factor_bits);
+        put_str_vec(hash, &self.layer_types);
+        put_usize(hash, self.linear_key_head_dim);
+        put_usize(hash, self.linear_value_head_dim);
+        put_usize(hash, self.linear_num_key_heads);
+        put_usize(hash, self.linear_num_value_heads);
+        put_usize(hash, self.linear_conv_kernel_dim);
 
         put_u32(hash, self.rope_theta_bits);
         match &self.rope_scaling {
@@ -455,6 +529,18 @@ pub enum KvCompatMismatch {
         expected: usize,
         observed: usize,
     },
+    UseQkNorm {
+        expected: bool,
+        observed: bool,
+    },
+    PartialRotaryFactor {
+        expected_bits: Option<u32>,
+        observed_bits: Option<u32>,
+    },
+    LayerTypes {
+        expected: Vec<String>,
+        observed: Vec<String>,
+    },
     RopeTheta {
         expected_bits: u32,
         observed_bits: u32,
@@ -523,6 +609,21 @@ impl std::fmt::Display for KvCompatMismatch {
             } => write!(
                 f,
                 "KV compat mismatch: geometry field {field:?} (expected {expected}, observed {observed})"
+            ),
+            KvCompatMismatch::UseQkNorm { expected, observed } => write!(
+                f,
+                "KV compat mismatch: use_qk_norm (expected {expected}, observed {observed})"
+            ),
+            KvCompatMismatch::PartialRotaryFactor {
+                expected_bits,
+                observed_bits,
+            } => write!(
+                f,
+                "KV compat mismatch: partial_rotary_factor (expected bits {expected_bits:?}, observed bits {observed_bits:?})"
+            ),
+            KvCompatMismatch::LayerTypes { expected, observed } => write!(
+                f,
+                "KV compat mismatch: layer_types (expected {expected:?}, observed {observed:?})"
             ),
             KvCompatMismatch::RopeTheta {
                 expected_bits,
@@ -647,6 +748,60 @@ pub fn check_compatibility(
             observed.hidden_size,
         ));
     }
+    // Effective attention behavior (changes K/V *values*, not just shape).
+    if expected.use_qk_norm != observed.use_qk_norm {
+        return Err(KvCompatMismatch::UseQkNorm {
+            expected: expected.use_qk_norm,
+            observed: observed.use_qk_norm,
+        });
+    }
+    if expected.partial_rotary_factor_bits != observed.partial_rotary_factor_bits {
+        return Err(KvCompatMismatch::PartialRotaryFactor {
+            expected_bits: expected.partial_rotary_factor_bits,
+            observed_bits: observed.partial_rotary_factor_bits,
+        });
+    }
+    if expected.layer_types != observed.layer_types {
+        return Err(KvCompatMismatch::LayerTypes {
+            expected: expected.layer_types.clone(),
+            observed: observed.layer_types.clone(),
+        });
+    }
+    if expected.linear_key_head_dim != observed.linear_key_head_dim {
+        return Err(geometry(
+            "linear_key_head_dim",
+            expected.linear_key_head_dim,
+            observed.linear_key_head_dim,
+        ));
+    }
+    if expected.linear_value_head_dim != observed.linear_value_head_dim {
+        return Err(geometry(
+            "linear_value_head_dim",
+            expected.linear_value_head_dim,
+            observed.linear_value_head_dim,
+        ));
+    }
+    if expected.linear_num_key_heads != observed.linear_num_key_heads {
+        return Err(geometry(
+            "linear_num_key_heads",
+            expected.linear_num_key_heads,
+            observed.linear_num_key_heads,
+        ));
+    }
+    if expected.linear_num_value_heads != observed.linear_num_value_heads {
+        return Err(geometry(
+            "linear_num_value_heads",
+            expected.linear_num_value_heads,
+            observed.linear_num_value_heads,
+        ));
+    }
+    if expected.linear_conv_kernel_dim != observed.linear_conv_kernel_dim {
+        return Err(geometry(
+            "linear_conv_kernel_dim",
+            expected.linear_conv_kernel_dim,
+            observed.linear_conv_kernel_dim,
+        ));
+    }
     if expected.rope_theta_bits != observed.rope_theta_bits {
         return Err(KvCompatMismatch::RopeTheta {
             expected_bits: expected.rope_theta_bits,
@@ -713,12 +868,79 @@ fn geometry(field: &'static str, expected: usize, observed: usize) -> KvCompatMi
 }
 
 // ===========================================================================
+// Reuse decision (fail-closed policy at the cache boundary)
+// ===========================================================================
+
+/// What to do with a cache encountered at the reuse boundary, produced by
+/// [`decide_cache_reuse`]. The policy is **fail-closed**: it never blesses a
+/// cache whose KV cannot be proven compatible with an authoritative identity.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum CacheReuseDecision {
+    /// Cache KV is provably compatible with an authoritative expected identity —
+    /// reuse it as-is.
+    Reuse,
+    /// Cache is empty and carries no stamp, and an authoritative expected
+    /// identity is available. Stamp it and keep the (empty) cache; prefill will
+    /// populate it under that identity.
+    StampFresh,
+    /// The cache's KV cannot be proven compatible. This covers a stamp mismatch,
+    /// an **unstamped but populated** cache (produced under an unknown identity),
+    /// and the absence of any authoritative expected identity. Discard the KV and
+    /// recompute; stamp with the authoritative identity if one is available.
+    DiscardAndRecompute,
+}
+
+/// Decide whether a cache may be reused, given the authoritative expected
+/// identity (if any), the stamp currently on the cache (if any), and whether the
+/// cache provably carries no KV.
+///
+/// Decision matrix (every non-`Reuse` outcome discards KV — fail-closed):
+///
+/// | expected | stored  | empty | decision              |
+/// |----------|---------|-------|-----------------------|
+/// | Some(e)  | Some(s) | *     | `e == s` ? Reuse : DiscardAndRecompute |
+/// | Some(_)  | None    | true  | StampFresh            |
+/// | Some(_)  | None    | false | DiscardAndRecompute   |
+/// | None     | *       | *     | DiscardAndRecompute   |
+///
+/// The unstamped-but-populated and no-authoritative-identity rows are the
+/// fail-closed guards: a cache we cannot authoritatively attribute is never
+/// reused, only recomputed.
+pub fn decide_cache_reuse(
+    expected: Option<&KvCompatFingerprint>,
+    stored: Option<&KvCompatFingerprint>,
+    cache_is_empty: bool,
+) -> CacheReuseDecision {
+    match (expected, stored) {
+        (Some(exp), Some(stored)) if exp == stored => CacheReuseDecision::Reuse,
+        (Some(_), None) if cache_is_empty => CacheReuseDecision::StampFresh,
+        _ => CacheReuseDecision::DiscardAndRecompute,
+    }
+}
+
+// ===========================================================================
 // Canonical byte framing for stable hashing
 // ===========================================================================
 
 #[inline]
 fn put_u32(hash: &mut Sha256, v: u32) {
     hash.update(v.to_le_bytes());
+}
+
+#[inline]
+fn put_opt_u32(hash: &mut Sha256, v: Option<u32>) {
+    match v {
+        Some(x) => {
+            hash.update([1u8]);
+            put_u32(hash, x);
+        }
+        None => hash.update([0u8]),
+    }
+}
+
+#[inline]
+fn put_bool(hash: &mut Sha256, v: bool) {
+    hash.update([if v { 1u8 } else { 0u8 }]);
 }
 
 #[inline]
@@ -750,6 +972,17 @@ fn put_opt_str(hash: &mut Sha256, s: Option<&str>) {
     }
 }
 
+/// Hash a `Vec<String>` as a length-prefixed sequence of canonicalized
+/// (trimmed, lowercased) strings so layout casing/order changes are caught.
+#[inline]
+fn put_str_vec(hash: &mut Sha256, v: &[String]) {
+    put_u64(hash, v.len() as u64);
+    for s in v {
+        let canon: String = s.trim().to_ascii_lowercase();
+        put_str(hash, &canon);
+    }
+}
+
 #[cfg(test)]
 #[allow(clippy::unwrap_used)]
 mod tests {
@@ -760,7 +993,7 @@ mod tests {
     fn baseline() -> KvCompatDescriptor {
         KvCompatDescriptor {
             format_version: KV_COMPAT_FORMAT_VERSION,
-            weights: WeightIdentity::base_only("my-model"),
+            weights: WeightIdentity::base_only("sha256:my-model-weights"),
             model_name: "my-model".to_string(),
             architecture: "llama".to_string(),
             model_version: 1,
@@ -769,6 +1002,15 @@ mod tests {
             num_key_value_heads: 8,
             head_dim: 128,
             hidden_size: 4096,
+            // Plain Llama: no QK-norm, full rotary, uniform layers, no linear attn.
+            use_qk_norm: false,
+            partial_rotary_factor_bits: None,
+            layer_types: Vec::new(),
+            linear_key_head_dim: 0,
+            linear_value_head_dim: 0,
+            linear_num_key_heads: 0,
+            linear_num_value_heads: 0,
+            linear_conv_kernel_dim: 0,
             rope_theta_bits: 10_000.0f32.to_bits(),
             rope_scaling: None,
             max_position_embeddings: 4096,
@@ -778,6 +1020,18 @@ mod tests {
             max_context: 4096,
             vocab_size: 32_000,
             tokenizer_hash: Some("deadbeef".to_string()),
+        }
+    }
+
+    /// Test helper: set one of the linear-attention dimensions by name.
+    fn set_linear_dim(d: &mut KvCompatDescriptor, field: &str, val: usize) {
+        match field {
+            "linear_key_head_dim" => d.linear_key_head_dim = val,
+            "linear_value_head_dim" => d.linear_value_head_dim = val,
+            "linear_num_key_heads" => d.linear_num_key_heads = val,
+            "linear_num_value_heads" => d.linear_num_value_heads = val,
+            "linear_conv_kernel_dim" => d.linear_conv_kernel_dim = val,
+            _ => panic!("unknown linear dim field {field}"),
         }
     }
 
@@ -838,15 +1092,15 @@ mod tests {
             |d| d.weights.base_revision = "other-model".into(),
             Some(KvCompatMismatch::Weights {
                 expected: WeightIdentity::base_only("other-model"),
-                observed: WeightIdentity::base_only("my-model"),
+                observed: WeightIdentity::base_only("sha256:my-model-weights"),
             }),
         );
         assert_field_diverges(
             "weights.adapter_generation",
             |d| d.weights.adapter_generation = 7,
             Some(KvCompatMismatch::Weights {
-                expected: WeightIdentity::base_only("my-model").with_adapter(7),
-                observed: WeightIdentity::base_only("my-model"),
+                expected: WeightIdentity::base_only("sha256:my-model-weights").with_adapter(7),
+                observed: WeightIdentity::base_only("sha256:my-model-weights"),
             }),
         );
         // Model identity.
@@ -879,6 +1133,74 @@ mod tests {
             |d| d.hidden_size = 2048,
             Some(geometry("hidden_size", 2048, 4096)),
         );
+        // Effective attention behavior (changes K/V *values*, not just shape).
+        assert_field_diverges(
+            "use_qk_norm",
+            |d| d.use_qk_norm = true,
+            Some(KvCompatMismatch::UseQkNorm {
+                expected: true,
+                observed: false,
+            }),
+        );
+        assert_field_diverges(
+            "partial_rotary_factor",
+            |d| d.set_partial_rotary_factor(Some(0.25)),
+            Some(KvCompatMismatch::PartialRotaryFactor {
+                expected_bits: Some(0.25f32.to_bits()),
+                observed_bits: None,
+            }),
+        );
+        assert_field_diverges(
+            "partial_rotary_factor None->Some spelling",
+            |d| d.set_partial_rotary_factor(Some(1.0)),
+            Some(KvCompatMismatch::PartialRotaryFactor {
+                expected_bits: Some(1.0f32.to_bits()),
+                observed_bits: None,
+            }),
+        );
+        assert_field_diverges(
+            "layer_types",
+            |d| d.layer_types = vec!["global".to_string(), "local".to_string()],
+            Some(KvCompatMismatch::LayerTypes {
+                expected: vec!["global".to_string(), "local".to_string()],
+                observed: Vec::new(),
+            }),
+        );
+        // layer_types must be compared case-insensitively (canonicalized).
+        {
+            let mut d = baseline();
+            let fp0 = d.fingerprint();
+            d.layer_types = vec!["GLOBAL".to_string(), "Local".to_string()];
+            let mut d2 = baseline();
+            d2.layer_types = vec!["global".to_string(), "local".to_string()];
+            assert_eq!(
+                d.fingerprint(),
+                d2.fingerprint(),
+                "layer_types casing must canonicalize before hashing"
+            );
+            assert_ne!(fp0, d.fingerprint(), "non-empty layer layout must diverge");
+        }
+        for (field, val) in [
+            ("linear_key_head_dim", 512usize),
+            ("linear_value_head_dim", 256usize),
+            ("linear_num_key_heads", 8usize),
+            ("linear_num_value_heads", 8usize),
+            ("linear_conv_kernel_dim", 4usize),
+        ] {
+            let mut d = baseline();
+            set_linear_dim(&mut d, field, val);
+            let divergent_fp = d.fingerprint();
+            assert_ne!(
+                baseline().fingerprint(),
+                divergent_fp,
+                "{field}: changing the linear dim must change the fingerprint"
+            );
+            assert_eq!(
+                check_compatibility(&d, &baseline()).unwrap_err(),
+                geometry(field, val, 0),
+                "{field}: mismatch variant"
+            );
+        }
         // Position encoding.
         assert_field_diverges(
             "rope_theta",
@@ -1091,7 +1413,97 @@ mod tests {
         // Adapter generation changes the fingerprint.
         let mut d = baseline();
         let fp0 = d.fingerprint();
-        d.weights = WeightIdentity::base_only("my-model").with_adapter(1);
+        d.weights = WeightIdentity::base_only("sha256:my-model-weights").with_adapter(1);
         assert_ne!(fp0, d.fingerprint());
+    }
+
+    /// Golden digest: pins the exact canonical bytes of a fully-populated
+    /// descriptor across builds/refactors. If this changes, it is an intentional
+    /// format bump (`KV_COMPAT_FORMAT_VERSION`) — never a silent drift.
+    #[test]
+    fn golden_digest_is_pinned() {
+        let fp = baseline().fingerprint();
+        let hex = fp.to_hex();
+        let expected = "767058c0b3505492e27b5f477f7cec63344a5a78c9bafa7837d44deab5730170";
+        assert_eq!(
+            hex, expected,
+            "KV-compat golden digest drifted; computed = {hex}. \
+             If the canonical encoding changed intentionally, bump \
+             KV_COMPAT_FORMAT_VERSION and update this pinned value."
+        );
+    }
+
+    /// Two weight snapshots sharing a basename but differing in *content* must
+    /// diverge in base identity (the #1277 "authoritative, not a label" rule).
+    #[test]
+    fn base_revision_content_diverges() {
+        let mut a = baseline();
+        let mut b = baseline();
+        a.weights.base_revision = "sha256:snapshot-A".into();
+        b.weights.base_revision = "sha256:snapshot-B".into();
+        assert_ne!(
+            a.fingerprint(),
+            b.fingerprint(),
+            "different base-weight content must produce different fingerprints"
+        );
+        // Same content → same fingerprint (stable).
+        let mut c = baseline();
+        c.weights.base_revision = "sha256:snapshot-A".into();
+        assert_eq!(a.fingerprint(), c.fingerprint());
+    }
+
+    #[test]
+    fn authority_completeness_gate() {
+        // Baseline is fully authoritative.
+        assert!(baseline().is_authoritatively_complete());
+
+        // Missing base-weight digest → not authoritative (fail-closed).
+        let mut no_base = baseline();
+        no_base.weights.base_revision.clear();
+        assert!(!no_base.is_authoritatively_complete());
+
+        // Missing tokenizer identity → not authoritative (fail-closed).
+        let mut no_tok = baseline();
+        no_tok.tokenizer_hash = None;
+        assert!(!no_tok.is_authoritatively_complete());
+    }
+
+    #[test]
+    fn decide_cache_reuse_is_fail_closed() {
+        use CacheReuseDecision::*;
+        let exp = baseline().fingerprint();
+        let other = {
+            let mut d = baseline();
+            d.kv_quant = KvQuantMode::Int8;
+            d.fingerprint()
+        };
+
+        // Authoritative + matching stamp → reuse.
+        assert_eq!(decide_cache_reuse(Some(&exp), Some(&exp), false), Reuse);
+        assert_eq!(decide_cache_reuse(Some(&exp), Some(&exp), true), Reuse);
+
+        // Authoritative + mismatching stamp → discard.
+        assert_eq!(
+            decide_cache_reuse(Some(&exp), Some(&other), false),
+            DiscardAndRecompute
+        );
+
+        // Authoritative + empty unstamped → stamp fresh and reuse (empty) cache.
+        assert_eq!(decide_cache_reuse(Some(&exp), None, true), StampFresh);
+
+        // Authoritative + POPULATED unstamped → fail-closed discard (the bug fix).
+        assert_eq!(
+            decide_cache_reuse(Some(&exp), None, false),
+            DiscardAndRecompute
+        );
+
+        // No authoritative identity at all → always discard, even on an empty
+        // unstamped cache (nothing to bless) and even on a stamped cache.
+        assert_eq!(decide_cache_reuse(None, None, true), DiscardAndRecompute);
+        assert_eq!(
+            decide_cache_reuse(None, Some(&exp), false),
+            DiscardAndRecompute
+        );
+        assert_eq!(decide_cache_reuse(None, Some(&exp), true), DiscardAndRecompute);
     }
 }

--- a/crates/hyprstream/src/runtime/mod.rs
+++ b/crates/hyprstream/src/runtime/mod.rs
@@ -38,6 +38,7 @@ pub mod device_pool; // Multi-GPU device abstraction (DevicePool) — Send+Sync,
 pub mod image_utils; // Image loading and preprocessing for multimodal models
 pub mod inference_profile; // Explicit inference isolation/deployment scheduling profile
 pub mod kv_cache; // Key-Value caching for efficient autoregressive generation
+pub mod kv_compat; // KV-cache compatibility fingerprint + rejection policy (#1277)
 pub mod model_config; // Unified model configuration management
 pub mod model_factory; // Single factory for model creation
 pub mod rope; // Rotary Position Embedding (RoPE) implementation
@@ -56,6 +57,12 @@ pub use device_pool::DevicePool;
 
 // KV cache exports for multi-session support
 pub use kv_cache::{CacheConfig, CacheOwner, KVCacheManager, KVCacheRegistry};
+
+// KV-cache compatibility fingerprint + rejection policy (#1277)
+pub use kv_compat::{
+    check_compatibility, KvCompatDescriptor, KvCompatFingerprint, KvCompatMismatch,
+    KvDtype, KvQuantMode, WeightIdentity, KV_COMPAT_FORMAT_VERSION,
+};
 
 // Generation metrics exports for self-supervised training
 pub use generation_metrics::{GenerationMetricsAccumulator, GenerationQualityMetrics, SessionMetrics};

--- a/crates/hyprstream/src/runtime/model_config.rs
+++ b/crates/hyprstream/src/runtime/model_config.rs
@@ -60,6 +60,14 @@ pub struct ModelConfig {
     pub rope_theta: f32,
     pub rope_scaling: Option<RopeScaling>,
 
+    // Local-RoPE / sliding-window attention (Gemma3 local-attention layers).
+    // A non-`None` sliding window restricts which tokens a local layer attends to;
+    // `rope_local_base_freq` is the RoPE theta used in those local layers. Both
+    // change local-layer K/V values, so they are authoritative for KV reuse
+    // (#1277). `None` for architectures without local attention.
+    pub sliding_window: Option<usize>,
+    pub rope_local_base_freq: Option<f32>,
+
     // Normalization
     pub rms_norm_eps: f32,
     pub layer_norm_eps: Option<f32>,
@@ -319,6 +327,10 @@ impl ModelConfig {
                 .or_else(|| config_source["rope_theta"].as_f64())
                 .unwrap_or(10_000.0) as f32,
             rope_scaling: Self::parse_rope_scaling(config_source),
+            // Local-RoPE / sliding-window (Gemma3); absent (None) for non-local
+            // architectures — present only when config.json carries them.
+            sliding_window: config_source["sliding_window"].as_u64().map(|v| v as usize),
+            rope_local_base_freq: config_source["rope_local_base_freq"].as_f64().map(|v| v as f32),
 
             rms_norm_eps: config_source["rms_norm_eps"].as_f64().unwrap_or(1e-5) as f32,
             layer_norm_eps: config_source["layer_norm_eps"].as_f64().map(|v| v as f32),
@@ -746,6 +758,8 @@ impl Default for ModelConfig {
             max_position_embeddings: 4096,
             rope_theta: 10_000.0,
             rope_scaling: None,
+            sliding_window: None,
+            rope_local_base_freq: None,
             rms_norm_eps: 1e-5,
             layer_norm_eps: None,
             hidden_activation: "silu".to_owned(),

--- a/crates/hyprstream/src/runtime/model_factory.rs
+++ b/crates/hyprstream/src/runtime/model_factory.rs
@@ -71,6 +71,24 @@ fn glob_shard_files(model_path: &Path) -> Result<Vec<std::path::PathBuf>> {
 /// Factory for creating models with proper configuration management
 pub struct ModelFactory;
 
+/// Resolved content of a weight shard after transparent LFS/XET pointer
+/// resolution — the exact bytes the loader builds tensors from.
+///
+/// Large ordinary shards are returned as an open [`File`] so the KV-compat
+/// base-weight digest can *stream* them (the on-disk bytes ARE the content —
+/// already smudged, or never a pointer). A resolved pointer, or any small file,
+/// is returned owned. This is the single shared resolution surface used by both
+/// the loader ([`ModelFactory::load_file_with_pointer_detection`]) and the
+/// KV-compat digest ([`ModelFactory::resolve_weight_for_digest`]) so the two
+/// never disagree about what bytes a shard resolves to (#1277).
+pub(crate) enum ResolvedWeight {
+    /// Resolved bytes held in memory (a resolved LFS/XET pointer, or a small
+    /// ordinary file).
+    Owned(Vec<u8>),
+    /// An open ordinary file ≥1 KiB; read or stream it directly.
+    File(std::fs::File),
+}
+
 impl ModelFactory {
     /// Detect the dtype of a model by examining its tensors
     pub async fn detect_model_dtype(model_path: &Path) -> Result<DType> {
@@ -383,6 +401,8 @@ impl ModelFactory {
     /// Load file with automatic LFS/XET pointer detection
     ///
     /// Fast path for already-smudged files, fallback for un-smudged pointers.
+    /// Resolution is shared with the KV-compat base-weight digest via
+    /// [`Self::try_resolve_lfs_pointer`] so both see the identical bytes (#1277).
     async fn load_file_with_pointer_detection(path: &Path) -> Result<Vec<u8>> {
         let metadata = tokio::fs::metadata(path).await?;
 
@@ -392,34 +412,80 @@ impl ModelFactory {
         }
 
         let data = tokio::fs::read(path).await?;
-
-        // Check for LFS pointer header
-        if data.len() < 1024 {
-            if let Ok(text) = String::from_utf8(data.clone()) {
-                if text.starts_with("version https://git-lfs") || text.starts_with("version https://hawser") {
-                    #[cfg(feature = "xet")]
-                    {
-                        debug!("Un-smudged LFS pointer, using git2db::lfs fallback: {}", path.display());
-                        let config = git2db::XetConfig::default();
-                        let storage = git2db::LfsStorage::new(&config).await
-                            .map_err(|e| anyhow!("Failed to create LfsStorage: {}", e))?;
-                        return storage.load_file(path).await
-                            .map_err(|e| anyhow!("Failed to load LFS file: {}", e));
-                    }
-
-                    #[cfg(not(feature = "xet"))]
-                    {
-                        anyhow::bail!(
-                            "Un-smudged LFS pointer at {} but XET feature disabled. \
-                             Enable with --features xet or ensure files are smudged during checkout.",
-                            path.display()
-                        );
-                    }
-                }
-            }
+        if let Some(resolved) = Self::try_resolve_lfs_pointer(path, &data).await? {
+            return Ok(resolved);
         }
-
         Ok(data)
+    }
+
+    /// If `data` is an un-smudged LFS/XET pointer, resolve it to the actual
+    /// object content via the git2db LFS fallback. Returns `Ok(None)` when
+    /// `data` is ordinary content (no pointer header, or too large to be one).
+    /// Any resolution failure propagates as an error — **fail-closed**: the
+    /// caller (loader *and* the KV-compat digest) never silently hashes or
+    /// deserializes a pointer stub in place of the resolved bytes.
+    ///
+    /// Single source of truth for pointer resolution: extracted from the old
+    /// inline block in `load_file_with_pointer_detection`.
+    async fn try_resolve_lfs_pointer(path: &Path, data: &[u8]) -> Result<Option<Vec<u8>>> {
+        // Large buffers cannot be LFS pointers (which are < 1 KiB).
+        if data.len() >= 1024 {
+            return Ok(None);
+        }
+        let text = match std::str::from_utf8(data) {
+            Ok(t) => t,
+            Err(_) => return Ok(None),
+        };
+        if !text.starts_with("version https://git-lfs")
+            && !text.starts_with("version https://hawser")
+        {
+            return Ok(None);
+        }
+        #[cfg(feature = "xet")]
+        {
+            debug!("Un-smudged LFS pointer, resolving via git2db::lfs fallback: {}", path.display());
+            let config = git2db::XetConfig::default();
+            let storage = git2db::LfsStorage::new(&config)
+                .await
+                .map_err(|e| anyhow!("Failed to create LfsStorage: {}", e))?;
+            let bytes = storage
+                .load_file(path)
+                .await
+                .map_err(|e| anyhow!("Failed to load LFS file: {}", e))?;
+            Ok(Some(bytes))
+        }
+        #[cfg(not(feature = "xet"))]
+        {
+            let _ = path;
+            anyhow::bail!(
+                "Un-smudged LFS pointer at {} but XET feature disabled. \
+                 Enable with --features xet or ensure files are smudged during checkout.",
+                path.display()
+            )
+        }
+    }
+
+    /// Resolve a weight shard for the KV-compat base-weight digest (#1277).
+    ///
+    /// Returns the shard's resolved content: a large ordinary shard as an open
+    /// [`File`] (to stream), and a resolved pointer or any small file as owned
+    /// bytes. This walks the **same** resolution path as the loader
+    /// ([`Self::load_file_with_pointer_detection`] → [`Self::try_resolve_lfs_pointer`]),
+    /// so the digest hashes the actual tensor bytes — never a pointer stub — and
+    /// fails closed (returns `Err`) on any metadata/read/resolve error.
+    pub(crate) async fn resolve_weight_for_digest(path: &Path) -> Result<ResolvedWeight> {
+        let metadata = tokio::fs::metadata(path).await?;
+        // A large file cannot be an LFS pointer (pointers are < 1 KiB): its
+        // on-disk bytes are the resolved content — stream it, don't buffer it.
+        if metadata.len() >= 1024 {
+            let file = std::fs::File::open(path)?;
+            return Ok(ResolvedWeight::File(file));
+        }
+        let data = tokio::fs::read(path).await?;
+        if let Some(resolved) = Self::try_resolve_lfs_pointer(path, &data).await? {
+            return Ok(ResolvedWeight::Owned(resolved));
+        }
+        Ok(ResolvedWeight::Owned(data))
     }
 
     /// Create tensors from deserialized safetensors

--- a/crates/hyprstream/src/runtime/model_factory.rs
+++ b/crates/hyprstream/src/runtime/model_factory.rs
@@ -217,7 +217,11 @@ impl ModelFactory {
     ///
     /// Prefers `model.safetensors.index.json` (authoritative HuggingFace shard manifest)
     /// over filename glob patterns, which are fragile across model families.
-    fn find_shard_files(model_path: &Path) -> Result<Vec<std::path::PathBuf>> {
+    ///
+    /// This is THE loader's shard selector — also used by the KV-compat
+    /// base-weight digest (#1277) so the fingerprint covers exactly the
+    /// loader-selected set, never extra/unreferenced `.safetensors` files.
+    pub(crate) fn find_shard_files(model_path: &Path) -> Result<Vec<std::path::PathBuf>> {
         // 1. Use index file if present (most reliable)
         let index_path = model_path.join("model.safetensors.index.json");
         if index_path.exists() {

--- a/crates/hyprstream/src/runtime/model_factory.rs
+++ b/crates/hyprstream/src/runtime/model_factory.rs
@@ -238,6 +238,33 @@ impl ModelFactory {
         glob_shard_files(model_path)
     }
 
+    /// Shard selection for the KV-compat base-weight digest (#1277).
+    ///
+    /// Fingerprint authority is stricter than loader permissiveness: the
+    /// loader may warn-and-continue on a manifest-less multi-shard glob
+    /// (unless [`STRICT_LOADER_ENV`]), but the digest must NEVER mint an
+    /// authoritative identity over that ambiguous set — a glob can silently
+    /// drop/duplicate shards, so two snapshots could share a fingerprint
+    /// while loading different weights. Such a set is rejected here
+    /// regardless of `HYPRSTREAM_STRICT_LOADER`, and the caller declines KV
+    /// reuse. A single globbed shard remains unambiguous and passes.
+    pub(crate) fn find_shard_files_for_digest(
+        model_path: &Path,
+    ) -> Result<Vec<std::path::PathBuf>> {
+        let shards = Self::find_shard_files(model_path)?;
+        if shards.len() > 1 && !model_path.join("model.safetensors.index.json").exists() {
+            return Err(anyhow!(
+                "{} loader-selected .safetensors shards in {} but no \
+                 model.safetensors.index.json manifest; the glob-selected set is \
+                 ambiguous, so no authoritative base-weight digest can be minted \
+                 (KV reuse is declined). Provide the index.json manifest.",
+                shards.len(),
+                model_path.display()
+            ));
+        }
+        Ok(shards)
+    }
+
     /// Parse shard filenames from `model.safetensors.index.json`.
     /// Returns unique shard paths in sorted order (guaranteed by the index).
     fn shard_files_from_index(

--- a/crates/hyprstream/src/runtime/torch_engine.rs
+++ b/crates/hyprstream/src/runtime/torch_engine.rs
@@ -765,40 +765,52 @@ impl TorchEngine {
     }
 
     /// Authoritative content digest of the base weights actually loaded from
-    /// `model_path` — a canonical SHA-256 over every `.safetensors` shard's
-    /// **resolved** bytes (shard count + length-prefixed name + per-shard content
-    /// digest), in sorted name order. This is the base-weight identity for the
-    /// KV-compat fingerprint (#1277): two snapshots sharing a basename but
-    /// differing in content diverge here, unlike a path/label.
+    /// `model_path` — a canonical SHA-256 over the **loader-selected**
+    /// `.safetensors` shards' **resolved** bytes (shard count + length-prefixed
+    /// name + per-shard content digest), in sorted name order. This is the
+    /// base-weight identity for the KV-compat fingerprint (#1277): two snapshots
+    /// sharing a basename but differing in content diverge here, unlike a
+    /// path/label.
+    ///
+    /// The shard set comes from the **same selector the loader uses**
+    /// (`ModelFactory::find_shard_files`: `model.safetensors.index.json` →
+    /// `model.safetensors` → shard-name glob), so the digest covers EXACTLY the
+    /// shards the loader reads — an extra/unreferenced `.safetensors` in the
+    /// directory (stale shard, alt-precision copy) cannot shift the fingerprint
+    /// while the loaded weights are identical.
     ///
     /// The digest hashes the **resolved** bytes — the identical resolution path
     /// the loader walks (`ModelFactory::resolve_weight_for_digest` transparently
     /// resolves an un-smudged LFS/XET pointer to its object content), so it never
     /// hashes a pointer stub in place of the real tensors. It is **fail-closed**:
-    /// any directory/entry/read/resolve error propagates, so the caller declines
+    /// any selection/read/resolve error, an empty selection, or an
+    /// index-referenced shard that is missing propagates, so the caller declines
     /// to mint a descriptor and KV reuse fails closed rather than hashing a
     /// partial shard set.
     async fn weights_content_digest(model_path: &Path) -> Result<String> {
         use crate::runtime::kv_compat;
         use crate::runtime::model_factory::{ModelFactory, ResolvedWeight};
 
-        // Fail-closed shard enumeration: propagate EVERY directory/entry error.
-        // (No `filter_map(Result::ok)` — swallowing an entry error would make the
-        // digest authoritative over a partial shard set, the opposite of closed.)
-        let mut shards: Vec<std::path::PathBuf> = Vec::new();
-        for entry in std::fs::read_dir(model_path)? {
-            let entry = entry?;
-            let path = entry.path();
-            if path.extension().and_then(|e| e.to_str()) == Some("safetensors") {
-                shards.push(path);
-            }
-        }
-        shards.sort();
+        // Resolve the loader-selected shard set (the loader's own selector).
+        let shards = ModelFactory::find_shard_files(model_path)?;
+
+        // Fail closed on an empty or inconsistent selection: the loader would
+        // have nothing authoritative to load (or the index disagrees with the
+        // directory), so reuse must be declined rather than minted over a
+        // partial/ambiguous set.
         if shards.is_empty() {
             anyhow::bail!(
-                "no .safetensors weight shards in {}",
+                "no loader-selected .safetensors weight shards in {}",
                 model_path.display()
             );
+        }
+        for shard in &shards {
+            if !shard.is_file() {
+                anyhow::bail!(
+                    "loader-selected shard {} is missing or not a regular file",
+                    shard.display()
+                );
+            }
         }
 
         let mut digested: Vec<(String, [u8; 32])> = Vec::with_capacity(shards.len());
@@ -2662,8 +2674,10 @@ mod tests {
     // ---- base-weight content digest (#1277, finding F1) ----
     //
     // The pure framing/digest helpers live in `kv_compat`; these cover the engine
-    // seam: fail-closed shard enumeration, resolved-byte hashing (incl. LFS/XET
-    // pointer handling), determinism, and parity with the pure helpers.
+    // seam: loader-selected shard-set resolution (extra/unreferenced `.safetensors`
+    // files are never hashed), fail-closed selection, resolved-byte hashing
+    // (incl. LFS/XET pointer handling), determinism, and parity with the pure
+    // helpers.
 
     use crate::runtime::kv_compat;
 
@@ -2674,6 +2688,24 @@ mod tests {
         let mut f = std::fs::File::create(&p).unwrap();
         f.write_all(bytes).unwrap();
         p
+    }
+
+    /// Write a minimal `model.safetensors.index.json` whose `weight_map`
+    /// references exactly `shard_names`.
+    fn write_index(dir: &std::path::Path, shard_names: &[&str]) {
+        let weight_map: serde_json::Map<String, serde_json::Value> = shard_names
+            .iter()
+            .enumerate()
+            .map(|(i, name)| {
+                (format!("tensor.{i}"), serde_json::Value::String((*name).to_owned()))
+            })
+            .collect();
+        let index = serde_json::json!({ "weight_map": weight_map });
+        std::fs::write(
+            dir.join("model.safetensors.index.json"),
+            serde_json::to_string_pretty(&index).unwrap(),
+        )
+        .unwrap();
     }
 
     #[tokio::test]
@@ -2795,6 +2827,132 @@ mod tests {
         assert!(
             res.is_err(),
             "an unreadable shard must fail closed, not hash a partial set"
+        );
+    }
+
+    /// An extra/unreferenced `.safetensors` in the directory must NOT shift the
+    /// digest: only the index-referenced (loader-selected) shards are hashed.
+    #[tokio::test]
+    async fn weights_content_digest_ignores_unreferenced_extra_shard() {
+        let dir = tempfile::tempdir().unwrap();
+        write_shard(dir.path(), "model-00001-of-00002.safetensors", b"AAAA-content");
+        write_shard(dir.path(), "model-00002-of-00002.safetensors", b"BBBB-content");
+        write_index(dir.path(), &[
+            "model-00001-of-00002.safetensors",
+            "model-00002-of-00002.safetensors",
+        ]);
+        let selected_only = TorchEngine::weights_content_digest(dir.path()).await.unwrap();
+
+        // A stale shard with a shard-like name the loader never references.
+        write_shard(dir.path(), "model-00003-of-00002.safetensors", b"STALE-alt-precision");
+        let with_extra = TorchEngine::weights_content_digest(dir.path()).await.unwrap();
+
+        assert_eq!(
+            selected_only, with_extra,
+            "an unreferenced extra shard must be invariant to the digest"
+        );
+        let expected = kv_compat::base_weight_digest_from_shards(&[
+            ("model-00001-of-00002.safetensors".into(), kv_compat::shard_content_digest(b"AAAA-content")),
+            ("model-00002-of-00002.safetensors".into(), kv_compat::shard_content_digest(b"BBBB-content")),
+        ]);
+        assert_eq!(
+            with_extra, expected,
+            "digest must cover exactly the loader-selected set, no more"
+        );
+    }
+
+    /// With a single `model.safetensors`, an extra shard-like file is not part
+    /// of the loader's selection and must not shift the digest.
+    #[tokio::test]
+    async fn weights_content_digest_single_file_ignores_extra_shard() {
+        let dir = tempfile::tempdir().unwrap();
+        write_shard(dir.path(), "model.safetensors", b"single-file-weights");
+        let baseline = TorchEngine::weights_content_digest(dir.path()).await.unwrap();
+        let expected = kv_compat::base_weight_digest_from_shards(&[(
+            "model.safetensors".into(),
+            kv_compat::shard_content_digest(b"single-file-weights"),
+        )]);
+        assert_eq!(baseline, expected);
+
+        // Even a name matching the shard glob is not selected when
+        // `model.safetensors` is the loader's pick.
+        write_shard(dir.path(), "model-00001-of-00001.safetensors", b"UNREFERENCED");
+        let with_extra = TorchEngine::weights_content_digest(dir.path()).await.unwrap();
+        assert_eq!(
+            baseline, with_extra,
+            "an extra shard next to model.safetensors must be invariant"
+        );
+    }
+
+    /// Changing a SELECTED shard changes the digest; adding, removing, or
+    /// mutating an UNREFERENCED shard does not.
+    #[tokio::test]
+    async fn weights_content_digest_selected_mutations_diverge_unreferenced_do_not() {
+        let dir = tempfile::tempdir().unwrap();
+        write_shard(dir.path(), "model-00001-of-00002.safetensors", b"AAAA-content");
+        write_shard(dir.path(), "model-00002-of-00002.safetensors", b"BBBB-content");
+        write_index(dir.path(), &[
+            "model-00001-of-00002.safetensors",
+            "model-00002-of-00002.safetensors",
+        ]);
+        let baseline = TorchEngine::weights_content_digest(dir.path()).await.unwrap();
+
+        // Add an unreferenced shard.
+        let extra = write_shard(dir.path(), "stale-backup.safetensors", b"stale");
+        assert_eq!(
+            TorchEngine::weights_content_digest(dir.path()).await.unwrap(),
+            baseline,
+            "adding an unreferenced shard must not change the digest"
+        );
+        // Mutate the unreferenced shard.
+        write_shard(dir.path(), "stale-backup.safetensors", b"stale-CHANGED");
+        assert_eq!(
+            TorchEngine::weights_content_digest(dir.path()).await.unwrap(),
+            baseline,
+            "mutating an unreferenced shard must not change the digest"
+        );
+        // Remove the unreferenced shard.
+        std::fs::remove_file(&extra).unwrap();
+        assert_eq!(
+            TorchEngine::weights_content_digest(dir.path()).await.unwrap(),
+            baseline,
+            "removing an unreferenced shard must not change the digest"
+        );
+        // Change a SELECTED shard.
+        write_shard(dir.path(), "model-00002-of-00002.safetensors", b"BBBB-CHANGED");
+        assert_ne!(
+            TorchEngine::weights_content_digest(dir.path()).await.unwrap(),
+            baseline,
+            "changing a selected shard must change the digest"
+        );
+    }
+
+    /// A directory whose only `.safetensors` files match no loader selection
+    /// pattern has ZERO selected shards and must fail closed (reuse declined).
+    #[tokio::test]
+    async fn weights_content_digest_zero_selected_shards_fails_closed() {
+        let dir = tempfile::tempdir().unwrap();
+        write_shard(dir.path(), "backup.safetensors", b"not-a-selected-shard");
+        write_shard(dir.path(), "optimizer.safetensors", b"also-not-selected");
+        assert!(
+            TorchEngine::weights_content_digest(dir.path()).await.is_err(),
+            "a dir with no loader-selected shards must fail closed"
+        );
+    }
+
+    /// An index referencing a shard that does not exist on disk is an
+    /// inconsistent selection and must fail closed (reuse declined).
+    #[tokio::test]
+    async fn weights_content_digest_missing_index_shard_fails_closed() {
+        let dir = tempfile::tempdir().unwrap();
+        write_shard(dir.path(), "model-00001-of-00002.safetensors", b"AAAA-content");
+        write_index(dir.path(), &[
+            "model-00001-of-00002.safetensors",
+            "model-00002-of-00002.safetensors", // referenced but absent
+        ]);
+        assert!(
+            TorchEngine::weights_content_digest(dir.path()).await.is_err(),
+            "an index referencing a missing shard must fail closed"
         );
     }
 

--- a/crates/hyprstream/src/runtime/torch_engine.rs
+++ b/crates/hyprstream/src/runtime/torch_engine.rs
@@ -773,26 +773,31 @@ impl TorchEngine {
     /// path/label.
     ///
     /// The shard set comes from the **same selector the loader uses**
-    /// (`ModelFactory::find_shard_files`: `model.safetensors.index.json` →
+    /// (`ModelFactory::find_shard_files_for_digest`, the digest-authoritative
+    /// variant of the loader's selector: `model.safetensors.index.json` →
     /// `model.safetensors` → shard-name glob), so the digest covers EXACTLY the
     /// shards the loader reads — an extra/unreferenced `.safetensors` in the
     /// directory (stale shard, alt-precision copy) cannot shift the fingerprint
-    /// while the loaded weights are identical.
+    /// while the loaded weights are identical. Unlike the loader, the digest
+    /// REJECTS an ambiguous manifest-less multi-shard glob set regardless of
+    /// `HYPRSTREAM_STRICT_LOADER` — fingerprint authority is stricter than
+    /// loader permissiveness.
     ///
     /// The digest hashes the **resolved** bytes — the identical resolution path
     /// the loader walks (`ModelFactory::resolve_weight_for_digest` transparently
     /// resolves an un-smudged LFS/XET pointer to its object content), so it never
     /// hashes a pointer stub in place of the real tensors. It is **fail-closed**:
-    /// any selection/read/resolve error, an empty selection, or an
-    /// index-referenced shard that is missing propagates, so the caller declines
-    /// to mint a descriptor and KV reuse fails closed rather than hashing a
-    /// partial shard set.
+    /// any selection/read/resolve error, an empty selection, an
+    /// index-referenced shard that is missing, or an ambiguous manifest-less
+    /// multi-shard set propagates, so the caller declines to mint a descriptor
+    /// and KV reuse fails closed rather than hashing a partial shard set.
     async fn weights_content_digest(model_path: &Path) -> Result<String> {
         use crate::runtime::kv_compat;
         use crate::runtime::model_factory::{ModelFactory, ResolvedWeight};
 
-        // Resolve the loader-selected shard set (the loader's own selector).
-        let shards = ModelFactory::find_shard_files(model_path)?;
+        // Resolve the loader-selected shard set (the digest-authoritative
+        // variant of the loader's own selector).
+        let shards = ModelFactory::find_shard_files_for_digest(model_path)?;
 
         // Fail closed on an empty or inconsistent selection: the loader would
         // have nothing authoritative to load (or the index disagrees with the
@@ -2713,6 +2718,10 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         write_shard(dir.path(), "model-00001-of-00002.safetensors", b"AAAA-content");
         write_shard(dir.path(), "model-00002-of-00002.safetensors", b"BBBB-content");
+        write_index(dir.path(), &[
+            "model-00001-of-00002.safetensors",
+            "model-00002-of-00002.safetensors",
+        ]);
         let a = TorchEngine::weights_content_digest(dir.path()).await.unwrap();
         let b = TorchEngine::weights_content_digest(dir.path()).await.unwrap();
         assert_eq!(a, b, "digest must be deterministic across runs");
@@ -2730,8 +2739,16 @@ mod tests {
         let d2 = tempfile::tempdir().unwrap();
         write_shard(d1.path(), "model-00001-of-00002.safetensors", b"content-A");
         write_shard(d1.path(), "model-00002-of-00002.safetensors", b"content-B");
+        write_index(d1.path(), &[
+            "model-00001-of-00002.safetensors",
+            "model-00002-of-00002.safetensors",
+        ]);
         write_shard(d2.path(), "model-00001-of-00002.safetensors", b"content-A!");
         write_shard(d2.path(), "model-00002-of-00002.safetensors", b"content-B");
+        write_index(d2.path(), &[
+            "model-00001-of-00002.safetensors",
+            "model-00002-of-00002.safetensors",
+        ]);
         let a = TorchEngine::weights_content_digest(d1.path()).await.unwrap();
         let b = TorchEngine::weights_content_digest(d2.path()).await.unwrap();
         assert_ne!(a, b, "same basenames, different content must diverge");
@@ -2745,9 +2762,17 @@ mod tests {
         let d2 = tempfile::tempdir().unwrap();
         write_shard(d1.path(), "model-00001-of-00002.safetensors", b"X");
         write_shard(d1.path(), "model-00002-of-00002.safetensors", b"Y");
+        write_index(d1.path(), &[
+            "model-00001-of-00002.safetensors",
+            "model-00002-of-00002.safetensors",
+        ]);
         // Reverse creation order in d2.
         write_shard(d2.path(), "model-00002-of-00002.safetensors", b"Y");
         write_shard(d2.path(), "model-00001-of-00002.safetensors", b"X");
+        write_index(d2.path(), &[
+            "model-00001-of-00002.safetensors",
+            "model-00002-of-00002.safetensors",
+        ]);
         let a = TorchEngine::weights_content_digest(d1.path()).await.unwrap();
         let b = TorchEngine::weights_content_digest(d2.path()).await.unwrap();
         assert_eq!(a, b, "digest must be independent of enumeration order");
@@ -2953,6 +2978,43 @@ mod tests {
         assert!(
             TorchEngine::weights_content_digest(dir.path()).await.is_err(),
             "an index referencing a missing shard must fail closed"
+        );
+    }
+
+    /// A manifest-less MULTI-shard glob selection is ambiguous (the glob can
+    /// silently drop/duplicate shards), so the digest must fail closed —
+    /// decline reuse — even though the LOADER only warns in its permissive
+    /// default mode. Fingerprint authority is stricter than loader
+    /// permissiveness (#1277 revise-4): this holds regardless of
+    /// `HYPRSTREAM_STRICT_LOADER` (the test env does not set it, exercising
+    /// the permissive loader path).
+    #[tokio::test]
+    async fn weights_content_digest_manifestless_multi_shard_fails_closed() {
+        let dir = tempfile::tempdir().unwrap();
+        write_shard(dir.path(), "model-00001-of-00002.safetensors", b"AAAA-content");
+        write_shard(dir.path(), "model-00002-of-00002.safetensors", b"BBBB-content");
+        // NO model.safetensors.index.json — the loader warns and continues;
+        // the digest must refuse.
+        assert!(
+            TorchEngine::weights_content_digest(dir.path()).await.is_err(),
+            "an ambiguous manifest-less multi-shard glob set must fail closed"
+        );
+    }
+
+    /// A SINGLE globbed shard (no index, no model.safetensors) is unambiguous
+    /// and must still digest — only multi-shard glob sets are ambiguous.
+    #[tokio::test]
+    async fn weights_content_digest_single_globbed_shard_passes() {
+        let dir = tempfile::tempdir().unwrap();
+        write_shard(dir.path(), "model-00001-of-00001.safetensors", b"single-shard-content");
+        let digest = TorchEngine::weights_content_digest(dir.path()).await.unwrap();
+        let expected = kv_compat::base_weight_digest_from_shards(&[(
+            "model-00001-of-00001.safetensors".into(),
+            kv_compat::shard_content_digest(b"single-shard-content"),
+        )]);
+        assert_eq!(
+            digest, expected,
+            "a single globbed shard is unambiguous and must digest"
         );
     }
 

--- a/crates/hyprstream/src/runtime/torch_engine.rs
+++ b/crates/hyprstream/src/runtime/torch_engine.rs
@@ -765,47 +765,82 @@ impl TorchEngine {
     }
 
     /// Authoritative content digest of the base weights actually loaded from
-    /// `model_path` — a SHA-256 over every `.safetensors` shard (filename + full
-    /// bytes) in sorted name order. This is the base-weight identity for the
+    /// `model_path` — a canonical SHA-256 over every `.safetensors` shard's
+    /// **resolved** bytes (shard count + length-prefixed name + per-shard content
+    /// digest), in sorted name order. This is the base-weight identity for the
     /// KV-compat fingerprint (#1277): two snapshots sharing a basename but
-    /// differing in content diverge here, unlike a path/label. Streams each
-    /// shard in 64 KiB chunks; returns an error when there are no shards or a
-    /// shard cannot be read, in which case the caller declines to build a
-    /// descriptor and KV reuse fails closed.
-    fn weights_content_digest(model_path: &Path) -> std::result::Result<String, std::io::Error> {
-        use sha2::Digest;
-        use std::io::Read;
-        let mut shards: Vec<std::path::PathBuf> = std::fs::read_dir(model_path)?
-            .filter_map(Result::ok)
-            .map(|e| e.path())
-            .filter(|p| p.extension().and_then(|e| e.to_str()) == Some("safetensors"))
-            .collect();
+    /// differing in content diverge here, unlike a path/label.
+    ///
+    /// The digest hashes the **resolved** bytes — the identical resolution path
+    /// the loader walks (`ModelFactory::resolve_weight_for_digest` transparently
+    /// resolves an un-smudged LFS/XET pointer to its object content), so it never
+    /// hashes a pointer stub in place of the real tensors. It is **fail-closed**:
+    /// any directory/entry/read/resolve error propagates, so the caller declines
+    /// to mint a descriptor and KV reuse fails closed rather than hashing a
+    /// partial shard set.
+    async fn weights_content_digest(model_path: &Path) -> Result<String> {
+        use crate::runtime::kv_compat;
+        use crate::runtime::model_factory::{ModelFactory, ResolvedWeight};
+
+        // Fail-closed shard enumeration: propagate EVERY directory/entry error.
+        // (No `filter_map(Result::ok)` — swallowing an entry error would make the
+        // digest authoritative over a partial shard set, the opposite of closed.)
+        let mut shards: Vec<std::path::PathBuf> = Vec::new();
+        for entry in std::fs::read_dir(model_path)? {
+            let entry = entry?;
+            let path = entry.path();
+            if path.extension().and_then(|e| e.to_str()) == Some("safetensors") {
+                shards.push(path);
+            }
+        }
         shards.sort();
         if shards.is_empty() {
-            return Err(std::io::Error::new(
-                std::io::ErrorKind::NotFound,
-                format!("no .safetensors weight shards in {}", model_path.display()),
-            ));
+            anyhow::bail!(
+                "no .safetensors weight shards in {}",
+                model_path.display()
+            );
         }
-        let mut hasher = sha2::Sha256::new();
-        let mut buf = [0u8; 65536];
+
+        let mut digested: Vec<(String, [u8; 32])> = Vec::with_capacity(shards.len());
         for shard in &shards {
             let name = shard
                 .file_name()
                 .and_then(|s| s.to_str())
-                .unwrap_or("");
-            hasher.update(name.as_bytes());
-            hasher.update([0u8]);
-            let mut f = std::fs::File::open(shard)?;
-            loop {
-                let n = f.read(&mut buf)?;
-                if n == 0 {
-                    break;
-                }
-                hasher.update(&buf[..n]);
-            }
+                .unwrap_or("")
+                .to_owned();
+            // Resolve transparently (LFS/XET pointer → object content), then
+            // hash the resolved bytes. Large ordinary shards stream; resolved
+            // pointers and small files hash their owned bytes.
+            let shard_digest = match ModelFactory::resolve_weight_for_digest(shard).await? {
+                ResolvedWeight::Owned(bytes) => kv_compat::shard_content_digest(&bytes),
+                ResolvedWeight::File(file) => Self::stream_file_digest(file)?,
+            };
+            digested.push((name, shard_digest));
         }
-        Ok(hex::encode(hasher.finalize()))
+        Ok(kv_compat::base_weight_digest_from_shards(&digested))
+    }
+
+    /// SHA-256 of a file's bytes, streamed in 64 KiB chunks so a multi-GB shard
+    /// is never fully buffered into memory just to hash it. Returns the resolved
+    /// read error (fail-closed) rather than a partial digest.
+    fn stream_file_digest(
+        file: std::fs::File,
+    ) -> std::result::Result<[u8; 32], std::io::Error> {
+        use sha2::Digest;
+        use std::io::Read;
+        let mut hasher = sha2::Sha256::new();
+        let mut f = file;
+        let mut buf = [0u8; 65536];
+        loop {
+            let n = f.read(&mut buf)?;
+            if n == 0 {
+                break;
+            }
+            hasher.update(&buf[..n]);
+        }
+        let mut out = [0u8; 32];
+        out.copy_from_slice(hasher.finalize().as_slice());
+        Ok(out)
     }
 
     /// Initialize XET storage with default configuration
@@ -894,11 +929,11 @@ impl TorchEngine {
         // by `load_tokenizer`, before any generation reads the fingerprint. If no
         // authoritative base digest can be computed, the descriptor is left unset
         // and the cache boundary fails closed (KV recomputed, not reused).
-        match Self::weights_content_digest(model_path) {
+        match Self::weights_content_digest(model_path).await {
             Ok(base_revision) => {
                 use crate::runtime::kv_compat::{
-                    KvCompatDescriptor, KvDtype, KvQuantMode, RopeScalingFp, WeightIdentity,
-                    KV_COMPAT_FORMAT_VERSION,
+                    KvCompatDescriptor, KvDtype, KvQuantMode, MoeRouting, RopeScalingFp,
+                    WeightIdentity, KV_COMPAT_FORMAT_VERSION,
                 };
                 let kv_quant = match self.config.kv_quant_type {
                     crate::runtime::KVQuantType::None => KvQuantMode::None,
@@ -934,6 +969,26 @@ impl TorchEngine {
                     linear_num_key_heads: config.linear_num_key_heads,
                     linear_num_value_heads: config.linear_num_value_heads,
                     linear_conv_kernel_dim: config.linear_conv_kernel_dim,
+                    // Effective model config — each demonstrably changes hidden
+                    // states / downstream K/V without changing coarse geometry
+                    // (#1277 review finding F3): normalization epsilon, activation,
+                    // embedding/attention scaling, MoE routing, and local-RoPE /
+                    // sliding-window. Taken verbatim from the resolved ModelConfig
+                    // that constructs the model.
+                    rms_norm_eps_bits: config.rms_norm_eps.to_bits(),
+                    layer_norm_eps_bits: config.layer_norm_eps.map(f32::to_bits),
+                    hidden_activation: config.hidden_activation.clone(),
+                    scale_embeddings: config.scale_embeddings,
+                    query_pre_attn_scalar_bits: config.query_pre_attn_scalar.map(f32::to_bits),
+                    moe: MoeRouting {
+                        is_moe: config.is_moe,
+                        num_experts: config.num_experts,
+                        num_experts_per_tok: config.num_experts_per_tok,
+                        moe_intermediate_size: config.moe_intermediate_size,
+                        shared_expert_intermediate_size: config.shared_expert_intermediate_size,
+                    },
+                    sliding_window: config.sliding_window,
+                    rope_local_base_freq_bits: config.rope_local_base_freq.map(f32::to_bits),
                     rope_theta_bits: config.rope_theta.to_bits(),
                     rope_scaling: config
                         .rope_scaling
@@ -2601,6 +2656,145 @@ mod tests {
         assert!(
             logs.contains("empty token sequence"),
             "failure path must still emit bounded metadata: {logs}"
+        );
+    }
+
+    // ---- base-weight content digest (#1277, finding F1) ----
+    //
+    // The pure framing/digest helpers live in `kv_compat`; these cover the engine
+    // seam: fail-closed shard enumeration, resolved-byte hashing (incl. LFS/XET
+    // pointer handling), determinism, and parity with the pure helpers.
+
+    use crate::runtime::kv_compat;
+
+    /// Write `bytes` to `dir/shard_name`.
+    fn write_shard(dir: &std::path::Path, shard_name: &str, bytes: &[u8]) -> std::path::PathBuf {
+        use std::io::Write;
+        let p = dir.join(shard_name);
+        let mut f = std::fs::File::create(&p).unwrap();
+        f.write_all(bytes).unwrap();
+        p
+    }
+
+    #[tokio::test]
+    async fn weights_content_digest_is_deterministic_and_matches_pure() {
+        let dir = tempfile::tempdir().unwrap();
+        write_shard(dir.path(), "model-00001-of-00002.safetensors", b"AAAA-content");
+        write_shard(dir.path(), "model-00002-of-00002.safetensors", b"BBBB-content");
+        let a = TorchEngine::weights_content_digest(dir.path()).await.unwrap();
+        let b = TorchEngine::weights_content_digest(dir.path()).await.unwrap();
+        assert_eq!(a, b, "digest must be deterministic across runs");
+        // Parity with the pure framing helper (engine resolves+hashes, pure fn frames).
+        let expected = kv_compat::base_weight_digest_from_shards(&[
+            ("model-00001-of-00002.safetensors".into(), kv_compat::shard_content_digest(b"AAAA-content")),
+            ("model-00002-of-00002.safetensors".into(), kv_compat::shard_content_digest(b"BBBB-content")),
+        ]);
+        assert_eq!(a, expected, "engine digest must equal the pure framing over resolved bytes");
+    }
+
+    #[tokio::test]
+    async fn weights_content_digest_same_basename_different_bytes_diverge() {
+        let d1 = tempfile::tempdir().unwrap();
+        let d2 = tempfile::tempdir().unwrap();
+        write_shard(d1.path(), "model-00001-of-00002.safetensors", b"content-A");
+        write_shard(d1.path(), "model-00002-of-00002.safetensors", b"content-B");
+        write_shard(d2.path(), "model-00001-of-00002.safetensors", b"content-A!");
+        write_shard(d2.path(), "model-00002-of-00002.safetensors", b"content-B");
+        let a = TorchEngine::weights_content_digest(d1.path()).await.unwrap();
+        let b = TorchEngine::weights_content_digest(d2.path()).await.unwrap();
+        assert_ne!(a, b, "same basenames, different content must diverge");
+    }
+
+    /// Two shard sets equal as a (name → content) map but enumerated in
+    /// different creation order must produce the same digest (sorted determinism).
+    #[tokio::test]
+    async fn weights_content_digest_is_order_independent() {
+        let d1 = tempfile::tempdir().unwrap();
+        let d2 = tempfile::tempdir().unwrap();
+        write_shard(d1.path(), "model-00001-of-00002.safetensors", b"X");
+        write_shard(d1.path(), "model-00002-of-00002.safetensors", b"Y");
+        // Reverse creation order in d2.
+        write_shard(d2.path(), "model-00002-of-00002.safetensors", b"Y");
+        write_shard(d2.path(), "model-00001-of-00002.safetensors", b"X");
+        let a = TorchEngine::weights_content_digest(d1.path()).await.unwrap();
+        let b = TorchEngine::weights_content_digest(d2.path()).await.unwrap();
+        assert_eq!(a, b, "digest must be independent of enumeration order");
+    }
+
+    #[tokio::test]
+    async fn weights_content_digest_empty_dir_fails_closed() {
+        let dir = tempfile::tempdir().unwrap();
+        assert!(
+            TorchEngine::weights_content_digest(dir.path()).await.is_err(),
+            "an empty model dir must fail closed, not mint a partial digest"
+        );
+    }
+
+    #[tokio::test]
+    async fn weights_content_digest_no_safetensors_fails_closed() {
+        let dir = tempfile::tempdir().unwrap();
+        write_shard(dir.path(), "config.json", b"{}");
+        write_shard(dir.path(), "tokenizer.json", b"{}");
+        assert!(
+            TorchEngine::weights_content_digest(dir.path()).await.is_err(),
+            "a dir with no .safetensors shards must fail closed"
+        );
+    }
+
+    /// A small (<1 KiB) ordinary shard that is NOT an LFS pointer must be hashed
+    /// as content (not skipped, not treated as a pointer).
+    #[tokio::test]
+    async fn weights_content_digest_small_plain_shard_hashed_as_content() {
+        let dir = tempfile::tempdir().unwrap();
+        let bytes = b"tiny-but-real-weights";
+        write_shard(dir.path(), "model.safetensors", bytes);
+        let digest = TorchEngine::weights_content_digest(dir.path()).await.unwrap();
+        let expected = kv_compat::base_weight_digest_from_shards(&[(
+            "model.safetensors".into(),
+            kv_compat::shard_content_digest(bytes),
+        )]);
+        assert_eq!(
+            digest, expected,
+            "a small non-pointer shard must hash its content bytes"
+        );
+    }
+
+    /// An un-smudged LFS/XET pointer shard must fail closed (never be hashed as a
+    /// pointer stub). With no resolvable object store in the test environment,
+    /// resolution errors out → the digest declines.
+    #[tokio::test]
+    async fn weights_content_digest_pointer_fails_closed() {
+        let dir = tempfile::tempdir().unwrap();
+        // A canonical LFS pointer header (<1 KiB). It is not resolvable here.
+        let pointer = b"version https://git-lfs.github.com/spec/v1\noid sha256:0000000000000000000000000000000000000000000000000000000000000000\nsize 1234\n";
+        write_shard(dir.path(), "model.safetensors", pointer);
+        assert!(
+            TorchEngine::weights_content_digest(dir.path()).await.is_err(),
+            "an un-smudged LFS pointer must fail closed, not be hashed as a stub"
+        );
+    }
+
+    /// An unreadable shard must fail closed (read error propagates), not produce
+    /// a digest over the readable remainder. Skipped when running as root (root
+    /// bypasses the 0o000 permission).
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn weights_content_digest_unreadable_shard_fails_closed() {
+        // Root bypasses the 0o000 permission, so the read would succeed and the
+        // fail-closed assertion could not hold — skip silently under root.
+        if unsafe { libc::geteuid() } == 0 {
+            return;
+        }
+        let dir = tempfile::tempdir().unwrap();
+        let p = write_shard(dir.path(), "model.safetensors", b"real-content");
+        use std::os::unix::fs::PermissionsExt;
+        std::fs::set_permissions(&p, std::fs::Permissions::from_mode(0o000)).unwrap();
+        let res = TorchEngine::weights_content_digest(dir.path()).await;
+        // Restore so tempdir cleanup can remove it.
+        let _ = std::fs::set_permissions(&p, std::fs::Permissions::from_mode(0o644));
+        assert!(
+            res.is_err(),
+            "an unreadable shard must fail closed, not hash a partial set"
         );
     }
 

--- a/crates/hyprstream/src/runtime/torch_engine.rs
+++ b/crates/hyprstream/src/runtime/torch_engine.rs
@@ -279,19 +279,30 @@ impl TorchEngine {
         );
     }
 
-    /// Current KV-cache compatibility fingerprint for the loaded model, or
-    /// `None` if no descriptor has been recorded (no model loaded yet).
+    /// Expected KV-cache compatibility fingerprint for the loaded model under the
+    /// given adapter/delta generation, or `None` when no authoritative identity is
+    /// available.
     ///
-    /// The session-reuse path compares this against each cache's stamped
-    /// fingerprint (#1277): a mismatch means the cache's KV was produced under
-    /// an incompatible config and is rejected (cleared + recomputed). `None`
-    /// means compatibility tracking is inactive — there is nothing to guard, so
-    /// callers treat it as "no gating" rather than "reject everything".
-    pub fn kv_compat_fingerprint(&self) -> Option<crate::runtime::kv_compat::KvCompatFingerprint> {
-        self.kv_compat
-            .lock()
-            .as_ref()
-            .map(crate::runtime::kv_compat::KvCompatFingerprint::of)
+    /// The effective identity folds in the base-weight content digest, the full
+    /// effective architecture/runtime config, and the live `adapter_generation`
+    /// actually applied to the request. Returns `None` when no descriptor was
+    /// built (the base-weight digest could not be computed) or when the descriptor
+    /// is not yet authoritatively complete (tokenizer identity not yet folded in,
+    /// or tokenizer hashing failed). The session-reuse path treats `None` as
+    /// **fail-closed**: it discards a cache rather than reusing it under a
+    /// missing or uncertain identity — it never treats absence as "no gating".
+    pub fn kv_compat_fingerprint_for(
+        &self,
+        adapter_generation: u64,
+    ) -> Option<crate::runtime::kv_compat::KvCompatFingerprint> {
+        let guard = self.kv_compat.lock();
+        let desc = guard.as_ref()?;
+        if !desc.is_authoritatively_complete() {
+            return None;
+        }
+        let mut effective = desc.clone();
+        effective.weights.adapter_generation = adapter_generation;
+        Some(crate::runtime::kv_compat::KvCompatFingerprint::of(&effective))
     }
 
     /// Compute a KV cache memory budget based on model size and available GPU memory.
@@ -753,6 +764,50 @@ impl TorchEngine {
         self.var_store.lock().is_some()
     }
 
+    /// Authoritative content digest of the base weights actually loaded from
+    /// `model_path` — a SHA-256 over every `.safetensors` shard (filename + full
+    /// bytes) in sorted name order. This is the base-weight identity for the
+    /// KV-compat fingerprint (#1277): two snapshots sharing a basename but
+    /// differing in content diverge here, unlike a path/label. Streams each
+    /// shard in 64 KiB chunks; returns an error when there are no shards or a
+    /// shard cannot be read, in which case the caller declines to build a
+    /// descriptor and KV reuse fails closed.
+    fn weights_content_digest(model_path: &Path) -> std::result::Result<String, std::io::Error> {
+        use sha2::Digest;
+        use std::io::Read;
+        let mut shards: Vec<std::path::PathBuf> = std::fs::read_dir(model_path)?
+            .filter_map(Result::ok)
+            .map(|e| e.path())
+            .filter(|p| p.extension().and_then(|e| e.to_str()) == Some("safetensors"))
+            .collect();
+        shards.sort();
+        if shards.is_empty() {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::NotFound,
+                format!("no .safetensors weight shards in {}", model_path.display()),
+            ));
+        }
+        let mut hasher = sha2::Sha256::new();
+        let mut buf = [0u8; 65536];
+        for shard in &shards {
+            let name = shard
+                .file_name()
+                .and_then(|s| s.to_str())
+                .unwrap_or("");
+            hasher.update(name.as_bytes());
+            hasher.update([0u8]);
+            let mut f = std::fs::File::open(shard)?;
+            loop {
+                let n = f.read(&mut buf)?;
+                if n == 0 {
+                    break;
+                }
+                hasher.update(&buf[..n]);
+            }
+        }
+        Ok(hex::encode(hasher.finalize()))
+    }
+
     /// Initialize XET storage with default configuration
     /// Initialize the persistent model instance using ModelFactory
     async fn initialize_persistent_model(&mut self, model_path: &Path) -> Result<()> {
@@ -834,49 +889,80 @@ impl TorchEngine {
         // identity of the model + runtime config that produces this engine's KV.
         // Every reusable/durable KV lookup is checked against its fingerprint.
         // Built here (where the full `ModelConfig` is in scope) from authoritative
-        // inputs only — never a human label. The tokenizer identity is folded in
-        // later by `load_tokenizer`, before any generation reads the fingerprint.
-        {
-            use crate::runtime::kv_compat::{
-                KvCompatDescriptor, KvDtype, KvQuantMode, RopeScalingFp, WeightIdentity,
-                KV_COMPAT_FORMAT_VERSION,
-            };
-            let kv_quant = match self.config.kv_quant_type {
-                crate::runtime::KVQuantType::None => KvQuantMode::None,
-                crate::runtime::KVQuantType::Int8 => KvQuantMode::Int8,
-                crate::runtime::KVQuantType::Nf4 => KvQuantMode::Nf4,
-                crate::runtime::KVQuantType::Fp4 => KvQuantMode::Fp4,
-            };
-            let model_name = model_path
-                .file_stem()
-                .and_then(|s| s.to_str())
-                .unwrap_or("")
-                .to_owned();
-            let descriptor = KvCompatDescriptor {
-                format_version: KV_COMPAT_FORMAT_VERSION,
-                weights: WeightIdentity::base_only(model_name.clone()),
-                model_name,
-                architecture: config.model_type.clone(),
-                model_version: config.version,
-                num_hidden_layers: config.num_hidden_layers,
-                num_attention_heads: config.num_attention_heads,
-                num_key_value_heads: config.num_key_value_heads,
-                head_dim: config.head_dim,
-                hidden_size: config.hidden_size,
-                rope_theta_bits: config.rope_theta.to_bits(),
-                rope_scaling: config
-                    .rope_scaling
-                    .as_ref()
-                    .map(|rs| RopeScalingFp::new(&rs.rope_type, rs.factor)),
-                max_position_embeddings: config.max_position_embeddings,
-                dtype: KvDtype::from_str(&config.dtype),
-                kv_quant,
-                block_size: crate::runtime::kv_cache::BLOCK_SIZE,
-                max_context: effective_max_context,
-                vocab_size: config.vocab_size,
-                tokenizer_hash: None,
-            };
-            *self.kv_compat.lock() = Some(descriptor);
+        // inputs only — never a human label. The base-weight identity is a content
+        // digest of the resolved shards; the tokenizer identity is folded in later
+        // by `load_tokenizer`, before any generation reads the fingerprint. If no
+        // authoritative base digest can be computed, the descriptor is left unset
+        // and the cache boundary fails closed (KV recomputed, not reused).
+        match Self::weights_content_digest(model_path) {
+            Ok(base_revision) => {
+                use crate::runtime::kv_compat::{
+                    KvCompatDescriptor, KvDtype, KvQuantMode, RopeScalingFp, WeightIdentity,
+                    KV_COMPAT_FORMAT_VERSION,
+                };
+                let kv_quant = match self.config.kv_quant_type {
+                    crate::runtime::KVQuantType::None => KvQuantMode::None,
+                    crate::runtime::KVQuantType::Int8 => KvQuantMode::Int8,
+                    crate::runtime::KVQuantType::Nf4 => KvQuantMode::Nf4,
+                    crate::runtime::KVQuantType::Fp4 => KvQuantMode::Fp4,
+                };
+                // `model_name` is a display label for mismatch messages; the
+                // authoritative weight identity is the content digest above.
+                let model_name = model_path
+                    .file_stem()
+                    .and_then(|s| s.to_str())
+                    .unwrap_or("")
+                    .to_owned();
+                let descriptor = KvCompatDescriptor {
+                    format_version: KV_COMPAT_FORMAT_VERSION,
+                    weights: WeightIdentity::base_only(base_revision),
+                    model_name,
+                    architecture: config.model_type.clone(),
+                    model_version: config.version,
+                    num_hidden_layers: config.num_hidden_layers,
+                    num_attention_heads: config.num_attention_heads,
+                    num_key_value_heads: config.num_key_value_heads,
+                    head_dim: config.head_dim,
+                    hidden_size: config.hidden_size,
+                    // Effective attention behavior — every field below can change
+                    // KV *values* without changing coarse geometry (#1277 review).
+                    use_qk_norm: config.use_qk_norm,
+                    partial_rotary_factor_bits: config.partial_rotary_factor.map(f32::to_bits),
+                    layer_types: config.layer_types.clone(),
+                    linear_key_head_dim: config.linear_key_head_dim,
+                    linear_value_head_dim: config.linear_value_head_dim,
+                    linear_num_key_heads: config.linear_num_key_heads,
+                    linear_num_value_heads: config.linear_num_value_heads,
+                    linear_conv_kernel_dim: config.linear_conv_kernel_dim,
+                    rope_theta_bits: config.rope_theta.to_bits(),
+                    rope_scaling: config
+                        .rope_scaling
+                        .as_ref()
+                        .map(|rs| RopeScalingFp::new(&rs.rope_type, rs.factor)),
+                    max_position_embeddings: config.max_position_embeddings,
+                    dtype: KvDtype::from_name(&config.dtype),
+                    kv_quant,
+                    block_size: crate::runtime::kv_cache::BLOCK_SIZE,
+                    max_context: effective_max_context,
+                    vocab_size: config.vocab_size,
+                    // Folded in by `load_tokenizer`; descriptor is non-authoritative
+                    // (fingerprint = None) until then, so reuse fails closed.
+                    tokenizer_hash: None,
+                };
+                *self.kv_compat.lock() = Some(descriptor);
+            }
+            Err(e) => {
+                warn!(
+                    "Cannot compute authoritative base-weight digest for {}: {} \
+                     — KV-cache reuse disabled (fail-closed)",
+                    model_path.display(),
+                    e
+                );
+                // Leave kv_compat unset (None): the reuse boundary will discard
+                // rather than adopt any cache, since there is no authoritative
+                // identity to compare against.
+                *self.kv_compat.lock() = None;
+            }
         }
 
         // Use the factory to create the model. When `device_pool` is set and
@@ -1002,21 +1088,30 @@ impl TorchEngine {
             // a different tokenizer (even with the same vocab size) must reject.
             // The on-disk `tokenizer.json` bytes are the authoritative identity;
             // deterministic model-driven mutation (e.g. Qwen vocab padding) is
-            // already captured by `vocab_size`.
+            // already captured by `vocab_size`. FAIL-CLOSED: if the bytes cannot
+            // be hashed, the tokenizer identity is left unset, the descriptor is
+            // non-authoritative (fingerprint = None), and the cache boundary
+            // discards rather than adopts any cache — we never silently degrade
+            // to a weaker vocab-only identity.
             {
                 let mut guard = self.kv_compat.lock();
-                let tokenizer_hash = std::fs::read(&tokenizer_path).ok().map(|bytes| {
-                    use sha2::{Digest, Sha256};
-                    let mut hasher = Sha256::new();
-                    hasher.update(&bytes);
-                    hex::encode(hasher.finalize())
-                });
-                if tokenizer_hash.is_none() {
-                    tracing::warn!(
-                        "Could not read {} for KV-compat tokenizer identity; matching on vocab size only",
-                        tokenizer_path.display()
-                    );
-                }
+                let tokenizer_hash = match std::fs::read(&tokenizer_path) {
+                    Ok(bytes) => {
+                        use sha2::{Digest, Sha256};
+                        let mut hasher = Sha256::new();
+                        hasher.update(&bytes);
+                        Some(hex::encode(hasher.finalize()))
+                    }
+                    Err(e) => {
+                        tracing::error!(
+                            "Could not read {} for KV-compat tokenizer identity ({}): \
+                             KV-cache reuse disabled (fail-closed)",
+                            tokenizer_path.display(),
+                            e
+                        );
+                        None
+                    }
+                };
                 if let Some(desc) = guard.as_mut() {
                     desc.set_tokenizer(final_vocab_size, tokenizer_hash);
                 }
@@ -1812,6 +1907,10 @@ impl TorchEngine {
     /// during generation. The delta is locked per-token (not held across the entire
     /// generation) to allow concurrent training updates.
     ///
+    /// `adapter_generation` is the live LoRA/delta generation actually applied to
+    /// this request; it is folded into the KV-compat expected identity so a
+    /// re-adapted model is detected as incompatible and its stale KV rejected.
+    ///
     /// `tenant_id` is the effective tenant whose delta contributed to the weights
     /// (`Some` only when a per-tenant delta is in play, `None` otherwise), and
     /// `weight_epoch` is that delta's current weight epoch. The pair is threaded
@@ -1826,6 +1925,7 @@ impl TorchEngine {
         delta: Option<std::sync::Arc<parking_lot::Mutex<crate::training::TenantDelta>>>,
         tenant_id: Option<String>,
         weight_epoch: u64,
+        adapter_generation: u64,
     ) -> Result<TextStream<'_>> {
         if let Some(seed) = request.seed {
             self.set_seed(seed as u64);
@@ -1835,7 +1935,14 @@ impl TorchEngine {
             request.timeout_ms = Some(self.config.default_generation_timeout_ms);
         }
 
-        TextStream::new_with_delta(self, request, delta, tenant_id, weight_epoch)
+        TextStream::new_with_delta(
+            self,
+            request,
+            delta,
+            tenant_id,
+            weight_epoch,
+            adapter_generation,
+        )
     }
 
     /// Non-streaming generation with optional delta (convenience wrapper)
@@ -1845,6 +1952,7 @@ impl TorchEngine {
         delta: Option<std::sync::Arc<parking_lot::Mutex<crate::training::TenantDelta>>>,
         tenant_id: Option<String>,
         weight_epoch: u64,
+        adapter_generation: u64,
     ) -> Result<crate::config::GenerationResult> {
         use futures::StreamExt;
 
@@ -1854,7 +1962,8 @@ impl TorchEngine {
             ));
         }
 
-        let mut stream = self.generate_with_delta(request, delta, tenant_id, weight_epoch)?;
+        let mut stream =
+            self.generate_with_delta(request, delta, tenant_id, weight_epoch, adapter_generation)?;
         let mut accumulated_text = String::new();
 
         while let Some(text_chunk) = stream.next().await {
@@ -2783,7 +2892,9 @@ pub struct TextStream<'a> {
 
 impl<'a> TextStream<'a> {
     fn new(engine: &'a TorchEngine, request: GenerationRequest) -> Result<Self> {
-        Self::new_with_delta(engine, request, None, None, 0)
+        // No delta path: no tenant dependency and adapter generation 0 (base
+        // weights only).
+        Self::new_with_delta(engine, request, None, None, 0, 0)
     }
 
     fn new_with_delta(
@@ -2792,6 +2903,7 @@ impl<'a> TextStream<'a> {
         delta: Option<std::sync::Arc<parking_lot::Mutex<crate::training::TenantDelta>>>,
         tenant_id: Option<String>,
         weight_epoch: u64,
+        adapter_generation: u64,
     ) -> Result<Self> {
         let prompt_tokens = engine.tokenize(&request.prompt)?;
         let prompt_len = prompt_tokens.len();
@@ -2845,30 +2957,57 @@ impl<'a> TextStream<'a> {
                     let mut cache_guard = cache.lock();
 
                     // KV-cache compatibility guard (#1277): KV produced under an
-                    // incompatible model/runtime config is never reused. A fresh
-                    // (un-stamped) cache is stamped with the current config; a
-                    // stamp mismatch discards the stale KV (clear + re-stamp) so
-                    // prefill recomputes from zero. This is the pull-based
+                    // incompatible (or unproven) model/runtime config is never
+                    // reused. The policy is **fail-closed** via
+                    // `decide_cache_reuse`: a stamp mismatch, an unstamped but
+                    // *populated* cache, or the absence of an authoritative
+                    // expected identity all discard the KV and recompute. Only a
+                    // genuinely fresh (empty) cache under an authoritative
+                    // identity is stamped for reuse. This is the pull-based
                     // complement to the registry's push-based delta invalidation.
-                    if let Some(expected) = engine.kv_compat_fingerprint() {
-                        match cache_guard.compat_fingerprint() {
-                            None => {
-                                // Fresh cache: stamp it with the config that will populate it.
-                                cache_guard.set_compat_fingerprint(expected);
+                    let expected = engine.kv_compat_fingerprint_for(adapter_generation);
+                    let stored = cache_guard.compat_fingerprint();
+                    let cache_is_empty = cache_guard.cached_token_count() == 0;
+                    match crate::runtime::kv_compat::decide_cache_reuse(
+                        expected.as_ref(),
+                        stored.as_ref(),
+                        cache_is_empty,
+                    ) {
+                        crate::runtime::kv_compat::CacheReuseDecision::Reuse => {
+                            tracing::debug!(target: "kv_compat", "KV cache reuse: compatible");
+                        }
+                        crate::runtime::kv_compat::CacheReuseDecision::StampFresh => {
+                            // Empty cache under an authoritative identity: stamp
+                            // it so the KV about to be produced is attributable.
+                            if let Some(exp) = expected {
+                                cache_guard.set_compat_fingerprint(exp);
                             }
-                            Some(stored) if stored != expected => {
-                                tracing::info!(
-                                    target: "kv_compat",
-                                    "KV cache compatibility mismatch \
-                                     (stored={}, expected={}): discarding stale KV and recomputing",
-                                    stored.to_hex(),
-                                    expected.to_hex(),
-                                );
-                                cache_guard.set_cached_tokens(Vec::new());
-                                cache_guard.clear_all();
-                                cache_guard.set_compat_fingerprint(expected);
+                        }
+                        crate::runtime::kv_compat::CacheReuseDecision::DiscardAndRecompute => {
+                            // Fail-closed: discard the (untrusted or mismatched)
+                            // KV and recompute from zero.
+                            let reason = match (expected.as_ref(), stored.as_ref()) {
+                                (_, Some(s)) => format!(
+                                    "stamp mismatch (stored={}, expected={})",
+                                    s.to_hex(),
+                                    expected
+                                        .map(|e| e.to_hex())
+                                        .unwrap_or_else(|| "<none>".into())
+                                ),
+                                (_, None) if !cache_is_empty =>
+                                    "populated cache with no compatibility stamp".into(),
+                                _ => "no authoritative compatibility identity".into(),
+                            };
+                            tracing::info!(
+                                target: "kv_compat",
+                                reason = %reason,
+                                "KV cache not reusable: discarding and recomputing (fail-closed)"
+                            );
+                            cache_guard.set_cached_tokens(Vec::new());
+                            cache_guard.clear_all();
+                            if let Some(exp) = expected {
+                                cache_guard.set_compat_fingerprint(exp);
                             }
-                            Some(_) => {} // compatible — reuse as-is
                         }
                     }
 

--- a/crates/hyprstream/src/runtime/torch_engine.rs
+++ b/crates/hyprstream/src/runtime/torch_engine.rs
@@ -138,6 +138,11 @@ pub struct TorchEngine {
     /// Current active session owner for KV cache selection
     /// If set, generation uses the corresponding cache from the registry
     active_cache_owner: Arc<Mutex<Option<crate::runtime::kv_cache::CacheOwner>>>,
+    /// KV-cache compatibility descriptor for the loaded model (#1277). The
+    /// authoritative identity every reusable/durable KV lookup is checked
+    /// against; `None` until a model is loaded. Built from the model config +
+    /// runtime config at load time, finalized with the tokenizer identity.
+    kv_compat: Arc<Mutex<Option<crate::runtime::kv_compat::KvCompatDescriptor>>>,
     // Note: XET/LFS handled by git-xet-filter + ModelFactory::load_file_with_pointer_detection()
     // Note: Pre-training not supported (persistent_model doesn't expose VarStore), LoRA only
 }
@@ -272,6 +277,21 @@ impl TorchEngine {
             "[TorchEngine] Initialized KV cache registry: {} layers, max_seq_len={}, budget={:?}",
             num_layers, max_seq_len, memory_budget
         );
+    }
+
+    /// Current KV-cache compatibility fingerprint for the loaded model, or
+    /// `None` if no descriptor has been recorded (no model loaded yet).
+    ///
+    /// The session-reuse path compares this against each cache's stamped
+    /// fingerprint (#1277): a mismatch means the cache's KV was produced under
+    /// an incompatible config and is rejected (cleared + recomputed). `None`
+    /// means compatibility tracking is inactive — there is nothing to guard, so
+    /// callers treat it as "no gating" rather than "reject everything".
+    pub fn kv_compat_fingerprint(&self) -> Option<crate::runtime::kv_compat::KvCompatFingerprint> {
+        self.kv_compat
+            .lock()
+            .as_ref()
+            .map(crate::runtime::kv_compat::KvCompatFingerprint::of)
     }
 
     /// Compute a KV cache memory budget based on model size and available GPU memory.
@@ -627,6 +647,7 @@ impl TorchEngine {
             eos_token_id: Arc::new(AtomicU32::new(0)),
             kv_cache_registry: None, // Initialized after model load when config is known
             active_cache_owner: Arc::new(Mutex::new(None)),
+            kv_compat: Arc::new(Mutex::new(None)), // Built from model config at load time (#1277)
         })
     }
 
@@ -809,6 +830,55 @@ impl TorchEngine {
             model_info.architecture = config.model_type.clone();
         }
 
+        // Build the KV-cache compatibility descriptor (#1277): the authoritative
+        // identity of the model + runtime config that produces this engine's KV.
+        // Every reusable/durable KV lookup is checked against its fingerprint.
+        // Built here (where the full `ModelConfig` is in scope) from authoritative
+        // inputs only — never a human label. The tokenizer identity is folded in
+        // later by `load_tokenizer`, before any generation reads the fingerprint.
+        {
+            use crate::runtime::kv_compat::{
+                KvCompatDescriptor, KvDtype, KvQuantMode, RopeScalingFp, WeightIdentity,
+                KV_COMPAT_FORMAT_VERSION,
+            };
+            let kv_quant = match self.config.kv_quant_type {
+                crate::runtime::KVQuantType::None => KvQuantMode::None,
+                crate::runtime::KVQuantType::Int8 => KvQuantMode::Int8,
+                crate::runtime::KVQuantType::Nf4 => KvQuantMode::Nf4,
+                crate::runtime::KVQuantType::Fp4 => KvQuantMode::Fp4,
+            };
+            let model_name = model_path
+                .file_stem()
+                .and_then(|s| s.to_str())
+                .unwrap_or("")
+                .to_owned();
+            let descriptor = KvCompatDescriptor {
+                format_version: KV_COMPAT_FORMAT_VERSION,
+                weights: WeightIdentity::base_only(model_name.clone()),
+                model_name,
+                architecture: config.model_type.clone(),
+                model_version: config.version,
+                num_hidden_layers: config.num_hidden_layers,
+                num_attention_heads: config.num_attention_heads,
+                num_key_value_heads: config.num_key_value_heads,
+                head_dim: config.head_dim,
+                hidden_size: config.hidden_size,
+                rope_theta_bits: config.rope_theta.to_bits(),
+                rope_scaling: config
+                    .rope_scaling
+                    .as_ref()
+                    .map(|rs| RopeScalingFp::new(&rs.rope_type, rs.factor)),
+                max_position_embeddings: config.max_position_embeddings,
+                dtype: KvDtype::from_str(&config.dtype),
+                kv_quant,
+                block_size: crate::runtime::kv_cache::BLOCK_SIZE,
+                max_context: effective_max_context,
+                vocab_size: config.vocab_size,
+                tokenizer_hash: None,
+            };
+            *self.kv_compat.lock() = Some(descriptor);
+        }
+
         // Use the factory to create the model. When `device_pool` is set and
         // multi-device, the factory builds the model as a single pipeline stage
         // spanning all decoder layers with a layer→device map (#314 wiring).
@@ -926,6 +996,31 @@ impl TorchEngine {
             self.tokenizer_vocab_size.store(final_vocab_size, Ordering::Relaxed);
 
             info!("Final tokenizer vocabulary size: {}", final_vocab_size);
+
+            // Fold the tokenizer identity into the KV-compat descriptor (#1277).
+            // Cached token ids are only meaningful relative to one tokenizer, so
+            // a different tokenizer (even with the same vocab size) must reject.
+            // The on-disk `tokenizer.json` bytes are the authoritative identity;
+            // deterministic model-driven mutation (e.g. Qwen vocab padding) is
+            // already captured by `vocab_size`.
+            {
+                let mut guard = self.kv_compat.lock();
+                let tokenizer_hash = std::fs::read(&tokenizer_path).ok().map(|bytes| {
+                    use sha2::{Digest, Sha256};
+                    let mut hasher = Sha256::new();
+                    hasher.update(&bytes);
+                    hex::encode(hasher.finalize())
+                });
+                if tokenizer_hash.is_none() {
+                    tracing::warn!(
+                        "Could not read {} for KV-compat tokenizer identity; matching on vocab size only",
+                        tokenizer_path.display()
+                    );
+                }
+                if let Some(desc) = guard.as_mut() {
+                    desc.set_tokenizer(final_vocab_size, tokenizer_hash);
+                }
+            }
 
             // Thread safe assignment
             let mut tokenizer_guard = self.tokenizer.lock();
@@ -2747,7 +2842,36 @@ impl<'a> TextStream<'a> {
             let prefix_len = if let Some(model_arc) = &engine.persistent_model {
                 let model = model_arc.lock();
                 if let Some(cache) = model.get_kv_cache() {
-                    let cache_guard = cache.lock();
+                    let mut cache_guard = cache.lock();
+
+                    // KV-cache compatibility guard (#1277): KV produced under an
+                    // incompatible model/runtime config is never reused. A fresh
+                    // (un-stamped) cache is stamped with the current config; a
+                    // stamp mismatch discards the stale KV (clear + re-stamp) so
+                    // prefill recomputes from zero. This is the pull-based
+                    // complement to the registry's push-based delta invalidation.
+                    if let Some(expected) = engine.kv_compat_fingerprint() {
+                        match cache_guard.compat_fingerprint() {
+                            None => {
+                                // Fresh cache: stamp it with the config that will populate it.
+                                cache_guard.set_compat_fingerprint(expected);
+                            }
+                            Some(stored) if stored != expected => {
+                                tracing::info!(
+                                    target: "kv_compat",
+                                    "KV cache compatibility mismatch \
+                                     (stored={}, expected={}): discarding stale KV and recomputing",
+                                    stored.to_hex(),
+                                    expected.to_hex(),
+                                );
+                                cache_guard.set_cached_tokens(Vec::new());
+                                cache_guard.clear_all();
+                                cache_guard.set_compat_fingerprint(expected);
+                            }
+                            Some(_) => {} // compatible — reuse as-is
+                        }
+                    }
+
                     let matched = cache_guard.prefix_match_len(&prompt_tokens);
                     if matched > 0 {
                         tracing::info!(

--- a/crates/hyprstream/src/runtime/torch_engine.rs
+++ b/crates/hyprstream/src/runtime/torch_engine.rs
@@ -3380,50 +3380,7 @@ impl<'a> TextStream<'a> {
                     // identity is stamped for reuse. This is the pull-based
                     // complement to the registry's push-based delta invalidation.
                     let expected = engine.kv_compat_fingerprint_for(adapter_generation);
-                    let stored = cache_guard.compat_fingerprint();
-                    let cache_is_empty = cache_guard.cached_token_count() == 0;
-                    match crate::runtime::kv_compat::decide_cache_reuse(
-                        expected.as_ref(),
-                        stored.as_ref(),
-                        cache_is_empty,
-                    ) {
-                        crate::runtime::kv_compat::CacheReuseDecision::Reuse => {
-                            tracing::debug!(target: "kv_compat", "KV cache reuse: compatible");
-                        }
-                        crate::runtime::kv_compat::CacheReuseDecision::StampFresh => {
-                            // Empty cache under an authoritative identity: stamp
-                            // it so the KV about to be produced is attributable.
-                            if let Some(exp) = expected {
-                                cache_guard.set_compat_fingerprint(exp);
-                            }
-                        }
-                        crate::runtime::kv_compat::CacheReuseDecision::DiscardAndRecompute => {
-                            // Fail-closed: discard the (untrusted or mismatched)
-                            // KV and recompute from zero.
-                            let reason = match (expected.as_ref(), stored.as_ref()) {
-                                (_, Some(s)) => format!(
-                                    "stamp mismatch (stored={}, expected={})",
-                                    s.to_hex(),
-                                    expected
-                                        .map(|e| e.to_hex())
-                                        .unwrap_or_else(|| "<none>".into())
-                                ),
-                                (_, None) if !cache_is_empty =>
-                                    "populated cache with no compatibility stamp".into(),
-                                _ => "no authoritative compatibility identity".into(),
-                            };
-                            tracing::info!(
-                                target: "kv_compat",
-                                reason = %reason,
-                                "KV cache not reusable: discarding and recomputing (fail-closed)"
-                            );
-                            cache_guard.set_cached_tokens(Vec::new());
-                            cache_guard.clear_all();
-                            if let Some(exp) = expected {
-                                cache_guard.set_compat_fingerprint(exp);
-                            }
-                        }
-                    }
+                    cache_guard.apply_reuse_policy(expected);
 
                     let matched = cache_guard.prefix_match_len(&prompt_tokens);
                     if matched > 0 {

--- a/crates/hyprstream/src/services/inference.rs
+++ b/crates/hyprstream/src/services/inference.rs
@@ -1090,7 +1090,11 @@ impl InferenceService {
         // Run the stream with StreamChannel's async publisher callback.
         // Engine read-lock held across await: generate_with_delta returns a stream borrowing engine.
         let engine = self.engine.read();
-        let stream_result = engine.generate_with_delta(request, delta, tenant_id, weight_epoch);
+        // Pass the live LoRA generation so the KV-compat expected identity reflects
+        // the effective adapter actually applied (#1277): a re-adapted model is
+        // detected as incompatible and its stale KV is rejected at the cache boundary.
+        let stream_result =
+            engine.generate_with_delta(request, delta, tenant_id, weight_epoch, lora_gen_now);
 
         // #1264/#1265: capture the completion stats out of the stream closure so
         // the token-spend can be posted after the client-visible completion frame


### PR DESCRIPTION
## Summary

Implements **#1277** — the foundational first item of **Epic #1276** (Native inference KV cache reuse and durability): a versioned, testable KV-cache **compatibility descriptor/fingerprint** plus a **rejection policy** that ensures KV produced under an incompatible config is never reused.

KV states are a pure function of the weights and every parameter that shapes the attention computation. Reusing KV produced under one configuration inside a request running under another is a silent correctness bug. This PR defines the authoritative identity of that function and gates reuse on it.

### What the fingerprint captures
Every field of `KvCompatDescriptor` is derived from authoritative model/runtime state — never a human label:
- **Effective weights** — base-weight revision + adapter/delta generation
- **Model identity** — name, architecture (`model_type`), config version
- **Attention geometry** — layers, KV heads, attention heads, head dim, hidden size (K/V tensor *shape*)
- **Position encoding** — RoPE theta, RoPE scaling, max position embeddings (K *values* post-RoPE)
- **Compute dtype**, **KV encoding/quant mode**, **block size** (`BLOCK_SIZE`)
- **Context cap**, **tokenizer identity** (vocab size + digest of tokenizer bytes)
- **Format version** of the fingerprint itself

The descriptor is reduced to a content-addressed SHA-256 `KvCompatFingerprint` over a canonical, byte-stable encoding (length-/tag-framed), so persisted fingerprints are portable across builds.

### Rejection policy
A cache whose fingerprint differs from the current config in **any** authoritative field is **rejected** — its KV is discarded and recomputed. This is the **pull-based** reuse guard, checked at the session-cache swap point (`TextStream::new_with_delta`). It **complements** (does not replace) the registry's existing push-based TTT delta invalidation (`invalidate_for_tenant`), which is preserved unchanged — the descriptor carries an `adapter_generation` slot that a live counter (#1260) will feed so the pull path also covers per-request delta changes.

### Wiring
- New module `crates/hyprstream/src/runtime/kv_compat.rs` — owns **no** `tch`/Cap'n-Proto dependency (pure data + hashing), so it is fully unit-testable without a loaded model (13 unit tests).
- `torch_engine.rs`: descriptor built from `ModelConfig` + `RuntimeConfig` at model load, finalized with the tokenizer identity, and enforced at the reuse point. A `compat_fingerprint` stamp added to `KVCacheManager`.

### Out of scope (separate lane issues)
Deliberately does **not** implement paging, cross-session prefix sharing, or persistence — those are later issues (#1278–#1287) that stack on this foundation.

Closes #1277
Part of Epic #1276.

> **Serialized `kv_cache.rs` lane** — this is position #1; every later KV-reuse issue stacks on it. Merge order per the epic: #1 → #2 → #2q → #4a → #3 → #4b → #5 → #6 → #7 → #8 → #9.