### PR TITLE
fix(wasm): gate dispatch_pep crate::service off wasm32 — unblock PR queue (same as #1307)

### DIFF
--- a/crates/hyprstream-rpc/src/auth/mac/mod.rs
+++ b/crates/hyprstream-rpc/src/auth/mac/mod.rs
@@ -106,6 +106,11 @@ pub mod bind;
 pub mod context;
 // #1268: the mandatory RPC dispatch PEP — fail-closed gate between
 // verify_claims and handle_request in process_request.
+//
+// Native-only: the PEP consumes `crate::service::EnvelopeContext`, and the
+// `service` module is compiled out on wasm32 — the browser client does no
+// server-side dispatch MAC enforcement (same gate pattern as #1307).
+#[cfg(not(target_arch = "wasm32"))]
 pub mod dispatch_pep;
 pub mod genesis;
 pub mod label;
@@ -113,6 +118,7 @@ pub mod lattice;
 pub mod manifest;
 
 pub use bind::{clamp_descendant, BindLabel, BindLabelMap};
+#[cfg(not(target_arch = "wasm32"))]
 pub use dispatch_pep::{
     check_dispatch_mac, global_mac_dispatch_pep, install_mac_dispatch_pep, DefaultMacDispatchPep,
     DenyAllMacPep, DenyAllObjectResolver, MacDecision, MacDenyReason, MacDispatchPep,


### PR DESCRIPTION
fix(wasm): gate dispatch_pep crate::service off wasm32 — unblock PR queue (same as #1307)

## The break
`crates/hyprstream-rpc/src/auth/mac/dispatch_pep.rs:51` imports `crate::service::EnvelopeContext`, which does not resolve on wasm32 — the `service` module is compiled out on the wasm target (`lib.rs:166`). This reds the **WASM (browser client)** CI job on main and on every PR.

## The fix
The MAC dispatch PEP is server-side dispatch enforcement; the wasm browser client does no dispatch PEP. Gate the module inclusion and its re-exports in `auth/mac/mod.rs` behind `#[cfg(not(target_arch = "wasm32"))]` — same gate pattern as #1307.

## Validation
- wasm32: `RUSTFLAGS='--cfg=web_sys_unstable_apis' cargo check --target wasm32-unknown-unknown -p hyprstream-rpc` — GREEN (the exact CI job command)
- native: `cargo check -p hyprstream-rpc` via hyprstream-build.sh — GREEN