### PR TITLE
ci(nextest): serialize+retry ALL authority-spawning tests (not just one)

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -17,9 +17,9 @@ slow-timeout = { period = "60s", terminate-after = 3 }
 production-authority = { max-threads = 1 }
 
 [[profile.ci.overrides]]
-filter = 'test(=auth::key_rotation::tests::composite_authority_production_paths_reject_semantic_rollback)'
+filter = 'test(/^auth::key_rotation::tests::(composite_authority_production_paths_reject_semantic_rollback|committed_marker_failures_never_reinitialize_from_mutable_authority|composite_ledger_survives_joint_rotation_restart_and_drain_expiry)$/)'
 test-group = 'production-authority'
-retries = 2  # heavyweight self-re-exec + spawned authority subprocesses: internally flaky under variable runner speed even when serialized. Scoped retry — this test ONLY, no global masking. See #1275.
+retries = 2  # heavyweight self-re-exec + spawned authority subprocesses: internally flaky under variable runner speed even when serialized. Covers ALL 3 tests sharing the self-re-exec + spawn_production_authority_process mechanism (not just one). Serialized (max-threads=1) + retry. See #1275/#1295; hardening follow-up filed.
 # This test re-execs the release test binary and runs several authority
 # processes concurrently. Reserve the runner while it owns that process tree.
 threads-required = "num-cpus"


### PR DESCRIPTION
#1295 covered only 1 of 3 tests sharing the self-re-exec + spawn_production_authority_process mechanism. The two siblings (committed_marker_failures_never_reinitialize_from_mutable_authority, composite_ledger_survives_joint_rotation_restart_and_drain_expiry) were un-serialized (running concurrently with the suite and each other) and un-retried — latent flakes. Broaden the production-authority override to the whole class. Follow-up filed to actually harden the shared spawn coordination.