### PR TITLE
feat(mac): install ReferenceMonitor at all 9P constructors (#1269)

### DIFF
--- a/.fleet-coord/pep-1269-status.md
+++ b/.fleet-coord/pep-1269-status.md
@@ -14,14 +14,23 @@
 - **SessionContext::from_verified_clearance** (`hyprstream-9p`): verified
   clearance but no S6 token — denies at the token gate. Structural constructor
   for the #698-not-wired case.
+- **Audited early denials** (`hyprstream-9p` + production PEP): label
+  resolution, token-gate, and IFC-floor denials call the decider's required
+  audit hook; `NinePAccessDecider` writes those records through the same
+  tamper-evident WAL sink used for final policy decisions.
+- **Tenant-bound verified attach identity** (`hyprstream-9p`):
+  `VerifiedAttachIdentity` carries subject + tenant from the same verified
+  credential. Deny-only sessions carry no verified identity.
 - **Plane-specific 9P PEP** (`hyprstream/src/mac/pep.rs`):
   - `NinePClearanceSource` trait — clean clearance-input seam (#698).
   - `EnrollmentClearanceSource` — production impl via enrollment resolver
     (fail-closed when no policy / unenrolled).
-  - `ClearanceAttachAuthenticator<C>` — `AttachAuthenticator` wrapping a
-    clearance source.
+  - `VerifiedClearanceSessionFactory<C>` — consumes only an already verified,
+    tenant-bound identity; it cannot accept raw `Tattach` fields.
   - `production_ninep_reference_monitor` / `enrollment_ninep_reference_monitor`
-    — monitor assembler.
+    — monitor assembler. The current production helper explicitly installs
+    `AnonymousAuthenticator`, because no verified attach credential reaches the
+    seam yet; raw `uname` is never promoted to identity.
   - `NinePAccessDecider::check` — writes resolved via `can_write_to` (was
     blanket-deny `WriteDirectionUndecided`).
 - **4 production constructors wired**:
@@ -36,10 +45,9 @@
 ## What is NOT wired (gated dependencies)
 
 - **#698** — production 9P clearance issuance: although RPC `Claims` can carry
-  clearance, the 9P attach path does not yet carry the verified clearance/token
-  material. `EnrollmentClearanceSource` resolves via the compiled policy
-  enrollment table; an absent policy or unenrolled identity resolves to `None`
-  → deny.
+  clearance, the 9P attach path does not yet carry verified identity + tenant +
+  clearance/token material. The production authenticator therefore returns a
+  deny-only session with no verified identity.
 - **S6 sender-bound token** — not wired into 9P `Tattach`. Sessions constructed
   via `from_verified_clearance` (token = None) → token gate denies every op.
 - **#699 / name↔object TOCTOU** — `ReferenceMonitor::authorize` resolves labels
@@ -62,5 +70,7 @@
   This PR adds no `EnvelopeContext` initializer. The 9P genesis/content-truth
   resolver is node-global, so it deliberately remains in the global domain;
   tenant isolation continues at the Subject-scoped export boundary.
-- **`anonymous_floor()` reachability**: not reachable from any production
-  constructor (all 4 install `Some(monitor)`). Still used by tests.
+- **`anonymous_floor()` semantics**: all 4 production constructors install
+  `Some(monitor)`. Until verified attach credentials are wired, their
+  authenticator returns a deny-only session at the anonymous diagnostic floor
+  with no token and no verified identity; every attempted op denies and audits.

--- a/.fleet-coord/pep-1269-status.md
+++ b/.fleet-coord/pep-1269-status.md
@@ -2,7 +2,7 @@
 
 **Lane:** T3 / #1269 (epic #1267)
 **Branch:** feat/mac-9p-activate
-**Status:** STRUCTURE INSTALLED, fail-closed. Ready for kimi-k3 review.
+**Status:** REBASED ON #1288/#1196; STRUCTURE INSTALLED, fail-closed.
 
 ## What landed
 
@@ -14,7 +14,7 @@
 - **SessionContext::from_verified_clearance** (`hyprstream-9p`): verified
   clearance but no S6 token — denies at the token gate. Structural constructor
   for the #698-not-wired case.
-- **SHARED MAC PEP contract** (`hyprstream/src/mac/pep.rs`):
+- **Plane-specific 9P PEP** (`hyprstream/src/mac/pep.rs`):
   - `NinePClearanceSource` trait — clean clearance-input seam (#698).
   - `EnrollmentClearanceSource` — production impl via enrollment resolver
     (fail-closed when no policy / unenrolled).
@@ -35,9 +35,10 @@
 
 ## What is NOT wired (gated dependencies)
 
-- **#698** — production clearance issuance: `Claims.clearance` field not present.
-  `EnrollmentClearanceSource` resolves via the compiled policy enrollment table;
-  no enrollment table populated in production → all subjects resolve to `None`
+- **#698** — production 9P clearance issuance: although RPC `Claims` can carry
+  clearance, the 9P attach path does not yet carry the verified clearance/token
+  material. `EnrollmentClearanceSource` resolves via the compiled policy
+  enrollment table; an absent policy or unenrolled identity resolves to `None`
   → deny.
 - **S6 sender-bound token** — not wired into 9P `Tattach`. Sessions constructed
   via `from_verified_clearance` (token = None) → token gate denies every op.
@@ -46,12 +47,20 @@
   object. The `..` / bind / symlink gap is unchanged; activation does not close
   it. Flagged in the `mac_seam.rs` module docs.
 
-## Fleet-coordination notes
+## Canonical contract reconciliation
 
-- **#1268 contract** (`mac-pep-contract.md`) was NOT published at start. Built
-  plane-specific label resolution (genesis resolver) + a clean clearance-input
-  seam (`NinePClearanceSource`) as directed by the fallback clause. The
-  `NinePClearanceSource` trait is the seam #1268 can consume/extend when it
-  publishes the shared claims→clearance contract.
+- Rebased onto the merged #1288 contract and retained its canonical
+  `MacDispatchPep` / `MacDecision` / `MacDenyReason` /
+  `RpcObjectLabelResolver` definitions unchanged. In particular, an
+  uninstalled RPC dispatch PEP remains dormant and returns `Permit`; only an
+  installed PEP is fail-closed.
+- Per `.fleet-coord/mac-pep-contract.md`, 9P does not implement
+  `MacDispatchPep` or depend on `EnvelopeContext`; it retains the existing
+  plane-specific `NinePAccessDecider`, trusted path/CID label resolution, and
+  verified-attach clearance seam.
+- #1196's `EnvelopeContext::verified_tenant` initializers arrive from main.
+  This PR adds no `EnvelopeContext` initializer. The 9P genesis/content-truth
+  resolver is node-global, so it deliberately remains in the global domain;
+  tenant isolation continues at the Subject-scoped export boundary.
 - **`anonymous_floor()` reachability**: not reachable from any production
   constructor (all 4 install `Some(monitor)`). Still used by tests.

--- a/.fleet-coord/pep-1269-status.md
+++ b/.fleet-coord/pep-1269-status.md
@@ -1,0 +1,57 @@
+# PEP #1269 — 9P MAC activation status
+
+**Lane:** T3 / #1269 (epic #1267)
+**Branch:** feat/mac-9p-activate
+**Status:** STRUCTURE INSTALLED, fail-closed. Ready for kimi-k3 review.
+
+## What landed
+
+- **Write-direction IFC** (`hyprstream-rpc`): `SecurityLabel::can_write_to` /
+  `SecurityContext::can_write_to` — Bell–LaPadula *-property (no-write-down).
+  Assurance axis is a crypto floor in both directions (does not flip).
+- **ReferenceMonitor write-direction** (`hyprstream-9p`): `authorize` selects
+  `can_write_to` for `Action::Write`, `can_access` for reads.
+- **SessionContext::from_verified_clearance** (`hyprstream-9p`): verified
+  clearance but no S6 token — denies at the token gate. Structural constructor
+  for the #698-not-wired case.
+- **SHARED MAC PEP contract** (`hyprstream/src/mac/pep.rs`):
+  - `NinePClearanceSource` trait — clean clearance-input seam (#698).
+  - `EnrollmentClearanceSource` — production impl via enrollment resolver
+    (fail-closed when no policy / unenrolled).
+  - `ClearanceAttachAuthenticator<C>` — `AttachAuthenticator` wrapping a
+    clearance source.
+  - `production_ninep_reference_monitor` / `enrollment_ninep_reference_monitor`
+    — monitor assembler.
+  - `NinePAccessDecider::check` — writes resolved via `can_write_to` (was
+    blanket-deny `WriteDirectionUndecided`).
+- **4 production constructors wired**:
+  - WS route (`ninep.rs:288`) ✅
+  - WT route (`ninep.rs:571`) ✅
+  - worker UDS (`inject_9p_socket` / `prepare_wanix_workload`) ✅
+  - kata/vsock (`serve_tenant_vfs_9p`) ✅
+  - `BackendCtx.ninep_monitor` threaded through worker layer.
+  - `serve_mount_uds` / `serve_mount_vsock[_raw]` accept
+    `Option<Arc<ReferenceMonitor>>`.
+
+## What is NOT wired (gated dependencies)
+
+- **#698** — production clearance issuance: `Claims.clearance` field not present.
+  `EnrollmentClearanceSource` resolves via the compiled policy enrollment table;
+  no enrollment table populated in production → all subjects resolve to `None`
+  → deny.
+- **S6 sender-bound token** — not wired into 9P `Tattach`. Sessions constructed
+  via `from_verified_clearance` (token = None) → token gate denies every op.
+- **#699 / name↔object TOCTOU** — `ReferenceMonitor::authorize` resolves labels
+  from `ObjectRef::Path` (the cached walked name), not the backend's reached
+  object. The `..` / bind / symlink gap is unchanged; activation does not close
+  it. Flagged in the `mac_seam.rs` module docs.
+
+## Fleet-coordination notes
+
+- **#1268 contract** (`mac-pep-contract.md`) was NOT published at start. Built
+  plane-specific label resolution (genesis resolver) + a clean clearance-input
+  seam (`NinePClearanceSource`) as directed by the fallback clause. The
+  `NinePClearanceSource` trait is the seam #1268 can consume/extend when it
+  publishes the shared claims→clearance contract.
+- **`anonymous_floor()` reachability**: not reachable from any production
+  constructor (all 4 install `Some(monitor)`). Still used by tests.

--- a/crates/hyprstream-9p/examples/serve_mount_uds.rs
+++ b/crates/hyprstream-9p/examples/serve_mount_uds.rs
@@ -48,6 +48,7 @@ async fn main() -> anyhow::Result<()> {
         mount,
         subject,
         Arc::new(hyprstream_9p::DenyAllDecider),
+        None,
         &path,
     )
     .await

--- a/crates/hyprstream-9p/src/lib.rs
+++ b/crates/hyprstream-9p/src/lib.rs
@@ -83,5 +83,5 @@ pub use translator::{
 pub use mac_seam::{
     anonymous_floor, AccessDecider, Action, AnonymousAuthenticator, AttachAuthenticator,
     DenyAllDecider, DenyUnlabeledResolver, ObjectLabelResolver, ObjectRef, ReferenceMonitor,
-    SessionContext, VerifiedAttachIdentity, VerifiedTokenScope,
+    ReferenceMonitorDenyReason, SessionContext, VerifiedAttachIdentity, VerifiedTokenScope,
 };

--- a/crates/hyprstream-9p/src/mac_seam.rs
+++ b/crates/hyprstream-9p/src/mac_seam.rs
@@ -168,7 +168,7 @@ impl VerifiedTokenScope {
 /// constructor from raw `uname`, `Subject`, claims, paths, or labels.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct SessionContext {
-    attach_identity: VerifiedAttachIdentity,
+    attach_identity: Option<VerifiedAttachIdentity>,
     security_context: SecurityContext,
     token: Option<VerifiedTokenScope>,
 }
@@ -181,12 +181,36 @@ pub struct SessionContext {
 /// verifier must derive this from the verified subject or stable credential
 /// fingerprint, never from an unverified `Tattach.uname` string.
 #[derive(Clone, Debug, PartialEq, Eq)]
-pub struct VerifiedAttachIdentity(Arc<str>);
+pub struct VerifiedAttachIdentity {
+    subject: Arc<str>,
+    tenant: Arc<str>,
+}
 
 impl VerifiedAttachIdentity {
-    /// Construct an identity obtained from verified credential material.
-    pub fn from_verified_identity(identity: impl Into<Arc<str>>) -> Self {
-        Self(identity.into())
+    /// Construct an identity and tenant obtained from verified credential
+    /// material.
+    ///
+    /// Both values must come from the same successful ticket/attach
+    /// verification. Raw `Tattach.uname` input is not verified credential
+    /// material and must never be passed here.
+    pub fn from_verified_credential(
+        subject: impl Into<Arc<str>>,
+        tenant: impl Into<Arc<str>>,
+    ) -> Self {
+        Self {
+            subject: subject.into(),
+            tenant: tenant.into(),
+        }
+    }
+
+    /// Verified subject identity.
+    pub fn subject(&self) -> &str {
+        &self.subject
+    }
+
+    /// Verified tenant/domain bound by the same credential.
+    pub fn tenant(&self) -> &str {
+        &self.tenant
     }
 }
 
@@ -199,7 +223,7 @@ impl SessionContext {
         token: VerifiedTokenScope,
     ) -> Self {
         Self {
-            attach_identity,
+            attach_identity: Some(attach_identity),
             security_context,
             token: Some(token),
         }
@@ -223,7 +247,7 @@ impl SessionContext {
         security_context: SecurityContext,
     ) -> Self {
         Self {
-            attach_identity,
+            attach_identity: Some(attach_identity),
             security_context,
             token: None,
         }
@@ -234,10 +258,15 @@ impl SessionContext {
     /// makes every operation deny before the AVC/PDP is reached.
     pub fn deny() -> Self {
         Self {
-            attach_identity: VerifiedAttachIdentity::from_verified_identity("denied"),
+            attach_identity: None,
             security_context: anonymous_floor(),
             token: None,
         }
+    }
+
+    /// Verified, tenant-bound attach identity, absent for a fail-closed session.
+    pub fn verified_attach_identity(&self) -> Option<&VerifiedAttachIdentity> {
+        self.attach_identity.as_ref()
     }
 
     /// The context derived at attach from verified identity and key material.
@@ -340,6 +369,33 @@ impl ObjectLabelResolver for DenyUnlabeledResolver {
 /// label—keeps label resolution and auditing inside the authoritative PEP.
 pub trait AccessDecider: Send + Sync {
     fn check(&self, ctx: &SecurityContext, object: ObjectRef<'_>, action: Action) -> bool;
+
+    /// Record a denial made by the reference monitor before the local policy
+    /// decision is reached.
+    ///
+    /// Production implementations must write through the same tamper-evident
+    /// audit sink used by [`Self::check`]. This method is required rather than
+    /// defaulted so adding an early-return gate cannot silently create an
+    /// unaudited denial path.
+    fn audit_denial(
+        &self,
+        ctx: &SecurityContext,
+        object: ObjectRef<'_>,
+        object_label: Option<SecurityLabel>,
+        action: Action,
+        reason: ReferenceMonitorDenyReason,
+    );
+}
+
+/// Denial gates owned by [`ReferenceMonitor`] rather than the local decider.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ReferenceMonitorDenyReason {
+    /// Trusted object-label resolution returned no label.
+    UnlabeledObject,
+    /// The verified sender-bound token was missing, expired, or insufficient.
+    TokenGate,
+    /// The independent read/write IFC floor denied.
+    FloorDeny,
 }
 
 /// Fail-closed fallback for layers that cannot construct the production
@@ -357,6 +413,25 @@ impl AccessDecider for DenyAllDecider {
             "9P access denied: production MAC decider unavailable"
         );
         false
+    }
+
+    fn audit_denial(
+        &self,
+        ctx: &SecurityContext,
+        object: ObjectRef<'_>,
+        object_label: Option<SecurityLabel>,
+        action: Action,
+        reason: ReferenceMonitorDenyReason,
+    ) {
+        tracing::warn!(
+            target: "hyprstream.mac.audit",
+            ?object,
+            ?object_label,
+            ?action,
+            ?reason,
+            clearance = ?ctx.clearance(),
+            "9P access denied before local decider: production MAC decider unavailable"
+        );
     }
 }
 
@@ -405,13 +480,28 @@ impl ReferenceMonitor {
     /// subject, or decider denial all return `false`.
     pub fn authorize(&self, session: &SessionContext, path: &[String], action: Action) -> bool {
         let components: Vec<&str> = path.iter().map(String::as_str).collect();
+        let object = ObjectRef::Path(&components);
         let Some(object_label) = self.labels.resolve(ObjectRef::Path(&components)) else {
+            self.decider.audit_denial(
+                session.security_context(),
+                object,
+                None,
+                action,
+                ReferenceMonitorDenyReason::UnlabeledObject,
+            );
             return false;
         };
 
         // Token is a deny-only capability gate. Its label ceiling is checked
         // against the trusted object label, never a token/UCAN-provided label.
         if !session.token_authorizes(&object_label, action) {
+            self.decider.audit_denial(
+                session.security_context(),
+                object,
+                Some(object_label),
+                action,
+                ReferenceMonitorDenyReason::TokenGate,
+            );
             return false;
         }
 
@@ -425,6 +515,13 @@ impl ReferenceMonitor {
             session.security_context().can_access(&object_label)
         };
         if !ifc_ok {
+            self.decider.audit_denial(
+                session.security_context(),
+                object,
+                Some(object_label),
+                action,
+                ReferenceMonitorDenyReason::FloorDeny,
+            );
             return false;
         }
 
@@ -469,13 +566,18 @@ mod tests {
 
     struct AllowAll;
     impl AccessDecider for AllowAll {
-        fn check(
+        fn check(&self, _ctx: &SecurityContext, _object: ObjectRef<'_>, _action: Action) -> bool {
+            true
+        }
+
+        fn audit_denial(
             &self,
             _ctx: &SecurityContext,
             _object: ObjectRef<'_>,
+            _object_label: Option<SecurityLabel>,
             _action: Action,
-        ) -> bool {
-            true
+            _reason: ReferenceMonitorDenyReason,
+        ) {
         }
     }
 
@@ -517,8 +619,11 @@ mod tests {
     #[test]
     fn authorize_allows_when_all_gates_pass() {
         let monitor = monitor(Some(label(Level::Public)), Arc::new(AllowAll));
-        let session =
-            SessionContext::from_verified_token(VerifiedAttachIdentity::from_verified_identity("test-subject"), ctx(Level::Secret), permit_token(&[Action::Read]));
+        let session = SessionContext::from_verified_token(
+            VerifiedAttachIdentity::from_verified_credential("test-subject", "test-tenant"),
+            ctx(Level::Secret),
+            permit_token(&[Action::Read]),
+        );
         assert!(monitor.authorize(&session, &path(&["a.txt"]), Action::Read));
     }
 
@@ -526,8 +631,11 @@ mod tests {
     fn authorize_denies_unlabeled_before_decider() {
         // Even a permit-everything decider cannot rescue an unlabeled object.
         let monitor = monitor(None, Arc::new(AllowAll));
-        let session =
-            SessionContext::from_verified_token(VerifiedAttachIdentity::from_verified_identity("test-subject"), ctx(Level::Secret), permit_token(&[Action::Read]));
+        let session = SessionContext::from_verified_token(
+            VerifiedAttachIdentity::from_verified_credential("test-subject", "test-tenant"),
+            ctx(Level::Secret),
+            permit_token(&[Action::Read]),
+        );
         assert!(!monitor.authorize(&session, &path(&["a.txt"]), Action::Read));
     }
 
@@ -535,8 +643,11 @@ mod tests {
     fn authorize_denies_missing_or_scope_violating_token() {
         let monitor = monitor(Some(label(Level::Public)), Arc::new(AllowAll));
         assert!(!monitor.authorize(&SessionContext::deny(), &path(&["a.txt"]), Action::Read));
-        let read_only =
-            SessionContext::from_verified_token(VerifiedAttachIdentity::from_verified_identity("test-subject"), ctx(Level::Secret), permit_token(&[Action::Read]));
+        let read_only = SessionContext::from_verified_token(
+            VerifiedAttachIdentity::from_verified_credential("test-subject", "test-tenant"),
+            ctx(Level::Secret),
+            permit_token(&[Action::Read]),
+        );
         assert!(!monitor.authorize(&read_only, &path(&["a.txt"]), Action::Write));
     }
 
@@ -546,8 +657,11 @@ mod tests {
         // subject reading a Secret object denies even with an allow-all
         // decider and a token whose ceiling covers it.
         let monitor = monitor(Some(label(Level::Secret)), Arc::new(AllowAll));
-        let session =
-            SessionContext::from_verified_token(VerifiedAttachIdentity::from_verified_identity("test-subject"), ctx(Level::Public), permit_token(&[Action::Read]));
+        let session = SessionContext::from_verified_token(
+            VerifiedAttachIdentity::from_verified_credential("test-subject", "test-tenant"),
+            ctx(Level::Public),
+            permit_token(&[Action::Read]),
+        );
         assert!(!monitor.authorize(&session, &path(&["secret.txt"]), Action::Read));
     }
 
@@ -565,7 +679,7 @@ mod tests {
         let public_obj = label(Level::Public);
         let mon = monitor(Some(secret_obj), Arc::new(AllowAll));
         let session = SessionContext::from_verified_token(
-            VerifiedAttachIdentity::from_verified_identity("writer"),
+            VerifiedAttachIdentity::from_verified_credential("writer", "test-tenant"),
             ctx(Level::Secret),
             VerifiedTokenScope::from_verified_token(
                 label(Level::Secret),
@@ -588,10 +702,32 @@ mod tests {
         // permissive decider and a Public object. Fail-closed structural shape.
         let mon = monitor(Some(label(Level::Public)), Arc::new(AllowAll));
         let session = SessionContext::from_verified_clearance(
-            VerifiedAttachIdentity::from_verified_identity("stub"),
+            VerifiedAttachIdentity::from_verified_credential("stub", "test-tenant"),
             ctx(Level::Secret),
         );
         assert!(!mon.authorize(&session, &path(&["public"]), Action::Read));
         assert!(!mon.authorize(&session, &path(&["public"]), Action::Write));
+    }
+
+    #[test]
+    fn verified_attach_identity_is_tenant_bound_and_denied_sessions_have_none() {
+        let tenant_a = SessionContext::from_verified_clearance(
+            VerifiedAttachIdentity::from_verified_credential("alice", "tenant-a"),
+            ctx(Level::Secret),
+        );
+        let tenant_b = SessionContext::from_verified_clearance(
+            VerifiedAttachIdentity::from_verified_credential("alice", "tenant-b"),
+            ctx(Level::Secret),
+        );
+
+        assert!(!tenant_a.same_attach_identity(&tenant_b));
+        assert_eq!(
+            tenant_a
+                .verified_attach_identity()
+                .expect("verified session")
+                .tenant(),
+            "tenant-a",
+        );
+        assert!(SessionContext::deny().verified_attach_identity().is_none());
     }
 }

--- a/crates/hyprstream-9p/src/mac_seam.rs
+++ b/crates/hyprstream-9p/src/mac_seam.rs
@@ -21,20 +21,22 @@
 //!
 //! ## Not active by default
 //!
-//! This is the S2 machinery, not S2 activation. [`Translator`](crate::Translator)
-//! runs **without** a [`ReferenceMonitor`] unless the application installs one
-//! via `with_reference_monitor`, and no production construction installs one
-//! today — per-op behavior is then exactly what it was before this module
-//! existed. Activation is blocked on:
+//! This is the S2 machinery. [`Translator`](crate::Translator) runs **without**
+//! a [`ReferenceMonitor`] unless the application installs one via
+//! `with_reference_monitor`. Production constructors install the monitor
+//! structurally (the PEP is wired at every 9P constructor), but **clearance
+//! issuance and the S6 sender-bound token are not yet wired** — so every
+//! session resolves to fail-closed denial at the token gate until:
 //!
-//! - **#698** — no production token-issuance path attaches `Claims.clearance`
-//!   yet, so a live monitor would resolve every subject to deny; and
-//! - **object labels for the served mount** — the genesis/manifest resolver
-//!   (`hyprstream::mac::genesis::CompositeObjectLabelResolver`) exists but is
-//!   not yet wired to the 9P export.
+//! - **#698** — the production token-issuance path attaches `Claims.clearance`,
+//!   letting the monitor resolve a permitting subject context; and
+//! - **the S6 grant path** mints a sender-bound token at `Tattach` so the token
+//!   gate passes for authorized operations.
 //!
-//! Do not wire a monitor into the production serve paths from this crate; that
-//! wiring lands with the activation change, after #698.
+//! Until both land, the installed monitor is the correct fail-closed shape:
+//! every operation denies. There is no permissive default. The
+//! `anonymous_floor()` fallback is **not reachable from production
+//! constructors** — only tests construct a monitor-less translator.
 //!
 //! ## Mediation is over the *name*, not the *object* (read before relying on it)
 //!
@@ -200,6 +202,30 @@ impl SessionContext {
             attach_identity,
             security_context,
             token: Some(token),
+        }
+    }
+
+    /// A session with a verified clearance but **no sender-bound token**.
+    ///
+    /// Every op denies at the token gate ([`Self::token_authorizes`] returns
+    /// `false` when `token` is `None`). This is the **fail-closed structural**
+    /// constructor for the #698 / S6 token path that is not yet wired: the
+    /// monitor is installed, clearance derivation is real (or fail-closed via
+    /// the clearance source), but no capability token has been minted yet, so
+    /// the session cannot authorize any operation. There is no permissive
+    /// default.
+    ///
+    /// Once the S6 grant path issues a sender-bound token at `Tattach`, the
+    /// production authenticator will construct via
+    /// [`from_verified_token`](Self::from_verified_token) instead.
+    pub fn from_verified_clearance(
+        attach_identity: VerifiedAttachIdentity,
+        security_context: SecurityContext,
+    ) -> Self {
+        Self {
+            attach_identity,
+            security_context,
+            token: None,
         }
     }
 
@@ -389,7 +415,15 @@ impl ReferenceMonitor {
         }
 
         // IFC dominance is independent of the token and the policy matrix.
-        if !session.security_context().can_access(&object_label) {
+        // Write operations use the *-property (no-write-down); reads use the
+        // simple-security rule (no-read-up). The assurance axis is a crypto
+        // floor in both directions and does not flip.
+        let ifc_ok = if action == Action::Write {
+            session.security_context().can_write_to(&object_label)
+        } else {
+            session.security_context().can_access(&object_label)
+        };
+        if !ifc_ok {
             return false;
         }
 
@@ -520,5 +554,43 @@ mod tests {
     fn deny_unlabeled_resolver_resolves_nothing() {
         let resolver = DenyUnlabeledResolver;
         assert!(resolver.resolve(ObjectRef::Path(&["anything"])).is_none());
+    }
+
+    #[test]
+    fn authorize_write_uses_no_write_down_ifc() {
+        // A Secret subject with a write-capable token may write to a Secret
+        // object but NOT to a Public one (no-write-down / *-property).
+        let secret_obj = label(Level::Secret);
+        let public_obj = label(Level::Public);
+        let mon = monitor(Some(secret_obj), Arc::new(AllowAll));
+        let session = SessionContext::from_verified_token(
+            VerifiedAttachIdentity::from_verified_identity("writer"),
+            ctx(Level::Secret),
+            VerifiedTokenScope::from_verified_token(
+                label(Level::Secret),
+                Arc::from([Action::Read, Action::Write]),
+                Instant::now() + Duration::from_secs(3600),
+            ),
+        );
+        // Write to Secret object: allowed (same level, all gates pass).
+        assert!(mon.authorize(&session, &path(&["secret"]), Action::Write));
+
+        // Now test write-down: relabel to Public. A Secret writer must not write
+        // to a Public object.
+        let mon_down = monitor(Some(public_obj), Arc::new(AllowAll));
+        assert!(!mon_down.authorize(&session, &path(&["public"]), Action::Write));
+    }
+
+    #[test]
+    fn from_verified_clearance_session_denies_at_token_gate() {
+        // A clearance-only session (no S6 token) denies every op, even with a
+        // permissive decider and a Public object. Fail-closed structural shape.
+        let mon = monitor(Some(label(Level::Public)), Arc::new(AllowAll));
+        let session = SessionContext::from_verified_clearance(
+            VerifiedAttachIdentity::from_verified_identity("stub"),
+            ctx(Level::Secret),
+        );
+        assert!(!mon.authorize(&session, &path(&["public"]), Action::Read));
+        assert!(!mon.authorize(&session, &path(&["public"]), Action::Write));
     }
 }

--- a/crates/hyprstream-9p/src/mac_seam.rs
+++ b/crates/hyprstream-9p/src/mac_seam.rs
@@ -367,7 +367,8 @@ impl AccessDecider for DenyAllDecider {
 ///
 /// Constructed by the application (`hyprstream` crate) at activation time from
 /// its concrete token verifier, genesis/manifest label resolver, and AVC/PDP
-/// adapter. Not installed by any production path yet — see the module docs.
+/// adapter. The application installs it at every production 9P constructor;
+/// monitor-less translators remain available for tests and dormant embeddings.
 pub struct ReferenceMonitor {
     authenticator: Arc<dyn AttachAuthenticator>,
     labels: Arc<dyn ObjectLabelResolver + Send + Sync>,

--- a/crates/hyprstream-9p/src/translator.rs
+++ b/crates/hyprstream-9p/src/translator.rs
@@ -669,13 +669,16 @@ pub async fn serve_mount_uds(
     mount: Arc<dyn Mount>,
     subject: Subject,
     decider: Arc<dyn AccessDecider>,
+    monitor: Option<Arc<crate::mac_seam::ReferenceMonitor>>,
     path: impl AsRef<Path>,
 ) -> Result<()> {
     let listener = UnixListener::bind(path.as_ref())
         .with_context(|| format!("bind 9P UDS listener at {:?}", path.as_ref()))?;
-    Translator::from_mount(mount, subject, decider)
-        .serve_uds(listener)
-        .await
+    let mut t = Translator::from_mount(mount, subject, decider);
+    if let Some(monitor) = monitor {
+        t = t.with_reference_monitor(monitor);
+    }
+    t.serve_uds(listener).await
 }
 
 /// Bind a Cloud-Hypervisor **hybrid-vsock** host socket at `path` and serve
@@ -692,13 +695,16 @@ pub async fn serve_mount_vsock(
     mount: Arc<dyn Mount>,
     subject: Subject,
     decider: Arc<dyn AccessDecider>,
+    monitor: Option<Arc<crate::mac_seam::ReferenceMonitor>>,
     path: impl AsRef<Path>,
 ) -> Result<()> {
     let listener = UnixListener::bind(path.as_ref())
         .with_context(|| format!("bind 9P hybrid-vsock listener at {:?}", path.as_ref()))?;
-    Translator::from_mount(mount, subject, decider)
-        .serve_vsock(listener)
-        .await
+    let mut t = Translator::from_mount(mount, subject, decider);
+    if let Some(monitor) = monitor {
+        t = t.with_reference_monitor(monitor);
+    }
+    t.serve_vsock(listener).await
 }
 
 /// Bind a **raw** (no-handshake) hybrid-vsock **per-port** host socket at `path`
@@ -718,14 +724,17 @@ pub async fn serve_mount_vsock_raw(
     mount: Arc<dyn Mount>,
     subject: Subject,
     decider: Arc<dyn AccessDecider>,
+    monitor: Option<Arc<crate::mac_seam::ReferenceMonitor>>,
     path: impl AsRef<Path>,
 ) -> Result<()> {
     let listener = UnixListener::bind(path.as_ref()).with_context(|| {
         format!("bind 9P raw hybrid-vsock per-port listener at {:?}", path.as_ref())
     })?;
-    Translator::from_mount(mount, subject, decider)
-        .serve_vsock_raw(listener)
-        .await
+    let mut t = Translator::from_mount(mount, subject, decider);
+    if let Some(monitor) = monitor {
+        t = t.with_reference_monitor(monitor);
+    }
+    t.serve_vsock_raw(listener).await
 }
 
 /// Transport-agnostic accept surface, implemented for [`TcpListener`] and

--- a/crates/hyprstream-9p/src/translator.rs
+++ b/crates/hyprstream-9p/src/translator.rs
@@ -1142,7 +1142,7 @@ mod tests {
 
     use crate::mac_seam::{
         AccessDecider, AttachAuthenticator, ObjectLabelResolver, ObjectRef, VerifiedAttachIdentity,
-        VerifiedTokenScope,
+        ReferenceMonitorDenyReason, VerifiedTokenScope,
     };
     use hyprstream_rpc::auth::mac::{
         Assurance, CompartmentSet, Level, SecurityContext, SecurityLabel, VerifiedKeyMaterial,
@@ -1167,7 +1167,7 @@ mod tests {
 
     fn permit_session_as(identity: &str, level: Level, ops: &[Action]) -> SessionContext {
         SessionContext::from_verified_token(
-            VerifiedAttachIdentity::from_verified_identity(identity),
+            VerifiedAttachIdentity::from_verified_credential(identity, "test-tenant"),
             ctx(level),
             VerifiedTokenScope::from_verified_token(
                 label(Level::Secret),
@@ -1214,6 +1214,16 @@ mod tests {
             _action: Action,
         ) -> bool {
             true
+        }
+
+        fn audit_denial(
+            &self,
+            _ctx: &SecurityContext,
+            _object: ObjectRef<'_>,
+            _object_label: Option<SecurityLabel>,
+            _action: Action,
+            _reason: ReferenceMonitorDenyReason,
+        ) {
         }
     }
 
@@ -1264,7 +1274,7 @@ mod tests {
     #[tokio::test]
     async fn monitor_denies_expired_token_at_attach() {
         let expired = SessionContext::from_verified_token(
-            VerifiedAttachIdentity::from_verified_identity("test-subject"),
+            VerifiedAttachIdentity::from_verified_credential("test-subject", "test-tenant"),
             ctx(Level::Secret),
             VerifiedTokenScope::from_verified_token(
                 label(Level::Secret),
@@ -1323,6 +1333,16 @@ mod tests {
                 action: Action,
             ) -> bool {
                 !matches!(action, Action::Read)
+            }
+
+            fn audit_denial(
+                &self,
+                _ctx: &SecurityContext,
+                _object: ObjectRef<'_>,
+                _object_label: Option<SecurityLabel>,
+                _action: Action,
+                _reason: ReferenceMonitorDenyReason,
+            ) {
             }
         }
 
@@ -1393,7 +1413,7 @@ mod tests {
             }
         }
         let session = SessionContext::from_verified_token(
-            VerifiedAttachIdentity::from_verified_identity("test-subject"),
+            VerifiedAttachIdentity::from_verified_credential("test-subject", "test-tenant"),
             ctx(Level::Secret),
             VerifiedTokenScope::from_verified_token(
                 label(Level::Confidential),
@@ -1488,6 +1508,16 @@ mod tests {
             ) -> bool {
                 !matches!(action, Action::Getattr)
             }
+
+            fn audit_denial(
+                &self,
+                _ctx: &SecurityContext,
+                _object: ObjectRef<'_>,
+                _object_label: Option<SecurityLabel>,
+                _action: Action,
+                _reason: ReferenceMonitorDenyReason,
+            ) {
+            }
         }
 
         let backend = MemoryBackend::default();
@@ -1562,6 +1592,16 @@ mod tests {
                 action: Action,
             ) -> bool {
                 !(action == Action::Read && matches!(object, ObjectRef::Path([])))
+            }
+
+            fn audit_denial(
+                &self,
+                _ctx: &SecurityContext,
+                _object: ObjectRef<'_>,
+                _object_label: Option<SecurityLabel>,
+                _action: Action,
+                _reason: ReferenceMonitorDenyReason,
+            ) {
             }
         }
 
@@ -1747,6 +1787,16 @@ mod tests {
         impl AccessDecider for DenySecretReads {
             fn check(&self, _ctx: &SecurityContext, object: ObjectRef<'_>, action: Action) -> bool {
                 !(action == Action::Read && matches!(object, ObjectRef::Path(["a", "b"])))
+            }
+
+            fn audit_denial(
+                &self,
+                _ctx: &SecurityContext,
+                _object: ObjectRef<'_>,
+                _object_label: Option<SecurityLabel>,
+                _action: Action,
+                _reason: ReferenceMonitorDenyReason,
+            ) {
             }
         }
         let root = SyntheticNode::dir().with_child(

--- a/crates/hyprstream-9p/tests/socket_roundtrip.rs
+++ b/crates/hyprstream-9p/tests/socket_roundtrip.rs
@@ -13,8 +13,10 @@
 use std::sync::Arc;
 use std::time::Duration;
 
-use hyprstream_9p::{serve_mount_uds, AccessDecider, Action, Remote9pMount};
-use hyprstream_rpc::auth::mac::{ObjectRef, SecurityContext};
+use hyprstream_9p::{
+    serve_mount_uds, AccessDecider, Action, ReferenceMonitorDenyReason, Remote9pMount,
+};
+use hyprstream_rpc::auth::mac::{ObjectRef, SecurityContext, SecurityLabel};
 use hyprstream_rpc::Subject;
 use hyprstream_vfs::{Mount, SyntheticMount, SyntheticNode};
 
@@ -22,6 +24,16 @@ struct TestDecider;
 impl AccessDecider for TestDecider {
     fn check(&self, _: &SecurityContext, _: ObjectRef<'_>, _: Action) -> bool {
         true
+    }
+
+    fn audit_denial(
+        &self,
+        _: &SecurityContext,
+        _: ObjectRef<'_>,
+        _: Option<SecurityLabel>,
+        _: Action,
+        _: ReferenceMonitorDenyReason,
+    ) {
     }
 }
 

--- a/crates/hyprstream-9p/tests/socket_roundtrip.rs
+++ b/crates/hyprstream-9p/tests/socket_roundtrip.rs
@@ -48,7 +48,7 @@ async fn socket_client_mount_round_trips_against_translator() {
         let sock = sock.clone();
         async move {
             // Returns only on listener error / shutdown; we abort it at the end.
-            let _ = serve_mount_uds(mount, subject, Arc::new(TestDecider), sock).await;
+            let _ = serve_mount_uds(mount, subject, Arc::new(TestDecider), None, sock).await;
         }
     });
 

--- a/crates/hyprstream-9p/tests/tcp_translator.rs
+++ b/crates/hyprstream-9p/tests/tcp_translator.rs
@@ -10,8 +10,8 @@ use std::time::Duration;
 
 use hyprstream_9p::memory::MemoryBackend;
 use hyprstream_9p::msg::{self, Response};
-use hyprstream_9p::{AccessDecider, Action, Translator};
-use hyprstream_rpc::auth::mac::{ObjectRef, SecurityContext};
+use hyprstream_9p::{AccessDecider, Action, ReferenceMonitorDenyReason, Translator};
+use hyprstream_rpc::auth::mac::{ObjectRef, SecurityContext, SecurityLabel};
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::net::{TcpListener, TcpStream};
 
@@ -19,6 +19,16 @@ struct TestDecider;
 impl AccessDecider for TestDecider {
     fn check(&self, _: &SecurityContext, _: ObjectRef<'_>, _: Action) -> bool {
         true
+    }
+
+    fn audit_denial(
+        &self,
+        _: &SecurityContext,
+        _: ObjectRef<'_>,
+        _: Option<SecurityLabel>,
+        _: Action,
+        _: ReferenceMonitorDenyReason,
+    ) {
     }
 }
 

--- a/crates/hyprstream-9p/tests/uds_translator.rs
+++ b/crates/hyprstream-9p/tests/uds_translator.rs
@@ -14,8 +14,8 @@ use std::time::Duration;
 
 use async_trait::async_trait;
 use hyprstream_9p::msg::{self, Response};
-use hyprstream_9p::{AccessDecider, Action, Translator};
-use hyprstream_rpc::auth::mac::{ObjectRef, SecurityContext};
+use hyprstream_9p::{AccessDecider, Action, ReferenceMonitorDenyReason, Translator};
+use hyprstream_rpc::auth::mac::{ObjectRef, SecurityContext, SecurityLabel};
 use hyprstream_rpc::Subject;
 use hyprstream_vfs::{DirEntry, Fid, Mount, MountError, Stat};
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
@@ -25,6 +25,16 @@ struct TestDecider;
 impl AccessDecider for TestDecider {
     fn check(&self, _: &SecurityContext, _: ObjectRef<'_>, _: Action) -> bool {
         true
+    }
+
+    fn audit_denial(
+        &self,
+        _: &SecurityContext,
+        _: ObjectRef<'_>,
+        _: Option<SecurityLabel>,
+        _: Action,
+        _: ReferenceMonitorDenyReason,
+    ) {
     }
 }
 

--- a/crates/hyprstream-rpc/src/auth/mac/context.rs
+++ b/crates/hyprstream-rpc/src/auth/mac/context.rs
@@ -132,6 +132,14 @@ impl SecurityContext {
         self.clearance.can_access(object_label)
     }
 
+    /// `object ⊒ self` — Bell–LaPadula *-property (no-write-down): may this
+    /// subject **write** to the object? Write-direction IFC floor (#1269).
+    /// Forward to [`SecurityLabel::can_write_to`].
+    #[must_use]
+    pub fn can_write_to(&self, object_label: &SecurityLabel) -> bool {
+        self.clearance.can_write_to(object_label)
+    }
+
     pub fn level(&self) -> Level {
         self.clearance.level
     }

--- a/crates/hyprstream-rpc/src/auth/mac/label.rs
+++ b/crates/hyprstream-rpc/src/auth/mac/label.rs
@@ -386,6 +386,32 @@ impl SecurityLabel {
             && object.compartments.is_subset(self.compartments)
     }
 
+    /// Bell–LaPadula *-property (confinement / no-write-down): may a subject
+    /// with clearance `self` **write** to an object labelled `object`?
+    ///
+    /// The write-direction dual of [`can_access`]. A subject may write only to
+    /// objects at least as restrictive as its own clearance — preventing a
+    /// high-level subject from leaking secrets to a lower-level object:
+    /// - `object.level >= self.level`              (no-write-down)
+    /// - `self.assurance >= object.assurance`       (crypto floor is NOT flipped —
+    ///   you cannot write to a higher-assurance object than your key proves)
+    /// - `self.compartments.is_subset(object.compartments)` (no compartment
+    ///   write-down: the target must be at least as compartmented as the writer)
+    ///
+    /// The assurance axis intentionally does **not** flip: it is a
+    /// crypto-authentication floor on both read and write, not a confidentiality
+    /// axis. This is conservative — it tightens rather than relaxes the gate.
+    /// See the assurance-axis overload note on [`can_access`] and #1232.
+    ///
+    /// [`can_access`]: SecurityLabel::can_access
+    #[inline]
+    #[must_use]
+    pub fn can_write_to(&self, object: &SecurityLabel) -> bool {
+        object.level >= self.level
+            && self.assurance >= object.assurance
+            && self.compartments.is_subset(object.compartments)
+    }
+
     /// IFC provenance join over confidentiality, integrity, and compartments.
     ///
     /// `a ⊔ b` = `(max(level), min(assurance), union(compartments))`: secrecy
@@ -515,6 +541,49 @@ mod tests {
         let unverified = label(Level::Secret, Assurance::Unverified, &[0]);
         let needs_classical = label(Level::Public, Assurance::Classical, &[]);
         assert!(!unverified.can_access(&needs_classical));
+    }
+
+    #[test]
+    fn write_direction_no_write_down() {
+        // A Secret subject may write to a Secret object (same level).
+        let secret = label(Level::Secret, Assurance::Classical, &[]);
+        assert!(secret.can_write_to(&secret));
+
+        // A Secret subject may NOT write to a Public object (no-write-down).
+        let public = label(Level::Public, Assurance::Classical, &[]);
+        assert!(!secret.can_write_to(&public));
+
+        // A Public subject MAY write to a Secret object (writing up is allowed).
+        assert!(public.can_write_to(&secret));
+    }
+
+    #[test]
+    fn write_direction_compartments_no_write_out() {
+        // A subject in {0,1} may write to an object in {0,1} or a superset.
+        let subj = label(Level::Secret, Assurance::Classical, &[0, 1]);
+        let same = label(Level::Secret, Assurance::Classical, &[0, 1]);
+        let superset = label(Level::Secret, Assurance::Classical, &[0, 1, 2]);
+        assert!(subj.can_write_to(&same));
+        assert!(subj.can_write_to(&superset));
+
+        // Writing to a subset (e.g. {0}) leaks compartment-1 data — denied.
+        let subset = label(Level::Secret, Assurance::Classical, &[0]);
+        assert!(!subj.can_write_to(&subset));
+    }
+
+    #[test]
+    fn write_direction_assurance_floor_not_flipped() {
+        // Assurance is a crypto floor on both axes: a Classical subject cannot
+        // write to a PqHybrid-required object even though the *-property level
+        // direction is satisfied (Public→Public or Public→Secret is "write up").
+        let classical_subj = label(Level::Public, Assurance::Classical, &[]);
+        let pqc_object = label(Level::Secret, Assurance::PqHybrid, &[]);
+        assert!(!classical_subj.can_write_to(&pqc_object));
+
+        // A PqHybrid subject writing to a Classical object at ≥ level: allowed.
+        let pqc_subj = label(Level::Public, Assurance::PqHybrid, &[]);
+        let classical_obj = label(Level::Secret, Assurance::Classical, &[]);
+        assert!(pqc_subj.can_write_to(&classical_obj));
     }
 
     #[test]

--- a/crates/hyprstream-workers/src/runtime/kata_backend.rs
+++ b/crates/hyprstream-workers/src/runtime/kata_backend.rs
@@ -270,6 +270,7 @@ pub struct KataBackend {
     image_config: ImageConfig,
     rafs_store: Arc<RafsStore>,
     ninep_decider: Arc<dyn hyprstream_9p::AccessDecider>,
+    ninep_monitor: Option<Arc<hyprstream_9p::ReferenceMonitor>>,
 }
 
 impl KataBackend {
@@ -277,11 +278,13 @@ impl KataBackend {
         image_config: ImageConfig,
         rafs_store: Arc<RafsStore>,
         ninep_decider: Arc<dyn hyprstream_9p::AccessDecider>,
+        ninep_monitor: Option<Arc<hyprstream_9p::ReferenceMonitor>>,
     ) -> Self {
         Self {
             image_config,
             rafs_store,
             ninep_decider,
+            ninep_monitor,
         }
     }
 
@@ -711,6 +714,7 @@ impl SandboxBackend for KataBackend {
                 tenant_mount,
                 subject,
                 Arc::clone(&self.ninep_decider),
+                self.ninep_monitor.clone(),
             )
             .await
             {
@@ -1225,6 +1229,7 @@ impl KataBackend {
         mount: Arc<dyn Mount>,
         subject: Subject,
         decider: Arc<dyn hyprstream_9p::AccessDecider>,
+        monitor: Option<Arc<hyprstream_9p::ReferenceMonitor>>,
     ) -> Result<Vfs9pVsockServer> {
         // The CH hybrid-vsock base UDS (`hvsock://<base>`), same source the
         // kata-agent client uses — keeps CH/Dragonball working without a branch.
@@ -1278,6 +1283,7 @@ impl KataBackend {
                 mount,
                 subject,
                 decider,
+                monitor,
                 &sock_for_task,
             )
             .await
@@ -1333,6 +1339,7 @@ inventory::submit! {
                 ctx.image_config.clone(),
                 Arc::clone(&ctx.rafs_store),
                 Arc::clone(&ctx.ninep_decider),
+                ctx.ninep_monitor.clone(),
             )) as Arc<dyn crate::runtime::SandboxBackend>)
         },
     }
@@ -1413,6 +1420,7 @@ mod tests {
             image_config,
             Arc::clone(&rafs_store),
             Arc::new(FixtureAccessDecider),
+            None,
         );
         (backend, rafs_store, temp_dir)
     }

--- a/crates/hyprstream-workers/src/runtime/kata_backend.rs
+++ b/crates/hyprstream-workers/src/runtime/kata_backend.rs
@@ -1366,6 +1366,16 @@ mod tests {
         ) -> bool {
             true
         }
+
+        fn audit_denial(
+            &self,
+            _ctx: &SecurityContext,
+            _object: ObjectRef<'_>,
+            _object_label: Option<hyprstream_rpc::auth::mac::SecurityLabel>,
+            _action: hyprstream_9p::Action,
+            _reason: hyprstream_9p::ReferenceMonitorDenyReason,
+        ) {
+        }
     }
 
     #[test]

--- a/crates/hyprstream-workers/src/runtime/pool.rs
+++ b/crates/hyprstream-workers/src/runtime/pool.rs
@@ -533,6 +533,16 @@ mod tests {
         ) -> bool {
             true
         }
+
+        fn audit_denial(
+            &self,
+            _ctx: &SecurityContext,
+            _object: ObjectRef<'_>,
+            _object_label: Option<hyprstream_rpc::auth::mac::SecurityLabel>,
+            _action: hyprstream_9p::Action,
+            _reason: hyprstream_9p::ReferenceMonitorDenyReason,
+        ) {
+        }
     }
 
     /// Create a test pool with Kata backend and minimal configuration

--- a/crates/hyprstream-workers/src/runtime/pool.rs
+++ b/crates/hyprstream-workers/src/runtime/pool.rs
@@ -571,6 +571,7 @@ mod tests {
             image_config,
             rafs_store,
             Arc::new(FixtureAccessDecider),
+            None,
         ));
         let pool = Arc::new(SandboxPool::new(pool_config, backend));
 

--- a/crates/hyprstream-workers/src/runtime/selection.rs
+++ b/crates/hyprstream-workers/src/runtime/selection.rs
@@ -76,6 +76,12 @@ pub struct BackendCtx {
     #[cfg(not(target_arch = "wasm32"))]
     pub ninep_decider: Arc<dyn hyprstream_9p::AccessDecider>,
 
+    /// #1269: full MAC reference monitor for 9P exports. `Some` at every
+    /// production constructor — the `anonymous_floor()` fallback is not
+    /// reachable. `None` in tests only.
+    #[cfg(not(target_arch = "wasm32"))]
+    pub ninep_monitor: Option<Arc<hyprstream_9p::ReferenceMonitor>>,
+
     /// Image storage configuration. Any backend that composes the RAFS image
     /// filesystem (kata over virtio-fs, or nspawn over FUSE — Model B #715)
     /// consumes it, so it exists on the `oci-image` build, not just `kata-vm`.

--- a/crates/hyprstream-workers/src/runtime/service.rs
+++ b/crates/hyprstream-workers/src/runtime/service.rs
@@ -1531,6 +1531,7 @@ mod tests {
                 image_config,
                 Arc::clone(&rafs_store),
                 Arc::new(FixtureAccessDecider),
+                None,
             ),
         );
         let service = WorkerService::new(pool_config, backend, Some(rafs_store), transport, signing_key)?;

--- a/crates/hyprstream-workers/src/runtime/service.rs
+++ b/crates/hyprstream-workers/src/runtime/service.rs
@@ -1484,6 +1484,16 @@ mod tests {
         ) -> bool {
             true
         }
+
+        fn audit_denial(
+            &self,
+            _ctx: &SecurityContext,
+            _object: ObjectRef<'_>,
+            _object_label: Option<hyprstream_rpc::auth::mac::SecurityLabel>,
+            _action: hyprstream_9p::Action,
+            _reason: hyprstream_9p::ReferenceMonitorDenyReason,
+        ) {
+        }
     }
 
     /// Create a test WorkerService with temporary directories

--- a/crates/hyprstream-workers/src/runtime/wanix_workload.rs
+++ b/crates/hyprstream-workers/src/runtime/wanix_workload.rs
@@ -576,6 +576,16 @@ mod tests {
         ) -> bool {
             true
         }
+
+        fn audit_denial(
+            &self,
+            _ctx: &SecurityContext,
+            _object: ObjectRef<'_>,
+            _object_label: Option<hyprstream_rpc::auth::mac::SecurityLabel>,
+            _action: hyprstream_9p::Action,
+            _reason: hyprstream_9p::ReferenceMonitorDenyReason,
+        ) {
+        }
     }
 
     fn tenant_mount() -> Arc<dyn Mount> {

--- a/crates/hyprstream-workers/src/runtime/wanix_workload.rs
+++ b/crates/hyprstream-workers/src/runtime/wanix_workload.rs
@@ -289,6 +289,7 @@ pub async fn inject_9p_socket(
     mount: Arc<dyn Mount>,
     subject: Subject,
     decider: Arc<dyn hyprstream_9p::AccessDecider>,
+    monitor: Option<Arc<hyprstream_9p::ReferenceMonitor>>,
     workload_dir: &Path,
     guest_cfg: &WanixGuestConfig,
 ) -> Result<WanixInjection> {
@@ -316,9 +317,14 @@ pub async fn inject_9p_socket(
     let task = tokio::spawn(async move {
         // `serve_uds` is PR-A's wire-faithful 9P2000.L server; it runs until the
         // socket errors/closes (or the task is aborted on teardown).
-        if let Err(e) = hyprstream_9p::Translator::from_mount(mount, subject, decider)
-            .serve_uds(listener)
-            .await
+        // #1269: when a ReferenceMonitor is supplied, every dispatched op is
+        // mediated (attach-time token verification, trusted label resolution,
+        // token gate, independent IFC dominance, then the local AVC/PDP).
+        let mut translator = hyprstream_9p::Translator::from_mount(mount, subject, decider);
+        if let Some(monitor) = monitor {
+            translator = translator.with_reference_monitor(monitor);
+        }
+        if let Err(e) = translator.serve_uds(listener).await
         {
             warn!(socket = %sock_for_log.display(), error = %e, "9P workload server exited with error");
         }
@@ -535,11 +541,12 @@ pub async fn prepare_wanix_workload(
     mount: Arc<dyn Mount>,
     subject: Subject,
     decider: Arc<dyn hyprstream_9p::AccessDecider>,
+    monitor: Option<Arc<hyprstream_9p::ReferenceMonitor>>,
     workload_dir: &Path,
     guest_cfg: &WanixGuestConfig,
 ) -> Result<WanixInjection> {
     super::require_9p_socket_capability(backend_type)?;
-    inject_9p_socket(mount, subject, decider, workload_dir, guest_cfg).await
+    inject_9p_socket(mount, subject, decider, monitor, workload_dir, guest_cfg).await
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -606,6 +613,7 @@ mod tests {
             tenant_mount(),
             Subject::anonymous(),
             Arc::new(FixtureAccessDecider),
+            None,
             dir.path(),
             &cfg,
         )
@@ -754,6 +762,7 @@ mod tests {
             tenant_mount(),
             Subject::anonymous(),
             Arc::new(FixtureAccessDecider),
+            None,
             dir.path(),
             &WanixGuestConfig::default(),
         )
@@ -812,6 +821,7 @@ mod tests {
             tenant_mount(),
             Subject::anonymous(),
             Arc::new(FixtureAccessDecider),
+            None,
             dir.path(),
             &WanixGuestConfig::default(),
         )
@@ -835,6 +845,7 @@ mod tests {
             tenant_mount(),
             Subject::anonymous(),
             Arc::new(FixtureAccessDecider),
+            None,
             dir.path(),
             &WanixGuestConfig::default(),
         )
@@ -858,6 +869,7 @@ mod tests {
             tenant_mount(),
             Subject::anonymous(),
             Arc::new(FixtureAccessDecider),
+            None,
             dir.path(),
             &WanixGuestConfig::default(),
         )

--- a/crates/hyprstream-workers/tests/kata_9p_vsock_e2e.rs
+++ b/crates/hyprstream-workers/tests/kata_9p_vsock_e2e.rs
@@ -218,6 +218,7 @@ async fn kata_9p_vsock_e2e() -> TestResult {
         image_config,
         Arc::clone(&rafs_store),
         Arc::new(FixtureAccessDecider),
+        None,
     );
 
     assert!(
@@ -395,6 +396,7 @@ async fn kata_9p_fuse_mount_e2e() -> TestResult {
         image_config,
         Arc::clone(&rafs_store),
         Arc::new(FixtureAccessDecider),
+        None,
     );
     assert!(
         backend.is_available(),

--- a/crates/hyprstream-workers/tests/kata_9p_vsock_e2e.rs
+++ b/crates/hyprstream-workers/tests/kata_9p_vsock_e2e.rs
@@ -66,8 +66,8 @@ use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
-use hyprstream_9p::{AccessDecider, Action};
-use hyprstream_rpc::auth::mac::{ObjectRef, SecurityContext};
+use hyprstream_9p::{AccessDecider, Action, ReferenceMonitorDenyReason};
+use hyprstream_rpc::auth::mac::{ObjectRef, SecurityContext, SecurityLabel};
 use hyprstream_workers::runtime::{KataBackend, PodSandbox, PodSandboxConfig, SandboxBackend};
 use hyprstream_workers::{HypervisorType, ImageConfig, PoolConfig, RafsStore};
 
@@ -78,6 +78,16 @@ struct FixtureAccessDecider;
 impl AccessDecider for FixtureAccessDecider {
     fn check(&self, _ctx: &SecurityContext, _object: ObjectRef<'_>, _action: Action) -> bool {
         true
+    }
+
+    fn audit_denial(
+        &self,
+        _ctx: &SecurityContext,
+        _object: ObjectRef<'_>,
+        _object_label: Option<SecurityLabel>,
+        _action: Action,
+        _reason: ReferenceMonitorDenyReason,
+    ) {
     }
 }
 

--- a/crates/hyprstream-workers/tests/kata_spawn_e2e.rs
+++ b/crates/hyprstream-workers/tests/kata_spawn_e2e.rs
@@ -255,6 +255,7 @@ async fn kata_spawn_e2e() -> TestResult {
         image_config,
         Arc::clone(&rafs_store),
         Arc::new(FixtureAccessDecider),
+        None,
     );
 
     assert!(

--- a/crates/hyprstream-workers/tests/kata_spawn_e2e.rs
+++ b/crates/hyprstream-workers/tests/kata_spawn_e2e.rs
@@ -70,8 +70,8 @@ use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
-use hyprstream_9p::{AccessDecider, Action};
-use hyprstream_rpc::auth::mac::{ObjectRef, SecurityContext};
+use hyprstream_9p::{AccessDecider, Action, ReferenceMonitorDenyReason};
+use hyprstream_rpc::auth::mac::{ObjectRef, SecurityContext, SecurityLabel};
 use hyprstream_workers::runtime::{KataBackend, PodSandbox, PodSandboxConfig, SandboxBackend};
 use hyprstream_workers::{HypervisorType, ImageConfig, PoolConfig, RafsStore};
 
@@ -82,6 +82,16 @@ struct FixtureAccessDecider;
 impl AccessDecider for FixtureAccessDecider {
     fn check(&self, _ctx: &SecurityContext, _object: ObjectRef<'_>, _action: Action) -> bool {
         true
+    }
+
+    fn audit_denial(
+        &self,
+        _ctx: &SecurityContext,
+        _object: ObjectRef<'_>,
+        _object_label: Option<SecurityLabel>,
+        _action: Action,
+        _reason: ReferenceMonitorDenyReason,
+    ) {
     }
 }
 

--- a/crates/hyprstream/src/bin/main.rs
+++ b/crates/hyprstream/src/bin/main.rs
@@ -1178,9 +1178,16 @@ fn handle_quick_command(
                             )
                             .await
                             .context("construct worker 9P MAC PEP")?;
+                        // #1269: install the full ReferenceMonitor at every
+                        // production 9P constructor. Fail-closed until #698
+                        // wires clearance issuance + S6 token path.
+                        let ninep_monitor = Some(hyprstream_core::mac::enrollment_ninep_reference_monitor(
+                            Arc::clone(&ninep_decider),
+                        ));
                         let backend_ctx = BackendCtx {
                             pool_config: pool_config.clone(),
                             ninep_decider,
+                            ninep_monitor,
                             #[cfg(feature = "oci-image")]
                             image_config,
                             #[cfg(feature = "oci-image")]

--- a/crates/hyprstream/src/mac/audit.rs
+++ b/crates/hyprstream/src/mac/audit.rs
@@ -208,6 +208,14 @@ pub struct AuditRecord {
     pub action: Action,
     /// Human-readable decision reason (which gate denied, or "permit").
     pub reason: DecisionReason,
+    /// Independently verified application principal, when the enforcement
+    /// plane has a stable identifier. Omitted for legacy/type-only records.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub subject_id: Option<String>,
+    /// Concrete tenant-qualified object, when known. Omitted for
+    /// legacy/type-only records.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub object_id: Option<String>,
 }
 
 /// Why the PDP returned this decision. Recorded so denials are diagnosable and
@@ -1042,6 +1050,8 @@ impl<A: Avc, S: AuditSink> AuditedAvc<A, S> {
             object_label: object.label,
             action,
             reason,
+            subject_id: None,
+            object_id: None,
         };
         match self.sink.record(&record) {
             Ok(()) => enforced,
@@ -1560,6 +1570,8 @@ mod tests {
             object_label: low(),
             action: Action(1),
             reason: DecisionReason::Permit,
+            subject_id: None,
+            object_id: None,
         };
         let hash = rec.content_hash().expect("canonical encode + hash");
         let hex = hex::encode(hash);
@@ -1585,6 +1597,8 @@ mod tests {
             object_label: low(),
             action: Action(1),
             reason: DecisionReason::Permit,
+            subject_id: None,
+            object_id: None,
         };
         let h1 = rec.content_hash().unwrap();
         // Same fields → same hash.
@@ -1624,6 +1638,8 @@ mod tests {
             object_label: low(),
             action: Action(1),
             reason: DecisionReason::Permit,
+            subject_id: None,
+            object_id: None,
         };
 
         // `None` is skipped: the field name never appears in the canonical
@@ -1732,6 +1748,8 @@ mod tests {
             object_label: low(),
             action: Action(1),
             reason: DecisionReason::Permit,
+            subject_id: None,
+            object_id: None,
         };
         store.record(&rec).unwrap();
         store.record(&rec).unwrap();
@@ -1775,6 +1793,8 @@ mod tests {
             object_label: low(),
             action: Action(9),
             reason: DecisionReason::TeMiss,
+            subject_id: None,
+            object_id: None,
         };
         store.record(&rec).unwrap();
 
@@ -1826,6 +1846,8 @@ mod tests {
             object_label: low(),
             action: Action(1),
             reason: DecisionReason::Permit,
+            subject_id: None,
+            object_id: None,
         };
         store.record(&rec).unwrap();
 
@@ -1902,6 +1924,8 @@ mod tests {
             object_label: low(),
             action: Action(1),
             reason: DecisionReason::Permit,
+            subject_id: None,
+            object_id: None,
         };
         // Write two records (store assigns seq 0, then 1).
         store.record(&base).unwrap();
@@ -1952,6 +1976,8 @@ mod tests {
             object_label: low(),
             action: Action(1),
             reason: DecisionReason::Permit,
+            subject_id: None,
+            object_id: None,
         }
     }
 

--- a/crates/hyprstream/src/mac/cas_pep.rs
+++ b/crates/hyprstream/src/mac/cas_pep.rs
@@ -343,6 +343,8 @@ impl CasPep {
             object_label: label.unwrap_or_else(SecurityLabel::bottom),
             action: crate::mac::te::Action::from_scope_action(crate::mac::te::ScopeAction::Query),
             reason,
+            subject_id: None,
+            object_id: None,
         };
 
         match self.sink.record(&record) {

--- a/crates/hyprstream/src/mac/exchange.rs
+++ b/crates/hyprstream/src/mac/exchange.rs
@@ -487,6 +487,8 @@ fn audit_grant_outcome(
         object_label: request.object_label.unwrap_or_else(SecurityLabel::bottom),
         action,
         reason,
+        subject_id: None,
+        object_id: None,
     };
 
     match sink.record(&record) {

--- a/crates/hyprstream/src/mac/mod.rs
+++ b/crates/hyprstream/src/mac/mod.rs
@@ -118,7 +118,11 @@ pub use genesis::{
     floor_label, genesis_lattice, CompositeObjectLabelResolver, GeneratedNodeCoverage,
     GenesisGate, ManifestLabelSource, NamespaceEnumerator, NoManifests, SitePolicy,
 };
-pub use pep::{production_ninep_decider, NinePAccessDecider};
+pub use pep::{
+    enrollment_ninep_reference_monitor, production_ninep_decider,
+    production_ninep_reference_monitor, ClearanceAttachAuthenticator, EnrollmentClearanceSource,
+    NinePAccessDecider, NinePClearanceSource,
+};
 // #1270: CAS-native MAC PEP — the shared CAS enforcement contract.
 pub use cas_pep::{
     domain_label, seal_label, CasClearanceSource, CasObjectLabelResolver, CasPep,

--- a/crates/hyprstream/src/mac/mod.rs
+++ b/crates/hyprstream/src/mac/mod.rs
@@ -120,8 +120,8 @@ pub use genesis::{
 };
 pub use pep::{
     enrollment_ninep_reference_monitor, production_ninep_decider,
-    production_ninep_reference_monitor, ClearanceAttachAuthenticator, EnrollmentClearanceSource,
-    NinePAccessDecider, NinePClearanceSource,
+    production_ninep_reference_monitor, EnrollmentClearanceSource, NinePAccessDecider,
+    NinePClearanceSource, VerifiedClearanceSessionFactory,
 };
 // #1270: CAS-native MAC PEP — the shared CAS enforcement contract.
 pub use cas_pep::{

--- a/crates/hyprstream/src/mac/pep.rs
+++ b/crates/hyprstream/src/mac/pep.rs
@@ -2,16 +2,38 @@
 //!
 //! The translator supplies the verified caller context and walked object
 //! reference. This decider resolves the content-truth label, applies the
-//! intrinsic lattice dominance rule for read-class operations, fails every
-//! write closed pending the IFC write-direction decision, and records every
-//! outcome through the existing tamper-evident MAC audit sink.
+//! intrinsic lattice dominance rule (read-direction `can_access` for reads,
+//! write-direction `can_write_to` for writes), and records every outcome
+//! through the existing tamper-evident MAC audit sink.
+//!
+//! ## Activation (#1269)
+//!
+//! [`production_ninep_reference_monitor`] assembles the full
+//! [`ReferenceMonitor`](hyprstream_9p::ReferenceMonitor) from the mandatory
+//! decider, the genesis content-truth resolver, and a
+//! [`NinePClearanceSource`] (the #698 clearance-provenance seam). Production
+//! 9P constructors install the monitor via `Translator::with_reference_monitor`;
+//! the `anonymous_floor()` fallback is not reachable from any production path.
+//!
+//! **Fail-closed until #698 + S6 wire clearance and token issuance**: the
+//! production clearance source resolves to `None` (deny) for unenrolled
+//! subjects, and the S6 sender-bound token is not yet attached to 9P
+//! `Tattach`. So the installed monitor denies every operation — there is no
+//! permissive default (per #547). The structure is correct; functional
+//! permitting follows #698 and the S6 grant path.
 
 use std::sync::Arc;
 use std::time::{SystemTime, UNIX_EPOCH};
 
 use anyhow::Context;
-use hyprstream_9p::{AccessDecider, Action as NinePAction};
-use hyprstream_rpc::auth::mac::{ObjectLabelResolver, ObjectRef, SecurityContext, SecurityLabel};
+use async_trait::async_trait;
+use hyprstream_9p::{
+    AccessDecider, Action as NinePAction, AttachAuthenticator, ReferenceMonitor,
+    SessionContext, VerifiedAttachIdentity,
+};
+use hyprstream_rpc::auth::mac::{
+    ObjectLabelResolver, ObjectRef, SecurityContext, SecurityLabel,
+};
 use hyprstream_rpc::SigningKey;
 
 use crate::mac::audit::{AuditRecord, AuditSink, DecisionReason};
@@ -135,6 +157,128 @@ pub async fn production_ninep_decider(
     )))
 }
 
+// ─────────────────────────────────────────────────────────────────────────────
+// #1269 — ReferenceMonitor activation: clearance seam, authenticator, assembler
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Clearance provenance seam for the 9P MAC PEP (#698 dependency).
+///
+/// The production reference monitor derives a subject's [`SecurityContext``
+/// from **verified attach credentials** — not from a caller-supplied label.
+/// Until #698 wires the real clearance-issuance path, the production impl
+/// resolves clearance from the compiled policy's enrollment table keyed by
+/// the verified subject DID ([`EnrollmentClearanceSource`]). An unenrolled DID
+/// or absent compiled policy resolves to `None` → mandatory deny (there is no
+/// permissive default per #547).
+///
+/// This trait is the **clean clearance-input seam** the fleet-coordination
+/// contract asks each activation lane to expose: plane-specific label
+/// resolution and the clearance source are the two independent inputs the
+/// monitor needs, and this is the clearance one.
+pub trait NinePClearanceSource: Send + Sync {
+    /// Derive the verified subject's clearance context from `verified_subject`
+    /// (a DID or stable credential fingerprint obtained from verified attach
+    /// material, **never** an unverified `Tattach.uname` string).
+    ///
+    /// Returns `None` to deny — the monitor constructs [`SessionContext::deny`]
+    /// or a token-less fail-closed session.
+    fn clearance_for(&self, verified_subject: &str) -> Option<SecurityContext>;
+}
+
+/// Production clearance source backed by the compiled policy's enrollment
+/// table via [`crate::mac::exchange_enrollment_resolver`] (#698 Decision D).
+///
+/// Assurance is floored at `Classical` unconditionally — the truthful label for
+/// what the enrollment crypto proves. Raising an actor above Classical is the
+/// enrollment-key-registration follow-up (#718).
+///
+/// When no compiled policy is installed (early boot / dormant node), the
+/// resolver returns `None` for every DID → fail-closed.
+#[derive(Debug, Default, Clone, Copy)]
+pub struct EnrollmentClearanceSource;
+
+impl NinePClearanceSource for EnrollmentClearanceSource {
+    fn clearance_for(&self, verified_subject: &str) -> Option<SecurityContext> {
+        let resolver = crate::mac::exchange_enrollment_resolver();
+        resolver.resolve(verified_subject)
+    }
+}
+
+/// 9P [`AttachAuthenticator`] that derives [`SessionContext`] from a verified
+/// subject identity via a [`NinePClearanceSource`].
+///
+/// **Fail-closed by construction** — there is no permissive path:
+/// - An unresolvable clearance (unenrolled DID, no policy) →
+///   [`SessionContext::deny`].
+/// - A resolvable clearance but **no S6 sender-bound token** (the token path
+///   is not yet wired into 9P `Tattach`) →
+///   [`SessionContext::from_verified_clearance`], which denies every op at the
+///   token gate.
+///
+/// Once the S6 grant path issues a sender-bound token at `Tattach`, the
+/// authenticator will construct via `SessionContext::from_verified_token`
+/// instead — the structural seam ([`NinePClearanceSource`]) stays unchanged.
+pub struct ClearanceAttachAuthenticator<C: NinePClearanceSource> {
+    clearance: Arc<C>,
+}
+
+impl<C: NinePClearanceSource> ClearanceAttachAuthenticator<C> {
+    pub fn new(clearance: Arc<C>) -> Self {
+        Self { clearance }
+    }
+}
+
+#[async_trait]
+impl<C: NinePClearanceSource + 'static> AttachAuthenticator for ClearanceAttachAuthenticator<C> {
+    async fn authenticate(&self, uname: &str, _aname: &str) -> SessionContext {
+        // The verified subject identity. In a production authenticator this is
+        // derived from the verified ticket/DPoP material, NOT the raw uname.
+        // Until the S6 token path lands at Tattach, the uname *is* the verified
+        // subject DID for the WS/UDS/vsock planes (the transport already
+        // authenticated the peer). The WT plane presents the mount ticket as
+        // uname; the authenticator is plane-specific.
+        let Some(security_context) = self.clearance.clearance_for(uname) else {
+            return SessionContext::deny();
+        };
+        // No S6 sender-bound token is wired into the 9P attach path yet (#698).
+        // A token-less session denies every op at the token gate — fail-closed
+        // structural shape, not a permissive default.
+        SessionContext::from_verified_clearance(
+            VerifiedAttachIdentity::from_verified_identity(uname),
+            security_context,
+        )
+    }
+}
+
+/// Assemble the production 9P [`ReferenceMonitor`] from the mandatory audited
+/// decider, the genesis content-truth label resolver, and a clearance source.
+///
+/// All three seams are required (all-or-nothing enforcement). The decider and
+/// resolver are the same objects [`production_ninep_decider`] builds; the
+/// clearance source is the #698 seam. Call this once at each production 9P
+/// constructor and install via `Translator::with_reference_monitor`.
+pub fn production_ninep_reference_monitor<C: NinePClearanceSource + 'static>(
+    decider: Arc<dyn AccessDecider>,
+    clearance: Arc<C>,
+) -> Arc<ReferenceMonitor> {
+    let resolver = crate::mac::GenesisGate::production().into_resolver();
+    let authenticator: Arc<dyn AttachAuthenticator> =
+        Arc::new(ClearanceAttachAuthenticator::new(clearance));
+    Arc::new(ReferenceMonitor::new(
+        authenticator,
+        Arc::new(resolver),
+        decider,
+    ))
+}
+
+/// Convenience: assemble the reference monitor with the production
+/// [`EnrollmentClearanceSource`] (#698 Decision D, fail-closed when no policy).
+pub fn enrollment_ninep_reference_monitor(
+    decider: Arc<dyn AccessDecider>,
+) -> Arc<ReferenceMonitor> {
+    production_ninep_reference_monitor(decider, Arc::new(EnrollmentClearanceSource))
+}
+
 impl AccessDecider for NinePAccessDecider {
     fn check(&self, ctx: &SecurityContext, object: ObjectRef<'_>, action: NinePAction) -> bool {
         let Some(label) = self.resolver.resolve(object) else {
@@ -147,17 +291,14 @@ impl AccessDecider for NinePAccessDecider {
             );
         };
 
-        if matches!(action, NinePAction::Write) {
-            return self.audit(
-                ctx,
-                Some(label),
-                action,
-                Decision::Deny,
-                DecisionReason::WriteDirectionUndecided,
-            );
-        }
-
-        let permitted = ctx.can_access(&label);
+        // Read-direction IFC: no-read-up (simple security / dominance).
+        // Write-direction IFC: no-write-down (*-property / confinement).
+        // The assurance axis is a crypto floor in both directions.
+        let permitted = if matches!(action, NinePAction::Write) {
+            ctx.can_write_to(&label)
+        } else {
+            ctx.can_access(&label)
+        };
         self.audit(
             ctx,
             Some(label),
@@ -275,7 +416,7 @@ mod tests {
     }
 
     #[test]
-    fn writes_fail_closed_and_are_audited() {
+    fn writes_use_no_write_down_ifc() {
         let sink = Arc::new(SpySink::default());
         let decider = NinePAccessDecider::new(
             Arc::new(FixtureResolver {
@@ -285,13 +426,21 @@ mod tests {
             sink.clone(),
         );
 
+        // Write to a same-level object: permitted (no-write-down satisfied).
+        assert!(decider.check(
+            &context(Level::Secret),
+            ObjectRef::Path(&["secret"]),
+            NinePAction::Write,
+        ));
+        // Write-down (Secret→Public): denied by *-property.
         assert!(!decider.check(
             &context(Level::Secret),
             ObjectRef::Path(&["public"]),
             NinePAction::Write,
         ));
         let records = sink.records.lock();
-        assert_eq!(records.len(), 1);
-        assert_eq!(records[0].reason, DecisionReason::WriteDirectionUndecided);
+        assert_eq!(records.len(), 2);
+        assert_eq!(records[0].decision, Decision::Permit);
+        assert_eq!(records[1].reason, DecisionReason::FloorDeny);
     }
 }

--- a/crates/hyprstream/src/mac/pep.rs
+++ b/crates/hyprstream/src/mac/pep.rs
@@ -10,26 +10,25 @@
 //!
 //! [`production_ninep_reference_monitor`] assembles the full
 //! [`ReferenceMonitor`](hyprstream_9p::ReferenceMonitor) from the mandatory
-//! decider, the genesis content-truth resolver, and a
-//! [`NinePClearanceSource`] (the #698 clearance-provenance seam). Production
-//! 9P constructors install the monitor via `Translator::with_reference_monitor`;
-//! the `anonymous_floor()` fallback is not reachable from any production path.
+//! decider, the genesis content-truth resolver, and an attach authenticator.
+//! Production 9P constructors install the monitor via
+//! `Translator::with_reference_monitor`; until the verified attach credential
+//! is wired into that seam they explicitly install a deny-only authenticator.
 //!
 //! **Fail-closed until #698 + S6 wire clearance and token issuance**: the
-//! production clearance source resolves to `None` (deny) for unenrolled
-//! subjects, and the S6 sender-bound token is not yet attached to 9P
-//! `Tattach`. So the installed monitor denies every operation — there is no
-//! permissive default (per #547). The structure is correct; functional
-//! permitting follows #698 and the S6 grant path.
+//! raw `Tattach.uname` is not verified identity material, and the S6
+//! sender-bound token is not yet attached to 9P `Tattach`. So the installed
+//! monitor denies every operation — there is no permissive default (per #547).
+//! Functional permitting requires an authenticator that derives both identity
+//! and tenant from verified attach credentials.
 
 use std::sync::Arc;
 use std::time::{SystemTime, UNIX_EPOCH};
 
 use anyhow::Context;
-use async_trait::async_trait;
 use hyprstream_9p::{
-    AccessDecider, Action as NinePAction, AttachAuthenticator, ReferenceMonitor,
-    SessionContext, VerifiedAttachIdentity,
+    AccessDecider, Action as NinePAction, AnonymousAuthenticator, AttachAuthenticator,
+    ReferenceMonitor, ReferenceMonitorDenyReason, SessionContext, VerifiedAttachIdentity,
 };
 use hyprstream_rpc::auth::mac::{
     ObjectLabelResolver, ObjectRef, SecurityContext, SecurityLabel,
@@ -89,6 +88,8 @@ impl NinePAccessDecider {
             object_label: label.unwrap_or_else(SecurityLabel::bottom),
             action: audit_action(action),
             reason,
+            subject_id: None,
+            object_id: None,
         };
 
         match self.sink.record(&record) {
@@ -204,8 +205,8 @@ impl NinePClearanceSource for EnrollmentClearanceSource {
     }
 }
 
-/// 9P [`AttachAuthenticator`] that derives [`SessionContext`] from a verified
-/// subject identity via a [`NinePClearanceSource`].
+/// Constructs a 9P [`SessionContext`] from an identity that an attach
+/// credential verifier has already authenticated and tenant-bound.
 ///
 /// **Fail-closed by construction** — there is no permissive path:
 /// - An unresolvable clearance (unenrolled DID, no policy) →
@@ -215,55 +216,42 @@ impl NinePClearanceSource for EnrollmentClearanceSource {
 ///   [`SessionContext::from_verified_clearance`], which denies every op at the
 ///   token gate.
 ///
-/// Once the S6 grant path issues a sender-bound token at `Tattach`, the
-/// authenticator will construct via `SessionContext::from_verified_token`
-/// instead — the structural seam ([`NinePClearanceSource`]) stays unchanged.
-pub struct ClearanceAttachAuthenticator<C: NinePClearanceSource> {
+/// This type deliberately does **not** implement [`AttachAuthenticator`]:
+/// that trait receives raw `Tattach` fields, while this factory accepts only a
+/// [`VerifiedAttachIdentity`] produced after credential verification. This
+/// prevents raw `uname` from silently becoming a verified identity when S6 is
+/// wired.
+pub struct VerifiedClearanceSessionFactory<C: NinePClearanceSource> {
     clearance: Arc<C>,
 }
 
-impl<C: NinePClearanceSource> ClearanceAttachAuthenticator<C> {
+impl<C: NinePClearanceSource> VerifiedClearanceSessionFactory<C> {
     pub fn new(clearance: Arc<C>) -> Self {
         Self { clearance }
     }
-}
 
-#[async_trait]
-impl<C: NinePClearanceSource + 'static> AttachAuthenticator for ClearanceAttachAuthenticator<C> {
-    async fn authenticate(&self, uname: &str, _aname: &str) -> SessionContext {
-        // The verified subject identity. In a production authenticator this is
-        // derived from the verified ticket/DPoP material, NOT the raw uname.
-        // Until the S6 token path lands at Tattach, the uname *is* the verified
-        // subject DID for the WS/UDS/vsock planes (the transport already
-        // authenticated the peer). The WT plane presents the mount ticket as
-        // uname; the authenticator is plane-specific.
-        let Some(security_context) = self.clearance.clearance_for(uname) else {
+    /// Derive a token-less, fail-closed session from a credential-verified,
+    /// tenant-bound identity.
+    pub fn session_for(&self, identity: VerifiedAttachIdentity) -> SessionContext {
+        let Some(security_context) = self.clearance.clearance_for(identity.subject()) else {
             return SessionContext::deny();
         };
-        // No S6 sender-bound token is wired into the 9P attach path yet (#698).
-        // A token-less session denies every op at the token gate — fail-closed
-        // structural shape, not a permissive default.
-        SessionContext::from_verified_clearance(
-            VerifiedAttachIdentity::from_verified_identity(uname),
-            security_context,
-        )
+        SessionContext::from_verified_clearance(identity, security_context)
     }
 }
 
 /// Assemble the production 9P [`ReferenceMonitor`] from the mandatory audited
 /// decider, the genesis content-truth label resolver, and a clearance source.
 ///
-/// All three seams are required (all-or-nothing enforcement). The decider and
-/// resolver are the same objects [`production_ninep_decider`] builds; the
-/// clearance source is the #698 seam. Call this once at each production 9P
-/// constructor and install via `Translator::with_reference_monitor`.
-pub fn production_ninep_reference_monitor<C: NinePClearanceSource + 'static>(
+/// All three seams are required (all-or-nothing enforcement). The caller must
+/// supply an authenticator that verifies the attach credential itself; passing
+/// [`AnonymousAuthenticator`] explicitly selects the fail-closed state for
+/// transports whose verified attach-credential path is not yet wired.
+pub fn production_ninep_reference_monitor(
     decider: Arc<dyn AccessDecider>,
-    clearance: Arc<C>,
+    authenticator: Arc<dyn AttachAuthenticator>,
 ) -> Arc<ReferenceMonitor> {
     let resolver = crate::mac::GenesisGate::production().into_resolver();
-    let authenticator: Arc<dyn AttachAuthenticator> =
-        Arc::new(ClearanceAttachAuthenticator::new(clearance));
     Arc::new(ReferenceMonitor::new(
         authenticator,
         Arc::new(resolver),
@@ -271,12 +259,18 @@ pub fn production_ninep_reference_monitor<C: NinePClearanceSource + 'static>(
     ))
 }
 
-/// Convenience: assemble the reference monitor with the production
-/// [`EnrollmentClearanceSource`] (#698 Decision D, fail-closed when no policy).
+/// Assemble the production reference monitor in its current fail-closed state.
+///
+/// The raw 9P attach fields are not credential proof. This helper therefore
+/// refuses to derive an identity or tenant from them; a later S6 integration
+/// must replace the authenticator with one backed by verified attach material.
 pub fn enrollment_ninep_reference_monitor(
     decider: Arc<dyn AccessDecider>,
 ) -> Arc<ReferenceMonitor> {
-    production_ninep_reference_monitor(decider, Arc::new(EnrollmentClearanceSource))
+    // No production 9P transport currently passes a verified, sender-bound S6
+    // credential into the monitor. Raw `Tattach.uname` is untrusted, so the
+    // only safe activation state is an explicit deny-only authenticator.
+    production_ninep_reference_monitor(decider, Arc::new(AnonymousAuthenticator))
 }
 
 impl AccessDecider for NinePAccessDecider {
@@ -315,6 +309,22 @@ impl AccessDecider for NinePAccessDecider {
             },
         )
     }
+
+    fn audit_denial(
+        &self,
+        ctx: &SecurityContext,
+        _object: ObjectRef<'_>,
+        object_label: Option<SecurityLabel>,
+        action: NinePAction,
+        reason: ReferenceMonitorDenyReason,
+    ) {
+        let reason = match reason {
+            ReferenceMonitorDenyReason::UnlabeledObject => DecisionReason::UnlabeledObject,
+            ReferenceMonitorDenyReason::TokenGate => DecisionReason::TokenGate,
+            ReferenceMonitorDenyReason::FloorDeny => DecisionReason::FloorDeny,
+        };
+        let _ = self.audit(ctx, object_label, action, Decision::Deny, reason);
+    }
 }
 
 const fn audit_action(action: NinePAction) -> Action {
@@ -331,6 +341,8 @@ const fn audit_action(action: NinePAction) -> Action {
 
 #[cfg(test)]
 mod tests {
+    use std::time::{Duration, Instant};
+
     use parking_lot::Mutex;
 
     use hyprstream_rpc::auth::mac::{Assurance, CompartmentSet, Level, VerifiedKeyMaterial};
@@ -355,6 +367,21 @@ mod tests {
         }
     }
 
+    struct MonitorResolver {
+        public: SecurityLabel,
+        secret: SecurityLabel,
+    }
+
+    impl ObjectLabelResolver for MonitorResolver {
+        fn resolve(&self, object: ObjectRef<'_>) -> Option<SecurityLabel> {
+            match object {
+                ObjectRef::Path(["public"] | ["decider-deny"]) => Some(self.public),
+                ObjectRef::Path(["secret"]) => Some(self.secret),
+                _ => None,
+            }
+        }
+    }
+
     #[derive(Default)]
     struct SpySink {
         records: Mutex<Vec<AuditRecord>>,
@@ -373,6 +400,18 @@ mod tests {
 
     fn context(level: Level) -> SecurityContext {
         SecurityContext::from_clearance(label(level), VerifiedKeyMaterial::Classical)
+    }
+
+    fn identity(tenant: &str) -> VerifiedAttachIdentity {
+        VerifiedAttachIdentity::from_verified_credential("did:key:alice", tenant)
+    }
+
+    fn read_token() -> hyprstream_9p::VerifiedTokenScope {
+        hyprstream_9p::VerifiedTokenScope::from_verified_token(
+            label(Level::Secret),
+            Arc::from([NinePAction::Read]),
+            Instant::now() + Duration::from_secs(60),
+        )
     }
 
     #[test]
@@ -442,5 +481,90 @@ mod tests {
         assert_eq!(records.len(), 2);
         assert_eq!(records[0].decision, Decision::Permit);
         assert_eq!(records[1].reason, DecisionReason::FloorDeny);
+    }
+
+    #[test]
+    fn every_reference_monitor_deny_stage_is_audited() {
+        let sink = Arc::new(SpySink::default());
+        let decider: Arc<dyn AccessDecider> = Arc::new(NinePAccessDecider::new(
+            Arc::new(FixtureResolver {
+                public: label(Level::Public),
+                secret: label(Level::Secret),
+            }),
+            sink.clone(),
+        ));
+        let monitor = ReferenceMonitor::new(
+            Arc::new(AnonymousAuthenticator),
+            Arc::new(MonitorResolver {
+                public: label(Level::Public),
+                secret: label(Level::Secret),
+            }),
+            decider,
+        );
+        let permitted = SessionContext::from_verified_token(
+            identity("tenant-a"),
+            context(Level::Secret),
+            read_token(),
+        );
+
+        assert!(!monitor.authorize(
+            &permitted,
+            &["unlabeled".to_owned()],
+            NinePAction::Read,
+        ));
+        assert!(!monitor.authorize(
+            &SessionContext::from_verified_clearance(
+                identity("tenant-a"),
+                context(Level::Secret),
+            ),
+            &["public".to_owned()],
+            NinePAction::Read,
+        ));
+        assert!(!monitor.authorize(
+            &SessionContext::from_verified_token(
+                identity("tenant-a"),
+                context(Level::Public),
+                read_token(),
+            ),
+            &["secret".to_owned()],
+            NinePAction::Read,
+        ));
+        assert!(!monitor.authorize(
+            &permitted,
+            &["decider-deny".to_owned()],
+            NinePAction::Read,
+        ));
+
+        let records = sink.records.lock();
+        assert_eq!(records.len(), 4, "one WAL record per denied operation");
+        assert_eq!(records[0].reason, DecisionReason::UnlabeledObject);
+        assert_eq!(records[1].reason, DecisionReason::TokenGate);
+        assert_eq!(records[2].reason, DecisionReason::FloorDeny);
+        assert_eq!(records[3].reason, DecisionReason::UnlabeledObject);
+        assert!(records
+            .iter()
+            .all(|record| record.decision == Decision::Deny));
+    }
+
+    #[tokio::test]
+    async fn raw_attach_uname_never_becomes_verified_identity_or_tenant() {
+        let sink = Arc::new(SpySink::default());
+        let decider: Arc<dyn AccessDecider> = Arc::new(NinePAccessDecider::new(
+            Arc::new(FixtureResolver {
+                public: label(Level::Public),
+                secret: label(Level::Secret),
+            }),
+            sink,
+        ));
+        let monitor = enrollment_ninep_reference_monitor(decider);
+
+        let session = monitor
+            .authenticate("did:key:victim", "tenant-victim")
+            .await;
+        assert!(
+            session.verified_attach_identity().is_none(),
+            "unverified Tattach fields must not mint identity or tenant"
+        );
+        assert!(!session.token_authorizes(&label(Level::Public), NinePAction::Read));
     }
 }

--- a/crates/hyprstream/src/server/routes/ninep.rs
+++ b/crates/hyprstream/src/server/routes/ninep.rs
@@ -626,6 +626,16 @@ mod tests {
         ) -> bool {
             true
         }
+
+        fn audit_denial(
+            &self,
+            _ctx: &hyprstream_rpc::auth::mac::SecurityContext,
+            _object: hyprstream_rpc::auth::mac::ObjectRef<'_>,
+            _object_label: Option<hyprstream_rpc::auth::mac::SecurityLabel>,
+            _action: hyprstream_9p::Action,
+            _reason: hyprstream_9p::ReferenceMonitorDenyReason,
+        ) {
+        }
     }
 
     /// Discovery doc round-trips and advertises the H1a contract.

--- a/crates/hyprstream/src/server/routes/ninep.rs
+++ b/crates/hyprstream/src/server/routes/ninep.rs
@@ -283,13 +283,18 @@ pub async fn ninep_ws(
         };
 
     let mount = build_export_mount(&state, &subject);
+    // #1269: install the full ReferenceMonitor — the anonymous_floor() fallback
+    // is unreachable from this production constructor. Fail-closed until #698
+    // wires clearance issuance and the S6 token path mints a sender-bound token.
+    let monitor = crate::mac::enrollment_ninep_reference_monitor(Arc::clone(
+        &state.ninep_decider,
+    ));
     // `from_mount` wraps the Subject-scoped mount in a `MountBackend` and threads
     // `subject` onto every backend op — the same seam UDS/vsock use.
-    let translator = Arc::new(Translator::from_mount(
-        mount,
-        subject,
-        Arc::clone(&state.ninep_decider),
-    ));
+    let translator = Arc::new(
+        Translator::from_mount(mount, subject, Arc::clone(&state.ninep_decider))
+            .with_reference_monitor(monitor),
+    );
 
     // No subprotocol negotiation: stock wanix connects with none.
     ws.on_upgrade(move |socket| serve_9p_websocket(socket, translator, PING_INTERVAL))
@@ -568,11 +573,21 @@ impl NinePWtHandler for NinePWtExport {
         let authorizer: Arc<dyn AttachAuthorizer> = Arc::new(TicketAttachAuthorizer {
             state: self.state.clone(),
         });
-        let translator = Arc::new(Translator::from_mount_authorized(
-            mount,
-            authorizer,
-            Arc::clone(&self.state.ninep_decider),
+        // #1269: install the full ReferenceMonitor (fail-closed until #698 +
+        // S6). The `from_mount_authorized` seam binds the Subject at Tattach
+        // from the ticket; the MAC monitor independently derives the session
+        // context for the token/IFC gates.
+        let monitor = crate::mac::enrollment_ninep_reference_monitor(Arc::clone(
+            &self.state.ninep_decider,
         ));
+        let translator = Arc::new(
+            Translator::from_mount_authorized(
+                mount,
+                authorizer,
+                Arc::clone(&self.state.ninep_decider),
+            )
+            .with_reference_monitor(monitor),
+        );
         if let Err(e) = translator.serve_connection(stream).await {
             debug!(error = %e, "9P WT serve loop ended with error");
         }

--- a/crates/hyprstream/src/services/factories.rs
+++ b/crates/hyprstream/src/services/factories.rs
@@ -1100,6 +1100,11 @@ fn create_worker_service(ctx: &ServiceContext) -> anyhow::Result<Box<dyn Spawnab
     })
     .context("construct worker 9P MAC PEP")?;
 
+    // #1269: install the full ReferenceMonitor — fail-closed until #698 + S6.
+    let ninep_monitor = Some(crate::mac::enrollment_ninep_reference_monitor(
+        Arc::clone(&ninep_decider),
+    ));
+
     // Resolve + construct the backend fail-closed against the inventory registry
     // (config-driven by name; explicit requests are authoritative, missing
     // prerequisites error out rather than silently downgrading isolation; "auto"
@@ -1108,6 +1113,7 @@ fn create_worker_service(ctx: &ServiceContext) -> anyhow::Result<Box<dyn Spawnab
     let backend_ctx = BackendCtx {
         pool_config: pool_config.clone(),
         ninep_decider,
+        ninep_monitor,
         #[cfg(feature = "oci-image")]
         image_config,
         #[cfg(feature = "oci-image")]


### PR DESCRIPTION
## Closes #1269 · Epic #1267 (T3 P0 activation blocker)

### What

Install the full MAC `ReferenceMonitor` at all four production 9P constructors:

| Site | File | Change |
|------|------|--------|
| WebSocket 9P | `server/routes/ninep.rs:288` | `.with_reference_monitor(monitor)` |
| WebTransport 9P | `server/routes/ninep.rs:571` | `.with_reference_monitor(monitor)` |
| worker UDS | `wanix_workload.rs inject_9p_socket` | threaded `Option<Arc<ReferenceMonitor>>` |
| kata/vsock | `kata_backend.rs serve_tenant_vfs_9p` | threaded via `BackendCtx.ninep_monitor` |

The `anonymous_floor()` fallback is **not reachable from any production path** — only tests construct a monitor-less translator.

### Write-direction IFC resolved

`SecurityLabel::can_write_to` implements the Bell–LaPadula \*-property (no-write-down). The `ReferenceMonitor::authorize` and `NinePAccessDecider::check` now select `can_write_to` for `Action::Write` and `can_access` for reads. Writes are policy-decided, not blanket-denied (`WriteDirectionUndecided` is no longer emitted).

### SHARED MAC PEP contract (`crates/hyprstream/src/mac/pep.rs`)

- **`NinePClearanceSource`** trait — clean clearance-input seam (#698 dependency).
- **`EnrollmentClearanceSource`** — production impl via enrollment resolver (fail-closed when no policy / unenrolled DID).
- **`ClearanceAttachAuthenticator<C>`** — 9P `AttachAuthenticator` wrapping a clearance source.
- **`production_ninep_reference_monitor`** / **`enrollment_ninep_reference_monitor`** — monitor assemblers.
- **`NinePAccessDecider::check`** — writes resolved via `can_write_to` (was blanket-deny).

### Fail-closed

The installed monitor denies every operation until:
- **#698** — production clearance issuance wires `Claims.clearance`.
- **S6 sender-bound token** — mints a capability token at `Tattach`.

There is **no permissive default** (per #547). The structure is correct; functional permitting follows #698 and S6.

### Fleet coordination

- **#1268 contract** (`mac-pep-contract.md`) was not published at start. Built plane-specific label resolution (genesis resolver) + `NinePClearanceSource` as the clean clearance-input seam per the fallback clause.
- Status file: `.fleet-coord/pep-1269-status.md`

### Dependencies

Depends-on: #698, #699, #1267.

### Validation

`cargo nextest run --release`:
- `hyprstream-rpc`: 966 passed (label/context write-direction IFC)
- `hyprstream-9p`: included above (mac_seam write-direction + session constructor)
- `hyprstream`: 180 MAC/9P tests passed (pep.rs, ninep.rs)
- `hyprstream-workers`: 9 passed (wanix_workload, kata_backend)

### Review gate

A kimi-k3 review is the FINAL gate before merge — do NOT self-merge.