### PR TITLE
feat(identity): add ATProto credential exchange

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6796,6 +6796,7 @@ dependencies = [
  "hyprstream-metrics",
  "hyprstream-p2p",
  "hyprstream-pds",
+ "hyprstream-pds-service",
  "hyprstream-rpc",
  "hyprstream-rpc-build",
  "hyprstream-rpc-derive",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6814,6 +6814,7 @@ dependencies = [
  "iroh",
  "json-threat-protection",
  "jsonwebtoken 10.3.0",
+ "k256",
  "keyring",
  "libc",
  "listenfd",

--- a/crates/hyprstream-pds-service/src/lib.rs
+++ b/crates/hyprstream-pds-service/src/lib.rs
@@ -24,6 +24,7 @@ const ACCOUNTS_DIRECTORY: &str = "accounts";
 const ACCOUNT_RECORD_FILE: &str = "account-record.cbor";
 const DEFAULT_MAX_RECORD_BYTES: usize = 64 * 1024;
 const READ_CHUNK_BYTES: usize = 8 * 1024;
+const OAUTH_ACCOUNT_RESOLVER_SUBJECT: &str = "service:oauth";
 
 /// Failure from the mandatory tenant boundary or the PDS record read.
 #[derive(Debug, Error)]
@@ -36,6 +37,12 @@ pub enum AccountReadError {
     InvalidVerifiedTenant(String),
     #[error("invalid hosted account label {0:?}")]
     InvalidAccountLabel(String),
+    #[error("PDS hosted-account tenant resolution denied for {0:?}")]
+    UnauthorizedTenantResolver(String),
+    #[error("invalid hosted account DID {0:?}")]
+    InvalidHostedAccountDid(String),
+    #[error("hosted account DID {0:?} is bound to more than one tenant")]
+    AmbiguousHostedAccountDid(String),
     #[error("PDS account record exceeds the {limit}-byte read limit")]
     RecordTooLarge { limit: usize },
     #[error("PDS account record for {requested:?} contains label {stored:?}")]
@@ -94,6 +101,69 @@ impl AccountRecordStore {
             tenant,
             subject,
         })
+    }
+
+    /// Resolve a hosted account DID to its authority-owned tenant binding.
+    ///
+    /// Unlike [`Self::scope`], this lookup starts without a tenant because the
+    /// ATProto assertion proves only the DID. It therefore accepts no tenant
+    /// argument: the OAuth service identity scans the account-record index and
+    /// returns the tenant containing the one canonical record whose DID
+    /// matches. Missing records return `Ok(None)` (federated-only identity);
+    /// corrupt, denied, or ambiguous records fail closed.
+    pub async fn resolve_tenant_for_hosted_did(
+        &self,
+        authority: &Subject,
+        did: &str,
+    ) -> Result<Option<String>, AccountReadError> {
+        if authority.name() != Some(OAUTH_ACCOUNT_RESOLVER_SUBJECT) {
+            return Err(AccountReadError::UnauthorizedTenantResolver(
+                authority.to_string(),
+            ));
+        }
+        let Some(label) = hosted_account_label(did)? else {
+            return Ok(None);
+        };
+
+        let tenants = read_directory(self.pds_mount.as_ref(), &[], authority).await?;
+        let mut resolved = None;
+        for entry in tenants.into_iter().filter(|entry| entry.is_dir) {
+            validate_tenant_component(&entry.name)?;
+            let components = [
+                entry.name.as_str(),
+                ACCOUNTS_DIRECTORY,
+                label,
+                ACCOUNT_RECORD_FILE,
+            ];
+            let bytes = match read_file(
+                self.pds_mount.as_ref(),
+                &components,
+                authority,
+                self.max_record_bytes,
+            )
+            .await
+            {
+                Ok(bytes) => bytes,
+                Err(AccountReadError::Mount(MountError::NotFound(_))) => continue,
+                Err(error) => return Err(error),
+            };
+            let record =
+                AccountRecord::from_dag_cbor(&bytes).map_err(AccountReadError::InvalidRecord)?;
+            if record.name().label() != label {
+                return Err(AccountReadError::RecordLabelMismatch {
+                    requested: label.to_owned(),
+                    stored: record.name().label().to_owned(),
+                });
+            }
+            if record.name().did() != did {
+                continue;
+            }
+            if resolved.is_some() {
+                return Err(AccountReadError::AmbiguousHostedAccountDid(did.to_owned()));
+            }
+            resolved = Some(entry.name);
+        }
+        Ok(resolved)
     }
 
     #[cfg(test)]
@@ -190,6 +260,22 @@ fn validate_account_label(label: &str) -> Result<(), AccountReadError> {
     }
 }
 
+fn hosted_account_label(did: &str) -> Result<Option<&str>, AccountReadError> {
+    let Some(host) = did.strip_prefix("did:web:") else {
+        return Ok(None);
+    };
+    if host.contains([':', '/']) {
+        return Err(AccountReadError::InvalidHostedAccountDid(did.to_owned()));
+    }
+    let label = host
+        .split('.')
+        .next()
+        .ok_or_else(|| AccountReadError::InvalidHostedAccountDid(did.to_owned()))?;
+    validate_account_label(label)
+        .map_err(|_| AccountReadError::InvalidHostedAccountDid(did.to_owned()))?;
+    Ok(Some(label))
+}
+
 async fn read_file(
     mount: &dyn Mount,
     components: &[&str],
@@ -203,6 +289,21 @@ async fn read_file(
     }
 
     let result = read_open_fid(mount, &fid, subject, limit).await;
+    mount.clunk(fid, subject).await;
+    result
+}
+
+async fn read_directory(
+    mount: &dyn Mount,
+    components: &[&str],
+    subject: &Subject,
+) -> Result<Vec<hyprstream_vfs::DirEntry>, AccountReadError> {
+    let mut fid = mount.walk(components, subject).await?;
+    if let Err(error) = mount.open(&mut fid, OREAD, subject).await {
+        mount.clunk(fid, subject).await;
+        return Err(error.into());
+    }
+    let result = mount.readdir(&fid, subject).await.map_err(Into::into);
     mount.clunk(fid, subject).await;
     result
 }
@@ -305,6 +406,10 @@ mod tests {
         )
     }
 
+    fn oauth_authority() -> Subject {
+        Subject::new(OAUTH_ACCOUNT_RESOLVER_SUBJECT)
+    }
+
     #[tokio::test]
     async fn verified_tenant_selects_the_only_visible_account_tree() {
         let store = store();
@@ -318,6 +423,59 @@ mod tests {
         assert_eq!(beta.tenant(), "beta");
         assert_eq!(acme_record.name().did(), "did:web:alice.acme.example");
         assert_eq!(beta_record.name().did(), "did:web:alice.beta.example");
+    }
+
+    #[tokio::test]
+    async fn oauth_authority_resolves_tenant_from_matching_account_record() {
+        let store = store();
+
+        assert_eq!(
+            store
+                .resolve_tenant_for_hosted_did(&oauth_authority(), "did:web:alice.acme.example",)
+                .await
+                .unwrap()
+                .as_deref(),
+            Some("acme"),
+        );
+        assert_eq!(
+            store
+                .resolve_tenant_for_hosted_did(&oauth_authority(), "did:web:missing.acme.example",)
+                .await
+                .unwrap(),
+            None,
+        );
+        assert_eq!(
+            store
+                .resolve_tenant_for_hosted_did(&oauth_authority(), "did:plc:federated-only",)
+                .await
+                .unwrap(),
+            None,
+        );
+    }
+
+    #[tokio::test]
+    async fn hosted_did_resolution_requires_oauth_authority_and_is_unambiguous() {
+        let denied = store()
+            .resolve_tenant_for_hosted_did(&Subject::new("alice"), "did:web:alice.acme.example")
+            .await
+            .unwrap_err();
+        assert!(matches!(
+            denied,
+            AccountReadError::UnauthorizedTenantResolver(_)
+        ));
+
+        let duplicated = account_bytes("alice", "acme.example");
+        let root = SyntheticNode::dir()
+            .with_child("acme", tenant_node("alice", duplicated.clone()))
+            .with_child("beta", tenant_node("alice", duplicated));
+        let ambiguous = AccountRecordStore::new(Arc::new(SyntheticMount::new(root)))
+            .resolve_tenant_for_hosted_did(&oauth_authority(), "did:web:alice.acme.example")
+            .await
+            .unwrap_err();
+        assert!(matches!(
+            ambiguous,
+            AccountReadError::AmbiguousHostedAccountDid(_)
+        ));
     }
 
     #[test]

--- a/crates/hyprstream-rpc-std/schema/policy.capnp
+++ b/crates/hyprstream-rpc-std/schema/policy.capnp
@@ -145,6 +145,11 @@ struct IssueToken {
   # Empty inherits the caller's verified tenant. Cross-tenant issuance requires
   # policy:IssueToken/manage in this target tenant.
   tenant @7 :Text $optional;
+
+  # Require the PolicyService to resolve an authority-owned enrollment
+  # clearance for the subject before minting. The resolved clearance is
+  # clamped to Classical assurance and stamped into the signed claims.
+  requireClearance @8 :Bool;
 }
 
 # Apply a built-in policy template

--- a/crates/hyprstream-util/src/ttl_cache.rs
+++ b/crates/hyprstream-util/src/ttl_cache.rs
@@ -186,6 +186,40 @@ where
         true
     }
 
+    /// Atomically insert `key` only if it is absent and capacity is available.
+    ///
+    /// Unlike [`Self::insert_if_absent`], this variant never evicts a live
+    /// entry to make room. It returns `false` for either a duplicate key or a
+    /// full cache. This fail-closed behavior is intended for replay caches
+    /// whose live entries are security state: evicting one early would allow
+    /// the corresponding assertion to be accepted again.
+    pub fn insert_if_absent_no_evict(&self, key: K, value: V, ttl: Duration) -> bool {
+        let now = Instant::now();
+        let expires_at = now + ttl;
+        let version = self.next_version.fetch_add(1, Ordering::Relaxed);
+
+        let mut inner = self.inner.lock();
+        Self::reap(&mut inner, now, self.reap_budget);
+
+        if inner.entries.contains_key(&key) || inner.entries.len() >= self.max_entries {
+            return false;
+        }
+        inner.entries.insert(
+            key.clone(),
+            Entry {
+                value,
+                expires_at,
+                version,
+            },
+        );
+        inner.heap.push(Reverse(HeapEntry {
+            expires_at,
+            key,
+            version,
+        }));
+        true
+    }
+
     /// Look up `key`, returning a clone of the value if present and not
     /// yet expired. Performs a bounded inline reap first.
     ///
