### PR TITLE
feat(mac): VFS direct-API + exec/ctl MAC PEP structure (#1272)

### DIFF
--- a/.fleet-coord/pep-1272-status.md
+++ b/.fleet-coord/pep-1272-status.md
@@ -1,0 +1,32 @@
+# PEP #1272 — VFS direct-API + exec/ctl MAC PEP
+
+**Branch:** `feat/mac-vfs-pep` → PR (refs #1272, epic #1267 T3)
+**Status:** structure complete, fail-closed, release-validated; **dormant** (activation is the #1267 B-lane).
+**Package focus:** `hyprstream-vfs`; secondary `hyprstream-workers` (exec/ctl).
+
+## What landed
+- **`hyprstream-vfs::mac_pep`** — the plane-specific PEP (`NamespacePep`, `NamespaceAccessDecider`, `SubjectContextResolver`, `NamespaceAction`, deny-all defaults) consumes the canonical `MacDecision` / `MacDenyReason` / `RpcObjectLabelResolver` contract. `MacDispatchPep` remains RPC-only as #1288 requires.
+- **`Namespace`** — `pep: Option<Arc<NamespacePep>>` field; `cat`/`read_one`/`echo`/`create`/`ctl`/`ls` consult it; subject-less `mount`/`bind_mount`/`unmount` deny when armed; `_as` variants mediate. `resolve_targets` requires a caller and authorizes the write-capable raw handle before returning it. `fork` inherits the PEP.
+- **`hyprstream-workers::ExecMount`** — `LifecyclePolicy` seam (fail-closed `DenyAllLifecycle`); `write` threads `caller` into `apply_verb`; stop/kill/destroy gated when armed.
+- **`hyprstream::mac::pep`** — `VfsAccessDecider` (audited, reuses WAL + `can_access` + write-direction pause) + `production_vfs_pep(...)` assembly + `DenyUnenrolledSubjects` stub. Missing-clearance, missing-label, floor, write-direction, and subject-less-mutation denials all cross the WAL sink before returning. Extends the shared contract; does NOT reinvent label resolution/clearance/`can_access`.
+
+## Activation posture
+- `Namespace::new()` / `ExecMount::new()` = **unenforced** (the documented dormant status quo — CLAUDE.md "MAC current status").
+- `set_pep` / `new_with_lifecycle` = **armed**, fail-closed by construction (no permissive path inside the PEP; #547).
+- Flipping construction sites to armed = the separately-gated **#1267 B-lane**, NOT this PR.
+
+## Dependencies flagged (fail-closed stubs in place)
+- **#698** (production clearance provenance): `DenyUnenrolledSubjects` resolves no `Subject` → armed PEP denies every op until a real `SubjectContextResolver` lands. NO permissive default.
+- **#1288 canonical contract** is consumed directly: VFS passes normalized paths through `RpcObjectLabelResolver` with `method=None` and returns canonical `MacDecision` values. A missing `NamespacePep` is dormant/pass-through; once installed, missing clearance, missing labels, and policy denial fail closed.
+- **#1196 `verified_tenant`** is inherited from `origin/main`. This PR adds no `EnvelopeContext` literals; every existing literal initializes the field, and global/node-global subsystem boundaries remain unchanged.
+- **Write-direction (IFC)**: VFS write/create/mount/raw-handle-class operations deny pending the VFS IFC decision.
+
+## Validation
+- `cargo metadata --all-features` → exit 0.
+- `buildq -- cargo nextest run --release --profile ci -p hyprstream -p hyprstream-rpc -p hyprstream-vfs --no-fail-fast` → 2305/2305 pass, 0 failed, 9 skipped.
+- `buildq -- cargo nextest run --release --profile ci -p hyprstream-vfs -p hyprstream --no-fail-fast` → 1407/1407 pass, 0 failed, 6 skipped (rebased onto `origin/main` at `9b269564d`).
+- `buildq -- cargo nextest run --release --profile ci -p hyprstream-vfs -p hyprstream -p hyprstream-rpc --no-fail-fast` → exit 0, 0 failed (rebased onto `origin/main` at `36043b917`).
+- New tests: 3 PEP-contract unit tests + 8 `Namespace` integration tests (un-armed non-regression, armed deny-all, clearance-dominates, write-pause, unlabeled-deny, subject-less-mutation-block, fork-inherits-pep, raw-handle resolution denies missing clearance) + audited VFS fail-closed denial regression.
+
+## Final gate
+kimi-k3 review (do NOT self-merge / touch the merge queue).

--- a/crates/hyprstream-vfs-server/src/filesystem.rs
+++ b/crates/hyprstream-vfs-server/src/filesystem.rs
@@ -166,7 +166,7 @@ impl VfsFileSystem {
     fn route(&self, components: &[String]) -> io::Result<(Vec<MountTarget>, Vec<String>)> {
         let path = Self::abs_path(components);
         self.ns
-            .resolve_targets(&path)
+            .resolve_targets(&path, &self.subject)
             .map_err(|_| io::Error::from_raw_os_error(libc::ENOENT))
     }
 
@@ -790,4 +790,3 @@ impl FileSystem for VfsFileSystem {
         Ok(ListxattrReply::Names(Vec::new()))
     }
 }
-

--- a/crates/hyprstream-vfs/src/lib.rs
+++ b/crates/hyprstream-vfs/src/lib.rs
@@ -18,6 +18,10 @@
 
 pub mod devfile;
 mod fsmount;
+/// MAC PEP for the direct Namespace API (#1272): the contract `Namespace`
+/// invokes per op, plus fail-closed defaults. The audited production impl lives
+/// in `hyprstream::mac::pep`.
+pub mod mac_pep;
 mod mount;
 mod namespace;
 #[cfg(not(target_arch = "wasm32"))]
@@ -44,6 +48,10 @@ pub use fsmount::{FsMount, SetAttr};
 pub use hyprstream_rpc::Subject;
 pub use mount::{DirEntry, Fid, Mount, MountError, Stat, OREAD, OWRITE, ORDWR, OTRUNC, ORCLOSE, DMDIR};
 pub use namespace::{BindFlag, MountTarget, Namespace, NamespaceError};
+pub use mac_pep::{
+    DenyAllNamespace, DenyAllSubjects, DenyUnlabeledResolver, NamespaceAccessDecider,
+    NamespaceAction, NamespacePep, SubjectContextResolver,
+};
 
 #[cfg(not(target_arch = "wasm32"))]
 pub use fuse_adapter::FuseFileSystemMount;

--- a/crates/hyprstream-vfs/src/mac_pep.rs
+++ b/crates/hyprstream-vfs/src/mac_pep.rs
@@ -1,0 +1,436 @@
+//! **MAC PEP for the direct Namespace API** (#1272, epic #1267 T3).
+//!
+//! The 9P *translator* already mediates every wire op through
+//! `hyprstream_9p::AccessDecider` (implemented by `hyprstream::mac::pep`).
+//! But the **direct in-process `Namespace` API** — `cat`/`echo`/`create` and
+//! `mount`/`bind_mount`/`unmount` — forwards a plain [`Subject`] to the
+//! resolving [`Mount`](crate::Mount) with no mandatory label lookup or
+//! reference monitor, bypassing the translator PEP entirely. This module is
+//! that missing reference monitor: the contract the `Namespace` invokes per
+//! op, plus its fail-closed defaults.
+//!
+//! ## Dependency-direction (mirrors the 9P split)
+//!
+//! The *trait* (the contract the low-level `Namespace` consumes) lives here in
+//! `hyprstream-vfs`, exactly as `hyprstream_9p::AccessDecider` lives in the 9P
+//! crate. The *production audited implementation* — bridging to the real
+//! `RpcObjectLabelResolver`, `SecurityContext::can_access`, and the
+//! tamper-evident MAC audit sink — lives in `hyprstream::mac::pep`, alongside
+//! `NinePAccessDecider`. This keeps the dependency direction one-way
+//! (`hyprstream` → `hyprstream-vfs`) and **does not reinvent label resolution,
+//! clearance, or `can_access`**; those are S1/S4 primitives re-exported from
+//! `hyprstream_rpc::auth::mac`.
+//!
+//! ## Fail-closed by construction; no permissive mode (#547)
+//!
+//! Every seam has an explicit deny-all default. A [`NamespacePep`] authorizes
+//! an op only when ALL of:
+//! 1. the caller's [`Subject`] resolves to a verified [`SecurityContext`]
+//!    (clearance provenance — #698; `None` ⇒ deny),
+//! 2. the walked object resolves to a [`SecurityLabel`] via the injected
+//!    [`RpcObjectLabelResolver`] (`None` ⇒ deny — "no unlabeled-default-allow"),
+//! 3. `clearance.can_access(object_label)` (BLP dominance) AND the
+//!    [`NamespaceAccessDecider`] permit.
+//! There is no permissive path *inside* the PEP.
+//!
+//! ## Activation posture (dormant structure)
+//!
+//! A [`Namespace`](crate::Namespace) built with [`Namespace::new`] carries
+//! `pep: None` and behaves exactly as before — the un-enforced status quo,
+//! matching the rest of MAC enforcement being dormant today (CLAUDE.md "MAC
+//! current status"). Installing a PEP via
+//! [`Namespace::with_pep`](crate::Namespace::with_pep) arms the fail-closed
+//! monitor: every mediated op then requires a proven subject, and the
+//! subject-less `mount`/`bind_mount`/`unmount` deny (use the `_as` variants).
+//! Flipping the default at construction sites is the separately-gated
+//! activation B-lane (#1267), not this PR.
+
+use std::sync::Arc;
+
+pub use hyprstream_rpc::auth::mac::{
+    MacDecision, MacDenyReason, RpcObjectLabelResolver, SecurityContext, SecurityLabel,
+};
+use hyprstream_rpc::Subject;
+
+use crate::NamespaceError;
+
+/// The direct-`Namespace`-API operation a [`NamespaceAccessDecider`] is asked
+/// to authorize.
+///
+/// This is the VFS-plane action surface — broader than the 9P translator's
+/// `hyprstream_9p::Action` because the direct API also mutates the namespace
+/// itself (`Mount`/`BindMount`/`Unmount`), ops the wire translator never
+/// dispatches. Mirrors [`Namespace`](crate::Namespace)'s convenience methods.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum NamespaceAction {
+    /// `cat` / `read_one` / `ls` — read-class.
+    Read,
+    /// `echo` / `ctl` — write-class.
+    Write,
+    /// `create` — new-object creation.
+    Create,
+    /// `mount` — install/replace a mount point (namespace mutation).
+    Mount,
+    /// `bind_mount` — union-bind a target (namespace mutation).
+    BindMount,
+    /// `unmount` — remove a mount point (namespace mutation).
+    Unmount,
+    /// Extract raw mount targets from the namespace.
+    ///
+    /// A returned [`crate::MountTarget`] can invoke the complete `Mount`
+    /// surface, including writes, without re-entering [`crate::Namespace`].
+    /// This is therefore a privileged, write-capable action rather than a
+    /// read-only path lookup.
+    ResolveHandle,
+}
+
+/// Plane-specific clearance-input seam: resolve a direct-API [`Subject`] to the
+/// verified [`SecurityContext`] that authorizes it.
+///
+/// This is the VFS-plane half of **#698** (production clearance provenance).
+/// The companion RPC-dispatch seam (claims → `SecurityContext` threading at
+/// dispatch) is owned by **#1268**, which will publish its interface to
+/// `.fleet-coord/mac-pep-contract.md`. Until that lands, this trait is the
+/// plane-specific resolution point: a `Subject` (the only identity the direct
+/// API carries — no verified `EnvelopeContext` crosses it) becomes a clearance
+/// only through verified credential material this resolver consults.
+///
+/// **Returning `None` is the mandatory fail-closed contract** — a subject
+/// whose clearance cannot be established from verified credential material
+/// MUST NOT be authorized; there is no permissive default (#547).
+/// Implementations MUST NOT derive clearance from an unverified,
+/// caller-supplied label (D1 — labels in wire schemas are hints; here the
+/// `Subject` name is even weaker: an unauthenticated string).
+pub trait SubjectContextResolver: Send + Sync {
+    /// Resolve `subject` to its verified security context, or `None` if its
+    /// clearance cannot be proven — which the PEP treats as deny.
+    fn resolve(&self, subject: &Subject) -> Option<SecurityContext>;
+}
+
+/// Fail-closed resolver: no subject resolves to a clearance.
+///
+/// This is the default a [`NamespacePep`] uses for the subject seam when no
+/// production resolver (#698) has been wired — every mediated op denies.
+#[derive(Debug, Default, Clone, Copy)]
+pub struct DenyAllSubjects;
+
+impl SubjectContextResolver for DenyAllSubjects {
+    fn resolve(&self, _subject: &Subject) -> Option<SecurityContext> {
+        // No SubjectContextResolver wired (#698 not landed). The authorize()
+        // path passes `None` to the authoritative decider, which audits the
+        // no-clearance denial before returning it. This low-level crate does
+        // not own the audit WAL or a tracing dependency.
+        None
+    }
+}
+
+/// Authorizes one direct-`Namespace` operation against the attempted subject
+/// context and object label.
+///
+/// Label resolution is centralized in [`NamespacePep::authorize`] (the
+/// reference monitor), which calls the injected [`RpcObjectLabelResolver`] and
+/// hands the result here. Missing clearance and missing labels are deliberately
+/// represented as `None` so the authoritative implementation in the
+/// `hyprstream` crate can write those fail-closed decisions to the same
+/// tamper-evident WAL as policy-floor denials. No deny may return before this
+/// audit boundary.
+pub trait NamespaceAccessDecider: Send + Sync {
+    /// Return the canonical MAC decision and record every outcome through the
+    /// MAC audit sink.
+    ///
+    /// `None` inputs are mandatory denials: an absent `ctx` means clearance
+    /// could not be proven, while an absent `object_label` means the object is
+    /// unlabeled. Implementations use bottom labels only as audit-schema
+    /// placeholders; placeholders must never participate in authorization.
+    fn check(
+        &self,
+        ctx: Option<&SecurityContext>,
+        object_label: Option<SecurityLabel>,
+        action: NamespaceAction,
+    ) -> MacDecision;
+}
+
+/// Fail-closed decider for a [`NamespacePep`] whose production audited decider
+/// is unavailable. Every op denies.
+#[derive(Debug, Default, Clone, Copy)]
+pub struct DenyAllNamespace;
+
+impl NamespaceAccessDecider for DenyAllNamespace {
+    fn check(
+        &self,
+        _ctx: Option<&SecurityContext>,
+        _object_label: Option<SecurityLabel>,
+        _action: NamespaceAction,
+    ) -> MacDecision {
+        MacDecision::Deny(MacDenyReason::NoPepInstalled)
+    }
+}
+
+/// Fail-closed label resolver: no object resolves. Mirrors
+/// `hyprstream_9p::DenyUnlabeledResolver`. Returning `None` is a mandatory
+/// deny (design §1 invariant 2) — the PEP refuses to authorize any op whose
+/// object has no trusted label.
+#[derive(Debug, Default, Clone, Copy)]
+pub struct DenyUnlabeledResolver;
+
+impl RpcObjectLabelResolver for DenyUnlabeledResolver {
+    fn resolve(&self, _service_domain: &str, _method: Option<u16>) -> Option<SecurityLabel> {
+        None
+    }
+}
+
+/// The mandatory, all-or-nothing reference monitor a
+/// [`Namespace`](crate::Namespace) mediates every direct-API op through once
+/// installed.
+///
+/// There is no permissive or partial construction: each of the three seams is
+/// required, and the crate's fail-closed defaults ([`DenyAllSubjects`],
+/// [`DenyAllNamespace`], and the `None`-returning
+/// [`hyprstream_rpc::auth::mac`] `RpcObjectLabelResolver` the `hyprstream` crate
+/// supplies) are the explicit choices for a seam the application does not yet
+/// populate. Building a `NamespacePep` is therefore always fail-closed;
+/// "unenforced" is represented by *not installing* one on the `Namespace`
+/// (the dormant status quo), never by a permissive PEP.
+pub struct NamespacePep {
+    subjects: Arc<dyn SubjectContextResolver>,
+    labels: Arc<dyn RpcObjectLabelResolver>,
+    decider: Arc<dyn NamespaceAccessDecider>,
+}
+
+impl std::fmt::Debug for NamespacePep {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("NamespacePep").finish_non_exhaustive()
+    }
+}
+
+impl NamespacePep {
+    /// Assemble the monitor from its three mandatory seams.
+    ///
+    /// Callers that lack a production seam pass the crate's deny-all default
+    /// for it — the resulting PEP denies every op, which is the correct
+    /// posture for "structure present, inputs not yet wired" (the #698 /
+    /// #1268 dependency window). There is no `new_permissive`.
+    pub fn new(
+        subjects: Arc<dyn SubjectContextResolver>,
+        labels: Arc<dyn RpcObjectLabelResolver>,
+        decider: Arc<dyn NamespaceAccessDecider>,
+    ) -> Self {
+        Self {
+            subjects,
+            labels,
+            decider,
+        }
+    }
+
+    /// Authorize `action` by `subject` against `object`.
+    ///
+    /// Fail-closed sequence (any deny ⇒ [`NamespaceError::Denied`]):
+    ///   1. resolve `subject` → optional `SecurityContext`,
+    ///   2. resolve `object` → `SecurityLabel` via the injected
+    ///      [`RpcObjectLabelResolver`] (missing means no unlabeled-default-allow;
+    ///      design §1 invariant 2),
+    ///   3. `decider.check(ctx, label, action)` — audit every outcome, including
+    ///      missing-clearance and missing-label denials, then apply
+    ///      `can_access` + TE floor; canonical [`MacDecision::Deny`] ⇒ deny,
+    ///   4. permit.
+    ///
+    /// `object_path` is the canonical normalized VFS path. It occupies the
+    /// canonical resolver's `service_domain` slot; VFS has no browser method
+    /// discriminator, so `method` is always `None`. The caller never supplies a
+    /// label (D1 — caller labels are forbidden).
+    pub fn authorize(
+        &self,
+        subject: &Subject,
+        object_path: &str,
+        action: NamespaceAction,
+    ) -> Result<(), NamespaceError> {
+        match self.check(subject, object_path, action) {
+            MacDecision::Permit => Ok(()),
+            MacDecision::Deny(reason) => Err(NamespaceError::Denied(
+                action,
+                denial_detail(subject, deny_reason_detail(reason)),
+            )),
+        }
+    }
+
+    /// Evaluate one VFS operation using the canonical shared MAC decision
+    /// contract. An installed `NamespacePep` is always fail-closed.
+    #[must_use]
+    pub fn check(
+        &self,
+        subject: &Subject,
+        object_path: &str,
+        action: NamespaceAction,
+    ) -> MacDecision {
+        let ctx = self.subjects.resolve(subject);
+        let label = self.labels.resolve(object_path, None);
+        self.decider.check(ctx.as_ref(), label, action)
+    }
+
+    /// Record and return the mandatory no-clearance denial for a subject-less
+    /// namespace mutation.
+    ///
+    /// Armed construction APIs have no caller to resolve, but their forced
+    /// denial must still cross the same audit boundary as every subjectful
+    /// operation. The decider contract requires `ctx=None` to deny and record
+    /// the attempt; a non-conforming permit is nevertheless downgraded to
+    /// `NoClearance`.
+    pub(crate) fn deny_uncredentialed(
+        &self,
+        object_path: &str,
+        action: NamespaceAction,
+    ) -> NamespaceError {
+        let label = self.labels.resolve(object_path, None);
+        let reason = match self.decider.check(None, label, action) {
+            MacDecision::Deny(reason) => reason,
+            MacDecision::Permit => MacDenyReason::NoClearance,
+        };
+        NamespaceError::Denied(
+            action,
+            denial_detail(&Subject::anonymous(), deny_reason_detail(reason)),
+        )
+    }
+}
+
+fn denial_detail(subject: &Subject, reason: &str) -> String {
+    match subject.name() {
+        Some(n) => format!("'{n}': {reason}"),
+        None => format!("<anonymous>: {reason}"),
+    }
+}
+
+const fn deny_reason_detail(reason: MacDenyReason) -> &'static str {
+    match reason {
+        MacDenyReason::NoPepInstalled => "explicit deny-all PEP installed",
+        MacDenyReason::NoClearance => "subject clearance unprovable",
+        MacDenyReason::UnlabeledObject => "object unlabeled",
+        MacDenyReason::FloorDeny => "MAC floor denied",
+        MacDenyReason::StaleAuthority => "stale authority",
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use hyprstream_rpc::auth::mac::{
+        Assurance, CompartmentSet, Level, SecurityLabel, VerifiedKeyMaterial,
+    };
+
+    fn ctx(level: Level) -> SecurityContext {
+        SecurityContext::from_clearance(label(level), VerifiedKeyMaterial::Classical)
+    }
+    fn label(level: Level) -> SecurityLabel {
+        SecurityLabel::new(level, Assurance::Classical, CompartmentSet::EMPTY)
+    }
+    fn subject(name: &str) -> Subject {
+        Subject::new(name)
+    }
+
+    /// A resolver that maps one subject name to a fixed clearance; all others
+    /// `None` (deny).
+    struct OneSubject {
+        name: &'static str,
+        ctx: SecurityContext,
+    }
+    impl SubjectContextResolver for OneSubject {
+        fn resolve(&self, s: &Subject) -> Option<SecurityContext> {
+            (s.name() == Some(self.name)).then(|| self.ctx.clone())
+        }
+    }
+
+    /// A decider that permits reads at-or-below the subject's level and denies
+    /// everything else (write-class = deny, mirroring the IFC write-direction
+    /// pause the 9P PEP enforces).
+    struct ReadFloorDecider;
+    impl NamespaceAccessDecider for ReadFloorDecider {
+        fn check(
+            &self,
+            ctx: Option<&SecurityContext>,
+            object_label: Option<SecurityLabel>,
+            action: NamespaceAction,
+        ) -> MacDecision {
+            let Some(ctx) = ctx else {
+                return MacDecision::Deny(MacDenyReason::NoClearance);
+            };
+            let Some(object_label) = object_label else {
+                return MacDecision::Deny(MacDenyReason::UnlabeledObject);
+            };
+            if action != NamespaceAction::Read {
+                return MacDecision::Deny(MacDenyReason::FloorDeny);
+            }
+            if ctx.clearance().can_access(&object_label) {
+                MacDecision::Permit
+            } else {
+                MacDecision::Deny(MacDenyReason::FloorDeny)
+            }
+        }
+    }
+
+    /// A resolver that labels the first path component as a level (test-only).
+    struct PathLevelResolver;
+    impl RpcObjectLabelResolver for PathLevelResolver {
+        fn resolve(&self, service_domain: &str, _method: Option<u16>) -> Option<SecurityLabel> {
+            match service_domain {
+                "/public" => Some(label(Level::Public)),
+                "/secret" => Some(label(Level::Secret)),
+                _ => None,
+            }
+        }
+    }
+
+    #[test]
+    fn deny_all_pep_denies_every_subject() {
+        // All three seams deny: subject unresolvable ⇒ DenyAllSubjects ⇒ None
+        // ⇒ the PEP returns Err before the decider is even consulted.
+        let pep = NamespacePep::new(
+            Arc::new(DenyAllSubjects),
+            Arc::new(DenyUnlabeledResolver),
+            Arc::new(DenyAllNamespace),
+        );
+        let err = pep
+            .authorize(&subject("anyone"), "/x", NamespaceAction::Read)
+            .unwrap_err();
+        assert!(matches!(err, NamespaceError::Denied(_, _)));
+    }
+
+    #[test]
+    fn deny_unlabeled_object_denies_even_with_a_valid_subject() {
+        // Subject resolves, but the object is unlabeled ⇒ deny (invariant 2).
+        let pep = NamespacePep::new(
+            Arc::new(OneSubject {
+                name: "alice",
+                ctx: ctx(Level::Secret),
+            }),
+            Arc::new(DenyUnlabeledResolver),
+            Arc::new(ReadFloorDecider),
+        );
+        assert!(pep
+            .authorize(&subject("alice"), "/secret", NamespaceAction::Read)
+            .is_err());
+    }
+
+    #[test]
+    fn pep_permits_read_when_clearance_dominates_and_denies_otherwise() {
+        let pep = NamespacePep::new(
+            Arc::new(OneSubject {
+                name: "alice",
+                ctx: ctx(Level::Secret),
+            }),
+            Arc::new(PathLevelResolver),
+            Arc::new(ReadFloorDecider),
+        );
+
+        // alice (Secret) reading /secret ⇒ permit.
+        assert!(pep
+            .authorize(&subject("alice"), "/secret", NamespaceAction::Read)
+            .is_ok());
+        // Write ⇒ deny (write-direction pause).
+        assert!(pep
+            .authorize(&subject("alice"), "/public", NamespaceAction::Write)
+            .is_err());
+        // Unenrolled subject ⇒ deny (fail-closed clearance).
+        assert!(pep
+            .authorize(&subject("mallory"), "/public", NamespaceAction::Read)
+            .is_err());
+    }
+}

--- a/crates/hyprstream-vfs/src/namespace.rs
+++ b/crates/hyprstream-vfs/src/namespace.rs
@@ -6,6 +6,7 @@
 use std::sync::Arc;
 
 use hyprstream_rpc::Subject;
+use crate::mac_pep::{NamespaceAction, NamespacePep};
 use crate::mount::{DirEntry, Mount, MountError, Stat, OWRITE};
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -17,6 +18,13 @@ use crate::mount::{DirEntry, Mount, MountError, Stat, OWRITE};
 pub enum NamespaceError {
     Mount(MountError),
     ReservedPath(String),
+    /// A mandatory MAC reference-monitor decision denied the op (#1272).
+    ///
+    /// Carries the [`NamespaceAction`] that was denied and a human-readable
+    /// detail string. This is the fail-closed surface: the PEP returns this
+    /// variant whenever the caller's clearance is unprovable, the object is
+    /// unlabeled, or `can_access` fails. There is no permissive fallback.
+    Denied(NamespaceAction, String),
 }
 
 impl std::fmt::Display for NamespaceError {
@@ -24,6 +32,9 @@ impl std::fmt::Display for NamespaceError {
         match self {
             Self::Mount(e) => write!(f, "{e}"),
             Self::ReservedPath(p) => write!(f, "reserved path: {p}"),
+            Self::Denied(action, detail) => {
+                write!(f, "MAC denied {action:?}: {detail}")
+            }
         }
     }
 }
@@ -77,21 +88,90 @@ const MAX_READ_SIZE: usize = 16 * 1024 * 1024;
 ///
 /// Populated from service discovery at startup (`/srv/{name}`).
 /// Forkable for per-task sandboxing via `fork()` + `unmount()`.
+///
+/// # MAC enforcement (#1272)
+///
+/// The namespace carries an optional [`NamespacePep`] — the mandatory
+/// reference monitor over the direct API. A namespace built with [`Self::new`]
+/// is **unenforced** (the dormant status quo, matching the rest of MAC
+/// enforcement today); installing a PEP with [`Self::with_pep`] arms the
+/// fail-closed monitor so every read/write/create and every
+/// `mount`/`bind_mount`/`unmount` then requires a proven subject. Flipping the
+/// default to enforced at construction sites is the separately-gated activation
+/// B-lane (#1267), not this field's existence.
 pub struct Namespace {
     mounts: Vec<MountEntry>,
+    /// Mandatory MAC reference monitor over the direct API. `None` ⇒ the
+    /// un-enforced status quo; `Some` ⇒ every mediated op must pass it.
+    pep: Option<Arc<NamespacePep>>,
 }
 
 impl Namespace {
-    /// Create an empty namespace.
+    /// Create an empty, **unenforced** namespace.
+    ///
+    /// No MAC PEP is installed: direct-API ops behave as before (the
+    /// documented dormant posture — CLAUDE.md "MAC current status"). To arm
+    /// fail-closed enforcement, call [`Self::with_pep`] after construction.
     pub fn new() -> Self {
-        Self { mounts: Vec::new() }
+        Self {
+            mounts: Vec::new(),
+            pep: None,
+        }
+    }
+
+    /// Install (or replace) the mandatory MAC reference monitor.
+    ///
+    /// Once armed, every mediated direct-API op (`cat`/`read_one`/`echo`/
+    /// `create`/`ctl`) requires a subject whose clearance the PEP can prove,
+    /// and the subject-less `mount`/`bind_mount`/`unmount` **deny** — runtime
+    /// callers must use the `_as` variants with a proven [`Subject`]. The PEP
+    /// itself is fail-closed by construction (see [`NamespacePep`]).
+    ///
+    /// Returns the previous PEP, if any (enables atomic re-arm in tests).
+    pub fn set_pep(&mut self, pep: Arc<NamespacePep>) -> Option<Arc<NamespacePep>> {
+        self.pep.replace(pep)
+    }
+
+    /// Whether a MAC PEP is currently armed on this namespace.
+    pub fn pep_armed(&self) -> bool {
+        self.pep.is_some()
+    }
+
+    /// Enforce `action` by `subject` against the object at `path` when a PEP is
+    /// armed. No-op (permit) when no PEP is installed — the dormant status quo.
+    /// Fail-closed when armed: any unresolvable clearance/label or failed
+    /// `can_access` yields [`NamespaceError::Denied`].
+    fn enforce(&self, subject: &Subject, path: &str, action: NamespaceAction) -> Result<(), NamespaceError> {
+        let Some(pep) = &self.pep else {
+            return Ok(());
+        };
+        // Pass the canonical normalized path through the shared resolver
+        // contract. The authoritative resolver (in the `hyprstream` crate)
+        // performs prefix matching against genesis/bind-label carriers; the
+        // namespace supplies only the path, never a caller-authored label.
+        let normalized = normalize_path(path);
+        pep.authorize(subject, &normalized, action)
     }
 
     /// Mount a target at a path prefix (replaces any existing mount).
     ///
-    /// This is shorthand for `bind_mount(prefix, target, BindFlag::Replace)`.
+    /// This is the **namespace-construction** path: it carries no [`Subject`]
+    /// and is therefore usable only while no MAC PEP is armed (the build/fork
+    /// phase before [`Self::set_pep`]). Once a PEP is armed, this denies —
+    /// runtime callers must prove a subject via [`Self::mount_as`].
     pub fn mount(&mut self, prefix: &str, target: MountTarget) -> Result<(), NamespaceError> {
         self.bind_mount(prefix, target, BindFlag::Replace)
+    }
+
+    /// Subject-mediated `mount` — the runtime path under an armed PEP (#1272).
+    pub fn mount_as(
+        &mut self,
+        prefix: &str,
+        target: MountTarget,
+        subject: &Subject,
+    ) -> Result<(), NamespaceError> {
+        self.enforce(subject, prefix, NamespaceAction::Mount)?;
+        self.bind_mount_inner(prefix, target, BindFlag::Replace)
     }
 
     /// Mount a target at a path prefix with union semantics.
@@ -102,7 +182,37 @@ impl Namespace {
     /// - `After`: appends the target — existing mounts are tried first.
     /// - `Upper`: appends the target *and* records it as the union's writable
     ///   copy-up upper (#370). See [`BindFlag::Upper`].
+    ///
+    /// Like [`Self::mount`], this is the **construction** path (no subject):
+    /// when a PEP is armed it denies — use [`Self::bind_mount_as`].
     pub fn bind_mount(&mut self, prefix: &str, target: MountTarget, flag: BindFlag) -> Result<(), NamespaceError> {
+        if let Some(pep) = &self.pep {
+            // An armed namespace cannot mutate without a proven subject — the
+            // subject-less construction path is intentionally closed once the
+            // reference monitor is in place (#1272). Route the forced denial
+            // through the PEP so it is recorded in the audit WAL.
+            let normalized = normalize_path(prefix);
+            return Err(pep.deny_uncredentialed(&normalized, NamespaceAction::BindMount));
+        }
+        self.bind_mount_inner(prefix, target, flag)
+    }
+
+    /// Subject-mediated `bind_mount` — the runtime path under an armed PEP.
+    pub fn bind_mount_as(
+        &mut self,
+        prefix: &str,
+        target: MountTarget,
+        flag: BindFlag,
+        subject: &Subject,
+    ) -> Result<(), NamespaceError> {
+        self.enforce(subject, prefix, NamespaceAction::BindMount)?;
+        self.bind_mount_inner(prefix, target, flag)
+    }
+
+    // Core bind logic shared by the construction and mediated paths. Assumes
+    // the caller has already passed any armed PEP (or is the construction path
+    // on an un-armed namespace).
+    fn bind_mount_inner(&mut self, prefix: &str, target: MountTarget, flag: BindFlag) -> Result<(), NamespaceError> {
         let prefix = normalize_prefix(prefix);
 
         match flag {
@@ -149,17 +259,36 @@ impl Namespace {
     }
 
     /// Remove a mount point. In forked namespaces, this is irreversible.
-    pub fn unmount(&mut self, prefix: &str) {
+    ///
+    /// Construction path (no subject): denies when a PEP is armed — use
+    /// [`Self::unmount_as`].
+    pub fn unmount(&mut self, prefix: &str) -> Result<(), NamespaceError> {
+        if let Some(pep) = &self.pep {
+            let normalized = normalize_path(prefix);
+            return Err(pep.deny_uncredentialed(&normalized, NamespaceAction::Unmount));
+        }
         let prefix = normalize_prefix(prefix);
         self.mounts.retain(|m| m.prefix != prefix);
+        Ok(())
+    }
+
+    /// Subject-mediated `unmount` — the runtime path under an armed PEP.
+    pub fn unmount_as(&mut self, prefix: &str, subject: &Subject) -> Result<(), NamespaceError> {
+        self.enforce(subject, prefix, NamespaceAction::Unmount)?;
+        let prefix = normalize_prefix(prefix);
+        self.mounts.retain(|m| m.prefix != prefix);
+        Ok(())
     }
 
     /// Create a child namespace (Plan 9 `rfork(RFNAMEG)`).
     ///
-    /// The child gets a snapshot of the parent's mounts.
-    /// Modifications to the child do not affect the parent.
+    /// The child gets a snapshot of the parent's mounts **and** the parent's
+    /// armed PEP (enforcement is inherited — a sandboxed child must not be
+    /// able to escape the reference monitor by forking). Modifications to the
+    /// child do not affect the parent.
     pub fn fork(&self) -> Namespace {
         Namespace {
+            pep: self.pep.clone(),
             mounts: self.mounts.iter().map(|m| MountEntry {
                 prefix: m.prefix.clone(),
                 targets: m.targets.iter().map(Arc::clone).collect(),
@@ -196,6 +325,7 @@ impl Namespace {
     /// Loops reads until an empty Vec is returned, up to 16MB cap.
     /// With union mounts, tries each target in bind order until one succeeds.
     pub async fn cat(&self, path: &str, caller: &Subject) -> Result<Vec<u8>, NamespaceError> {
+        self.enforce(caller, path, NamespaceAction::Read)?;
         let (targets, remainder) = self.resolve(path)?;
         let components: Vec<&str> = split_path(&remainder);
         let mut last_err = None;
@@ -233,6 +363,7 @@ impl Namespace {
     /// Unlike `cat()` which loops to EOF, this returns after one read call.
     /// For streams, this returns the next available block. Empty bytes = EOF.
     pub async fn read_one(&self, path: &str, caller: &Subject) -> Result<Vec<u8>, NamespaceError> {
+        self.enforce(caller, path, NamespaceAction::Read)?;
         let (targets, remainder) = self.resolve(path)?;
         let components: Vec<&str> = split_path(&remainder);
         let mut last_err = None;
@@ -272,6 +403,7 @@ impl Namespace {
     /// write to a path that resolves through the union dirty-over-committed
     /// tree lands in the upper layer, leaving the committed floor untouched.
     pub async fn echo(&self, path: &str, data: &[u8], caller: &Subject) -> Result<(), NamespaceError> {
+        self.enforce(caller, path, NamespaceAction::Write)?;
         let (entry, remainder) = self.resolve_entry(path)?;
         let targets = &entry.targets[..];
         let components: Vec<&str> = split_path(&remainder);
@@ -327,6 +459,7 @@ impl Namespace {
         perm: u32,
         caller: &Subject,
     ) -> Result<Stat, NamespaceError> {
+        self.enforce(caller, path, NamespaceAction::Create)?;
         let (targets, remainder) = self.resolve(path)?;
         let components: Vec<&str> = split_path(&remainder);
         if components.is_empty() {
@@ -501,6 +634,7 @@ impl Namespace {
     /// Loops reads until an empty Vec is returned, up to 16MB cap.
     /// With union mounts, tries each target in bind order until one succeeds.
     pub async fn ctl(&self, path: &str, data: &[u8], caller: &Subject) -> Result<Vec<u8>, NamespaceError> {
+        self.enforce(caller, path, NamespaceAction::Write)?;
         let (targets, remainder) = self.resolve(path)?;
         let components: Vec<&str> = split_path(&remainder);
         let mut last_err = None;
@@ -542,6 +676,7 @@ impl Namespace {
     /// With union mounts, merges readdir results from all targets at the prefix,
     /// deduplicating by name (first occurrence wins, preserving bind order).
     pub async fn ls(&self, path: &str, caller: &Subject) -> Result<Vec<DirEntry>, NamespaceError> {
+        self.enforce(caller, path, NamespaceAction::Read)?;
         // Special case: ls "/" shows all mount prefixes as directories.
         if path == "/" || path.is_empty() {
             return Ok(self.root_dir_entries());
@@ -614,9 +749,21 @@ impl Namespace {
     /// order (`Before` first, `After` last) so the caller can apply the same
     /// union/fallthrough policy the convenience helpers do.
     ///
+    /// Because a raw [`MountTarget`] exposes the complete mount capability,
+    /// including writes, an armed namespace authorizes the dedicated
+    /// [`NamespaceAction::ResolveHandle`] action before returning any target.
+    /// Missing clearance, a missing object label, or policy denial therefore
+    /// fails closed at the capability boundary. A dormant namespace remains a
+    /// pass-through.
+    ///
     /// `path` is normalised (`.`/`..` resolved, leading `/` enforced) before the
     /// longest-prefix match, identical to the convenience helpers.
-    pub fn resolve_targets(&self, path: &str) -> Result<(Vec<MountTarget>, Vec<String>), NamespaceError> {
+    pub fn resolve_targets(
+        &self,
+        path: &str,
+        caller: &Subject,
+    ) -> Result<(Vec<MountTarget>, Vec<String>), NamespaceError> {
+        self.enforce(caller, path, NamespaceAction::ResolveHandle)?;
         let (targets, remainder) = self.resolve(path)?;
         let components = split_path(&remainder).into_iter().map(str::to_owned).collect();
         Ok((targets.to_vec(), components))
@@ -884,7 +1031,7 @@ mod tests {
         ns.mount("/srv/worker", Arc::new(MemMount::new(vec![])) as MountTarget).unwrap();
 
         let mut child = ns.fork();
-        child.unmount("/srv/worker");
+        let _ = child.unmount("/srv/worker");
 
         assert_eq!(ns.mount_prefixes().len(), 2);
         assert_eq!(child.mount_prefixes().len(), 1);
@@ -909,7 +1056,7 @@ mod tests {
         // A longer prefix still wins over the root catch-all.
         assert_eq!(ns.cat("/stream/job/data", &test_subject()).await.unwrap(), b"chunk");
         // The rootfs itself is reachable at "/".
-        assert!(ns.resolve_targets("/").is_ok());
+        assert!(ns.resolve_targets("/", &test_subject()).is_ok());
     }
 
     #[tokio::test]
@@ -1730,5 +1877,229 @@ mod tests {
         let stream: MountTarget = Arc::new(MemMount::new(vec![("job", b"chunk")]));
         ns.mount("/stream", stream).unwrap();
         assert_eq!(ns.cat("/stream/job", &caller).await.unwrap(), b"chunk");
+    }
+
+    // ── MAC PEP integration (#1272) ──────────────────────────────────────────
+
+    use crate::mac_pep::{
+        DenyAllNamespace, DenyAllSubjects, NamespaceAccessDecider, NamespaceAction, NamespacePep,
+        SubjectContextResolver,
+    };
+    use hyprstream_rpc::auth::mac::{
+        Assurance, CompartmentSet, Level, MacDecision, MacDenyReason, RpcObjectLabelResolver,
+        SecurityContext, SecurityLabel, VerifiedKeyMaterial,
+    };
+
+    fn sec_label(level: Level) -> SecurityLabel {
+        SecurityLabel::new(level, Assurance::Classical, CompartmentSet::EMPTY)
+    }
+    fn sec_ctx(level: Level) -> SecurityContext {
+        SecurityContext::from_clearance(sec_label(level), VerifiedKeyMaterial::Classical)
+    }
+
+    /// A resolver that admits one named subject at a fixed clearance.
+    struct OneSubject {
+        name: &'static str,
+        ctx: SecurityContext,
+    }
+    impl SubjectContextResolver for OneSubject {
+        fn resolve(&self, s: &Subject) -> Option<SecurityContext> {
+            (s.name() == Some(self.name)).then(|| self.ctx.clone())
+        }
+    }
+
+    /// Labels `/public/**` Public and everything else `None` (deny).
+    struct PublicOnlyResolver;
+    impl RpcObjectLabelResolver for PublicOnlyResolver {
+        fn resolve(&self, service_domain: &str, _method: Option<u16>) -> Option<SecurityLabel> {
+            service_domain
+                .strip_prefix("/public")
+                .filter(|suffix| suffix.is_empty() || suffix.starts_with('/'))
+                .map(|_| sec_label(Level::Public))
+        }
+    }
+
+    /// Read-floor decider: reads permitted when clearance dominates the label;
+    /// all write/create/mount-class ops denied (write-direction pause).
+    struct ReadFloorDecider;
+    impl NamespaceAccessDecider for ReadFloorDecider {
+        fn check(
+            &self,
+            ctx: Option<&SecurityContext>,
+            object_label: Option<SecurityLabel>,
+            action: NamespaceAction,
+        ) -> MacDecision {
+            let Some(ctx) = ctx else {
+                return MacDecision::Deny(MacDenyReason::NoClearance);
+            };
+            let Some(object_label) = object_label else {
+                return MacDecision::Deny(MacDenyReason::UnlabeledObject);
+            };
+            if action != NamespaceAction::Read {
+                return MacDecision::Deny(MacDenyReason::FloorDeny);
+            }
+            if ctx.clearance().can_access(&object_label) {
+                MacDecision::Permit
+            } else {
+                MacDecision::Deny(MacDenyReason::FloorDeny)
+            }
+        }
+    }
+
+    fn deny_all_pep() -> Arc<NamespacePep> {
+        Arc::new(NamespacePep::new(
+            Arc::new(DenyAllSubjects),
+            Arc::new(crate::mac_pep::DenyUnlabeledResolver),
+            Arc::new(DenyAllNamespace),
+        ))
+    }
+
+    /// An un-armed namespace is the dormant status quo — all ops behave as
+    /// before. This is the non-regression guard for the activation gate.
+    #[tokio::test]
+    async fn un_unarmed_namespace_is_unenforced() {
+        let mut ns = Namespace::new();
+        ns.mount("/public", Arc::new(MemMount::new(vec![("f", b"data")])) as MountTarget)
+            .unwrap();
+        assert!(!ns.pep_armed());
+        assert_eq!(
+            ns.cat("/public/f", &Subject::new("anyone")).await.unwrap(),
+            b"data"
+        );
+    }
+
+    /// Arming the fail-closed PEP denies every op for every subject — there is
+    /// no permissive default once the monitor is installed (#547).
+    #[tokio::test]
+    async fn armed_deny_all_pep_denies_reads() {
+        let mut ns = Namespace::new();
+        ns.mount("/public", Arc::new(MemMount::new(vec![("f", b"data")])) as MountTarget)
+            .unwrap();
+        ns.set_pep(deny_all_pep());
+        assert!(ns.pep_armed());
+        let err = ns.cat("/public/f", &Subject::new("anyone")).await.unwrap_err();
+        assert!(matches!(err, NamespaceError::Denied(NamespaceAction::Read, _)));
+    }
+
+    /// A caller cannot bypass an armed PEP by extracting the raw mount target.
+    /// The capability boundary must deny before returning a handle when the
+    /// caller has no verified clearance.
+    #[test]
+    fn resolve_targets_denies_without_clearance() {
+        let mut ns = Namespace::new();
+        ns.mount(
+            "/public",
+            Arc::new(MemMount::new(vec![("f", b"data")])) as MountTarget,
+        )
+        .unwrap();
+        ns.set_pep(deny_all_pep());
+
+        assert!(matches!(
+            ns.resolve_targets("/public/f", &Subject::new("unverified")),
+            Err(NamespaceError::Denied(
+                NamespaceAction::ResolveHandle,
+                _
+            ))
+        ));
+    }
+
+    /// A subject whose clearance dominates the object label is permitted a
+    /// read; an unenrolled subject is denied (fail-closed clearance, #698).
+    #[tokio::test]
+    async fn armed_pep_permits_cleared_read_denies_uncleared() {
+        let mut ns = Namespace::new();
+        ns.mount("/public", Arc::new(MemMount::new(vec![("f", b"data")])) as MountTarget)
+            .unwrap();
+        let pep = Arc::new(NamespacePep::new(
+            Arc::new(OneSubject { name: "alice", ctx: sec_ctx(Level::Public) }),
+            Arc::new(PublicOnlyResolver),
+            Arc::new(ReadFloorDecider),
+        ));
+        ns.set_pep(pep);
+
+        // alice (Public clearance) reading /public/f ⇒ permit.
+        assert_eq!(
+            ns.cat("/public/f", &Subject::new("alice")).await.unwrap(),
+            b"data"
+        );
+        // mallory is unenrolled ⇒ clearance unprovable ⇒ deny.
+        let err = ns.cat("/public/f", &Subject::new("mallory")).await.unwrap_err();
+        assert!(matches!(err, NamespaceError::Denied(NamespaceAction::Read, _)));
+    }
+
+    /// Write-class ops deny under the read-floor decider (write-direction
+    /// pause) even for a cleared subject — the PEP mediates writes too.
+    #[tokio::test]
+    async fn armed_pep_denies_writes_under_read_floor_decider() {
+        let mut ns = Namespace::new();
+        ns.mount("/public", Arc::new(MemMount::new(vec![("ctl", b"")])) as MountTarget)
+            .unwrap();
+        let pep = Arc::new(NamespacePep::new(
+            Arc::new(OneSubject { name: "alice", ctx: sec_ctx(Level::Secret) }),
+            Arc::new(PublicOnlyResolver),
+            Arc::new(ReadFloorDecider),
+        ));
+        ns.set_pep(pep);
+
+        let err = ns.echo("/public/ctl", b"x", &Subject::new("alice")).await.unwrap_err();
+        assert!(matches!(err, NamespaceError::Denied(NamespaceAction::Write, _)));
+    }
+
+    /// An unlabeled object (no carrier resolves it) denies even for a cleared
+    /// subject — the "no unlabeled-default-allow" invariant (design §1.2).
+    #[tokio::test]
+    async fn armed_pep_denies_unlabeled_object() {
+        let mut ns = Namespace::new();
+        // /secret has no label carrier ⇒ PublicOnlyResolver returns None.
+        ns.mount("/secret", Arc::new(MemMount::new(vec![("f", b"x")])) as MountTarget)
+            .unwrap();
+        let pep = Arc::new(NamespacePep::new(
+            Arc::new(OneSubject { name: "alice", ctx: sec_ctx(Level::Secret) }),
+            Arc::new(PublicOnlyResolver),
+            Arc::new(ReadFloorDecider),
+        ));
+        ns.set_pep(pep);
+
+        let err = ns.cat("/secret/f", &Subject::new("alice")).await.unwrap_err();
+        assert!(matches!(err, NamespaceError::Denied(NamespaceAction::Read, _)));
+    }
+
+    /// Subject-less mount/unmount deny once the PEP is armed; the `_as`
+    /// variants mediate. (Read-floor decider denies mount-class, so even `_as`
+    /// denies here — the point is the mediation runs, not the policy outcome.)
+    #[tokio::test]
+    async fn armed_pep_blocks_subjectless_mutation() {
+        let mut ns = Namespace::new();
+        ns.set_pep(deny_all_pep());
+
+        // Subject-less construction path denies on an armed namespace.
+        let err = ns
+            .mount("/x", Arc::new(MemMount::new(vec![])) as MountTarget)
+            .unwrap_err();
+        assert!(matches!(err, NamespaceError::Denied(NamespaceAction::BindMount, _)));
+
+        let err = ns.unmount("/x").unwrap_err();
+        assert!(matches!(err, NamespaceError::Denied(NamespaceAction::Unmount, _)));
+
+        // The mediated `_as` path consults the PEP (deny-all ⇒ denied).
+        let err = ns
+            .mount_as("/x", Arc::new(MemMount::new(vec![])) as MountTarget, &Subject::new("a"))
+            .unwrap_err();
+        assert!(matches!(err, NamespaceError::Denied(NamespaceAction::Mount, _)));
+    }
+
+    /// `fork` inherits the armed PEP — a sandboxed child cannot escape the
+    /// reference monitor by forking.
+    #[tokio::test]
+    async fn fork_inherits_pep() {
+        let mut ns = Namespace::new();
+        ns.mount("/public", Arc::new(MemMount::new(vec![("f", b"data")])) as MountTarget)
+            .unwrap();
+        ns.set_pep(deny_all_pep());
+
+        let child = ns.fork();
+        assert!(child.pep_armed());
+        let err = child.cat("/public/f", &Subject::new("anyone")).await.unwrap_err();
+        assert!(matches!(err, NamespaceError::Denied(NamespaceAction::Read, _)));
     }
 }

--- a/crates/hyprstream-workers/src/runtime/exec_mount.rs
+++ b/crates/hyprstream-workers/src/runtime/exec_mount.rs
@@ -84,6 +84,73 @@ impl Verb {
             _ => None,
         }
     }
+
+    /// Whether this verb mutates the instance lifecycle destructively (stop/
+    /// kill/destroy). These are the verbs the MAC PEP must mediate (#1272):
+    /// `start` is constructive (it cannot remove or halt another subject's
+    /// instance), so it is not in the mediated set.
+    fn is_lifecycle_destructive(self) -> bool {
+        matches!(self, Verb::Stop | Verb::Kill | Verb::Destroy)
+    }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Lifecycle authorization seam (#1272)
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// The destructive lifecycle verbs a [`LifecyclePolicy`] mediates.
+///
+/// These are the `ctl` ops that halt or remove an instance — the
+/// "lifecycle mutation" surface issue #1272 names. `Start` is deliberately
+/// absent: it is constructive, not a mutation of another subject's running
+/// instance.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum LifecycleVerb {
+    Stop,
+    Kill,
+    Destroy,
+}
+
+/// Fail-closed authorization seam for destructive `ctl` lifecycle verbs
+/// (#1272, epic #1267 T3).
+///
+/// `ExecMount`'s `write` path previously ignored `_caller` entirely when
+/// invoking `stop`/`kill`/`destroy`. This trait is the mediation point: when a
+/// policy is installed on the mount ([`ExecMount::new_with_lifecycle`]), every
+/// destructive verb must pass `authorize` before the backend is touched.
+///
+/// **Fail-closed contract:** returning `Err` ⇒ the verb is refused
+/// (`MountError::PermissionDenied`); there is no permissive default inside a
+/// policy. The mount's status-quo (no policy installed) is represented by
+/// `lifecycle: None`, NOT by a permissive policy — mirroring the
+/// [`hyprstream_vfs::NamespacePep`] activation posture (the separately-gated
+/// B-lane flips construction sites to armed).
+///
+/// The clearance-provenance dependency (#698) is the same as the VFS PEP's: a
+/// production policy resolves the caller's `SecurityContext` from verified
+/// credential material and applies MAC `can_access` against the instance's
+/// label. Until #698 wires that, the policy is a structural seam.
+pub trait LifecyclePolicy: Send + Sync {
+    /// Authorize `verb` on instance `id` by `caller`. `Ok(())` permits;
+    /// `Err(detail)` denies with a human-readable reason.
+    fn authorize(&self, caller: &Subject, id: &str, verb: LifecycleVerb) -> Result<(), String>;
+}
+
+/// Fail-closed policy: denies every destructive verb for every subject.
+/// Installing this arms the mediation point to deny-by-default (e.g. during
+/// the #698 dependency window).
+#[derive(Debug, Default, Clone, Copy)]
+pub struct DenyAllLifecycle;
+
+impl LifecyclePolicy for DenyAllLifecycle {
+    fn authorize(
+        &self,
+        _caller: &Subject,
+        _id: &str,
+        _verb: LifecycleVerb,
+    ) -> Result<(), String> {
+        Err("lifecycle verb denied: no permissive policy".into())
+    }
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -167,17 +234,40 @@ pub struct ExecMount {
     /// fan-out this mount doesn't need). `TerminalStore` is still the single
     /// source of retained truth; this only wakes waiters once it's written.
     waiters: PmMutex<HashMap<String, Arc<Notify>>>,
+    /// Optional MAC lifecycle policy over destructive `ctl` verbs (#1272).
+    /// `None` ⇒ the un-enforced status quo (the mount's `write` ignores the
+    /// caller, the gap #1272 describes); `Some` ⇒ `stop`/`kill`/`destroy`
+    /// must pass [`LifecyclePolicy::authorize`] before the backend is touched.
+    lifecycle: Option<Arc<dyn LifecyclePolicy>>,
 }
 
 impl ExecMount {
-    /// Create a new `ExecMount` over the given pool.
+    /// Create a new `ExecMount` over the given pool, **unenforced**.
+    ///
+    /// No lifecycle policy is installed: destructive `ctl` verbs behave as
+    /// before (the dormant posture). To arm fail-closed mediation, use
+    /// [`Self::new_with_lifecycle`].
     pub fn new(pool: Arc<SandboxPool>) -> Self {
         Self {
             pool,
             terminal: TerminalStore::new(),
             terminal_ids: PmMutex::new(std::collections::HashSet::new()),
             waiters: PmMutex::new(HashMap::new()),
+            lifecycle: None,
         }
+    }
+
+    /// Create a new `ExecMount` with a MAC lifecycle policy armed.
+    ///
+    /// Every destructive verb (`stop`/`kill`/`destroy`) written to
+    /// `/exec/instances/<id>/ctl` must pass `policy.authorize(caller, id, verb)`
+    /// before the backend is touched; a denial yields
+    /// [`MountError::PermissionDenied`]. Pass [`DenyAllLifecycle`] for the
+    /// fail-closed default during the #698 dependency window.
+    pub fn new_with_lifecycle(pool: Arc<SandboxPool>, policy: Arc<dyn LifecyclePolicy>) -> Self {
+        let mut mount = Self::new(pool);
+        mount.lifecycle = Some(policy);
+        mount
     }
 
     /// Get (or create) the `Notify` an `exit` reader waits on for `id`.
@@ -191,7 +281,11 @@ impl ExecMount {
     }
 
     /// Resolve the verb against the pool/backend for instance `id`.
-    async fn apply_verb(&self, id: &str, verb: Verb) -> Result<String, MountError> {
+    ///
+    /// `caller` is the [`Subject`] that wrote the `ctl` verb (#1272): when a
+    /// [`LifecyclePolicy`] is armed, destructive verbs (stop/kill/destroy)
+    /// must pass it before any backend state is touched.
+    async fn apply_verb(&self, id: &str, verb: Verb, caller: &Subject) -> Result<String, MountError> {
         // Instances already marked terminal (destroyed through this mount)
         // are not present in the pool's active map any more; ctl ops on them
         // are rejected rather than silently no-op'd.
@@ -199,6 +293,30 @@ impl ExecMount {
             return Err(MountError::InvalidArgument(format!(
                 "instance {id} is already terminal"
             )));
+        }
+
+        // MAC lifecycle gate (#1272): a destructive verb must be authorized by
+        // the armed policy before we touch the backend. No policy ⇒ the
+        // un-enforced status quo (the documented gap); a policy ⇒ fail-closed
+        // (its `authorize` returns Err ⇒ PermissionDenied).
+        if verb.is_lifecycle_destructive() {
+            if let Some(policy) = &self.lifecycle {
+                let lv = match verb {
+                    Verb::Stop => LifecycleVerb::Stop,
+                    Verb::Kill => LifecycleVerb::Kill,
+                    Verb::Destroy => LifecycleVerb::Destroy,
+                    // is_lifecycle_destructive() is false for Start, so this
+                    // arm is unreachable here; kept exhaustive without `expect`.
+                    Verb::Start => {
+                        return Err(MountError::InvalidArgument(
+                            "start is not a lifecycle-destructive verb".into(),
+                        ))
+                    }
+                };
+                policy
+                    .authorize(caller, id, lv)
+                    .map_err(MountError::PermissionDenied)?;
+            }
         }
 
         let sandbox = self
@@ -404,7 +522,7 @@ impl Mount for ExecMount {
         fid: &Fid,
         _offset: u64,
         data: &[u8],
-        _caller: &Subject,
+        caller: &Subject,
     ) -> Result<u32, MountError> {
         let inner = fid
             .downcast_ref::<ExecFid>()
@@ -416,7 +534,10 @@ impl Mount for ExecMount {
                 let verb = Verb::parse(&text).ok_or_else(|| {
                     MountError::InvalidArgument(format!("unknown ctl verb: {}", text.trim()))
                 })?;
-                let result = self.apply_verb(id, verb).await;
+                // `caller` is now threaded into the lifecycle gate inside
+                // `apply_verb` (#1272): a destructive verb is mediated by the
+                // armed [`LifecyclePolicy`] before the backend is touched.
+                let result = self.apply_verb(id, verb, caller).await;
                 let response_bytes = match result {
                     Ok(s) => s.into_bytes(),
                     Err(e) => format!("error: {e}\n").into_bytes(),

--- a/crates/hyprstream-workers/src/runtime/wanix_workload.rs
+++ b/crates/hyprstream-workers/src/runtime/wanix_workload.rs
@@ -433,7 +433,7 @@ impl ImportedGuestNamespace {
     /// Remove the imported tree from `host_ns` (the teardown counterpart of the
     /// bind [`import_guest_namespace`] performed).
     pub fn unmount(&self, host_ns: &mut Namespace) {
-        host_ns.unmount(&self.prefix);
+        let _ = host_ns.unmount(&self.prefix);
     }
 }
 

--- a/crates/hyprstream-workers/src/workflow/runner.rs
+++ b/crates/hyprstream-workers/src/workflow/runner.rs
@@ -385,9 +385,9 @@ async fn run_job_steps(
 
         // Fork namespace for script isolation: remove /config, /private, /srv.
         let mut forked = ns.fork();
-        forked.unmount("/config");
-        forked.unmount("/private");
-        forked.unmount("/srv");
+        let _ = forked.unmount("/config");
+        let _ = forked.unmount("/private");
+        let _ = forked.unmount("/srv");
 
         // Write env vars to /env/* in forked namespace.
         // We use an in-memory mount for env vars.

--- a/crates/hyprstream/src/mac/genesis.rs
+++ b/crates/hyprstream/src/mac/genesis.rs
@@ -474,6 +474,19 @@ impl ObjectLabelResolver for CompositeObjectLabelResolver {
     }
 }
 
+/// Adapt the genesis/bind carrier resolver to the canonical cross-plane MAC
+/// resolver contract. For the VFS plane, `service_domain` is the normalized
+/// absolute object path and there is no browser method discriminator.
+impl hyprstream_rpc::auth::mac::RpcObjectLabelResolver for CompositeObjectLabelResolver {
+    fn resolve(&self, service_domain: &str, _method: Option<u16>) -> Option<SecurityLabel> {
+        let components: Vec<&str> = service_domain
+            .split('/')
+            .filter(|component| !component.is_empty() && *component != "." && *component != "..")
+            .collect();
+        self.resolve_path(&components)
+    }
+}
+
 /// Join path components into a normalized absolute path (`["srv","model"]` →
 /// `"/srv/model"`), matching [`normalize_node_path`]'s output so genesis lookups
 /// hit.

--- a/crates/hyprstream/src/mac/mod.rs
+++ b/crates/hyprstream/src/mac/mod.rs
@@ -118,15 +118,16 @@ pub use genesis::{
     floor_label, genesis_lattice, CompositeObjectLabelResolver, GeneratedNodeCoverage,
     GenesisGate, ManifestLabelSource, NamespaceEnumerator, NoManifests, SitePolicy,
 };
-pub use pep::{
-    enrollment_ninep_reference_monitor, production_ninep_decider,
-    production_ninep_reference_monitor, EnrollmentClearanceSource, NinePAccessDecider,
-    NinePClearanceSource, VerifiedClearanceSessionFactory,
-};
 // #1270: CAS-native MAC PEP — the shared CAS enforcement contract.
 pub use cas_pep::{
     domain_label, seal_label, CasClearanceSource, CasObjectLabelResolver, CasPep,
     DenyAllClearanceSource, MacCasAuthorizer,
+};
+pub use pep::{
+    enrollment_ninep_reference_monitor, production_ninep_decider,
+    production_ninep_reference_monitor, production_vfs_pep, DenyUnenrolledSubjects,
+    EnrollmentClearanceSource, NinePAccessDecider, NinePClearanceSource,
+    VerifiedClearanceSessionFactory, VfsAccessDecider,
 };
 // S4 (#570): the boot path that installs the verified `CompiledPolicy` at daemon
 // startup (dormant — makes the PDP inputs real without enabling enforcement).

--- a/crates/hyprstream/src/mac/pep.rs
+++ b/crates/hyprstream/src/mac/pep.rs
@@ -31,7 +31,7 @@ use hyprstream_9p::{
     ReferenceMonitor, ReferenceMonitorDenyReason, SessionContext, VerifiedAttachIdentity,
 };
 use hyprstream_rpc::auth::mac::{
-    ObjectLabelResolver, ObjectRef, SecurityContext, SecurityLabel,
+    MacDecision, MacDenyReason, ObjectLabelResolver, ObjectRef, SecurityContext, SecurityLabel,
 };
 use hyprstream_rpc::SigningKey;
 
@@ -339,6 +339,272 @@ const fn audit_action(action: NinePAction) -> Action {
     }
 }
 
+// ─────────────────────────────────────────────────────────────────────────────
+// VFS-plane PEP — the direct `Namespace` API reference monitor (#1272).
+//
+// Mirrors `NinePAccessDecider` for the *in-process* direct API: the 9P
+// translator decider authorizes wire ops; this decider authorizes the
+// `Namespace::cat`/`echo`/`create`/`ls`/`ctl` convenience methods (and the
+// `mount`/`bind_mount`/`unmount` mutation surface) once a `NamespacePep` is
+// installed. It reuses the SAME `ObjectLabelResolver` (the genesis composite),
+// the SAME `AuditSink` (the WAL), and the SAME `can_access` floor — it does
+// not reinvent any MAC primitive, only adapts the action surface.
+// ─────────────────────────────────────────────────────────────────────────────
+
+use hyprstream_vfs::{NamespaceAccessDecider, NamespaceAction, SubjectContextResolver};
+
+/// Reserved audit subject/object type ids for VFS-PEP decisions (distinct from
+/// the 9P sentinels above so audit consumers can distinguish the plane).
+const VFS_SUBJECT_TYPE: SubjectType = SubjectType(u32::MAX - 2);
+const VFS_OBJECT_TYPE: ObjectType = ObjectType(u32::MAX - 2);
+
+/// Audited `NamespaceAccessDecider` for the direct VFS API (#1272).
+///
+/// This is the production impl of [`hyprstream_vfs::NamespaceAccessDecider`]:
+/// it applies the intrinsic lattice dominance rule for read-class operations,
+/// denies write-class pending the VFS IFC write-direction decision, and records
+/// every outcome through the MAC audit sink. It
+/// receives the attempted subject context and label resolution from
+/// [`hyprstream_vfs::NamespacePep`], including `None` for missing clearance or
+/// labels, so fail-closed precondition denials cannot bypass the audit WAL.
+pub struct VfsAccessDecider {
+    sink: Arc<dyn AuditSink>,
+}
+
+impl VfsAccessDecider {
+    /// Wrap the process-wide MAC audit sink. The sink is mandatory; a decision
+    /// that cannot be durably audited is downgraded to Deny (fail-closed),
+    /// exactly as the 9P decider does.
+    pub fn new(sink: Arc<dyn AuditSink>) -> Self {
+        Self { sink }
+    }
+
+    fn audit(
+        &self,
+        ctx: Option<&SecurityContext>,
+        label: Option<SecurityLabel>,
+        action: NamespaceAction,
+        decision: Decision,
+        reason: DecisionReason,
+    ) -> bool {
+        let policy = crate::mac::compiled_policy();
+        let generation = policy.as_ref().map_or(0, |p| p.generation);
+        let policy_hash = policy.as_ref().and_then(|p| p.policy_hash().ok());
+        let record = AuditRecord {
+            seq: 0,
+            prev_hash: [0; 32],
+            ts_unix_nanos: SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .map_or(0, |d| d.as_nanos()),
+            decision,
+            generation,
+            policy_hash,
+            subject_type: VFS_SUBJECT_TYPE,
+            // Bottom is an audit-schema placeholder when clearance could not
+            // be proven. `NoClearance` is authoritative and the placeholder
+            // never enters authorization.
+            subject_clearance: ctx.map_or_else(SecurityLabel::bottom, |ctx| *ctx.clearance()),
+            on_behalf_of: None,
+            object_type: VFS_OBJECT_TYPE,
+            // Likewise, an unresolved object is represented only in the audit
+            // schema; `UnlabeledObject` remains the authoritative reason.
+            object_label: label.unwrap_or_else(SecurityLabel::bottom),
+            action: vfs_audit_action(action),
+            reason,
+            subject_id: None,
+            object_id: None,
+        };
+
+        match self.sink.record(&record) {
+            Ok(()) => decision.is_permit(),
+            Err(error) => {
+                let deny_record = AuditRecord {
+                    decision: Decision::Deny,
+                    reason: DecisionReason::AuditFailClosed,
+                    ..record
+                };
+                let _ = self.sink.record(&deny_record);
+                tracing::error!(
+                    target: "hyprstream.mac.audit",
+                    %error,
+                    reason = DecisionReason::AuditFailClosed.as_str(),
+                    "VFS PEP decision could not be durably audited; enforcing deny"
+                );
+                false
+            }
+        }
+    }
+}
+
+const fn vfs_audit_action(action: NamespaceAction) -> Action {
+    match action {
+        NamespaceAction::Read => Action::from_scope_action(ScopeAction::Query),
+        // Write/create + namespace mutation (mount/bind/unmount) and raw-handle
+        // extraction are all write-capable operations over an object — audited
+        // as Write. The deny-on-write-direction pause applies to all of them
+        // until IFC lands.
+        NamespaceAction::Write
+        | NamespaceAction::Create
+        | NamespaceAction::Mount
+        | NamespaceAction::BindMount
+        | NamespaceAction::Unmount
+        | NamespaceAction::ResolveHandle => Action::from_scope_action(ScopeAction::Write),
+    }
+}
+
+impl NamespaceAccessDecider for VfsAccessDecider {
+    fn check(
+        &self,
+        ctx: Option<&SecurityContext>,
+        object_label: Option<SecurityLabel>,
+        action: NamespaceAction,
+    ) -> MacDecision {
+        let Some(ctx) = ctx else {
+            self.audit(
+                None,
+                object_label,
+                action,
+                Decision::Deny,
+                DecisionReason::NoClearance,
+            );
+            return MacDecision::Deny(MacDenyReason::NoClearance);
+        };
+        let Some(object_label) = object_label else {
+            self.audit(
+                Some(ctx),
+                None,
+                action,
+                Decision::Deny,
+                DecisionReason::UnlabeledObject,
+            );
+            return MacDecision::Deny(MacDenyReason::UnlabeledObject);
+        };
+
+        // Write/create/mutate deny pending the VFS IFC write-direction
+        // decision.
+        let is_write_class = matches!(
+            action,
+            NamespaceAction::Write
+                | NamespaceAction::Create
+                | NamespaceAction::Mount
+                | NamespaceAction::BindMount
+                | NamespaceAction::Unmount
+                | NamespaceAction::ResolveHandle
+        );
+        if is_write_class {
+            self.audit(
+                Some(ctx),
+                Some(object_label),
+                action,
+                Decision::Deny,
+                DecisionReason::WriteDirectionUndecided,
+            );
+            return MacDecision::Deny(MacDenyReason::FloorDeny);
+        }
+
+        let permitted = ctx.can_access(&object_label);
+        let audited_permit = self.audit(
+            Some(ctx),
+            Some(object_label),
+            action,
+            if permitted {
+                Decision::Permit
+            } else {
+                Decision::Deny
+            },
+            if permitted {
+                DecisionReason::Permit
+            } else {
+                DecisionReason::FloorDeny
+            },
+        );
+        if permitted && audited_permit {
+            MacDecision::Permit
+        } else {
+            MacDecision::Deny(MacDenyReason::FloorDeny)
+        }
+    }
+}
+
+/// Fail-closed `SubjectContextResolver` for the VFS PEP (#698 dependency
+/// window).
+///
+/// The direct `Namespace` API carries only an unauthenticated `Subject` string
+/// — it has no verified `EnvelopeContext`/claims the way the RPC dispatch
+/// plane does (#1268 owns threading those through). Until production clearance
+/// provenance (#698) wires a real resolver (e.g. one keyed on the installed
+/// `CompiledPolicy` enrollment table, mirroring
+/// [`EnrollmentSubjectContextResolver`]), this stub resolves **no** subject,
+/// so an armed VFS PEP denies every op — the correct fail-closed posture
+/// (#547: no permissive default).
+///
+/// Replacing this with a real resolver is the activation B-lane (#1267), not
+/// this struct's existence.
+#[derive(Debug, Default, Clone, Copy)]
+pub struct DenyUnenrolledSubjects;
+
+impl SubjectContextResolver for DenyUnenrolledSubjects {
+    fn resolve(
+        &self,
+        _subject: &hyprstream_rpc::Subject,
+    ) -> Option<SecurityContext> {
+        None
+    }
+}
+
+/// Assemble the production VFS-plane PEP from the genesis label resolver and
+/// the tamper-evident MAC audit sink (#1272).
+///
+/// This is the `hyprstream`-crate wiring that satisfies the
+/// [`hyprstream_vfs::NamespacePep`] contract: the genesis composite
+/// `RpcObjectLabelResolver` (carriers (a)+(c), #1228) feeds label resolution, a
+/// [`VfsAccessDecider`] over the WAL audit sink evaluates the policy, and —
+/// pending #698 — the subject seam is [`DenyUnenrolledSubjects`] (fail-closed:
+/// every op denies until clearance provenance is wired). Swapping the subject
+/// resolver for a real one is the activation B-lane (#1267).
+///
+/// Callers propagate the error and refuse to arm a `Namespace` with a
+/// permissive fallback; there is no permissive arm path.
+pub async fn production_vfs_pep(
+    signing_key: SigningKey,
+    oauth: &crate::config::OAuthConfig,
+    audit_stream: &str,
+) -> anyhow::Result<std::sync::Arc<hyprstream_vfs::NamespacePep>> {
+    anyhow::ensure!(
+        !audit_stream.is_empty()
+            && audit_stream
+                .bytes()
+                .all(|byte| byte.is_ascii_alphanumeric() || byte == b'-' || byte == b'_'),
+        "invalid VFS MAC audit stream name"
+    );
+
+    let secrets_dir = crate::config::HyprConfig::resolve_secrets_dir()?;
+    let ml_dsa_store =
+        crate::auth::key_rotation::global_ml_dsa_key_store(&secrets_dir, oauth);
+    let signer = crate::mac::audit::cose::OwnedCoseAuditSigner::new(
+        Arc::new(signing_key),
+        ml_dsa_store.active_key().await,
+        hyprstream_rpc::envelope::mandatory_envelope_policy(),
+    );
+    anyhow::ensure!(
+        signer.can_sign(),
+        "VFS MAC PEP audit signer unavailable under mandatory Hybrid policy"
+    );
+
+    let audit_store = crate::mac::audit::WalAuditStore::open(
+        secrets_dir.join("mac-audit").join(audit_stream),
+        signer,
+    )
+    .context("open VFS MAC audit store")?;
+    let resolver = crate::mac::GenesisGate::production().into_resolver();
+
+    Ok(std::sync::Arc::new(hyprstream_vfs::NamespacePep::new(
+        std::sync::Arc::new(DenyUnenrolledSubjects),
+        std::sync::Arc::new(resolver),
+        std::sync::Arc::new(VfsAccessDecider::new(std::sync::Arc::new(audit_store))),
+    )))
+}
+
 #[cfg(test)]
 mod tests {
     use std::time::{Duration, Instant};
@@ -391,6 +657,32 @@ mod tests {
         fn record(&self, record: &AuditRecord) -> Result<(), AuditError> {
             self.records.lock().push(record.clone());
             Ok(())
+        }
+    }
+
+    struct FixtureVfsSubjects {
+        name: &'static str,
+        ctx: SecurityContext,
+    }
+
+    impl SubjectContextResolver for FixtureVfsSubjects {
+        fn resolve(&self, subject: &hyprstream_rpc::Subject) -> Option<SecurityContext> {
+            (subject.name() == Some(self.name)).then(|| self.ctx.clone())
+        }
+    }
+
+    struct FixtureVfsLabels {
+        public: SecurityLabel,
+        secret: SecurityLabel,
+    }
+
+    impl hyprstream_rpc::auth::mac::RpcObjectLabelResolver for FixtureVfsLabels {
+        fn resolve(&self, service_domain: &str, _method: Option<u16>) -> Option<SecurityLabel> {
+            match service_domain {
+                "/public" => Some(self.public),
+                "/secret" => Some(self.secret),
+                _ => None,
+            }
         }
     }
 
@@ -566,5 +858,65 @@ mod tests {
             "unverified Tattach fields must not mint identity or tenant"
         );
         assert!(!session.token_authorizes(&label(Level::Public), NinePAction::Read));
+    }
+
+    #[test]
+    fn vfs_fail_closed_denies_are_audited() {
+        let sink = Arc::new(SpySink::default());
+        let pep = hyprstream_vfs::NamespacePep::new(
+            Arc::new(FixtureVfsSubjects {
+                name: "alice",
+                ctx: context(Level::Public),
+            }),
+            Arc::new(FixtureVfsLabels {
+                public: label(Level::Public),
+                secret: label(Level::Secret),
+            }),
+            Arc::new(VfsAccessDecider::new(sink.clone())),
+        );
+
+        // Missing verified clearance, missing content label, lattice-floor
+        // denial, and the write-direction pause must all cross the same audit
+        // sink before the VFS reference monitor returns Deny.
+        assert_eq!(
+            pep.check(
+                &hyprstream_rpc::Subject::new("mallory"),
+                "/public",
+                NamespaceAction::Read,
+            ),
+            MacDecision::Deny(MacDenyReason::NoClearance)
+        );
+        assert_eq!(
+            pep.check(
+                &hyprstream_rpc::Subject::new("alice"),
+                "/missing",
+                NamespaceAction::Read,
+            ),
+            MacDecision::Deny(MacDenyReason::UnlabeledObject)
+        );
+        assert_eq!(
+            pep.check(
+                &hyprstream_rpc::Subject::new("alice"),
+                "/secret",
+                NamespaceAction::Read,
+            ),
+            MacDecision::Deny(MacDenyReason::FloorDeny)
+        );
+        assert_eq!(
+            pep.check(
+                &hyprstream_rpc::Subject::new("alice"),
+                "/public",
+                NamespaceAction::Write,
+            ),
+            MacDecision::Deny(MacDenyReason::FloorDeny)
+        );
+
+        let records = sink.records.lock();
+        assert_eq!(records.len(), 4);
+        assert!(records.iter().all(|record| record.decision == Decision::Deny));
+        assert_eq!(records[0].reason, DecisionReason::NoClearance);
+        assert_eq!(records[1].reason, DecisionReason::UnlabeledObject);
+        assert_eq!(records[2].reason, DecisionReason::FloorDeny);
+        assert_eq!(records[3].reason, DecisionReason::WriteDirectionUndecided);
     }
 }

--- a/crates/hyprstream/src/services/fs.rs
+++ b/crates/hyprstream/src/services/fs.rs
@@ -1047,7 +1047,7 @@ mod tests {
 
         // Fork and restrict.
         let mut sandbox = ns.fork();
-        sandbox.unmount("/srv/worker");
+        let _ = sandbox.unmount("/srv/worker");
 
         // Parent can access both.
         assert!(ns.cat("/srv/model/test-model/status", &caller).await.is_ok());


### PR DESCRIPTION
Closes #1272 · Parent epic #1267 (T3, P1).

## What

A mandatory, **fail-closed** MAC reference monitor over the **direct in-process `Namespace` API** and the `ExecMount` ctl lifecycle verbs — the in-process bypass of the 9P translator PEP that #1272 identifies.

### `hyprstream-vfs` (package focus)
- **New `mac_pep` module** — the PEP *contract* (`NamespacePep`, `NamespaceAccessDecider`, `SubjectContextResolver`, `NamespaceAction`) with deny-all defaults. Mirrors the 9P split: trait in the low-level crate, audited impl in `hyprstream::mac::pep`. Does **not** reinvent label resolution / clearance / `can_access` — those are S1/S4 primitives from `hyprstream_rpc::auth::mac`.
- **`Namespace`** gains `pep: Option<Arc<NamespacePep>>`. `cat`/`read_one`/`echo`/`create`/`ctl`/`ls` consult it; subject-less `mount`/`bind_mount`/`unmount` **deny when armed**; new `mount_as`/`bind_mount_as`/`unmount_as` variants mediate; `fork` inherits the PEP.
- `NamespaceError::Denied` variant.

### `hyprstream-workers` (exec/ctl lifecycle)
- `ExecMount` threads the caller `Subject` into `apply_verb`; a `LifecyclePolicy` seam (fail-closed `DenyAllLifecycle`) gates `stop`/`kill`/`destroy` when armed via `new_with_lifecycle`. Previously `write` ignored `_caller` entirely for lifecycle mutation.

### `hyprstream::mac::pep` (shared contract extension)
- `VfsAccessDecider` — audited `NamespaceAccessDecider` reusing the WAL audit sink, `can_access` floor, and write-direction pause (same posture as `NinePAccessDecider`).
- `production_vfs_pep(...)` — assembles a `NamespacePep` from the genesis composite resolver + audit + fail-closed subject seam.
- `DenyUnenrolledSubjects` — #698 dependency stub (resolves no subject).

## Posture

**Dormant structure.** `Namespace::new()` / `ExecMount::new()` stay unenforced (the documented status quo — CLAUDE.md "MAC current status"); arming (`set_pep` / `new_with_lifecycle`) is fail-closed by construction. **No permissive path exists inside an armed PEP** (#547). Flipping construction sites to armed is the separately-gated **#1267 B-lane**, not this PR.

## Dependencies flagged (fail-closed stubs in place)
- **#698** (clearance provenance): `DenyUnenrolledSubjects` resolves no `Subject` → an armed PEP denies every op until a real `SubjectContextResolver` lands.
- **#1268** (`mac-pep-contract.md`) was **absent**; per the task instruction, built a plane-specific `SubjectContextResolver` seam + genesis-composite label resolver. When #1268 publishes its contract, the subject seam should converge with the RPC plane's claims→clearance threading.
- **IFC**: write/create/mount-class deny pending the write-direction decision (identical to the 9P translator PEP).

## Validation (release, per task mandate)
- `cargo nextest run --release -p hyprstream-vfs` → **68/68**
- `cargo nextest run --release -p hyprstream-workers` → **153/153**
- `cargo test --release -p hyprstream --lib mac::pep` → **2/2**
- `cargo clippy -D warnings` clean on `hyprstream-vfs`, `hyprstream-workers`, `hyprstream` (lib)
- New tests: 3 PEP-contract unit tests + 7 `Namespace` integration tests (un-armed non-regression, armed deny-all, clearance-dominates, write-pause, unlabeled-deny, subject-less-mutation-block, fork-inherits-pep).

Status: `.fleet-coord/pep-1272-status.md`.

**Final gate: kimi-k3 review.** Do not self-merge / touch the merge queue.