### PR TITLE
test(auth): fix authority-test flakiness at root (120s barrier timeout) + un-quarantine [#1299]

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -17,9 +17,9 @@ slow-timeout = { period = "60s", terminate-after = 3 }
 production-authority = { max-threads = 1 }
 
 [[profile.ci.overrides]]
-filter = 'test(=auth::key_rotation::tests::composite_authority_production_paths_reject_semantic_rollback)'
+filter = 'test(/^auth::key_rotation::tests::(composite_authority_production_paths_reject_semantic_rollback|committed_marker_failures_never_reinitialize_from_mutable_authority|composite_ledger_survives_joint_rotation_restart_and_drain_expiry)$/)'
 test-group = 'production-authority'
-retries = 2  # heavyweight self-re-exec + spawned authority subprocesses: internally flaky under variable runner speed even when serialized. Scoped retry — this test ONLY, no global masking. See #1275.
-# This test re-execs the release test binary and runs several authority
-# processes concurrently. Reserve the runner while it owns that process tree.
+# The heavyweight test re-execs the release test binary and runs several
+# authority processes concurrently. Reserve the runner for this authority-test
+# class while each test owns its process tree.
 threads-required = "num-cpus"

--- a/crates/hyprstream/src/auth/key_rotation.rs
+++ b/crates/hyprstream/src/auth/key_rotation.rs
@@ -2429,8 +2429,11 @@ mod tests {
         Ok(())
     }
 
+    const PRODUCTION_AUTHORITY_BARRIER_TIMEOUT: std::time::Duration =
+        std::time::Duration::from_secs(120);
+
     fn wait_path(path: &Path) {
-        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(20);
+        let deadline = std::time::Instant::now() + PRODUCTION_AUTHORITY_BARRIER_TIMEOUT;
         while !path.exists() {
             assert!(
                 std::time::Instant::now() < deadline,
@@ -2446,7 +2449,7 @@ mod tests {
         wait_path(&target_path);
         let target: CompositeCommit =
             serde_json::from_slice(&std::fs::read(target_path).unwrap()).unwrap();
-        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(20);
+        let deadline = std::time::Instant::now() + PRODUCTION_AUTHORITY_BARRIER_TIMEOUT;
         loop {
             let snapshot = hyprstream_rpc::auth::global_composite_key_set().snapshot();
             if snapshot.version() == target.version


### PR DESCRIPTION
Root cause: file-barrier coordination deadlines were 20s — too tight under slow on-demand runners (correlated failures, retries useless). Fix: PRODUCTION_AUTHORITY_BARRIER_TIMEOUT=120s, serialize all 3 authority tests, remove the #1300 quarantine. Assertions unchanged. **HOLD for merge until the 3 tests are confirmed passing reliably in release** — merging this un-quarantines the gate, so it must be validated first (its own merge-group will run them at 120s).