@@ -378,5 +412,17 @@ mod tests {
         assert!(cache.insert_if_absent("jti".to_owned(), (), Duration::from_millis(5)));
         std::thread::sleep(Duration::from_millis(20));
         assert!(cache.insert_if_absent("jti".to_owned(), (), Duration::from_secs(60)));
+    }
+
+    #[test]
+    fn insert_if_absent_no_evict_fails_closed_at_capacity() {
+        let cache: TtlCache<String, ()> = TtlCache::new(2, 16);
+        assert!(cache.insert_if_absent_no_evict("jti-1".to_owned(), (), Duration::from_secs(60)));
+        assert!(cache.insert_if_absent_no_evict("jti-2".to_owned(), (), Duration::from_secs(60)));
+
+        assert!(!cache.insert_if_absent_no_evict("jti-3".to_owned(), (), Duration::from_secs(60)));
+        assert_eq!(cache.len(), 2);
+        assert_eq!(cache.get("jti-1"), Some(()));
+        assert_eq!(cache.get("jti-2"), Some(()));
     }
 }

--- a/crates/hyprstream/Cargo.toml
+++ b/crates/hyprstream/Cargo.toml
@@ -56,6 +56,7 @@ ml-dsa = { workspace = true }  # ML-DSA-65 — always compiled (runtime CryptoPo
 hyprstream-rpc-std = { path = "../hyprstream-rpc-std" }  # Standard service schemas + clients
 hyprstream-discovery = { path = "../hyprstream-discovery" }  # Service discovery
 hyprstream-pds = { path = "../hyprstream-pds" }  # atproto PDS record store: DAG-CBOR + MST + signed commit + CAR proof (#392/#431)
+hyprstream-pds-service = { path = "../hyprstream-pds-service" }  # authority-owned hosted-account tenant lookup
 hyprstream-ledger = { path = "../hyprstream-ledger", optional = true }  # Cellular credit ledger accounting plane (#923); the Phase-1 local-enforcer service (#925) lands behind the `ledger` feature, default off
 hyprstream-crypto = { path = "../hyprstream-crypto" }  # COSE composite (EdDSA + ML-DSA-65) sign/verify — used by the ledger checkpoint signer (#925)
 hyprstream-service = { path = "../hyprstream-service" }  # Service orchestration

--- a/crates/hyprstream/Cargo.toml
+++ b/crates/hyprstream/Cargo.toml
@@ -171,6 +171,7 @@ base64.workspace = true                  # JWT token encoding
 ed25519-dalek.workspace = true           # JWT Ed25519 signatures
 ssh-key = { version = "0.6", features = ["ed25519", "encryption"] }  # OpenSSH Ed25519 key import (user create --ssh)
 p256.workspace = true                    # ES256 DPoP verification (atproto interop)
+k256.workspace = true                    # ES256K ATProto service-auth verification
 keyring = { version = "3", features = ["linux-native"] }  # OS keyring — Linux keyutils
 curve25519-dalek.workspace = true        # Ristretto255 DH for stream authentication
 hkdf.workspace = true                    # HKDF key derivation

--- a/crates/hyprstream/src/auth/key_rotation.rs
+++ b/crates/hyprstream/src/auth/key_rotation.rs
@@ -2650,6 +2650,7 @@ mod tests {
                         dpop_jkt: None,
                         issuer: None,
                         tenant: None,
+                        require_clearance: false,
                     })
                     .await?
                     .token;
@@ -2777,6 +2778,7 @@ mod tests {
                         dpop_jkt: None,
                         issuer: None,
                         tenant: None,
+                        require_clearance: false,
                     })
                     .await;
                 anyhow::ensure!(result.is_err(), "stale PolicyService minted a token");
@@ -2937,6 +2939,7 @@ mod tests {
                         dpop_jkt: None,
                         issuer: None,
                         tenant: None,
+                        require_clearance: false,
                     })
                     .await?
                     .token;
@@ -3072,6 +3075,7 @@ mod tests {
                         dpop_jkt: None,
                         issuer: None,
                         tenant: None,
+                        require_clearance: false,
                     })
                     .await?;
                 let client = reqwest::Client::new();
@@ -3302,6 +3306,7 @@ mod tests {
                         dpop_jkt: None,
                         issuer: None,
                         tenant: None,
+                        require_clearance: false,
                     })
                     .await?
                     .token;

--- a/crates/hyprstream/src/config/mod.rs
+++ b/crates/hyprstream/src/config/mod.rs
@@ -1304,6 +1304,22 @@ pub struct OAuthConfig {
     /// When `false`, the XRPC routes are not mounted at all.
     #[serde(default)]
     pub xrpc_read_slice: bool,
+
+    /// Read-only PLC directory used to resolve ATProto account signing keys.
+    #[serde(default = "default_atproto_plc_directory_url")]
+    pub atproto_plc_directory_url: String,
+
+    /// TTL for validated ATProto DID documents.
+    #[serde(default = "default_atproto_did_cache_ttl")]
+    pub atproto_did_cache_ttl_secs: u64,
+}
+
+fn default_atproto_plc_directory_url() -> String {
+    "https://plc.directory".to_owned()
+}
+
+fn default_atproto_did_cache_ttl() -> u64 {
+    3600
 }
 
 fn default_oauth_cors() -> server::CorsConfig {
@@ -1341,6 +1357,8 @@ impl Default for OAuthConfig {
             // atproto profile at the authorize handler level.
             require_pushed_authorization_requests: false,
             xrpc_read_slice: false,
+            atproto_plc_directory_url: default_atproto_plc_directory_url(),
+            atproto_did_cache_ttl_secs: default_atproto_did_cache_ttl(),
             deployment_well_known_dir: None,
         }
     }

--- a/crates/hyprstream/src/services/oauth/jwt_bearer.rs
+++ b/crates/hyprstream/src/services/oauth/jwt_bearer.rs
@@ -111,6 +111,7 @@ pub async fn exchange_jwt_bearer(
             dpop_jkt: None,
             issuer: None,
             tenant: claims.tenant.clone(),
+            require_clearance: false,
         })
         .await;
 

--- a/crates/hyprstream/src/services/oauth/jwt_bearer.rs
+++ b/crates/hyprstream/src/services/oauth/jwt_bearer.rs
@@ -95,7 +95,7 @@ pub async fn exchange_jwt_bearer(
     };
 
     let sub = claims.sub.clone();
-
+    let tenant = authority_verified_assertion_tenant(&claims, verified_service_key.is_some());
 
     // Delegate token issuance to PolicyService (authorization enforced there via Casbin).
     let result = state
@@ -110,7 +110,7 @@ pub async fn exchange_jwt_bearer(
             user_pub_key: verified_service_key.map(|key| URL_SAFE_NO_PAD.encode(key.to_bytes())),
             dpop_jkt: None,
             issuer: None,
-            tenant: claims.tenant.clone(),
+            tenant,
             require_clearance: false,
         })
         .await;
@@ -138,6 +138,21 @@ pub async fn exchange_jwt_bearer(
             tracing::error!(sub = %sub, error = %e, "JWT bearer token issuance failed");
             jwt_bearer_error(StatusCode::INTERNAL_SERVER_ERROR, "server_error", "Failed to issue token")
         }
+    }
+}
+
+/// Preserve tenant claims only for assertions signed by a locally published
+/// service key. A trusted federated issuer proves identity, not membership in
+/// a local tenant; carrying its claim into a locally issued token would
+/// launder that external assertion into `verified_tenant`.
+fn authority_verified_assertion_tenant(
+    claims: &hyprstream_rpc::auth::Claims,
+    locally_verified_service: bool,
+) -> Option<String> {
+    if locally_verified_service {
+        claims.tenant.clone()
+    } else {
+        None
     }
 }
 
@@ -280,5 +295,28 @@ mod tests {
                 .with_issuer("https://issuer.example".to_owned())
                 .with_audience(Some("https://issuer.example/oauth/token".to_owned())), &retired);
         assert!(decode_with_any_service_key_at(&trust, &retired_assertion, "model", "https://issuer.example/oauth/token", retirement).is_none());
+    }
+
+    #[test]
+    fn federated_bearer_cannot_launder_tenant_into_local_token() {
+        let now = chrono::Utc::now().timestamp();
+        let claims = hyprstream_rpc::auth::Claims::new(
+            "external-user".to_owned(),
+            now,
+            now + 300,
+        )
+        .with_issuer("https://federated.example".to_owned())
+        .with_tenant("victim-domain".to_owned());
+
+        assert_eq!(
+            authority_verified_assertion_tenant(&claims, false),
+            None,
+            "a federated assertion's tenant must not reach PolicyService",
+        );
+        assert_eq!(
+            authority_verified_assertion_tenant(&claims, true).as_deref(),
+            Some("victim-domain"),
+            "a locally published service key remains an authority source",
+        );
     }
 }

--- a/crates/hyprstream/src/services/oauth/mod.rs
+++ b/crates/hyprstream/src/services/oauth/mod.rs
@@ -391,6 +391,9 @@ pub struct OAuthService {
     jwt_verifying_key: [u8; 32],
     /// Shared JTI blocklist (same Arc as PolicyService) for cross-plane revocation.
     jti_blocklist: Option<Arc<hyprstream_rpc::auth::InMemoryJtiBlocklist>>,
+    /// Authority-owned hosted-account records for ATProto DID → tenant
+    /// resolution. Attached by the PDS service composition layer.
+    hosted_account_store: Option<Arc<hyprstream_pds_service::AccountRecordStore>>,
 }
 
 impl OAuthService {
@@ -413,6 +416,7 @@ impl OAuthService {
             verifying_key,
             jwt_verifying_key: jwt_verifying_key.to_bytes(),
             jti_blocklist: None,
+            hosted_account_store: None,
         }
     }
 
@@ -428,6 +432,15 @@ impl OAuthService {
         bl: Arc<hyprstream_rpc::auth::InMemoryJtiBlocklist>,
     ) -> Self {
         self.jti_blocklist = Some(bl);
+        self
+    }
+
+    /// Attach the PDS hosted-account read service.
+    pub fn with_hosted_account_store(
+        mut self,
+        store: Arc<hyprstream_pds_service::AccountRecordStore>,
+    ) -> Self {
+        self.hosted_account_store = Some(store);
         self
     }
 }
@@ -731,6 +744,9 @@ impl Spawnable for OAuthService {
                 discovery_client.clone(),
                 jwt_verifying_key,
             );
+            if let Some(store) = &self.hosted_account_store {
+                oauth_state = oauth_state.with_hosted_account_store(Arc::clone(store));
+            }
             if let Some(store) = user_store {
                 oauth_state = oauth_state.with_user_store(store);
             }
