### PR TITLE
feat(mac): CAS ingest/read PEP + trusted content-bound label at seal

### DIFF
--- a/.fleet-coord/pep-1270-status.md
+++ b/.fleet-coord/pep-1270-status.md
@@ -1,0 +1,28 @@
+# PEP-1270 Status — CAS ingest/read MAC PEP
+
+**Branch:** `feat/mac-cas-pep`
+**Issue:** [#1270](https://github.com/hyprstream/hyprstream/issues/1270) · T3 · epic [#1267](https://github.com/hyprstream/hyprstream/issues/1267)
+**Status:** PR open, pending kimi-k3 review (final gate).
+
+## What landed
+
+- **NEW `mac/cas_pep.rs`**: CAS-native MAC PEP — consumes the canonical `MacDecision`, `MacDenyReason`, and `RpcObjectLabelResolver` contract; provides `CasPep`, the authority-bound `CasClearanceSource` seam, `DenyAllClearanceSource`, `MacCasAuthorizer` (implements `CasMountAuthorizer`), and `domain_label()` + `seal_label()` (trusted content-bound label derivation from `DedupDomain`). `MacDispatchPep` remains RPC-plane-only.
+- **Substrate (`storage/cas/substrate.rs`)**: `put()` now derives the trusted label via `seal_label(domain, hint)` — no longer caller-asserted plumb-through. The hint parameter is a D1 restrict-only input from our own staging path.
+- **Registry (`services/registry.rs`)**: read continuation (`execute_get_blob_stream`) performs a MAC PEP recheck before streaming any bytes. Verified subject and `verified_tenant` are captured from `EnvelopeContext` and threaded through the continuation; the registry CAS/provenance store remains in its node-global dedup domain.
+- **Xet HTTP (`services/xet.rs`)**: `BootstrapCasAuthorizer` replaced with `MacCasAuthorizer::fail_closed()` at the xorb read handler.
+- **Manifest (`storage/cas/manifest.rs`)**: doc updated — carrier field is now the trusted derived label, not plumb-through.
+- **Mount (`storage/cas/mount.rs`)**: seal_slot comment updated; test updated for BLP join semantics (assurance degrades to Classical — weakest link).
+
+## Dependencies / open gaps
+
+- **CAS clearance adapter**: #698's clearance primitives have landed, but the CAS plane still needs an authority-backed `CasClearanceSource` adapter. Until installed, `DenyAllClearanceSource` makes the explicitly active CAS PEP fail closed.
+- **RPC activation boundary**: the canonical #1288 dispatcher remains dormant/pass-through (`Permit`) until a `MacDispatchPep` is installed. The CAS lane does not reinterpret absence as `NoPepInstalled`.
+- **Lattice internment**: `domain_label()` uses `CompartmentSet::EMPTY` (level-axis enforcement only). Compartment isolation is structural (distinct physical storage roots per domain). Enriching the seal label with interned compartment bits requires threading the `Lattice` to the CAS layer.
+
+## Validation
+
+- `cargo metadata --all-features`: ✓
+- `cargo check -p hyprstream --lib --tests`: ✓
+- `cargo test -p hyprstream mac::cas_pep --lib`: ✓ 16 passed, 0 failed
+- `cargo test --release -p hyprstream services::xet::tests::get_xorb --lib`: ✓ 2 passed, 0 failed
+- Cross-package release nextest: pending final installation-seam candidate.

--- a/crates/hyprstream/src/mac/audit.rs
+++ b/crates/hyprstream/src/mac/audit.rs
@@ -220,6 +220,8 @@ pub enum DecisionReason {
     FloorDeny,
     /// The PEP could not resolve a content-bound label for the object.
     UnlabeledObject,
+    /// The PEP could not derive a verified subject clearance.
+    NoClearance,
     /// A write was denied because the system's IFC write direction is not yet
     /// ratified. Writes fail closed until that policy decision is made.
     WriteDirectionUndecided,
@@ -267,6 +269,7 @@ impl DecisionReason {
             DecisionReason::Permit => "permit",
             DecisionReason::FloorDeny => "floor_deny",
             DecisionReason::UnlabeledObject => "unlabeled_object",
+            DecisionReason::NoClearance => "no_clearance",
             DecisionReason::WriteDirectionUndecided => "write_direction_undecided",
             DecisionReason::TeMiss => "te_miss",
             DecisionReason::Escalate => "escalate",

--- a/crates/hyprstream/src/mac/cas_pep.rs
+++ b/crates/hyprstream/src/mac/cas_pep.rs
@@ -1,0 +1,750 @@
+//! CAS-native MAC Policy Enforcement Point (#1270, epic #1267 T3).
+//!
+//! The CAS data plane — substrate ingest, `CasMount` read, registry streaming
+//! continuation, and xet HTTP — had **no native-MAC PEP** and no trusted label
+//! at seal (T2 audit `.fleet-coord/mac-pep-audit.md`, rows "CAS substrate
+//! ingest" / "CAS substrate read" / "`CasMount` object/xorb open/read/stat" /
+//! "Registry CAS read continuation" / "Xet HTTP CAS read"). Every read was
+//! either unmediated or gated only by `BootstrapCasAuthorizer` ("any
+//! authenticated caller"), with labels caller-asserted or absent.
+//!
+//! This module provides the CAS-plane PEP that all CAS read paths consume. It
+//! uses the canonical RPC MAC contract's [`MacDecision`], [`MacDenyReason`],
+//! and [`RpcObjectLabelResolver`] seam while deliberately not implementing
+//! [`MacDispatchPep`](hyprstream_rpc::auth::mac::MacDispatchPep), whose
+//! `EnvelopeContext` input is RPC-plane-specific.
+//!
+//! - **Trusted content-bound label at seal** ([`domain_label`] /
+//!   [`seal_label`]): derived from the [`DedupDomain`]'s structural properties
+//!   (trust boundary → level axis), **not** caller-asserted. The domain is the
+//!   content's provenance — it encodes *where the content lives* (local vs
+//!   shared-remote) and *which tenant it belongs to* (compartment). The staging
+//!   path's joined hint label is a D1 hint trusted only from our own ingest
+//!   service; the domain label is authoritative and the effective seal label is
+//!   the restrict-only `join` of the two.
+//!
+//! - **Clearance-input seam** ([`CasClearanceSource`]): consumes authority-bound
+//!   subject + `verified_tenant` inputs. Until a production CAS adapter is
+//!   installed, [`DenyAllClearanceSource`] returns `None` for every subject —
+//!   **fail-closed**, never a permissive default. There is no permissive mode
+//!   (per #547).
+//!
+//! - **Per-op enforcement** ([`CasPep`]): resolves the subject clearance via
+//!   the seam, checks `clearance.can_access(object_label)`, and records every
+//!   decision through the existing tamper-evident MAC audit sink. Missing
+//!   subject, missing clearance, missing label, or audit failure → deny.
+//!
+//! - **`CasMount` integration** ([`MacCasAuthorizer`]): implements
+//!   [`CasMountAuthorizer`](`crate::storage::cas::mount::CasMountAuthorizer`)
+//!   so that the existing per-op authorization hook in `CasMount::open`/
+//!   `read`/`stat` delegates to the MAC PEP without adding a new enforcement
+//!   surface.
+//!
+//! ## What this module does NOT do
+//!
+//! - It does not author, derive, or enforce MAC policy from the `Compartment`
+//!   string in [`DedupDomain`] — that requires lattice internment which lives
+//!   in the policy layer. Compartment isolation is already structural (distinct
+//!   physical storage roots per domain); the label's level axis is the
+//!   load-bearing enforcement here. Enriching the seal label with compartment
+//!   bits via the lattice is a follow-up gated on threading the lattice to the
+//!   CAS layer.
+//!
+//! - It does not fake a clearance for any subject. If the clearance source
+//!   returns `None`, the installed PEP denies. The #698 clearance primitives
+//!   have landed, but a plane-specific adapter must still be installed before
+//!   a CAS subject can pass.
+
+use std::sync::Arc;
+
+use hyprstream_rpc::auth::mac::{
+    MacDecision, MacDenyReason, RpcObjectLabelResolver, SecurityContext, SecurityLabel,
+};
+use hyprstream_vfs::Subject;
+
+use crate::mac::audit::{AuditRecord, AuditSink, DecisionReason};
+use crate::mac::te::{Decision, ObjectType, SubjectType};
+use crate::storage::cas::{DedupDomain, TrustBoundary};
+
+/// Reserved audit type ids for CAS PEP decisions (below the grant-path
+/// `u32::MAX` sentinels, above the 9P sentinels).
+const CAS_SUBJECT_TYPE: SubjectType = SubjectType(u32::MAX - 3);
+const CAS_OBJECT_TYPE: ObjectType = ObjectType(u32::MAX - 3);
+const CAS_SERVICE_DOMAIN: &str = "cas";
+
+// ────────────────────────────────────────────────────────────────────────────
+// Trusted content-bound label derivation
+// ────────────────────────────────────────────────────────────────────────────
+
+/// Derive a **trusted, content-bound** [`SecurityLabel`] from a [`DedupDomain`].
+///
+/// The label is derived from the domain's structural properties — the trust
+/// boundary determines the level axis, and the assurance floors at `Classical`
+/// (the substrate cannot prove PQ-hybrid for stored content). This is **not**
+/// caller-asserted: the domain is the content's physical provenance, set by the
+/// storage layer at domain construction, not by the ingest caller.
+///
+/// Mapping:
+/// - [`TrustBoundary::Local`] → [`Level::Internal`](hyprstream_rpc::auth::mac::Level::Internal):
+///   node-local content is at least org-internal.
+/// - [`TrustBoundary::SharedRemote`] → [`Level::Confidential`](hyprstream_rpc::auth::mac::Level::Confidential):
+///   federated/remote content carries higher sensitivity.
+///
+/// Compartment bits are **not** populated here: the lattice internment lives in
+/// the policy layer, not the storage layer. Compartment isolation is already
+/// structural — each domain maps to a distinct physical storage root
+/// ([`DedupDomain::relative_path`]) — so cross-compartment content leakage is
+/// physically impossible at the substrate level. The MAC label's level axis
+/// provides the independent clearance enforcement on top.
+///
+/// Enriching the seal label with interned compartment bits is a follow-up gated
+/// on threading the [`Lattice`](hyprstream_rpc::auth::mac::Lattice) to the CAS
+/// layer.
+pub fn domain_label(domain: &DedupDomain) -> SecurityLabel {
+    use hyprstream_rpc::auth::mac::{Assurance, CompartmentSet, Level};
+    let level = match domain.trust_boundary {
+        TrustBoundary::Local => Level::Internal,
+        TrustBoundary::SharedRemote => Level::Confidential,
+    };
+    SecurityLabel::new(level, Assurance::Classical, CompartmentSet::EMPTY)
+}
+
+/// Compute the **effective seal label**: `join(domain_label(domain), hint)`.
+///
+/// The domain label is authoritative (content-bound). The `hint` is a D1 label
+/// from our own staging path — trusted as a *restrict-only* input, never
+/// permissive. `join` (BLP least-upper-bound) can only make the effective label
+/// *more* restrictive than either input, never less.
+///
+/// Callers:
+/// - [`CasSubstrate::put`](crate::storage::CasSubstrate::put) calls this when a
+///   staging hint is supplied, stamping the result on the
+///   [`BlobManifest`](crate::storage::cas::BlobManifest) carrier field.
+/// - The seal path in `CasMount::seal_slot` passes the staging-joined label as
+///   the hint.
+pub fn seal_label(domain: &DedupDomain, hint: Option<SecurityLabel>) -> SecurityLabel {
+    let base = domain_label(domain);
+    match hint {
+        Some(h) => base.join(&h),
+        None => base,
+    }
+}
+
+// ────────────────────────────────────────────────────────────────────────────
+// Canonical object-label resolver seam
+// ────────────────────────────────────────────────────────────────────────────
+
+/// Adapt a trusted CAS carrier label to the canonical object-label resolver.
+///
+/// CAS supplies the concrete label from either a sealed manifest or the
+/// structural [`DedupDomain`] floor. The RPC-only method discriminator is
+/// always `None` on this plane.
+#[derive(Debug, Clone, Copy)]
+pub struct CasObjectLabelResolver {
+    label: Option<SecurityLabel>,
+}
+
+impl CasObjectLabelResolver {
+    /// Resolve a known trusted label.
+    pub const fn new(label: Option<SecurityLabel>) -> Self {
+        Self { label }
+    }
+
+    /// Resolve the structural floor for a CAS dedup domain.
+    pub fn from_domain(domain: &DedupDomain) -> Self {
+        Self::new(Some(domain_label(domain)))
+    }
+}
+
+impl RpcObjectLabelResolver for CasObjectLabelResolver {
+    fn resolve(&self, service_domain: &str, method: Option<u16>) -> Option<SecurityLabel> {
+        if service_domain == CAS_SERVICE_DOMAIN && method.is_none() {
+            self.label
+        } else {
+            None
+        }
+    }
+}
+
+// ────────────────────────────────────────────────────────────────────────────
+// Clearance-input seam
+// ────────────────────────────────────────────────────────────────────────────
+
+/// Resolve a verified subject identity to a MAC [`SecurityContext`] for CAS
+/// access.
+///
+/// The CAS PEP calls
+/// [`CasClearanceSource::clearance_for`] with the verified subject and tenant
+/// binding (extracted from `EnvelopeContext` or an equivalent verified HTTP
+/// identity) and receives a `SecurityContext` — **never** a caller-supplied
+/// clearance.
+///
+/// `None` ⇒ **unresolvable** ⇒ the PEP MUST deny. Implementors must NOT
+/// manufacture a permissive default.
+///
+/// The #698 clearance primitives are available, but until a CAS-specific
+/// adapter is installed [`DenyAllClearanceSource`] returns `None` for every
+/// subject.
+pub trait CasClearanceSource: Send + Sync {
+    /// Resolve `subject_id` to its MAC clearance, or `None` if unresolvable.
+    fn clearance_for(
+        &self,
+        subject_id: &str,
+        verified_tenant: Option<&str>,
+    ) -> Option<SecurityContext>;
+}
+
+/// Fail-closed clearance source: denies every subject.
+///
+/// Every CAS read through this explicitly installed source denies. This is the
+/// safe default while no authority-backed CAS adapter is configured.
+pub struct DenyAllClearanceSource;
+
+impl CasClearanceSource for DenyAllClearanceSource {
+    fn clearance_for(
+        &self,
+        _subject_id: &str,
+        _verified_tenant: Option<&str>,
+    ) -> Option<SecurityContext> {
+        None
+    }
+}
+
+// ────────────────────────────────────────────────────────────────────────────
+// CAS PEP — per-op enforcement
+// ────────────────────────────────────────────────────────────────────────────
+
+/// The CAS MAC Policy Enforcement Point.
+///
+/// Holds the clearance-input seam ([`CasClearanceSource`]) and the audit sink.
+/// Every CAS read path calls [`CasPep::check_read`] before serving bytes:
+///
+/// 1. Resolve the subject clearance via the seam → `None` = deny (fail-closed).
+/// 2. Check `clearance.can_access(object_label)`.
+/// 3. Audit every decision (a decision that cannot be durably audited is
+///    downgraded to `Deny`, same fail-closed contract as
+///    [`NinePAccessDecider`](crate::mac::pep::NinePAccessDecider)).
+pub struct CasPep {
+    clearance_source: Arc<dyn CasClearanceSource>,
+    sink: Arc<dyn AuditSink>,
+}
+
+impl CasPep {
+    /// Construct a CAS PEP with the given clearance source and audit sink.
+    pub fn new(clearance_source: Arc<dyn CasClearanceSource>, sink: Arc<dyn AuditSink>) -> Self {
+        Self {
+            clearance_source,
+            sink,
+        }
+    }
+
+    /// Construct a fail-closed CAS PEP using [`DenyAllClearanceSource`] and the
+    /// null audit sink. Every read denies. Use this at production constructors
+    /// where no production CAS clearance adapter is configured.
+    pub fn fail_closed() -> Self {
+        Self::new(
+            Arc::new(DenyAllClearanceSource),
+            Arc::new(crate::mac::audit::NullAuditSink),
+        )
+    }
+
+    /// Check read access for a verified subject against a trusted object-label
+    /// resolver.
+    ///
+    /// Returns the canonical [`MacDecision`]. An installed CAS PEP is
+    /// fail-closed for:
+    /// - missing clearance (subject not resolvable via the seam)
+    /// - missing object label (resolver returns `None`, per #547)
+    /// - audit failure (downgraded to deny)
+    #[must_use]
+    pub fn check_read(
+        &self,
+        subject_id: &str,
+        verified_tenant: Option<&str>,
+        resolver: &dyn RpcObjectLabelResolver,
+    ) -> MacDecision {
+        self.check(
+            subject_id,
+            verified_tenant,
+            resolver.resolve(CAS_SERVICE_DOMAIN, None),
+        )
+    }
+
+    /// Internal: resolve clearance, check dominance, audit.
+    fn check(
+        &self,
+        subject_id: &str,
+        verified_tenant: Option<&str>,
+        label: Option<SecurityLabel>,
+    ) -> MacDecision {
+        let Some(ctx) = self
+            .clearance_source
+            .clearance_for(subject_id, verified_tenant)
+        else {
+            return self.audit(None, label, MacDecision::Deny(MacDenyReason::NoClearance));
+        };
+
+        let Some(label) = label else {
+            return self.audit(
+                Some(&ctx),
+                None,
+                MacDecision::Deny(MacDenyReason::UnlabeledObject),
+            );
+        };
+
+        let decision = if ctx.can_access(&label) {
+            MacDecision::Permit
+        } else {
+            MacDecision::Deny(MacDenyReason::FloorDeny)
+        };
+        self.audit(Some(&ctx), Some(label), decision)
+    }
+
+    fn audit(
+        &self,
+        ctx: Option<&SecurityContext>,
+        label: Option<SecurityLabel>,
+        decision: MacDecision,
+    ) -> MacDecision {
+        use std::time::{SystemTime, UNIX_EPOCH};
+
+        let (audit_decision, reason) = match decision {
+            MacDecision::Permit => (Decision::Permit, DecisionReason::Permit),
+            MacDecision::Deny(MacDenyReason::NoClearance) => {
+                (Decision::Deny, DecisionReason::NoClearance)
+            }
+            MacDecision::Deny(MacDenyReason::UnlabeledObject) => {
+                (Decision::Deny, DecisionReason::UnlabeledObject)
+            }
+            MacDecision::Deny(
+                MacDenyReason::FloorDeny
+                | MacDenyReason::NoPepInstalled
+                | MacDenyReason::StaleAuthority,
+            ) => (Decision::Deny, DecisionReason::FloorDeny),
+        };
+        let policy = crate::mac::compiled_policy();
+        let generation = policy.as_ref().map_or(0, |p| p.generation);
+        let policy_hash = policy.as_ref().and_then(|p| p.policy_hash().ok());
+        let record = AuditRecord {
+            seq: 0,
+            prev_hash: [0; 32],
+            ts_unix_nanos: SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .map_or(0, |d| d.as_nanos()),
+            decision: audit_decision,
+            generation,
+            policy_hash,
+            subject_type: CAS_SUBJECT_TYPE,
+            subject_clearance: ctx
+                .map(|c| *c.clearance())
+                .unwrap_or_else(SecurityLabel::bottom),
+            on_behalf_of: None,
+            object_type: CAS_OBJECT_TYPE,
+            object_label: label.unwrap_or_else(SecurityLabel::bottom),
+            action: crate::mac::te::Action::from_scope_action(crate::mac::te::ScopeAction::Query),
+            reason,
+        };
+
+        match self.sink.record(&record) {
+            Ok(()) => decision,
+            Err(error) => {
+                let deny_record = AuditRecord {
+                    decision: Decision::Deny,
+                    reason: DecisionReason::AuditFailClosed,
+                    ..record
+                };
+                let _ = self.sink.record(&deny_record);
+                tracing::error!(
+                    target: "hyprstream.mac.cas_pep",
+                    %error,
+                    reason = DecisionReason::AuditFailClosed.as_str(),
+                    "CAS PEP decision could not be durably audited; enforcing deny"
+                );
+                // The canonical contract has no audit-specific deny variant.
+                // Keep the detailed cause in the audit vocabulary and expose a
+                // conservative floor denial to shared consumers.
+                MacDecision::Deny(MacDenyReason::FloorDeny)
+            }
+        }
+    }
+}
+
+// ────────────────────────────────────────────────────────────────────────────
+// CasMount integration
+// ────────────────────────────────────────────────────────────────────────────
+
+/// A [`CasMountAuthorizer`] backed by the CAS MAC PEP.
+///
+/// This replaces [`BootstrapCasAuthorizer`] at production constructors. On each
+/// `open`/`read`/`stat` it derives the content-bound label from the request's
+/// [`DedupDomain`] and checks the subject clearance via the PEP.
+///
+/// The label is derived from the domain (structural, trusted), NOT from any
+/// caller-supplied value. This is the trusted content-bound label at the point
+/// of use.
+pub struct MacCasAuthorizer {
+    pep: Arc<CasPep>,
+}
+
+impl MacCasAuthorizer {
+    /// Construct a MAC CAS authorizer wrapping the given PEP.
+    pub fn new(pep: Arc<CasPep>) -> Self {
+        Self { pep }
+    }
+
+    /// Construct a fail-closed MAC CAS authorizer (every read denies).
+    /// Use this at production constructors where no authority-backed CAS
+    /// clearance adapter is configured.
+    pub fn fail_closed() -> Self {
+        Self::new(Arc::new(CasPep::fail_closed()))
+    }
+}
+
+impl crate::storage::cas::CasMountAuthorizer for MacCasAuthorizer {
+    fn authorize(
+        &self,
+        caller: &Subject,
+        request: crate::storage::cas::CasMountAuthzRequest<'_>,
+    ) -> Result<(), hyprstream_vfs::MountError> {
+        let resolver = CasObjectLabelResolver::from_domain(request.domain);
+        let decision = self.pep.check_read(&caller.to_string(), None, &resolver);
+        if decision.is_permit() {
+            Ok(())
+        } else {
+            Err(hyprstream_vfs::MountError::PermissionDenied(format!(
+                "CAS MAC {} {:?} {} denied for {}: {decision:?} (#1270)",
+                request.operation, request.kind, request.address, caller,
+            )))
+        }
+    }
+}
+
+// ────────────────────────────────────────────────────────────────────────────
+// Tests
+// ────────────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+mod tests {
+    use parking_lot::Mutex;
+
+    use hyprstream_rpc::auth::mac::{
+        Assurance, CompartmentSet, Level, SecurityContext, SecurityLabel, VerifiedKeyMaterial,
+    };
+
+    use super::*;
+    use crate::mac::audit::{AuditError, AuditRecord};
+    use crate::storage::cas::{CasMountAuthorizer, CasMountAuthzRequest, CasMountObjectKind};
+    use crate::storage::cas::{DedupDomain, TrustBoundary};
+
+    // ── domain_label ────────────────────────────────────────────────────────
+
+    #[test]
+    fn local_domain_label_is_internal() {
+        let label = domain_label(&DedupDomain::local_default());
+        assert_eq!(label.level, Level::Internal);
+        assert_eq!(label.assurance, Assurance::Classical);
+        assert!(label.compartments.is_empty());
+    }
+
+    #[test]
+    fn shared_remote_domain_label_is_confidential() {
+        let domain = DedupDomain {
+            trust_boundary: TrustBoundary::SharedRemote,
+            ..DedupDomain::local_default()
+        };
+        let label = domain_label(&domain);
+        assert_eq!(label.level, Level::Confidential);
+    }
+
+    // ── seal_label ──────────────────────────────────────────────────────────
+
+    #[test]
+    fn seal_label_without_hint_is_domain_label() {
+        let domain = DedupDomain::local_default();
+        assert_eq!(seal_label(&domain, None), domain_label(&domain));
+    }
+
+    #[test]
+    fn seal_label_join_is_restrict_only() {
+        // Domain label = Internal; hint = Secret → join = Secret (more restrictive).
+        let domain = DedupDomain::local_default();
+        let hint = SecurityLabel::new(Level::Secret, Assurance::Classical, CompartmentSet::EMPTY);
+        let effective = seal_label(&domain, Some(hint));
+        assert_eq!(effective.level, Level::Secret);
+    }
+
+    #[test]
+    fn seal_label_hint_cannot_lower_below_domain() {
+        // Domain label = Confidential (shared-remote); hint = Public → join stays
+        // Confidential (join never lowers).
+        let domain = DedupDomain {
+            trust_boundary: TrustBoundary::SharedRemote,
+            ..DedupDomain::local_default()
+        };
+        let hint = SecurityLabel::new(Level::Public, Assurance::Classical, CompartmentSet::EMPTY);
+        let effective = seal_label(&domain, Some(hint));
+        assert_eq!(
+            effective.level,
+            Level::Confidential,
+            "seal label must never be less restrictive than the domain floor"
+        );
+    }
+
+    #[test]
+    fn cas_resolver_uses_canonical_service_and_non_browser_method() {
+        let resolver = CasObjectLabelResolver::from_domain(&DedupDomain::local_default());
+        assert!(resolver.resolve(CAS_SERVICE_DOMAIN, None).is_some());
+        assert!(resolver.resolve("registry", None).is_none());
+        assert!(resolver.resolve(CAS_SERVICE_DOMAIN, Some(1)).is_none());
+    }
+
+    // ── DenyAllClearanceSource ──────────────────────────────────────────────
+
+    #[test]
+    fn deny_all_clearance_source_returns_none() {
+        let src = DenyAllClearanceSource;
+        assert!(src.clearance_for("anyone", Some("tenant-a")).is_none());
+        assert!(src.clearance_for("admin", None).is_none());
+    }
+
+    // ── CasPep fail-closed ──────────────────────────────────────────────────
+
+    #[test]
+    fn fail_closed_pep_denies_every_read() {
+        let pep = CasPep::fail_closed();
+        let label = domain_label(&DedupDomain::local_default());
+        let labeled = CasObjectLabelResolver::new(Some(label));
+        assert_eq!(
+            pep.check_read("any-subject", Some("tenant-a"), &labeled),
+            MacDecision::Deny(MacDenyReason::NoClearance)
+        );
+        // Unlabeled object also denies.
+        let unlabeled = CasObjectLabelResolver::new(None);
+        assert_eq!(
+            pep.check_read("any-subject", Some("tenant-a"), &unlabeled),
+            MacDecision::Deny(MacDenyReason::NoClearance)
+        );
+    }
+
+    // ── CasPep with a real clearance source ─────────────────────────────────
+
+    struct FixtureClearance {
+        subject: String,
+        ctx: SecurityContext,
+    }
+
+    impl CasClearanceSource for FixtureClearance {
+        fn clearance_for(
+            &self,
+            subject_id: &str,
+            _verified_tenant: Option<&str>,
+        ) -> Option<SecurityContext> {
+            if subject_id == self.subject {
+                Some(self.ctx.clone())
+            } else {
+                None
+            }
+        }
+    }
+
+    fn ctx(level: Level) -> SecurityContext {
+        SecurityContext::from_clearance(
+            SecurityLabel::new(level, Assurance::Classical, CompartmentSet::EMPTY),
+            VerifiedKeyMaterial::Classical,
+        )
+    }
+
+    struct TenantClearance;
+
+    impl CasClearanceSource for TenantClearance {
+        fn clearance_for(
+            &self,
+            subject_id: &str,
+            verified_tenant: Option<&str>,
+        ) -> Option<SecurityContext> {
+            (subject_id == "alice" && verified_tenant == Some("tenant-a"))
+                .then(|| ctx(Level::Secret))
+        }
+    }
+
+    fn check(pep: &CasPep, subject_id: &str, label: Option<SecurityLabel>) -> MacDecision {
+        let resolver = CasObjectLabelResolver::new(label);
+        pep.check_read(subject_id, Some("tenant-a"), &resolver)
+    }
+
+    #[derive(Default)]
+    struct SpySink {
+        records: Mutex<Vec<AuditRecord>>,
+    }
+
+    impl AuditSink for SpySink {
+        fn record(&self, record: &AuditRecord) -> Result<(), AuditError> {
+            self.records.lock().push(record.clone());
+            Ok(())
+        }
+    }
+
+    #[test]
+    fn pep_permits_when_clearance_dominates_label() {
+        let sink = Arc::new(SpySink::default());
+        let pep = CasPep::new(
+            Arc::new(FixtureClearance {
+                subject: "secret-user".to_owned(),
+                ctx: ctx(Level::Secret),
+            }),
+            sink.clone(),
+        );
+        let label = domain_label(&DedupDomain::local_default()); // Internal
+        assert_eq!(check(&pep, "secret-user", Some(label)), MacDecision::Permit);
+
+        let records = sink.records.lock();
+        assert_eq!(records.len(), 1);
+        assert_eq!(records[0].decision, Decision::Permit);
+    }
+
+    #[test]
+    fn pep_threads_verified_tenant_to_clearance_source() {
+        let pep = CasPep::new(Arc::new(TenantClearance), Arc::new(SpySink::default()));
+        let resolver = CasObjectLabelResolver::from_domain(&DedupDomain::local_default());
+        assert_eq!(
+            pep.check_read("alice", Some("tenant-a"), &resolver),
+            MacDecision::Permit
+        );
+        assert_eq!(
+            pep.check_read("alice", None, &resolver),
+            MacDecision::Deny(MacDenyReason::NoClearance)
+        );
+    }
+
+    #[test]
+    fn pep_denies_when_clearance_insufficient() {
+        let sink = Arc::new(SpySink::default());
+        let pep = CasPep::new(
+            Arc::new(FixtureClearance {
+                subject: "public-user".to_owned(),
+                ctx: ctx(Level::Public),
+            }),
+            sink.clone(),
+        );
+        let label = domain_label(&DedupDomain::local_default()); // Internal
+        assert_eq!(
+            check(&pep, "public-user", Some(label)),
+            MacDecision::Deny(MacDenyReason::FloorDeny)
+        );
+
+        let records = sink.records.lock();
+        assert_eq!(records[0].decision, Decision::Deny);
+        assert_eq!(records[0].reason, DecisionReason::FloorDeny);
+    }
+
+    #[test]
+    fn pep_denies_unresolvable_subject() {
+        let sink = Arc::new(SpySink::default());
+        let pep = CasPep::new(
+            Arc::new(FixtureClearance {
+                subject: "known".to_owned(),
+                ctx: ctx(Level::Secret),
+            }),
+            sink.clone(),
+        );
+        let label = domain_label(&DedupDomain::local_default());
+        assert_eq!(
+            check(&pep, "unknown", Some(label)),
+            MacDecision::Deny(MacDenyReason::NoClearance)
+        );
+
+        let records = sink.records.lock();
+        assert_eq!(records[0].reason, DecisionReason::NoClearance);
+    }
+
+    #[test]
+    fn pep_denies_unlabeled_object_even_with_clearance() {
+        let sink = Arc::new(SpySink::default());
+        let pep = CasPep::new(
+            Arc::new(FixtureClearance {
+                subject: "admin".to_owned(),
+                ctx: ctx(Level::Secret),
+            }),
+            sink.clone(),
+        );
+        assert_eq!(
+            check(&pep, "admin", None),
+            MacDecision::Deny(MacDenyReason::UnlabeledObject)
+        );
+
+        let records = sink.records.lock();
+        assert_eq!(records[0].reason, DecisionReason::UnlabeledObject);
+    }
+
+    // ── MacCasAuthorizer ────────────────────────────────────────────────────
+
+    #[test]
+    fn mac_cas_authorizer_denies_with_fail_closed_pep() {
+        let authz = MacCasAuthorizer::fail_closed();
+        let domain = DedupDomain::local_default();
+        let req = CasMountAuthzRequest {
+            kind: CasMountObjectKind::Xorb,
+            address: "deadbeef",
+            domain: &domain,
+            operation: "read",
+            requested_label: None,
+        };
+        let subject = Subject::new("user");
+        assert!(authz.authorize(&subject, req).is_err());
+    }
+
+    #[test]
+    fn mac_cas_authorizer_permits_with_dominating_clearance() {
+        let sink = Arc::new(SpySink::default());
+        let pep = Arc::new(CasPep::new(
+            Arc::new(FixtureClearance {
+                subject: "secret-user".to_owned(),
+                ctx: ctx(Level::Secret),
+            }),
+            sink,
+        ));
+        let authz = MacCasAuthorizer::new(pep);
+        let domain = DedupDomain::local_default();
+        let req = CasMountAuthzRequest {
+            kind: CasMountObjectKind::Xorb,
+            address: "deadbeef",
+            domain: &domain,
+            operation: "read",
+            requested_label: None,
+        };
+        let subject = Subject::new("secret-user");
+        assert!(authz.authorize(&subject, req).is_ok());
+    }
+
+    #[test]
+    fn mac_cas_authorizer_uses_domain_for_label() {
+        // SharedRemote domain → Confidential. A Secret clearance dominates; a
+        // Public clearance does not.
+        let sink = Arc::new(SpySink::default());
+        let pep = Arc::new(CasPep::new(
+            Arc::new(FixtureClearance {
+                subject: "public-user".to_owned(),
+                ctx: ctx(Level::Public),
+            }),
+            sink,
+        ));
+        let authz = MacCasAuthorizer::new(pep);
+        let domain = DedupDomain {
+            trust_boundary: TrustBoundary::SharedRemote,
+            ..DedupDomain::local_default()
+        };
+        let req = CasMountAuthzRequest {
+            kind: CasMountObjectKind::Object,
+            address: "some-addr",
+            domain: &domain,
+            operation: "open",
+            requested_label: None,
+        };
+        let subject = Subject::new("public-user");
+        assert!(
+            authz.authorize(&subject, req).is_err(),
+            "Public clearance must not read Confidential (shared-remote) content"
+        );
+    }
+}

--- a/crates/hyprstream/src/mac/mod.rs
+++ b/crates/hyprstream/src/mac/mod.rs
@@ -71,6 +71,9 @@ pub mod genesis;
 pub mod lattice;
 // #676: the production S3-scope ↔ S5-TE-rule vocabulary (injective + exact;
 // wildcards expand at compile time over a closed registry).
+// #1270: CAS-native MAC PEP — trusted content-bound label at seal +
+// can_access enforcement on ingest/read (epic #1267 T3).
+pub mod cas_pep;
 pub mod pep;
 pub mod permission_map;
 pub mod te;
@@ -111,6 +114,11 @@ pub use genesis::{
     GenesisGate, ManifestLabelSource, NamespaceEnumerator, NoManifests, SitePolicy,
 };
 pub use pep::{production_ninep_decider, NinePAccessDecider};
+// #1270: CAS-native MAC PEP — the shared CAS enforcement contract.
+pub use cas_pep::{
+    domain_label, seal_label, CasClearanceSource, CasObjectLabelResolver, CasPep,
+    DenyAllClearanceSource, MacCasAuthorizer,
+};
 // S4 (#570): the boot path that installs the verified `CompiledPolicy` at daemon
 // startup (dormant — makes the PDP inputs real without enabling enforcement).
 pub use bootload::{compile_sign_load_install, install_baseline_boot_policy, BootPolicyError};

--- a/crates/hyprstream/src/services/factories.rs
+++ b/crates/hyprstream/src/services/factories.rs
@@ -1304,6 +1304,9 @@ fn create_xet_service(ctx: &ServiceContext) -> anyhow::Result<Box<dyn Spawnable>
         store: crate::storage::CasSubstrate::from_env(),
         registry: Some(registry_client),
         auth,
+        // #1270: an explicitly installed PEP is fail-closed until an
+        // authority-backed CAS clearance adapter is configured.
+        cas_authorizer: Arc::new(crate::mac::MacCasAuthorizer::fail_closed()),
     };
 
     let xet_service = XetService::new(

--- a/crates/hyprstream/src/services/registry.rs
+++ b/crates/hyprstream/src/services/registry.rs
@@ -1051,6 +1051,8 @@ impl RegistryService {
         &self,
         address: String,
         client_ephemeral_pubkey: Option<&[u8]>,
+        subject_id: String,
+        verified_tenant: Option<String>,
     ) -> Result<(StreamInfo, hyprstream_rpc::service::Continuation)> {
         let client_pub_bytes = client_ephemeral_pubkey
             .ok_or_else(|| anyhow!("Streaming requires client ephemeral pubkey for E2E authentication"))?;
@@ -1082,7 +1084,14 @@ impl RegistryService {
         };
 
         let continuation: hyprstream_rpc::service::Continuation = Box::pin(async move {
-            Self::execute_get_blob_stream(stream_channel, stream_ctx, address).await;
+            Self::execute_get_blob_stream(
+                stream_channel,
+                stream_ctx,
+                address,
+                subject_id,
+                verified_tenant,
+            )
+            .await;
         });
 
         Ok((stream_info, continuation))
@@ -1090,10 +1099,18 @@ impl RegistryService {
 
     /// Continuation body: reconstruct bytes and stream them. Reuses
     /// `cas_serve::CasStore` for reconstruction (no reimplementation).
+    ///
+    /// #1270: performs a MAC `can_access` recheck at the point of use (before
+    /// any bytes are read from the substrate). The subject identity was captured
+    /// from the verified `EnvelopeContext` at handler time. The explicitly
+    /// installed fail-closed [`CasPep`] denies when no CAS clearance adapter is
+    /// configured. There is no permissive mode inside the installed PEP.
     async fn execute_get_blob_stream(
         stream_channel: StreamChannel,
         stream_ctx: StreamContext,
         address: String,
+        subject_id: String,
+        verified_tenant: Option<String>,
     ) {
         // 64 KiB publish frames — bound per-message size for GB-scale weights.
         const CHUNK: usize = 64 * 1024;
@@ -1104,6 +1121,30 @@ impl RegistryService {
                 // layout-compatible with the legacy CasStore root (#812).
                 let substrate = crate::storage::CasSubstrate::from_env();
                 let domain = crate::storage::DedupDomain::local_default();
+
+                // #1270 MAC PEP recheck at point of use: derive the trusted
+                // content-bound label from the domain and check the subject's
+                // clearance BEFORE reading any bytes. Fail-closed: a deny
+                // produces zero bytes of output.
+                let resolver = crate::mac::CasObjectLabelResolver::from_domain(&domain);
+                let pep = crate::mac::cas_pep::CasPep::fail_closed();
+                let decision =
+                    pep.check_read(&subject_id, verified_tenant.as_deref(), &resolver);
+                if !decision.is_permit() {
+                    tracing::warn!(
+                        target: "hyprstream.mac.cas_pep",
+                        %subject_id,
+                        verified_tenant = ?verified_tenant,
+                        %address,
+                        ?decision,
+                        "getBlob MAC PEP denied at continuation; no bytes streamed (#1270)"
+                    );
+                    return (publisher, Err(anyhow!(
+                        "getBlob denied: MAC clearance check failed at point of use: \
+                         {decision:?} (#1270)"
+                    )));
+                }
+
                 let bytes = match substrate.get(&domain, &address).await {
                     Ok(b) => b,
                     Err(e) => return (publisher, Err(anyhow!("getBlob reconstruction failed: {}", e))),
@@ -1826,9 +1867,17 @@ impl RegistryHandler for RegistryService {
         // error response (no StreamInfo, no continuation, no bytes).
         let address = self.authorize_get_blob(ctx, data).await?;
         let client_ephemeral_pubkey = ctx.ephemeral_pubkey();
+        // #1270: capture the verified subject for the post-RPC MAC recheck in
+        // the streaming continuation. The continuation runs after the RPC
+        // returns; the PEP re-evaluates clearance at the point of use (before
+        // any bytes are read from the substrate).
+        let subject_id = ctx.subject().to_string();
+        let verified_tenant = ctx.verified_tenant().map(str::to_owned);
         self.prepare_get_blob_stream(
             address,
             client_ephemeral_pubkey.as_ref().map(<[u8; 32]>::as_slice),
+            subject_id,
+            verified_tenant,
         )
         .await
     }
@@ -1958,16 +2007,20 @@ impl RegistryService {
 
         // ── Chunk + seal a labeled manifest + SERVER-SIDE merkle ────────────
         // An uploader without a verified MAC clearance cannot create a CAS
-        // object: there is no default label. The derived context is already
-        // clamped to the verified signature's assurance.
+        // object. The verified clearance is a trusted restrict-only hint; the
+        // substrate joins it with the node-global CAS domain floor and binds
+        // the effective label into the manifest CID.
         let security_label = *ctx
             .security_context()
             .ok_or_else(|| anyhow!("putBlob requires a verified security clearance label"))?
             .clearance();
         let substrate = crate::storage::CasSubstrate::from_env();
+        // Registry CAS/provenance paths are node-global and carry no tenant key;
+        // preserve #1196's global-domain boundary rather than deriving a tenant
+        // domain from `EnvelopeContext::verified_tenant()`.
         let domain = crate::storage::DedupDomain::local_default();
         let put = substrate
-            .put(&domain, &data.bytes, security_label)
+            .put(&domain, &data.bytes, Some(security_label))
             .await
             .map_err(|e| anyhow!("CAS ingest failed: {e}"))?;
 

--- a/crates/hyprstream/src/services/xet.rs
+++ b/crates/hyprstream/src/services/xet.rs
@@ -36,22 +36,18 @@
 //! `grantRepo` and enforces per-repo entitlement — "the hash is not a
 //! capability"). #813 moved this route behind the Subject-threaded CAS mount so
 //! the policy boundary is the same `Mount` surface used by namespaces, and
-//! #1094 made that boundary **enforcing**: the mount runs
-//! [`BootstrapCasAuthorizer`], where the day-one grant "any authenticated
-//! subject may read xorb X" is an explicit, audited policy object and
-//! everything else is default-deny — plane #1 of #1091's R4b
-//! compile-and-ratchet MAC rollout. The remaining work is attaching
-//! repo/compartment provenance labels to xorb objects (#699) and flowing
-//! subject clearances (#698) so grant breadth ratchets to 0 and the mount can
-//! make a full AVC decision; the ratchet path is documented on
-//! [`BootstrapCasAuthorizer`].
+//! #1270 made that boundary a **MAC-enforcing** PEP: the mount runs
+//! [`MacCasAuthorizer`](crate::mac::MacCasAuthorizer), which derives the trusted
+//! content-bound label from the dedup domain and checks the subject clearance
+//! via the CAS PEP. Until an authority-backed CAS clearance adapter is
+//! configured, this explicitly installed PEP is fail-closed (deny all reads).
 
 use crate::config::{TlsConfig, XetConfig};
 use crate::server::state::ResourceAuthState;
 use crate::server::tls::{resolve_rustls_config, serve_app};
 use crate::server::{AuthenticatedUser, middleware as server_middleware};
 use crate::services::RegistryClient;
-use crate::storage::cas::{BootstrapCasAuthorizer, CasMount, CasSubstrate, DedupDomain};
+use crate::storage::cas::{CasMount, CasMountAuthorizer, CasSubstrate, DedupDomain};
 use anyhow::Result;
 use axum::{
     Json, Router,
@@ -91,6 +87,13 @@ pub struct XetState {
     pub registry: Option<RegistryClient>,
     /// Shared OAI-equivalent authentication and rate-limit state.
     pub auth: ResourceAuthState,
+    /// Explicitly installed CAS read PEP.
+    ///
+    /// Production installs [`crate::mac::MacCasAuthorizer::fail_closed`]
+    /// until an authority-backed clearance adapter is configured. Tests and
+    /// future production wiring may inject another concrete authorizer without
+    /// bypassing the `CasMount` enforcement point.
+    pub cas_authorizer: Arc<dyn CasMountAuthorizer>,
 }
 
 /// XetService — HF-XET CAS HTTP face.
@@ -183,13 +186,10 @@ async fn get_xorb_handler(
     axum::extract::Extension(user): axum::extract::Extension<AuthenticatedUser>,
 ) -> Response {
     let subject = Subject::new(user.user);
-    let mount = CasMount::with_authorizer(
+    let mount = CasMount::with_shared_authorizer(
         state.store.clone(),
         DedupDomain::local_default(),
-        // #1094 plane #1: enforcing authorizer behind the explicit day-one
-        // bootstrap grant ("any authenticated subject may read xorb X"),
-        // default-deny for everything else. Never AllowAll on this route.
-        BootstrapCasAuthorizer::new(),
+        Arc::clone(&state.cas_authorizer),
     );
     let mut fid = match mount.walk(&["xorb", hash.as_str()], &subject).await {
         Ok(fid) => fid,
@@ -511,6 +511,9 @@ mod tests {
                 federation_resolver,
                 Arc::new(InMemoryJtiBlocklist::new()),
             ),
+            // These handler tests exercise successful byte/range behavior.
+            // Production installs the fail-closed MAC authorizer in the factory.
+            cas_authorizer: Arc::new(crate::storage::cas::AllowAllCasAuthorizer),
         }
     }
 

--- a/crates/hyprstream/src/storage/cas/manifest.rs
+++ b/crates/hyprstream/src/storage/cas/manifest.rs
@@ -47,8 +47,14 @@ pub struct BlobManifest {
     /// Total byte length of the reconstructed content.
     pub byte_len: u64,
 
-    /// The MAC object label for this sealed blob. It is required and covered by
-    /// the manifest CID, so relabeling necessarily creates a distinct object.
+    /// **Trusted content-bound label (#1270).** The MAC object label for this
+    /// sealed blob, derived from the
+    /// [`DedupDomain`](crate::storage::cas::DedupDomain) at seal time.
+    ///
+    /// The substrate derives this via [`crate::mac::cas_pep::seal_label`] as a
+    /// restrict-only join of the domain's structural label and any trusted
+    /// staging hint. It is required and covered by the manifest CID, so
+    /// relabeling necessarily creates a distinct object.
     pub security_label: SecurityLabel,
 }
 

--- a/crates/hyprstream/src/storage/cas/mount.rs
+++ b/crates/hyprstream/src/storage/cas/mount.rs
@@ -649,6 +649,24 @@ impl CasMount {
         Self::with_authorizer_and_staging(substrate, domain, authorizer, StagingConfig::default())
     }
 
+    /// Construct a CAS mount with an already shared authorizer.
+    ///
+    /// Service state uses this form so the installed policy object is explicit
+    /// and injectable without wrapping an `Arc` inside another `Arc`.
+    pub fn with_shared_authorizer(
+        substrate: CasSubstrate,
+        domain: DedupDomain,
+        authorizer: Arc<dyn CasMountAuthorizer>,
+    ) -> Self {
+        Self {
+            substrate,
+            domain,
+            authorizer,
+            staging: Arc::new(StagingRegistry::new()),
+            staging_cfg: StagingConfig::default(),
+        }
+    }
+
     /// Construct a CAS mount with an explicit authorizer and staging config.
     pub fn with_authorizer_and_staging<A>(
         substrate: CasSubstrate,
@@ -794,8 +812,10 @@ impl CasMount {
             }
         }
 
-        // Won the CAS. Take the bytes + labels out from under their locks so we
-        // don't hold them across the async substrate put.
+        // Won the CAS. Take the bytes + staging hint label out from under their
+        // locks so we don't hold them across the async substrate put. The hint
+        // is a D1 restrict-only input — the substrate derives the trusted
+        // content-bound label via seal_label(domain, hint) (#1270).
         let bytes = std::mem::take(&mut *slot.buffer.lock());
         let joined = match slot.joined_label() {
             Some(label) => label,
@@ -813,7 +833,10 @@ impl CasMount {
                 return Err(MountError::PermissionDenied(msg));
             }
         };
-        let put_result = self.substrate.put(&self.domain, &bytes, joined).await;
+        let put_result = self
+            .substrate
+            .put(&self.domain, &bytes, Some(joined))
+            .await;
 
         match put_result {
             Ok(manifest) => {
@@ -1543,7 +1566,7 @@ mod tests {
         let substrate = CasSubstrate::new(dir.path());
         let domain = DedupDomain::local_default();
         let manifest = substrate
-            .put(&domain, b"hello-cas-mount", label())
+            .put(&domain, b"hello-cas-mount", Some(label()))
             .await
             .unwrap();
         let authz = std::sync::Arc::new(RecordingAuthorizer::default());
@@ -1580,7 +1603,7 @@ mod tests {
         let substrate = CasSubstrate::new(dir.path());
         let domain = DedupDomain::local_default();
         let manifest = substrate
-            .put(&domain, b"secret bytes", label())
+            .put(&domain, b"secret bytes", Some(label()))
             .await
             .unwrap();
         let mount = CasMount::new(substrate, domain);
@@ -1600,7 +1623,7 @@ mod tests {
         let substrate = CasSubstrate::new(dir.path());
         let domain = DedupDomain::local_default();
         let manifest = substrate
-            .put(&domain, b"xorb-backed-payload", label())
+            .put(&domain, b"xorb-backed-payload", Some(label()))
             .await
             .unwrap();
         let xorb = manifest.xorb_hashes.first().expect("xorb hash").clone();
@@ -1638,7 +1661,7 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let substrate = CasSubstrate::new(dir.path());
         let manifest = substrate
-            .put(&DedupDomain::local_default(), bytes, label())
+            .put(&DedupDomain::local_default(), bytes, Some(label()))
             .await
             .unwrap();
         let xorb = manifest.xorb_hashes.first().expect("xorb hash").clone();
@@ -1682,7 +1705,7 @@ mod tests {
     async fn bootstrap_grant_denies_obj_reads_and_stage_ops() {
         let (_dir, substrate, xorb) = substrate_with_xorb(b"bootstrap-xorb").await;
         let manifest = substrate
-            .put(&DedupDomain::local_default(), b"obj-bytes", label())
+            .put(&DedupDomain::local_default(), b"obj-bytes", Some(label()))
             .await
             .unwrap();
         let mount = CasMount::with_authorizer(

--- a/crates/hyprstream/src/storage/cas/substrate.rs
+++ b/crates/hyprstream/src/storage/cas/substrate.rs
@@ -112,7 +112,15 @@ impl CasSubstrate {
     /// Chunking (gearhash CDC), xorb aggregation, content-addressed dedup, and the
     /// server-computed merkle all happen inside the underlying `CasStore` — byte
     /// boundaries stay identical to xet-core. The substrate adds the canonical
-    /// manifest CID with a required, content-bound `security_label`.
+    /// manifest CID and derives a required, **trusted content-bound**
+    /// `security_label` from the domain (#1270).
+    ///
+    /// The `hint_label` parameter is a D1 hint trusted only from our own staging
+    /// path (the `CasMount::seal_slot` joined LUB). The effective seal label is
+    /// `join(domain_label(domain), hint)` — restrict-only, never permissive. A
+    /// `None` hint yields just the domain-derived label. **Callers must not pass
+    /// untrusted/caller-asserted labels** — the interface policy in `CLAUDE.md`
+    /// forbids caller-supplied labels as authoritative PDP inputs.
     ///
     /// Only **BLAKE3-256** ingest is implemented today: the merkle the store
     /// computes is the 32-byte BLAKE3 reconstruction hash, so the domain must
@@ -126,7 +134,7 @@ impl CasSubstrate {
         &self,
         domain: &DedupDomain,
         data: &[u8],
-        security_label: SecurityLabel,
+        hint_label: Option<SecurityLabel>,
     ) -> Result<BlobManifest, CasError> {
         if domain.algorithm != HashAlgo::Blake3 || domain.digest_length != 32 {
             return Err(CasError::UnsupportedIngestAlgorithm(domain.algorithm));
@@ -141,6 +149,9 @@ impl CasSubstrate {
             "store merkle must be the declared {}-byte digest",
             domain.digest_length
         );
+        // #1270: derive the trusted label from structural provenance and only
+        // use the staging label as a restrict-only hint.
+        let security_label = crate::mac::cas_pep::seal_label(domain, hint_label);
         let manifest = BlobManifest::new(
             put.merkle,
             put.xorb_hashes,
@@ -217,7 +228,7 @@ mod tests {
         let domain = DedupDomain::local_default();
         let original = payload(7, 256 * 1024);
 
-        let m = sub.put(&domain, &original, label()).await.unwrap();
+        let m = sub.put(&domain, &original, Some(label())).await.unwrap();
         assert!(m.cid.starts_with('b'));
         assert_eq!(m.byte_len, original.len() as u64);
         assert!(m.bytes_stored > 0);
@@ -238,7 +249,7 @@ mod tests {
         let original = payload(3, 200 * 1024);
 
         let m = sub
-            .put(&DedupDomain::local_default(), &original, label())
+            .put(&DedupDomain::local_default(), &original, Some(label()))
             .await
             .unwrap();
 
@@ -257,8 +268,14 @@ mod tests {
         let default_domain = DedupDomain::local_default();
         let tenant_domain = DedupDomain::local_tenant(Compartment::new("tenant:acme"));
 
-        let a = sub.put(&default_domain, &original, label()).await.unwrap();
-        let b = sub.put(&tenant_domain, &original, label()).await.unwrap();
+        let a = sub
+            .put(&default_domain, &original, Some(label()))
+            .await
+            .unwrap();
+        let b = sub
+            .put(&tenant_domain, &original, Some(label()))
+            .await
+            .unwrap();
 
         // Content-addressed ⇒ identical merkle regardless of domain.
         assert_eq!(a.merkle, b.merkle);
@@ -280,8 +297,14 @@ mod tests {
         let domain = DedupDomain::local_default();
         let original = payload(11, 200 * 1024);
 
-        let first = sub.put(&domain, &original, label()).await.unwrap();
-        let second = sub.put(&domain, &original, label()).await.unwrap();
+        let first = sub
+            .put(&domain, &original, Some(label()))
+            .await
+            .unwrap();
+        let second = sub
+            .put(&domain, &original, Some(label()))
+            .await
+            .unwrap();
         assert_eq!(first.merkle, second.merkle);
         assert_eq!(second.bytes_stored, 0, "same-domain re-upload fully dedups");
     }
@@ -295,7 +318,10 @@ mod tests {
             digest_length: 32,
             ..DedupDomain::local_default()
         };
-        let err = sub.put(&domain, b"hello", label()).await.unwrap_err();
+        let err = sub
+            .put(&domain, b"hello", Some(label()))
+            .await
+            .unwrap_err();
         assert!(matches!(err, CasError::UnsupportedIngestAlgorithm(_)));
     }
 
@@ -311,7 +337,10 @@ mod tests {
             digest_length: 64,
             ..DedupDomain::local_default()
         };
-        let err = sub.put(&domain, b"hello", label()).await.unwrap_err();
+        let err = sub
+            .put(&domain, b"hello", Some(label()))
+            .await
+            .unwrap_err();
         assert!(
             matches!(err, CasError::UnsupportedIngestAlgorithm(_)),
             "BLAKE3-512 ingest must be rejected until #881 lands"
@@ -319,19 +348,19 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn carrier_label_is_passed_through() {
+    async fn seal_label_is_derived_from_domain() {
         use hyprstream_rpc::auth::mac::{Assurance, CompartmentSet, Level};
         let dir = tempfile::tempdir().unwrap();
         let sub = CasSubstrate::new(dir.path());
-        let label =
-            SecurityLabel::new(Level::Internal, Assurance::Classical, CompartmentSet::EMPTY);
+        // No hint → label derived purely from the domain (local_default → Internal).
         let m = sub
-            .put(&DedupDomain::local_default(), b"payload-bytes", label)
+            .put(&DedupDomain::local_default(), b"payload-bytes", None)
             .await
             .unwrap();
+        let expected = SecurityLabel::new(Level::Internal, Assurance::Classical, CompartmentSet::EMPTY);
         assert_eq!(
-            m.security_label, label,
-            "required label plumbs through unchanged"
+            m.security_label, expected,
+            "seal label must be derived from the domain, not caller-asserted"
         );
     }
 
@@ -340,13 +369,31 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let domain = DedupDomain::local_default();
         let manifest = CasSubstrate::new(dir.path())
-            .put(&domain, b"durable-manifest", label())
+            .put(&domain, b"durable-manifest", Some(label()))
             .await
             .unwrap();
         let reopened = CasSubstrate::new(dir.path());
         assert_eq!(
             reopened.get(&domain, &manifest.cid).await.unwrap(),
             b"durable-manifest"
+        );
+    }
+
+    #[tokio::test]
+    async fn seal_label_hint_joins_restrict_only() {
+        use hyprstream_rpc::auth::mac::{Assurance, CompartmentSet, Level};
+        let dir = tempfile::tempdir().unwrap();
+        let sub = CasSubstrate::new(dir.path());
+        // Hint = Secret → effective = Secret (more restrictive than domain's Internal).
+        let hint = SecurityLabel::new(Level::Secret, Assurance::Classical, CompartmentSet::EMPTY);
+        let m = sub
+            .put(&DedupDomain::local_default(), b"payload-bytes", Some(hint))
+            .await
+            .unwrap();
+        assert_eq!(
+            m.security_label.level,
+            Level::Secret,
+            "hint label must join restrict-only with the domain floor"
         );
     }
 }


### PR DESCRIPTION
Closes #1270. References #1267 (MAC Enforcement Activation Gate T3).

## Summary

The CAS data plane — substrate ingest, CasMount read, registry streaming continuation, and xet HTTP — had **no native-MAC PEP** and no trusted label at seal (T2 PEP audit rows: "CAS substrate ingest", "CAS substrate read", "CasMount open/read/stat", "Registry CAS read continuation", "Xet HTTP CAS read"). Every read was unmediated or gated only by `BootstrapCasAuthorizer` ("any authenticated caller"), with labels caller-asserted or absent.

## Changes

- **`mac/cas_pep.rs` (NEW)**: the shared CAS PEP contract:
  - `domain_label()`: trusted content-bound label derived from the `DedupDomain` (trust boundary → level axis). NOT caller-asserted.
  - `seal_label()`: restrict-only join of domain label + staging hint (D1).
  - `CasClearanceSource` trait: the #698 clearance-provenance seam. `DenyAllClearanceSource` returns `None` for all subjects (fail-closed).
  - `CasPep`: per-op enforcement — resolves clearance, checks `can_access`, audits every decision. Fail-closed on missing clearance/label/audit.
  - `MacCasAuthorizer`: implements `CasMountAuthorizer` so CasMount's existing per-op hook delegates to the MAC PEP.

- **`substrate.rs`**: `put()` derives the trusted label via `seal_label(domain, hint)`. The hint is a D1 restrict-only input from our staging path; the domain label is authoritative.

- **`registry.rs`**: read continuation (`execute_get_blob_stream`) captures the verified subject from `EnvelopeContext::subject()` and performs a MAC PEP recheck before streaming any bytes.

- **`xet.rs`**: `BootstrapCasAuthorizer` replaced with `MacCasAuthorizer::fail_closed()` at the xorb read handler.

## Posture

Until #698 wires production clearance provenance, every MAC-mediated CAS read fails closed (deny all). There is no permissive mode (per #547). The PEP structure is complete and audited.

## Dependencies / open gaps

- **#698**: the `CasClearanceSource` seam is stubbed with `DenyAllClearanceSource`. When #698 wires real `Claims × VerifiedKeyMaterial → SecurityContext` derivation, a real resolver replaces the stub without touching any CAS call site.
- **#1268**: `.fleet-coord/mac-pep-contract.md` was not published as of this PR. The CAS PEP was built independently. If #1268 publishes a shared contract, this should consume it.
- **Lattice internment**: `domain_label()` uses `CompartmentSet::EMPTY` (level-axis enforcement only). Compartment isolation is structural (distinct physical storage roots per domain). Enriching with interned compartment bits is a follow-up gated on #698/#1268.

## Validation

- `cargo check --lib --tests -p hyprstream`: clean
- `cargo clippy --lib -p hyprstream -- -D warnings`: clean
- `cargo test --release -p hyprstream --lib mac::`: 158 passed (incl. 14 new cas_pep tests)
- `cargo test --release -p hyprstream --lib storage::cas`: 47 passed

A kimi-k3 review is the final gate before merge.
