### PR TITLE
B2: seal canonical hosted-account DID documents

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7158,6 +7158,7 @@ dependencies = [
  "ed25519-dalek 2.2.0",
  "git2",
  "git2db",
+ "hex",
  "hyprstream-crypto",
  "hyprstream-rpc",
  "iroh",
@@ -7173,6 +7174,7 @@ dependencies = [
  "tokio-test",
  "tracing",
  "tracing-subscriber",
+ "url",
 ]
 
 [[package]]

--- a/crates/hyprstream-pds-service/src/lib.rs
+++ b/crates/hyprstream-pds-service/src/lib.rs
@@ -349,7 +349,7 @@ mod tests {
         sign_genesis, GenesisRepoHead, GenesisRotationKeys, HostKeyEnrollment, HybridRotationKey,
         RecoveryKeyEnrollment, UserRotationKey,
     };
-    use hyprstream_pds::{AllocatedAccountName, Cid, HostedAccountMint};
+    use hyprstream_pds::{AllocatedAccountName, HostedAccountMint};
     use hyprstream_rpc::Subject;
     use hyprstream_vfs::{SyntheticMount, SyntheticNode};
     use rand::rngs::OsRng;
@@ -366,9 +366,10 @@ mod tests {
         )
         .unwrap();
         let name = AllocatedAccountName::new(label, format!("did:web:{label}.{zone}")).unwrap();
-        let pending = HostedAccountMint::begin(name, rotations)
-            .unwrap()
-            .prepare_genesis(Cid::from_raw(zone.as_bytes()), GenesisRepoHead::EmptyRepo)
+        let mint = HostedAccountMint::begin(name, rotations).unwrap();
+        let document = mint.seal_did_document("https://pds.example.com").unwrap();
+        let pending = mint
+            .prepare_genesis(document, GenesisRepoHead::EmptyRepo)
             .unwrap();
         let signature = sign_genesis(pending.unsigned_genesis(), &ed, &pq).unwrap();
         pending.seal(signature).unwrap().record_bytes().to_vec()

--- a/crates/hyprstream-pds/Cargo.toml
+++ b/crates/hyprstream-pds/Cargo.toml
@@ -36,6 +36,7 @@ tracing = { workspace = true }
 # resolved DID document, so the trust-chain primitive is self-contained.
 serde_json = { workspace = true }
 bs58 = "0.5"
+url = { workspace = true }
 # Note: DAG-CBOR + CIDv1 + varints are hand-rolled in src/dag_cbor.rs and
 # src/cid.rs to enforce the determinism invariants (sorted keys, minimal ints,
 # tag-42 links) that serde-driven CBOR cannot guarantee. No CBOR/CID crate dep.
@@ -56,6 +57,7 @@ git2db = { path = "../git2db" }
 git2 = { workspace = true }
 # Temp dirs for the git2db registry + source repos.
 tempfile = { workspace = true }
+hex = { workspace = true }
 # Async test runtime (git2db commit/clone are async).
 tokio = { workspace = true }
 tokio-test = { workspace = true }

--- a/crates/hyprstream-pds/src/hosted_account.rs
+++ b/crates/hyprstream-pds/src/hosted_account.rs
@@ -4,9 +4,9 @@
 //!
 //! 1. [`HostedAccountMint::begin`] consumes an already-allocated account name
 //!    and generates a fresh per-account ES256 `#atproto` key.
-//! 2. The caller uses [`HostedAccountMint::atproto_verifying_key`] to build and
-//!    seal the canonical DID document (B2/#1164), then supplies that document's
-//!    CID to [`HostedAccountMint::prepare_genesis`].
+//! 2. [`HostedAccountMint::seal_did_document`] builds the canonical DID
+//!    document (B2/#1164) from that generated key, and
+//!    [`HostedAccountMint::prepare_genesis`] binds the sealed artifact.
 //! 3. The user signs [`PendingHostedAccountMint::signing_bytes`] with the
 //!    required priority-zero Hybrid rotation key.
 //! 4. [`PendingHostedAccountMint::seal`] verifies that signature before it can
@@ -37,12 +37,14 @@ use crate::did_op::{
     validate_host_form_did_web, DidOpSignature, GenesisDidOp, GenesisRepoHead, GenesisRotationKeys,
     UnsignedGenesisDidOp,
 };
+use crate::hosted_did_document::SealedHostedDidDocument;
 
 /// Version of the durable hosted-account record.
 pub const ACCOUNT_RECORD_VERSION: u16 = 1;
 const COMPRESSED_P256_PUBLIC_KEY_LEN: usize = 33;
 const ACCOUNT_RECORD_FILE: &str = "account-record.cbor";
 const GENESIS_DID_OP_FILE: &str = "genesis.didop.cbor";
+const DID_DOCUMENT_FILE: &str = "did-document.json";
 const ATPROTO_SIGNING_KEY_FILE: &str = "atproto-signing-key";
 
 /// The output of the A2 allocation + A3 configured-zone seam.
@@ -273,17 +275,47 @@ impl HostedAccountMint {
         *self.atproto_signing_key.verifying_key()
     }
 
+    /// Build the canonical DID document from this mint's DID and generated
+    /// account-specific `#atproto` key.
+    pub fn seal_did_document(&self, pds_endpoint: &str) -> Result<SealedHostedDidDocument> {
+        SealedHostedDidDocument::seal(
+            &self.name,
+            self.atproto_signing_key.verifying_key(),
+            pds_endpoint,
+        )
+    }
+
     /// Bind the sealed DID document and deliberate genesis repo-head state.
+    ///
+    /// Accepting the artifact instead of a free-form CID makes DID/key
+    /// substitution unrepresentable at this boundary.
     pub fn prepare_genesis(
         self,
-        doc_cid: Cid,
+        did_document: SealedHostedDidDocument,
         head_at_op: GenesisRepoHead,
     ) -> Result<PendingHostedAccountMint> {
-        let unsigned =
-            UnsignedGenesisDidOp::new(self.name.did.clone(), doc_cid, self.rotations, head_at_op)?;
+        ensure!(
+            did_document.did() == self.name.did(),
+            "sealed DID document names a different hosted account"
+        );
+        ensure!(
+            did_document.atproto_verifying_key()?.to_encoded_point(true)
+                == self
+                    .atproto_signing_key
+                    .verifying_key()
+                    .to_encoded_point(true),
+            "sealed DID document contains a different #atproto key"
+        );
+        let unsigned = UnsignedGenesisDidOp::new(
+            self.name.did.clone(),
+            did_document.cid(),
+            self.rotations,
+            head_at_op,
+        )?;
         Ok(PendingHostedAccountMint {
             name: self.name,
             atproto_signing_key: self.atproto_signing_key,
+            did_document,
             unsigned,
         })
     }
@@ -295,6 +327,7 @@ impl HostedAccountMint {
 pub struct PendingHostedAccountMint {
     name: AllocatedAccountName,
     atproto_signing_key: AtprotoSigningKey,
+    did_document: SealedHostedDidDocument,
     unsigned: UnsignedGenesisDidOp,
 }
 
@@ -334,6 +367,7 @@ impl PendingHostedAccountMint {
             record_bytes,
             genesis,
             genesis_bytes,
+            did_document: self.did_document,
             atproto_signing_key: self.atproto_signing_key,
         })
     }