@@ -1310,6 +1326,7 @@ mod tests {
         use hyprstream_rpc::transport::lazy_uds::LazyUdsTransport;
         use hyprstream_rpc::transport::TransportConfig;
         use hyprstream_service::{InprocManager, ServiceManager as _};
+        use hyprstream_vfs::{SyntheticMount, SyntheticNode};
         use sha2::{Digest as _, Sha256};
 
         use super::state::RegisteredClient;
@@ -1324,7 +1341,8 @@ mod tests {
         const CLIENT_ID: &str = "handler-client";
         const PRIVATE_CLIENT_ID: &str = "handler-private-client";
         const REDIRECT_URI: &str = "https://client.example.test/callback";
-        const MAPPED_DID: &str = "did:plc:abcdefghijklmnqrstuvwx2p";
+        const MAPPED_DID: &str = "did:web:alice.acct.example.test";
+        const HOSTED_TENANT: &str = "tenant-demo";
         const PKCE_VERIFIER: &str = "r5-handler-pkce-verifier-abcdefghijklmnopqrstuvwxyz012345";
         const GENERIC_PKCE_VERIFIER: &str =
             "r7-generic-pkce-verifier-abcdefghijklmnopqrstuvwxyz012345";
@@ -1431,8 +1449,53 @@ mod tests {
                 Ok(self.0.clone())
             }
         }
-        let atproto_signing_key =
-            p256::ecdsa::SigningKey::random(&mut rand::rngs::OsRng);
+        // #1314: the hosted account record is the authority binding between
+        // this DID and HOSTED_TENANT. Its generated #atproto key signs the
+        // service assertion below, so the fixture exercises the real record
+        // shape rather than an independent tenant map.
+        let account_ed = ed25519_dalek::SigningKey::generate(&mut rand::rngs::OsRng);
+        let (account_pq, account_pq_vk) = hyprstream_crypto::pq::ml_dsa_generate_keypair();
+        let account_hybrid = hyprstream_pds::did_op::HybridRotationKey::new(
+            account_ed.verifying_key().to_bytes(),
+            hyprstream_crypto::pq::ml_dsa_vk_bytes(&account_pq_vk),
+        )?;
+        let account_rotations = hyprstream_pds::did_op::GenesisRotationKeys::new(
+            hyprstream_pds::did_op::UserRotationKey::new(account_hybrid),
+            hyprstream_pds::did_op::RecoveryKeyEnrollment::Declined,
+            hyprstream_pds::did_op::HostKeyEnrollment::Absent,
+        )?;
+        let account_mint = hyprstream_pds::HostedAccountMint::begin(
+            hyprstream_pds::AllocatedAccountName::new("alice", MAPPED_DID)?,
+            account_rotations,
+        )?;
+        let pending_account = account_mint.prepare_genesis(
+            hyprstream_pds::Cid::from_raw(b"handler-hosted-account-doc"),
+            hyprstream_pds::did_op::GenesisRepoHead::EmptyRepo,
+        )?;
+        let account_signature = hyprstream_pds::did_op::sign_genesis(
+            pending_account.unsigned_genesis(),
+            &account_ed,
+            &account_pq,
+        )?;
+        let sealed_account = pending_account.seal(account_signature)?;
+        let atproto_signing_key = sealed_account.atproto_signing_key().clone();
+        let pds_root = SyntheticNode::dir().with_child(
+            HOSTED_TENANT,
+            SyntheticNode::dir().with_child(
+                "accounts",
+                SyntheticNode::dir().with_child(
+                    "alice",
+                    SyntheticNode::dir().with_child(
+                        "account-record.cbor",
+                        SyntheticNode::file(sealed_account.record_bytes().to_vec()),
+                    ),
+                ),
+            ),
+        );
+        let hosted_account_store =
+            Arc::new(hyprstream_pds_service::AccountRecordStore::new(Arc::new(
+                SyntheticMount::new(pds_root),
+            )));
         let mut atproto_multikey = vec![0x80, 0x24];
         atproto_multikey.extend_from_slice(
             atproto_signing_key
@@ -1459,6 +1522,7 @@ mod tests {
             service_key.verifying_key().to_bytes(),
         )
         .with_user_store(user_store)
+        .with_hosted_account_store(hosted_account_store)
         .with_atproto_did_resolver(Arc::new(FixtureAtprotoDidResolver(
             atproto_document,
         )));
@@ -1569,7 +1633,7 @@ mod tests {
             "demo-1119-jti",
         )?;
         use tower::ServiceExt as _;
-        let exchange_request = |jwt: &str| {
+        let exchange_request = |jwt: &str, tenant: &str| {
             axum::http::Request::post("/xrpc/ai.hyprstream.identity.exchangeUcan")
                 .header(axum::http::header::CONTENT_TYPE, "application/json")
                 .header(
@@ -1578,7 +1642,7 @@ mod tests {
                 )
                 .body(axum::body::Body::from(
                     serde_json::json!({
-                        "tenant": "tenant-foreign",
+                        "tenant": tenant,
                         "scope": "transition:generic",
                         "audience": ISSUER
                     })
@@ -1593,7 +1657,7 @@ mod tests {
         )?;
         let rejected_audience = app
             .clone()
-            .oneshot(exchange_request(&wrong_audience))
+            .oneshot(exchange_request(&wrong_audience, HOSTED_TENANT))
             .await?;
         assert_eq!(
             rejected_audience.status(),
@@ -1604,12 +1668,38 @@ mod tests {
             "com.atproto.repo.uploadBlob",
             "demo-1119-wrong-lxm",
         )?;
-        let rejected_lxm = app.clone().oneshot(exchange_request(&wrong_lxm)).await?;
+        let rejected_lxm = app
+            .clone()
+            .oneshot(exchange_request(&wrong_lxm, HOSTED_TENANT))
+            .await?;
         assert_eq!(rejected_lxm.status(), axum::http::StatusCode::UNAUTHORIZED);
 
-        // #1314: enrollment supplies MAC clearance only. Even this enrolled DID
-        // cannot turn the request's tenant into a verified local binding.
-        let rejected_tenant = app.clone().oneshot(exchange_request(&service_jwt)).await?;
+        // #1314: the authority-owned account record supplies the binding. A
+        // matching request succeeds and the minted credential carries exactly
+        // that record's tenant.
+        let exchanged = app
+            .clone()
+            .oneshot(exchange_request(&service_jwt, HOSTED_TENANT))
+            .await?;
+        assert_eq!(exchanged.status(), axum::http::StatusCode::OK);
+        let exchanged_json = response_json(exchanged).await;
+        let exchanged_token = exchanged_json["access_token"]
+            .as_str()
+            .expect("hosted ATProto identity receives a credential");
+        let exchanged_claims = jwt_claims(exchanged_token);
+        assert_eq!(exchanged_claims["sub"], MAPPED_DID);
+        assert_eq!(exchanged_claims["tenant"], HOSTED_TENANT);
+        assert_eq!(exchanged_claims["scope"], "transition:generic");
+
+        let wrong_tenant_jwt = make_service_jwt(
+            "did:web:pds.example.test",
+            token_exchange::ATPROTO_EXCHANGE_NSID,
+            "demo-1119-wrong-tenant",
+        )?;
+        let rejected_tenant = app
+            .clone()
+            .oneshot(exchange_request(&wrong_tenant_jwt, "tenant-foreign"))
+            .await?;
         assert_eq!(
             rejected_tenant.status(),
             axum::http::StatusCode::BAD_REQUEST
@@ -1618,11 +1708,11 @@ mod tests {
         assert_eq!(rejected_tenant_json["error"], "InvalidRequest");
         assert_eq!(
             rejected_tenant_json["message"],
-            "subject token has no verified local tenant binding"
+            "requested tenant differs from the verified source-token tenant"
         );
         assert!(
             rejected_tenant_json.get("access_token").is_none(),
-            "an enrolled external DID must not receive a credential for a client-selected tenant"
+            "a hosted DID must not receive a credential for a tenant other than its account binding"
         );
 
         // Device authorization rejects unknown clients at the real endpoint.

--- a/crates/hyprstream/src/services/oauth/mod.rs
+++ b/crates/hyprstream/src/services/oauth/mod.rs
@@ -1536,8 +1536,8 @@ mod tests {
         };
         let app = create_app(Arc::clone(&state), &cors);
 
-        // #1119 demo path: exact lxm/aud service auth becomes a tenant-scoped,
-        // authority-labeled local session credential.
+        // #1119 service assertions prove the external DID and requested
+        // operation. They do not bind that DID to a local tenant.
         let now = chrono::Utc::now().timestamp();
         let service_header = URL_SAFE_NO_PAD.encode(
             serde_json::to_vec(&serde_json::json!({
@@ -1578,7 +1578,7 @@ mod tests {
                 )
                 .body(axum::body::Body::from(
                     serde_json::json!({
-                        "tenant": "tenant-demo",
+                        "tenant": "tenant-foreign",
                         "scope": "transition:generic",
                         "audience": ISSUER
                     })
@@ -1607,59 +1607,23 @@ mod tests {
         let rejected_lxm = app.clone().oneshot(exchange_request(&wrong_lxm)).await?;
         assert_eq!(rejected_lxm.status(), axum::http::StatusCode::UNAUTHORIZED);
 
-        let exchanged = app.clone().oneshot(exchange_request(&service_jwt)).await?;
-        assert_eq!(exchanged.status(), axum::http::StatusCode::OK);
-        let exchanged_json = response_json(exchanged).await;
-        assert_eq!(exchanged_json["token_type"], "Bearer");
+        // #1314: enrollment supplies MAC clearance only. Even this enrolled DID
+        // cannot turn the request's tenant into a verified local binding.
+        let rejected_tenant = app.clone().oneshot(exchange_request(&service_jwt)).await?;
+        assert_eq!(
+            rejected_tenant.status(),
+            axum::http::StatusCode::BAD_REQUEST
+        );
+        let rejected_tenant_json = response_json(rejected_tenant).await;
+        assert_eq!(rejected_tenant_json["error"], "InvalidRequest");
+        assert_eq!(
+            rejected_tenant_json["message"],
+            "subject token has no verified local tenant binding"
+        );
         assert!(
-            exchanged_json["expires_in"].as_i64().is_some_and(|ttl| {
-                ttl > 0 && ttl <= i64::from(token_exchange::MAX_ATPROTO_EXCHANGE_TOKEN_TTL)
-            })
+            rejected_tenant_json.get("access_token").is_none(),
+            "an enrolled external DID must not receive a credential for a client-selected tenant"
         );
-        let exchanged_token = exchanged_json["access_token"].as_str().unwrap();
-        let exchanged_claims = jwt_claims(exchanged_token);
-        assert_eq!(exchanged_claims["sub"], MAPPED_DID);
-        assert_eq!(exchanged_claims["tenant"], "tenant-demo");
-        assert_eq!(exchanged_claims["scope"], "transition:generic");
-        assert_eq!(exchanged_claims["clearance"]["level"], "secret");
-        assert_eq!(exchanged_claims["clearance"]["assurance"], "classical");
-        assert!(
-            exchanged_claims.get("cnf").is_none(),
-            "service-auth is bearer auth; do not fabricate sender binding"
-        );
-
-        // verified_tenant survives for a local issuer and is stripped at the
-        // federation boundary.
-        let mut local_claims = auth::validate_oauth_access_token(&state, exchanged_token)
-            .await
-            .map_err(anyhow::Error::msg)?;
-        local_claims.strip_federated_tenant(&[GENERIC_ISSUER]);
-        assert_eq!(local_claims.tenant.as_deref(), Some("tenant-demo"));
-        use hyprstream_rpc::auth::mac::SubjectContextClaims as _;
-        let subject_context = local_claims
-            .security_context(hyprstream_rpc::auth::mac::VerifiedKeyMaterial::Classical)
-            .expect("exchange must produce a labeled subject");
-        let authorized_object = hyprstream_rpc::auth::mac::SecurityLabel::new(
-            hyprstream_rpc::auth::mac::Level::Confidential,
-            hyprstream_rpc::auth::mac::Assurance::Classical,
-            hyprstream_rpc::auth::mac::CompartmentSet::single(0),
-        );
-        assert!(subject_context.can_access(&authorized_object));
-        let pq_only_object = hyprstream_rpc::auth::mac::SecurityLabel::new(
-            hyprstream_rpc::auth::mac::Level::Public,
-            hyprstream_rpc::auth::mac::Assurance::PqHybrid,
-            hyprstream_rpc::auth::mac::CompartmentSet::EMPTY,
-        );
-        assert!(!subject_context.can_access(&pq_only_object));
-        local_claims.iss = "https://foreign.example".to_owned();
-        local_claims.strip_federated_tenant(&[GENERIC_ISSUER]);
-        local_claims.strip_federated_clearance(&[GENERIC_ISSUER]);
-        assert_eq!(local_claims.tenant, None);
-        assert_eq!(local_claims.clearance, None);
-
-        let replay = app.clone().oneshot(exchange_request(&service_jwt)).await?;
-        assert_eq!(replay.status(), axum::http::StatusCode::BAD_REQUEST);
-        assert_eq!(response_json(replay).await["error"], "InvalidToken");
 
         // Device authorization rejects unknown clients at the real endpoint.
         let unknown_device = post_form(

--- a/crates/hyprstream/src/services/oauth/mod.rs
+++ b/crates/hyprstream/src/services/oauth/mod.rs
@@ -115,6 +115,10 @@ pub fn create_app(state: Arc<OAuthState>, cors_config: &crate::config::CorsConfi
         )
         .route("/oauth/register", post(registration::register_client))
         .route(
+            "/xrpc/ai.hyprstream.identity.exchangeUcan",
+            post(token_exchange::exchange_atproto_ucan),
+        )
+        .route(
             "/oauth/authorize",
             get(authorize::authorize_get).post(authorize::authorize_post),
         )
@@ -1352,7 +1356,19 @@ mod tests {
             git2db,
             TransportConfig::inproc(&policy_tag),
         )
-        .with_default_audience(GENERIC_ISSUER.to_owned());
+        .with_default_audience(GENERIC_ISSUER.to_owned())
+        .with_token_clearance_resolver(Arc::new(|subject| {
+            use hyprstream_rpc::auth::mac::{
+                Assurance, CompartmentSet, Level, SecurityLabel,
+            };
+            (subject == MAPPED_DID).then(|| {
+                SecurityLabel::new(
+                    Level::Secret,
+                    Assurance::PqHybrid,
+                    CompartmentSet::single(0),
+                )
+            })
+        }));
         let manager = InprocManager::new();
         let mut policy_handle = manager.spawn(Box::new(policy_service)).await?;
         let policy_client = PolicyClient::for_local_endpoint_bootstrap(
@@ -1403,13 +1419,49 @@ mod tests {
         let mut config = crate::config::OAuthConfig::default();
         // Generic OAuth preserves this path; atproto emissions use its origin.
         config.external_url = Some(GENERIC_ISSUER.to_owned());
+
+        struct FixtureAtprotoDidResolver(serde_json::Value);
+        #[async_trait::async_trait]
+        impl super::state::AtprotoDidDocumentResolver for FixtureAtprotoDidResolver {
+            async fn resolve_document(&self, did: &str) -> anyhow::Result<serde_json::Value> {
+                anyhow::ensure!(
+                    self.0.get("id").and_then(serde_json::Value::as_str) == Some(did),
+                    "fixture DID mismatch"
+                );
+                Ok(self.0.clone())
+            }
+        }
+        let atproto_signing_key =
+            p256::ecdsa::SigningKey::random(&mut rand::rngs::OsRng);
+        let mut atproto_multikey = vec![0x80, 0x24];
+        atproto_multikey.extend_from_slice(
+            atproto_signing_key
+                .verifying_key()
+                .to_encoded_point(true)
+                .as_bytes(),
+        );
+        let atproto_document = serde_json::json!({
+            "id": MAPPED_DID,
+            "verificationMethod": [{
+                "id": format!("{MAPPED_DID}#atproto"),
+                "type": "Multikey",
+                "controller": MAPPED_DID,
+                "publicKeyMultibase": format!(
+                    "z{}",
+                    bs58::encode(atproto_multikey).into_string()
+                )
+            }]
+        });
         let mut oauth_state = OAuthState::new(
             &config,
             policy_client,
             DiscoveryClient::new(dummy_rpc),
             service_key.verifying_key().to_bytes(),
         )
-        .with_user_store(user_store);
+        .with_user_store(user_store)
+        .with_atproto_did_resolver(Arc::new(FixtureAtprotoDidResolver(
+            atproto_document,
+        )));
         let token_dir = tempfile::TempDir::new()?;
         oauth_state.with_token_store_impl(Arc::new(RocksDbTokenStore::open(
             token_dir.path().join("refresh.db"),
@@ -1483,6 +1535,131 @@ mod tests {
             ..Default::default()
         };
         let app = create_app(Arc::clone(&state), &cors);
+
+        // #1119 demo path: exact lxm/aud service auth becomes a tenant-scoped,
+        // authority-labeled local session credential.
+        let now = chrono::Utc::now().timestamp();
+        let service_header = URL_SAFE_NO_PAD.encode(
+            serde_json::to_vec(&serde_json::json!({
+                "alg": "ES256", "typ": "JWT", "kid": "#atproto"
+            }))?,
+        );
+        let make_service_jwt = |audience: &str, lxm: &str, jti: &str| -> anyhow::Result<String> {
+            let payload = URL_SAFE_NO_PAD.encode(
+                serde_json::to_vec(&serde_json::json!({
+                    "iss": MAPPED_DID,
+                    "aud": audience,
+                    "iat": now,
+                    "exp": now + 60,
+                    "lxm": lxm,
+                    "jti": jti
+                }))?,
+            );
+            let signing_input = format!("{service_header}.{payload}");
+            let signature: p256::ecdsa::Signature =
+                atproto_signing_key.sign(signing_input.as_bytes());
+            Ok(format!(
+                "{signing_input}.{}",
+                URL_SAFE_NO_PAD.encode(signature.to_bytes())
+            ))
+        };
+        let service_jwt = make_service_jwt(
+            "did:web:pds.example.test",
+            token_exchange::ATPROTO_EXCHANGE_NSID,
+            "demo-1119-jti",
+        )?;
+        use tower::ServiceExt as _;
+        let exchange_request = |jwt: &str| {
+            axum::http::Request::post("/xrpc/ai.hyprstream.identity.exchangeUcan")
+                .header(axum::http::header::CONTENT_TYPE, "application/json")
+                .header(
+                    axum::http::header::AUTHORIZATION,
+                    format!("Bearer {jwt}"),
+                )
+                .body(axum::body::Body::from(
+                    serde_json::json!({
+                        "tenant": "tenant-demo",
+                        "scope": "transition:generic",
+                        "audience": ISSUER
+                    })
+                    .to_string(),
+                ))
+                .unwrap()
+        };
+        let wrong_audience = make_service_jwt(
+            "did:web:other.example",
+            token_exchange::ATPROTO_EXCHANGE_NSID,
+            "demo-1119-wrong-aud",
+        )?;
+        let rejected_audience = app
+            .clone()
+            .oneshot(exchange_request(&wrong_audience))
+            .await?;
+        assert_eq!(
+            rejected_audience.status(),
+            axum::http::StatusCode::UNAUTHORIZED
+        );
+        let wrong_lxm = make_service_jwt(
+            "did:web:pds.example.test",
+            "com.atproto.repo.uploadBlob",
+            "demo-1119-wrong-lxm",
+        )?;
+        let rejected_lxm = app.clone().oneshot(exchange_request(&wrong_lxm)).await?;
+        assert_eq!(rejected_lxm.status(), axum::http::StatusCode::UNAUTHORIZED);
+
+        let exchanged = app.clone().oneshot(exchange_request(&service_jwt)).await?;
+        assert_eq!(exchanged.status(), axum::http::StatusCode::OK);
+        let exchanged_json = response_json(exchanged).await;
+        assert_eq!(exchanged_json["token_type"], "Bearer");
+        assert!(
+            exchanged_json["expires_in"].as_i64().is_some_and(|ttl| {
+                ttl > 0 && ttl <= i64::from(token_exchange::MAX_ATPROTO_EXCHANGE_TOKEN_TTL)
+            })
+        );
+        let exchanged_token = exchanged_json["access_token"].as_str().unwrap();
+        let exchanged_claims = jwt_claims(exchanged_token);
+        assert_eq!(exchanged_claims["sub"], MAPPED_DID);
+        assert_eq!(exchanged_claims["tenant"], "tenant-demo");
+        assert_eq!(exchanged_claims["scope"], "transition:generic");
+        assert_eq!(exchanged_claims["clearance"]["level"], "secret");
+        assert_eq!(exchanged_claims["clearance"]["assurance"], "classical");
+        assert!(
+            exchanged_claims.get("cnf").is_none(),
+            "service-auth is bearer auth; do not fabricate sender binding"
+        );
+
+        // verified_tenant survives for a local issuer and is stripped at the
+        // federation boundary.
+        let mut local_claims = auth::validate_oauth_access_token(&state, exchanged_token)
+            .await
+            .map_err(anyhow::Error::msg)?;
+        local_claims.strip_federated_tenant(&[GENERIC_ISSUER]);
+        assert_eq!(local_claims.tenant.as_deref(), Some("tenant-demo"));
+        use hyprstream_rpc::auth::mac::SubjectContextClaims as _;
+        let subject_context = local_claims
+            .security_context(hyprstream_rpc::auth::mac::VerifiedKeyMaterial::Classical)
+            .expect("exchange must produce a labeled subject");
+        let authorized_object = hyprstream_rpc::auth::mac::SecurityLabel::new(
+            hyprstream_rpc::auth::mac::Level::Confidential,
+            hyprstream_rpc::auth::mac::Assurance::Classical,
+            hyprstream_rpc::auth::mac::CompartmentSet::single(0),
+        );
+        assert!(subject_context.can_access(&authorized_object));
+        let pq_only_object = hyprstream_rpc::auth::mac::SecurityLabel::new(
+            hyprstream_rpc::auth::mac::Level::Public,
+            hyprstream_rpc::auth::mac::Assurance::PqHybrid,
+            hyprstream_rpc::auth::mac::CompartmentSet::EMPTY,
+        );
+        assert!(!subject_context.can_access(&pq_only_object));
+        local_claims.iss = "https://foreign.example".to_owned();
+        local_claims.strip_federated_tenant(&[GENERIC_ISSUER]);
+        local_claims.strip_federated_clearance(&[GENERIC_ISSUER]);
+        assert_eq!(local_claims.tenant, None);
+        assert_eq!(local_claims.clearance, None);
+
+        let replay = app.clone().oneshot(exchange_request(&service_jwt)).await?;
+        assert_eq!(replay.status(), axum::http::StatusCode::BAD_REQUEST);
+        assert_eq!(response_json(replay).await["error"], "InvalidToken");
 
         // Device authorization rejects unknown clients at the real endpoint.
         let unknown_device = post_form(
@@ -2339,6 +2516,7 @@ mod tests {
                 dpop_jkt: None,
                 issuer: None,
                 tenant: None,
+                require_clearance: false,
             })
             .await?
             .token;
@@ -2370,6 +2548,7 @@ mod tests {
                 dpop_jkt: None,
                 issuer: None,
                 tenant: None,
+                require_clearance: false,
             })
             .await?
             .token;
@@ -2417,6 +2596,7 @@ mod tests {
                 dpop_jkt: None,
                 issuer: None,
                 tenant: None,
+                require_clearance: false,
             })
             .await?
             .token;

--- a/crates/hyprstream/src/services/oauth/state.rs
+++ b/crates/hyprstream/src/services/oauth/state.rs
@@ -963,6 +963,10 @@ pub struct OAuthState {
     /// Now backed by `user_service`. Legacy code uses `user_store_reader()`.
     /// Kept as Option for backward-compatible `is_none()` checks.
     pub user_service: Option<Arc<UserService>>,
+    /// Authority-owned hosted-account records used to resolve an ATProto DID
+    /// to its local tenant binding. `None` means every ATProto identity is
+    /// federated-only for tenant exchange purposes.
+    pub hosted_account_store: Option<Arc<hyprstream_pds_service::AccountRecordStore>>,
     /// Ed25519 signing key for signing entity configurations (OpenID Federation 1.0).
     /// `None` when not configured.
     pub signing_key: Option<ed25519_dalek::SigningKey>,
@@ -1159,6 +1163,7 @@ impl OAuthState {
                 .unwrap_or_default(),
             verifying_key_bytes,
             user_service: None,
+            hosted_account_store: None,
             signing_key: None,
             root_identity_key_store: None,
             authority_hints: config.authority_hints.clone(),
@@ -1218,6 +1223,33 @@ impl OAuthState {
     ) -> Self {
         self.atproto_did_resolver = resolver;
         self
+    }
+
+    /// Attach the authority-owned hosted-account record store.
+    pub fn with_hosted_account_store(
+        mut self,
+        store: Arc<hyprstream_pds_service::AccountRecordStore>,
+    ) -> Self {
+        self.hosted_account_store = Some(store);
+        self
+    }
+
+    /// Resolve a signed ATProto subject DID to its hosted local tenant.
+    ///
+    /// The request tenant is deliberately absent from this API. A missing
+    /// store or record is a federated-only identity (`Ok(None)`); store
+    /// corruption, authorization failure, and ambiguous bindings are errors.
+    pub async fn hosted_account_tenant(&self, did: &str) -> Result<Option<String>, String> {
+        let Some(store) = &self.hosted_account_store else {
+            return Ok(None);
+        };
+        store
+            .resolve_tenant_for_hosted_did(
+                &hyprstream_rpc::Subject::new("service:oauth"),
+                did,
+            )
+            .await
+            .map_err(|error| format!("hosted account tenant resolution failed: {error}"))
     }
 
     /// Host service DID accepted in ATProto service-auth `aud`.

--- a/crates/hyprstream/src/services/oauth/state.rs
+++ b/crates/hyprstream/src/services/oauth/state.rs
@@ -18,6 +18,65 @@ use crate::config::OAuthConfig;
 use crate::services::{DiscoveryClient, PolicyClient};
 use hyprstream_util::TtlCache;
 
+/// Read-only resolver used by the ATProto service-auth exchange perimeter.
+#[async_trait::async_trait]
+pub trait AtprotoDidDocumentResolver: Send + Sync {
+    async fn resolve_document(&self, did: &str) -> anyhow::Result<serde_json::Value>;
+}
+
+struct HttpAtprotoDidDocumentResolver {
+    plc: hyprstream_rpc::did_plc::DidPlcResolver<hyprstream_rpc::did_plc::HttpPlcFetcher>,
+    web: hyprstream_rpc::did_web::HttpDidDocFetcher,
+}
+
+#[async_trait::async_trait]
+impl AtprotoDidDocumentResolver for HttpAtprotoDidDocumentResolver {
+    async fn resolve_document(&self, did: &str) -> anyhow::Result<serde_json::Value> {
+        if hyprstream_rpc::did_plc::is_did_plc(did) {
+            return self.plc.resolve_document(did).await;
+        }
+        if did.starts_with("did:web:") {
+            use hyprstream_rpc::did_web::DidDocFetcher as _;
+            let url = hyprstream_rpc::did_web::did_web_to_url(did)?;
+            let doc = self.web.fetch(&url).await?;
+            anyhow::ensure!(
+                doc.get("id").and_then(serde_json::Value::as_str) == Some(did),
+                "did:web document id does not match requested DID"
+            );
+            return Ok(doc);
+        }
+        anyhow::bail!("unsupported ATProto account DID method")
+    }
+}
+
+struct DenyAtprotoDidDocumentResolver(String);
+
+#[async_trait::async_trait]
+impl AtprotoDidDocumentResolver for DenyAtprotoDidDocumentResolver {
+    async fn resolve_document(&self, _did: &str) -> anyhow::Result<serde_json::Value> {
+        anyhow::bail!("ATProto DID resolver is unavailable: {}", self.0)
+    }
+}
+
+fn atproto_did_resolver(config: &OAuthConfig) -> Arc<dyn AtprotoDidDocumentResolver> {
+    let build = (|| -> anyhow::Result<HttpAtprotoDidDocumentResolver> {
+        let ttl = Duration::from_secs(config.atproto_did_cache_ttl_secs);
+        let base = url::Url::parse(&config.atproto_plc_directory_url)?;
+        let plc_config = hyprstream_rpc::did_plc::PlcResolverConfig::new(base, ttl)?;
+        Ok(HttpAtprotoDidDocumentResolver {
+            plc: hyprstream_rpc::did_plc::DidPlcResolver::new(plc_config)?,
+            web: hyprstream_rpc::did_web::HttpDidDocFetcher::new(ttl)?,
+        })
+    })();
+    match build {
+        Ok(resolver) => Arc::new(resolver),
+        Err(error) => {
+            tracing::error!(%error, "ATProto DID resolver configuration rejected");
+            Arc::new(DenyAtprotoDidDocumentResolver(error.to_string()))
+        }
+    }
+}
+
 /// Extract RSA public key components (n, e) from PKCS#8 DER and build a JWK.
 ///
 /// Uses simple_asn1 (transitive dep of jsonwebtoken) for DER parsing.
@@ -952,6 +1011,11 @@ pub struct OAuthState {
     /// the assertion's remaining `exp` lifetime. See
     /// `check_and_record_assertion_jti`.
     pub assertion_jti_seen: TtlCache<String, ()>,
+    /// One-use ATProto service-auth JTIs, namespaced by issuer and retained
+    /// until the source assertion expires.
+    pub atproto_service_jti_seen: TtlCache<String, ()>,
+    /// Validated did:plc/did:web document source for service-auth keys.
+    pub atproto_did_resolver: Arc<dyn AtprotoDidDocumentResolver>,
     /// Server-issued DPoP nonces. Value = expiry unix timestamp.
     pub dpop_nonces: RwLock<HashMap<String, i64>>,
     /// Per-client (keyed by DPoP `jkt` thumbprint) nonce-issuance state.
@@ -1114,6 +1178,11 @@ impl OAuthState {
                 Self::ASSERTION_JTI_MAX_ENTRIES,
                 Self::ASSERTION_JTI_REAP_BUDGET,
             ),
+            atproto_service_jti_seen: TtlCache::new(
+                Self::ASSERTION_JTI_MAX_ENTRIES,
+                Self::ASSERTION_JTI_REAP_BUDGET,
+            ),
+            atproto_did_resolver: atproto_did_resolver(config),
             dpop_nonces: RwLock::new(HashMap::new()),
             dpop_clients_seen: RwLock::new(HashMap::new()),
             trusted_issuers: config.trusted_issuers.clone(),
@@ -1140,6 +1209,21 @@ impl OAuthState {
     pub fn with_device_store(mut self, store: Arc<dyn crate::auth::DeviceStore>) -> Self {
         self.device_store = Some(store);
         self
+    }
+
+    /// Override ATProto DID resolution with a validated fixture or private resolver.
+    pub fn with_atproto_did_resolver(
+        mut self,
+        resolver: Arc<dyn AtprotoDidDocumentResolver>,
+    ) -> Self {
+        self.atproto_did_resolver = resolver;
+        self
+    }
+
+    /// Host service DID accepted in ATProto service-auth `aud`.
+    pub fn atproto_service_did(&self) -> Option<String> {
+        super::did_document::issuer_authority(&self.issuer_url)
+            .map(|authority| format!("did:web:{authority}"))
     }
 
     /// Set JWT signing key validity window for the JWKS endpoint.
@@ -1385,6 +1469,25 @@ impl OAuthState {
         let ttl_secs = ((iat + 120) - now).max(0) as u64;
         self.dpop_jti_seen
             .insert_if_absent(jti.to_owned(), (), Duration::from_secs(ttl_secs))
+    }
+
+    /// Atomically consume an ATProto service-auth assertion identifier.
+    pub fn check_and_record_atproto_service_jti(
+        &self,
+        issuer: &str,
+        jti: &str,
+        exp: i64,
+    ) -> bool {
+        let remaining = exp - chrono::Utc::now().timestamp();
+        if remaining <= 0 {
+            return false;
+        }
+        let ttl_secs = remaining as u64;
+        self.atproto_service_jti_seen.insert_if_absent_no_evict(
+            format!("{issuer}\u{1f}{jti}"),
+            (),
+            Duration::from_secs(ttl_secs),
+        )
     }
 
     /// Check a client-assertion JTI for replay and record it if new

--- a/crates/hyprstream/src/services/oauth/token.rs
+++ b/crates/hyprstream/src/services/oauth/token.rs
@@ -75,6 +75,8 @@ pub struct TokenRequest {
     pub scope: Option<String>,
     #[serde(default)]
     pub audience: Option<String>,
+    #[serde(default)]
+    pub tenant: Option<String>,
 }
 
 /// POST /oauth/token — token exchange
@@ -170,6 +172,7 @@ pub async fn exchange_token(
                 params.scope.as_deref(),
                 params.actor_token.as_deref(),
                 params.requested_token_type.as_deref(),
+                params.tenant.as_deref(),
             ).await
         }
         _ => token_error(
@@ -1018,6 +1021,7 @@ async fn issue_token_with_refresh(
             dpop_jkt: dpop_jkt.clone(),
             issuer: Some(token_issuer.clone()),
             tenant: None,
+            require_clearance: false,
         })
         .await;
 
@@ -1601,6 +1605,7 @@ mod tests {
             actor_token: None,
             scope: None,
             audience: None,
+            tenant: None,
         };
         let resp = exchange_refresh_token(Arc::clone(&state), params, None, None, None).await;
 
@@ -1666,6 +1671,7 @@ mod tests {
             actor_token: None,
             scope: None,
             audience: None,
+            tenant: None,
         };
         let resp = exchange_refresh_token(state.clone(), params, None, None, None).await;
 

--- a/crates/hyprstream/src/services/oauth/token_exchange.rs
+++ b/crates/hyprstream/src/services/oauth/token_exchange.rs
@@ -9,11 +9,13 @@
 use std::sync::Arc;
 
 use axum::{
-    http::{header, StatusCode},
+    extract::State,
+    http::{header, HeaderMap, StatusCode},
     response::{IntoResponse, Response},
     Json,
 };
 use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine as _};
+use serde::Deserialize;
 use sha2::{Digest, Sha256};
 
 use super::state::OAuthState;
@@ -25,6 +27,9 @@ const TOKEN_TYPE_ID_TOKEN: &str = "urn:ietf:params:oauth:token-type:id_token";
 const TOKEN_TYPE_ACCESS_TOKEN: &str = "urn:ietf:params:oauth:token-type:access_token";
 const TOKEN_TYPE_JWT: &str = "urn:ietf:params:oauth:token-type:jwt";
 const ISSUED_TOKEN_TYPE: &str = "urn:ietf:params:oauth:token-type:access_token";
+pub const ATPROTO_EXCHANGE_NSID: &str = "ai.hyprstream.identity.exchangeUcan";
+const MAX_ATPROTO_SERVICE_TOKEN_LIFETIME: i64 = 3600;
+pub(super) const MAX_ATPROTO_EXCHANGE_TOKEN_TTL: u32 = 300;
 
 struct VerifiedSubject {
     sub: String,
@@ -33,6 +38,10 @@ struct VerifiedSubject {
     /// Authority from a locally validated OAuth access-token grant. Identity
     /// tokens and generic JWTs do not carry a server-authorized OAuth grant.
     granted_scopes: Option<Vec<String>>,
+    verified_tenant: Option<String>,
+    atproto_replay: Option<(String, String, i64)>,
+    require_clearance: bool,
+    ttl_ceiling: Option<u32>,
 }
 
 /// POST /oauth/token — token-exchange grant (RFC 8693).
@@ -44,6 +53,7 @@ pub async fn exchange_token_exchange(
     scope: Option<&str>,
     actor_token: Option<&str>,
     requested_token_type: Option<&str>,
+    tenant: Option<&str>,
 ) -> Response {
     // Actor token (delegation) is deferred — RFC 8693 §4.
     if actor_token.is_some() {
@@ -92,6 +102,13 @@ pub async fn exchange_token_exchange(
         }
     };
 
+    let tenant = match exchange_tenant(&verified, tenant) {
+        Ok(tenant) => tenant,
+        Err(description) => {
+            return tx_error(StatusCode::BAD_REQUEST, "invalid_target", description);
+        }
+    };
+
     // The PolicyService check remains the shared signing boundary for every
     // RPC issuer; this gives RFC 8693 callers a concrete OAuth error before a
     // legacy subject can reach that RPC boundary.
@@ -103,10 +120,13 @@ pub async fn exchange_token_exchange(
         );
     }
 
-    // Replay prevention: SHA-256 of the subject token as the replay key.
-    // Covers all token types, regardless of whether they carry a jti claim.
-    let token_hash = URL_SAFE_NO_PAD.encode(Sha256::digest(subject_token.as_bytes()));
-    if !state.check_and_record_dpop_jti(&token_hash, verified.iat) {
+    let fresh = if let Some((issuer, jti, exp)) = verified.atproto_replay.as_ref() {
+        state.check_and_record_atproto_service_jti(issuer, jti, *exp)
+    } else {
+        let token_hash = URL_SAFE_NO_PAD.encode(Sha256::digest(subject_token.as_bytes()));
+        state.check_and_record_dpop_jti(&token_hash, verified.iat)
+    };
+    if !fresh {
         return tx_error(
             StatusCode::BAD_REQUEST,
             "invalid_grant",
@@ -121,13 +141,16 @@ pub async fn exchange_token_exchange(
         .policy_client
         .issue_token(&IssueToken {
             requested_scopes,
-            ttl: Some(state.token_ttl),
+            ttl: Some(state.token_ttl.min(
+                verified.ttl_ceiling.unwrap_or(state.token_ttl),
+            )),
             audience: audience.map(str::to_owned),
             subject: Some(verified.sub.clone()),
             user_pub_key,
             dpop_jkt: None,
             issuer: None,
-            tenant: None,
+            tenant,
+            require_clearance: verified.require_clearance,
         })
         .await;
 
@@ -201,6 +224,10 @@ async fn verify_id_token(state: &Arc<OAuthState>, token: &str) -> Result<Verifie
         cnf_key_bytes: None, // ID tokens carry no key binding
         iat: claims.iat,
         granted_scopes: None,
+        verified_tenant: None,
+        atproto_replay: None,
+        require_clearance: false,
+        ttl_ceiling: None,
     })
 }
 
@@ -221,6 +248,10 @@ async fn verify_access_token(state: &OAuthState, token: &str) -> Result<Verified
         cnf_key_bytes,
         iat: claims.iat,
         granted_scopes,
+        verified_tenant: claims.tenant,
+        atproto_replay: None,
+        require_clearance: false,
+        ttl_ceiling: None,
     })
 }
 
@@ -230,6 +261,18 @@ async fn verify_access_token(state: &OAuthState, token: &str) -> Result<Verified
 /// For other subjects: issuer must be in `trusted_issuers`.
 /// Audience must equal the token endpoint URL (same constraint as RFC 7523).
 async fn verify_jwt(state: &Arc<OAuthState>, token: &str) -> Result<VerifiedSubject, String> {
+    let issuer_hint = token
+        .split('.')
+        .nth(1)
+        .and_then(|payload| URL_SAFE_NO_PAD.decode(payload).ok())
+        .and_then(|payload| serde_json::from_slice::<serde_json::Value>(&payload).ok())
+        .and_then(|payload| payload.get("iss").and_then(serde_json::Value::as_str).map(str::to_owned));
+    if issuer_hint.as_deref().is_some_and(|issuer| {
+        issuer.starts_with("did:plc:") || issuer.starts_with("did:web:")
+    }) {
+        return verify_atproto_service_jwt(state, token).await;
+    }
+
     let unverified = hyprstream_rpc::auth::decode_unverified(token)
         .map_err(|e| format!("Cannot parse jwt: {e}"))?;
 
@@ -269,7 +312,274 @@ async fn verify_jwt(state: &Arc<OAuthState>, token: &str) -> Result<VerifiedSubj
         cnf_key_bytes,
         iat: claims.iat,
         granted_scopes: None,
+        verified_tenant: None,
+        atproto_replay: None,
+        require_clearance: false,
+        ttl_ceiling: None,
     })
+}
+
+#[derive(Deserialize)]
+struct AtprotoJwtHeader {
+    alg: String,
+    #[serde(default)]
+    typ: Option<String>,
+    #[serde(default)]
+    kid: Option<String>,
+}
+
+#[derive(Deserialize)]
+struct AtprotoServiceClaims {
+    iss: String,
+    aud: String,
+    exp: i64,
+    iat: i64,
+    lxm: String,
+    jti: String,
+}
+
+async fn verify_atproto_service_jwt(
+    state: &Arc<OAuthState>,
+    token: &str,
+) -> Result<VerifiedSubject, String> {
+    let parts: Vec<&str> = token.split('.').collect();
+    if parts.len() != 3 || parts.iter().any(|part| part.is_empty()) {
+        return Err("ATProto service JWT must contain exactly three segments".to_owned());
+    }
+    let header: AtprotoJwtHeader = decode_jwt_json(parts[0], "header")?;
+    let claims: AtprotoServiceClaims = decode_jwt_json(parts[1], "claims")?;
+    if !matches!(header.alg.as_str(), "ES256" | "ES256K") {
+        return Err("ATProto service JWT alg must be ES256 or ES256K".to_owned());
+    }
+    if header.typ.as_deref().is_some_and(|typ| !typ.eq_ignore_ascii_case("JWT")) {
+        return Err("ATProto service JWT typ must be JWT when present".to_owned());
+    }
+    super::state::subject_did_for(&state.issuer_url, &claims.iss)
+        .map_err(|error| format!("invalid ATProto issuer DID: {error}"))?;
+    let expected_audience = state.atproto_service_did()
+        .ok_or_else(|| "OAuth issuer cannot be represented as a host service DID".to_owned())?;
+    if claims.aud != expected_audience {
+        return Err(format!("ATProto service JWT aud must equal host DID {expected_audience}"));
+    }
+    if claims.lxm != ATPROTO_EXCHANGE_NSID {
+        return Err(format!("ATProto service JWT lxm must equal {ATPROTO_EXCHANGE_NSID}"));
+    }
+    let now = chrono::Utc::now().timestamp();
+    if claims.exp <= now {
+        return Err("ATProto service JWT is expired".to_owned());
+    }
+    if claims.iat > now + 5 || claims.exp <= claims.iat {
+        return Err("ATProto service JWT has an invalid iat/exp interval".to_owned());
+    }
+    if claims.exp - claims.iat > MAX_ATPROTO_SERVICE_TOKEN_LIFETIME {
+        return Err("ATProto service JWT lifetime exceeds one hour".to_owned());
+    }
+    if claims.jti.is_empty() || claims.jti.len() > 256 {
+        return Err("ATProto service JWT jti must be 1..=256 bytes".to_owned());
+    }
+
+    let document = state.atproto_did_resolver.resolve_document(&claims.iss).await
+        .map_err(|error| format!("ATProto DID resolution failed: {error}"))?;
+    let fragment = header.kid.as_deref().unwrap_or("#atproto");
+    let key_id = if fragment.starts_with('#') {
+        format!("{}{fragment}", claims.iss)
+    } else {
+        fragment.to_owned()
+    };
+    if !key_id.starts_with(&format!("{}#", claims.iss)) {
+        return Err("ATProto signing kid must be a fragment of the issuer DID".to_owned());
+    }
+    let methods = document.get("verificationMethod")
+        .and_then(serde_json::Value::as_array)
+        .ok_or_else(|| "ATProto DID document has no verificationMethod array".to_owned())?;
+    let mut matches = methods.iter().filter(|method| {
+        method.get("id").and_then(serde_json::Value::as_str) == Some(key_id.as_str())
+    });
+    let method = matches.next()
+        .ok_or_else(|| format!("ATProto signing method {key_id} not found"))?;
+    if matches.next().is_some() {
+        return Err(format!("ATProto signing method {key_id} is ambiguous"));
+    }
+    if method.get("type").and_then(serde_json::Value::as_str) != Some("Multikey")
+        || method.get("controller").and_then(serde_json::Value::as_str)
+            != Some(claims.iss.as_str())
+    {
+        return Err("ATProto signing method must be a subject-controlled Multikey".to_owned());
+    }
+    let multikey = method.get("publicKeyMultibase")
+        .and_then(serde_json::Value::as_str)
+        .ok_or_else(|| "ATProto signing method has no publicKeyMultibase".to_owned())?;
+    verify_atproto_ecdsa(
+        &header.alg,
+        multikey,
+        format!("{}.{}", parts[0], parts[1]).as_bytes(),
+        parts[2],
+    )?;
+
+    Ok(VerifiedSubject {
+        sub: claims.iss.clone(),
+        cnf_key_bytes: None,
+        iat: claims.iat,
+        granted_scopes: Some(vec!["transition:generic".to_owned()]),
+        verified_tenant: None,
+        atproto_replay: Some((claims.iss, claims.jti, claims.exp)),
+        require_clearance: true,
+        ttl_ceiling: Some(MAX_ATPROTO_EXCHANGE_TOKEN_TTL),
+    })
+}
+
+fn decode_jwt_json<T: serde::de::DeserializeOwned>(
+    segment: &str,
+    name: &str,
+) -> Result<T, String> {
+    let bytes = URL_SAFE_NO_PAD.decode(segment)
+        .map_err(|_| format!("ATProto service JWT {name} is not base64url"))?;
+    serde_json::from_slice(&bytes)
+        .map_err(|error| format!("ATProto service JWT {name} is invalid: {error}"))
+}
+
+fn verify_atproto_ecdsa(
+    alg: &str,
+    multikey: &str,
+    signing_input: &[u8],
+    signature_segment: &str,
+) -> Result<(), String> {
+    use p256::ecdsa::signature::Verifier as _;
+
+    let encoded = multikey.strip_prefix('z')
+        .ok_or_else(|| "ATProto Multikey must use base58btc".to_owned())?;
+    let key = bs58::decode(encoded).into_vec()
+        .map_err(|_| "ATProto Multikey is invalid base58btc".to_owned())?;
+    let signature = URL_SAFE_NO_PAD.decode(signature_segment)
+        .map_err(|_| "ATProto service JWT signature is not base64url".to_owned())?;
+    match alg {
+        "ES256" => {
+            let raw = key.strip_prefix(&[0x80, 0x24])
+                .ok_or_else(|| "ES256 requires a p256-pub Multikey".to_owned())?;
+            let verifying_key = p256::ecdsa::VerifyingKey::from_sec1_bytes(raw)
+                .map_err(|_| "invalid P-256 ATProto signing key".to_owned())?;
+            let signature = p256::ecdsa::Signature::from_slice(&signature)
+                .map_err(|_| "invalid ES256 service JWT signature encoding".to_owned())?;
+            verifying_key.verify(signing_input, &signature)
+                .map_err(|_| "ATProto service JWT signature verification failed".to_owned())
+        }
+        "ES256K" => {
+            let raw = key.strip_prefix(&[0xe7, 0x01])
+                .ok_or_else(|| "ES256K requires a secp256k1-pub Multikey".to_owned())?;
+            let verifying_key = k256::ecdsa::VerifyingKey::from_sec1_bytes(raw)
+                .map_err(|_| "invalid secp256k1 ATProto signing key".to_owned())?;
+            let signature = k256::ecdsa::Signature::from_slice(&signature)
+                .map_err(|_| "invalid ES256K service JWT signature encoding".to_owned())?;
+            verifying_key.verify(signing_input, &signature)
+                .map_err(|_| "ATProto service JWT signature verification failed".to_owned())
+        }
+        _ => Err("unsupported ATProto service JWT algorithm".to_owned()),
+    }
+}
+
+fn exchange_tenant(
+    subject: &VerifiedSubject,
+    requested: Option<&str>,
+) -> Result<Option<String>, &'static str> {
+    let requested = requested.map(str::trim);
+    if requested.is_some_and(|tenant| {
+        tenant.is_empty() || tenant == "*" || tenant.len() > 128
+            || tenant.chars().any(char::is_control)
+    }) {
+        return Err("tenant must be a concrete, non-empty domain");
+    }
+    match (subject.verified_tenant.as_deref(), requested) {
+        (Some(verified), Some(requested)) if verified != requested => {
+            Err("requested tenant differs from the verified source-token tenant")
+        }
+        (Some(verified), _) => Ok(Some(verified.to_owned())),
+        (None, Some(requested)) => Ok(Some(requested.to_owned())),
+        (None, None) if subject.require_clearance => {
+            Err("tenant is required for the ATProto exchange")
+        }
+        (None, None) => Ok(None),
+    }
+}
+
+#[derive(Deserialize)]
+pub struct AtprotoExchangeRequest {
+    pub tenant: String,
+    #[serde(default)]
+    pub scope: Option<String>,
+    #[serde(default)]
+    pub audience: Option<String>,
+}
+
+/// XRPC adapter over the RFC 8693 exchange core.
+pub async fn exchange_atproto_ucan(
+    State(state): State<Arc<OAuthState>>,
+    headers: HeaderMap,
+    Json(request): Json<AtprotoExchangeRequest>,
+) -> Response {
+    let Some(assertion) = headers.get(header::AUTHORIZATION)
+        .and_then(|value| value.to_str().ok())
+        .and_then(|value| value.split_once(' '))
+        .filter(|(scheme, token)| {
+            scheme.eq_ignore_ascii_case("Bearer")
+                && !token.is_empty()
+                && !token.chars().any(char::is_whitespace)
+        })
+        .map(|(_, token)| token)
+    else {
+        return xrpc_error(
+            StatusCode::UNAUTHORIZED,
+            "InvalidToken",
+            "Authorization: Bearer service JWT is required",
+        );
+    };
+    let response = exchange_token_exchange(
+        &state,
+        assertion,
+        TOKEN_TYPE_JWT,
+        request.audience.as_deref(),
+        request.scope.as_deref(),
+        None,
+        Some(ISSUED_TOKEN_TYPE),
+        Some(&request.tenant),
+    ).await;
+    if response.status().is_success() {
+        return response;
+    }
+
+    let status = response.status();
+    let body = axum::body::to_bytes(response.into_body(), 16 * 1024)
+        .await
+        .ok()
+        .and_then(|bytes| serde_json::from_slice::<serde_json::Value>(&bytes).ok());
+    let oauth_error = body.as_ref()
+        .and_then(|value| value.get("error"))
+        .and_then(serde_json::Value::as_str);
+    let message = body.as_ref()
+        .and_then(|value| value.get("error_description"))
+        .and_then(serde_json::Value::as_str)
+        .unwrap_or("ATProto credential exchange failed");
+    let error = match oauth_error {
+        Some("invalid_grant") => "InvalidToken",
+        Some("invalid_scope" | "invalid_target" | "invalid_request") => "InvalidRequest",
+        _ if status.is_server_error() => "InternalServerError",
+        _ => "InvalidRequest",
+    };
+    xrpc_error(status, error, message)
+}
+
+fn xrpc_error(status: StatusCode, error: &str, message: &str) -> Response {
+    (
+        status,
+        [
+            (header::CACHE_CONTROL, "no-store"),
+            (header::PRAGMA, "no-cache"),
+        ],
+        Json(serde_json::json!({
+            "error": error,
+            "message": message,
+        })),
+    )
+        .into_response()
 }
 
 /// Bound an RFC 8693 scope request to authority already present on the verified
@@ -1136,6 +1446,59 @@ mod tests {
     use hyprstream_rpc::auth::mac::{
         Assurance, CompartmentSet, Level, SecurityLabel, VerifiedKeyMaterial,
     };
+
+    #[test]
+    fn atproto_ecdsa_accepts_p256_and_secp256k1_multikeys() {
+        use p256::ecdsa::signature::Signer as _;
+
+        let message = b"header.payload";
+        let p256_key = p256::ecdsa::SigningKey::random(&mut rand::rngs::OsRng);
+        let mut p256_multikey = vec![0x80, 0x24];
+        p256_multikey.extend_from_slice(
+            p256_key.verifying_key().to_encoded_point(true).as_bytes(),
+        );
+        let p256_signature: p256::ecdsa::Signature = p256_key.sign(message);
+        verify_atproto_ecdsa(
+            "ES256",
+            &format!("z{}", bs58::encode(p256_multikey).into_string()),
+            message,
+            &URL_SAFE_NO_PAD.encode(p256_signature.to_bytes()),
+        )
+        .unwrap();
+
+        let k256_key = k256::ecdsa::SigningKey::random(&mut rand::rngs::OsRng);
+        let mut k256_multikey = vec![0xe7, 0x01];
+        k256_multikey.extend_from_slice(
+            k256_key.verifying_key().to_encoded_point(true).as_bytes(),
+        );
+        let k256_signature: k256::ecdsa::Signature = k256_key.sign(message);
+        verify_atproto_ecdsa(
+            "ES256K",
+            &format!("z{}", bs58::encode(k256_multikey).into_string()),
+            message,
+            &URL_SAFE_NO_PAD.encode(k256_signature.to_bytes()),
+        )
+        .unwrap();
+    }
+
+    #[test]
+    fn exchange_tenant_honors_verified_source_and_rejects_replacement() {
+        let subject = VerifiedSubject {
+            sub: "did:plc:abcdefghijklmnqrstuvwx2p".to_owned(),
+            cnf_key_bytes: None,
+            iat: 1,
+            granted_scopes: None,
+            verified_tenant: Some("tenant-source".to_owned()),
+            atproto_replay: None,
+            require_clearance: false,
+            ttl_ceiling: None,
+        };
+        assert_eq!(
+            exchange_tenant(&subject, None).unwrap().as_deref(),
+            Some("tenant-source")
+        );
+        assert!(exchange_tenant(&subject, Some("tenant-other")).is_err());
+    }
 
     fn mint_test_state() -> Arc<OAuthState> {
         use crate::config::OAuthConfig;

--- a/crates/hyprstream/src/services/oauth/token_exchange.rs
+++ b/crates/hyprstream/src/services/oauth/token_exchange.rs
@@ -415,13 +415,17 @@ async fn verify_atproto_service_jwt(
         format!("{}.{}", parts[0], parts[1]).as_bytes(),
         parts[2],
     )?;
+    // The service assertion proves the DID, not a tenant. Resolve any local
+    // tenant binding only after signature verification and only from the
+    // authority-owned hosted-account record store.
+    let verified_tenant = state.hosted_account_tenant(&claims.iss).await?;
 
     Ok(VerifiedSubject {
         sub: claims.iss.clone(),
         cnf_key_bytes: None,
         iat: claims.iat,
         granted_scopes: Some(vec!["transition:generic".to_owned()]),
-        verified_tenant: None,
+        verified_tenant,
         atproto_replay: Some((claims.iss, claims.jti, claims.exp)),
         require_clearance: true,
         ttl_ceiling: Some(MAX_ATPROTO_EXCHANGE_TOKEN_TTL),
@@ -494,11 +498,10 @@ fn exchange_tenant(
         }
         (Some(verified), _) => Ok(Some(verified.to_owned())),
         // Tenant selection is an authority assertion, not an exchange
-        // parameter. Federated identity proofs (including enrolled ATProto
-        // DIDs) establish identity and possibly clearance, but do not bind the
-        // subject to a local Casbin domain. Mirror `strip_federated_tenant`:
-        // only a tenant preserved from a verified local-issuer token may reach
-        // PolicyService.
+        // parameter. Federated identity proofs establish identity but do not
+        // bind the subject to a local Casbin domain. Only a tenant preserved
+        // from a verified local-issuer token or resolved from a hosted account
+        // record may reach PolicyService.
         (None, Some(_)) => Err("subject token has no verified local tenant binding"),
         (None, None) if subject.require_clearance => {
             Err("tenant is required for the ATProto exchange")

--- a/crates/hyprstream/src/services/oauth/token_exchange.rs
+++ b/crates/hyprstream/src/services/oauth/token_exchange.rs
@@ -493,7 +493,13 @@ fn exchange_tenant(
             Err("requested tenant differs from the verified source-token tenant")
         }
         (Some(verified), _) => Ok(Some(verified.to_owned())),
-        (None, Some(requested)) => Ok(Some(requested.to_owned())),
+        // Tenant selection is an authority assertion, not an exchange
+        // parameter. Federated identity proofs (including enrolled ATProto
+        // DIDs) establish identity and possibly clearance, but do not bind the
+        // subject to a local Casbin domain. Mirror `strip_federated_tenant`:
+        // only a tenant preserved from a verified local-issuer token may reach
+        // PolicyService.
+        (None, Some(_)) => Err("subject token has no verified local tenant binding"),
         (None, None) if subject.require_clearance => {
             Err("tenant is required for the ATProto exchange")
         }
@@ -1482,8 +1488,8 @@ mod tests {
     }
 
     #[test]
-    fn exchange_tenant_honors_verified_source_and_rejects_replacement() {
-        let subject = VerifiedSubject {
+    fn exchange_tenant_requires_verified_local_binding() {
+        let local_subject = VerifiedSubject {
             sub: "did:plc:abcdefghijklmnqrstuvwx2p".to_owned(),
             cnf_key_bytes: None,
             iat: 1,
@@ -1494,10 +1500,32 @@ mod tests {
             ttl_ceiling: None,
         };
         assert_eq!(
-            exchange_tenant(&subject, None).unwrap().as_deref(),
+            exchange_tenant(&local_subject, None).unwrap().as_deref(),
             Some("tenant-source")
         );
-        assert!(exchange_tenant(&subject, Some("tenant-other")).is_err());
+        assert_eq!(
+            exchange_tenant(&local_subject, Some("tenant-source"))
+                .unwrap()
+                .as_deref(),
+            Some("tenant-source")
+        );
+        assert!(exchange_tenant(&local_subject, Some("tenant-other")).is_err());
+
+        let external_enrolled_subject = VerifiedSubject {
+            sub: "did:plc:externalenrolledsubject".to_owned(),
+            cnf_key_bytes: None,
+            iat: 1,
+            granted_scopes: Some(vec!["transition:generic".to_owned()]),
+            verified_tenant: None,
+            atproto_replay: None,
+            require_clearance: true,
+            ttl_ceiling: Some(MAX_ATPROTO_EXCHANGE_TOKEN_TTL),
+        };
+        assert_eq!(
+            exchange_tenant(&external_enrolled_subject, Some("tenant-foreign")),
+            Err("subject token has no verified local tenant binding"),
+            "an enrolled external DID cannot turn a client assertion into a local tenant binding"
+        );
     }
 
     fn mint_test_state() -> Arc<OAuthState> {

--- a/crates/hyprstream/src/services/policy.rs
+++ b/crates/hyprstream/src/services/policy.rs
@@ -103,6 +103,10 @@ pub struct PolicyService {
     es256_key_store: Option<Arc<crate::auth::Es256SigningKeyStore>>,
     /// ML-DSA-65 key rotation store for PQ-hybrid composite token issuance.
     ml_dsa_key_store: Option<Arc<crate::auth::MlDsaSigningKeyStore>>,
+    /// Authority-owned enrollment lookup for MAC-labeled credentials.
+    token_clearance_resolver: Arc<
+        dyn Fn(&str) -> Option<hyprstream_rpc::auth::mac::SecurityLabel> + Send + Sync,
+    >,
 }
 
 impl PolicyService {
@@ -131,6 +135,10 @@ impl PolicyService {
             jti_blocklist: Arc::new(hyprstream_rpc::auth::InMemoryJtiBlocklist::new()),
             es256_key_store: None,
             ml_dsa_key_store: None,
+            token_clearance_resolver: Arc::new(|subject| {
+                let policy = crate::mac::compiled_policy()?;
+                policy.clearance_for(subject)
+            }),
         }
     }
 
@@ -142,6 +150,17 @@ impl PolicyService {
     /// Set the default audience for issued tokens (typically the OAuth issuer URL).
     pub fn with_default_audience(mut self, audience: String) -> Self {
         self.default_audience = Some(audience);
+        self
+    }
+
+    /// Override enrollment lookup for an isolated service fixture.
+    pub fn with_token_clearance_resolver(
+        mut self,
+        resolver: Arc<
+            dyn Fn(&str) -> Option<hyprstream_rpc::auth::mac::SecurityLabel> + Send + Sync,
+        >,
+    ) -> Self {
+        self.token_clearance_resolver = resolver;
         self
     }
 
@@ -449,6 +468,25 @@ impl PolicyHandler for PolicyService {
             ctx.user().to_owned()
         };
 
+        let subject_clearance = if data.require_clearance {
+            (self.token_clearance_resolver)(&subject).map(|clearance| {
+                let context = hyprstream_rpc::auth::mac::SecurityContext::from_clearance(
+                    clearance,
+                    hyprstream_rpc::auth::mac::VerifiedKeyMaterial::Classical,
+                );
+                *context.clearance()
+            })
+        } else {
+            None
+        };
+        if data.require_clearance && subject_clearance.is_none() {
+            return Ok(PolicyResponseVariant::Error(ErrorInfo {
+                message: format!("Subject '{subject}' has no verified enrollment clearance"),
+                code: "UNLABELED_SUBJECT".to_owned(),
+                details: "MAC-enforcing token issuance fails closed for unenrolled subjects".to_owned(),
+            }));
+        }
+
         // #1159 freeze: this is the shared signing boundary for every caller
         // using PolicyClient::issue_token, including RFC 8693 token exchange
         // and RFC 7523 JWT bearer. Check the resolved concrete subject, not
@@ -584,6 +622,9 @@ impl PolicyHandler for PolicyService {
          .with_scope(granted_scope);
         if target_domain != "*" {
             claims = claims.with_tenant(target_domain);
+        }
+        if let Some(clearance) = subject_clearance {
+            claims = claims.with_clearance(clearance);
         }
 
         // DPoP jkt takes priority over userPubKey (RFC 9449 § 6).
@@ -1908,6 +1949,7 @@ mod tests {
             dpop_jkt: None,
             issuer: None,
             tenant: None,
+            require_clearance: false,
         }
     }
 

--- a/lexicons/ai/hyprstream/identity/exchangeUcan.json
+++ b/lexicons/ai/hyprstream/identity/exchangeUcan.json
@@ -1,0 +1,55 @@
+{
+  "lexicon": 1,
+  "id": "ai.hyprstream.identity.exchangeUcan",
+  "defs": {
+    "main": {
+      "type": "procedure",
+      "description": "Exchange a one-use ATProto service-auth JWT for a short-lived, MAC-labeled hyprstream bearer session credential.",
+      "input": {
+        "encoding": "application/json",
+        "schema": {
+          "type": "object",
+          "required": ["tenant"],
+          "properties": {
+            "tenant": {
+              "type": "string",
+              "minLength": 1,
+              "maxLength": 128
+            },
+            "scope": {
+              "type": "string",
+              "description": "Optional attenuation of the fixed transition:generic exchange grant."
+            },
+            "audience": {
+              "type": "string",
+              "description": "Optional RFC 8707 resource indicator for the issued credential."
+            }
+          }
+        }
+      },
+      "output": {
+        "encoding": "application/json",
+        "schema": {
+          "type": "object",
+          "required": [
+            "access_token",
+            "issued_token_type",
+            "token_type",
+            "expires_in"
+          ],
+          "properties": {
+            "access_token": { "type": "string" },
+            "issued_token_type": { "type": "string", "const": "urn:ietf:params:oauth:token-type:access_token" },
+            "token_type": { "type": "string", "const": "Bearer" },
+            "expires_in": { "type": "integer", "minimum": 0 }
+          }
+        }
+      },
+      "errors": [
+        { "name": "InvalidToken", "description": "The service-auth JWT is invalid, expired, or already used." },
+        { "name": "InvalidRequest", "description": "The requested tenant, scope, or audience is invalid." },
+        { "name": "InternalServerError", "description": "The host could not issue a credential." }
+      ]
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- add the `ai.hyprstream.identity.exchangeUcan` XRPC/Lexicon endpoint over the RFC 8693 exchange core
- verify ATProto service-auth JWTs against hardened `did:plc` / host-form `did:web` resolution, including `iss`, host `did:web` audience, `exp`/`iat`, exact `lxm`, ES256/ES256K keys, and one-use issuer-scoped `jti`
- mint a short-lived bearer session credential with the verified account DID, fixed/attenuated `transition:generic` scope, explicit target tenant, and authority-resolved MAC clearance clamped to the Classical source-key floor
- preserve a verified local source-token tenant, reject attempts to replace it, and leave federated tenant/clearance stripping at the existing trust boundary
- fail closed for unresolved DIDs, replay-cache capacity, unenrolled identities, and unauthorized cross-tenant issuance

## Security posture

ATProto service-auth is bearer authentication and has no `cnf`/DPoP sender binding. The exchange does not manufacture one. Its compensating controls are an exact host `did:web` audience, exact XRPC `lxm`, a one-hour assertion lifetime ceiling, one-use `jti` retention through source expiry, and a five-minute issued-token ceiling.

MAC remains enforcing. Clearance comes from the authority-owned compiled enrollment policy rather than request claims, is signed into the credential, and is clamped to Classical assurance. Cross-tenant issuance still passes the existing target-domain `policy:IssueToken/manage` check. Unenrolled subjects fail closed.

## Validation

- `cargo metadata --all-features --format-version 1`
- focused XRPC/MAC/replay e2e: passed
- fail-closed replay-cache capacity test: passed
- CUDA 13.0 libtorch release gate:
  `buildq -- cargo nextest run --release --profile ci -p hyprstream -p hyprstream-rpc -p hyprstream-rpc-std -p hyprstream-util --no-fail-fast`
  - 2,278 passed, 0 failed, 9 skipped

Closes #1119
