### PR TITLE
fix(wasm): gate inventory + otel off wasm32 — unblock the PR queue

### DIFF
--- a/crates/hyprstream-rpc-derive/src/codegen/vfs.rs
+++ b/crates/hyprstream-rpc-derive/src/codegen/vfs.rs
@@ -406,11 +406,17 @@ pub fn generate_mount(service_name: &str, resolved: &ResolvedSchema) -> TokenStr
         // #699 carrier (a) inventory: register this table so the genesis
         // coverage gate can walk every reachable generated node (annotated or
         // not) at startup. Submitted at module scope via the `inventory`
-        // re-export on `hyprstream_rpc::metadata` (wasm-safe; same pattern as
+        // re-export on `hyprstream_rpc::metadata` (same pattern as
         // `ScopeDefinition`), so consumer crates need not declare an `inventory`
         // dep directly. The gate iterates this to build the startup activation
         // gate; a node missing a `$vfsMac` surfaces as a finding (unlabeled ⇒
         // deny) rather than being silently absent.
+        //
+        // Native-only (#1305): inventory's linker-section registration does not
+        // resolve on wasm32, so the submit is gated off there. The generated
+        // `vfs_nodes()` fn above stays available on all targets — it is the
+        // wasm-compatible path for any browser client that needs the table.
+        #[cfg(not(target_arch = "wasm32"))]
         hyprstream_rpc::metadata::inventory::submit! {
             hyprstream_rpc::metadata::VfsNodeTable {
                 name: #service_name,

--- a/crates/hyprstream-rpc-derive/src/lib.rs
+++ b/crates/hyprstream-rpc-derive/src/lib.rs
@@ -1024,12 +1024,16 @@ pub fn register_scopes(_attr: TokenStream, item: TokenStream) -> TokenStream {
         }
     }
 
-    // Generate inventory submissions
+    // Generate inventory submissions.
+    //
+    // Native-only (#1305): inventory's linker-section registration doesn't
+    // resolve on wasm32, so each submit is gated off there.
     let registrations: Vec<_> = scopes.iter().map(|(action, resource)| {
         let example = format!("{action}:{resource}:*");
         let description = format!("{action} on {resource}");
 
         quote! {
+            #[cfg(not(target_arch = "wasm32"))]
             inventory::submit! {
                 hyprstream_rpc::auth::ScopeDefinition::new(
                     #action,
@@ -1117,11 +1121,16 @@ pub fn service_factory(attr: TokenStream, item: TokenStream) -> TokenStream {
         quote! { .with_depends_on(&[#(#deps),*]) }
     };
 
+    // The `submit!` registrations are native-only (#1305): inventory's
+    // linker-section registration doesn't resolve on wasm32. All current
+    // `#[service_factory]` consumers are native (the daemon); the factory fn
+    // itself is re-emitted ungated.
     let expanded = match (&args.schema, &args.metadata) {
         (Some(schema_path), Some(metadata_path)) => {
             quote! {
                 #func
 
+                #[cfg(not(target_arch = "wasm32"))]
                 inventory::submit! {
                     hyprstream_service::ServiceFactory::with_metadata(
                         #name,
@@ -1136,6 +1145,7 @@ pub fn service_factory(attr: TokenStream, item: TokenStream) -> TokenStream {
             quote! {
                 #func
 
+                #[cfg(not(target_arch = "wasm32"))]
                 inventory::submit! {
                     hyprstream_service::ServiceFactory::with_schema(
                         #name,
@@ -1149,6 +1159,7 @@ pub fn service_factory(attr: TokenStream, item: TokenStream) -> TokenStream {
             quote! {
                 #func
 
+                #[cfg(not(target_arch = "wasm32"))]
                 inventory::submit! {
                     hyprstream_service::ServiceFactory::new(
                         #name,

--- a/crates/hyprstream-rpc/src/_metadata.rs
+++ b/crates/hyprstream-rpc/src/_metadata.rs
@@ -188,6 +188,10 @@ pub type VfsNodesFn = fn() -> (&'static str, &'static [VfsNode]);
 /// walks it) and lets this crate stay free of a `hyprstream-service`
 /// dependency: the macro emits the `inventory::submit!` in whatever crate owns
 /// the generated client module, and the gate (in the daemon crate) iterates it.
+///
+/// On wasm32 (#1305) the link-time registration is compiled out (inventory's
+/// linker-section mechanism doesn't resolve there); the generated
+/// `vfs_nodes()` fn is the wasm-compatible path and stays directly callable.
 pub struct VfsNodeTable {
     /// The `/srv/{name}` service this table belongs to.
     pub name: &'static str,
@@ -195,6 +199,7 @@ pub struct VfsNodeTable {
     pub nodes_fn: VfsNodesFn,
 }
 
+#[cfg(not(target_arch = "wasm32"))]
 inventory::collect!(VfsNodeTable);
 
 /// Function type for service schema metadata.

--- a/crates/hyprstream-rpc/src/auth/scope_registry.rs
+++ b/crates/hyprstream-rpc/src/auth/scope_registry.rs
@@ -27,10 +27,16 @@ impl ScopeDefinition {
     }
 }
 
-// Collect all registered scopes
+// Collect all registered scopes.
+//
+// Native-only (#1305): inventory's link-time registration doesn't resolve on
+// wasm32. The browser client has no scope-registry consumer, so no wasm
+// fallback is needed — the collection and its iterator are compiled out.
+#[cfg(not(target_arch = "wasm32"))]
 inventory::collect!(ScopeDefinition);
 
 /// Get all registered scopes.
+#[cfg(not(target_arch = "wasm32"))]
 pub fn registered_scopes() -> impl Iterator<Item = &'static ScopeDefinition> {
     inventory::iter::<ScopeDefinition>()
 }

--- a/crates/hyprstream-rpc/src/lib.rs
+++ b/crates/hyprstream-rpc/src/lib.rs
@@ -135,6 +135,14 @@ pub mod metadata {
     /// declare an `inventory` dependency — `hyprstream_rpc::metadata::inventory`
     /// resolves wherever `hyprstream-rpc` is a dependency (same pattern the crate
     /// already uses internally for `ScopeDefinition`).
+    ///
+    /// Native-only (#1305): `inventory`'s link-time section registration does not
+    /// work on wasm32, so the dep lives under `cfg(not(target_arch = "wasm32"))`
+    /// and the codegen emits the `submit!` behind the same cfg. On wasm32 the
+    /// generated `vfs_nodes()` table fn remains directly callable — that is the
+    /// wasm-compatible path; nothing in the browser client consumes the
+    /// link-time registry (the only iterator is the native genesis gate).
+    #[cfg(not(target_arch = "wasm32"))]
     pub use inventory;
 
     pub use crate::_metadata::*;

--- a/crates/hyprstream/Cargo.toml
+++ b/crates/hyprstream/Cargo.toml
@@ -72,12 +72,6 @@ hyprstream-p2p = { workspace = true, optional = true }  # P2P transport (formerl
 clap.workspace = true
 inquire = "0.7"
 tracing.workspace = true
-tracing-opentelemetry = { workspace = true, optional = true }
-opentelemetry = { workspace = true, optional = true }
-opentelemetry_sdk = { workspace = true, optional = true }
-opentelemetry-otlp = { workspace = true, optional = true }
-opentelemetry-semantic-conventions = { workspace = true, optional = true }
-opentelemetry-stdout = { workspace = true, optional = true }
 parking_lot.workspace = true
 num_cpus.workspace = true
 once_cell.workspace = true  # For global GitService singleton
@@ -205,13 +199,32 @@ keyring = { version = "3", features = ["windows-native"] }
 [target.'cfg(any(target_os = "freebsd", target_os = "openbsd"))'.dependencies]
 keyring = { version = "3", features = ["sync-secret-service", "crypto-rust"] }
 
+# OpenTelemetry (#1305): the SDK/OTLP stack is not wasm32-compatible (SDK
+# std::time panic opentelemetry-rust#696; OTLP Send-bounds #3155 — both
+# upstream-open), so the optional `otel` deps are native-only. The `otel`
+# feature may still be *enabled* on a wasm32 build (feature flags are
+# target-independent); all otel code is therefore gated
+# `#[cfg(all(feature = "otel", not(target_arch = "wasm32")))]`.
+[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
+tracing-opentelemetry = { workspace = true, optional = true }
+opentelemetry = { workspace = true, optional = true }
+opentelemetry_sdk = { workspace = true, optional = true }
+opentelemetry-otlp = { workspace = true, optional = true }
+opentelemetry-semantic-conventions = { workspace = true, optional = true }
+opentelemetry-stdout = { workspace = true, optional = true }
+
 [features]
 default = ["gittorrent", "xet", "systemd", "otel", "kata-vm", "nspawn"]
 cuda = []
 valkey = ["dep:fred"]  # Enable Valkey/Redis-backed user and token stores
 bnb = ["dep:bitsandbytes-sys"]  # Enable bitsandbytes KV cache quantization (requires compatible ROCm/CUDA)
 xet = ["git2db/xet-storage"]  # Enable XET large file storage
-otel = ["dep:tracing-opentelemetry", "dep:opentelemetry", "dep:opentelemetry_sdk", "dep:opentelemetry-otlp", "dep:opentelemetry-semantic-conventions", "dep:opentelemetry-stdout"]
+# NOTE: plain dependency names (not `dep:`) — cargo rejects `dep:` references
+# to target-specific optional dependencies, and the otel stack is target-gated
+# to non-wasm (#1305, see the target table below). On wasm32 the feature may be
+# enabled but pulls nothing; all otel code is gated
+# `#[cfg(all(feature = "otel", not(target_arch = "wasm32")))]`.
+otel = ["tracing-opentelemetry", "opentelemetry", "opentelemetry_sdk", "opentelemetry-otlp", "opentelemetry-semantic-conventions", "opentelemetry-stdout"]
 gittorrent = ["dep:hyprstream-p2p", "git2db/gittorrent-transport"]  # Enable P2P model sharing via hyprstream-p2p transport (feature name kept for compat)
 download-libtorch = ["tch/download-libtorch"]
 overlayfs = ["git2db/overlayfs"]  # Enable overlayfs-backed worktrees (delegated to git2db)

--- a/crates/hyprstream/src/bin/main.rs
+++ b/crates/hyprstream/src/bin/main.rs
@@ -78,19 +78,19 @@ fn supports_tui() -> bool {
     true
 }
 // Tracing imports (feature-gated)
-#[cfg(feature = "otel")]
+#[cfg(all(feature = "otel", not(target_arch = "wasm32")))]
 use opentelemetry::trace::TracerProvider;
-#[cfg(feature = "otel")]
+#[cfg(all(feature = "otel", not(target_arch = "wasm32")))]
 use opentelemetry::KeyValue;
-#[cfg(feature = "otel")]
+#[cfg(all(feature = "otel", not(target_arch = "wasm32")))]
 use opentelemetry_otlp::{SpanExporter, WithExportConfig};
-#[cfg(feature = "otel")]
+#[cfg(all(feature = "otel", not(target_arch = "wasm32")))]
 use opentelemetry_sdk::Resource;
-#[cfg(feature = "otel")]
+#[cfg(all(feature = "otel", not(target_arch = "wasm32")))]
 use tracing_opentelemetry::OpenTelemetryLayer;
-#[cfg(not(feature = "otel"))]
+#[cfg(any(not(feature = "otel"), target_arch = "wasm32"))]
 use tracing_subscriber::EnvFilter;
-#[cfg(feature = "otel")]
+#[cfg(all(feature = "otel", not(target_arch = "wasm32")))]
 use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt, EnvFilter};
 use tracing_appender::rolling::{RollingFileAppender, Rotation};
 
@@ -370,7 +370,7 @@ where
 // Telemetry
 // ─────────────────────────────────────────────────────────────────────────────
 
-#[cfg(feature = "otel")]
+#[cfg(all(feature = "otel", not(target_arch = "wasm32")))]
 /// Telemetry provider type
 #[derive(Debug, Clone, Copy)]
 enum TelemetryProvider {
@@ -380,7 +380,7 @@ enum TelemetryProvider {
     Stdout,
 }
 
-#[cfg(feature = "otel")]
+#[cfg(all(feature = "otel", not(target_arch = "wasm32")))]
 /// Initialize OpenTelemetry with the specified provider
 fn init_telemetry(provider: TelemetryProvider) -> Result<()> {
     let service_name =
@@ -1709,7 +1709,7 @@ fn main() -> Result<()> {
     let is_service_command = matches.subcommand_name() == Some("service");
     let _log_guard: Option<tracing_appender::non_blocking::WorkerGuard>;
 
-    #[cfg(feature = "otel")]
+    #[cfg(all(feature = "otel", not(target_arch = "wasm32")))]
     {
         let telemetry_provider = if is_service_command {
             TelemetryProvider::Otlp
@@ -1763,7 +1763,7 @@ fn main() -> Result<()> {
         }
     }
 
-    #[cfg(not(feature = "otel"))]
+    #[cfg(any(not(feature = "otel"), target_arch = "wasm32"))]
     {
         let default_log_level = if is_service_command {
             "hyprstream=info"


### PR DESCRIPTION
Closes #1305

Unblocks the wasm queue (#1260 / #1261 / #1265): main is RED on the `WASM (browser client)` check (`cargo check -p hyprstream-rpc --target wasm32-unknown-unknown`) — this makes it green without changing native behavior.

## Changes

**1. inventory (the confirmed break)** — `inventory`'s link-time section registration doesn't resolve on wasm32.
- `hyprstream-rpc`: gated `metadata::inventory` re-export, `inventory::collect!(VfsNodeTable)`, and the `ScopeDefinition` collect/`registered_scopes()` behind `#[cfg(not(target_arch = "wasm32"))]` (the dep was already native-only in Cargo.toml; the code wasn't).
- `hyprstream-rpc-derive`: gated the macro-emitted `inventory::submit!` (`VfsNodeTable` in codegen/vfs.rs, `#[register_scopes]`, `#[service_factory]`) behind the same cfg — this is the mechanism, not the 72 use sites.
- **Wasm-compatible path**: the generated `vfs_nodes()` table fn stays compiled on all targets and is directly callable. Recon confirmed nothing in the browser client (`hyprstream-rpc-std`) iterates the link-time registry — the only `inventory::iter::<VfsNodeTable>` consumer is the native genesis gate (`hyprstream/src/mac/genesis.rs`), and `rpc-std`'s own `MountFactory` inventory use was already wasm-gated — so no wasm registration fallback is needed.

**2. jwt.rs** — already fixed on main: `auth/jwt.rs:429,443` already carry `#[cfg(not(target_arch = "wasm32"))]` for the `tracing`/`FederationKey` uses. No change needed; verified the wasm build passes.

**3. otel** — opentelemetry SDK/OTLP are not wasm32-compatible (upstream-open: opentelemetry-rust #696, #3155).
- `hyprstream/Cargo.toml`: the six optional otel deps moved under `[target.'cfg(not(target_arch = "wasm32"))'.dependencies]`. The `otel` feature now uses plain dep names — cargo rejects `dep:` refs to target-specific optional deps (verified: feature enabled + wasm target resolves and builds).
- `bin/main.rs`: all otel code paths gated `#[cfg(all(feature = "otel", not(target_arch = "wasm32")))]` (and the fallback `any(not(feature = "otel"), target_arch = "wasm32")`). This is the pattern #1261's `token_metrics` needs when it rebases.

## Validation (both gates green locally)

- **wasm32**: `cargo check --target wasm32-unknown-unknown -p hyprstream-rpc` (the CI gate) green; `-p hyprstream-rpc-std` (browser client, with the frontend's `--cfg getrandom_backend="wasm_js"` flag) green.
- **native**: `cargo build -p hyprstream --no-default-features --features "gittorrent,xet,otel"` green (rocm71 libtorch, via hyprstream-build.sh); `clippy --all-targets -- -D warnings` clean on the touched crates; otel-off (`gittorrent,xet`) check green.

Merge-authorized per #1305 (owner), but an independent review must clear before merge.