@@ -350,6 +384,7 @@ pub struct SealedHostedAccount {
     record_bytes: Vec<u8>,
     genesis: GenesisDidOp,
     genesis_bytes: Vec<u8>,
+    did_document: SealedHostedDidDocument,
     atproto_signing_key: AtprotoSigningKey,
 }
 
@@ -370,6 +405,10 @@ impl SealedHostedAccount {
         &self.genesis_bytes
     }
 
+    pub fn did_document(&self) -> &SealedHostedDidDocument {
+        &self.did_document
+    }
+
     pub fn atproto_signing_key(&self) -> &AtprotoSigningKey {
         &self.atproto_signing_key
     }
@@ -382,6 +421,7 @@ impl SealedHostedAccount {
         Vec<u8>,
         GenesisDidOp,
         Vec<u8>,
+        SealedHostedDidDocument,
         AtprotoSigningKey,
     ) {
         (
@@ -389,6 +429,7 @@ impl SealedHostedAccount {
             self.record_bytes,
             self.genesis,
             self.genesis_bytes,
+            self.did_document,
             self.atproto_signing_key,
         )
     }
@@ -412,8 +453,9 @@ impl SealedHostedAccount {
 /// written in this order:
 ///
 /// 1. the generated `#atproto` private key;
-/// 2. the sealed genesis operation;
-/// 3. the public account record, **last**, as the publication marker.
+/// 2. the sealed canonical DID document;
+/// 3. the sealed genesis operation;
+/// 4. the public account record, **last**, as the publication marker.
 ///
 /// A crash before publication leaves no label directory. A crash after
 /// publication leaves the complete account. A retry removes only an invalid or
@@ -466,6 +508,13 @@ impl DirectoryHostedAccountStore {
             WriteFault::AtprotoFileCreate,
             WriteFault::AtprotoFileWrite,
             WriteFault::AtprotoFileSync,
+        )?;
+        self.write_new_file(
+            &staging_dir.join(DID_DOCUMENT_FILE),
+            account.did_document.as_bytes(),
+            WriteFault::DidDocumentFileCreate,
+            WriteFault::DidDocumentFileWrite,
+            WriteFault::DidDocumentFileSync,
         )?;
         self.write_new_file(
             &staging_dir.join(GENESIS_DID_OP_FILE),
@@ -587,6 +636,9 @@ enum WriteFault {
     AtprotoFileCreate,
     AtprotoFileWrite,
     AtprotoFileSync,
+    DidDocumentFileCreate,
+    DidDocumentFileWrite,
+    DidDocumentFileSync,
     GenesisFileCreate,
     GenesisFileWrite,
     GenesisFileSync,
@@ -599,11 +651,14 @@ enum WriteFault {
 }
 
 #[cfg(test)]
-const WRITE_FAULTS: [WriteFault; 13] = [
+const WRITE_FAULTS: [WriteFault; 16] = [
     WriteFault::StagingDirectoryCreate,
     WriteFault::AtprotoFileCreate,
     WriteFault::AtprotoFileWrite,
     WriteFault::AtprotoFileSync,
+    WriteFault::DidDocumentFileCreate,
+    WriteFault::DidDocumentFileWrite,
+    WriteFault::DidDocumentFileSync,
     WriteFault::GenesisFileCreate,
     WriteFault::GenesisFileWrite,
     WriteFault::GenesisFileSync,
@@ -643,6 +698,7 @@ fn complete_account_matches(path: &Path, expected: &SealedHostedAccount) -> Resu
             }
         }
     };
+    let document_bytes = read(DID_DOCUMENT_FILE)?;
     let (Some(record_bytes), Some(genesis_bytes), Some(secret_bytes)) = (
         read(ACCOUNT_RECORD_FILE)?,
         read(GENESIS_DID_OP_FILE)?,
@@ -674,6 +730,24 @@ fn complete_account_matches(path: &Path, expected: &SealedHostedAccount) -> Resu
             && genesis_bytes == expected.genesis_bytes
             && secret_bytes == expected.atproto_signing_key.to_bytes().as_slice(),
         "hosted-account label directory {path:?} already contains a different complete account"
+    );
+    let document_bytes = document_bytes.ok_or_else(|| {
+        anyhow::anyhow!(
+            "hosted-account label directory {path:?} is a valid pre-B2 account without its sealed DID document; preserve it and run an explicit migration"
+        )
+    })?;
+    let document = SealedHostedDidDocument::from_canonical_json(&document_bytes)
+        .context("hosted-account directory contains an invalid sealed DID document")?;
+    ensure!(
+        record.doc_cid() == document.cid()
+            && record.name().did() == document.did()
+            && record.atproto_verifying_key()?.to_encoded_point(true)
+                == document.atproto_verifying_key()?.to_encoded_point(true),
+        "hosted-account directory's sealed DID document does not match its account record"
+    );
+    ensure!(
+        document_bytes == expected.did_document.as_bytes(),
+        "hosted-account label directory {path:?} contains a different sealed DID document"
     );
     Ok(true)
 }
@@ -736,6 +810,25 @@ fn validate_sealed_bundle(account: &SealedHostedAccount) -> Result<()> {
     ensure!(
         account.record.doc_cid() == account.genesis.unsigned().doc_cid(),
         "account record and genesis operation disagree on the DID document CID"
+    );
+    ensure!(
+        account.record.doc_cid() == account.did_document.cid(),
+        "account record does not name its sealed DID document"
+    );
+    ensure!(
+        account.record.name().did() == account.did_document.did(),
+        "account record and sealed DID document name different accounts"
+    );
+    ensure!(
+        account
+            .record
+            .atproto_verifying_key()?
+            .to_encoded_point(true)
+            == account
+                .did_document
+                .atproto_verifying_key()?
+                .to_encoded_point(true),
+        "account record and sealed DID document contain different #atproto keys"
     );
     ensure!(
         account
@@ -835,6 +928,12 @@ mod tests {
         .unwrap()
     }
 
+    fn prepare(mint: HostedAccountMint) -> PendingHostedAccountMint {
+        let document = mint.seal_did_document("https://pds.example.com").unwrap();
+        mint.prepare_genesis(document, GenesisRepoHead::EmptyRepo)
+            .unwrap()
+    }
+
     #[test]
     fn mint_generates_account_specific_atproto_key_and_never_serializes_secret() {
         let user = user_signer();
@@ -846,9 +945,7 @@ mod tests {
             second.atproto_verifying_key().to_encoded_point(true)
         );
 
-        let pending = first
-            .prepare_genesis(Cid::from_raw(b"did document"), GenesisRepoHead::EmptyRepo)
-            .unwrap();
+        let pending = prepare(first);
         let signature = sign_genesis(pending.unsigned_genesis(), &user.ed, &user.pq).unwrap();
         let sealed = pending.seal(signature).unwrap();
         assert_eq!(
@@ -880,18 +977,30 @@ mod tests {
     fn account_record_is_not_produced_before_valid_user_signature() {
         let user = user_signer();
         let attacker = user_signer();
-        let pending = begin(&user)
-            .prepare_genesis(Cid::from_raw(b"did document"), GenesisRepoHead::EmptyRepo)
-            .unwrap();
+        let pending = prepare(begin(&user));
         assert!(sign_genesis(pending.unsigned_genesis(), &attacker.ed, &attacker.pq).is_err());
+    }
+
+    #[test]
+    fn genesis_rejects_a_document_from_another_mint() {
+        let user = user_signer();
+        let first = begin(&user);
+        let other_document = first.seal_did_document("https://pds.example.com").unwrap();
+        let second = begin(&user);
+        let error = second
+            .prepare_genesis(other_document, GenesisRepoHead::EmptyRepo)
+            .err()
+            .expect("a document with another mint's #atproto key must fail");
+        assert!(
+            error.to_string().contains("different #atproto key"),
+            "{error:#}"
+        );
     }
 
     #[test]
     fn account_and_genesis_roundtrip_byte_exactly() {
         let user = user_signer();
-        let pending = begin(&user)
-            .prepare_genesis(Cid::from_raw(b"did document"), GenesisRepoHead::EmptyRepo)
-            .unwrap();
+        let pending = prepare(begin(&user));
         let signature = sign_genesis(pending.unsigned_genesis(), &user.ed, &user.pq).unwrap();
         let sealed = pending.seal(signature).unwrap();
         let account = AccountRecord::from_dag_cbor(sealed.record_bytes()).unwrap();
@@ -901,6 +1010,7 @@ mod tests {
         assert_eq!(account.genesis_op(), genesis.cid().unwrap());
         assert_eq!(account.current_op(), account.genesis_op());
         assert_eq!(account.doc_cid(), genesis.unsigned().doc_cid());
+        assert_eq!(account.doc_cid(), sealed.did_document().cid());
     }
 
     #[test]
@@ -917,9 +1027,7 @@ mod tests {
     #[test]
     fn operation_one_version_is_sealed_before_account_record() {
         let user = user_signer();
-        let pending = begin(&user)
-            .prepare_genesis(Cid::from_raw(b"did document"), GenesisRepoHead::EmptyRepo)
-            .unwrap();
+        let pending = prepare(begin(&user));
         let signing_value = DagCbor::decode(&pending.signing_bytes().unwrap()).unwrap();
         assert_eq!(
             signing_value.get("version").unwrap().as_unsigned().unwrap(),
@@ -932,14 +1040,13 @@ mod tests {
     #[test]
     fn durable_writer_publishes_record_last_and_never_overwrites() {
         let user = user_signer();
-        let pending = begin(&user)
-            .prepare_genesis(Cid::from_raw(b"did document"), GenesisRepoHead::EmptyRepo)
-            .unwrap();
+        let pending = prepare(begin(&user));
         let signature = sign_genesis(pending.unsigned_genesis(), &user.ed, &user.pq).unwrap();
         let sealed = pending.seal(signature).unwrap();
         let expected_record = sealed.record().clone();
         let expected_record_bytes = sealed.record_bytes().to_vec();
         let expected_genesis_bytes = sealed.genesis_bytes().to_vec();
+        let expected_document_bytes = sealed.did_document().as_bytes().to_vec();
         let expected_secret = sealed.atproto_signing_key().to_bytes();
 
         let temporary = tempfile::tempdir().unwrap();
@@ -957,17 +1064,16 @@ mod tests {
             expected_genesis_bytes
         );
         assert_eq!(
+            std::fs::read(account_dir.join(DID_DOCUMENT_FILE)).unwrap(),
+            expected_document_bytes
+        );
+        assert_eq!(
             std::fs::read(account_dir.join(ATPROTO_SIGNING_KEY_FILE)).unwrap(),
             expected_secret.as_slice()
         );
 
         // The label directory is the exclusive never-overwrite boundary.
-        let second = begin(&user)
-            .prepare_genesis(
-                Cid::from_raw(b"other did document"),
-                GenesisRepoHead::EmptyRepo,
-            )
-            .unwrap();
+        let second = prepare(begin(&user));
         let second_signature = sign_genesis(second.unsigned_genesis(), &user.ed, &user.pq).unwrap();
         assert!(second
             .seal(second_signature)
@@ -996,9 +1102,7 @@ mod tests {
     #[test]
     fn durable_writer_recovers_from_every_interrupted_boundary() {
         let user = user_signer();
-        let pending = begin(&user)
-            .prepare_genesis(Cid::from_raw(b"did document"), GenesisRepoHead::EmptyRepo)
-            .unwrap();
+        let pending = prepare(begin(&user));
         let signature = sign_genesis(pending.unsigned_genesis(), &user.ed, &user.pq).unwrap();
         let sealed = pending.seal(signature).unwrap();
 
@@ -1023,5 +1127,28 @@ mod tests {
             recovery.write_new(&sealed).unwrap();
             assert!(complete_account_matches(&final_directory, &sealed).unwrap());
         }
+    }
+
+    #[test]
+    fn durable_writer_preserves_a_valid_pre_b2_account_for_explicit_migration() {
+        let user = user_signer();
+        let pending = prepare(begin(&user));
+        let signature = sign_genesis(pending.unsigned_genesis(), &user.ed, &user.pq).unwrap();
+        let sealed = pending.seal(signature).unwrap();
+
+        let temporary = tempfile::tempdir().unwrap();
+        let store = DirectoryHostedAccountStore::new(temporary.path().join("accounts"));
+        sealed.write_to(&store).unwrap();
+        let account_dir = store.root().join("alice");
+        std::fs::remove_file(account_dir.join(DID_DOCUMENT_FILE)).unwrap();
+
+        let error = sealed
+            .write_to(&store)
+            .expect_err("pre-B2 account must require an explicit migration");
+        assert!(error.to_string().contains("pre-B2"), "{error:#}");
+        assert!(account_dir.join(ACCOUNT_RECORD_FILE).exists());
+        assert!(account_dir.join(GENESIS_DID_OP_FILE).exists());
+        assert!(account_dir.join(ATPROTO_SIGNING_KEY_FILE).exists());
+        assert!(!account_dir.join(DID_DOCUMENT_FILE).exists());
     }
 }

--- a/crates/hyprstream-pds/src/hosted_did_document.rs
+++ b/crates/hyprstream-pds/src/hosted_did_document.rs
@@ -1,0 +1,487 @@
+//! Canonical DID-document artifact for a hyprstream-hosted account.
+//!
+//! The account document is an immutable input to genesis, not a response
+//! assembled by an HTTP handler. [`HostedAccountMint`](crate::HostedAccountMint)
+//! builds it from the mint's own account DID and generated ES256 key, then
+//! [`SealedHostedDidDocument::cid`] is signed into the genesis `DidOp`.
+//! Serving code must return [`SealedHostedDidDocument::as_bytes`] byte-for-byte.
+
+use std::collections::BTreeSet;
+
+use anyhow::{bail, ensure, Context, Result};
+use p256::ecdsa::VerifyingKey;
+use serde_json::{json, Map, Value};
+
+use crate::cid::Cid;
+use crate::did_op::validate_host_form_did_web;
+use crate::hosted_account::AllocatedAccountName;
+
+/// Media type for the canonical account DID-document bytes.
+pub const DID_DOCUMENT_MEDIA_TYPE: &str = "application/did+json";
+/// Relative path at which B3 serves the canonical document.
+pub const DID_DOCUMENT_PATH: &str = "/.well-known/did.json";
+/// Relative path at which B3 serves the account's operation log.
+pub const DID_OPERATION_LOG_PATH: &str = "/.well-known/did-log.json";
+
+const MAX_DID_DOCUMENT_BYTES: usize = 16 * 1024;
+const P256_MULTICODEC_PREFIX: [u8; 2] = [0x80, 0x24];
+const COMPRESSED_P256_PUBLIC_KEY_LEN: usize = 33;
+const DID_CONTEXT: &str = "https://www.w3.org/ns/did/v1";
+const MULTIKEY_CONTEXT: &str = "https://w3id.org/security/multikey/v1";
+
+/// A validated, byte-stable hosted-account DID document and its raw CID.
+///
+/// Fields are private so a caller cannot change a document after its CID has
+/// been bound into genesis.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct SealedHostedDidDocument {
+    did: String,
+    handle: String,
+    pds_endpoint: String,
+    atproto_key: Vec<u8>,
+    bytes: Vec<u8>,
+    cid: Cid,
+}
+
+impl SealedHostedDidDocument {
+    /// Parse and strictly validate canonical bytes loaded from sealed storage.
+    ///
+    /// The accepted shape is deliberately exact: one `#atproto` P-256
+    /// `Multikey`, one atproto PDS service, one operation-log service, and one
+    /// `at://` alias equal to the immutable account host. Unknown fields,
+    /// alternate aliases, and non-canonical JSON fail closed.
+    pub fn from_canonical_json(bytes: &[u8]) -> Result<Self> {
+        ensure!(
+            bytes.len() <= MAX_DID_DOCUMENT_BYTES,
+            "hosted DID document exceeds {MAX_DID_DOCUMENT_BYTES} bytes"
+        );
+        let value: Value =
+            serde_json::from_slice(bytes).context("hosted DID document is not valid JSON")?;
+        ensure!(
+            canonical_json(&value)? == bytes,
+            "hosted DID document is not canonical JSON"
+        );
+        validate_exact_keys(
+            &value,
+            &[
+                "@context",
+                "alsoKnownAs",
+                "id",
+                "service",
+                "verificationMethod",
+            ],
+            "hosted DID document",
+        )?;
+
+        let did = required_string(&value, "id", "hosted DID document")?.to_owned();
+        validate_host_form_did_web(&did)?;
+        let host = did
+            .strip_prefix("did:web:")
+            .ok_or_else(|| anyhow::anyhow!("hosted DID document id must use did:web"))?;
+
+        let contexts = required_array(&value, "@context", "hosted DID document")?;
+        ensure!(
+            contexts
+                == [
+                    Value::String(DID_CONTEXT.to_owned()),
+                    Value::String(MULTIKEY_CONTEXT.to_owned()),
+                ],
+            "hosted DID document has an unsupported @context"
+        );
+
+        let aliases = required_array(&value, "alsoKnownAs", "hosted DID document")?;
+        let expected_handle = format!("at://{host}");
+        ensure!(
+            aliases == [Value::String(expected_handle.clone())],
+            "hosted DID document must contain exactly the account at:// handle and no other alias"
+        );
+
+        let methods = required_array(&value, "verificationMethod", "hosted DID document")?;
+        ensure!(
+            methods.len() == 1,
+            "hosted DID document must contain exactly one verification method"
+        );
+        let method = methods
+            .first()
+            .ok_or_else(|| anyhow::anyhow!("hosted DID document omits #atproto"))?;
+        validate_exact_keys(
+            method,
+            &["controller", "id", "publicKeyMultibase", "type"],
+            "#atproto verification method",
+        )?;
+        ensure!(
+            required_string(method, "id", "#atproto verification method")?
+                == format!("{did}#atproto"),
+            "hosted DID document verification method must be the account's #atproto fragment"
+        );
+        ensure!(
+            required_string(method, "controller", "#atproto verification method")? == did,
+            "hosted DID document #atproto controller does not match its id"
+        );
+        ensure!(
+            required_string(method, "type", "#atproto verification method")? == "Multikey",
+            "hosted DID document #atproto method must use Multikey"
+        );
+        let atproto_key = decode_p256_multibase(required_string(
+            method,
+            "publicKeyMultibase",
+            "#atproto verification method",
+        )?)?;
+
+        let services = required_array(&value, "service", "hosted DID document")?;
+        ensure!(
+            services.len() == 2,
+            "hosted DID document must contain exactly the PDS and operation-log services"
+        );
+        let pds = services
+            .first()
+            .ok_or_else(|| anyhow::anyhow!("hosted DID document omits its PDS service"))?;
+        validate_service(
+            pds,
+            &format!("{did}#atproto_pds"),
+            "AtprotoPersonalDataServer",
+        )?;
+        let pds_endpoint =
+            required_string(pds, "serviceEndpoint", "atproto PDS service")?.to_owned();
+        validate_https_origin(&pds_endpoint)?;
+
+        let operation_log = services.get(1).ok_or_else(|| {
+            anyhow::anyhow!("hosted DID document omits its operation-log service")
+        })?;
+        validate_service(operation_log, &format!("{did}#did-log"), "DidOperationLog")?;
+        let operation_log_endpoint = required_string(
+            operation_log,
+            "serviceEndpoint",
+            "DID operation-log service",
+        )?;
+        ensure!(
+            operation_log_endpoint == format!("https://{host}{DID_OPERATION_LOG_PATH}"),
+            "hosted DID document operation-log endpoint must be served by its own did:web host"
+        );
+
+        Ok(Self {
+            did,
+            handle: expected_handle,
+            pds_endpoint,
+            atproto_key,
+            cid: Cid::from_raw(bytes),
+            bytes: bytes.to_vec(),
+        })
+    }
+
+    pub(crate) fn seal(
+        name: &AllocatedAccountName,
+        atproto_key: &VerifyingKey,
+        pds_endpoint: &str,
+    ) -> Result<Self> {
+        validate_https_origin(pds_endpoint)?;
+        let did = name.did();
+        validate_host_form_did_web(did)?;
+        let host = did
+            .strip_prefix("did:web:")
+            .ok_or_else(|| anyhow::anyhow!("hosted account DID must use did:web"))?;
+        let handle = format!("at://{host}");
+        let public_key_multibase = encode_p256_multibase(atproto_key);
+
+        let document = json!({
+            "@context": [DID_CONTEXT, MULTIKEY_CONTEXT],
+            "alsoKnownAs": [handle],
+            "id": did,
+            "service": [
+                {
+                    "id": format!("{did}#atproto_pds"),
+                    "serviceEndpoint": pds_endpoint,
+                    "type": "AtprotoPersonalDataServer",
+                },
+                {
+                    "id": format!("{did}#did-log"),
+                    "serviceEndpoint": format!("https://{host}{DID_OPERATION_LOG_PATH}"),
+                    "type": "DidOperationLog",
+                },
+            ],
+            "verificationMethod": [{
+                "controller": did,
+                "id": format!("{did}#atproto"),
+                "publicKeyMultibase": public_key_multibase,
+                "type": "Multikey",
+            }],
+        });
+        let bytes = canonical_json(&document)?;
+        let sealed = Self::from_canonical_json(&bytes)?;
+        ensure!(
+            sealed.atproto_verifying_key()?.to_encoded_point(true)
+                == atproto_key.to_encoded_point(true),
+            "sealed DID document changed the mint's #atproto key"
+        );
+        Ok(sealed)
+    }
+
+    /// Immutable account DID named by this artifact.
+    #[must_use]
+    pub fn did(&self) -> &str {
+        &self.did
+    }
+
+    /// Account handle, always `at://` plus the host-form DID authority.
+    #[must_use]
+    pub fn handle(&self) -> &str {
+        &self.handle
+    }
+
+    /// Origin advertised by the atproto PDS service entry.
+    #[must_use]
+    pub fn pds_endpoint(&self) -> &str {
+        &self.pds_endpoint
+    }
+
+    /// Generated account-specific P-256 key carried by `#atproto`.
+    pub fn atproto_verifying_key(&self) -> Result<VerifyingKey> {
+        VerifyingKey::from_sec1_bytes(&self.atproto_key)
+            .context("sealed DID document contains an invalid #atproto P-256 key")
+    }
+
+    /// Canonical bytes to place in sealed storage and serve byte-for-byte.
+    #[must_use]
+    pub fn as_bytes(&self) -> &[u8] {
+        &self.bytes
+    }
+
+    /// Raw-codec CID over the exact canonical JSON bytes.
+    #[must_use]
+    pub fn cid(&self) -> Cid {
+        self.cid
+    }
+}
+
+fn encode_p256_multibase(key: &VerifyingKey) -> String {
+    let point = key.to_encoded_point(true);
+    let mut payload =
+        Vec::with_capacity(P256_MULTICODEC_PREFIX.len() + COMPRESSED_P256_PUBLIC_KEY_LEN);
+    payload.extend_from_slice(&P256_MULTICODEC_PREFIX);
+    payload.extend_from_slice(point.as_bytes());
+    format!("z{}", bs58::encode(payload).into_string())
+}
+
+fn decode_p256_multibase(encoded: &str) -> Result<Vec<u8>> {
+    let payload = encoded
+        .strip_prefix('z')
+        .ok_or_else(|| anyhow::anyhow!("#atproto publicKeyMultibase must use base58btc"))?;
+    let decoded = bs58::decode(payload)
+        .into_vec()
+        .context("#atproto publicKeyMultibase is not valid base58btc")?;
+    ensure!(
+        decoded.starts_with(&P256_MULTICODEC_PREFIX),
+        "#atproto publicKeyMultibase must use the p256-pub multicodec"
+    );
+    let key = decoded[P256_MULTICODEC_PREFIX.len()..].to_vec();
+    ensure!(
+        key.len() == COMPRESSED_P256_PUBLIC_KEY_LEN,
+        "#atproto P-256 key must be a compressed SEC1 point"
+    );
+    VerifyingKey::from_sec1_bytes(&key).context("#atproto P-256 key is invalid")?;
+    Ok(key)
+}
+
+fn validate_service(value: &Value, id: &str, service_type: &str) -> Result<()> {
+    validate_exact_keys(value, &["id", "serviceEndpoint", "type"], service_type)?;
+    ensure!(
+        required_string(value, "id", service_type)? == id,
+        "{service_type} service id is invalid"
+    );
+    ensure!(
+        required_string(value, "type", service_type)? == service_type,
+        "{service_type} service type is invalid"
+    );
+    Ok(())
+}
+
+fn validate_https_origin(endpoint: &str) -> Result<()> {
+    let parsed = url::Url::parse(endpoint).context("PDS service endpoint is not a valid URL")?;
+    ensure!(
+        parsed.scheme() == "https",
+        "PDS service endpoint must use HTTPS"
+    );
+    ensure!(
+        parsed.host().is_some(),
+        "PDS service endpoint must have a host"
+    );
+    ensure!(
+        parsed.username().is_empty() && parsed.password().is_none(),
+        "PDS service endpoint must not contain credentials"
+    );
+    ensure!(
+        parsed.path() == "/" && parsed.query().is_none() && parsed.fragment().is_none(),
+        "PDS service endpoint must be an origin without path, query, or fragment"
+    );
+    ensure!(
+        endpoint == parsed.origin().ascii_serialization(),
+        "PDS service endpoint must use its canonical origin form"
+    );
+    Ok(())
+}
+
+fn validate_exact_keys(value: &Value, expected: &[&str], what: &str) -> Result<()> {
+    let object = value
+        .as_object()
+        .ok_or_else(|| anyhow::anyhow!("{what} must be a JSON object"))?;
+    let actual = object.keys().map(String::as_str).collect::<BTreeSet<_>>();
+    let expected = expected.iter().copied().collect::<BTreeSet<_>>();
+    ensure!(actual == expected, "{what} has missing or unknown fields");
+    Ok(())
+}
+
+fn required_string<'a>(value: &'a Value, key: &str, what: &str) -> Result<&'a str> {
+    value
+        .get(key)
+        .and_then(Value::as_str)
+        .ok_or_else(|| anyhow::anyhow!("{what} field {key:?} must be a string"))
+}
+
+fn required_array<'a>(value: &'a Value, key: &str, what: &str) -> Result<&'a [Value]> {
+    value
+        .get(key)
+        .and_then(Value::as_array)
+        .map(Vec::as_slice)
+        .ok_or_else(|| anyhow::anyhow!("{what} field {key:?} must be an array"))
+}
+
+/// Serialize the restricted DID-document value as RFC 8785-compatible JSON.
+///
+/// These documents contain only objects, arrays, strings, booleans, and null.
+/// Rejecting numbers avoids silently implementing only part of JCS numeric
+/// normalization if the document profile grows later.
+fn canonical_json(value: &Value) -> Result<Vec<u8>> {
+    let mut output = Vec::new();
+    write_canonical_json(value, &mut output)?;
+    Ok(output)
+}
+
+fn write_canonical_json(value: &Value, output: &mut Vec<u8>) -> Result<()> {
+    match value {
+        Value::Null => output.extend_from_slice(b"null"),
+        Value::Bool(true) => output.extend_from_slice(b"true"),
+        Value::Bool(false) => output.extend_from_slice(b"false"),
+        Value::Number(_) => bail!("hosted DID document canonical JSON does not permit numbers"),
+        Value::String(string) => {
+            serde_json::to_writer(&mut *output, string)
+                .context("failed to serialize hosted DID document string")?;
+        }
+        Value::Array(items) => {
+            output.push(b'[');
+            for (index, item) in items.iter().enumerate() {
+                if index != 0 {
+                    output.push(b',');
+                }
+                write_canonical_json(item, output)?;
+            }
+            output.push(b']');
+        }
+        Value::Object(object) => write_canonical_object(object, output)?,
+    }
+    Ok(())
+}
+
+fn write_canonical_object(object: &Map<String, Value>, output: &mut Vec<u8>) -> Result<()> {
+    output.push(b'{');
+    let mut entries = object.iter().collect::<Vec<_>>();
+    entries.sort_unstable_by_key(|(key, _)| *key);
+    for (index, (key, value)) in entries.into_iter().enumerate() {
+        if index != 0 {
+            output.push(b',');
+        }
+        serde_json::to_writer(&mut *output, key)
+            .context("failed to serialize hosted DID document key")?;
+        output.push(b':');
+        write_canonical_json(value, output)?;
+    }
+    output.push(b'}');
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    #![allow(clippy::expect_used, clippy::unwrap_used)]
+
+    use p256::ecdsa::SigningKey;
+    use rand::rngs::OsRng;
+    use sha2::{Digest, Sha256};
+
+    use super::*;
+
+    fn artifact() -> SealedHostedDidDocument {
+        let name = AllocatedAccountName::new("alice", "did:web:alice.acct.example.com").unwrap();
+        let key = SigningKey::random(&mut OsRng);
+        SealedHostedDidDocument::seal(&name, key.verifying_key(), "https://pds.example.com")
+            .unwrap()
+    }
+
+    #[test]
+    fn account_document_is_exact_atproto_profile_and_roundtrips() {
+        let artifact = artifact();
+        let document: Value = serde_json::from_slice(artifact.as_bytes()).unwrap();
+        assert_eq!(document["id"], "did:web:alice.acct.example.com");
+        assert_eq!(
+            document["alsoKnownAs"],
+            json!(["at://alice.acct.example.com"])
+        );
+        assert_eq!(document["verificationMethod"].as_array().unwrap().len(), 1);
+        assert_eq!(document["verificationMethod"][0]["type"], "Multikey");
+        assert_eq!(document["service"].as_array().unwrap().len(), 2);
+        assert_eq!(document["service"][0]["type"], "AtprotoPersonalDataServer");
+        assert_eq!(document["service"][1]["type"], "DidOperationLog");
+
+        let parsed = SealedHostedDidDocument::from_canonical_json(artifact.as_bytes()).unwrap();
+        assert_eq!(parsed, artifact);
+        assert_eq!(parsed.cid(), Cid::from_raw(parsed.as_bytes()));
+    }
+
+    #[test]
+    fn canonical_bytes_are_stable() {
+        let name = AllocatedAccountName::new("alice", "did:web:alice.acct.example.com").unwrap();
+        let key = SigningKey::from_slice(&[7; 32]).unwrap();
+        let artifact =
+            SealedHostedDidDocument::seal(&name, key.verifying_key(), "https://pds.example.com")
+                .unwrap();
+        let digest = hex::encode(Sha256::digest(artifact.as_bytes()));
+        assert_eq!(
+            digest,
+            "f619b0958da09951c69b11f935f4077adf35cf7a6d84f003962955941e058ba5"
+        );
+    }
+
+    #[test]
+    fn account_document_rejects_host_capsule_alias_and_noncanonical_bytes() {
+        let artifact = artifact();
+        let mut document: Value = serde_json::from_slice(artifact.as_bytes()).unwrap();
+        document["alsoKnownAs"] = json!(["did:at9p:bafk-host-capsule"]);
+        let tampered = canonical_json(&document).unwrap();
+        let error = SealedHostedDidDocument::from_canonical_json(&tampered).unwrap_err();
+        assert!(error.to_string().contains("at://"), "{error:#}");
+
+        let pretty = serde_json::to_vec_pretty(&document).unwrap();
+        let error = SealedHostedDidDocument::from_canonical_json(&pretty).unwrap_err();
+        assert!(error.to_string().contains("canonical"), "{error:#}");
+    }
+
+    #[test]
+    fn account_document_rejects_wrong_key_shape_and_pds_endpoint() {
+        let artifact = artifact();
+        let mut document: Value = serde_json::from_slice(artifact.as_bytes()).unwrap();
+        document["verificationMethod"][0]["publicKeyMultibase"] = json!("zBadKey");
+        let tampered = canonical_json(&document).unwrap();
+        assert!(SealedHostedDidDocument::from_canonical_json(&tampered).is_err());
+
+        let name = AllocatedAccountName::new("alice", "did:web:alice.acct.example.com").unwrap();
+        let key = SigningKey::random(&mut OsRng);
+        for endpoint in [
+            "http://pds.example.com",
+            "https://pds.example.com/oauth",
+            "https://user@pds.example.com",
+        ] {
+            assert!(
+                SealedHostedDidDocument::seal(&name, key.verifying_key(), endpoint).is_err(),
+                "{endpoint} must be rejected"
+            );
+        }
+    }
+}

--- a/crates/hyprstream-pds/src/lib.rs
+++ b/crates/hyprstream-pds/src/lib.rs
@@ -65,6 +65,7 @@ pub mod dag_cbor;
 pub mod did_op;
 pub mod event_group;
 pub mod hosted_account;
+pub mod hosted_did_document;
 pub mod ledger;
 pub mod list_record;
 pub mod mst;
@@ -84,6 +85,9 @@ pub use did_op::{
 pub use hosted_account::{
     AccountRecord, AllocatedAccountName, DirectoryHostedAccountStore, HostedAccountMint,
     PendingHostedAccountMint, SealedHostedAccount, ACCOUNT_RECORD_VERSION,
+};
+pub use hosted_did_document::{
+    SealedHostedDidDocument, DID_DOCUMENT_MEDIA_TYPE, DID_DOCUMENT_PATH, DID_OPERATION_LOG_PATH,
 };
 pub use ledger::{AllocationRecord, CheckpointRecord, GrantClass, ReceiptRecord, StateRoot, Unit};
 pub use name_record::NameRecord;

--- a/crates/hyprstream/src/auth/key_rotation.rs
+++ b/crates/hyprstream/src/auth/key_rotation.rs
@@ -2296,11 +2296,12 @@ mod tests {
             label,
             format!("did:web:{label}.{zone}"),
         )?;
-        let pending = hyprstream_pds::HostedAccountMint::begin(name, rotations)?
-            .prepare_genesis(
-                hyprstream_pds::Cid::from_raw(zone.as_bytes()),
-                hyprstream_pds::did_op::GenesisRepoHead::EmptyRepo,
-            )?;
+        let mint = hyprstream_pds::HostedAccountMint::begin(name, rotations)?;
+        let document = mint.seal_did_document(&format!("https://{zone}"))?;
+        let pending = mint.prepare_genesis(
+            document,
+            hyprstream_pds::did_op::GenesisRepoHead::EmptyRepo,
+        )?;
         let signature =
             hyprstream_pds::did_op::sign_genesis(pending.unsigned_genesis(), &ed, &pq)?;
         let record = pending.seal(signature)?.record_bytes().to_vec();

--- a/crates/hyprstream/src/services/oauth/mod.rs
+++ b/crates/hyprstream/src/services/oauth/mod.rs
@@ -1481,8 +1481,9 @@ mod tests {
             hyprstream_pds::AllocatedAccountName::new("alice", MAPPED_DID)?,
             account_rotations,
         )?;
+        let account_document = account_mint.seal_did_document(ISSUER)?;
         let pending_account = account_mint.prepare_genesis(
-            hyprstream_pds::Cid::from_raw(b"handler-hosted-account-doc"),
+            account_document,
             hyprstream_pds::did_op::GenesisRepoHead::EmptyRepo,
         )?;
         let account_signature = hyprstream_pds::did_op::sign_genesis(
@@ -1492,6 +1493,8 @@ mod tests {
         )?;
         let sealed_account = pending_account.seal(account_signature)?;
         let atproto_signing_key = sealed_account.atproto_signing_key().clone();
+        let atproto_document =
+            serde_json::from_slice(sealed_account.did_document().as_bytes())?;
         let pds_root = SyntheticNode::dir().with_child(
             HOSTED_TENANT,
             SyntheticNode::dir().with_child(
@@ -1509,25 +1512,6 @@ mod tests {
             Arc::new(hyprstream_pds_service::AccountRecordStore::new(Arc::new(
                 SyntheticMount::new(pds_root),
             )));
-        let mut atproto_multikey = vec![0x80, 0x24];
-        atproto_multikey.extend_from_slice(
-            atproto_signing_key
-                .verifying_key()
-                .to_encoded_point(true)
-                .as_bytes(),
-        );
-        let atproto_document = serde_json::json!({
-            "id": MAPPED_DID,
-            "verificationMethod": [{
-                "id": format!("{MAPPED_DID}#atproto"),
-                "type": "Multikey",
-                "controller": MAPPED_DID,
-                "publicKeyMultibase": format!(
-                    "z{}",
-                    bs58::encode(atproto_multikey).into_string()
-                )
-            }]
-        });
         let mut oauth_state = OAuthState::new(
             &config,
             policy_client,

--- a/scripts/loopback-baseline.txt
+++ b/scripts/loopback-baseline.txt
@@ -29,7 +29,6 @@
 1	crates/hyprstream/src/cli/sign_challenge.rs
 1	crates/hyprstream/src/cli/wizard_handlers.rs
 10	crates/hyprstream/src/config/mod.rs
-4	crates/hyprstream/src/config/server.rs
 5	crates/hyprstream/src/server/middleware.rs
 14	crates/hyprstream/src/services/oauth/authorize.rs
 10	crates/hyprstream/src/services/oauth/mod.rs


### PR DESCRIPTION
Closes #1164
Progresses #1158

## State found

B1 (#1163) supplied the hosted-account mint state machine, account record, and genesis `DidOp`, but genesis still accepted an arbitrary DID-document CID. The OAuth DID builder only covered node/root documents and the frozen legacy path-form account document. The tenant boundary already lives in the hosted-account binding: `hyprstream-pds-service` derives the tenant from the MAC-verified `EnvelopeContext` and locates the account record under `/pds/{verified_tenant}/accounts/{label}`.

## What changed

- Add a sealed, canonical, byte-stable hosted-account DID-document artifact with a raw CID.
- Enforce the B2 profile: host-form `did:web`, one P-256 `#atproto` Multikey, one matching `at://` handle alias, and exactly the PDS plus `DidOperationLog` services.
- Reject unknown/missing fields, noncanonical bytes, path/auth/HTTP-bearing PDS endpoints, invalid key codecs, and host `did:at9p` aliases.
- Bind mint genesis to the sealed document's DID, key, and CID, eliminating caller-selected document CID substitution.
- Persist the DID document atomically before genesis/account markers and preserve valid pre-B2 directories for explicit migration.
- Add canonicalization, substitution, profile, endpoint, crash-boundary, and legacy-preservation tests.

## MAC and tenant boundary

This does not add a caller-supplied tenant or encode tenant as a DID-document field. Tenant remains the authority-verified hosted-account binding: the service obtains it from the MAC-verified request context, threads the subject through 9P operations, and resolves the account record within that verified tenant's namespace.

## Validation

- `cargo metadata --all-features`: passed
- Focused `hyprstream-pds` / `hyprstream-pds-service` tests: 262 passed
- Focused all-target Clippy with `-D warnings`: passed
- Required release CI profile: **2271 passed, 0 failed, 9 skipped**
- Commit-time workspace release Clippy hook: passed

## Security review

Kimi K3 reviewed the exact pushed commit `8e700326d` and returned **PASS — no blocking findings**. It found the MAC tenant boundary intact, canonical/CID/key binding sound, cross-mint substitution closed, and persistence/recovery ordering sound. Non-blocking follow-ups are minor negative-test gaps and ensuring B3 sources the PDS endpoint only from deployment configuration.
