### PR TITLE
inference: add tenant-bound CPU deployment profile

### DIFF
--- a/crates/hyprstream/src/runtime/inference_profile.rs
+++ b/crates/hyprstream/src/runtime/inference_profile.rs
@@ -1,0 +1,385 @@
+//! Deployment and scheduling contract for inference-engine instances.
+//!
+//! Engine isolation is deliberately separate from model architecture. A
+//! `TorchEngine` keeps one contract whether an operator places it in the host
+//! process, a tenant subprocess, or an isolated task/microVM.
+
+use anyhow::{ensure, Result};
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+use std::path::{Path, PathBuf};
+
+/// Address-space isolation selected for an inference engine.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum InferenceIsolationProfile {
+    /// Dedicated engine thread in the model-service process.
+    ///
+    /// Valid only for a single-tenant development deployment.
+    InProcess,
+    /// One operating-system process per authority-verified tenant.
+    PerTenantSubprocess,
+    /// One sandbox task or microVM per authority-verified tenant.
+    PerTenantMicroVmTask {
+        /// Explicit worker backend (for example `kata`). An unavailable backend
+        /// must fail rather than downgrade.
+        backend: String,
+    },
+}
+
+/// Tenancy posture of the deployment hosting inference.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum InferenceTenancy {
+    /// One tenant, intended for development and trusted appliances.
+    SingleTenantDevelopment,
+    /// More than one mutually untrusted tenant may reach the deployment.
+    SharedMultiTenant,
+}
+
+/// Accelerator class reserved for each engine instance.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum InferenceCompute {
+    /// CPU-only execution. This is the initial demo profile.
+    Cpu,
+    /// A specific GPU is assigned by the scheduler.
+    Gpu,
+    /// Preserve legacy auto-detection in single-tenant development.
+    Auto,
+}
+
+/// Per-instance resource and lifecycle limits.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct InferenceResourceBudget {
+    /// CPU reservation in millicores.
+    pub cpu_millis: u32,
+    /// Resident-memory ceiling.
+    pub memory_bytes: u64,
+    /// VRAM ceiling. Must be zero for [`InferenceCompute::Cpu`].
+    pub gpu_vram_bytes: u64,
+    /// Maximum time allowed for model preparation.
+    pub startup_timeout_ms: u64,
+    /// Maximum time a health probe may take.
+    pub health_check_timeout_ms: u64,
+    /// Maximum time allowed for drain and teardown.
+    pub teardown_timeout_ms: u64,
+}
+
+impl Default for InferenceResourceBudget {
+    fn default() -> Self {
+        Self {
+            cpu_millis: 1_000,
+            memory_bytes: 8 * 1024 * 1024 * 1024,
+            gpu_vram_bytes: 0,
+            startup_timeout_ms: 300_000,
+            health_check_timeout_ms: 5_000,
+            teardown_timeout_ms: 30_000,
+        }
+    }
+}
+
+/// Explicit inference deployment profile validated before scheduling.
+///
+/// The current in-process path consumes the compute selector. Isolation and
+/// resource budgets are the contract for an external launcher; selecting one
+/// of those profiles fails closed until that launcher is present.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct InferenceDeploymentProfile {
+    pub isolation: InferenceIsolationProfile,
+    pub tenancy: InferenceTenancy,
+    pub compute: InferenceCompute,
+    pub resources: InferenceResourceBudget,
+}
+
+impl Default for InferenceDeploymentProfile {
+    fn default() -> Self {
+        Self {
+            isolation: InferenceIsolationProfile::InProcess,
+            tenancy: InferenceTenancy::SingleTenantDevelopment,
+            compute: InferenceCompute::Auto,
+            resources: InferenceResourceBudget::default(),
+        }
+    }
+}
+
+impl InferenceDeploymentProfile {
+    /// CPU-only profile used by the demo.
+    #[must_use]
+    pub fn cpu_demo(isolation: InferenceIsolationProfile, tenancy: InferenceTenancy) -> Self {
+        Self {
+            isolation,
+            tenancy,
+            compute: InferenceCompute::Cpu,
+            resources: InferenceResourceBudget::default(),
+        }
+    }
+
+    /// Load the production scheduling profile from explicit environment
+    /// signals. Unknown values fail startup; they never fall back to weaker
+    /// isolation or automatic accelerator selection.
+    pub fn from_env() -> Result<Self> {
+        let mut profile = Self::default();
+        if let Ok(value) = std::env::var("HYPRSTREAM_INFERENCE_ISOLATION") {
+            profile.isolation = match value.as_str() {
+                "in-process" => InferenceIsolationProfile::InProcess,
+                "per-tenant-subprocess" => InferenceIsolationProfile::PerTenantSubprocess,
+                "per-tenant-microvm-task" => {
+                    let backend =
+                        std::env::var("HYPRSTREAM_INFERENCE_SANDBOX_BACKEND").map_err(|_| {
+                            anyhow::anyhow!(
+                                "HYPRSTREAM_INFERENCE_SANDBOX_BACKEND is required for \
+                                 per-tenant-microvm-task"
+                            )
+                        })?;
+                    InferenceIsolationProfile::PerTenantMicroVmTask { backend }
+                }
+                other => anyhow::bail!(
+                    "HYPRSTREAM_INFERENCE_ISOLATION must be 'in-process', \
+                     'per-tenant-subprocess', or 'per-tenant-microvm-task', got {other:?}"
+                ),
+            };
+        }
+        if let Ok(value) = std::env::var("HYPRSTREAM_INFERENCE_TENANCY") {
+            profile.tenancy = match value.as_str() {
+                "single-tenant-development" => InferenceTenancy::SingleTenantDevelopment,
+                "shared-multi-tenant" => InferenceTenancy::SharedMultiTenant,
+                other => anyhow::bail!(
+                    "HYPRSTREAM_INFERENCE_TENANCY must be 'single-tenant-development' \
+                     or 'shared-multi-tenant', got {other:?}"
+                ),
+            };
+        }
+        if let Ok(value) = std::env::var("HYPRSTREAM_INFERENCE_COMPUTE") {
+            profile.compute = match value.as_str() {
+                "cpu" => InferenceCompute::Cpu,
+                "gpu" => InferenceCompute::Gpu,
+                "auto" => InferenceCompute::Auto,
+                other => anyhow::bail!(
+                    "HYPRSTREAM_INFERENCE_COMPUTE must be 'cpu', 'gpu', or 'auto', got {other:?}"
+                ),
+            };
+        }
+        apply_u32_env(
+            "HYPRSTREAM_INFERENCE_CPU_MILLIS",
+            &mut profile.resources.cpu_millis,
+        )?;
+        apply_u64_env(
+            "HYPRSTREAM_INFERENCE_MEMORY_BYTES",
+            &mut profile.resources.memory_bytes,
+        )?;
+        apply_u64_env(
+            "HYPRSTREAM_INFERENCE_GPU_VRAM_BYTES",
+            &mut profile.resources.gpu_vram_bytes,
+        )?;
+        apply_u64_env(
+            "HYPRSTREAM_INFERENCE_STARTUP_TIMEOUT_MS",
+            &mut profile.resources.startup_timeout_ms,
+        )?;
+        apply_u64_env(
+            "HYPRSTREAM_INFERENCE_HEALTH_TIMEOUT_MS",
+            &mut profile.resources.health_check_timeout_ms,
+        )?;
+        apply_u64_env(
+            "HYPRSTREAM_INFERENCE_TEARDOWN_TIMEOUT_MS",
+            &mut profile.resources.teardown_timeout_ms,
+        )?;
+        profile.validate()?;
+        Ok(profile)
+    }
+
+    /// Validate the deployment contract before an engine is loaded.
+    pub fn validate(&self) -> Result<()> {
+        ensure!(
+            self.resources.cpu_millis > 0,
+            "inference CPU budget must be non-zero"
+        );
+        ensure!(
+            self.resources.memory_bytes > 0,
+            "inference memory budget must be non-zero"
+        );
+        ensure!(
+            self.resources.startup_timeout_ms > 0
+                && self.resources.health_check_timeout_ms > 0
+                && self.resources.teardown_timeout_ms > 0,
+            "inference lifecycle timeouts must be non-zero"
+        );
+        if self.compute == InferenceCompute::Cpu {
+            ensure!(
+                self.resources.gpu_vram_bytes == 0,
+                "CPU inference profile cannot reserve GPU VRAM"
+            );
+        }
+        if self.compute == InferenceCompute::Gpu {
+            ensure!(
+                self.resources.gpu_vram_bytes > 0,
+                "GPU inference profile requires an explicit VRAM budget"
+            );
+        }
+        ensure!(
+            !(self.tenancy == InferenceTenancy::SharedMultiTenant
+                && self.isolation == InferenceIsolationProfile::InProcess),
+            "shared multi-tenant inference requires per-tenant subprocess or microVM/task isolation"
+        );
+        if let InferenceIsolationProfile::PerTenantMicroVmTask { backend } = &self.isolation {
+            ensure!(
+                !backend.trim().is_empty() && backend != "auto",
+                "microVM/task inference requires an explicit sandbox backend"
+            );
+        }
+        Ok(())
+    }
+
+    /// Whether this profile needs an out-of-process launcher.
+    #[must_use]
+    pub fn requires_isolated_launcher(&self) -> bool {
+        !matches!(self.isolation, InferenceIsolationProfile::InProcess)
+    }
+}
+
+fn apply_u32_env(name: &str, target: &mut u32) -> Result<()> {
+    if let Ok(value) = std::env::var(name) {
+        *target = value.parse().map_err(|e| {
+            anyhow::anyhow!("{name} must be an unsigned integer, got {value:?}: {e}")
+        })?;
+    }
+    Ok(())
+}
+
+fn apply_u64_env(name: &str, target: &mut u64) -> Result<()> {
+    if let Ok(value) = std::env::var(name) {
+        *target = value.parse().map_err(|e| {
+            anyhow::anyhow!("{name} must be an unsigned integer, got {value:?}: {e}")
+        })?;
+    }
+    Ok(())
+}
+
+/// Tenant/model/replica identity used for placement and endpoint derivation.
+///
+/// The tenant is accepted only after it came from `EnvelopeContext::domain()`.
+/// It is never derived from subject text or caller-supplied model input.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct InferenceInstanceId {
+    tenant: String,
+    model_ref: String,
+    replica: u16,
+}
+
+impl InferenceInstanceId {
+    pub fn new(verified_tenant: &str, model_ref: &str, replica: u16) -> Result<Self> {
+        let tenant = verified_tenant.trim();
+        ensure!(
+            !tenant.is_empty() && tenant != "*",
+            "inference instance requires a non-empty, non-wildcard verified tenant"
+        );
+        ensure!(
+            !model_ref.trim().is_empty(),
+            "inference instance requires a model ref"
+        );
+        Ok(Self {
+            tenant: tenant.to_owned(),
+            model_ref: model_ref.to_owned(),
+            replica,
+        })
+    }
+
+    #[must_use]
+    pub fn tenant(&self) -> &str {
+        &self.tenant
+    }
+
+    #[must_use]
+    pub fn model_ref(&self) -> &str {
+        &self.model_ref
+    }
+
+    #[must_use]
+    pub fn replica(&self) -> u16 {
+        self.replica
+    }
+
+    /// Opaque, deterministic name safe for registries and process managers.
+    #[must_use]
+    pub fn service_name(&self) -> String {
+        let mut digest = Sha256::new();
+        digest.update(b"hyprstream-inference-instance-v1\0");
+        digest.update(self.tenant.as_bytes());
+        digest.update(b"\0");
+        digest.update(self.model_ref.as_bytes());
+        digest.update(b"\0");
+        digest.update(self.replica.to_be_bytes());
+        let suffix = hex::encode(&digest.finalize()[..12]);
+        format!("inference-{suffix}")
+    }
+
+    /// Same-host cross-process dial target for a subprocess placement.
+    #[must_use]
+    pub fn ipc_transport(&self, runtime_dir: &Path) -> hyprstream_rpc::transport::TransportConfig {
+        let path: PathBuf = runtime_dir.join(format!("{}.sock", self.service_name()));
+        hyprstream_rpc::transport::TransportConfig::ipc(path)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn shared_tenancy_rejects_in_process_profile() {
+        let profile = InferenceDeploymentProfile::cpu_demo(
+            InferenceIsolationProfile::InProcess,
+            InferenceTenancy::SharedMultiTenant,
+        );
+        assert!(profile.validate().is_err());
+    }
+
+    #[test]
+    fn shared_cpu_subprocess_profile_is_valid() {
+        let profile = InferenceDeploymentProfile::cpu_demo(
+            InferenceIsolationProfile::PerTenantSubprocess,
+            InferenceTenancy::SharedMultiTenant,
+        );
+        assert!(profile.validate().is_ok());
+        assert!(profile.requires_isolated_launcher());
+    }
+
+    #[test]
+    fn two_tenants_get_distinct_opaque_dial_targets() -> Result<()> {
+        let first = InferenceInstanceId::new("tenant-a", "tiny-llama:main", 0)?;
+        let second = InferenceInstanceId::new("tenant-b", "tiny-llama:main", 0)?;
+        assert_ne!(first.service_name(), second.service_name());
+        assert_ne!(
+            first.ipc_transport(Path::new("/run/hyprstream")),
+            second.ipc_transport(Path::new("/run/hyprstream"))
+        );
+        assert!(!first.service_name().contains("tenant-a"));
+        Ok(())
+    }
+
+    #[test]
+    fn wildcard_or_blank_tenant_fails_closed() {
+        assert!(InferenceInstanceId::new("*", "model:main", 0).is_err());
+        assert!(InferenceInstanceId::new(" ", "model:main", 0).is_err());
+    }
+
+    #[test]
+    fn replica_identity_changes_dial_target() -> Result<()> {
+        let first = InferenceInstanceId::new("tenant-a", "tiny-llama:main", 0)?;
+        let second = InferenceInstanceId::new("tenant-a", "tiny-llama:main", 1)?;
+        assert_ne!(first.service_name(), second.service_name());
+        Ok(())
+    }
+
+    #[test]
+    fn two_cpu_models_get_distinct_service_addresses() -> Result<()> {
+        let first = InferenceInstanceId::new("tenant-a", "model-one:main", 0)?;
+        let second = InferenceInstanceId::new("tenant-a", "model-two:main", 0)?;
+        assert_ne!(first.service_name(), second.service_name());
+        assert_ne!(
+            first.ipc_transport(Path::new("/run/hyprstream")),
+            second.ipc_transport(Path::new("/run/hyprstream"))
+        );
+        Ok(())
+    }
+}

--- a/crates/hyprstream/src/runtime/mod.rs
+++ b/crates/hyprstream/src/runtime/mod.rs
@@ -35,6 +35,7 @@ pub use crate::services::generated::model_client::KVQuantType;
 pub mod tensor_sampling; // Device-agnostic tensor-based sampling
 pub mod device_pool; // Multi-GPU device abstraction (DevicePool) — Send+Sync, holds only Device values
 pub mod image_utils; // Image loading and preprocessing for multimodal models
+pub mod inference_profile; // Explicit inference isolation/deployment scheduling profile
 pub mod kv_cache; // Key-Value caching for efficient autoregressive generation
 pub mod model_config; // Unified model configuration management
 pub mod model_factory; // Single factory for model creation

--- a/crates/hyprstream/src/services/factories.rs
+++ b/crates/hyprstream/src/services/factories.rs
@@ -988,16 +988,18 @@ fn create_model_service(ctx: &ServiceContext) -> anyhow::Result<Box<dyn Spawnabl
             .build()
             .expect("failed to create runtime for model factory");
         let local = tokio::task::LocalSet::new();
-        local.block_on(
-            &rt,
+        local.block_on(&rt, {
+            let mut model_config = ModelServiceConfig::default();
+            model_config.inference_deployment =
+                crate::runtime::inference_profile::InferenceDeploymentProfile::from_env()?;
             ModelService::new(
-                ModelServiceConfig::default(),
+                model_config,
                 sk.clone(),
                 policy_client,
                 registry_client,
                 ctx.transport("model", SocketKind::Rep),
-            ),
-        )
+            )
+        })
     })?;
     if let Some(issuer) = ctx.oauth_issuer_url() {
         model_service = model_service.with_expected_audience(issuer.to_owned());

--- a/crates/hyprstream/src/services/inference.rs
+++ b/crates/hyprstream/src/services/inference.rs
@@ -167,6 +167,11 @@ pub struct InferenceServiceInner {
     /// LoRA generation counter — incremented on create/load/unload.
     /// Checked before generation to detect LoRA reconfiguration mid-stream.
     lora_generation: Arc<AtomicU64>,
+    /// Authority-verified tenant that owns this engine instance.
+    tenant_domain: String,
+    /// Verified key of the ModelService controller allowed to bridge a local
+    /// request into this tenant-bound instance.
+    controller_pubkey: VerifyingKey,
 }
 
 /// ZMQ-based inference service
@@ -194,6 +199,23 @@ impl std::ops::Deref for InferenceService {
 // TestTimeTrainer, etc.) which all have `unsafe impl Send + Sync`.
 unsafe impl Send for InferenceServiceInner {}
 unsafe impl Sync for InferenceServiceInner {}
+
+fn resolve_instance_domain(
+    tenant_domain: &str,
+    controller_pubkey: &VerifyingKey,
+    ctx: &EnvelopeContext,
+) -> Result<String> {
+    let domain = ctx.domain()?;
+    if domain == tenant_domain {
+        return Ok(domain);
+    }
+    if domain == "local" && ctx.cnf == controller_pubkey.to_bytes() {
+        return Ok(tenant_domain.to_owned());
+    }
+    anyhow::bail!(
+        "authorization denied: inference instance is bound to a different verified tenant"
+    )
+}
 
 // Intermediate response structs (DeltaStatusInfo, SaveAdaptationResult, SnapshotDeltaResult,
 // ExportPeftResult) eliminated — handlers return generated types directly.
@@ -255,6 +277,8 @@ impl InferenceService {
         nonce_cache: Arc<InMemoryNonceCache>,
         policy_client: PolicyClient,
         fs: Option<WorktreeClient>,
+        tenant_domain: String,
+        controller_pubkey: VerifyingKey,
     ) -> Result<Self> {
         // Capture runtime handle for reuse in handlers
         let runtime_handle = Handle::current();
@@ -401,8 +425,20 @@ impl InferenceService {
                 fs,
                 transport: hyprstream_rpc::transport::TransportConfig::inproc("inference-unset"),
                 lora_generation: Arc::new(AtomicU64::new(0)),
+                tenant_domain,
+                controller_pubkey,
             }),
         })
