### PR TITLE
security: allow browser bearer and DPoP product API calls

### DIFF
--- a/README.md
+++ b/README.md
@@ -342,7 +342,12 @@ export HYPRSTREAM_SERVER_PORT=6789
 
 # CORS settings
 export HYPRSTREAM_CORS_ENABLED=true
+# This is the default: browser authority is carried by Bearer/DPoP headers,
+# so the product and MCP APIs allow any origin without ambient credentials.
 export HYPRSTREAM_CORS_ORIGINS="*"
+# Legacy cookie/HTTP-auth deployments must use an exact list before opting in:
+# export HYPRSTREAM_CORS_ORIGINS="https://app.example"
+# export HYPRSTREAM_CORS_CREDENTIALS=true
 
 # Model management
 export HYPRSTREAM_PRELOAD_MODELS=model1,model2,model3

--- a/crates/hyprstream/src/config/server.rs
+++ b/crates/hyprstream/src/config/server.rs
@@ -18,11 +18,20 @@ pub struct CorsConfig {
     #[serde(default = "default_cors_enabled")]
     pub enabled: bool,
 
-    /// Allowed origins (use ["*"] for all origins - NOT recommended for production)
+    /// Allowed origins.
+    ///
+    /// The default is `["*"]` because these HTTP resource faces carry authority
+    /// explicitly in Bearer/DPoP headers, never in ambient browser credentials.
+    /// Operators may still configure an exact origin list; pairing that list
+    /// with `allow_credentials = true` preserves the legacy deployment posture.
     #[serde(default = "default_cors_origins")]
     pub allowed_origins: Vec<String>,
 
-    /// Allow credentials in CORS requests
+    /// Allow ambient browser credentials (cookies or HTTP authentication).
+    ///
+    /// Disabled by default. Bearer and DPoP request headers do not require this
+    /// flag and remain subject to the normal authentication, tenant, and MAC
+    /// enforcement path.
     #[serde(default = "default_cors_credentials")]
     pub allow_credentials: bool,
 
@@ -47,15 +56,10 @@ fn default_cors_enabled() -> bool {
     true
 }
 fn default_cors_origins() -> Vec<String> {
-    vec![
-        "http://localhost:3000".to_owned(),
-        "http://localhost:3001".to_owned(),
-        "http://127.0.0.1:3000".to_owned(),
-        "http://127.0.0.1:3001".to_owned(),
-    ]
+    vec!["*".to_owned()]
 }
 fn default_cors_credentials() -> bool {
-    true
+    false
 }
 fn default_cors_max_age() -> u64 {
     3600
@@ -358,7 +362,6 @@ impl ServerConfigBuilder {
         self
     }
 
-    
     pub fn cancellation_check_interval(mut self, interval: u64) -> Self {
         self.config.cancellation_check_interval = interval;
         self
@@ -454,7 +457,6 @@ impl ServerConfigBuilder {
             }
         }
 
-        
         if let Ok(interval) = std::env::var("HYPRSTREAM_CANCELLATION_CHECK_INTERVAL") {
             if let Ok(i) = interval.parse() {
                 self.config.cancellation_check_interval = i;
@@ -494,7 +496,15 @@ impl ServerConfigBuilder {
         }
 
         if let Ok(cors_credentials) = std::env::var("HYPRSTREAM_CORS_CREDENTIALS") {
-            if !self.config.cors.allowed_origins.contains(&"*".to_owned()) {
+            if self.config.cors.allowed_origins.contains(&"*".to_owned()) {
+                if cors_credentials.eq_ignore_ascii_case("true") {
+                    tracing::warn!(
+                        "HYPRSTREAM_CORS_CREDENTIALS=true ignored: wildcard CORS origins require \
+                         credentials to remain disabled; set HYPRSTREAM_CORS_ORIGINS to an exact \
+                         origin list before enabling credentials"
+                    );
+                }
+            } else {
                 self.config.cors.allow_credentials = cors_credentials.to_lowercase() == "true";
             }
         }
@@ -557,8 +567,7 @@ mod tests {
         for seg in rel.split('/') {
             p.push(seg);
         }
-        std::fs::read_to_string(&p)
-            .unwrap_or_else(|e| panic!("could not read src/{rel}: {e}"))
+        std::fs::read_to_string(&p).unwrap_or_else(|e| panic!("could not read src/{rel}: {e}"))
     }
 
     /// The four TLS knobs + mTLS CA + the two CORS helpers must not reappear in

--- a/crates/hyprstream/src/server/middleware.rs
+++ b/crates/hyprstream/src/server/middleware.rs
@@ -4,7 +4,7 @@ use crate::auth::jwt;
 use crate::server::state::{ResourceAuthState, ServerState};
 use axum::{
     extract::{Request, State},
-    http::{HeaderValue, StatusCode, header},
+    http::{header, HeaderValue, StatusCode},
     middleware::Next,
     response::{IntoResponse, Response},
 };
@@ -295,6 +295,30 @@ pub async fn browser_provisioning_rate_limit_middleware(
     next.run(request).await
 }
 
+/// Rate-limit public metadata and pre-upgrade routes with one stable bucket.
+///
+/// These routes intentionally have no authenticated subject from which to
+/// derive a per-tenant bucket. Forwarding headers are client-controlled at
+/// this boundary, so neither `X-Forwarded-For` nor `X-Real-IP` may select the
+/// bucket. Health probes use a separate, unmetered router.
+pub async fn public_route_rate_limit_middleware(
+    State(rate_limiter): State<Arc<RateLimiter>>,
+    request: Request,
+    next: Next,
+) -> Response {
+    const PUBLIC_ROUTE_BUCKET: &str = "public-routes";
+    if rate_limiter.check_and_increment(PUBLIC_ROUTE_BUCKET) {
+        warn!("Public route rate limit exceeded");
+        return (
+            StatusCode::TOO_MANY_REQUESTS,
+            "Public route rate limit exceeded — retry after window expires",
+        )
+            .into_response();
+    }
+
+    next.run(request).await
+}
+
 /// Verify a bearer/ticket token to its validated [`jwt::Claims`] using the
 /// shared server auth chain.
 ///
@@ -511,7 +535,7 @@ fn unauthorized_response(message: &str, www_authenticate: &str) -> Response {
 /// Exported for use in other middleware-like contexts (e.g. MCP inline auth).
 /// Returns an empty string on any parse failure.
 pub fn extract_iss_from_token(token: &str) -> String {
-    use base64::{Engine, engine::general_purpose::URL_SAFE_NO_PAD};
+    use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine};
     let parts: Vec<&str> = token.splitn(3, '.').collect();
     if parts.len() < 2 {
         return String::new();
@@ -537,7 +561,7 @@ pub fn extract_iss_from_token(token: &str) -> String {
 
 /// Extract `kid` from a JWT header without full validation.
 pub fn extract_kid_from_token(token: &str) -> Option<String> {
-    use base64::{Engine, engine::general_purpose::URL_SAFE_NO_PAD};
+    use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine};
     let header_b64 = token.split('.').next()?;
     if header_b64.len() > 4096 {
         return None;
@@ -583,6 +607,12 @@ pub fn cors_layer(config: &crate::server::state::CorsConfig) -> tower_http::cors
             Method::DELETE,
             Method::OPTIONS,
         ])
+        // Cross-origin clients must be able to follow RFC 9728 challenges and
+        // consume RFC 9449 nonce challenges. Neither header carries authority.
+        .expose_headers([
+            header::WWW_AUTHENTICATE,
+            HeaderName::from_static("dpop-nonce"),
+        ])
         .max_age(std::time::Duration::from_secs(config.max_age));
 
     // Configure allowed headers
@@ -599,6 +629,8 @@ pub fn cors_layer(config: &crate::server::state::CorsConfig) -> tower_http::cors
             // Standard HTTP headers
             header::CONTENT_TYPE,
             header::AUTHORIZATION,
+            // RFC 9449 proof accompanying `Authorization: DPoP ...`.
+            HeaderName::from_static("dpop"),
             header::USER_AGENT,
             header::ACCEPT,
             header::ACCEPT_LANGUAGE,
@@ -673,184 +705,309 @@ pub fn cors_layer(config: &crate::server::state::CorsConfig) -> tower_http::cors
 
 /// Runtime-behavior tests for [`cors_layer`].
 ///
-/// These drive the real axum `Router` + `CorsLayer` and assert the
-/// `Access-Control-Allow-Origin` / `Access-Control-Allow-Credentials` headers a
-/// browser would actually observe. They exist because the credentialed router's
-/// origin list used to be built with a per-origin loop of `allow_origin(...)`,
-/// which silently honored only the LAST entry — a config-vec assertion can't
-/// catch that (the vec is correct; the layer is wrong), so every check here
-/// exercises the layer end-to-end.
+/// Every assertion drives the real tower-http layer on an axum router. Config
+/// value tests would not catch origin-list override bugs or rejected browser
+/// preflights.
 #[cfg(test)]
 #[allow(clippy::expect_used, clippy::unwrap_used)]
 mod cors_layer_tests {
     use super::cors_layer;
     use crate::config::server::ServerConfig;
     use crate::server::state::CorsConfig;
-    use axum::{body::Body, http::Request as HttpRequest, routing::get, Router};
+    use axum::{
+        body::Body,
+        http::{header, Method, Request as HttpRequest, Response},
+        routing::get,
+        Router,
+    };
     use tower::ServiceExt;
 
-    /// Drive the credentialed CORS layer on a real `Router` and return the
-    /// `Access-Control-Allow-Origin` header it emits for `origin` (or `None` if
-    /// the request was rejected / header absent). This is the only honest way to
-    /// catch the classic "only the last origin in the list is honored" bug, which
-    /// a config-vec assertion will happily report as fixed while the runtime is
-    /// broken.
-    async fn acao_for(config: &CorsConfig, origin: &str) -> Option<String> {
+    async fn response_for(
+        config: &CorsConfig,
+        method: Method,
+        origin: &str,
+        requested_method: Option<&str>,
+        requested_headers: Option<&str>,
+    ) -> Response<Body> {
         let app = Router::new()
             .route("/probe", get(|| async { "ok" }))
             .layer(cors_layer(config));
-        let req = HttpRequest::get("/probe")
-            .header("Origin", origin)
-            .body(Body::empty())
-            .expect("request");
-        let resp = app.oneshot(req).await.expect("response");
-        resp.headers()
-            .get(axum::http::header::ACCESS_CONTROL_ALLOW_ORIGIN)
+        let mut request = HttpRequest::builder()
+            .method(method)
+            .uri("/probe")
+            .header(header::ORIGIN, origin);
+        if let Some(requested_method) = requested_method {
+            request = request.header(header::ACCESS_CONTROL_REQUEST_METHOD, requested_method);
+        }
+        if let Some(requested_headers) = requested_headers {
+            request = request.header(header::ACCESS_CONTROL_REQUEST_HEADERS, requested_headers);
+        }
+        app.oneshot(request.body(Body::empty()).expect("request"))
+            .await
+            .expect("response")
+    }
+
+    async fn acao_for(config: &CorsConfig, origin: &str) -> Option<String> {
+        response_for(config, Method::GET, origin, None, None)
+            .await
+            .headers()
+            .get(header::ACCESS_CONTROL_ALLOW_ORIGIN)
             .and_then(|v| v.to_str().ok())
             .map(str::to_owned)
     }
 
     #[tokio::test]
-    async fn cors_layer_allows_every_default_origin_at_runtime() {
-        // Regression: the credentialed default list previously honored only the
-        // LAST origin (loop-of-override bug). Every dev origin must each produce
-        // an ACAO echoing itself back.
+    async fn default_posture_is_wildcard_at_runtime() {
         let config = CorsConfig::default();
-        for origin in [
-            "http://localhost:3000",
-            "http://localhost:3001",
-            "http://127.0.0.1:3000",
-            "http://127.0.0.1:3001",
-        ] {
+        for origin in ["https://hyprstream.com", "https://third-party.example"] {
             assert_eq!(
                 acao_for(&config, origin).await,
-                Some(origin.to_owned()),
-                "credentialed CORS layer must echo allowed origin {origin}"
+                Some("*".to_owned()),
+                "default public API posture must allow {origin}"
             );
         }
     }
 
     #[tokio::test]
-    async fn cors_layer_rejects_near_miss_origins() {
-        // tower-http's list path uses exact `HeaderValue` equality, so
-        // prefix/suffix/subdomain near-misses must NOT be reflected back. These
-        // are the classic CORS-bypass tricks; a reflect-any bug would leak them.
-        let config = ServerConfig::builder()
+    async fn default_posture_never_advertises_credentials() {
+        let response = response_for(
+            &CorsConfig::default(),
+            Method::GET,
+            "https://third-party.example",
+            None,
+            None,
+        )
+        .await;
+        assert!(
+            !response
+                .headers()
+                .contains_key(header::ACCESS_CONTROL_ALLOW_CREDENTIALS),
+            "wildcard resource API must not advertise ambient credentials"
+        );
+    }
+
+    fn explicit_origins() -> CorsConfig {
+        ServerConfig::builder()
             .cors_origins(vec![
                 "https://hyprstream.com".to_owned(),
                 "https://www.hyprstream.com".to_owned(),
+                "https://app.example.com".to_owned(),
             ])
             .build()
-            .cors;
+            .cors
+    }
+
+    #[tokio::test]
+    async fn explicit_origin_list_still_exact_matches() {
+        let config = explicit_origins();
+        for origin in [
+            "https://hyprstream.com",
+            "https://www.hyprstream.com",
+            "https://app.example.com",
+        ] {
+            assert_eq!(
+                acao_for(&config, origin).await,
+                Some(origin.to_owned()),
+                "explicit origin list must honor {origin}"
+            );
+        }
+        assert_eq!(acao_for(&config, "https://evil.example.com").await, None);
+    }
+
+    #[tokio::test]
+    async fn explicit_list_near_miss_origins_are_rejected() {
+        let config = explicit_origins();
         for evil in [
-            "https://hyprstream.com.evil.tld", // suffix hijack
-            "https://evilhyprstream.com",      // subdomain look-alike
-            "http://hyprstream.com",           // scheme downgrade (no TLS)
-            "https://www.hyprstream.com.evil", // www suffix hijack
+            "https://hyprstream.com.evil.tld",
+            "https://evilhyprstream.com",
+            "http://hyprstream.com",
+            "https://www.hyprstream.com.evil",
         ] {
             assert_eq!(
                 acao_for(&config, evil).await,
                 None,
-                "credentialed CORS layer must reject near-miss origin {evil}"
+                "explicit origin list must reject near miss {evil}"
             );
         }
     }
 
     #[tokio::test]
-    async fn cors_layer_multiorigin_override_honors_all_entries() {
-        // An operator who supplies MULTIPLE origins via
-        // HYPRSTREAM_CORS_ORIGINS / builder must have all of them honored, not
-        // just the last. Single-origin overrides always worked; this guards the
-        // multi-origin case.
+    async fn explicit_list_with_credentials_preserves_legacy_escape_hatch() {
         let config = ServerConfig::builder()
-            .cors_origins(vec![
-                "https://a.example.com".to_owned(),
-                "https://b.example.com".to_owned(),
-                "https://c.example.com".to_owned(),
-            ])
+            .cors_origins(vec!["https://app.example.com".to_owned()])
+            .cors_allow_credentials(true)
             .build()
             .cors;
-        for origin in [
-            "https://a.example.com",
-            "https://b.example.com",
-            "https://c.example.com",
-        ] {
-            assert_eq!(
-                acao_for(&config, origin).await,
-                Some(origin.to_owned()),
-                "multi-origin override must honor {origin}"
-            );
-        }
-        // And an unrelated origin still gets nothing.
+        let response =
+            response_for(&config, Method::GET, "https://app.example.com", None, None).await;
         assert_eq!(
-            acao_for(&config, "https://evil.example.com").await,
-            None,
-            "multi-origin override must not leak to unrelated origins"
+            response
+                .headers()
+                .get(header::ACCESS_CONTROL_ALLOW_CREDENTIALS)
+                .and_then(|value| value.to_str().ok()),
+            Some("true")
         );
     }
 
     #[tokio::test]
-    async fn cors_layer_credentials_header_present_for_allowed_origin() {
-        // The credentialed router must advertise `Access-Control-Allow-Credentials:
-        // true` so browser credentialed requests succeed for an allowed origin.
-        let config = CorsConfig::default();
-        let app = Router::new()
-            .route("/probe", get(|| async { "ok" }))
-            .layer(cors_layer(&config));
-        let resp = app
-            .oneshot(
-                HttpRequest::builder()
-                    .method("GET")
-                    .uri("/probe")
-                    .header("Origin", "http://localhost:3000")
-                    .body(Body::empty())
-                    .expect("request"),
-            )
-            .await
-            .expect("response");
-        assert_eq!(
-            resp.headers()
-                .get(axum::http::header::ACCESS_CONTROL_ALLOW_CREDENTIALS)
-                .and_then(|v| v.to_str().ok()),
-            Some("true"),
-            "credentialed router must set Access-Control-Allow-Credentials: true"
-        );
-    }
-
-    #[tokio::test]
-    async fn cors_layer_wildcard_never_pairs_with_credentials() {
-        // Even a hand-edited config with `["*"]` + credentials-true must be
-        // defused at layer-build time: wildcard forces credentials OFF.
+    async fn wildcard_never_pairs_with_credentials() {
         let mut config = CorsConfig::public();
-        config.allow_credentials = true; // adversarial: try to force creds on with "*"
-        let app = Router::new()
-            .route("/probe", get(|| async { "ok" }))
-            .layer(cors_layer(&config));
-        let resp = app
-            .oneshot(
-                HttpRequest::builder()
-                    .method("GET")
-                    .uri("/probe")
-                    .header("Origin", "https://evil.example.com")
-                    .body(Body::empty())
-                    .expect("request"),
-            )
-            .await
-            .expect("response");
-        // Wildcard surface mirrors any origin...
-        assert_eq!(
-            resp.headers()
-                .get(axum::http::header::ACCESS_CONTROL_ALLOW_ORIGIN)
-                .and_then(|v| v.to_str().ok()),
-            Some("*"),
-        );
-        // ...but must NOT advertise credentials (spec-invalid + credential leak).
-        assert_eq!(
-            resp.headers()
-                .get(axum::http::header::ACCESS_CONTROL_ALLOW_CREDENTIALS),
+        config.allow_credentials = true;
+        let response = response_for(
+            &config,
+            Method::GET,
+            "https://third-party.example",
             None,
-            "wildcard + credentials is spec-invalid; layer must drop credentials"
+            None,
+        )
+        .await;
+        assert_eq!(
+            response
+                .headers()
+                .get(header::ACCESS_CONTROL_ALLOW_ORIGIN)
+                .and_then(|v| v.to_str().ok()),
+            Some("*")
         );
+        assert!(!response
+            .headers()
+            .contains_key(header::ACCESS_CONTROL_ALLOW_CREDENTIALS));
+    }
+
+    #[tokio::test]
+    async fn preflight_allows_bearer_and_dpop_headers() {
+        let response = response_for(
+            &CorsConfig::default(),
+            Method::OPTIONS,
+            "https://third-party.example",
+            Some("POST"),
+            Some("authorization,dpop"),
+        )
+        .await;
+        assert_eq!(
+            response
+                .headers()
+                .get(header::ACCESS_CONTROL_ALLOW_ORIGIN)
+                .and_then(|v| v.to_str().ok()),
+            Some("*")
+        );
+        let allowed = response
+            .headers()
+            .get(header::ACCESS_CONTROL_ALLOW_HEADERS)
+            .and_then(|value| value.to_str().ok())
+            .expect("successful preflight must advertise allowed headers")
+            .to_ascii_lowercase();
+        assert!(allowed
+            .split(',')
+            .any(|value| value.trim() == "authorization"));
+        assert!(allowed.split(',').any(|value| value.trim() == "dpop"));
+    }
+
+    #[tokio::test]
+    async fn preflight_rejects_unlisted_header() {
+        let response = response_for(
+            &CorsConfig::default(),
+            Method::OPTIONS,
+            "https://third-party.example",
+            Some("POST"),
+            Some("x-not-allowed"),
+        )
+        .await;
+        let allowed = response
+            .headers()
+            .get(header::ACCESS_CONTROL_ALLOW_HEADERS)
+            .and_then(|value| value.to_str().ok())
+            .expect("explicit policy advertises its configured allowlist")
+            .to_ascii_lowercase();
+        assert!(
+            !allowed
+                .split(',')
+                .any(|value| value.trim() == "x-not-allowed"),
+            "product API header policy must not admit unlisted request headers"
+        );
+    }
+
+    #[tokio::test]
+    async fn auth_challenge_headers_are_exposed() {
+        let response = response_for(
+            &CorsConfig::default(),
+            Method::GET,
+            "https://third-party.example",
+            None,
+            None,
+        )
+        .await;
+        let exposed = response
+            .headers()
+            .get(header::ACCESS_CONTROL_EXPOSE_HEADERS)
+            .and_then(|value| value.to_str().ok())
+            .expect("cross-origin clients need readable auth challenges")
+            .to_ascii_lowercase();
+        assert!(exposed
+            .split(',')
+            .any(|value| value.trim() == "www-authenticate"));
+        assert!(exposed.split(',').any(|value| value.trim() == "dpop-nonce"));
+    }
+
+    #[tokio::test]
+    async fn permissive_headers_remain_confined_to_did_documents() {
+        let did_response = response_for(
+            &CorsConfig::did_document(),
+            Method::OPTIONS,
+            "https://third-party.example",
+            Some("GET"),
+            Some("x-did-extension"),
+        )
+        .await;
+        assert_eq!(
+            did_response
+                .headers()
+                .get(header::ACCESS_CONTROL_ALLOW_HEADERS)
+                .and_then(|value| value.to_str().ok()),
+            Some("*")
+        );
+
+        let product_response = response_for(
+            &CorsConfig::default(),
+            Method::OPTIONS,
+            "https://third-party.example",
+            Some("GET"),
+            Some("x-did-extension"),
+        )
+        .await;
+        let product_headers = product_response
+            .headers()
+            .get(header::ACCESS_CONTROL_ALLOW_HEADERS)
+            .and_then(|value| value.to_str().ok())
+            .expect("product API advertises its explicit allowlist")
+            .to_ascii_lowercase();
+        assert_ne!(product_headers, "*");
+        assert!(!product_headers
+            .split(',')
+            .any(|value| value.trim() == "x-did-extension"));
+    }
+
+    #[tokio::test]
+    async fn public_and_default_layers_share_wildcard_without_credentials() {
+        for config in [CorsConfig::default(), CorsConfig::public()] {
+            let response = response_for(
+                &config,
+                Method::GET,
+                "https://third-party.example",
+                None,
+                None,
+            )
+            .await;
+            assert_eq!(
+                response
+                    .headers()
+                    .get(header::ACCESS_CONTROL_ALLOW_ORIGIN)
+                    .and_then(|value| value.to_str().ok()),
+                Some("*")
+            );
+            assert!(!response
+                .headers()
+                .contains_key(header::ACCESS_CONTROL_ALLOW_CREDENTIALS));
+        }
     }
 }
 
@@ -860,7 +1017,7 @@ mod tests {
 
     #[test]
     fn test_extract_iss_from_token() {
-        use base64::{Engine, engine::general_purpose::URL_SAFE_NO_PAD};
+        use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine};
 
         // Craft a JWT with iss in payload: header.payload.sig
         // payload = base64url({"iss":"https://node-a","sub":"alice","exp":9999999999,"iat":0})
@@ -889,7 +1046,7 @@ mod tests {
 #[allow(clippy::unwrap_used, clippy::expect_used)]
 mod rotation_aware_tests {
     use super::*;
-    use base64::{Engine as _, engine::general_purpose::URL_SAFE_NO_PAD};
+    use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine as _};
     use ed25519_dalek::{Signer as _, SigningKey};
 
     const AUD: &str = "https://node-a/resource";
@@ -1121,7 +1278,7 @@ mod rotation_aware_tests {
 mod composite_aware_tests {
     use super::*;
     use crate::auth::jwt::encode_composite_ml_dsa_65_ed25519;
-    use base64::{Engine, engine::general_purpose::URL_SAFE_NO_PAD};
+    use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine};
     use ed25519_dalek::SigningKey;
 
     const AUD: &str = "https://node-a/resource";
@@ -1298,17 +1455,15 @@ mod composite_aware_tests {
             published_pair(pq_b_vk, ed_b.verifying_key()),
         ];
 
-        assert!(
-            decode_local_multi_key(
-                &cross_token,
-                &ca.verifying_key(),
-                &[ed_a.verifying_key(), ed_b.verifying_key()],
-                &published,
-                Some(AUD),
-                false,
-            )
-            .is_err()
-        );
+        assert!(decode_local_multi_key(
+            &cross_token,
+            &ca.verifying_key(),
+            &[ed_a.verifying_key(), ed_b.verifying_key()],
+            &published,
+            Some(AUD),
+            false,
+        )
+        .is_err());
     }
 
     #[test]
@@ -1446,17 +1601,15 @@ mod composite_aware_tests {
         let sig_bytes = URL_SAFE_NO_PAD.decode(sig_b64).unwrap();
         for stripped in [&sig_bytes[..3309], &sig_bytes[3309..]] {
             let tampered = format!("{}.{}", &token[..dot2], URL_SAFE_NO_PAD.encode(stripped));
-            assert!(
-                decode_local_multi_key(
-                    &tampered,
-                    &ca.verifying_key(),
-                    &published_ed,
-                    &pairs,
-                    Some(AUD),
-                    false,
-                )
-                .is_err()
-            );
+            assert!(decode_local_multi_key(
+                &tampered,
+                &ca.verifying_key(),
+                &published_ed,
+                &pairs,
+                Some(AUD),
+                false,
+            )
+            .is_err());
         }
     }
 
@@ -1485,17 +1638,15 @@ mod composite_aware_tests {
         .unwrap();
         assert_eq!(claims.sub, "alice");
 
-        assert!(
-            decode_local_multi_key(
-                &token,
-                &ca.verifying_key(),
-                &published_ed,
-                &pairs,
-                Some(AUD),
-                false,
-            )
-            .is_err()
-        );
+        assert!(decode_local_multi_key(
+            &token,
+            &ca.verifying_key(),
+            &published_ed,
+            &pairs,
+            Some(AUD),
+            false,
+        )
+        .is_err());
     }
 
     #[test]
@@ -1584,9 +1735,9 @@ mod composite_aware_tests {
 
 #[cfg(test)]
 #[allow(clippy::expect_used)]
-mod browser_provisioning_rate_limit_tests {
+mod public_rate_limit_tests {
     use super::*;
-    use axum::{Router, body::Body, http::Request as HttpRequest, middleware, routing::get};
+    use axum::{body::Body, http::Request as HttpRequest, middleware, routing::get, Router};
     use std::sync::atomic::{AtomicUsize, Ordering};
     use tower::ServiceExt;
 
@@ -1636,5 +1787,73 @@ mod browser_provisioning_rate_limit_tests {
             1,
             "rejected request must not enter resolver/signing handler work"
         );
+    }
+
+    #[tokio::test]
+    async fn public_route_limit_returns_429_over_quota() {
+        let limiter = Arc::new(RateLimiter::new(1, 60));
+        let app = Router::new()
+            .route("/metadata", get(|| async { StatusCode::OK }))
+            .layer(middleware::from_fn_with_state(
+                limiter,
+                public_route_rate_limit_middleware,
+            ));
+
+        let first = app
+            .clone()
+            .oneshot(
+                HttpRequest::get("/metadata")
+                    .body(Body::empty())
+                    .expect("request"),
+            )
+            .await
+            .expect("first response");
+        let rejected = app
+            .oneshot(
+                HttpRequest::get("/metadata")
+                    .body(Body::empty())
+                    .expect("request"),
+            )
+            .await
+            .expect("limited response");
+
+        assert_eq!(first.status(), StatusCode::OK);
+        assert_eq!(rejected.status(), StatusCode::TOO_MANY_REQUESTS);
+    }
+
+    #[tokio::test]
+    async fn public_route_bucket_is_not_selected_by_forwarding_headers() {
+        let limiter = Arc::new(RateLimiter::new(1, 60));
+        let app = Router::new()
+            .route("/metadata", get(|| async { StatusCode::OK }))
+            .layer(middleware::from_fn_with_state(
+                limiter,
+                public_route_rate_limit_middleware,
+            ));
+
+        let first = app
+            .clone()
+            .oneshot(
+                HttpRequest::get("/metadata")
+                    .header("x-forwarded-for", "192.0.2.10")
+                    .header("x-real-ip", "192.0.2.11")
+                    .body(Body::empty())
+                    .expect("request"),
+            )
+            .await
+            .expect("first response");
+        let rejected = app
+            .oneshot(
+                HttpRequest::get("/metadata")
+                    .header("x-forwarded-for", "198.51.100.20")
+                    .header("x-real-ip", "198.51.100.21")
+                    .body(Body::empty())
+                    .expect("request"),
+            )
+            .await
+            .expect("limited response");
+
+        assert_eq!(first.status(), StatusCode::OK);
+        assert_eq!(rejected.status(), StatusCode::TOO_MANY_REQUESTS);
     }
 }

--- a/crates/hyprstream/src/server/mod.rs
+++ b/crates/hyprstream/src/server/mod.rs
@@ -5,13 +5,16 @@
 //! - Model management at /models
 
 use anyhow::Result;
-use axum::{middleware as axum_middleware, response::IntoResponse, routing::get, Json, Router};
+use axum::http::StatusCode;
+use axum::{
+    extract::State, middleware as axum_middleware, response::IntoResponse, routing::get, Json,
+    Router,
+};
 use std::net::SocketAddr;
 use std::sync::Arc;
 use std::time::Duration;
 use tokio::net::TcpListener;
 use tokio::sync::Notify;
-use axum::http::StatusCode;
 use tower_http::{timeout::TimeoutLayer, trace::TraceLayer};
 use tracing::info;
 
@@ -20,9 +23,9 @@ pub mod routes;
 pub mod state;
 pub mod tls;
 
+use axum::Extension;
 pub use middleware::AuthenticatedUser;
 use state::ServerState;
-use axum::Extension;
 
 /// Extract user identity from optional authenticated user extension.
 /// Returns "anonymous" if no authentication present.
@@ -61,10 +64,16 @@ pub fn create_app(state: ServerState) -> Router {
     // `PublicExemption` entry plus a handler arm below (two review surfaces).
     // Every route NOT here stays on the protected (auth-mediated) router; the
     // default is mediated, never permissive. See `mac::public_exemptions`.
-    let (public_routes, browser_provisioning_routes) =
-        build_public_routes_from_registry(Arc::clone(&state.browser_provisioning_rate_limiter));
+    let (public_routes, browser_provisioning_routes) = build_public_routes_from_registry(
+        Arc::clone(&state.public_route_rate_limiter),
+        Arc::clone(&state.browser_provisioning_rate_limiter),
+    );
 
-    // Protected routes (auth required)
+    // Protected routes (auth required). CORS only controls which browser
+    // origins may read responses; it never supplies identity or authority.
+    // The verified token drives tenant resolution (the DID's hosted-account
+    // binding) and the enforcing MAC path; `Origin` is not an authorization
+    // or tenant input.
     let protected_routes = Router::new()
         // OpenAI-compatible API routes at /oai/v1
         .nest("/oai/v1", routes::openai::create_router())
@@ -84,7 +93,10 @@ pub fn create_app(state: ServerState) -> Router {
         .merge(browser_provisioning_routes)
         .merge(protected_routes)
         // Add middleware (order matters: timeout should be before state)
-        .layer(TimeoutLayer::with_status_code(StatusCode::REQUEST_TIMEOUT, timeout_duration))
+        .layer(TimeoutLayer::with_status_code(
+            StatusCode::REQUEST_TIMEOUT,
+            timeout_duration,
+        ))
         .layer(TraceLayer::new_for_http())
         .with_state(state);
 
@@ -104,11 +116,13 @@ pub fn create_app(state: ServerState) -> Router {
 /// registry, so an unmediated route cannot appear without a reviewed
 /// `PublicExemption` entry plus a handler arm in the exhaustive match below.
 fn build_public_routes_from_registry(
+    public_route_rate_limiter: Arc<crate::server::middleware::RateLimiter>,
     browser_provisioning_rate_limiter: Arc<crate::server::middleware::RateLimiter>,
 ) -> (Router<ServerState>, Router<ServerState>) {
     use crate::mac::public_exemptions::{for_face, HttpFace, PublicRouteHandler, RouteMethod};
 
     let mut public_routes: Router<ServerState> = Router::new();
+    let mut rate_limited_public_routes: Router<ServerState> = Router::new();
     let mut browser_provisioning_routes: Router<ServerState> = Router::new();
 
     for exemption in for_face(HttpFace::MainApp) {
@@ -130,19 +144,20 @@ fn build_public_routes_from_registry(
                 public_routes = public_routes.route(exemption.path, get(health_check));
             }
             PublicRouteHandler::OauthProtectedResourceMetadata => {
-                public_routes = public_routes
+                rate_limited_public_routes = rate_limited_public_routes
                     .route(exemption.path, get(oauth_protected_resource_metadata));
             }
             PublicRouteHandler::Export9pMetadata => {
-                public_routes =
-                    public_routes.route(exemption.path, get(routes::ninep::export9p_metadata));
+                rate_limited_public_routes = rate_limited_public_routes
+                    .route(exemption.path, get(routes::ninep::export9p_metadata));
             }
             PublicRouteHandler::WirePlanesMetadata => {
-                public_routes =
-                    public_routes.route(exemption.path, get(routes::ninep::wire_planes_metadata));
+                rate_limited_public_routes = rate_limited_public_routes
+                    .route(exemption.path, get(routes::ninep::wire_planes_metadata));
             }
             PublicRouteHandler::NinepWebSocket => {
-                public_routes = public_routes.route(exemption.path, get(routes::ninep::ninep_ws));
+                rate_limited_public_routes =
+                    rate_limited_public_routes.route(exemption.path, get(routes::ninep::ninep_ws));
             }
             PublicRouteHandler::BrowserProvisioning => {
                 // Public browser provisioning is independently rate-limited
@@ -170,6 +185,16 @@ fn build_public_routes_from_registry(
         }
     }
 
+    // Public metadata and the 9P pre-upgrade path have no authenticated
+    // subject. Meter them through one non-client-selectable bucket while
+    // keeping liveness probes out of the failure domain.
+    public_routes = public_routes.merge(rate_limited_public_routes.layer(
+        axum_middleware::from_fn_with_state(
+            public_route_rate_limiter,
+            middleware::public_route_rate_limit_middleware,
+        ),
+    ));
+
     (public_routes, browser_provisioning_routes)
 }
 
@@ -185,14 +210,10 @@ async fn health_check() -> impl IntoResponse {
 /// Protected Resource Metadata (RFC 9728) for the OAI server.
 ///
 /// Advertises the OAuth authorization server that protects this resource.
-async fn oauth_protected_resource_metadata() -> impl IntoResponse {
-    let config = crate::config::HyprConfig::load().unwrap_or_default();
-    let oai_url = config.oai.resource_url();
-    let oauth_issuer = config.oauth.issuer_url();
-
+async fn oauth_protected_resource_metadata(State(state): State<ServerState>) -> impl IntoResponse {
     let mut meta = crate::services::oauth::protected_resource_metadata(
-        &oai_url,
-        &oauth_issuer,
+        &state.resource_url,
+        &state.oauth_issuer_url,
     );
     meta.resource_name = Some("HyprStream OpenAI-Compatible API".to_owned());
     meta.scopes_supported = Some(vec!["infer:model:*".into(), "read:model:*".into()]);
@@ -230,7 +251,11 @@ pub async fn start_server_tls(
     )
     .await?;
 
-    let scheme = if rustls_config.is_some() { "https" } else { "http" };
+    let scheme = if rustls_config.is_some() {
+        "https"
+    } else {
+        "http"
+    };
     info!("OpenAI-compatible API available at {scheme}://{addr}/oai/v1");
 
     let app = create_app(state);
@@ -292,7 +317,8 @@ mod tests {
         public_exemptions::validate().expect("registry must be self-consistent before wiring");
 
         let rate_limiter = Arc::new(middleware::RateLimiter::new(u32::MAX, 3600));
-        let (public, browser_provisioning) = build_public_routes_from_registry(rate_limiter);
+        let (public, browser_provisioning) =
+            build_public_routes_from_registry(Arc::clone(&rate_limiter), rate_limiter);
         let live = live_router_paths(&public.merge(browser_provisioning));
         let registered = for_face(HttpFace::MainApp)
             .map(|exemption| exemption.path.to_owned())

--- a/crates/hyprstream/src/server/state.rs
+++ b/crates/hyprstream/src/server/state.rs
@@ -80,6 +80,12 @@ pub struct ServerState {
     /// before checkpoint resolution and hybrid projection signing.
     pub browser_provisioning_rate_limiter: Arc<crate::server::middleware::RateLimiter>,
 
+    /// Stable global limiter for public metadata and pre-upgrade routes.
+    ///
+    /// There is no authenticated tenant on these routes, and client-controlled
+    /// forwarding headers must not select independent buckets.
+    pub public_route_rate_limiter: Arc<crate::server::middleware::RateLimiter>,
+
     /// Mandatory resolver-backed, audited PEP shared by every 9P transport.
     pub ninep_decider: Arc<dyn hyprstream_9p::AccessDecider>,
 }
@@ -245,6 +251,9 @@ impl ServerState {
             browser_provisioning_rate_limiter: Arc::new(
                 crate::server::middleware::RateLimiter::new(60, 60),
             ),
+            public_route_rate_limiter: Arc::new(crate::server::middleware::RateLimiter::new(
+                3_000, 60,
+            )),
             ninep_decider,
         })
     }


### PR DESCRIPTION
Closes #1144

## Summary

- default product/MCP CORS to any origin with ambient credentials disabled
- allow browser preflights for Authorization and DPoP, and expose WWW-Authenticate and DPoP-Nonce
- retain an explicit-origin plus credentials compatibility mode while forcing wildcard credentials off
- rate-limit unauthenticated metadata and 9P pre-upgrade routes without trusting forwarding headers; keep health probes unmetered
- serve protected-resource metadata from cached server state

## Security invariants

CORS does not grant identity or authority. Protected requests still traverse bearer/DPoP verification and the enforcing MAC path. Origin is never a tenant input: the verified token resolves the tenant as the DID hosted-account binding. The reviewed public-exemption registry is unchanged.

The browser 9P WebSocket path retains its existing one-shot, pre-upgrade ticket validation and subject-scoped MAC decider. Wildcard CORS does not alter WebSocket origin semantics.

## Validation

- cargo metadata --all-features --format-version 1: passed
- cargo clippy -p hyprstream --all-targets -- -D warnings: passed
- buildq -- cargo nextest run --release --profile ci -p hyprstream -p hyprstream-rpc --no-fail-fast: 2,279 passed, 9 skipped, 0 failed
- buildq -- cargo nextest run --release --profile ci -p hyprstream --no-fail-fast (after rebase onto current main): 1,347 passed, 6 skipped, 0 failed

No self-merge.