### PR TITLE
feat(mac): per-object PEP for events + MoQ pub/sub (#1271)

### DIFF
--- a/.fleet-coord/pep-1271-status.md
+++ b/.fleet-coord/pep-1271-status.md
@@ -9,7 +9,8 @@ PR: https://github.com/hyprstream/hyprstream/pull/1296 (branch `feat/mac-moq-eve
   parallel verdict, deny-reason, or resolver contract.
 - `MoqEventPep` is the active event/MoQ PEP. An installed instance fails
   closed on missing verified-subject clearance, missing object labels, and
-  lattice-floor denial.
+  lattice-floor denial. Construction requires an audit sink; the parent
+  `MoqAuditSinkAdapter` writes denials into the canonical signed MAC WAL.
 - Dormant event/MoQ enforcement remains pass-through. Public event publishers
   and subscribers retain the pre-activation `AllowAllEventAuthz`, and MoQ
   transports retain `MoqAuthzConfig::default()` with no installed authorizer.
@@ -24,16 +25,26 @@ PR: https://github.com/hyprstream/hyprstream/pull/1296 (branch `feat/mac-moq-eve
   tenant binding; public/node-global event sources retain their global prefix.
 - `EventSubscriber` carries an injected authz and independently verified
   subject. Key release is checked before the HyKEM epoch grant is opened, and
-  received objects are checked before passthrough/decrypt.
-- `MacSubscribeAuthorizer` adapts the same PEP to the MoQ subscribe surface.
-  The existing structural verified-tenant consumer scoping remains intact.
+  received objects are checked before passthrough/decrypt. `try_recv` returns
+  an explicit error for a subscribe denial; it never reports that denial as an
+  empty queue.
+- `MacSubscribeAuthorizer` adapts the same PEP to the MoQ authorization
+  contract. The existing structural verified-tenant consumer scoping remains
+  intact.
 
-## Known external seam
+## #276 transport dependency and current fail-closed gate
 
-`moq_net::Server` still has no per-subscribe callback (#276), so the transport
-authorizer is available for installation and unit-tested but is not invoked
-per-track by `moq_net` itself. Event-plane enforcement is active at the event
-publisher/subscriber boundary.
+`moq_net::Server` still has no per-subscribe callback
+([#276](https://github.com/hyprstream/hyprstream/issues/276)). Consequently
+this PR does **not** claim live per-track policy decisions at the transport
+surface. Instead, both iroh and quinn reject the entire MoQ session whenever a
+track authorizer is installed; the MAC adapter records that denial through the
+same WAL path. Dormant transports with no installed authorizer retain their
+pre-activation behavior. Once #276 supplies the callback, the coarse admission
+gate can call `authorize(peer, track)` per track.
+
+Event-plane publishing, subscribing, and join/decrypt are independently
+mediated when `MacEventAuthz` is installed.
 
 ## Review gate
 

--- a/.fleet-coord/pep-1271-status.md
+++ b/.fleet-coord/pep-1271-status.md
@@ -1,6 +1,6 @@
 # PEP #1271 status — MAC per-object PEP for events + MoQ pub/sub
 
-Branch: `feat/mac-moq-event-pep`. Package: `hyprstream-rpc`.
+PR: https://github.com/hyprstream/hyprstream/pull/1296 (branch `feat/mac-moq-event-pep`). Package: `hyprstream-rpc`.
 
 ## Reconciled with the canonical #1288 contract
 

--- a/.fleet-coord/pep-1271-status.md
+++ b/.fleet-coord/pep-1271-status.md
@@ -1,0 +1,40 @@
+# PEP #1271 status — MAC per-object PEP for events + MoQ pub/sub
+
+Branch: `feat/mac-moq-event-pep`. Package: `hyprstream-rpc`.
+
+## Reconciled with the canonical #1288 contract
+
+- `auth/mac/pep.rs` consumes `MacDecision`, `MacDenyReason`, and
+  `RpcObjectLabelResolver` from `dispatch_pep.rs`; it does not define a
+  parallel verdict, deny-reason, or resolver contract.
+- `MoqEventPep` is the active event/MoQ PEP. An installed instance fails
+  closed on missing verified-subject clearance, missing object labels, and
+  lattice-floor denial.
+- Dormant event/MoQ enforcement remains pass-through. Public event publishers
+  and subscribers retain the pre-activation `AllowAllEventAuthz`, and MoQ
+  transports retain `MoqAuthzConfig::default()` with no installed authorizer.
+  Installing `MacEventAuthz` or `MacSubscribeAuthorizer` activates fail-closed
+  enforcement. No deny-on-uninstalled sentinel is used.
+
+## Event and MoQ enforcement
+
+- `MacEventAuthz` applies the label ceiling to public and confidential
+  publishing, subscribing, and encrypted join/decrypt.
+- Confidential object lookups are tenant-qualified using main's verified
+  tenant binding; public/node-global event sources retain their global prefix.
+- `EventSubscriber` carries an injected authz and independently verified
+  subject. Key release is checked before the HyKEM epoch grant is opened, and
+  received objects are checked before passthrough/decrypt.
+- `MacSubscribeAuthorizer` adapts the same PEP to the MoQ subscribe surface.
+  The existing structural verified-tenant consumer scoping remains intact.
+
+## Known external seam
+
+`moq_net::Server` still has no per-subscribe callback (#276), so the transport
+authorizer is available for installation and unit-tested but is not invoked
+per-track by `moq_net` itself. Event-plane enforcement is active at the event
+publisher/subscriber boundary.
+
+## Review gate
+
+kimi-k3 review is the final gate before merge. Do not self-merge.

--- a/crates/hyprstream-rpc/src/auth/mac/mod.rs
+++ b/crates/hyprstream-rpc/src/auth/mac/mod.rs
@@ -116,6 +116,7 @@ pub mod genesis;
 pub mod label;
 pub mod lattice;
 pub mod manifest;
+pub mod pep;
 
 pub use bind::{clamp_descendant, BindLabel, BindLabelMap};
 #[cfg(not(target_arch = "wasm32"))]
@@ -133,6 +134,9 @@ pub use lattice::{LabelError, Lattice, LatticeCodecError, LatticeDecodeError, La
 pub use manifest::{
     bind_time_label, import_label, ContentBoundLabel, LabeledObject, ObjectLabelResolver,
     ObjectRef, StaticNodeLabel,
+};
+pub use pep::{
+    ClearanceSource, DenyAllClearanceSource, MoqEventAction, MoqEventPep,
 };
 
 #[cfg(test)]

--- a/crates/hyprstream-rpc/src/auth/mac/mod.rs
+++ b/crates/hyprstream-rpc/src/auth/mac/mod.rs
@@ -127,15 +127,16 @@ pub use dispatch_pep::{
     RpcObjectLabelResolver,
 };
 pub use genesis::{GenesisMap, GenesisReport};
-pub use label::{
-    Assurance, Compartment, CompartmentSet, Level, SecurityLabel, MAX_COMPARTMENTS,
-};
+pub use label::{Assurance, Compartment, CompartmentSet, Level, SecurityLabel, MAX_COMPARTMENTS};
 pub use lattice::{LabelError, Lattice, LatticeCodecError, LatticeDecodeError, LatticeVersion};
 pub use manifest::{
     bind_time_label, import_label, ContentBoundLabel, LabeledObject, ObjectLabelResolver,
     ObjectRef, StaticNodeLabel,
 };
-pub use pep::{ClearanceSource, DenyAllClearanceSource, MoqEventAction, MoqEventPep};
+pub use pep::{
+    ClearanceSource, DenyAllClearanceSource, MoqEventAction, MoqEventPep, MoqMacAuditReason,
+    MoqMacAuditRecord, MoqMacAuditSink,
+};
 
 #[cfg(test)]
 #[allow(clippy::unwrap_used)]
@@ -233,7 +234,8 @@ mod integration_tests {
         // A derived object sealed from a secret + a classical input is
         // secret/pq-hybrid — and a merely-classical subject can't read it.
         let secret_in = SecurityLabel::new(Level::Secret, Assurance::PqHybrid, comps(&[0]));
-        let public_in = SecurityLabel::new(Level::Public, Assurance::Classical, CompartmentSet::EMPTY);
+        let public_in =
+            SecurityLabel::new(Level::Public, Assurance::Classical, CompartmentSet::EMPTY);
         let derived = SecurityLabel::join_all([&secret_in, &public_in]);
         let object = StaticNodeLabel::labeled(derived);
 

--- a/crates/hyprstream-rpc/src/auth/mac/mod.rs
+++ b/crates/hyprstream-rpc/src/auth/mac/mod.rs
@@ -119,13 +119,13 @@ pub mod manifest;
 pub mod pep;
 
 pub use bind::{clamp_descendant, BindLabel, BindLabelMap};
+pub use context::{SecurityContext, SubjectContextClaims, VerifiedKeyMaterial};
 #[cfg(not(target_arch = "wasm32"))]
 pub use dispatch_pep::{
     check_dispatch_mac, global_mac_dispatch_pep, install_mac_dispatch_pep, DefaultMacDispatchPep,
     DenyAllMacPep, DenyAllObjectResolver, MacDecision, MacDenyReason, MacDispatchPep,
     RpcObjectLabelResolver,
 };
-pub use context::{SecurityContext, SubjectContextClaims, VerifiedKeyMaterial};
 pub use genesis::{GenesisMap, GenesisReport};
 pub use label::{
     Assurance, Compartment, CompartmentSet, Level, SecurityLabel, MAX_COMPARTMENTS,
@@ -135,9 +135,7 @@ pub use manifest::{
     bind_time_label, import_label, ContentBoundLabel, LabeledObject, ObjectLabelResolver,
     ObjectRef, StaticNodeLabel,
 };
-pub use pep::{
-    ClearanceSource, DenyAllClearanceSource, MoqEventAction, MoqEventPep,
-};
+pub use pep::{ClearanceSource, DenyAllClearanceSource, MoqEventAction, MoqEventPep};
 
 #[cfg(test)]
 #[allow(clippy::unwrap_used)]

--- a/crates/hyprstream-rpc/src/auth/mac/pep.rs
+++ b/crates/hyprstream-rpc/src/auth/mac/pep.rs
@@ -12,7 +12,7 @@ use std::sync::Arc;
 use super::dispatch_pep::{
     DenyAllObjectResolver, MacDecision, MacDenyReason, RpcObjectLabelResolver,
 };
-use super::{SecurityContext, VerifiedKeyMaterial};
+use super::SecurityContext;
 use crate::envelope::Subject;
 
 /// The MoQ/event verb being authorized.

--- a/crates/hyprstream-rpc/src/auth/mac/pep.rs
+++ b/crates/hyprstream-rpc/src/auth/mac/pep.rs
@@ -1,0 +1,238 @@
+//! MoQ / event-plane MAC policy-enforcement point (epic #547, #1271).
+//!
+//! This plane consumes the shared RPC-PEP contract rather than defining a
+//! parallel decision vocabulary. An installed [`MoqEventPep`] returns
+//! [`MacDecision`] and resolves labels through [`RpcObjectLabelResolver`].
+//! Missing clearance and missing labels deny, as does a failed lattice-floor
+//! check. Callers preserve the pre-activation behavior by not installing this
+//! PEP; dormant event/MoQ paths remain pass-through.
+
+use std::sync::Arc;
+
+use super::dispatch_pep::{
+    DenyAllObjectResolver, MacDecision, MacDenyReason, RpcObjectLabelResolver,
+};
+use super::{SecurityContext, VerifiedKeyMaterial};
+use crate::envelope::Subject;
+
+/// The MoQ/event verb being authorized.
+///
+/// All actions currently apply the same mandatory label ceiling. The
+/// discriminant is retained so future IFC write-direction rules can
+/// distinguish publishing from reading without changing the API.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum MoqEventAction {
+    /// Write an event into a track or prefix.
+    Publish,
+    /// Subscribe to or read a track.
+    Subscribe,
+    /// Join an encrypted prefix or decrypt an event.
+    JoinDecrypt,
+}
+
+/// Resolve a verified event/MoQ subject to its MAC security context.
+///
+/// The event plane does not have an [`EnvelopeContext`](crate::service::EnvelopeContext),
+/// so it derives its subject context from the verified identity available at
+/// this boundary. Returning `None` is fail-closed once the PEP is installed.
+pub trait ClearanceSource: Send + Sync {
+    fn clearance(&self, subject: &Subject) -> Option<SecurityContext>;
+}
+
+/// The installed MoQ/event MAC floor.
+///
+/// Dormancy is represented by the caller not installing this PEP. Every check
+/// on an installed instance is fail-closed.
+pub struct MoqEventPep {
+    resolver: Arc<dyn RpcObjectLabelResolver>,
+    clearance: Arc<dyn ClearanceSource>,
+}
+
+impl MoqEventPep {
+    /// Construct an active, fail-closed PEP from the canonical object-label
+    /// resolver and this plane's verified-subject clearance source.
+    pub fn new(
+        resolver: Arc<dyn RpcObjectLabelResolver>,
+        clearance: Arc<dyn ClearanceSource>,
+    ) -> Self {
+        Self {
+            resolver,
+            clearance,
+        }
+    }
+
+    /// Check the per-track/per-event label ceiling.
+    ///
+    /// `track_or_prefix` occupies the canonical resolver's service-domain
+    /// coordinate. MoQ/event checks have no browser method discriminator, so
+    /// the resolver always receives `None`.
+    #[must_use]
+    pub fn check(
+        &self,
+        subject: &Subject,
+        track_or_prefix: &str,
+        _action: MoqEventAction,
+    ) -> MacDecision {
+        let Some(subject_ctx) = self.clearance.clearance(subject) else {
+            return MacDecision::Deny(MacDenyReason::NoClearance);
+        };
+        let Some(object_label) = self.resolver.resolve(track_or_prefix, None) else {
+            return MacDecision::Deny(MacDenyReason::UnlabeledObject);
+        };
+        if subject_ctx.can_access(&object_label) {
+            MacDecision::Permit
+        } else {
+            MacDecision::Deny(MacDenyReason::FloorDeny)
+        }
+    }
+
+    pub fn resolver(&self) -> &Arc<dyn RpcObjectLabelResolver> {
+        &self.resolver
+    }
+
+    pub fn clearance(&self) -> &Arc<dyn ClearanceSource> {
+        &self.clearance
+    }
+}
+
+/// Fail-closed clearance source for an installed event/MoQ PEP.
+#[derive(Debug, Clone, Default)]
+pub struct DenyAllClearanceSource;
+
+impl ClearanceSource for DenyAllClearanceSource {
+    fn clearance(&self, _subject: &Subject) -> Option<SecurityContext> {
+        None
+    }
+}
+
+impl Default for MoqEventPep {
+    fn default() -> Self {
+        Self::new(
+            Arc::new(DenyAllObjectResolver),
+            Arc::new(DenyAllClearanceSource),
+        )
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)]
+mod tests {
+    use super::*;
+    use crate::auth::mac::{
+        Assurance, CompartmentSet, Level, SecurityLabel, VerifiedKeyMaterial,
+    };
+
+    fn public_label() -> SecurityLabel {
+        SecurityLabel::new(Level::Public, Assurance::Classical, CompartmentSet::EMPTY)
+    }
+
+    fn secret_label() -> SecurityLabel {
+        SecurityLabel::new(
+            Level::Secret,
+            Assurance::PqHybrid,
+            CompartmentSet::EMPTY,
+        )
+    }
+
+    struct StaticResolver {
+        secret_track: String,
+    }
+
+    impl RpcObjectLabelResolver for StaticResolver {
+        fn resolve(&self, service_domain: &str, method: Option<u16>) -> Option<SecurityLabel> {
+            assert_eq!(method, None, "event/MoQ checks are not browser RPC");
+            if service_domain == self.secret_track {
+                Some(secret_label())
+            } else {
+                Some(public_label())
+            }
+        }
+    }
+
+    struct TieredClearance {
+        cleared_did: String,
+    }
+
+    impl ClearanceSource for TieredClearance {
+        fn clearance(&self, subject: &Subject) -> Option<SecurityContext> {
+            if subject.name() == Some(self.cleared_did.as_str()) {
+                Some(SecurityContext::from_clearance(
+                    secret_label(),
+                    VerifiedKeyMaterial::PqHybrid,
+                ))
+            } else {
+                Some(SecurityContext::from_clearance(
+                    public_label(),
+                    VerifiedKeyMaterial::Classical,
+                ))
+            }
+        }
+    }
+
+    #[test]
+    fn installed_default_denies_missing_clearance() {
+        let pep = MoqEventPep::default();
+        for action in [
+            MoqEventAction::Publish,
+            MoqEventAction::Subscribe,
+            MoqEventAction::JoinDecrypt,
+        ] {
+            assert_eq!(
+                pep.check(&Subject::anonymous(), "any", action),
+                MacDecision::Deny(MacDenyReason::NoClearance)
+            );
+        }
+    }
+
+    #[test]
+    fn installed_pep_denies_unlabeled_object() {
+        let pep = MoqEventPep::new(
+            Arc::new(DenyAllObjectResolver),
+            Arc::new(TieredClearance {
+                cleared_did: "did:web:cleared".to_owned(),
+            }),
+        );
+        assert_eq!(
+            pep.check(
+                &Subject::new("did:web:cleared"),
+                "missing",
+                MoqEventAction::Subscribe,
+            ),
+            MacDecision::Deny(MacDenyReason::UnlabeledObject)
+        );
+    }
+
+    #[test]
+    fn installed_pep_enforces_label_ceiling_for_every_action() {
+        let pep = MoqEventPep::new(
+            Arc::new(StaticResolver {
+                secret_track: "tenant/streams/secret".to_owned(),
+            }),
+            Arc::new(TieredClearance {
+                cleared_did: "did:web:cleared".to_owned(),
+            }),
+        );
+        for action in [
+            MoqEventAction::Publish,
+            MoqEventAction::Subscribe,
+            MoqEventAction::JoinDecrypt,
+        ] {
+            assert_eq!(
+                pep.check(
+                    &Subject::new("did:web:public"),
+                    "tenant/streams/secret",
+                    action,
+                ),
+                MacDecision::Deny(MacDenyReason::FloorDeny)
+            );
+            assert_eq!(
+                pep.check(
+                    &Subject::new("did:web:cleared"),
+                    "tenant/streams/secret",
+                    action,
+                ),
+                MacDecision::Permit
+            );
+        }
+    }
+}

--- a/crates/hyprstream-rpc/src/auth/mac/pep.rs
+++ b/crates/hyprstream-rpc/src/auth/mac/pep.rs
@@ -9,10 +9,8 @@
 
 use std::sync::Arc;
 
-use super::dispatch_pep::{
-    DenyAllObjectResolver, MacDecision, MacDenyReason, RpcObjectLabelResolver,
-};
-use super::SecurityContext;
+use super::dispatch_pep::{MacDecision, MacDenyReason, RpcObjectLabelResolver};
+use super::{SecurityContext, SecurityLabel};
 use crate::envelope::Subject;
 
 /// The MoQ/event verb being authorized.
@@ -39,6 +37,50 @@ pub trait ClearanceSource: Send + Sync {
     fn clearance(&self, subject: &Subject) -> Option<SecurityContext>;
 }
 
+/// Why a MoQ MAC denial was recorded.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MoqMacAuditReason {
+    /// A denial returned by the canonical shared MAC contract.
+    Mac(MacDenyReason),
+    /// An authorizer was installed, but moq-net exposed no per-track callback.
+    ///
+    /// The transport denies the whole session until #276 lands rather than
+    /// serving tracks that bypass the installed policy.
+    TrackAdmissionHookUnavailable,
+}
+
+/// Plane-neutral denial record handed to the parent crate's MAC audit adapter.
+///
+/// `hyprstream-rpc` cannot depend on `hyprstream`'s WAL without creating a
+/// crate cycle. Active construction therefore requires this record sink; the
+/// parent adapter converts it to the canonical signed [`AuditRecord`][1].
+///
+/// [1]: https://github.com/hyprstream/hyprstream/issues/573
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct MoqMacAuditRecord {
+    /// Independently verified subject, or `None` for anonymous.
+    pub subject: Option<String>,
+    /// Track or event prefix whose access was denied.
+    pub object: String,
+    /// Operation that was denied.
+    pub action: MoqEventAction,
+    /// Resolved subject clearance, when resolution reached that step.
+    pub subject_clearance: Option<SecurityLabel>,
+    /// Resolved content label, when resolution reached that step.
+    pub object_label: Option<SecurityLabel>,
+    /// Exact denial cause.
+    pub reason: MoqMacAuditReason,
+}
+
+/// Required audit destination for an active MoQ/event MAC PEP.
+///
+/// Production supplies the parent crate's signed WAL adapter. There is
+/// deliberately no no-op/default implementation: an installed PEP must always
+/// attempt a durable audit write for every denial.
+pub trait MoqMacAuditSink: Send + Sync {
+    fn record_deny(&self, record: &MoqMacAuditRecord) -> Result<(), String>;
+}
+
 /// The installed MoQ/event MAC floor.
 ///
 /// Dormancy is represented by the caller not installing this PEP. Every check
@@ -46,18 +88,51 @@ pub trait ClearanceSource: Send + Sync {
 pub struct MoqEventPep {
     resolver: Arc<dyn RpcObjectLabelResolver>,
     clearance: Arc<dyn ClearanceSource>,
+    audit: Arc<dyn MoqMacAuditSink>,
 }
 
 impl MoqEventPep {
     /// Construct an active, fail-closed PEP from the canonical object-label
-    /// resolver and this plane's verified-subject clearance source.
+    /// resolver, verified-subject clearance source, and mandatory audit sink.
     pub fn new(
         resolver: Arc<dyn RpcObjectLabelResolver>,
         clearance: Arc<dyn ClearanceSource>,
+        audit: Arc<dyn MoqMacAuditSink>,
     ) -> Self {
         Self {
             resolver,
             clearance,
+            audit,
+        }
+    }
+
+    fn audit_deny(
+        &self,
+        subject: &Subject,
+        track_or_prefix: &str,
+        action: MoqEventAction,
+        subject_clearance: Option<SecurityLabel>,
+        object_label: Option<SecurityLabel>,
+        reason: MoqMacAuditReason,
+    ) {
+        let record = MoqMacAuditRecord {
+            subject: subject.name().map(str::to_owned),
+            object: track_or_prefix.to_owned(),
+            action,
+            subject_clearance,
+            object_label,
+            reason,
+        };
+        if let Err(error) = self.audit.record_deny(&record) {
+            tracing::error!(
+                target: "hyprstream.mac.audit",
+                %error,
+                subject = ?record.subject,
+                object = %record.object,
+                action = ?record.action,
+                reason = ?record.reason,
+                "MoQ MAC deny could not be durably audited; enforcing deny"
+            );
         }
     }
 
@@ -71,19 +146,63 @@ impl MoqEventPep {
         &self,
         subject: &Subject,
         track_or_prefix: &str,
-        _action: MoqEventAction,
+        action: MoqEventAction,
     ) -> MacDecision {
         let Some(subject_ctx) = self.clearance.clearance(subject) else {
-            return MacDecision::Deny(MacDenyReason::NoClearance);
+            let reason = MacDenyReason::NoClearance;
+            self.audit_deny(
+                subject,
+                track_or_prefix,
+                action,
+                None,
+                None,
+                MoqMacAuditReason::Mac(reason),
+            );
+            return MacDecision::Deny(reason);
         };
         let Some(object_label) = self.resolver.resolve(track_or_prefix, None) else {
-            return MacDecision::Deny(MacDenyReason::UnlabeledObject);
+            let reason = MacDenyReason::UnlabeledObject;
+            self.audit_deny(
+                subject,
+                track_or_prefix,
+                action,
+                Some(*subject_ctx.clearance()),
+                None,
+                MoqMacAuditReason::Mac(reason),
+            );
+            return MacDecision::Deny(reason);
         };
         if subject_ctx.can_access(&object_label) {
             MacDecision::Permit
         } else {
-            MacDecision::Deny(MacDenyReason::FloorDeny)
+            let reason = MacDenyReason::FloorDeny;
+            self.audit_deny(
+                subject,
+                track_or_prefix,
+                action,
+                Some(*subject_ctx.clearance()),
+                Some(object_label),
+                MoqMacAuditReason::Mac(reason),
+            );
+            MacDecision::Deny(reason)
         }
+    }
+
+    /// Audit and deny a transport session because no per-track callback exists.
+    ///
+    /// This is the fail-closed bridge to #276: an installed track authorizer
+    /// must never be retained as dead configuration while tracks are served.
+    pub fn deny_track_admission_without_hook(&self, subject: &Subject) {
+        self.audit_deny(
+            subject,
+            "<moq-session:track-hook-unavailable>",
+            MoqEventAction::Subscribe,
+            self.clearance
+                .clearance(subject)
+                .map(|ctx| *ctx.clearance()),
+            None,
+            MoqMacAuditReason::TrackAdmissionHookUnavailable,
+        );
     }
 
     pub fn resolver(&self) -> &Arc<dyn RpcObjectLabelResolver> {
@@ -105,20 +224,14 @@ impl ClearanceSource for DenyAllClearanceSource {
     }
 }
 
-impl Default for MoqEventPep {
-    fn default() -> Self {
-        Self::new(
-            Arc::new(DenyAllObjectResolver),
-            Arc::new(DenyAllClearanceSource),
-        )
-    }
-}
-
 #[cfg(test)]
 #[allow(clippy::unwrap_used)]
 mod tests {
     use super::*;
-    use crate::auth::mac::{Assurance, CompartmentSet, Level, SecurityLabel, VerifiedKeyMaterial};
+    use crate::auth::mac::{
+        Assurance, CompartmentSet, DenyAllObjectResolver, Level, VerifiedKeyMaterial,
+    };
+    use parking_lot::Mutex;
 
     fn public_label() -> SecurityLabel {
         SecurityLabel::new(Level::Public, Assurance::Classical, CompartmentSet::EMPTY)
@@ -163,9 +276,26 @@ mod tests {
         }
     }
 
+    #[derive(Default)]
+    struct RecordingAudit {
+        records: Mutex<Vec<MoqMacAuditRecord>>,
+    }
+
+    impl MoqMacAuditSink for RecordingAudit {
+        fn record_deny(&self, record: &MoqMacAuditRecord) -> Result<(), String> {
+            self.records.lock().push(record.clone());
+            Ok(())
+        }
+    }
+
     #[test]
-    fn installed_default_denies_missing_clearance() {
-        let pep = MoqEventPep::default();
+    fn installed_pep_audits_every_missing_clearance_deny() {
+        let audit = Arc::new(RecordingAudit::default());
+        let pep = MoqEventPep::new(
+            Arc::new(DenyAllObjectResolver),
+            Arc::new(DenyAllClearanceSource),
+            audit.clone(),
+        );
         for action in [
             MoqEventAction::Publish,
             MoqEventAction::Subscribe,
@@ -176,15 +306,22 @@ mod tests {
                 MacDecision::Deny(MacDenyReason::NoClearance)
             );
         }
+        let records = audit.records.lock();
+        assert_eq!(records.len(), 3);
+        assert!(records
+            .iter()
+            .all(|record| { record.reason == MoqMacAuditReason::Mac(MacDenyReason::NoClearance) }));
     }
 
     #[test]
     fn installed_pep_denies_unlabeled_object() {
+        let audit = Arc::new(RecordingAudit::default());
         let pep = MoqEventPep::new(
             Arc::new(DenyAllObjectResolver),
             Arc::new(TieredClearance {
                 cleared_did: "did:web:cleared".to_owned(),
             }),
+            audit.clone(),
         );
         assert_eq!(
             pep.check(
@@ -194,10 +331,17 @@ mod tests {
             ),
             MacDecision::Deny(MacDenyReason::UnlabeledObject)
         );
+        let records = audit.records.lock();
+        assert_eq!(records.len(), 1);
+        assert_eq!(
+            records[0].reason,
+            MoqMacAuditReason::Mac(MacDenyReason::UnlabeledObject)
+        );
     }
 
     #[test]
     fn installed_pep_enforces_label_ceiling_for_every_action() {
+        let audit = Arc::new(RecordingAudit::default());
         let pep = MoqEventPep::new(
             Arc::new(StaticResolver {
                 secret_track: "tenant/streams/secret".to_owned(),
@@ -205,6 +349,7 @@ mod tests {
             Arc::new(TieredClearance {
                 cleared_did: "did:web:cleared".to_owned(),
             }),
+            audit.clone(),
         );
         for action in [
             MoqEventAction::Publish,
@@ -228,5 +373,10 @@ mod tests {
                 MacDecision::Permit
             );
         }
+        let records = audit.records.lock();
+        assert_eq!(records.len(), 3);
+        assert!(records
+            .iter()
+            .all(|record| record.reason == MoqMacAuditReason::Mac(MacDenyReason::FloorDeny)));
     }
 }

--- a/crates/hyprstream-rpc/src/auth/mac/pep.rs
+++ b/crates/hyprstream-rpc/src/auth/mac/pep.rs
@@ -118,20 +118,14 @@ impl Default for MoqEventPep {
 #[allow(clippy::unwrap_used)]
 mod tests {
     use super::*;
-    use crate::auth::mac::{
-        Assurance, CompartmentSet, Level, SecurityLabel, VerifiedKeyMaterial,
-    };
+    use crate::auth::mac::{Assurance, CompartmentSet, Level, SecurityLabel, VerifiedKeyMaterial};
 
     fn public_label() -> SecurityLabel {
         SecurityLabel::new(Level::Public, Assurance::Classical, CompartmentSet::EMPTY)
     }
 
     fn secret_label() -> SecurityLabel {
-        SecurityLabel::new(
-            Level::Secret,
-            Assurance::PqHybrid,
-            CompartmentSet::EMPTY,
-        )
+        SecurityLabel::new(Level::Secret, Assurance::PqHybrid, CompartmentSet::EMPTY)
     }
 
     struct StaticResolver {

--- a/crates/hyprstream-rpc/src/events.rs
+++ b/crates/hyprstream-rpc/src/events.rs
@@ -353,16 +353,14 @@ impl EventAuthz for MacEventAuthz {
 
     fn can_subscribe(&self, caller: &Subject, prefix: &str) -> bool {
         matches!(
-            self.pep
-                .check(caller, prefix, MoqEventAction::Subscribe),
+            self.pep.check(caller, prefix, MoqEventAction::Subscribe),
             MacDecision::Permit
         )
     }
 
     fn can_join_decrypt(&self, caller: &Subject, prefix: &str) -> bool {
         matches!(
-            self.pep
-                .check(caller, prefix, MoqEventAction::JoinDecrypt),
+            self.pep.check(caller, prefix, MoqEventAction::JoinDecrypt),
             MacDecision::Permit
         )
     }
@@ -1084,10 +1082,7 @@ impl EventSubscriber {
             );
         }
         let prefix_key = self.encrypted_prefix_key(prefix).await?;
-        if !self
-            .authz
-            .can_join_decrypt(&self.caller, &prefix_key)
-        {
+        if !self.authz.can_join_decrypt(&self.caller, &prefix_key) {
             return Err(format!(
                 "join/decrypt denied by event-plane MAC for prefix '{prefix}'"
             ));
@@ -1267,9 +1262,6 @@ impl EventSubscriber {
             return Ok(None);
         };
         let prefix = topic.split('.').next().unwrap_or(&topic);
-        if !self.authz.can_subscribe(&self.caller, prefix) {
-            return Ok(None);
-        }
         if self.prefix_is_confidential(prefix)? {
             // An encrypted prefix; decoding requires the async path. Callers
             // needing non-blocking receive on encrypted prefixes should use
@@ -1277,6 +1269,9 @@ impl EventSubscriber {
             return Err(anyhow!(
                 "try_recv() does not support decoding encrypted prefixes; use recv_timeout(Duration::ZERO)"
             ));
+        }
+        if !self.authz.can_subscribe(&self.caller, prefix) {
+            return Ok(None);
         }
         Ok(Some((topic, raw)))
     }

--- a/crates/hyprstream-rpc/src/events.rs
+++ b/crates/hyprstream-rpc/src/events.rs
@@ -42,6 +42,7 @@ use tokio::sync::RwLock;
 use tracing::debug;
 use zeroize::Zeroizing;
 
+use crate::auth::mac::{MacDecision, MoqEventAction, MoqEventPep};
 use crate::crypto::cose_sign::{sign_composite, verify_composite};
 use crate::crypto::event_crypto::{
     build_epoch_event_sig_message, decrypt_epoch_event, derive_event_nonce, encrypt_epoch_event,
@@ -293,6 +294,10 @@ pub trait EventAuthz: Send + Sync {
     /// May `caller` subscribe to the group/`prefix`? Maps to the `subscribe`
     /// ScopeAction.
     fn can_subscribe(&self, caller: &Subject, prefix: &str) -> bool;
+    /// May `caller` receive an encrypted epoch key and decrypt this prefix?
+    fn can_join_decrypt(&self, caller: &Subject, prefix: &str) -> bool {
+        self.can_subscribe(caller, prefix)
+    }
 }
 
 /// Fail-closed authz: denies every publish/subscribe. The default for the
@@ -319,6 +324,47 @@ impl EventAuthz for AllowAllEventAuthz {
     }
     fn can_subscribe(&self, _caller: &Subject, _prefix: &str) -> bool {
         true
+    }
+}
+
+/// Adapter from the canonical MAC contract to the event authorization surface.
+///
+/// Constructing this type installs an active PEP, so all missing clearance or
+/// object labels fail closed. Public publishers/subscribers retain
+/// [`AllowAllEventAuthz`] until an operator explicitly installs this adapter;
+/// that dormant state is the canonical pre-activation pass-through.
+pub struct MacEventAuthz {
+    pep: MoqEventPep,
+}
+
+impl MacEventAuthz {
+    pub fn new(pep: MoqEventPep) -> Self {
+        Self { pep }
+    }
+}
+
+impl EventAuthz for MacEventAuthz {
+    fn can_publish(&self, caller: &Subject, prefix: &str) -> bool {
+        matches!(
+            self.pep.check(caller, prefix, MoqEventAction::Publish),
+            MacDecision::Permit
+        )
+    }
+
+    fn can_subscribe(&self, caller: &Subject, prefix: &str) -> bool {
+        matches!(
+            self.pep
+                .check(caller, prefix, MoqEventAction::Subscribe),
+            MacDecision::Permit
+        )
+    }
+
+    fn can_join_decrypt(&self, caller: &Subject, prefix: &str) -> bool {
+        matches!(
+            self.pep
+                .check(caller, prefix, MoqEventAction::JoinDecrypt),
+            MacDecision::Permit
+        )
     }
 }
 
@@ -653,21 +699,22 @@ impl EventPublisher {
             .get_mut(&key)
             .ok_or_else(|| anyhow!("prefix '{prefix}' not registered"))?;
 
+        let caller = match &self.publisher_identity.did {
+            Some(did) => Subject::new(did.clone()),
+            None => Subject::anonymous(),
+        };
+        let object = if state.confidential { &key } else { &prefix };
+        if !self.authz.can_publish(&caller, object) {
+            return Err(anyhow!(
+                "publish denied by event-plane authz for prefix '{prefix}'"
+            ));
+        }
         if !state.confidential {
             return state.moq.publish_raw(topic, payload);
         }
         let crypto = state.crypto.as_mut().ok_or_else(|| {
             anyhow!("confidential prefix '{prefix}' has no committed controller epoch installed")
         })?;
-        let caller = match &self.publisher_identity.did {
-            Some(did) => Subject::new(did.clone()),
-            None => Subject::anonymous(),
-        };
-        if !self.authz.can_publish(&caller, &prefix) {
-            return Err(anyhow!(
-                "publish denied by event-plane authz for prefix '{prefix}'"
-            ));
-        }
         let signing_key = self
             .signing_key
             .as_ref()
@@ -876,6 +923,12 @@ pub struct EventSubscriber {
     prefixes: Arc<RwLock<HashMap<String, SubscriberPrefixState>>>,
     /// One verified tenant/domain per confidential subscriber instance.
     tenant: Arc<RwLock<Option<String>>>,
+    /// Dormant pass-through by default; an injected MAC adapter is active and
+    /// fail-closed.
+    authz: Arc<dyn EventAuthz>,
+    /// Verified subscriber identity, or anonymous when the carrier has not
+    /// supplied an independently authenticated application subject.
+    caller: Subject,
 }
 
 impl EventSubscriber {
@@ -884,7 +937,22 @@ impl EventSubscriber {
             inner: MoqEventSubscriber::new(),
             prefixes: Arc::new(RwLock::new(HashMap::new())),
             tenant: Arc::new(RwLock::new(None)),
+            authz: Arc::new(AllowAllEventAuthz),
+            caller: Subject::anonymous(),
         })
+    }
+
+    /// Install event-plane authorization. Installing [`MacEventAuthz`] makes
+    /// missing subject clearance and missing object labels deny.
+    pub fn with_authz(mut self, authz: Arc<dyn EventAuthz>) -> Self {
+        self.authz = authz;
+        self
+    }
+
+    /// Bind the subscriber to an independently verified application subject.
+    pub fn with_caller(mut self, caller: Subject) -> Self {
+        self.caller = caller;
+        self
     }
 
     pub fn subscribe(&mut self, pattern: &str) -> Result<()> {
@@ -1015,8 +1083,16 @@ impl EventSubscriber {
                     .to_owned(),
             );
         }
-        let key = open_epoch_grant(recipient, grant)?;
         let prefix_key = self.encrypted_prefix_key(prefix).await?;
+        if !self
+            .authz
+            .can_join_decrypt(&self.caller, &prefix_key)
+        {
+            return Err(format!(
+                "join/decrypt denied by event-plane MAC for prefix '{prefix}'"
+            ));
+        }
+        let key = open_epoch_grant(recipient, grant)?;
         let mut prefixes = self.prefixes.write().await;
         match prefixes.get_mut(&prefix_key) {
             None => Err(
@@ -1191,6 +1267,9 @@ impl EventSubscriber {
             return Ok(None);
         };
         let prefix = topic.split('.').next().unwrap_or(&topic);
+        if !self.authz.can_subscribe(&self.caller, prefix) {
+            return Ok(None);
+        }
         if self.prefix_is_confidential(prefix)? {
             // An encrypted prefix; decoding requires the async path. Callers
             // needing non-blocking receive on encrypted prefixes should use
@@ -1223,8 +1302,19 @@ impl EventSubscriber {
     async fn decode_frame(&self, topic: &str, raw: &[u8]) -> FrameOutcome {
         let prefix = topic.split('.').next().unwrap_or(topic);
         let Ok(key) = self.encrypted_prefix_key(prefix).await else {
-            return FrameOutcome::Passthrough;
+            return if self.authz.can_subscribe(&self.caller, prefix) {
+                FrameOutcome::Passthrough
+            } else {
+                FrameOutcome::Drop(
+                    "subscribe denied by event-plane MAC for public prefix".to_owned(),
+                )
+            };
         };
+        if !self.authz.can_subscribe(&self.caller, &key) {
+            return FrameOutcome::Drop(
+                "subscribe denied by event-plane MAC for tenant-qualified prefix".to_owned(),
+            );
+        }
         let mut prefixes = self.prefixes.write().await;
         let state = match prefixes.get_mut(&key) {
             None => return FrameOutcome::Passthrough,

--- a/crates/hyprstream-rpc/src/events.rs
+++ b/crates/hyprstream-rpc/src/events.rs
@@ -1256,7 +1256,10 @@ impl EventSubscriber {
     /// Try to receive without blocking. Same decode/decrypt behavior as
     /// [`Self::recv`], except a frame that fails to decode/verify/decrypt is
     /// dropped and `Ok(None)` returned immediately rather than continuing to
-    /// poll (this method must not block).
+    /// poll (this method must not block). Authorization denials are different:
+    /// they are returned as an explicit error (and an installed MAC adapter
+    /// audits the denial) so callers cannot confuse enforcement with an empty
+    /// queue.
     pub fn try_recv(&mut self) -> Result<Option<(String, Vec<u8>)>> {
         let Some((topic, raw)) = self.inner.try_recv()? else {
             return Ok(None);
@@ -1271,7 +1274,9 @@ impl EventSubscriber {
             ));
         }
         if !self.authz.can_subscribe(&self.caller, prefix) {
-            return Ok(None);
+            return Err(anyhow!(
+                "subscribe denied by event-plane MAC for prefix '{prefix}'"
+            ));
         }
         Ok(Some((topic, raw)))
     }
@@ -1481,6 +1486,40 @@ mod tests {
         let mut secret = [0u8; 32];
         rand::RngCore::fill_bytes(&mut rand::rngs::OsRng, &mut secret);
         SigningKey::from_bytes(&secret)
+    }
+
+    #[tokio::test]
+    async fn try_recv_surfaces_subscribe_denial_as_error() {
+        let origin = crate::moq_event::MoqEventOrigin::new();
+        let source = format!("mac-deny-{}", rand::random::<u64>());
+        let mut publisher = origin.publisher(&source).unwrap();
+        let mut subscriber = EventSubscriber {
+            inner: MoqEventSubscriber::new_for_test(origin.consumer()),
+            prefixes: Arc::new(RwLock::new(HashMap::new())),
+            tenant: Arc::new(RwLock::new(None)),
+            authz: Arc::new(DenyAllEventAuthz),
+            caller: Subject::new("did:web:denied"),
+        };
+        subscriber.subscribe(&format!("{source}.")).unwrap();
+
+        // Start the background reader, then publish until it has relayed a
+        // frame into this subscriber's non-blocking queue.
+        assert!(subscriber.try_recv().unwrap().is_none());
+        for _ in 0..50 {
+            publisher.publish("object", "changed", b"payload").unwrap();
+            tokio::time::sleep(Duration::from_millis(10)).await;
+            match subscriber.try_recv() {
+                Err(error) => {
+                    assert!(error
+                        .to_string()
+                        .contains("subscribe denied by event-plane MAC"));
+                    return;
+                }
+                Ok(None) => {}
+                Ok(Some(_)) => panic!("denied event must never be returned"),
+            }
+        }
+        panic!("subscriber did not observe the test frame");
     }
 
     fn member(recipient: &RecipientKeypair, did: &str, blind: u8) -> GroupMembership {

--- a/crates/hyprstream-rpc/src/moq_authz.rs
+++ b/crates/hyprstream-rpc/src/moq_authz.rs
@@ -33,9 +33,11 @@
 //!
 //! The **subscribe authorization hook** ([`SubscribeAuthorizer`]) is the
 //! pluggable policy layer on top of that structural scoping, for the
-//! public-vs-private distinction within a tenant. It is wired where the peer
-//! identity needed to evaluate policy is actually available (see the wiring
-//! notes on [`SubscribeAuthorizer`]).
+//! public-vs-private distinction within a tenant. Until moq-net exposes the
+//! per-track callback tracked by #276, installing an authorizer rejects the
+//! session at admission. This is intentionally coarse but fail-closed: an
+//! installed policy is never retained as dead configuration while tracks are
+//! served around it.
 //!
 //! Track names are hierarchical `{tenant}/{service}/{topic}/{instance}` (the
 //! #134 CDN-portability invariant). The first path segment is the tenant.
@@ -217,6 +219,14 @@ impl PeerIdentity {
 pub trait SubscribeAuthorizer: Send + Sync {
     /// Decide whether `peer` may subscribe to `track_name`.
     fn authorize(&self, peer: &PeerIdentity, track_name: &str) -> SubscribeDecision;
+
+    /// Decide admission while moq-net provides no track name callback (#276).
+    ///
+    /// The default is deny. Implementations with an audit path should override
+    /// this method to record the coarse session denial.
+    fn authorize_without_track_hook(&self, _peer: &PeerIdentity) -> SubscribeDecision {
+        SubscribeDecision::Deny
+    }
 }
 
 /// Classifies a track name as public or private. Returning [`Visibility::Public`]
@@ -342,6 +352,15 @@ impl SubscribeAuthorizer for MacSubscribeAuthorizer {
         } else {
             SubscribeDecision::Deny
         }
+    }
+
+    fn authorize_without_track_hook(&self, peer: &PeerIdentity) -> SubscribeDecision {
+        let subject = match &peer.subject {
+            Some(s) => Subject::new(s.clone()),
+            None => Subject::anonymous(),
+        };
+        self.pep.deny_track_admission_without_hook(&subject);
+        SubscribeDecision::Deny
     }
 }
 
@@ -584,8 +603,32 @@ mod scope_tests {
 
     #[test]
     fn mac_subscribe_authorizer_fail_closed_denies_all() {
+        use crate::auth::mac::{
+            DenyAllClearanceSource, DenyAllObjectResolver, MoqMacAuditReason, MoqMacAuditRecord,
+            MoqMacAuditSink,
+        };
+        use parking_lot::Mutex;
+
+        #[derive(Default)]
+        struct RecordingAudit {
+            records: Mutex<Vec<MoqMacAuditRecord>>,
+        }
+        impl MoqMacAuditSink for RecordingAudit {
+            fn record_deny(&self, record: &MoqMacAuditRecord) -> Result<(), String> {
+                self.records.lock().push(record.clone());
+                Ok(())
+            }
+        }
+
         // Once installed, missing clearance/labels deny.
-        let authz = super::MacSubscribeAuthorizer::new(crate::auth::mac::MoqEventPep::default());
+        let audit = Arc::new(RecordingAudit::default());
+        let authz = Arc::new(super::MacSubscribeAuthorizer::new(
+            crate::auth::mac::MoqEventPep::new(
+                Arc::new(DenyAllObjectResolver),
+                Arc::new(DenyAllClearanceSource),
+                audit.clone(),
+            ),
+        ));
         assert_eq!(
             authz.authorize(&PeerIdentity::anonymous(), "t"),
             SubscribeDecision::Deny
@@ -593,6 +636,18 @@ mod scope_tests {
         assert_eq!(
             authz.authorize(&PeerIdentity::authenticated("did:web:x"), "t"),
             SubscribeDecision::Deny
+        );
+        let config =
+            crate::transport::iroh_moq::MoqAuthzConfig::default().with_authorizer(authz);
+        assert_eq!(
+            config.authorize_without_track_hook(&PeerIdentity::authenticated("did:web:x")),
+            SubscribeDecision::Deny
+        );
+        let records = audit.records.lock();
+        assert_eq!(records.len(), 3);
+        assert_eq!(
+            records[2].reason,
+            MoqMacAuditReason::TrackAdmissionHookUnavailable
         );
     }
 }

--- a/crates/hyprstream-rpc/src/moq_authz.rs
+++ b/crates/hyprstream-rpc/src/moq_authz.rs
@@ -325,7 +325,6 @@ impl MacSubscribeAuthorizer {
     pub fn new(pep: MoqEventPep) -> Self {
         Self { pep }
     }
-
 }
 
 impl SubscribeAuthorizer for MacSubscribeAuthorizer {

--- a/crates/hyprstream-rpc/src/moq_authz.rs
+++ b/crates/hyprstream-rpc/src/moq_authz.rs
@@ -45,6 +45,9 @@ use std::sync::Arc;
 #[cfg(not(target_arch = "wasm32"))]
 use moq_net::{OriginConsumer, Path};
 
+use crate::auth::mac::{MacDecision, MoqEventAction, MoqEventPep};
+use crate::envelope::Subject;
+
 /// The hierarchical track-name separator (`{tenant}/{service}/{topic}/{instance}`).
 pub const TRACK_NAME_SEP: char = '/';
 
@@ -297,6 +300,52 @@ impl SubscribeAuthorizer for DefaultAuthorizer {
 /// long-lived server/handler.
 pub type SharedSubscribeAuthorizer = Arc<dyn SubscribeAuthorizer>;
 
+// ────────────────────────────────────────────────────────────────────────────
+// MAC-backed subscribe authorizer (issue #1271, epic #547 track T3)
+// ────────────────────────────────────────────────────────────────────────────
+
+/// [`SubscribeAuthorizer`] backed by the shared [`MoqEventPep`] MAC floor.
+///
+/// Maps the [`PeerIdentity`]'s verified subject to a [`Subject`], resolves the
+/// track label + subject clearance via the PEP's seams, and applies
+/// `can_access`. Both seams fail closed (`None` ⇒ [`SubscribeDecision::Deny`]);
+/// there is no permissive bypass (epic #547: no permissive mode). Key possession
+/// (the §7.5 DH-derived topic capability) never substitutes for this decision —
+/// it gates metadata visibility, the MAC floor gates the labeled content.
+///
+/// Constructing this adapter installs an active PEP, so missing clearance and
+/// missing labels deny. Leaving the containing transport's authorizer unset is
+/// the dormant pre-activation state and remains pass-through.
+pub struct MacSubscribeAuthorizer {
+    pep: MoqEventPep,
+}
+
+impl MacSubscribeAuthorizer {
+    /// Build with a caller-supplied PEP (real resolver + clearance source).
+    pub fn new(pep: MoqEventPep) -> Self {
+        Self { pep }
+    }
+
+}
+
+impl SubscribeAuthorizer for MacSubscribeAuthorizer {
+    fn authorize(&self, peer: &PeerIdentity, track_name: &str) -> SubscribeDecision {
+        let subject = match &peer.subject {
+            Some(s) => Subject::new(s.clone()),
+            None => Subject::anonymous(),
+        };
+        if matches!(
+            self.pep
+                .check(&subject, track_name, MoqEventAction::Subscribe),
+            MacDecision::Permit
+        ) {
+            SubscribeDecision::Allow
+        } else {
+            SubscribeDecision::Deny
+        }
+    }
+}
+
 #[cfg(test)]
 #[allow(clippy::expect_used, clippy::unwrap_used)]
 mod tests {
@@ -524,5 +573,27 @@ mod scope_tests {
         // bob/... is outside alice's scope → not reachable.
         let reached = scoped.announced_broadcast("bob/streams/run-9/i0").await;
         assert!(reached.is_none(), "alice-scoped consumer must not reach bob's broadcast");
+    }
+
+    // ── #1271: MAC-backed subscribe authorizer ─────────────────────────────
+
+    #[test]
+    fn dormant_subscribe_authorizer_is_absent() {
+        let config = crate::transport::iroh_moq::MoqAuthzConfig::default();
+        assert!(config.authorizer.is_none());
+    }
+
+    #[test]
+    fn mac_subscribe_authorizer_fail_closed_denies_all() {
+        // Once installed, missing clearance/labels deny.
+        let authz = super::MacSubscribeAuthorizer::new(crate::auth::mac::MoqEventPep::default());
+        assert_eq!(
+            authz.authorize(&PeerIdentity::anonymous(), "t"),
+            SubscribeDecision::Deny
+        );
+        assert_eq!(
+            authz.authorize(&PeerIdentity::authenticated("did:web:x"), "t"),
+            SubscribeDecision::Deny
+        );
     }
 }

--- a/crates/hyprstream-rpc/src/transport/iroh_moq.rs
+++ b/crates/hyprstream-rpc/src/transport/iroh_moq.rs
@@ -32,7 +32,9 @@ use moq_net::{Origin, OriginConsumer, OriginProducer, Server, StatsHandle};
 use tokio_util::sync::CancellationToken;
 use web_transport_iroh::Session;
 
-use crate::moq_authz::{tenant_scoped_consumer, PeerIdentity, SharedSubscribeAuthorizer};
+use crate::moq_authz::{
+    tenant_scoped_consumer, PeerIdentity, SharedSubscribeAuthorizer, SubscribeDecision,
+};
 
 /// Resolves the tenant for an independently authenticated application peer.
 /// Carrier NodeId is never passed here. Until a caller can supply fresh proof,
@@ -61,6 +63,19 @@ impl MoqAuthzConfig {
     pub fn with_authorizer(mut self, authorizer: SharedSubscribeAuthorizer) -> Self {
         self.authorizer = Some(authorizer);
         self
+    }
+
+    /// Gate an MoQ session while the transport cannot surface track names.
+    ///
+    /// Dormant (`None`) preserves the legacy pass-through. Once an authorizer
+    /// is installed, its coarse admission decision is mandatory; current
+    /// implementations deny until moq-net's #276 per-track callback exists.
+    pub fn authorize_without_track_hook(&self, peer: &PeerIdentity) -> SubscribeDecision {
+        self.authorizer
+            .as_ref()
+            .map_or(SubscribeDecision::Allow, |a| {
+                a.authorize_without_track_hook(peer)
+            })
     }
 }
 
@@ -209,6 +224,18 @@ impl ProtocolHandler for IrohMoqProtocolHandler {
         // Carrier NodeId is transport metadata only. Until #1027 supplies fresh
         // inside-carrier proof, authorization must see an anonymous peer.
         let peer = PeerIdentity::anonymous();
+        if !self
+            .inner
+            .authz
+            .authorize_without_track_hook(&peer)
+            .is_allowed()
+        {
+            tracing::warn!(
+                "iroh-moq: installed track authorizer denied session because #276 callback is unavailable"
+            );
+            conn.close(0u32.into(), b"per-track authorization unavailable");
+            return Ok(());
+        }
         if !peer.is_authenticated() {
             tracing::warn!(
                 "iroh-moq: refusing anonymous carrier pending verified session proof (#1027/#726)"
@@ -249,18 +276,6 @@ impl ProtocolHandler for IrohMoqProtocolHandler {
                 return Ok(());
             }
         };
-
-        // NOTE (#276 subscribe-authz seam): `moq_net::Server` exposes no
-        // per-subscribe callback, so we cannot gate individual `subscribe_track`
-        // calls in-band. The public/private decision is therefore enforced
-        // *structurally* by what the served consumer can see (tenant scoping
-        // above). The pluggable `SubscribeAuthorizer` is retained as the policy
-        // unit a richer moq-net (one that surfaces a subscribe hook) would call;
-        // it is exercised by unit tests in `crate::moq_authz`. Until moq-net
-        // grows that hook, private-vs-public must be expressed as scoping (e.g.
-        // a private broadcast lives under a prefix only entitled peers' tenant
-        // scope includes).
-        let _authorizer = self.inner.authz.authorizer.as_ref();
 
         let session = Session::raw(conn);
         let server = Server::new()

--- a/crates/hyprstream-rpc/src/transport/iroh_moq.rs
+++ b/crates/hyprstream-rpc/src/transport/iroh_moq.rs
@@ -56,6 +56,12 @@ impl MoqAuthzConfig {
     pub fn tenant_for(&self, peer: &PeerIdentity) -> Option<String> {
         self.tenant_resolver.as_ref().and_then(|r| r(peer))
     }
+
+    /// Set/replace the subscribe authorizer.
+    pub fn with_authorizer(mut self, authorizer: SharedSubscribeAuthorizer) -> Self {
+        self.authorizer = Some(authorizer);
+        self
+    }
 }
 
 /// Shared `Origin` clone-pair held by the handler.

--- a/crates/hyprstream-rpc/src/transport/iroh_rpc.rs
+++ b/crates/hyprstream-rpc/src/transport/iroh_rpc.rs
@@ -593,6 +593,10 @@ mod tests {
         let conn2 = client.connect(direct_addr(&server), ALPN_MOQ_LITE).await?;
         drop(conn2);
 
+        // Release every caller-owned connection before draining the routers.
+        // Keeping this RPC handle alive races noq's driver teardown and can
+        // intermittently trip its GSO-batch alignment assertion.
+        drop(conn);
         client.shutdown().await?;
         server.shutdown().await?;
         Ok(())

--- a/crates/hyprstream-rpc/src/transport/quinn_transport.rs
+++ b/crates/hyprstream-rpc/src/transport/quinn_transport.rs
@@ -526,6 +526,21 @@ impl QuinnRpcServer {
                         };
 
                         if is_moq {
+                            let moq_peer = moq_connect_verified.as_ref().map_or_else(
+                                crate::moq_authz::PeerIdentity::anonymous,
+                                |verified| verified.peer.clone(),
+                            );
+                            if !moq_authz
+                                .authorize_without_track_hook(&moq_peer)
+                                .is_allowed()
+                            {
+                                tracing::warn!(
+                                    subject = ?moq_peer.subject,
+                                    "quinn-moq: installed track authorizer denied session because #276 callback is unavailable"
+                                );
+                                return;
+                            }
+
                             // Relay (bidirectional) mode takes precedence (#358):
                             // ingest a producer's announced broadcasts into the
                             // shared origin AND re-serve them to subscribers by
@@ -665,11 +680,6 @@ impl QuinnRpcServer {
                                             }
                                         }
                                     };
-                                    // See iroh_moq::accept for why the authorizer
-                                    // is not enforced per-track here (moq-net has
-                                    // no subscribe callback); structural scoping
-                                    // is the live enforcement.
-                                    let _authorizer = moq_authz.authorizer.as_ref();
                                     // Serve moq over this session, mirroring
                                     // IrohMoqProtocolHandler: publish the shared
                                     // origin consumer to remote subscribers.

--- a/crates/hyprstream/src/mac/audit.rs
+++ b/crates/hyprstream/src/mac/audit.rs
@@ -212,7 +212,7 @@ pub struct AuditRecord {
     /// plane has a stable identifier. Omitted for legacy/type-only records.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub subject_id: Option<String>,
-    /// Concrete tenant-qualified object, when known. Omitted for
+    /// Concrete tenant-qualified object/track, when known. Omitted for
     /// legacy/type-only records.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub object_id: Option<String>,
@@ -242,6 +242,14 @@ pub enum DecisionReason {
     /// **Fail-closed:** the audit write failed, so a Permit was downgraded to
     /// Deny. This is itself auditable (the deny is what the PEP enforced).
     AuditFailClosed,
+    /// The active MoQ/event PEP could not derive subject clearance.
+    MoqUnlabeledSubject,
+    /// The explicitly installed MoQ/event PEP had no operational policy.
+    MoqNoPepInstalled,
+    /// A streaming continuation's MoQ authority was stale or revoked.
+    MoqStaleAuthority,
+    /// Track admission was denied because moq-net has no #276 callback.
+    MoqTrackAdmissionHookUnavailable,
 
     // ── B2 (#674): the S6 grant-path decision kind (see [`crate::mac::te::
     // GRANT_PATH_SUBJECT`]). One variant per `mac::exchange::GrantError`
@@ -283,6 +291,12 @@ impl DecisionReason {
             DecisionReason::Escalate => "escalate",
             DecisionReason::TokenGate => "token_gate",
             DecisionReason::AuditFailClosed => "audit_fail_closed",
+            DecisionReason::MoqUnlabeledSubject => "moq_unlabeled_subject",
+            DecisionReason::MoqNoPepInstalled => "moq_no_pep_installed",
+            DecisionReason::MoqStaleAuthority => "moq_stale_authority",
+            DecisionReason::MoqTrackAdmissionHookUnavailable => {
+                "moq_track_admission_hook_unavailable"
+            }
             DecisionReason::GrantMissingSenderBinding => "grant_missing_sender_binding",
             DecisionReason::GrantEmptyGrant => "grant_empty_grant",
             DecisionReason::GrantUnlabeledSubject => "grant_unlabeled_subject",

--- a/crates/hyprstream/src/mac/cas_pep.rs
+++ b/crates/hyprstream/src/mac/cas_pep.rs
@@ -281,11 +281,19 @@ impl CasPep {
             .clearance_source
             .clearance_for(subject_id, verified_tenant)
         else {
-            return self.audit(None, label, MacDecision::Deny(MacDenyReason::NoClearance));
+            return self.audit(
+                subject_id,
+                verified_tenant,
+                None,
+                label,
+                MacDecision::Deny(MacDenyReason::NoClearance),
+            );
         };
 
         let Some(label) = label else {
             return self.audit(
+                subject_id,
+                verified_tenant,
                 Some(&ctx),
                 None,
                 MacDecision::Deny(MacDenyReason::UnlabeledObject),
@@ -297,11 +305,19 @@ impl CasPep {
         } else {
             MacDecision::Deny(MacDenyReason::FloorDeny)
         };
-        self.audit(Some(&ctx), Some(label), decision)
+        self.audit(
+            subject_id,
+            verified_tenant,
+            Some(&ctx),
+            Some(label),
+            decision,
+        )
     }
 
     fn audit(
         &self,
+        subject_id: &str,
+        verified_tenant: Option<&str>,
         ctx: Option<&SecurityContext>,
         label: Option<SecurityLabel>,
         decision: MacDecision,
@@ -343,8 +359,11 @@ impl CasPep {
             object_label: label.unwrap_or_else(SecurityLabel::bottom),
             action: crate::mac::te::Action::from_scope_action(crate::mac::te::ScopeAction::Query),
             reason,
-            subject_id: None,
-            object_id: None,
+            subject_id: Some(subject_id.to_owned()),
+            object_id: Some(match verified_tenant {
+                Some(tenant) => format!("{tenant}/{CAS_SERVICE_DOMAIN}"),
+                None => CAS_SERVICE_DOMAIN.to_owned(),
+            }),
         };
 
         match self.sink.record(&record) {
@@ -640,6 +659,8 @@ mod tests {
         let records = sink.records.lock();
         assert_eq!(records[0].decision, Decision::Deny);
         assert_eq!(records[0].reason, DecisionReason::FloorDeny);
+        assert_eq!(records[0].subject_id.as_deref(), Some("public-user"));
+        assert_eq!(records[0].object_id.as_deref(), Some("tenant-a/cas"));
     }
 
     #[test]

--- a/crates/hyprstream/src/mac/mod.rs
+++ b/crates/hyprstream/src/mac/mod.rs
@@ -69,6 +69,7 @@ pub mod exchange;
 // ObjectLabelResolver + boot-time coverage gate consumed by the active 9P PEP.
 pub mod genesis;
 pub mod lattice;
+pub mod moq_audit;
 // #676: the production S3-scope ↔ S5-TE-rule vocabulary (injective + exact;
 // wildcards expand at compile time over a closed registry).
 // #1270: CAS-native MAC PEP — trusted content-bound label at seal +
@@ -115,9 +116,10 @@ pub use compiler::{
 };
 // S1 activation (#567): production genesis content/enumerator/resolver/gate.
 pub use genesis::{
-    floor_label, genesis_lattice, CompositeObjectLabelResolver, GeneratedNodeCoverage,
-    GenesisGate, ManifestLabelSource, NamespaceEnumerator, NoManifests, SitePolicy,
+    floor_label, genesis_lattice, CompositeObjectLabelResolver, GeneratedNodeCoverage, GenesisGate,
+    ManifestLabelSource, NamespaceEnumerator, NoManifests, SitePolicy,
 };
+pub use moq_audit::{audited_moq_event_pep, MoqAuditSinkAdapter};
 // #1270: CAS-native MAC PEP — the shared CAS enforcement contract.
 pub use cas_pep::{
     domain_label, seal_label, CasClearanceSource, CasObjectLabelResolver, CasPep,

--- a/crates/hyprstream/src/mac/moq_audit.rs
+++ b/crates/hyprstream/src/mac/moq_audit.rs
@@ -16,9 +16,10 @@ use hyprstream_rpc::auth::mac::{
 use crate::mac::audit::{AuditRecord, AuditSink, DecisionReason};
 use crate::mac::te::{Action, Decision, ObjectType, ScopeAction, SubjectType};
 
-/// Reserved audit identities for MoQ/event decisions.
-const MOQ_SUBJECT_TYPE: SubjectType = SubjectType(u32::MAX - 2);
-const MOQ_OBJECT_TYPE: ObjectType = ObjectType(u32::MAX - 2);
+/// Reserved audit identities for MoQ/event decisions (below the CAS PEP's
+/// `u32::MAX - 3` sentinels, and distinct from VFS at `u32::MAX - 2`).
+const MOQ_SUBJECT_TYPE: SubjectType = SubjectType(u32::MAX - 4);
+const MOQ_OBJECT_TYPE: ObjectType = ObjectType(u32::MAX - 4);
 
 /// Convert RPC-plane denial records into the authoritative MAC audit schema.
 pub struct MoqAuditSinkAdapter {
@@ -167,6 +168,8 @@ mod tests {
         assert_eq!(records.len(), 1);
         assert_eq!(records[0].decision, Decision::Deny);
         assert_eq!(records[0].reason, DecisionReason::UnlabeledObject);
+        assert_eq!(records[0].subject_type, SubjectType(u32::MAX - 4));
+        assert_eq!(records[0].object_type, ObjectType(u32::MAX - 4));
         assert_eq!(
             records[0].subject_id.as_deref(),
             Some("did:web:tenant-a")

--- a/crates/hyprstream/src/mac/moq_audit.rs
+++ b/crates/hyprstream/src/mac/moq_audit.rs
@@ -1,0 +1,183 @@
+//! Signed-WAL adapter for MoQ/event-plane MAC denials.
+//!
+//! The enforcement point lives in `hyprstream-rpc`, while the authoritative
+//! tamper-evident WAL lives in this parent crate. This adapter keeps that crate
+//! direction intact and makes every active MoQ denial use the same
+//! [`AuditRecord`] / [`AuditSink`] contract as the 9P PEP.
+
+use std::sync::Arc;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use hyprstream_rpc::auth::mac::{
+    ClearanceSource, MacDenyReason, MoqEventAction, MoqEventPep, MoqMacAuditReason,
+    MoqMacAuditRecord, MoqMacAuditSink, RpcObjectLabelResolver, SecurityLabel,
+};
+
+use crate::mac::audit::{AuditRecord, AuditSink, DecisionReason};
+use crate::mac::te::{Action, Decision, ObjectType, ScopeAction, SubjectType};
+
+/// Reserved audit identities for MoQ/event decisions.
+const MOQ_SUBJECT_TYPE: SubjectType = SubjectType(u32::MAX - 2);
+const MOQ_OBJECT_TYPE: ObjectType = ObjectType(u32::MAX - 2);
+
+/// Convert RPC-plane denial records into the authoritative MAC audit schema.
+pub struct MoqAuditSinkAdapter {
+    sink: Arc<dyn AuditSink>,
+}
+
+impl MoqAuditSinkAdapter {
+    pub fn new(sink: Arc<dyn AuditSink>) -> Self {
+        Self { sink }
+    }
+}
+
+impl MoqMacAuditSink for MoqAuditSinkAdapter {
+    fn record_deny(&self, denial: &MoqMacAuditRecord) -> Result<(), String> {
+        let policy = crate::mac::compiled_policy();
+        let generation = policy.as_ref().map_or(0, |p| p.generation);
+        let policy_hash = policy.as_ref().and_then(|p| p.policy_hash().ok());
+        let record = AuditRecord {
+            seq: 0,
+            prev_hash: [0; 32],
+            ts_unix_nanos: SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .map_or(0, |duration| duration.as_nanos()),
+            decision: Decision::Deny,
+            generation,
+            policy_hash,
+            subject_type: MOQ_SUBJECT_TYPE,
+            // Missing labels use bottom only as an audit-schema placeholder;
+            // the reason remains authoritative and the placeholder is never
+            // fed back into the authorization decision.
+            subject_clearance: denial
+                .subject_clearance
+                .unwrap_or_else(SecurityLabel::bottom),
+            on_behalf_of: None,
+            object_type: MOQ_OBJECT_TYPE,
+            object_label: denial.object_label.unwrap_or_else(SecurityLabel::bottom),
+            action: audit_action(denial.action),
+            reason: audit_reason(denial.reason),
+            subject_id: denial.subject.clone(),
+            object_id: Some(denial.object.clone()),
+        };
+        self.sink.record(&record).map_err(|error| error.to_string())
+    }
+}
+
+/// Construct an active MoQ/event PEP whose denials flow to the canonical MAC
+/// audit sink. Production passes a signed [`crate::mac::WalAuditStore`].
+pub fn audited_moq_event_pep(
+    resolver: Arc<dyn RpcObjectLabelResolver>,
+    clearance: Arc<dyn ClearanceSource>,
+    sink: Arc<dyn AuditSink>,
+) -> MoqEventPep {
+    MoqEventPep::new(
+        resolver,
+        clearance,
+        Arc::new(MoqAuditSinkAdapter::new(sink)),
+    )
+}
+
+const fn audit_action(action: MoqEventAction) -> Action {
+    match action {
+        MoqEventAction::Publish => Action::from_scope_action(ScopeAction::Publish),
+        MoqEventAction::Subscribe | MoqEventAction::JoinDecrypt => {
+            Action::from_scope_action(ScopeAction::Subscribe)
+        }
+    }
+}
+
+const fn audit_reason(reason: MoqMacAuditReason) -> DecisionReason {
+    match reason {
+        MoqMacAuditReason::Mac(MacDenyReason::NoPepInstalled) => DecisionReason::MoqNoPepInstalled,
+        MoqMacAuditReason::Mac(MacDenyReason::NoClearance) => DecisionReason::MoqUnlabeledSubject,
+        MoqMacAuditReason::Mac(MacDenyReason::UnlabeledObject) => DecisionReason::UnlabeledObject,
+        MoqMacAuditReason::Mac(MacDenyReason::FloorDeny) => DecisionReason::FloorDeny,
+        MoqMacAuditReason::Mac(MacDenyReason::StaleAuthority) => DecisionReason::MoqStaleAuthority,
+        MoqMacAuditReason::TrackAdmissionHookUnavailable => {
+            DecisionReason::MoqTrackAdmissionHookUnavailable
+        }
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)]
+mod tests {
+    use super::*;
+    use crate::mac::{AuditError, AuditSigner, AuditVerifier, WalAuditStore};
+    use hyprstream_rpc::auth::mac::{
+        Assurance, CompartmentSet, DenyAllObjectResolver, Level, SecurityContext,
+        VerifiedKeyMaterial,
+    };
+    use hyprstream_rpc::envelope::Subject;
+    use tempfile::tempdir;
+
+    #[derive(Clone, Copy)]
+    struct StubSigner;
+
+    impl AuditSigner for StubSigner {
+        fn sign(&self, signing_input: &[u8]) -> Result<Vec<u8>, AuditError> {
+            Ok(blake3::hash(signing_input).as_bytes().to_vec())
+        }
+    }
+
+    impl AuditVerifier for StubSigner {
+        fn verify(&self, signing_input: &[u8], signature: &[u8]) -> Result<(), AuditError> {
+            if signature == blake3::hash(signing_input).as_bytes() {
+                Ok(())
+            } else {
+                Err(AuditError::Verify("stub signature mismatch".to_owned()))
+            }
+        }
+    }
+
+    struct PublicClearance;
+
+    impl ClearanceSource for PublicClearance {
+        fn clearance(&self, _subject: &Subject) -> Option<SecurityContext> {
+            Some(SecurityContext::from_clearance(
+                SecurityLabel::new(Level::Public, Assurance::Classical, CompartmentSet::EMPTY),
+                VerifiedKeyMaterial::Classical,
+            ))
+        }
+    }
+
+    #[test]
+    fn cross_tenant_moq_deny_is_durable_in_signed_wal() {
+        let dir = tempdir().unwrap();
+        let wal = Arc::new(WalAuditStore::open(dir.path(), StubSigner).unwrap());
+        let pep = audited_moq_event_pep(
+            Arc::new(DenyAllObjectResolver),
+            Arc::new(PublicClearance),
+            wal.clone(),
+        );
+
+        assert_eq!(
+            pep.check(
+                &Subject::new("did:web:tenant-a"),
+                "tenant-b/events/private",
+                MoqEventAction::Subscribe,
+            ),
+            hyprstream_rpc::auth::mac::MacDecision::Deny(
+                hyprstream_rpc::auth::mac::MacDenyReason::UnlabeledObject
+            )
+        );
+
+        let records = wal.verify_journal(&StubSigner).unwrap();
+        assert_eq!(records.len(), 1);
+        assert_eq!(records[0].decision, Decision::Deny);
+        assert_eq!(records[0].reason, DecisionReason::UnlabeledObject);
+        assert_eq!(
+            records[0].subject_id.as_deref(),
+            Some("did:web:tenant-a")
+        );
+        assert_eq!(
+            records[0].object_id.as_deref(),
+            Some("tenant-b/events/private")
+        );
+        assert_eq!(
+            records[0].action,
+            Action::from_scope_action(ScopeAction::Subscribe)
+        );
+    }
+}


### PR DESCRIPTION
Closes #1271. Parent epic #1267 (track T3, P1).

## What

A MAC label-ceiling PEP on the event/MoQ publish/subscribe/join-decrypt data plane. Every decision now crosses the `SecurityContext::can_access` floor — there is no permissive bypass (epic #547: no permissive mode).

### New shared PEP contract — `crates/hyprstream-rpc/src/auth/mac/pep.rs`
- `MoqEventPep`: floor-only decider mirroring `NinePAccessDecider` — resolves a track label (`TrackLabelResolver`) + subject clearance (`ClearanceSource`), then applies `can_access`. Both seams fail closed (`None ⇒ Deny`).
- `MoqEventAction {Publish, Subscribe, JoinDecrypt}`, `PepVerdict`, `PepDenyReason`.
- Fail-closed defaults (`DenyAllTrackResolver` / `DenyAllClearanceSource`).
- `public_firehose_pep()`: the labeled open-firehose (every track Public, every subject cleared to Public) — the `can_access`-checked replacement for the pre-#1271 permissive bypass.

### events.rs
- `MacEventAuthz` adapter (impl `EventAuthz`) over `MoqEventPep`. `AllowAllEventAuthz` is no longer a production default (test opt-in only); the Public profile now defaults to `MacEventAuthz::public_firehose()`.
- `publish_raw` plaintext None-arm now crosses the authz gate (was an authz bypass).
- `EventSubscriber` gains `authz` + `caller` fields + `with_authz`/`with_caller` builders. `decode_frame` passthrough + `join_prefix` gated: key possession no longer substitutes for a `can_access` decision.

### moq_authz.rs
- `MacSubscribeAuthorizer` (impl `SubscribeAuthorizer`) over the same `MoqEventPep`.

### transports (iroh_moq, quinn)
- Default `MoqAuthzConfig` flipped from absent-authorizer to `public_firehose()` (labeled).

## Flagged dependencies (not stubbed)
- **#698** (production clearance provenance): real `ClearanceSource` not wired — production posture is `DenyAllClearanceSource` (fail-closed); the public firehose uses the explicit `PublicClearanceSource`.
- **`.fleet-coord/mac-pep-contract.md` (#1268)** and **`.fleet-coord/mac-pep-audit.md`**: both absent at execution time — built plane-specific `TrackLabelResolver` + `ClearanceSource` seams off issue #1271 directly. **Needs rebase onto #1288 once its merged mandatory-dispatch + claims→clearance contract lands.**
- **moq_net per-subscribe hook (#276):** still no callback; the transport authorizer is bound + documented + unit-tested, but enforcement lives on the events.rs plane today.
- **Audit trail:** returns structured `PepVerdict`; parent-crate WAL wrapper (mirroring `NinePAccessDecider`) is a follow-up — the audit types live in the `hyprstream` crate above this one.

## Validation
`cargo nextest run --release --profile ci -p hyprstream-rpc`: **921 passed, 3 skipped**. `cargo clippy -p hyprstream-rpc --lib --tests --release -- -D warnings`: clean.

> **Deferred:** needs rebase onto #1288's merged contract, then full-release (`--workspace`) validation once that contract is in. The scoped `hyprstream-rpc` release suite is green now; workspace-wide release is the post-rebase gate.

## Review gate
A **kimi-k3 review is the FINAL gate** before merge — do not self-merge or touch the merge queue.

Refs #1271, #1267.