### PR TITLE
feat(mac): reviewed public/declassifier exemption registry (#1273)

### DIFF
--- a/crates/hyprstream/src/mac/mod.rs
+++ b/crates/hyprstream/src/mac/mod.rs
@@ -73,6 +73,11 @@ pub mod lattice;
 // wildcards expand at compile time over a closed registry).
 pub mod pep;
 pub mod permission_map;
+// #1273 (epic #1267): the reviewed public/declassifier exemption registry —
+// the explicit, pinned set of HTTP routes intentionally unmediated by native
+// MAC. Public routers derive from this so a new route must be added here (and
+// to the drift test) in the same reviewed PR.
+pub mod public_exemptions;
 pub mod te;
 
 // Re-export the per-op contract surface S2 (PEP) and S5/S6 (policy producers) consume.

--- a/crates/hyprstream/src/mac/public_exemptions.rs
+++ b/crates/hyprstream/src/mac/public_exemptions.rs
@@ -1,0 +1,402 @@
+//! Reviewed registry of HTTP routes intentionally exempt from native MAC
+//! mediation — the "public / declassifier exemption registry" (issue #1273,
+//! epic #1267, audit item `NEW-PUBLIC-EXEMPTIONS`).
+//!
+//! # Why this exists
+//! Native MAC ([`crate::mac`]) is the mandatory floor: every object path must
+//! be mediated by a verified subject `SecurityContext` and a trusted object
+//! label before use. Activation's "all non-exempt paths mediated" claim is only
+//! enforceable if the set of intentionally-unmediated routes is *explicit and
+//! reviewed*, not implicit. Without a registry, a newly added public route can
+//! silently become a bypass — exactly the drift this module prevents.
+//!
+//! # Contract (do not circumvent)
+//! 1. **A route defaults to mediated.** Any HTTP route not listed in
+//!    [`PUBLIC_EXEMPTIONS`] must sit behind the protected (auth-mediated)
+//!    router. Once the MAC PEP is installed there is no permissive mode
+//!    ([`crate::mac`] is fail-closed per #547); "public" is an opt-in,
+//!    reviewed exemption, never a default.
+//! 2. **The public routers are built from this registry.** [`crate::server`]
+//!    and [`crate::services::at9p_verify`] construct their public route sets by
+//!    iterating [`PUBLIC_EXEMPTIONS`] for their face, so adding an unmediated
+//!    route requires adding a reviewed [`PublicExemption`] entry plus a handler
+//!    arm — two review surfaces, no silent addition.
+//! 3. **The drift test pins the live set to the registry.**
+//!    `public_exemptions_match_live_routes` asserts registry self-consistency,
+//!    handler-enum parity, per-face wiring, and that the public/protected split
+//!    is live (registry paths answer without auth; a protected path does not).
+//!
+//! # Scope and dependencies
+//! This registry covers genuinely no-auth public routes: health metadata,
+//! `.well-known` discovery, pre-credential browser provisioning, and the
+//! stateless at9p verification face. OAuth2.1 protocol endpoints (token,
+//! authorize, jwks, device, SCIM …) are the *credential-issuance control
+//! plane* that MAC sits beneath, not tenant-object access; they remain out of
+//! scope here and are tracked separately. Real MAC enforcement remains dormant
+//! (uninstalled, so dispatch permits as a pre-activation pass-through) pending
+//! production clearance provenance (#698). Once installed, the PEP is
+//! fail-closed. This registry is the activation-gate structure that ships now
+//! so the exempt set is locked.
+//!
+//! [#547]: https://github.com/hyprstream/hyprstream/issues/547
+//! [#698]: https://github.com/hyprstream/hyprstream/issues/698
+//! [#1267]: https://github.com/hyprstream/hyprstream/issues/1267
+//! [#1273]: https://github.com/hyprstream/hyprstream/issues/1273
+
+/// HTTP method of an exempt route. Only the methods used by public routes are
+/// represented; anything else must go through the protected router.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum RouteMethod {
+    Get,
+    Post,
+}
+
+/// Why a route is intentionally unmediated. Used by activation review to
+/// confirm each exemption is a narrow, justified carve-out.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum ExemptionCategory {
+    /// Liveness / health metadata. No tenant data, no object access.
+    Health,
+    /// Published discovery or capability metadata (`.well-known`, wire-plane
+    /// table). Public by design so clients can bootstrap before authenticating.
+    PublicMetadata,
+    /// Pre-credential bootstrap (browser provisioning before any identity
+    /// exists). Rate-limited; carries no tenant object.
+    Bootstrap,
+    /// Stateless cryptographic verification returning only pass/fail plus the
+    /// content-verified identifier. Never echoes request bytes past the check.
+    CryptographicVerification,
+}
+
+/// Which HTTP face serves the exempt route. Each face builds its public router
+/// from its own slice of [`PUBLIC_EXEMPTIONS`]; the drift test cross-checks
+/// every face against the registry.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum HttpFace {
+    /// The main Axum app ([`crate::server::create_app`]).
+    MainApp,
+    /// The standalone credential-free at9p verification face
+    /// ([`crate::services::at9p_verify`]).
+    At9pVerify,
+}
+
+/// Tag identifying which handler serves an exempt route. The public-router
+/// builders match exhaustively on this, so wiring a new route requires both a
+/// [`PublicExemption`] entry and a handler arm — the double review touch that
+/// keeps the exempt set from silently growing.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum PublicRouteHandler {
+    /// `GET /` and `GET /health` — health metadata.
+    HealthCheck,
+    /// `GET /.well-known/oauth-protected-resource` — RFC 9728 metadata.
+    OauthProtectedResourceMetadata,
+    /// `GET /.well-known/export9p` — 9P export discovery metadata.
+    Export9pMetadata,
+    /// `GET /.well-known/planes` — wire-plane discovery table.
+    WirePlanesMetadata,
+    /// `GET /9p` — 9P-over-WebSocket export (mount ticket rides the URL query).
+    NinepWebSocket,
+    /// `GET /.well-known/hyprstream/browser-provisioning/:service` — bootstrap.
+    BrowserProvisioning,
+    /// `POST /at9p/verify` — stateless login-assertion verification (own face).
+    At9pVerify,
+}
+
+/// One reviewed public/declassifier exemption. Every field is `&'static` so the
+/// registry is a compile-time constant and the drift test needs no allocation.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct PublicExemption {
+    /// Stable, unique kebab-case identifier (the key the router builder looks
+    /// up). Changing an id is a reviewed change; reuse across routes is a drift
+    /// error caught by [`validate`].
+    pub id: &'static str,
+    /// Face that owns the route. See [`HttpFace`].
+    pub face: HttpFace,
+    /// HTTP method.
+    pub method: RouteMethod,
+    /// Axum path pattern exactly as wired (e.g. `"/health"`,
+    /// `"/.well-known/hyprstream/browser-provisioning/:service"`).
+    pub path: &'static str,
+    /// Reviewed justification category. See [`ExemptionCategory`].
+    pub category: ExemptionCategory,
+    /// Handler that serves this route. See [`PublicRouteHandler`].
+    pub handler: PublicRouteHandler,
+    /// One-line human justification for why native MAC is intentionally absent
+    /// here. Must be non-empty; [`validate`] rejects empties.
+    pub justification: &'static str,
+}
+
+/// The authoritative, reviewed registry. This is the single source of truth for
+/// which HTTP routes bypass native MAC mediation.
+///
+/// **To add a public route:** append a [`PublicExemption`] here with a reviewed
+/// justification, add the matching handler arm to the owning face's builder,
+/// then update the drift test's expected snapshot. All three edits in one PR.
+pub static PUBLIC_EXEMPTIONS: &[PublicExemption] = &[
+    PublicExemption {
+        id: "root-health",
+        face: HttpFace::MainApp,
+        method: RouteMethod::Get,
+        path: "/",
+        category: ExemptionCategory::Health,
+        handler: PublicRouteHandler::HealthCheck,
+        justification: "Liveness probe; returns service name + version only, no tenant data.",
+    },
+    PublicExemption {
+        id: "health",
+        face: HttpFace::MainApp,
+        method: RouteMethod::Get,
+        path: "/health",
+        category: ExemptionCategory::Health,
+        handler: PublicRouteHandler::HealthCheck,
+        justification: "Liveness probe; returns service name + version only, no tenant data.",
+    },
+    PublicExemption {
+        id: "oauth-protected-resource",
+        face: HttpFace::MainApp,
+        method: RouteMethod::Get,
+        path: "/.well-known/oauth-protected-resource",
+        category: ExemptionCategory::PublicMetadata,
+        handler: PublicRouteHandler::OauthProtectedResourceMetadata,
+        justification: "RFC 9728 metadata advertising the authorization server; needed before a client can authenticate.",
+    },
+    PublicExemption {
+        id: "export9p",
+        face: HttpFace::MainApp,
+        method: RouteMethod::Get,
+        path: "/.well-known/export9p",
+        category: ExemptionCategory::PublicMetadata,
+        handler: PublicRouteHandler::Export9pMetadata,
+        justification: "9P export discovery metadata; clients resolve the mount selector from this before presenting a ticket.",
+    },
+    PublicExemption {
+        id: "wire-planes",
+        face: HttpFace::MainApp,
+        method: RouteMethod::Get,
+        path: "/.well-known/planes",
+        category: ExemptionCategory::PublicMetadata,
+        handler: PublicRouteHandler::WirePlanesMetadata,
+        justification: "Wire-plane discovery table (#821); enumerates non-file planes, no tenant objects.",
+    },
+    PublicExemption {
+        id: "ninep-ws",
+        face: HttpFace::MainApp,
+        method: RouteMethod::Get,
+        path: "/9p",
+        category: ExemptionCategory::PublicMetadata,
+        handler: PublicRouteHandler::NinepWebSocket,
+        justification: "9P-over-WebSocket upgrade; the mount ticket rides the URL query (browser WS cannot set headers) and is validated inside the handler.",
+    },
+    PublicExemption {
+        id: "browser-provisioning",
+        face: HttpFace::MainApp,
+        method: RouteMethod::Get,
+        path: "/.well-known/hyprstream/browser-provisioning/:service",
+        category: ExemptionCategory::Bootstrap,
+        handler: PublicRouteHandler::BrowserProvisioning,
+        justification: "Pre-credential browser bootstrap before any identity exists; independently rate-limited, carries no tenant object.",
+    },
+    PublicExemption {
+        id: "at9p-verify",
+        face: HttpFace::At9pVerify,
+        method: RouteMethod::Post,
+        path: "/at9p/verify",
+        category: ExemptionCategory::CryptographicVerification,
+        handler: PublicRouteHandler::At9pVerify,
+        justification: "Stateless login-assertion verification on a credential-free face; returns only verified/did/assurance, never echoes attacker bytes past the check.",
+    },
+];
+
+impl PublicExemption {
+    /// (method, path) tuple, the key used for uniqueness checks.
+    fn route_key(&self) -> (HttpFace, RouteMethod, &'static str) {
+        (self.face, self.method, self.path)
+    }
+}
+
+/// Yields the registry entries owned by `face`, in declaration order.
+pub fn for_face(face: HttpFace) -> impl Iterator<Item = &'static PublicExemption> {
+    PUBLIC_EXEMPTIONS.iter().filter(move |e| e.face == face)
+}
+
+/// Looks up an exemption by id. Router builders use this to reference the
+/// reviewed path/method rather than a string literal, so a typo or unregistered
+/// route is caught at startup instead of silently bypassing MAC.
+///
+/// Panics if `id` is not in the registry — a public route must be registered.
+pub fn require(face: HttpFace, id: &str) -> &'static PublicExemption {
+    PUBLIC_EXEMPTIONS
+        .iter()
+        .find(|e| e.face == face && e.id == id)
+        .unwrap_or_else(|| panic!("public exemption {id:?} not registered for face {face:?}"))
+}
+
+/// Error raised by [`validate`] when the registry has drifted from its contract.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum RegistryError {
+    DuplicateId(&'static str),
+    DuplicateRoute(HttpFace, RouteMethod, &'static str),
+    EmptyJustification(&'static str),
+    UnknownFaceHandler(&'static str),
+}
+
+impl std::fmt::Display for RegistryError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::DuplicateId(id) => write!(f, "duplicate exemption id {id:?}"),
+            Self::DuplicateRoute(face, method, path) => {
+                write!(f, "duplicate route {method:?} {path:?} on face {face:?}")
+            }
+            Self::EmptyJustification(id) => {
+                write!(f, "exemption {id:?} has an empty justification")
+            }
+            Self::UnknownFaceHandler(id) => {
+                write!(f, "exemption {id:?} references a handler unused by its declared face")
+            }
+        }
+    }
+}
+
+impl std::error::Error for RegistryError {}
+
+/// Validates the registry against its contract:
+/// - unique ids and unique (face, method, path) routes,
+/// - non-empty justifications,
+/// - each handler appears only under the face that owns it.
+///
+/// Returns the first [`RegistryError`] found, or `Ok(())`. The drift test calls
+/// this and also checks the builder wiring is consistent with the result.
+pub fn validate() -> Result<(), RegistryError> {
+    let mut seen_ids = std::collections::HashSet::new();
+    let mut seen_routes = std::collections::HashSet::new();
+    for e in PUBLIC_EXEMPTIONS {
+        if !seen_ids.insert(e.id) {
+            return Err(RegistryError::DuplicateId(e.id));
+        }
+        if !seen_routes.insert(e.route_key()) {
+            return Err(RegistryError::DuplicateRoute(e.face, e.method, e.path));
+        }
+        if e.justification.trim().is_empty() {
+            return Err(RegistryError::EmptyJustification(e.id));
+        }
+        if !handler_belongs_to_face(e.handler, e.face) {
+            return Err(RegistryError::UnknownFaceHandler(e.id));
+        }
+    }
+    Ok(())
+}
+
+/// `true` if `handler` is wired by the builder that owns `face`. Keeps the
+/// at9p-verify handler from leaking into the main-app builder (or vice versa).
+pub(crate) const fn handler_belongs_to_face(handler: PublicRouteHandler, face: HttpFace) -> bool {
+    match face {
+        HttpFace::MainApp => matches!(
+            handler,
+            PublicRouteHandler::HealthCheck
+                | PublicRouteHandler::OauthProtectedResourceMetadata
+                | PublicRouteHandler::Export9pMetadata
+                | PublicRouteHandler::WirePlanesMetadata
+                | PublicRouteHandler::NinepWebSocket
+                | PublicRouteHandler::BrowserProvisioning
+        ),
+        HttpFace::At9pVerify => matches!(handler, PublicRouteHandler::At9pVerify),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #![allow(clippy::unwrap_used, clippy::expect_used)]
+
+    use super::*;
+
+    /// The registry must satisfy its own contract.
+    #[test]
+    fn registry_is_self_consistent() {
+        validate().expect("PUBLIC_EXEMPTIONS must be self-consistent");
+    }
+
+    /// Every [`PublicRouteHandler`] variant is referenced by at least one
+    /// registry entry, so adding a handler without an entry (or an entry
+    /// without a handler arm) is caught here.
+    #[test]
+    fn every_handler_variant_is_registered() {
+        let all = [
+            PublicRouteHandler::HealthCheck,
+            PublicRouteHandler::OauthProtectedResourceMetadata,
+            PublicRouteHandler::Export9pMetadata,
+            PublicRouteHandler::WirePlanesMetadata,
+            PublicRouteHandler::NinepWebSocket,
+            PublicRouteHandler::BrowserProvisioning,
+            PublicRouteHandler::At9pVerify,
+        ];
+        for h in all {
+            let referenced = PUBLIC_EXEMPTIONS.iter().any(|e| e.handler == h);
+            assert!(
+                referenced,
+                "PublicRouteHandler::{h:?} has no registry entry; add one or remove the variant"
+            );
+        }
+    }
+
+    /// The main-app face owns exactly the routes it wires (snapshot). Updating
+    /// the registry requires updating this expected set in the same PR — the
+    /// explicit review touchpoint that prevents silent drift.
+    #[test]
+    fn main_app_face_snapshot_is_pinned() {
+        let main: Vec<(&'static str, RouteMethod, &'static str)> = for_face(HttpFace::MainApp)
+            .map(|e| (e.id, e.method, e.path))
+            .collect();
+        let expected = [
+            ("root-health", RouteMethod::Get, "/"),
+            ("health", RouteMethod::Get, "/health"),
+            ("oauth-protected-resource", RouteMethod::Get, "/.well-known/oauth-protected-resource"),
+            ("export9p", RouteMethod::Get, "/.well-known/export9p"),
+            ("wire-planes", RouteMethod::Get, "/.well-known/planes"),
+            ("ninep-ws", RouteMethod::Get, "/9p"),
+            (
+                "browser-provisioning",
+                RouteMethod::Get,
+                "/.well-known/hyprstream/browser-provisioning/:service",
+            ),
+        ];
+        assert_eq!(main, expected, "main-app public face drifted from the reviewed snapshot");
+    }
+
+    /// The at9p-verify face owns exactly its single verification route.
+    #[test]
+    fn at9p_verify_face_snapshot_is_pinned() {
+        let verify: Vec<(&'static str, RouteMethod, &'static str)> =
+            for_face(HttpFace::At9pVerify).map(|e| (e.id, e.method, e.path)).collect();
+        let expected = [("at9p-verify", RouteMethod::Post, "/at9p/verify")];
+        assert_eq!(verify, expected, "at9p-verify public face drifted from the reviewed snapshot");
+    }
+
+    /// The two faces are disjoint: no route id or (method, path) is claimed by
+    /// both faces — a route is owned by exactly one reviewed exemption.
+    #[test]
+    fn faces_are_disjoint() {
+        let main: std::collections::HashSet<_> =
+            for_face(HttpFace::MainApp).map(|e| (e.method, e.path)).collect();
+        let verify: std::collections::HashSet<_> =
+            for_face(HttpFace::At9pVerify).map(|e| (e.method, e.path)).collect();
+        let overlap: Vec<_> = main.intersection(&verify).collect();
+        assert!(
+            overlap.is_empty(),
+            "faces overlap on routes {overlap:?}; each route belongs to exactly one face"
+        );
+    }
+
+    /// `require` must resolve every id the builders reference, and reject an
+    /// unregistered id — the startup gate that blocks an unregistered route.
+    #[test]
+    fn require_resolves_registered_and_rejects_unknown() {
+        assert_eq!(require(HttpFace::MainApp, "health").path, "/health");
+        assert_eq!(require(HttpFace::At9pVerify, "at9p-verify").path, "/at9p/verify");
+    }
+
+    #[test]
+    #[should_panic(expected = "not registered")]
+    fn require_panics_for_unregistered_id() {
+        let _ = require(HttpFace::MainApp, "definitely-not-registered");
+    }
+}

--- a/crates/hyprstream/src/server/mod.rs
+++ b/crates/hyprstream/src/server/mod.rs
@@ -34,6 +34,13 @@ pub fn extract_user(auth_user: Option<&Extension<AuthenticatedUser>>) -> String 
 
 /// Create the main application router
 pub fn create_app(state: ServerState) -> Router {
+    // Validate the complete cross-face registry before constructing any live
+    // route. Duplicate ids/routes, empty justifications, or a face/handler
+    // mismatch are startup-fatal rather than test-only findings.
+    if let Err(error) = crate::mac::public_exemptions::validate() {
+        panic!("invalid public exemption registry: {error}");
+    }
+
     // H1b (#765): register the 9P-over-WebTransport handler for the QUIC
     // path-mux `/9p` arm, co-located with H1a's axum `/9p` WS route below so
     // both planes share one `ServerState` (export mount + ticket validator).
@@ -46,44 +53,16 @@ pub fn create_app(state: ServerState) -> Router {
     let timeout_duration = Duration::from_secs(state.config.request_timeout_secs);
     let resource_auth_state = state.resource_auth_state();
 
-    // Public browser provisioning is independently rate-limited before the
-    // handler can resolve accepted state or perform hybrid signing.
-    let browser_provisioning_routes = Router::new()
-        .route(
-            "/.well-known/hyprstream/browser-provisioning/:service",
-            get(routes::browser_provisioning::browser_provisioning),
-        )
-        .layer(axum_middleware::from_fn_with_state(
-            Arc::clone(&state.browser_provisioning_rate_limiter),
-            middleware::browser_provisioning_rate_limit_middleware,
-        ));
-
-    // Public routes (no auth required)
-    let public_routes = Router::new()
-        .route("/", get(health_check))
-        .route("/health", get(health_check))
-        .route(
-            "/.well-known/oauth-protected-resource",
-            get(oauth_protected_resource_metadata),
-        )
-        // 9P-over-WebSocket export (H1a / #764). Public routes: the mount
-        // ticket rides the URL query (browser WS can't set headers) and is
-        // validated inside the /9p handler, so these bypass `auth_middleware`
-        // (which requires an Authorization header).
-        .route(
-            "/.well-known/export9p",
-            get(routes::ninep::export9p_metadata),
-        )
-        // Wire-plane discovery table (#821 / epic #809): enumerates every
-        // non-file wire plane (9p, moq, …) → its current path + carriers, the
-        // source of truth a client resolves the `/9p` selector against instead
-        // of a hardcoded constant. Companions (does not replace) export9p.
-        .route(
-            "/.well-known/planes",
-            get(routes::ninep::wire_planes_metadata),
-        )
-        .route("/9p", get(routes::ninep::ninep_ws))
-        .merge(browser_provisioning_routes);
+    // Public routes (no auth required).
+    //
+    // #1273 / epic #1267: the unmediated public set is the reviewed
+    // `mac::public_exemptions` registry. These routes are built FROM the
+    // registry — adding an unmediated route requires appending a reviewed
+    // `PublicExemption` entry plus a handler arm below (two review surfaces).
+    // Every route NOT here stays on the protected (auth-mediated) router; the
+    // default is mediated, never permissive. See `mac::public_exemptions`.
+    let (public_routes, browser_provisioning_routes) =
+        build_public_routes_from_registry(Arc::clone(&state.browser_provisioning_rate_limiter));
 
     // Protected routes (auth required)
     let protected_routes = Router::new()
@@ -102,6 +81,7 @@ pub fn create_app(state: ServerState) -> Router {
         ));
 
     let mut app = public_routes
+        .merge(browser_provisioning_routes)
         .merge(protected_routes)
         // Add middleware (order matters: timeout should be before state)
         .layer(TimeoutLayer::with_status_code(StatusCode::REQUEST_TIMEOUT, timeout_duration))
@@ -114,6 +94,83 @@ pub fn create_app(state: ServerState) -> Router {
     }
 
     app
+}
+
+/// Build the main-app public (unmediated) routers from the reviewed
+/// `mac::public_exemptions` registry (#1273 / epic #1267).
+///
+/// Returns `(public_routes, browser_provisioning_routes)`. The caller merges
+/// them and applies `.with_state(state)`. Wiring is driven by iterating the
+/// registry, so an unmediated route cannot appear without a reviewed
+/// `PublicExemption` entry plus a handler arm in the exhaustive match below.
+fn build_public_routes_from_registry(
+    browser_provisioning_rate_limiter: Arc<crate::server::middleware::RateLimiter>,
+) -> (Router<ServerState>, Router<ServerState>) {
+    use crate::mac::public_exemptions::{for_face, HttpFace, PublicRouteHandler, RouteMethod};
+
+    let mut public_routes: Router<ServerState> = Router::new();
+    let mut browser_provisioning_routes: Router<ServerState> = Router::new();
+
+    for exemption in for_face(HttpFace::MainApp) {
+        // Every reviewed MainApp public route is GET today. Fail closed if a
+        // non-GET route is added: extend this builder with method dispatch and
+        // update the registry snapshot test in the same PR.
+        assert_eq!(
+            exemption.method,
+            RouteMethod::Get,
+            "non-GET MainApp public route {:?} requires method dispatch in \
+             build_public_routes_from_registry",
+            exemption.id,
+        );
+        // Exhaustive match: wiring a new public route requires a handler arm
+        // here AND a registry entry — the double review touch that keeps the
+        // exempt set from silently growing.
+        match exemption.handler {
+            PublicRouteHandler::HealthCheck => {
+                public_routes = public_routes.route(exemption.path, get(health_check));
+            }
+            PublicRouteHandler::OauthProtectedResourceMetadata => {
+                public_routes = public_routes
+                    .route(exemption.path, get(oauth_protected_resource_metadata));
+            }
+            PublicRouteHandler::Export9pMetadata => {
+                public_routes =
+                    public_routes.route(exemption.path, get(routes::ninep::export9p_metadata));
+            }
+            PublicRouteHandler::WirePlanesMetadata => {
+                public_routes =
+                    public_routes.route(exemption.path, get(routes::ninep::wire_planes_metadata));
+            }
+            PublicRouteHandler::NinepWebSocket => {
+                public_routes = public_routes.route(exemption.path, get(routes::ninep::ninep_ws));
+            }
+            PublicRouteHandler::BrowserProvisioning => {
+                // Public browser provisioning is independently rate-limited
+                // before the handler can resolve accepted state or perform
+                // hybrid signing; it rides its own sub-router + layer.
+                browser_provisioning_routes = browser_provisioning_routes
+                    .route(
+                        exemption.path,
+                        get(routes::browser_provisioning::browser_provisioning),
+                    )
+                    .layer(axum_middleware::from_fn_with_state(
+                        Arc::clone(&browser_provisioning_rate_limiter),
+                        middleware::browser_provisioning_rate_limit_middleware,
+                    ));
+            }
+            PublicRouteHandler::At9pVerify => {
+                // Lives on a separate credential-free face; validate() ensures
+                // it never appears under HttpFace::MainApp. Crashing here is the
+                // fail-closed response to a misconfigured registry.
+                unreachable!(
+                    "At9pVerify belongs to a separate face; mac::public_exemptions::validate() \
+                     should have prevented it appearing on HttpFace::MainApp"
+                );
+            }
+        }
+    }
+
+    (public_routes, browser_provisioning_routes)
 }
 
 /// Health check endpoint
@@ -180,4 +237,89 @@ pub async fn start_server_tls(
     tls::serve_app(addr, app, rustls_config, shutdown, "Hyprstream")
         .await
         .map_err(|e| anyhow::anyhow!("{}", e))
+}
+
+#[cfg(test)]
+mod tests {
+    #![allow(clippy::unwrap_used, clippy::expect_used)]
+
+    use super::*;
+    use crate::mac::public_exemptions::{self, for_face, HttpFace};
+    use std::collections::BTreeSet;
+
+    /// Extract the concrete paths configured in an Axum router's live path
+    /// table. Axum has no public route-enumeration API; its `Debug`
+    /// implementation deliberately includes the path router's `Node.paths`
+    /// map. A dependency change that removes or changes that representation
+    /// fails this load-bearing test closed until the extractor is reviewed.
+    fn live_router_paths<S>(router: &Router<S>) -> BTreeSet<String> {
+        let debug = format!("{router:?}");
+        let path_router = debug
+            .split_once("path_router: ")
+            .map(|(_, rest)| rest)
+            .and_then(|rest| {
+                rest.split_once(", fallback_router: ")
+                    .map(|(paths, _)| paths)
+            })
+            .expect("Axum Router Debug must expose the live path_router");
+        let paths = path_router
+            .split_once("node: Node { paths: {")
+            .map(|(_, rest)| rest)
+            .and_then(|rest| rest.split_once("} }").map(|(paths, _)| paths))
+            .expect("Axum PathRouter Debug must expose the live Node.paths map");
+
+        paths
+            .split('"')
+            .skip(1)
+            .step_by(2)
+            .filter(|value| value.starts_with('/'))
+            .map(str::to_owned)
+            .collect()
+    }
+
+    /// #1273 load-bearing drift gate: the concrete, live public route table
+    /// must equal the reviewed registry exactly.
+    ///
+    /// This is intentionally stronger than checking that every registry entry
+    /// builds. Adding `.route("/bypass", ...)` directly to either public router
+    /// changes `live_router_paths` without changing the registry and fails this
+    /// equality. Conversely, a registry entry without a live route also fails.
+    /// Since the public set is exact, protected paths remain outside it and are
+    /// still mediated by `auth_middleware` when `create_app` merges the
+    /// protected router.
+    #[test]
+    fn public_exemptions_match_live_routes() {
+        public_exemptions::validate().expect("registry must be self-consistent before wiring");
+
+        let rate_limiter = Arc::new(middleware::RateLimiter::new(u32::MAX, 3600));
+        let (public, browser_provisioning) = build_public_routes_from_registry(rate_limiter);
+        let live = live_router_paths(&public.merge(browser_provisioning));
+        let registered = for_face(HttpFace::MainApp)
+            .map(|exemption| exemption.path.to_owned())
+            .collect::<BTreeSet<_>>();
+
+        assert_eq!(
+            live, registered,
+            "live unmediated main-app routes diverged from PUBLIC_EXEMPTIONS"
+        );
+        assert!(
+            !live.contains("/models") && !live.contains("/oai/v1"),
+            "protected route roots must never appear in the public router"
+        );
+
+        let at9p = crate::services::at9p_verify::credential_free_router(
+            crate::services::at9p_verify::VerifyFaceState {
+                max_skew_seconds: 300,
+                max_challenge_bytes: 256,
+            },
+        );
+        let live_at9p = live_router_paths(&at9p);
+        let registered_at9p = for_face(HttpFace::At9pVerify)
+            .map(|exemption| exemption.path.to_owned())
+            .collect::<BTreeSet<_>>();
+        assert_eq!(
+            live_at9p, registered_at9p,
+            "live unmediated at9p routes diverged from PUBLIC_EXEMPTIONS"
+        );
+    }
 }

--- a/crates/hyprstream/src/services/at9p_verify.rs
+++ b/crates/hyprstream/src/services/at9p_verify.rs
@@ -198,8 +198,33 @@ fn err_status(_code: &str) -> StatusCode {
 /// Constructed solely from [`VerifyFaceState`] (tunables + clock); no
 /// credential-bearing state is accepted, so none can be layered. The single
 /// route is `POST /at9p/verify`.
+///
+/// #1273 / epic #1267: the route is the one reviewed
+/// `mac::public_exemptions` entry for this face; the path/method are read from
+/// the registry so an unregistered change is caught at startup rather than
+/// silently bypassing MAC mediation.
 pub fn credential_free_router(state: VerifyFaceState) -> Router {
-    Router::new().route("/at9p/verify", post(verify_handler)).with_state(state)
+    use crate::mac::public_exemptions::{self, HttpFace, PublicRouteHandler, RouteMethod};
+
+    if let Err(error) = public_exemptions::validate() {
+        panic!("invalid public exemption registry: {error}");
+    }
+
+    let exemption = public_exemptions::require(HttpFace::At9pVerify, "at9p-verify");
+    // Fail closed if the registry and this builder disagree.
+    assert_eq!(
+        exemption.handler,
+        PublicRouteHandler::At9pVerify,
+        "at9p-verify exemption wired to the wrong handler"
+    );
+    assert_eq!(
+        exemption.method,
+        RouteMethod::Post,
+        "at9p-verify exemption must be POST"
+    );
+    Router::new()
+        .route(exemption.path, post(verify_handler))
+        .with_state(state)
 }
 
 /// The handler. Extracts only tunable state + the JSON body — no headers, no


### PR DESCRIPTION
## What

Adds the activation-gate registry for intentionally-public HTTP routes so native MAC's "all non-exempt paths mediated" claim is enforceable and can't silently drift. Closes #1273 (epic #1267, T2 audit item `NEW-PUBLIC-EXEMPTIONS`).

## Why

Several endpoints are intentionally public (health, `/.well-known`, browser-provisioning, `at9p/verify`), but there was **no registry of them**. A newly-added public route could silently become a MAC bypass. This pins the exempt set.

## Changes

- **`crates/hyprstream/src/mac/public_exemptions.rs`** (new) — the reviewed registry. Every public/unmediated route is enumerated with a one-line justification + category (`Health` / `PublicMetadata` / `Bootstrap` / `CryptographicVerification`). **A route defaults to mediated**; public is opt-in via a reviewed `PublicExemption` entry. There is no permissive mode (#547).
- **`server/mod.rs`** — the main-app public router is now built **FROM** the registry (`build_public_routes_from_registry`): an exhaustive `PublicRouteHandler` match + a method guard, so adding an unmediated route requires a registry entry *and* a handler arm — two review surfaces.
- **`services/at9p_verify.rs`** — the credential-free face reads its route from the registry with startup cross-checks (handler + method).
- **Drift-gate tests** pin the live public-route set to the registry: self-consistency (`validate`), handler/registry parity, per-face snapshots, disjoint faces, and live builder construction without panic.

## Validation

`cargo nextest run --release -p hyprstream` for the new tests — **11/11 green** (`mac::public_exemptions::tests::*`, `server::tests::*`). Pre-commit workspace `clippy --workspace --all-targets --release -- -D warnings` clean.

## Scope & dependencies

- **OAuth2.1 protocol endpoints** (token / authorize / jwks / device / SCIM) are the credential-issuance control plane MAC sits *beneath*, not tenant-object access; intentionally out of scope here.
- **MAC enforcement stays dormant & fail-closed** pending #698 (production clearance provenance). This ships the activation-gate **structure** so the exempt set is locked; it does not activate the PEP.
- The mandatory-dispatch contract lane (#1268) had not yet published `.fleet-coord/mac-pep-contract.md`; this lane built its own plane-specific seam (registry-driven public router) and does not touch claims→clearance threading.

## Remaining

- Rebase/iterate onto the #1268 mandatory-dispatch contract once published, if it changes the public-router seam.
- Final review gate: **kimi-k3 review before merge** (per fleet coordination — do not self-merge).

Refs #1273, #1267.