+    }
+
+    /// Resolve the authorization domain for this tenant-bound engine.
+    ///
+    /// A direct caller must carry the same authority-verified tenant. The only
+    /// exception is the local ModelService bridge, whose verified signer key is
+    /// pinned when the instance is created; that bridge inherits this
+    /// instance's tenant instead of the generic `local` domain.
+    fn authorization_domain(&self, ctx: &EnvelopeContext) -> Result<String> {
+        resolve_instance_domain(&self.tenant_domain, &self.controller_pubkey, ctx)
     }
 
     /// Resolve the effective delta for a subject: compose base_delta + tenant delta if both exist.
@@ -1892,7 +1928,7 @@ fn map_adaptation_strategy(
 impl InferenceHandler for InferenceService {
     async fn authorize(&self, ctx: &EnvelopeContext, resource: &str, operation: &str) -> Result<()> {
         let subject = ctx.subject();
-        let domain = ctx.domain()?;
+        let domain = self.authorization_domain(ctx)?;
         let allowed = self.policy_client.check(&PolicyCheck { subject: subject.to_string(), domain, resource: resource.to_owned(), operation: operation.to_owned() }).await.unwrap_or_else(|e| {
             warn!("Policy check failed for {} on {}: {} - denying access", subject, resource, e);
             false
@@ -2374,6 +2410,8 @@ impl hyprstream_rpc::service::RequestService for InferenceZmqAdapter {
     }
 
     fn name(&self) -> &str {
+        // Keep the canonical MAC object label even though the Spawnable
+        // registration is instance-specific.
         "inference"
     }
 
@@ -2424,6 +2462,7 @@ impl hyprstream_rpc::service::RequestService for InferenceZmqAdapter {
 /// It is `Send` and can be moved to a dedicated thread via `Spawnable::run()`.
 /// The actual GPU initialization happens on the service thread.
 pub struct InferenceServiceConfig {
+    service_name: String,
     model_path: PathBuf,
     config: RuntimeConfig,
     server_pubkey: VerifyingKey,
@@ -2439,6 +2478,10 @@ pub struct InferenceServiceConfig {
     expected_audience: Option<String>,
     /// JWT key source for verifying JWTs (local and federated).
     jwt_key_source: Option<std::sync::Arc<dyn hyprstream_rpc::auth::JwtKeySource>>,
+    /// Tenant binding inherited from the authority-verified ModelService call.
+    tenant_domain: String,
+    /// ModelService key allowed to bridge local calls into this tenant.
+    controller_pubkey: VerifyingKey,
 }
 
 impl InferenceServiceConfig {
@@ -2460,6 +2503,7 @@ impl InferenceServiceConfig {
     ) -> Self {
         let policy_signing_key = signing_key.clone();
         Self {
+            service_name: "inference".to_owned(),
             model_path: model_path.as_ref().to_path_buf(),
             config,
             server_pubkey,
@@ -2469,7 +2513,23 @@ impl InferenceServiceConfig {
             fs,
             expected_audience: None,
             jwt_key_source: None,
+            tenant_domain: "local".to_owned(),
+            controller_pubkey: server_pubkey,
         }
+    }
+
+    /// Bind this engine to one verified tenant and one controller identity.
+    #[must_use]
+    pub fn with_instance_identity(
+        mut self,
+        service_name: String,
+        tenant_domain: String,
+        controller_pubkey: VerifyingKey,
+    ) -> Self {
+        self.service_name = service_name;
+        self.tenant_domain = tenant_domain;
+        self.controller_pubkey = controller_pubkey;
+        self
     }
 
     /// Set the expected audience for JWT validation.
@@ -2490,7 +2550,7 @@ impl InferenceServiceConfig {
 
 impl hyprstream_service::Spawnable for InferenceServiceConfig {
     fn name(&self) -> &str {
-        "inference"
+        &self.service_name
     }
 
     fn registrations(&self) -> Vec<(hyprstream_rpc::registry::SocketKind, hyprstream_rpc::transport::TransportConfig)> {
@@ -2521,6 +2581,7 @@ impl hyprstream_service::Spawnable for InferenceServiceConfig {
 
             // Destructure so the (Send) config moves into the on-thread builder.
             let InferenceServiceConfig {
+                service_name: _,
                 model_path,
                 config,
                 server_pubkey,
@@ -2530,6 +2591,8 @@ impl hyprstream_service::Spawnable for InferenceServiceConfig {
                 fs,
                 expected_audience,
                 jwt_key_source,
+                tenant_domain,
+                controller_pubkey,
             } = *self;
             let adapter_transport = transport.clone();
 
@@ -2552,6 +2615,8 @@ impl hyprstream_service::Spawnable for InferenceServiceConfig {
                         Arc::clone(&bridge_nonce),
                         policy_client,
                         fs,
+                        tenant_domain,
+                        controller_pubkey,
                     )
                     .await
                     .map_err(|e| anyhow::anyhow!("inference init: {e}"))?;
@@ -2681,3 +2746,58 @@ impl StreamChunkMessage {
 
 // StreamHandle consolidated: uses hyprstream_rpc::streaming::StreamHandle (re-exported via rpc_types)
 // Use StreamChunkMessage::from_stream_payload() to convert StreamPayload → StreamChunkMessage
+
+#[cfg(test)]
+mod tenant_binding_tests {
+    use super::*;
+    use hyprstream_rpc::envelope::Subject;
+
+    fn key(seed: u8) -> SigningKey {
+        SigningKey::from_bytes(&[seed; 32])
+    }
+
+    #[test]
+    fn direct_request_must_match_instance_tenant() {
+        let controller = key(7).verifying_key();
+        let caller = key(8).verifying_key();
+        let same = EnvelopeContext::for_test_authenticated_subject_in_tenant(
+            Subject::new("alice"),
+            "tenant-a",
+            caller,
+        );
+        assert_eq!(
+            resolve_instance_domain("tenant-a", &controller, &same)
+                .unwrap_or_else(|e| panic!("matching tenant must pass: {e}")),
+            "tenant-a"
+        );
+
+        let other = EnvelopeContext::for_test_authenticated_subject_in_tenant(
+            Subject::new("mallory"),
+            "tenant-b",
+            caller,
+        );
+        assert!(resolve_instance_domain("tenant-a", &controller, &other).is_err());
+    }
+
+    #[test]
+    fn only_pinned_controller_can_bridge_local_domain() {
+        let controller = key(7).verifying_key();
+        let local_controller = EnvelopeContext::for_test_authenticated_subject_in_tenant(
+            Subject::new("system"),
+            "local",
+            controller,
+        );
+        assert_eq!(
+            resolve_instance_domain("tenant-a", &controller, &local_controller)
+                .unwrap_or_else(|e| panic!("pinned controller must pass: {e}")),
+            "tenant-a"
+        );
+
+        let impostor = EnvelopeContext::for_test_authenticated_subject_in_tenant(
+            Subject::new("system"),
+            "local",
+            key(9).verifying_key(),
+        );
+        assert!(resolve_instance_domain("tenant-a", &controller, &impostor).is_err());
+    }
+}

--- a/crates/hyprstream/src/services/model.rs
+++ b/crates/hyprstream/src/services/model.rs
@@ -31,6 +31,10 @@ use async_trait::async_trait;
 // GenerationRequest import removed — was only used by deleted ModelZmqClient
 use crate::runtime::KVQuantType;
 use crate::runtime::RuntimeConfig;
+use crate::runtime::inference_profile::{
+    InferenceCompute, InferenceDeploymentProfile, InferenceInstanceId,
+    InferenceIsolationProfile,
+};
 use crate::services::{
     EnvelopeContext,
     PolicyClient,
@@ -89,6 +93,8 @@ pub enum ModelLoadTerminal {
 /// per-epoch keying the first `Loaded` latch would shadow every reload.
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub struct ModelLoadKey {
+    /// Authority-verified tenant that owns this load attempt.
+    pub tenant: String,
     /// The model reference string (e.g. "qwen3-small:main").
     pub model_ref: String,
     /// Monotonic load-attempt number for this process.
@@ -102,6 +108,8 @@ pub struct ModelLoadKey {
 
 /// Information about a loaded model
 pub struct LoadedModel {
+    /// Tenant/model/replica identity of this inference instance.
+    pub instance: InferenceInstanceId,
     /// Model reference string (e.g., "qwen3-small:main")
     pub model_ref: String,
     /// Resolved transport for this model's InferenceService (#320). For a
@@ -144,6 +152,8 @@ pub struct ModelServiceConfig {
     pub max_context: Option<u32>,
     /// KV cache quantization type
     pub kv_quant: KVQuantType,
+    /// Isolation, tenancy, compute, and resource contract for spawned engines.
+    pub inference_deployment: InferenceDeploymentProfile,
 }
 
 impl Default for ModelServiceConfig {
@@ -152,6 +162,7 @@ impl Default for ModelServiceConfig {
             max_models: 5,
             max_context: None,
             kv_quant: KVQuantType::None,
+            inference_deployment: InferenceDeploymentProfile::default(),
         }
     }
 }
@@ -160,9 +171,9 @@ impl Default for ModelServiceConfig {
 pub struct ModelServiceInner {
     // Business logic
     /// LRU cache of loaded models
-    loaded_models: RwLock<LruCache<String, LoadedModel>>,
+    loaded_models: RwLock<LruCache<InferenceInstanceId, LoadedModel>>,
     /// Models currently being loaded (accepted but not yet in LRU cache)
-    pending_loads: Mutex<HashSet<String>>,
+    pending_loads: Mutex<HashSet<InferenceInstanceId>>,
     /// Service configuration
     config: ModelServiceConfig,
     /// Ed25519 signing key for creating InferenceClients
@@ -184,8 +195,8 @@ pub struct ModelServiceInner {
     /// federation; `resolve_model_ref`'s at:// branch then falls through to
     /// local resolution.
     discovery_client: Option<Arc<hyprstream_discovery::DiscoveryClient>>,
-    /// Persistent 9P synthetic tree for the fs scope (lazily initialized).
-    fs_tree: std::sync::OnceLock<crate::services::fs::SyntheticTree>,
+    /// Persistent 9P synthetic trees, partitioned by authority-verified tenant.
+    fs_trees: dashmap::DashMap<String, Arc<crate::services::fs::SyntheticTree>>,
     /// Retained terminal for each model load attempt (EV7/#649) — the
     /// host-side "file holds the truth" retain. A late `load --wait` reads the
     /// retained [`ModelLoadTerminal`] from here instead of missing the live
@@ -197,6 +208,9 @@ pub struct ModelServiceInner {
     /// allocates the next value, keying a fresh [`TerminalStore`] entry so a
     /// reload latches under a new key (reload ⇒ new terminal, EV7/#649).
     load_epoch: AtomicU64,
+    /// The sole tenant admitted by an in-process deployment. A second tenant
+    /// must never share the FFI engine fault radius.
+    in_process_tenant: std::sync::OnceLock<String>,
 }
 
 /// Model service that manages InferenceService lifecycle.
@@ -210,6 +224,30 @@ pub struct ModelServiceInner {
 /// list, health, info, and other requests during long GPU weight transfers.
 pub struct ModelService {
     inner: Arc<ModelServiceInner>,
+}
+
+fn admit_in_process_tenant(
+    admitted_tenant: &std::sync::OnceLock<String>,
+    verified_tenant: &str,
+) -> Result<()> {
+    if let Some(admitted) = admitted_tenant.get() {
+        anyhow::ensure!(
+            admitted == verified_tenant,
+            "in-process inference is bound to tenant {admitted:?}; refusing cross-tenant engine sharing"
+        );
+        return Ok(());
+    }
+
+    if admitted_tenant.set(verified_tenant.to_owned()).is_err() {
+        let admitted = admitted_tenant
+            .get()
+            .ok_or_else(|| anyhow!("in-process tenant admission raced without a winner"))?;
+        anyhow::ensure!(
+            admitted == verified_tenant,
+            "in-process inference is bound to tenant {admitted:?}; refusing cross-tenant engine sharing"
+        );
+    }
+    Ok(())
 }
 
 impl Clone for ModelService {
@@ -293,6 +331,7 @@ impl ModelService {
         registry: RegistryClient,
         transport: TransportConfig,
     ) -> Result<Self> {
+        config.inference_deployment.validate()?;
         // SAFETY: 5 is a valid non-zero value
         const DEFAULT_CACHE_SIZE: NonZeroUsize = match NonZeroUsize::new(5) {
             Some(n) => n,
@@ -316,9 +355,10 @@ impl ModelService {
             expected_audience: None,
             jwt_key_source: None,
             discovery_client: None,
-            fs_tree: std::sync::OnceLock::new(),
+            fs_trees: dashmap::DashMap::new(),
             load_terminals: TerminalStore::new(),
             load_epoch: AtomicU64::new(0),
+            in_process_tenant: std::sync::OnceLock::new(),
         })})
     }
 
@@ -384,7 +424,12 @@ impl ModelService {
     /// wins; a real attempt always latches under a fresh epoch, so the guard is
     /// belt-and-suspenders. Split out so the latch decision is unit-testable
     /// independent of the full load path.
-    fn latch_load_terminal(&self, model_ref: &str, epoch: u64, result: &Result<String>) {
+    fn latch_load_terminal(
+        &self,
+        instance: &InferenceInstanceId,
+        epoch: u64,
+        result: &Result<String>,
+    ) {
         let terminal = match result {
             Ok(endpoint) => Terminal {
                 value: ModelLoadTerminal::Loaded { endpoint: endpoint.clone() },
@@ -395,14 +440,42 @@ impl ModelService {
                 latched_by: "model-service".to_owned(),
             },
         };
-        let key = ModelLoadKey { model_ref: model_ref.to_owned(), epoch };
+        let key = ModelLoadKey {
+            tenant: instance.tenant().to_owned(),
+            model_ref: instance.model_ref().to_owned(),
+            epoch,
+        };
         let _ = self.load_terminals.latch(key, terminal);
     }
 
-    fn inference_transport(model_ref_str: &str) -> TransportConfig {
-        let safe_name = model_ref_str.replace([':', '/', '\\'], "-");
-        let service_name = format!("inference-{safe_name}");
-        registry().endpoint(&service_name, SocketKind::Rep)
+    /// Build an instance key only from the authority-verified tenant binding.
+    fn inference_instance(
+        ctx: &EnvelopeContext,
+        model_ref_str: &str,
+    ) -> Result<InferenceInstanceId> {
+        InferenceInstanceId::new(&ctx.domain()?, model_ref_str, 0)
+    }
+
+    /// Enforce the configured fault-radius contract before touching model state.
+    fn admit_instance(&self, instance: &InferenceInstanceId) -> Result<()> {
+        self.config.inference_deployment.validate()?;
+        match &self.config.inference_deployment.isolation {
+            InferenceIsolationProfile::InProcess => {
+                admit_in_process_tenant(&self.in_process_tenant, instance.tenant())
+            }
+            InferenceIsolationProfile::PerTenantSubprocess
+            | InferenceIsolationProfile::PerTenantMicroVmTask { .. } => {
+                anyhow::bail!(
+                    "inference isolation profile {:?} requires the external tenant launcher; \
+                     refusing to downgrade to an in-process engine",
+                    self.config.inference_deployment.isolation
+                )
+            }
+        }
+    }
+
+    fn inference_transport(instance: &InferenceInstanceId) -> TransportConfig {
+        registry().endpoint(&instance.service_name(), SocketKind::Rep)
     }
 
     /// The deterministic InferenceService endpoint *string* for a model ref.
@@ -410,8 +483,8 @@ impl ModelService {
     /// Retained only for human-facing display and the JSON `model.loaded` event
     /// (`EventPayload::ModelLoaded`); the routable reach is the typed
     /// [`Self::inference_transport`] / the capnp `reach` list (#320).
-    fn inference_endpoint(model_ref_str: &str) -> String {
-        Self::inference_transport(model_ref_str).endpoint_string()
+    fn inference_endpoint(instance: &InferenceInstanceId) -> String {
+        Self::inference_transport(instance).endpoint_string()
     }
 
     /// The network-routable reach list a remote caller would use to dial this
@@ -682,14 +755,21 @@ impl ModelService {
     }
 
     /// Load a model by reference with optional per-model config, returns the inference endpoint
-    async fn load_model(&self, model_ref_str: &str, max_context: Option<u32>, kv_quant: Option<KVQuantType>) -> Result<String> {
+    async fn load_model(
+        &self,
+        instance: &InferenceInstanceId,
+        max_context: Option<u32>,
+        kv_quant: Option<KVQuantType>,
+    ) -> Result<String> {
+        self.admit_instance(instance)?;
+        let model_ref_str = instance.model_ref();
         // Check if already loaded
         {
             let mut cache = self.loaded_models.write().await;
-            if let Some(model) = cache.get_mut(model_ref_str) {
+            if let Some(model) = cache.get_mut(instance) {
                 model.last_used = Instant::now();
                 debug!("Model {} already loaded", model_ref_str);
-                return Ok(Self::inference_endpoint(model_ref_str));
+                return Ok(Self::inference_endpoint(instance));
             }
         }
 
@@ -698,7 +778,7 @@ impl ModelService {
         // HashSet::insert returns false if the value was already present.
         {
             let mut pending = self.pending_loads.lock().await;
-            if !pending.insert(model_ref_str.to_owned()) {
+            if !pending.insert(instance.clone()) {
                 anyhow::bail!(
                     "Model {} is already being loaded — please retry shortly",
                     model_ref_str
@@ -711,14 +791,14 @@ impl ModelService {
         // terminal latches under a new key (reload ⇒ new terminal).
         let epoch = self.allocate_load_epoch();
 
-        let result = self.load_model_inner(model_ref_str, max_context, kv_quant).await;
+        let result = self.load_model_inner(instance, max_context, kv_quant).await;
 
         // Always remove from pending, whether load succeeded or failed
-        self.pending_loads.lock().await.remove(model_ref_str);
+        self.pending_loads.lock().await.remove(instance);
 
         // EV7/#649: latch the retained terminal (Loaded / LoadFailed) for this
         // load attempt — the host-side retain a late `load --wait` reads.
-        self.latch_load_terminal(model_ref_str, epoch, &result);
+        self.latch_load_terminal(instance, epoch, &result);
 
         if result.is_ok() {
             info!("Model {} loaded successfully", model_ref_str);
@@ -727,7 +807,13 @@ impl ModelService {
     }
 
     /// Inner model loading logic, called by load_model() which manages pending_loads.
-    async fn load_model_inner(&self, model_ref_str: &str, max_context: Option<u32>, kv_quant: Option<KVQuantType>) -> Result<String> {
+    async fn load_model_inner(
+        &self,
+        instance: &InferenceInstanceId,
+        max_context: Option<u32>,
+        kv_quant: Option<KVQuantType>,
+    ) -> Result<String> {
+        let model_ref_str = instance.model_ref();
         // Parse/resolve model reference
         let model_ref = self.resolve_model_ref(model_ref_str).await?;
 
@@ -755,7 +841,7 @@ impl ModelService {
             ));
         }
 
-        let endpoint = Self::inference_endpoint(model_ref_str);
+        let endpoint = Self::inference_endpoint(instance);
 
         info!("Loading model {} at endpoint {}", model_ref_str, endpoint);
 
@@ -763,6 +849,17 @@ impl ModelService {
         let runtime_config = RuntimeConfig {
             max_context: max_context.or(self.config.max_context),
             kv_quant_type: kv_quant.unwrap_or(self.config.kv_quant),
+            use_gpu: self.config.inference_deployment.compute != InferenceCompute::Cpu,
+            gpu_device_id: if self.config.inference_deployment.compute == InferenceCompute::Cpu {
+                None
+            } else {
+                RuntimeConfig::default().gpu_device_id
+            },
+            devices: if self.config.inference_deployment.compute == InferenceCompute::Cpu {
+                Vec::new()
+            } else {
+                RuntimeConfig::default().devices
+            },
             ..Default::default()
         };
 
@@ -779,7 +876,7 @@ impl ModelService {
         // the inference client path. (The cross-host/Iroh reach is resolved via
         // the Resolver when an inference service has a network endpoint; pkarr
         // auto-discovery stays deferred to #282.)
-        let transport = Self::inference_transport(model_ref_str);
+        let transport = Self::inference_transport(instance);
         let mut service_config = crate::services::InferenceServiceConfig::new(
             &model_path,
             runtime_config,
@@ -787,6 +884,11 @@ impl ModelService {
             self.signing_key.clone(),
             transport.clone(),
             fs,
+        )
+        .with_instance_identity(
+            instance.service_name(),
+            instance.tenant().to_owned(),
+            self.signing_key.verifying_key(),
         );
         if let Some(ref aud) = self.expected_audience {
             service_config = service_config.with_expected_audience(aud.clone());
@@ -835,7 +937,11 @@ impl ModelService {
             let mut cache = self.loaded_models.write().await;
             if cache.len() >= self.config.max_models {
                 if let Some((evicted_ref, mut evicted)) = cache.pop_lru() {
-                    info!("Evicting model {} to load {}", evicted_ref, model_ref_str);
+                    info!(
+                        "Evicting model {} to load {}",
+                        evicted_ref.model_ref(),
+                        model_ref_str
+                    );
                     // Stop the evicted service in background (fire-and-forget)
                     #[allow(clippy::let_underscore_future)]
                     let _ = tokio::spawn(async move {
@@ -846,8 +952,9 @@ impl ModelService {
 
             // Add to cache
             cache.put(
-                model_ref_str.to_owned(),
+                instance.clone(),
                 LoadedModel {
+                    instance: instance.clone(),
                     model_ref: model_ref_str.to_owned(),
                     transport: transport.clone(),
                     service_handle,
@@ -885,9 +992,10 @@ impl ModelService {
     }
 
     /// Unload a model
-    async fn unload_model(&self, model_ref_str: &str) -> Result<()> {
+    async fn unload_model(&self, instance: &InferenceInstanceId) -> Result<()> {
+        let model_ref_str = instance.model_ref();
         let mut cache = self.loaded_models.write().await;
-        if let Some((_, mut model)) = cache.pop_entry(model_ref_str) {
+        if let Some((_, mut model)) = cache.pop_entry(instance) {
             info!("Unloading model {}", model_ref_str);
             let _ = model.service_handle.stop().await;
             let model_name = model_ref_str.split(':').next().unwrap_or(model_ref_str);
@@ -935,11 +1043,12 @@ impl ModelService {
 
     /// Return status entries for all known models (loaded + loading).
     /// Absence from this list means unloaded.
-    async fn model_status_all(&self) -> Vec<GenModelStatusEntry> {
+    async fn model_status_all(&self, verified_tenant: &str) -> Vec<GenModelStatusEntry> {
         let cache = self.loaded_models.read().await;
         let pending = self.pending_loads.lock().await;
         let mut entries: Vec<GenModelStatusEntry> = cache
             .iter()
+            .filter(|(instance, _)| instance.tenant() == verified_tenant)
             .map(|(_, model)| GenModelStatusEntry {
                 model_ref: model.model_ref.clone(),
                 status: "loaded".to_owned(),
@@ -952,10 +1061,10 @@ impl ModelService {
                 generation_defaults: Self::sampling_params_to_wire(&model.generation_defaults),
             })
             .collect();
-        for model_ref in pending.iter() {
-            if !cache.contains(model_ref) {
+        for instance in pending.iter().filter(|instance| instance.tenant() == verified_tenant) {
+            if !cache.contains(instance) {
                 entries.push(GenModelStatusEntry {
-                    model_ref: model_ref.clone(),
+                    model_ref: instance.model_ref().to_owned(),
                     status: "loading".to_owned(),
                     reach: Vec::new(),
                     loaded_at: 0,
@@ -969,11 +1078,11 @@ impl ModelService {
     }
 
     /// Return status entry for a specific model ref (0 or 1 element).
-    async fn model_status_single(&self, model_ref_str: &str) -> Vec<GenModelStatusEntry> {
+    async fn model_status_single(&self, instance: &InferenceInstanceId) -> Vec<GenModelStatusEntry> {
         let cache = self.loaded_models.read().await;
-        if let Some(model) = cache.peek(model_ref_str) {
+        if let Some(model) = cache.peek(instance) {
             return vec![GenModelStatusEntry {
-                model_ref: model_ref_str.to_owned(),
+                model_ref: instance.model_ref().to_owned(),
                 status: "loaded".to_owned(),
                 reach: Self::model_reach(&model.transport),
                 loaded_at: model.loaded_at.elapsed().as_millis() as i64,
@@ -985,9 +1094,9 @@ impl ModelService {
             }];
         }
         let pending = self.pending_loads.lock().await;
-        if pending.contains(model_ref_str) {
+        if pending.contains(instance) {
             vec![GenModelStatusEntry {
-                model_ref: model_ref_str.to_owned(),
+                model_ref: instance.model_ref().to_owned(),
                 status: "loading".to_owned(),
                 reach: Vec::new(),
                 loaded_at: 0,
@@ -1001,9 +1110,9 @@ impl ModelService {
     }
 
     /// Get model status
-    async fn model_status(&self, model_ref_str: &str) -> ModelStatusResponse {
+    async fn model_status(&self, instance: &InferenceInstanceId) -> ModelStatusResponse {
         let cache = self.loaded_models.read().await;
-        if let Some(model) = cache.peek(model_ref_str) {
+        if let Some(model) = cache.peek(instance) {
             ModelStatusResponse {
                 loaded: true,
                 reach: Self::model_reach(&model.transport),
@@ -1017,10 +1126,11 @@ impl ModelService {
         }
     }
     async fn get_inference_client(&self, model_ref_str: &str, ctx: &EnvelopeContext) -> Result<InferenceClient> {
-        let _endpoint = self.load_model(model_ref_str, None, None).await?;
+        let instance = Self::inference_instance(ctx, model_ref_str)?;
+        let _endpoint = self.load_model(&instance, None, None).await?;
         let mut cache = self.loaded_models.write().await;
         let model = cache
-            .get_mut(model_ref_str)
+            .get_mut(&instance)
             .ok_or_else(|| anyhow!("Model {} not found after loading", model_ref_str))?;
         model.last_used = Instant::now();
         // #322 placement key. The envelope does not yet carry an explicit
@@ -1206,7 +1316,7 @@ impl TttHandler for ModelService {
     }
 
     async fn handle_write_ttt_config(
-        &self, _ctx: &EnvelopeContext, _request_id: u64,
+        &self, ctx: &EnvelopeContext, _request_id: u64,
         model_ref: &str, data: &WriteTttConfigRequest,
     ) -> Result<()> {
         // 1. Parse/resolve model ref and resolve worktree path
@@ -1269,14 +1379,15 @@ impl TttHandler for ModelService {
 
         // 5. Auto-reload if requested and model is loaded
         if data.auto_reload {
+            let instance = Self::inference_instance(ctx, model_ref)?;
             let is_loaded = {
                 let cache = self.loaded_models.read().await;
-                cache.contains(model_ref)
+                cache.contains(&instance)
             };
             if is_loaded {
                 info!("Auto-reloading {} after TTT config change", model_ref);
-                self.unload_model(model_ref).await?;
-                self.load_model(model_ref, None, None).await?;
+                self.unload_model(&instance).await?;
+                self.load_model(&instance, None, None).await?;
             }
         }
 
@@ -1403,9 +1514,10 @@ impl InferHandler for ModelService {
     }
 
     async fn handle_status(
-        &self, _ctx: &EnvelopeContext, _request_id: u64, model_ref: &str,
+        &self, ctx: &EnvelopeContext, _request_id: u64, model_ref: &str,
     ) -> Result<ModelStatusResponse> {
-        Ok(self.model_status(model_ref).await)
+        let instance = Self::inference_instance(ctx, model_ref)?;
+        Ok(self.model_status(&instance).await)
     }
 }
 
@@ -1426,16 +1538,17 @@ impl ModelHandler for ModelService {
     }
 
     async fn handle_load(
-        &self, _ctx: &EnvelopeContext, _request_id: u64,
+        &self, ctx: &EnvelopeContext, _request_id: u64,
         data: &LoadModelRequest,
     ) -> Result<ModelResponseVariant> {
         let max_ctx = data.max_context.filter(|&n| n != 0);
         let kv_q = data.kv_quant.filter(|q| *q != KVQuantType::None);
         let model_ref = &data.model_ref;
-        match self.load_model(model_ref, max_ctx, kv_q).await {
+        let instance = Self::inference_instance(ctx, model_ref)?;
+        match self.load_model(&instance, max_ctx, kv_q).await {
             Ok(_endpoint) => Ok(ModelResponseVariant::LoadResult(LoadedModelResponse {
                 model_ref: model_ref.to_owned(),
-                reach: Self::model_reach(&Self::inference_transport(model_ref)),
+                reach: Self::model_reach(&Self::inference_transport(&instance)),
             })),
             Err(e) => Ok(ModelResponseVariant::Error(ErrorInfo {
                 message: format!("Failed to load model: {e}"),
@@ -1446,11 +1559,12 @@ impl ModelHandler for ModelService {
     }
 
     async fn handle_unload(
-        &self, _ctx: &EnvelopeContext, _request_id: u64,
+        &self, ctx: &EnvelopeContext, _request_id: u64,
         data: &UnloadModelRequest,
     ) -> Result<ModelResponseVariant> {
         let model_ref = &data.model_ref;
-        match self.unload_model(model_ref).await {
+        let instance = Self::inference_instance(ctx, model_ref)?;
+        match self.unload_model(&instance).await {
             Ok(()) => Ok(ModelResponseVariant::UnloadResult),
             Err(e) => Ok(ModelResponseVariant::Error(ErrorInfo {
                 message: format!("Failed to unload model: {e}"),
@@ -1461,30 +1575,36 @@ impl ModelHandler for ModelService {
     }
 
     async fn handle_status(
-        &self, _ctx: &EnvelopeContext, _request_id: u64,
+        &self, ctx: &EnvelopeContext, _request_id: u64,
         data: &StatusRequest,
     ) -> Result<ModelResponseVariant> {
+        let tenant = ctx.domain()?;
         let entries = if data.model_ref.is_empty() {
-            self.model_status_all().await
+            self.model_status_all(&tenant).await
         } else {
-            self.model_status_single(&data.model_ref).await
+            let instance = InferenceInstanceId::new(&tenant, &data.model_ref, 0)?;
+            self.model_status_single(&instance).await
         };
         Ok(ModelResponseVariant::StatusResult(entries))
     }
 
     async fn handle_health_check(
-        &self, _ctx: &EnvelopeContext, _request_id: u64,
+        &self, ctx: &EnvelopeContext, _request_id: u64,
     ) -> Result<ModelResponseVariant> {
+        let tenant = ctx.domain()?;
         let cache = self.loaded_models.read().await;
-                let loaded_count = cache.len() as u32;
-                let max_models = self.config.max_models as u32;
-                drop(cache);
-                Ok(ModelResponseVariant::HealthCheckResult(ModelHealthStatus {
-                    status: "healthy".into(),
-                    loaded_model_count: loaded_count,
-                    max_models,
-                    total_memory_bytes: 0,
-                }))
+        let loaded_count = cache
+            .iter()
+            .filter(|(instance, _)| instance.tenant() == tenant.as_str())
+            .count() as u32;
+        let max_models = self.config.max_models as u32;
+        drop(cache);
+        Ok(ModelResponseVariant::HealthCheckResult(ModelHealthStatus {
+            status: "healthy".into(),
+            loaded_model_count: loaded_count,
+            max_models,
+            total_memory_bytes: 0,
+        }))
     }
 }
 
@@ -1502,15 +1622,26 @@ use crate::services::fs::{SyntheticTree, SyntheticNode, SyntheticQid};
 use hyprstream_vfs::DirEntry;
 
 impl ModelService {
-    /// Get the persistent synthetic 9P tree (lazily initialized).
-    fn fs_tree(&self) -> &SyntheticTree {
-        self.inner.fs_tree.get_or_init(|| self.build_fs_tree())
+    /// Get the persistent tenant-partitioned synthetic 9P tree.
+    fn fs_tree(&self, verified_tenant: &str) -> Arc<SyntheticTree> {
+        if let Some(tree) = self.inner.fs_trees.get(verified_tenant) {
+            return Arc::clone(tree.value());
+        }
+        let tree = Arc::new(self.build_fs_tree(verified_tenant.to_owned()));
+        let entry = self
+            .inner
+            .fs_trees
+            .entry(verified_tenant.to_owned())
+            .or_insert(tree);
+        Arc::clone(entry.value())
     }
 
     /// Build a synthetic 9P tree from current model service state.
-    fn build_fs_tree(&self) -> SyntheticTree {
+    fn build_fs_tree(&self, verified_tenant: String) -> SyntheticTree {
         let inner_list = Arc::clone(&self.inner);
         let inner_resolve = Arc::clone(&self.inner);
+        let list_tenant = verified_tenant.clone();
+        let resolve_tenant = verified_tenant;
 
         SyntheticTree::new(SyntheticNode::DynamicDir {
             list: Box::new(move || {
@@ -1518,19 +1649,40 @@ impl ModelService {
                 let pending = inner_list.pending_loads.blocking_lock();
                 let mut entries: Vec<DirEntry> = cache
                     .iter()
-                    .map(|(name, _)| DirEntry { name: name.clone(), is_dir: true, size: 0, stat: None })
+                    .filter(|(instance, _)| instance.tenant() == list_tenant)
+                    .map(|(instance, _)| DirEntry {
+                        name: instance.service_name(),
+                        is_dir: true,
+                        size: 0,
+                        stat: None,
+                    })
                     .collect();
-                for name in pending.iter() {
-                    if !cache.contains(name) {
-                        entries.push(DirEntry { name: name.clone(), is_dir: true, size: 0, stat: None });
+                for instance in pending
+                    .iter()
+                    .filter(|instance| instance.tenant() == list_tenant)
+                {
+                    if !cache.contains(instance) {
+                        entries.push(DirEntry {
+                            name: instance.service_name(),
+                            is_dir: true,
+                            size: 0,
+                            stat: None,
+                        });
                     }
                 }
                 entries
             }),
             resolve: Box::new(move |ref_name| {
                 let cache = inner_resolve.loaded_models.blocking_read();
-                let is_loaded = cache.contains(ref_name);
-                let defaults_json = if let Some(model) = cache.peek(ref_name) {
+                let model = cache
+                    .iter()
+                    .find(|(instance, _)| {
+                        instance.tenant() == resolve_tenant
+                            && instance.service_name() == ref_name
+                    })
+                    .map(|(_, model)| model);
+                let is_loaded = model.is_some();
+                let defaults_json = if let Some(model) = model {
                     serde_json::to_vec_pretty(&model.generation_defaults).unwrap_or_default()
                 } else {
                     b"{}".to_vec()
@@ -1566,7 +1718,7 @@ impl FsHandler for ModelService {
     async fn handle_walk(&self, ctx: &EnvelopeContext, _request_id: u64,
         _model_ref: &str, data: &NpWalk,
     ) -> Result<RWalk> {
-        let tree = self.fs_tree();
+        let tree = self.fs_tree(&ctx.domain()?);
         let owner = ctx.subject().to_string();
         let (_fid, qid) = tree.walk(&data.wnames, &owner, Some(data.newfid))
             .map_err(|e| anyhow::anyhow!(e))?;
@@ -1576,7 +1728,7 @@ impl FsHandler for ModelService {
     async fn handle_open(&self, ctx: &EnvelopeContext, _request_id: u64,
         _model_ref: &str, data: &NpOpen,
     ) -> Result<ROpen> {
-        let tree = self.fs_tree();
+        let tree = self.fs_tree(&ctx.domain()?);
         let owner = ctx.subject().to_string();
         // Re-walk to get the fid, then open.
         let (qid, iounit) = tree.open(data.fid, data.mode, &owner)
@@ -1587,7 +1739,7 @@ impl FsHandler for ModelService {
     async fn handle_read(&self, ctx: &EnvelopeContext, _request_id: u64,
         _model_ref: &str, data: &NpRead,
     ) -> Result<RRead> {
-        let tree = self.fs_tree();
+        let tree = self.fs_tree(&ctx.domain()?);
         let owner = ctx.subject().to_string();
         let bytes = tree.read(data.fid, data.offset, data.count, &owner)
             .map_err(|e| anyhow::anyhow!(e))?;
@@ -1597,7 +1749,7 @@ impl FsHandler for ModelService {
     async fn handle_write(&self, ctx: &EnvelopeContext, _request_id: u64,
         _model_ref: &str, data: &NpWrite,
     ) -> Result<RWrite> {
-        let tree = self.fs_tree();
+        let tree = self.fs_tree(&ctx.domain()?);
         let subject = ctx.subject();
         let owner = subject.to_string();
         let count = tree.write(data.fid, data.offset, &data.data, &owner, &subject)
@@ -1608,7 +1760,7 @@ impl FsHandler for ModelService {
     async fn handle_clunk(&self, ctx: &EnvelopeContext, _request_id: u64,
         _model_ref: &str, data: &NpClunk,
     ) -> Result<()> {
-        let tree = self.fs_tree();
+        let tree = self.fs_tree(&ctx.domain()?);
         let owner = ctx.subject().to_string();
         tree.clunk(data.fid, &owner);
         Ok(())
@@ -1617,7 +1769,7 @@ impl FsHandler for ModelService {
     async fn handle_stat(&self, ctx: &EnvelopeContext, _request_id: u64,
         _model_ref: &str, data: &NpStatReq,
     ) -> Result<RStat> {
-        let tree = self.fs_tree();
+        let tree = self.fs_tree(&ctx.domain()?);
         let owner = ctx.subject().to_string();
         let (qid, name) = tree.stat(data.fid, &owner)
             .map_err(|e| anyhow::anyhow!(e))?;
@@ -1729,10 +1881,23 @@ impl crate::services::RequestService for ModelService {
         // Instead, return an immediate "accepted" response and do the actual
         // load in a Continuation (spawned via spawn_local after the REP is sent).
         if let Some((request_id, load_data)) = Self::try_parse_load_request(payload) {
+            // This fast path bypasses generated dispatch, so reproduce its
+            // mandatory operation-level authorization and audit record exactly
+            // (`load` is `$scope(write)` in model.capnp).
+            let audit_resource = "model:Load";
+            let authorization =
+                <Self as ModelHandler>::authorize(self, ctx, audit_resource, "write").await;
+            ctx.audit_authz(audit_resource, "write", authorization.is_ok());
+            authorization?;
+
+            // This interception runs before generated dispatch, so derive the
+            // instance only from the already-verified tenant in the envelope.
+            let instance = Self::inference_instance(ctx, &load_data.model_ref)?;
+            self.admit_instance(&instance)?;
             // Fast path: if already loaded or already loading, return immediately
             {
                 let mut cache = self.loaded_models.write().await;
-                if let Some(model) = cache.get_mut(&load_data.model_ref) {
+                if let Some(model) = cache.get_mut(&instance) {
                     model.last_used = Instant::now();
                     let response = serialize_response(request_id, &ModelResponseVariant::LoadResult(
                         LoadedModelResponse {
@@ -1747,12 +1912,12 @@ impl crate::services::RequestService for ModelService {
             // without spawning a duplicate continuation
             {
                 let pending = self.pending_loads.lock().await;
-                if pending.contains(&load_data.model_ref) {
+                if pending.contains(&instance) {
                     debug!("Model {} already being loaded, deduplicating", load_data.model_ref);
                     let response = serialize_response(request_id, &ModelResponseVariant::LoadResult(
                         LoadedModelResponse {
                             model_ref: load_data.model_ref.clone(),
-                            reach: Self::model_reach(&Self::inference_transport(&load_data.model_ref)),
+                            reach: Self::model_reach(&Self::inference_transport(&instance)),
                         },
                     ))?;
                     return Ok((response, None));
@@ -1766,7 +1931,7 @@ impl crate::services::RequestService for ModelService {
             let response = serialize_response(request_id, &ModelResponseVariant::LoadResult(
                 LoadedModelResponse {
                     model_ref: model_ref.clone(),
-                    reach: Self::model_reach(&Self::inference_transport(&model_ref)),
+                    reach: Self::model_reach(&Self::inference_transport(&instance)),
                 },
             ))?;
 
@@ -1775,7 +1940,7 @@ impl crate::services::RequestService for ModelService {
             let continuation: crate::services::Continuation = Box::pin(async move {
                 let model_name = model_ref.split(':').next().unwrap_or(&model_ref);
                 let scope = format!("serve:model:{}", model_name);
-                match service.load_model(&model_ref, load_max_context, load_kv_quant).await {
+                match service.load_model(&instance, load_max_context, load_kv_quant).await {
                     Ok(endpoint) => {
                         info!("Model {} loaded successfully at {}", model_ref, endpoint);
                         let event = crate::events::EventEnvelope::new(
@@ -1868,6 +2033,10 @@ mod tests {
         assert_eq!(config.max_models, 5);
         assert_eq!(config.max_context, None);
         assert_eq!(config.kv_quant, KVQuantType::None);
+        assert_eq!(
+            config.inference_deployment.isolation,
+            InferenceIsolationProfile::InProcess
+        );
     }
 
     // ========================================================================
@@ -1911,7 +2080,11 @@ mod tests {
     #[test]
     fn load_terminal_is_monotonic_write_once_per_epoch() {
         let store: TerminalStore<ModelLoadKey, ModelLoadTerminal> = TerminalStore::new();
-        let key = ModelLoadKey { model_ref: "qwen3:main".to_owned(), epoch: 1 };
+        let key = ModelLoadKey {
+            tenant: "tenant-a".to_owned(),
+            model_ref: "qwen3:main".to_owned(),
+            epoch: 1,
+        };
         assert!(store.latch(key.clone(), loaded_term("ep1")));
         // A late failure for the SAME attempt cannot overwrite the real Loaded.
         assert!(!store.latch(key.clone(), failed_term("race")));
@@ -1928,10 +2101,18 @@ mod tests {
     fn reload_latches_new_terminal_under_new_epoch() {
         let store: TerminalStore<ModelLoadKey, ModelLoadTerminal> = TerminalStore::new();
         // First load attempt (epoch 1): Loaded.
-        let k1 = ModelLoadKey { model_ref: "qwen3:main".to_owned(), epoch: 1 };
+        let k1 = ModelLoadKey {
+            tenant: "tenant-a".to_owned(),
+            model_ref: "qwen3:main".to_owned(),
+            epoch: 1,
+        };
         assert!(store.latch(k1.clone(), loaded_term("ep1")));
         // Reload (epoch 2): a distinct key, so it latches a fresh terminal.
-        let k2 = ModelLoadKey { model_ref: "qwen3:main".to_owned(), epoch: 2 };
+        let k2 = ModelLoadKey {
+            tenant: "tenant-a".to_owned(),
+            model_ref: "qwen3:main".to_owned(),
+            epoch: 2,
+        };
         assert!(store.latch(k2.clone(), loaded_term("ep2")));
         // Both attempts' terminals are retained (monotonic per-epoch).
         assert_eq!(
@@ -1950,12 +2131,49 @@ mod tests {
     #[test]
     fn failed_then_reload_latches_distinct_terminals() {
         let store: TerminalStore<ModelLoadKey, ModelLoadTerminal> = TerminalStore::new();
-        let kf = ModelLoadKey { model_ref: "qwen3:main".to_owned(), epoch: 1 };
+        let kf = ModelLoadKey {
+            tenant: "tenant-a".to_owned(),
+            model_ref: "qwen3:main".to_owned(),
+            epoch: 1,
+        };
         assert!(store.latch(kf.clone(), failed_term("oom")));
-        let ks = ModelLoadKey { model_ref: "qwen3:main".to_owned(), epoch: 2 };
+        let ks = ModelLoadKey {
+            tenant: "tenant-a".to_owned(),
+            model_ref: "qwen3:main".to_owned(),
+            epoch: 2,
+        };
         assert!(store.latch(ks.clone(), loaded_term("ep2")));
         assert!(matches!(latched_value(&store, &kf), ModelLoadTerminal::LoadFailed { .. }));
         assert!(matches!(latched_value(&store, &ks), ModelLoadTerminal::Loaded { .. }));
+    }
+
+    #[test]
+    fn load_terminals_are_tenant_scoped() {
+        let store: TerminalStore<ModelLoadKey, ModelLoadTerminal> = TerminalStore::new();
+        let tenant_a = ModelLoadKey {
+            tenant: "tenant-a".to_owned(),
+            model_ref: "qwen3:main".to_owned(),
+            epoch: 1,
+        };
+        let tenant_b = ModelLoadKey {
+            tenant: "tenant-b".to_owned(),
+            model_ref: "qwen3:main".to_owned(),
+            epoch: 1,
+        };
+        assert!(store.latch(tenant_a.clone(), loaded_term("a")));
+        assert!(store.latch(tenant_b.clone(), loaded_term("b")));
+        assert_ne!(
+            latched_value(&store, &tenant_a),
+            latched_value(&store, &tenant_b)
+        );
+    }
+
+    #[test]
+    fn in_process_profile_never_admits_two_tenants() {
+        let admitted = std::sync::OnceLock::new();
+        assert!(admit_in_process_tenant(&admitted, "tenant-a").is_ok());
+        assert!(admit_in_process_tenant(&admitted, "tenant-a").is_ok());
+        assert!(admit_in_process_tenant(&admitted, "tenant-b").is_err());
     }
 
     /// #320: the co-located InferenceService resolves (via the local Resolver
@@ -1965,12 +2183,14 @@ mod tests {
     fn inference_transport_is_inproc_co_located() {
         // Default registry mode is Inproc; idempotent if another test inited it.
         hyprstream_rpc::registry::init(hyprstream_rpc::registry::EndpointMode::Inproc, None);
-        let t = ModelService::inference_transport("qwen3-small:main");
+        let instance = InferenceInstanceId::new("tenant-a", "qwen3-small:main", 0)
+            .unwrap_or_else(|e| panic!("valid instance: {e}"));
+        let t = ModelService::inference_transport(&instance);
         match &t.endpoint {
             hyprstream_rpc::transport::EndpointType::Inproc { endpoint } => {
                 assert!(
-                    endpoint.contains("inference-qwen3-small-main"),
-                    "deterministic per-model inproc name, got {endpoint}"
+                    endpoint.contains("inference-"),
+                    "opaque deterministic per-tenant/model inproc name, got {endpoint}"
                 );
             }
             other => panic!("expected Inproc co-located transport, got {other:?}"),


### PR DESCRIPTION
## State found

- The inference RPC already had transport-neutral in-process/IPC serving, load/unload/health lifecycle, and the mandatory native-MAC dispatch PEP.
- ModelService still keyed engines and endpoints only by model ref, spawned every engine as a thread, and used a generic `local` tenant for the ModelService-to-InferenceService bridge.
- The asynchronous model-load interception bypassed the generated `model:Load` / `write` policy check.
- #314 remains open, so #1236 still cannot claim a production exact-range stage handler or true subset loading. Remote replica dialing and tenant forwarding remain in #1237/#1248.

## Demo slice

- Add an explicit inference deployment profile: isolation, tenancy posture, CPU/GPU selection, and per-instance lifecycle/resource budgets.
- Make CPU mode active (`use_gpu = false`, no GPU device selection).
- Derive opaque service identities and IPC/in-process addresses from `verified_tenant + model_ref + replica`.
- Scope loaded/pending state, terminals, status/health, inference clients, and the synthetic 9P view by `EnvelopeContext::domain()`.
- Keep the native-MAC object label canonical (`inference`) while using instance-specific registration names.
- Bind each InferenceService to its verified tenant. Direct callers must match it; the only `local` bridge exception is pinned to the ModelService controller key.
- Restore the generated `model:Load` / `write` authorization and audit step on the async load fast path.
- Fail closed for shared-tenancy in-process placement and for subprocess/microVM profiles until an external isolated launcher is implemented.

For the two-service CPU demo:

```text
HYPRSTREAM_INFERENCE_COMPUTE=cpu
HYPRSTREAM_INFERENCE_TENANCY=single-tenant-development
HYPRSTREAM_INFERENCE_ISOLATION=in-process
```

Loading two different model refs for the verified tenant produces two distinct addressable inference-service instances.

## Validation

- `cargo metadata --all-features`
- `cargo clippy -p hyprstream --lib --tests --no-deps -- -D warnings`
- repository pre-commit release Clippy gate
- focused tests: 6 deployment/address, 2 tenant-binding authorization, 19 model lifecycle/routing
- required release `nextest` is running on the pushed head; result will be added here

Progresses #1236 and #1247. This intentionally does not close either ticket while #314 and the isolated launcher remain open.
