### PR TITLE
feat(auth): enforce tenant domains on HTTP faces

### DIFF
--- a/crates/hyprstream-flight/src/lib.rs
+++ b/crates/hyprstream-flight/src/lib.rs
@@ -21,10 +21,10 @@ pub mod service;
 
 // Re-export main types
 pub use client::FlightClient;
-pub use service::FlightSqlServer;
+pub use service::{DenyAllFlightAuthorizer, FlightAuthError, FlightAuthorizer, FlightSqlServer};
 
-use hyprstream_metrics::RegistryClient;
 use hyprstream_metrics::storage::{duckdb::DuckDbBackend, StorageBackendType};
+use hyprstream_metrics::RegistryClient;
 use std::collections::HashMap;
 use std::net::SocketAddr;
 use std::path::PathBuf;
@@ -120,6 +120,22 @@ pub async fn start_flight_server(
     dataset_name: &str,
     config: FlightConfig,
 ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+    start_flight_server_with_authorizer(
+        client,
+        dataset_name,
+        config,
+        Arc::new(DenyAllFlightAuthorizer),
+    )
+    .await
+}
+
+/// Start Flight with an explicit authentication + tenant-policy boundary.
+pub async fn start_flight_server_with_authorizer(
+    client: Option<Arc<dyn RegistryClient>>,
+    dataset_name: &str,
+    config: FlightConfig,
+    authorizer: Arc<dyn FlightAuthorizer>,
+) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     // Determine connection string based on whether we have a registry client
     let connection_string = if let Some(ref registry_client) = client {
         // Look up dataset in registry
@@ -159,6 +175,14 @@ pub async fn start_flight_server(
     let flight_service = FlightSqlServer::new(StorageBackendType::DuckDb(backend))
         .await
         .map_err(|e| format!("Failed to create Flight SQL server: {e}"))?
+        .with_authorizer(
+            authorizer,
+            if dataset_name.is_empty() {
+                "flight:*".to_owned()
+            } else {
+                format!("flight:dataset:{dataset_name}")
+            },
+        )
         .into_service();
 
     let mut server = Server::builder();

--- a/crates/hyprstream-flight/src/service.rs
+++ b/crates/hyprstream-flight/src/service.rs
@@ -1,32 +1,80 @@
 // tonic::Status is the idiomatic gRPC error type - boxing would break API
 #![allow(clippy::result_large_err)]
 
-use hyprstream_metrics::storage::{
-    view::ViewDefinition,
-    StorageBackend, StorageBackendType,
-};
-use hyprstream_metrics::query::QueryOrchestrator;
 use arrow_flight::{
+    encode::FlightDataEncoderBuilder,
+    error::FlightError,
     flight_service_server::{FlightService, FlightServiceServer},
     sql::{
-        server::FlightSqlService,
-        CommandStatementQuery, TicketStatementQuery,
+        server::FlightSqlService, ActionClosePreparedStatementRequest,
         ActionCreatePreparedStatementRequest, ActionCreatePreparedStatementResult,
-        ActionClosePreparedStatementRequest, CommandPreparedStatementQuery,
-        SqlInfo, ProstMessageExt,
+        CommandPreparedStatementQuery, CommandStatementQuery, ProstMessageExt, SqlInfo,
+        TicketStatementQuery,
     },
-    Action, FlightDescriptor, FlightInfo, Ticket, HandshakeRequest, HandshakeResponse, FlightEndpoint,
-    encode::FlightDataEncoderBuilder, error::FlightError,
+    Action, FlightDescriptor, FlightEndpoint, FlightInfo, HandshakeRequest, HandshakeResponse,
+    Ticket,
 };
-use futures::{Stream, StreamExt, TryStreamExt};
-use prost::Message;
-use std::pin::Pin;
 use arrow_schema::Schema;
+use futures::{Stream, StreamExt, TryStreamExt};
+use hyprstream_metrics::query::QueryOrchestrator;
+use hyprstream_metrics::storage::{view::ViewDefinition, StorageBackend, StorageBackendType};
+use parking_lot::Mutex;
+use prost::Message;
 use serde::Deserialize;
 use serde_json;
+use std::pin::Pin;
 use std::sync::{atomic::AtomicU64, Arc};
-use parking_lot::Mutex;
 use tonic::{Request, Response, Status, Streaming};
+
+/// Transport-neutral failure from the embedding server's Flight PEP.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum FlightAuthError {
+    Unauthenticated(String),
+    Forbidden(String),
+    Internal(String),
+}
+
+impl FlightAuthError {
+    fn into_status(self) -> Status {
+        match self {
+            Self::Unauthenticated(message) => Status::unauthenticated(message),
+            Self::Forbidden(message) => Status::permission_denied(message),
+            Self::Internal(message) => Status::internal(message),
+        }
+    }
+}
+
+/// Authentication and tenant-policy boundary for the Flight data plane.
+///
+/// The implementation lives in the embedding binary so this leaf crate does
+/// not depend on Hyprstream's JWT or PolicyClient types.
+#[tonic::async_trait]
+pub trait FlightAuthorizer: Send + Sync {
+    async fn authorize(
+        &self,
+        authorization: Option<&str>,
+        resource: &str,
+        operation: &str,
+    ) -> Result<(), FlightAuthError>;
+}
+
+/// Fail-closed default used by standalone constructors.
+#[derive(Debug, Default)]
+pub struct DenyAllFlightAuthorizer;
+
+#[tonic::async_trait]
+impl FlightAuthorizer for DenyAllFlightAuthorizer {
+    async fn authorize(
+        &self,
+        _authorization: Option<&str>,
+        _resource: &str,
+        _operation: &str,
+    ) -> Result<(), FlightAuthError> {
+        Err(FlightAuthError::Unauthenticated(
+            "Flight authorization is not configured".to_owned(),
+        ))
+    }
+}
 
 #[derive(Debug, Deserialize)]
 struct CreateTableCmd {
@@ -83,8 +131,14 @@ impl Command {
 /// Command types for table and view operations
 #[derive(Debug)]
 enum TableCommand {
-    CreateTable { name: String, schema: Arc<Schema> },
-    CreateView { name: String, definition: ViewDefinition },
+    CreateTable {
+        name: String,
+        schema: Arc<Schema>,
+    },
+    CreateView {
+        name: String,
+        definition: ViewDefinition,
+    },
     DropTable(String),
     DropView(String),
 }
@@ -121,7 +175,8 @@ impl TableCommand {
                     })?;
                 let name = value["data"]["name"]
                     .as_str()
-                    .ok_or_else(|| Status::invalid_argument("Missing view name"))?.to_owned();
+                    .ok_or_else(|| Status::invalid_argument("Missing view name"))?
+                    .to_owned();
                 Ok(TableCommand::CreateView { name, definition })
             }
             Some("drop_table") => {
@@ -149,6 +204,33 @@ pub struct FlightSqlServer {
     #[allow(dead_code)]
     statement_counter: Arc<AtomicU64>,
     prepared_statements: Arc<Mutex<Vec<(u64, String)>>>,
+    authorizer: Arc<dyn FlightAuthorizer>,
+    resource: String,
+}
+
+impl std::fmt::Debug for FlightSqlServer {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("FlightSqlServer")
+            .field("resource", &self.resource)
+            .finish_non_exhaustive()
+    }
+}
+
+impl FlightSqlServer {
+    fn authorization<T>(request: &Request<T>) -> Option<String> {
+        request
+            .metadata()
+            .get("authorization")
+            .and_then(|value| value.to_str().ok())
+            .map(str::to_owned)
+    }
+
+    async fn authorize(&self, authorization: Option<&str>, operation: &str) -> Result<(), Status> {
+        self.authorizer
+            .authorize(authorization, &self.resource, operation)
+            .await
+            .map_err(FlightAuthError::into_status)
+    }
 }
 
 #[tonic::async_trait]
@@ -160,7 +242,12 @@ impl FlightSqlService for FlightSqlServer {
     async fn do_handshake(
         &self,
         request: Request<Streaming<HandshakeRequest>>,
-    ) -> Result<Response<Pin<Box<dyn Stream<Item = Result<HandshakeResponse, Status>> + Send>>>, Status> {
+    ) -> Result<
+        Response<Pin<Box<dyn Stream<Item = Result<HandshakeResponse, Status>> + Send>>>,
+        Status,
+    > {
+        let authorization = Self::authorization(&request);
+        self.authorize(authorization.as_deref(), "query").await?;
         let mut stream = request.into_inner();
         let response_stream = async_stream::try_stream! {
             while let Some(request) = stream.next().await {
@@ -179,8 +266,13 @@ impl FlightSqlService for FlightSqlServer {
         query: CommandStatementQuery,
         request: Request<FlightDescriptor>,
     ) -> Result<Response<FlightInfo>, Status> {
+        let authorization = Self::authorization(&request);
+        self.authorize(authorization.as_deref(), "query").await?;
         // Use QueryOrchestrator to prepare and get schema
-        let cached_stmt = self.orchestrator.prepare(&query.query).await
+        let cached_stmt = self
+            .orchestrator
+            .prepare(&query.query)
+            .await
             .map_err(|e| Status::internal(format!("Query preparation failed: {e}")))?;
 
         let schema = cached_stmt.schema.clone();
@@ -204,10 +296,9 @@ impl FlightSqlService for FlightSqlServer {
             .try_with_schema(schema.as_ref())
             .map_err(|e| Status::internal(format!("Unable to serialize schema: {e}")))?
             .with_descriptor(flight_descriptor)
-            .with_endpoint(FlightEndpoint::new()
-                .with_ticket(Ticket {
-                    ticket: ticket.as_any().encode_to_vec().into(),
-                }))
+            .with_endpoint(FlightEndpoint::new().with_ticket(Ticket {
+                ticket: ticket.as_any().encode_to_vec().into(),
+            }))
             .with_total_records(-1)
             .with_total_bytes(-1)
             .with_ordered(false);
@@ -218,30 +309,39 @@ impl FlightSqlService for FlightSqlServer {
     async fn do_get_statement(
         &self,
         ticket: TicketStatementQuery,
-        _request: Request<Ticket>,
+        request: Request<Ticket>,
     ) -> Result<Response<<Self as FlightService>::DoGetStream>, Status> {
+        let authorization = Self::authorization(&request);
+        self.authorize(authorization.as_deref(), "query").await?;
         // Get statement handle from ticket
         let handle = u64::from_le_bytes(
-            ticket.statement_handle.to_vec()
+            ticket
+                .statement_handle
+                .to_vec()
                 .try_into()
-                .map_err(|_| Status::invalid_argument("Invalid statement handle"))?
+                .map_err(|_| Status::invalid_argument("Invalid statement handle"))?,
         );
 
         // Get cached statement from orchestrator
-        let cached_stmt = self.orchestrator.get_statement(handle).await
+        let cached_stmt = self
+            .orchestrator
+            .get_statement(handle)
+            .await
             .ok_or_else(|| Status::invalid_argument("Statement handle not found"))?;
 
         let schema = cached_stmt.schema.clone();
 
         // Execute using the orchestrator's cached physical plan
-        let result_stream = self.orchestrator.execute(&cached_stmt).await
+        let result_stream = self
+            .orchestrator
+            .execute(&cached_stmt)
+            .await
             .map_err(|e| Status::internal(format!("Query execution failed: {e}")))?;
 
         // Convert DataFusion stream to Flight stream
-        let stream = result_stream
-            .map_err(|e| FlightError::ExternalError(Box::new(std::io::Error::other(
-                e.to_string(),
-            ))));
+        let stream = result_stream.map_err(|e| {
+            FlightError::ExternalError(Box::new(std::io::Error::other(e.to_string())))
+        });
 
         let stream = FlightDataEncoderBuilder::new()
             .with_schema(schema)
@@ -256,7 +356,9 @@ impl FlightSqlService for FlightSqlServer {
         _cmd: CommandPreparedStatementQuery,
         _request: Request<FlightDescriptor>,
     ) -> Result<Response<FlightInfo>, Status> {
-        Err(Status::unimplemented("get_flight_info_prepared_statement not implemented"))
+        Err(Status::unimplemented(
+            "get_flight_info_prepared_statement not implemented",
+        ))
     }
 
     async fn do_get_prepared_statement(
@@ -264,7 +366,9 @@ impl FlightSqlService for FlightSqlServer {
         _query: CommandPreparedStatementQuery,
         _request: Request<Ticket>,
     ) -> Result<Response<<Self as FlightService>::DoGetStream>, Status> {
-        Err(Status::unimplemented("do_get_prepared_statement not implemented"))
+        Err(Status::unimplemented(
+            "do_get_prepared_statement not implemented",
+        ))
     }
 
     async fn do_action_create_prepared_statement(
@@ -272,7 +376,9 @@ impl FlightSqlService for FlightSqlServer {
         _query: ActionCreatePreparedStatementRequest,
         _request: Request<Action>,
     ) -> Result<ActionCreatePreparedStatementResult, Status> {
-        Err(Status::unimplemented("do_action_create_prepared_statement not implemented"))
+        Err(Status::unimplemented(
+            "do_action_create_prepared_statement not implemented",
+        ))
     }
 
     async fn do_action_close_prepared_statement(
@@ -280,7 +386,9 @@ impl FlightSqlService for FlightSqlServer {
         _query: ActionClosePreparedStatementRequest,
         _request: Request<Action>,
     ) -> Result<(), Status> {
-        Err(Status::unimplemented("do_action_close_prepared_statement not implemented"))
+        Err(Status::unimplemented(
+            "do_action_close_prepared_statement not implemented",
+        ))
     }
 }
 
@@ -298,7 +406,20 @@ impl FlightSqlServer {
             orchestrator: Arc::new(orchestrator),
             statement_counter: Arc::new(AtomicU64::new(0)),
             prepared_statements: Arc::new(Mutex::new(Vec::new())),
+            authorizer: Arc::new(DenyAllFlightAuthorizer),
+            resource: "flight:*".to_owned(),
         })
+    }
+
+    /// Install the embedding server's JWT + tenant-policy authorizer.
+    pub fn with_authorizer(
+        mut self,
+        authorizer: Arc<dyn FlightAuthorizer>,
+        resource: impl Into<String>,
+    ) -> Self {
+        self.authorizer = authorizer;
+        self.resource = resource.into();
+        self
     }
 
     pub fn into_service(self) -> FlightServiceServer<Self> {
@@ -340,13 +461,18 @@ impl FlightSqlServer {
             }
             Command::Sql(SqlCommand::Execute(sql)) => {
                 // Execute statement via orchestrator
-                self.orchestrator.query_collect(&sql).await
+                self.orchestrator
+                    .query_collect(&sql)
+                    .await
                     .map_err(|e| Status::internal(format!("Query execution failed: {e}")))?;
                 Ok(vec![])
             }
             Command::Sql(SqlCommand::Query(sql)) => {
                 // Prepare statement via orchestrator
-                let cached_stmt = self.orchestrator.prepare(&sql).await
+                let cached_stmt = self
+                    .orchestrator
+                    .prepare(&sql)
+                    .await
                     .map_err(|e| Status::internal(format!("Query preparation failed: {e}")))?;
 
                 let handle = cached_stmt.handle;
@@ -366,5 +492,23 @@ impl FlightSqlServer {
     /// Get reference to the query orchestrator
     pub fn orchestrator(&self) -> &Arc<QueryOrchestrator> {
         &self.orchestrator
+    }
+}
+
+#[cfg(test)]
+mod authorization_tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn standalone_flight_authorizer_fails_closed() {
+        let authorizer = DenyAllFlightAuthorizer;
+        assert_eq!(
+            authorizer
+                .authorize(Some("Bearer attacker"), "flight:*", "query")
+                .await,
+            Err(FlightAuthError::Unauthenticated(
+                "Flight authorization is not configured".to_owned()
+            ))
+        );
     }
 }

--- a/crates/hyprstream-rpc/src/auth/claims.rs
+++ b/crates/hyprstream-rpc/src/auth/claims.rs
@@ -976,6 +976,9 @@ pub struct IdTokenClaims {
     /// Authorized party (REQUIRED when aud has multiple values).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub azp: Option<String>,
+    /// Authority-verified hosted-account tenant for local token exchange.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tenant: Option<String>,
 
     // ── Profile claims (included based on requested scopes) ─────────────
     /// Full name.
@@ -1004,6 +1007,7 @@ impl IdTokenClaims {
             nonce: None,
             auth_time: None,
             azp: None,
+            tenant: None,
             name: None,
             email: None,
             email_verified: None,
@@ -1020,6 +1024,12 @@ impl IdTokenClaims {
     /// Set the authentication time.
     pub fn with_auth_time(mut self, auth_time: i64) -> Self {
         self.auth_time = Some(auth_time);
+        self
+    }
+
+    /// Bind this local ID token to the user's hosted-account tenant.
+    pub fn with_tenant(mut self, tenant: String) -> Self {
+        self.tenant = Some(tenant);
         self
     }
 

--- a/crates/hyprstream/src/auth/key_rotation.rs
+++ b/crates/hyprstream/src/auth/key_rotation.rs
@@ -2277,6 +2277,53 @@ mod tests {
     use super::*;
     use tempfile::TempDir;
 
+    fn hosted_account_store(
+        label: &str,
+        zone: &str,
+    ) -> anyhow::Result<Arc<hyprstream_pds_service::AccountRecordStore>> {
+        let ed = ed25519_dalek::SigningKey::generate(&mut rand::rngs::OsRng);
+        let (pq, pq_vk) = hyprstream_crypto::pq::ml_dsa_generate_keypair();
+        let hybrid = hyprstream_pds::did_op::HybridRotationKey::new(
+            ed.verifying_key().to_bytes(),
+            hyprstream_crypto::pq::ml_dsa_vk_bytes(&pq_vk),
+        )?;
+        let rotations = hyprstream_pds::did_op::GenesisRotationKeys::new(
+            hyprstream_pds::did_op::UserRotationKey::new(hybrid),
+            hyprstream_pds::did_op::RecoveryKeyEnrollment::Declined,
+            hyprstream_pds::did_op::HostKeyEnrollment::Absent,
+        )?;
+        let name = hyprstream_pds::AllocatedAccountName::new(
+            label,
+            format!("did:web:{label}.{zone}"),
+        )?;
+        let pending = hyprstream_pds::HostedAccountMint::begin(name, rotations)?
+            .prepare_genesis(
+                hyprstream_pds::Cid::from_raw(zone.as_bytes()),
+                hyprstream_pds::did_op::GenesisRepoHead::EmptyRepo,
+            )?;
+        let signature =
+            hyprstream_pds::did_op::sign_genesis(pending.unsigned_genesis(), &ed, &pq)?;
+        let record = pending.seal(signature)?.record_bytes().to_vec();
+        let root = hyprstream_vfs::SyntheticNode::dir().with_child(
+            zone,
+            hyprstream_vfs::SyntheticNode::dir().with_child(
+                "accounts",
+                hyprstream_vfs::SyntheticNode::dir().with_child(
+                    label,
+                    hyprstream_vfs::SyntheticNode::dir().with_child(
+                        "account-record.cbor",
+                        hyprstream_vfs::SyntheticNode::file(record),
+                    ),
+                ),
+            ),
+        );
+        Ok(Arc::new(
+            hyprstream_pds_service::AccountRecordStore::new(Arc::new(
+                hyprstream_vfs::SyntheticMount::new(root),
+            )),
+        ))
+    }
+
     fn test_config() -> OAuthConfig {
         OAuthConfig {
             jwt_key_active_days: 14,
@@ -2542,12 +2589,37 @@ mod tests {
                     SigningKey::from_bytes(&[0x77; 32]).verifying_key(),
                     None,
                 )?;
-                let state = Arc::new(crate::services::oauth::state::OAuthState::new(
-                    &config,
-                    policy_client_for_socket(&dir)?,
-                    discovery,
-                    authority_ca_key().verifying_key().to_bytes(),
-                ));
+                let user_store = Arc::new(crate::auth::RocksDbUserStore::open(
+                    &dir.join("oauth-users"),
+                )?);
+                crate::auth::UserStore::register(user_store.as_ref(), "multiprocess-oauth").await?;
+                crate::auth::UserStore::set_profile(
+                    user_store.as_ref(),
+                    "multiprocess-oauth",
+                    crate::auth::UserProfilePatch {
+                        atproto_did: Some(Some(
+                            "did:web:multiprocess-oauth.example.test".to_owned(),
+                        )),
+                        ..Default::default()
+                    },
+                )
+                .await?;
+                let state = Arc::new(
+                    crate::services::oauth::state::OAuthState::new(
+                        &config,
+                        policy_client_for_socket(&dir)?,
+                        discovery,
+                        authority_ca_key().verifying_key().to_bytes(),
+                    )
+                    .with_user_store(user_store)
+                    .with_hosted_account_zone(crate::account::AccountZone::new(
+                        "example.test",
+                    )?)
+                    .with_hosted_account_store(hosted_account_store(
+                        "multiprocess-oauth",
+                        "example.test",
+                    )?),
+                );
                 let verifier = "multiprocess-pkce-verifier";
                 let challenge = URL_SAFE_NO_PAD.encode(Sha256::digest(verifier.as_bytes()));
                 for code in [

--- a/crates/hyprstream/src/config/mod.rs
+++ b/crates/hyprstream/src/config/mod.rs
@@ -666,9 +666,17 @@ impl OAIConfig {
             } else {
                 "http"
             };
-            let host = if self.host == "0.0.0.0" { "localhost" } else { &self.host };
+            let host = resource_url_host(&self.host);
             format!("{scheme}://{host}:{}", self.port)
         }
+    }
+}
+
+fn resource_url_host(bind_host: &str) -> &str {
+    if bind_host == "0.0.0.0" {
+        "localhost"
+    } else {
+        bind_host
     }
 }
 
@@ -810,6 +818,10 @@ pub struct FlightConfig {
     #[serde(default = "default_flight_port")]
     pub port: u16,
 
+    /// External resource URL used as the exact JWT audience.
+    #[serde(default)]
+    pub external_url: Option<String>,
+
     /// Default dataset to serve (optional)
     #[serde(default)]
     pub default_dataset: Option<String>,
@@ -832,11 +844,28 @@ impl Default for FlightConfig {
         Self {
             host: default_flight_host(),
             port: default_flight_port(),
+            external_url: None,
             default_dataset: None,
             tls_cert: None,
             tls_key: None,
             quic_port: None,
         }
+    }
+}
+
+impl FlightConfig {
+    /// Resource URL used as the exact Flight access-token audience.
+    pub fn resource_url(&self) -> String {
+        if let Some(ref url) = self.external_url {
+            return url.clone();
+        }
+        let scheme = if self.tls_cert.is_some() && self.tls_key.is_some() {
+            "https"
+        } else {
+            "http"
+        };
+        let host = resource_url_host(&self.host);
+        format!("{scheme}://{host}:{}", self.port)
     }
 }
 

--- a/crates/hyprstream/src/mac/cas_pep.rs
+++ b/crates/hyprstream/src/mac/cas_pep.rs
@@ -409,7 +409,9 @@ impl crate::storage::cas::CasMountAuthorizer for MacCasAuthorizer {
         request: crate::storage::cas::CasMountAuthzRequest<'_>,
     ) -> Result<(), hyprstream_vfs::MountError> {
         let resolver = CasObjectLabelResolver::from_domain(request.domain);
-        let decision = self.pep.check_read(&caller.to_string(), None, &resolver);
+        let decision = self
+            .pep
+            .check_read(&caller.to_string(), request.verified_tenant, &resolver);
         if decision.is_permit() {
             Ok(())
         } else {
@@ -689,6 +691,7 @@ mod tests {
             kind: CasMountObjectKind::Xorb,
             address: "deadbeef",
             domain: &domain,
+            verified_tenant: Some("tenant-a"),
             operation: "read",
             requested_label: None,
         };
@@ -712,11 +715,43 @@ mod tests {
             kind: CasMountObjectKind::Xorb,
             address: "deadbeef",
             domain: &domain,
+            verified_tenant: Some("tenant-a"),
             operation: "read",
             requested_label: None,
         };
         let subject = Subject::new("secret-user");
         assert!(authz.authorize(&subject, req).is_ok());
+    }
+
+    #[test]
+    fn mac_cas_authorizer_uses_verified_http_tenant_for_clearance() {
+        let pep = Arc::new(CasPep::new(
+            Arc::new(TenantClearance),
+            Arc::new(SpySink::default()),
+        ));
+        let authz = MacCasAuthorizer::new(pep);
+        let domain = DedupDomain::local_default();
+        let subject = Subject::new("alice");
+
+        let tenant_a = CasMountAuthzRequest {
+            kind: CasMountObjectKind::Xorb,
+            address: "deadbeef",
+            domain: &domain,
+            verified_tenant: Some("tenant-a"),
+            operation: "read",
+            requested_label: None,
+        };
+        assert!(authz.authorize(&subject, tenant_a).is_ok());
+
+        let tenant_b = CasMountAuthzRequest {
+            kind: CasMountObjectKind::Xorb,
+            address: "deadbeef",
+            domain: &domain,
+            verified_tenant: Some("tenant-b"),
+            operation: "read",
+            requested_label: None,
+        };
+        assert!(authz.authorize(&subject, tenant_b).is_err());
     }
 
     #[test]
@@ -740,6 +775,7 @@ mod tests {
             kind: CasMountObjectKind::Object,
             address: "some-addr",
             domain: &domain,
+            verified_tenant: Some("tenant-a"),
             operation: "open",
             requested_label: None,
         };

--- a/crates/hyprstream/src/server/middleware.rs
+++ b/crates/hyprstream/src/server/middleware.rs
@@ -4,7 +4,7 @@ use crate::auth::jwt;
 use crate::server::state::{ResourceAuthState, ServerState};
 use axum::{
     extract::{Request, State},
-    http::{HeaderValue, StatusCode, header},
+    http::{header, HeaderValue, StatusCode},
     middleware::Next,
     response::{IntoResponse, Response},
 };
@@ -20,6 +20,11 @@ use tracing::{debug, info, warn};
 pub struct AuthenticatedUser {
     /// Username (from JWT sub claim)
     pub user: String,
+    /// Tenant/Casbin domain from the authority-verified hosted-account binding.
+    ///
+    /// This is copied only from a successfully verified JWT. It is never
+    /// inferred from `user` or accepted from request data.
+    pub verified_tenant: Option<String>,
     /// Original JWT token for e2e verification through service chain.
     /// SECURITY: Never logged — custom Debug impl redacts this field.
     pub token: Option<String>,
@@ -31,9 +36,45 @@ impl std::fmt::Debug for AuthenticatedUser {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("AuthenticatedUser")
             .field("user", &self.user)
+            .field("verified_tenant", &self.verified_tenant)
             .field("token", &self.token.as_ref().map(|_| "[REDACTED]"))
             .field("exp", &self.exp)
             .finish()
+    }
+}
+
+impl AuthenticatedUser {
+    /// Select the Casbin domain for an authenticated HTTP request.
+    ///
+    /// Tenant-bound identities stay in their authority-verified hosted-account
+    /// tenant. A tenantless `service:*` authority may use the global domain,
+    /// matching `PolicyService::request_domain`; ordinary tenantless identities
+    /// fail closed. A present but malformed/wildcard binding always fails,
+    /// including for services.
+    pub fn authorization_domain(&self) -> Result<String, &'static str> {
+        if let Some(tenant) = self.verified_tenant.as_deref() {
+            let valid_component = !tenant.is_empty()
+                && tenant.len() <= 253
+                && tenant != "."
+                && tenant != ".."
+                && tenant != "*"
+                && tenant.bytes().all(|byte| {
+                    byte.is_ascii_alphanumeric()
+                        || byte == b'-'
+                        || byte == b'_'
+                        || byte == b'.'
+                });
+            if !valid_component {
+                return Err("invalid verified tenant");
+            }
+            return Ok(tenant.to_owned());
+        }
+
+        if self.user.starts_with("service:") {
+            return Ok("*".to_owned());
+        }
+
+        Err("missing verified tenant")
     }
 }
 
@@ -90,7 +131,10 @@ pub async fn auth_middleware(
     // audience validation, JTI revocation). Reused verbatim by the 9P mount
     // ticket validator (H1a / #764). DPoP sender-binding is enforced below,
     // after we hold the claims, because it is header/scheme-specific.
-    let local_issuers: &[&str] = &[&*state.oauth_issuer_url];
+    let atproto_issuer =
+        crate::services::oauth::state::canonical_issuer_origin(&state.oauth_issuer_url)
+            .unwrap_or_else(|| state.oauth_issuer_url.clone());
+    let local_issuers: &[&str] = &[&*state.oauth_issuer_url, &atproto_issuer];
     let claims = match verify_resource_token_claims(&state, &token).await {
         Ok(c) => c,
         Err(reason) => {
@@ -175,9 +219,18 @@ pub async fn auth_middleware(
     };
     let user = AuthenticatedUser {
         user: user_str,
+        verified_tenant: claims.tenant.clone(),
         token: Some(token),
         exp: Some(claims.exp),
     };
+    if let Err(reason) = user.authorization_domain() {
+        warn!(subject = %user.user, reason, "HTTP authorization has no valid hosted-account tenant binding");
+        return (
+            StatusCode::FORBIDDEN,
+            "Verified hosted-account tenant binding required",
+        )
+            .into_response();
+    }
     request.extensions_mut().insert(user);
     next.run(request).await
 }
@@ -400,7 +453,7 @@ fn local_issuer_matches(claims: &jwt::Claims, expected: &str) -> bool {
     claims.iss == expected
 }
 
-async fn verify_resource_token_claims(
+pub(crate) async fn verify_resource_token_claims(
     state: &ResourceAuthState,
     token: &str,
 ) -> Result<jwt::Claims, &'static str> {
@@ -410,8 +463,11 @@ async fn verify_resource_token_claims(
 
     // Extract iss for key routing (local node key vs trusted federation peer).
     let iss = extract_iss_from_token(token);
-    let local_issuers: &[&str] = &[&*state.oauth_issuer_url];
-    let claims = if hyprstream_rpc::auth::is_local_iss(&iss, local_issuers) {
+    let atproto_issuer =
+        crate::services::oauth::state::canonical_issuer_origin(&state.oauth_issuer_url)
+            .unwrap_or_else(|| state.oauth_issuer_url.clone());
+    let local_issuers: &[&str] = &[&*state.oauth_issuer_url, &atproto_issuer];
+    let mut claims = if hyprstream_rpc::auth::is_local_iss(&iss, local_issuers) {
         // Local-issuer tokens may be signed by EITHER the cluster CA key OR any
         // currently-published rotation slot (the OAuth token endpoint signs with
         // `active_jwt_signing_key()` → the rotation active slot). Validate against
@@ -479,6 +535,9 @@ async fn verify_resource_token_claims(
         }
     }
 
+    // Federation is trusted for identity, never for choosing a local PDS/Casbin
+    // tenant. Only this node's OAuth authority may assert the hosted binding.
+    claims.strip_federated_tenant(local_issuers);
     Ok(claims)
 }
 
@@ -511,7 +570,7 @@ fn unauthorized_response(message: &str, www_authenticate: &str) -> Response {
 /// Exported for use in other middleware-like contexts (e.g. MCP inline auth).
 /// Returns an empty string on any parse failure.
 pub fn extract_iss_from_token(token: &str) -> String {
-    use base64::{Engine, engine::general_purpose::URL_SAFE_NO_PAD};
+    use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine};
     let parts: Vec<&str> = token.splitn(3, '.').collect();
     if parts.len() < 2 {
         return String::new();
@@ -537,7 +596,7 @@ pub fn extract_iss_from_token(token: &str) -> String {
 
 /// Extract `kid` from a JWT header without full validation.
 pub fn extract_kid_from_token(token: &str) -> Option<String> {
-    use base64::{Engine, engine::general_purpose::URL_SAFE_NO_PAD};
+    use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine};
     let header_b64 = token.split('.').next()?;
     if header_b64.len() > 4096 {
         return None;
@@ -855,12 +914,138 @@ mod cors_layer_tests {
 }
 
 #[cfg(test)]
+#[allow(clippy::expect_used, clippy::unwrap_used)]
 mod tests {
     use super::*;
 
     #[test]
+    fn http_domain_uses_verified_hosted_account_tenant_not_subject() {
+        let alice = AuthenticatedUser {
+            user: "did:web:alice.accounts.example".to_owned(),
+            verified_tenant: Some("acme.example".to_owned()),
+            token: None,
+            exp: None,
+        };
+        let bob = AuthenticatedUser {
+            user: "did:web:bob.accounts.example".to_owned(),
+            verified_tenant: Some("acme.example".to_owned()),
+            token: None,
+            exp: None,
+        };
+
+        assert_eq!(
+            alice.authorization_domain().unwrap(),
+            "acme.example"
+        );
+        assert_eq!(alice.authorization_domain(), bob.authorization_domain());
+        assert_ne!(alice.authorization_domain().unwrap(), alice.user);
+    }
+
+    #[test]
+    fn http_domain_fails_closed_except_for_tenantless_services() {
+        for verified_tenant in [
+            None,
+            Some(String::new()),
+            Some("*".to_owned()),
+            Some(" acme.example".to_owned()),
+            Some("did:web:alice.acme.example".to_owned()),
+            Some("../acme".to_owned()),
+        ] {
+            let user = AuthenticatedUser {
+                user: "did:web:alice.accounts.example".to_owned(),
+                verified_tenant,
+                token: None,
+                exp: None,
+            };
+            assert!(user.authorization_domain().is_err());
+        }
+
+        let service = AuthenticatedUser {
+            user: "service:oauth".to_owned(),
+            verified_tenant: None,
+            token: None,
+            exp: None,
+        };
+        assert_eq!(service.authorization_domain().unwrap(), "*");
+
+        let malformed_service = AuthenticatedUser {
+            user: "service:oauth".to_owned(),
+            verified_tenant: Some("*".to_owned()),
+            token: None,
+            exp: None,
+        };
+        assert!(malformed_service.authorization_domain().is_err());
+    }
+
+    #[test]
+    fn federated_tenant_assertion_cannot_select_http_domain() {
+        let mut claims = jwt::Claims::new("service:forged".to_owned(), 1, 2)
+            .with_issuer("https://idp.example".to_owned())
+            .with_tenant("victim.example".to_owned());
+        claims.strip_federated_tenant(&["https://oauth.local"]);
+        let subject = claims.subject(&["https://oauth.local"]);
+        let user = AuthenticatedUser {
+            user: subject.name().unwrap().to_owned(),
+            verified_tenant: claims.tenant,
+            token: None,
+            exp: None,
+        };
+        assert!(user.authorization_domain().is_err());
+        assert!(!user.user.starts_with("service:"));
+    }
+
+    #[tokio::test]
+    async fn http_policy_domain_blocks_cross_tenant_replay() {
+        let policy = crate::auth::PolicyManager::new_in_memory().await.unwrap();
+        policy
+            .add_policy_with_domain(
+                "did:web:alice.accounts.example",
+                "tenant-a.example",
+                "model:qwen",
+                "infer.generate",
+                "allow",
+            )
+            .await
+            .unwrap();
+
+        let tenant_a = AuthenticatedUser {
+            user: "did:web:alice.accounts.example".to_owned(),
+            verified_tenant: Some("tenant-a.example".to_owned()),
+            token: None,
+            exp: None,
+        };
+        let replayed_in_tenant_b = AuthenticatedUser {
+            user: tenant_a.user.clone(),
+            verified_tenant: Some("tenant-b.example".to_owned()),
+            token: None,
+            exp: None,
+        };
+
+        assert!(
+            policy
+                .check_with_domain(
+                    &tenant_a.user,
+                    &tenant_a.authorization_domain().unwrap(),
+                    "model:qwen",
+                    "infer.generate",
+                )
+                .await
+        );
+        assert!(
+            !policy
+                .check_with_domain(
+                    &replayed_in_tenant_b.user,
+                    &replayed_in_tenant_b.authorization_domain().unwrap(),
+                    "model:qwen",
+                    "infer.generate",
+                )
+                .await
+        );
+    }
+
+    #[test]
     fn test_extract_iss_from_token() {
-        use base64::{Engine, engine::general_purpose::URL_SAFE_NO_PAD};
+        use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine};
 
         // Craft a JWT with iss in payload: header.payload.sig
         // payload = base64url({"iss":"https://node-a","sub":"alice","exp":9999999999,"iat":0})
@@ -889,7 +1074,7 @@ mod tests {
 #[allow(clippy::unwrap_used, clippy::expect_used)]
 mod rotation_aware_tests {
     use super::*;
-    use base64::{Engine as _, engine::general_purpose::URL_SAFE_NO_PAD};
+    use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine as _};
     use ed25519_dalek::{Signer as _, SigningKey};
 
     const AUD: &str = "https://node-a/resource";
@@ -1121,7 +1306,7 @@ mod rotation_aware_tests {
 mod composite_aware_tests {
     use super::*;
     use crate::auth::jwt::encode_composite_ml_dsa_65_ed25519;
-    use base64::{Engine, engine::general_purpose::URL_SAFE_NO_PAD};
+    use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine};
     use ed25519_dalek::SigningKey;
 
     const AUD: &str = "https://node-a/resource";
@@ -1298,17 +1483,15 @@ mod composite_aware_tests {
             published_pair(pq_b_vk, ed_b.verifying_key()),
         ];
 
-        assert!(
-            decode_local_multi_key(
-                &cross_token,
-                &ca.verifying_key(),
-                &[ed_a.verifying_key(), ed_b.verifying_key()],
-                &published,
-                Some(AUD),
-                false,
-            )
-            .is_err()
-        );
+        assert!(decode_local_multi_key(
+            &cross_token,
+            &ca.verifying_key(),
+            &[ed_a.verifying_key(), ed_b.verifying_key()],
+            &published,
+            Some(AUD),
+            false,
+        )
+        .is_err());
     }
 
     #[test]
@@ -1446,17 +1629,15 @@ mod composite_aware_tests {
         let sig_bytes = URL_SAFE_NO_PAD.decode(sig_b64).unwrap();
         for stripped in [&sig_bytes[..3309], &sig_bytes[3309..]] {
             let tampered = format!("{}.{}", &token[..dot2], URL_SAFE_NO_PAD.encode(stripped));
-            assert!(
-                decode_local_multi_key(
-                    &tampered,
-                    &ca.verifying_key(),
-                    &published_ed,
-                    &pairs,
-                    Some(AUD),
-                    false,
-                )
-                .is_err()
-            );
+            assert!(decode_local_multi_key(
+                &tampered,
+                &ca.verifying_key(),
+                &published_ed,
+                &pairs,
+                Some(AUD),
+                false,
+            )
+            .is_err());
         }
     }
 
@@ -1485,17 +1666,15 @@ mod composite_aware_tests {
         .unwrap();
         assert_eq!(claims.sub, "alice");
 
-        assert!(
-            decode_local_multi_key(
-                &token,
-                &ca.verifying_key(),
-                &published_ed,
-                &pairs,
-                Some(AUD),
-                false,
-            )
-            .is_err()
-        );
+        assert!(decode_local_multi_key(
+            &token,
+            &ca.verifying_key(),
+            &published_ed,
+            &pairs,
+            Some(AUD),
+            false,
+        )
+        .is_err());
     }
 
     #[test]
@@ -1586,7 +1765,7 @@ mod composite_aware_tests {
 #[allow(clippy::expect_used)]
 mod browser_provisioning_rate_limit_tests {
     use super::*;
-    use axum::{Router, body::Body, http::Request as HttpRequest, middleware, routing::get};
+    use axum::{body::Body, http::Request as HttpRequest, middleware, routing::get, Router};
     use std::sync::atomic::{AtomicUsize, Ordering};
     use tower::ServiceExt;
 

--- a/crates/hyprstream/src/server/mod.rs
+++ b/crates/hyprstream/src/server/mod.rs
@@ -32,6 +32,14 @@ pub fn extract_user(auth_user: Option<&Extension<AuthenticatedUser>>) -> String 
         .unwrap_or_else(|| "anonymous".to_owned())
 }
 
+/// Extract the subject and its authority-verified hosted-account policy domain.
+pub fn extract_policy_identity(
+    auth_user: Option<&Extension<AuthenticatedUser>>,
+) -> Result<(String, String), &'static str> {
+    let Extension(user) = auth_user.ok_or("authenticated identity missing")?;
+    Ok((user.user.clone(), user.authorization_domain()?))
+}
+
 /// Create the main application router
 pub fn create_app(state: ServerState) -> Router {
     // Validate the complete cross-face registry before constructing any live

--- a/crates/hyprstream/src/server/routes/models.rs
+++ b/crates/hyprstream/src/server/routes/models.rs
@@ -1,6 +1,10 @@
 //! Model management endpoints
 
-use crate::{auth::Operation, server::{self, state::ServerState, AuthenticatedUser}, storage::paths::StoragePaths};
+use crate::{
+    auth::Operation,
+    server::{self, state::ServerState, AuthenticatedUser},
+    storage::paths::StoragePaths,
+};
 use axum::{
     extract::{Json, Path, State},
     http::StatusCode,
@@ -29,8 +33,10 @@ async fn resolve_model_path(
     }
     // Derive path locally
     let storage_paths = StoragePaths::new()?;
-    Ok(storage_paths.worktree_path(model_ref.name(), &branch)?
-        .to_string_lossy().to_string())
+    Ok(storage_paths
+        .worktree_path(model_ref.name(), &branch)?
+        .to_string_lossy()
+        .to_string())
 }
 
 /// Create model management router
@@ -42,7 +48,7 @@ pub fn create_router() -> Router<ServerState> {
         .route("/:id/load", post(load_model))
         .route("/:id/unload", post(unload_model))
         .route("/cache/refresh", post(refresh_cache))
-        // REMOVED: .route("/cache/stats", get(cache_stats)) - ModelCache replaced by ZMQ
+    // REMOVED: .route("/cache/stats", get(cache_stats)) - ModelCache replaced by ZMQ
 }
 
 /// Request to download a model
@@ -73,24 +79,48 @@ struct ModelListItem {
     local_path: Option<String>,
 }
 
+#[allow(clippy::result_large_err)]
+fn policy_identity(
+    auth_user: Option<&Extension<AuthenticatedUser>>,
+) -> Result<(String, String), axum::response::Response> {
+    server::extract_policy_identity(auth_user).map_err(|_| {
+        (
+            StatusCode::FORBIDDEN,
+            Json(serde_json::json!({
+                "error": "Verified hosted-account tenant binding required"
+            })),
+        )
+            .into_response()
+    })
+}
+
 /// List all available models
 async fn list_models(
     State(state): State<ServerState>,
     auth_user: Option<Extension<AuthenticatedUser>>,
 ) -> impl IntoResponse {
-    let user = server::extract_user(auth_user.as_ref());
-    if !state.policy_client.check(&crate::services::generated::policy_client::PolicyCheck {
-        subject: user.clone(),
-        domain: user.clone(),
-        resource: "registry:*".to_owned(),
-        operation: Operation::Query.as_str().to_owned(),
-    }).await.unwrap_or(false) {
+    let (user, domain) = match policy_identity(auth_user.as_ref()) {
+        Ok(identity) => identity,
+        Err(response) => return response,
+    };
+    if !state
+        .policy_client
+        .check(&crate::services::generated::policy_client::PolicyCheck {
+            subject: user.clone(),
+            domain,
+            resource: "registry:*".to_owned(),
+            operation: Operation::Query.as_str().to_owned(),
+        })
+        .await
+        .unwrap_or(false)
+    {
         return (
             StatusCode::FORBIDDEN,
             Json(serde_json::json!({
                 "error": format!("Permission denied: user '{}' cannot query registry", user)
             })),
-        ).into_response();
+        )
+            .into_response();
     }
 
     // Inline list_models: iterate repos + worktrees
@@ -98,12 +128,16 @@ async fn list_models(
         let repos = state.registry.list().await?;
         let mut model_list = Vec::new();
         for repo in repos {
-            if repo.name.is_empty() { continue; }
+            if repo.name.is_empty() {
+                continue;
+            }
             let name = &repo.name;
             match state.registry.repo(&repo.id).list_worktrees().await {
                 Ok(worktrees) => {
                     for wt in worktrees {
-                        if wt.branch_name.is_empty() { continue; }
+                        if wt.branch_name.is_empty() {
+                            continue;
+                        }
                         let display = format!("{}:{}", name, wt.branch_name);
                         model_list.push(ModelListItem {
                             id: name.clone(),
@@ -122,7 +156,8 @@ async fn list_models(
             }
         }
         Ok(model_list)
-    }.await;
+    }
+    .await;
 
     match result {
         Ok(model_list) => Json(model_list).into_response(),
@@ -142,28 +177,36 @@ async fn get_model_info(
     auth_user: Option<Extension<AuthenticatedUser>>,
     Path(id): Path<String>,
 ) -> impl IntoResponse {
-    let user = server::extract_user(auth_user.as_ref());
+    let (user, domain) = match policy_identity(auth_user.as_ref()) {
+        Ok(identity) => identity,
+        Err(response) => return response,
+    };
     let resource = format!("model:{id}");
-    if !state.policy_client.check(&crate::services::generated::policy_client::PolicyCheck {
-        subject: user.clone(),
-        domain: user.clone(),
-        resource: resource.clone(),
-        operation: Operation::Query.as_str().to_owned(),
-    }).await.unwrap_or(false) {
+    if !state
+        .policy_client
+        .check(&crate::services::generated::policy_client::PolicyCheck {
+            subject: user.clone(),
+            domain,
+            resource: resource.clone(),
+            operation: Operation::Query.as_str().to_owned(),
+        })
+        .await
+        .unwrap_or(false)
+    {
         return (
             StatusCode::FORBIDDEN,
             Json(serde_json::json!({
                 "error": format!("Permission denied: user '{}' cannot query '{}'", user, resource)
             })),
-        ).into_response();
+        )
+            .into_response();
     }
 
     // Parse model reference and resolve path
     use crate::storage::model_ref::ModelRef;
     if let Ok(model_ref) = ModelRef::parse(&id) {
-        let path_result: Result<String, anyhow::Error> = async {
-            resolve_model_path(&state.registry, &model_ref).await
-        }.await;
+        let path_result: Result<String, anyhow::Error> =
+            async { resolve_model_path(&state.registry, &model_ref).await }.await;
         if let Ok(_path) = path_result {
             // Create metadata for the found model
             let metadata = crate::storage::ModelMetadata {
@@ -195,19 +238,28 @@ async fn download_model(
     auth_user: Option<Extension<AuthenticatedUser>>,
     Json(request): Json<DownloadModelRequest>,
 ) -> impl IntoResponse {
-    let user = server::extract_user(auth_user.as_ref());
-    if !state.policy_client.check(&crate::services::generated::policy_client::PolicyCheck {
-        subject: user.clone(),
-        domain: user.clone(),
-        resource: "registry:*".to_owned(),
-        operation: Operation::Write.as_str().to_owned(),
-    }).await.unwrap_or(false) {
+    let (user, domain) = match policy_identity(auth_user.as_ref()) {
+        Ok(identity) => identity,
+        Err(response) => return response,
+    };
+    if !state
+        .policy_client
+        .check(&crate::services::generated::policy_client::PolicyCheck {
+            subject: user.clone(),
+            domain,
+            resource: "registry:*".to_owned(),
+            operation: Operation::Write.as_str().to_owned(),
+        })
+        .await
+        .unwrap_or(false)
+    {
         return (
             StatusCode::FORBIDDEN,
             Json(serde_json::json!({
                 "error": format!("Permission denied: user '{}' cannot write to registry", user)
             })),
-        ).into_response();
+        )
+            .into_response();
     }
 
     // Basic validation - must be a non-empty string
@@ -256,7 +308,8 @@ async fn download_model(
             .split('/')
             .next_back()
             .unwrap_or("")
-            .trim_end_matches(".git").to_owned()
+            .trim_end_matches(".git")
+            .to_owned()
     });
 
     if model_name.is_empty() {
@@ -270,13 +323,17 @@ async fn download_model(
     }
 
     // Use registry client to clone model (no duplicate service)
-    if let Err(e) = state.registry.clone(&crate::services::generated::registry_client::CloneRequest {
-        url: request.uri.clone(),
-        name: model_name.clone(),
-        shallow: true,
-        depth: 1,
-        branch: String::new(),
-    }).await {
+    if let Err(e) = state
+        .registry
+        .clone(&crate::services::generated::registry_client::CloneRequest {
+            url: request.uri.clone(),
+            name: model_name.clone(),
+            shallow: true,
+            depth: 1,
+            branch: String::new(),
+        })
+        .await
+    {
         return (
             StatusCode::INTERNAL_SERVER_ERROR,
             Json(serde_json::json!({
@@ -316,20 +373,29 @@ async fn load_model(
     auth_user: Option<Extension<AuthenticatedUser>>,
     Path(id): Path<String>,
 ) -> impl IntoResponse {
-    let user = server::extract_user(auth_user.as_ref());
+    let (user, domain) = match policy_identity(auth_user.as_ref()) {
+        Ok(identity) => identity,
+        Err(response) => return response,
+    };
     let resource = format!("model:{id}");
-    if !state.policy_client.check(&crate::services::generated::policy_client::PolicyCheck {
-        subject: user.clone(),
-        domain: user.clone(),
-        resource: resource.clone(),
-        operation: Operation::Manage.as_str().to_owned(),
-    }).await.unwrap_or(false) {
+    if !state
+        .policy_client
+        .check(&crate::services::generated::policy_client::PolicyCheck {
+            subject: user.clone(),
+            domain,
+            resource: resource.clone(),
+            operation: Operation::Manage.as_str().to_owned(),
+        })
+        .await
+        .unwrap_or(false)
+    {
         return (
             StatusCode::FORBIDDEN,
             Json(serde_json::json!({
                 "error": format!("Permission denied: user '{}' cannot manage '{}'", user, resource)
             })),
-        ).into_response();
+        )
+            .into_response();
     }
 
     // Parse model reference
@@ -375,20 +441,29 @@ async fn unload_model(
     auth_user: Option<Extension<AuthenticatedUser>>,
     Path(id): Path<String>,
 ) -> impl IntoResponse {
-    let user = server::extract_user(auth_user.as_ref());
+    let (user, domain) = match policy_identity(auth_user.as_ref()) {
+        Ok(identity) => identity,
+        Err(response) => return response,
+    };
     let resource = format!("model:{id}");
-    if !state.policy_client.check(&crate::services::generated::policy_client::PolicyCheck {
-        subject: user.clone(),
-        domain: user.clone(),
-        resource: resource.clone(),
-        operation: Operation::Manage.as_str().to_owned(),
-    }).await.unwrap_or(false) {
+    if !state
+        .policy_client
+        .check(&crate::services::generated::policy_client::PolicyCheck {
+            subject: user.clone(),
+            domain,
+            resource: resource.clone(),
+            operation: Operation::Manage.as_str().to_owned(),
+        })
+        .await
+        .unwrap_or(false)
+    {
         return (
             StatusCode::FORBIDDEN,
             Json(serde_json::json!({
                 "error": format!("Permission denied: user '{}' cannot manage '{}'", user, resource)
             })),
-        ).into_response();
+        )
+            .into_response();
     }
 
     Json(serde_json::json!({
@@ -403,19 +478,28 @@ async fn refresh_cache(
     State(state): State<ServerState>,
     auth_user: Option<Extension<AuthenticatedUser>>,
 ) -> impl IntoResponse {
-    let user = server::extract_user(auth_user.as_ref());
-    if !state.policy_client.check(&crate::services::generated::policy_client::PolicyCheck {
-        subject: user.clone(),
-        domain: user.clone(),
-        resource: "registry:*".to_owned(),
-        operation: Operation::Manage.as_str().to_owned(),
-    }).await.unwrap_or(false) {
+    let (user, domain) = match policy_identity(auth_user.as_ref()) {
+        Ok(identity) => identity,
+        Err(response) => return response,
+    };
+    if !state
+        .policy_client
+        .check(&crate::services::generated::policy_client::PolicyCheck {
+            subject: user.clone(),
+            domain,
+            resource: "registry:*".to_owned(),
+            operation: Operation::Manage.as_str().to_owned(),
+        })
+        .await
+        .unwrap_or(false)
+    {
         return (
             StatusCode::FORBIDDEN,
             Json(serde_json::json!({
                 "error": format!("Permission denied: user '{}' cannot manage registry", user)
             })),
-        ).into_response();
+        )
+            .into_response();
     }
 
     // Cache is automatically maintained

--- a/crates/hyprstream/src/server/routes/ninep.rs
+++ b/crates/hyprstream/src/server/routes/ninep.rs
@@ -336,8 +336,11 @@ async fn verify_mount_ticket(
     if !crate::services::oauth::mount_ticket::is_mount_ticket_for(&claims, plane, namespace_path) {
         return Err("token is not valid for this 9P plane/path");
     }
-    let local_issuers: &[&str] = &[&*state.oauth_issuer_url];
-    let subject = claims.subject(local_issuers);
+    let atproto_issuer =
+        crate::services::oauth::state::canonical_issuer_origin(&state.oauth_issuer_url)
+            .unwrap_or_else(|| state.oauth_issuer_url.clone());
+    let local_issuers = [&*state.oauth_issuer_url, atproto_issuer.as_str()];
+    let subject = claims.subject(&local_issuers);
     subject
         .validate()
         .map_err(|_| "subject validation failed")?;

--- a/crates/hyprstream/src/server/routes/openai.rs
+++ b/crates/hyprstream/src/server/routes/openai.rs
@@ -16,20 +16,19 @@ use tracing::{error, info, trace};
 use crate::{
     api::{
         openai_compat::{
-            ChatChoice, ChatCompletionRequest, ChatCompletionResponse, ChatMessage, CompletionChoice,
-            CompletionRequest, CompletionResponse, EmbeddingRequest, ListModelsResponse, Model,
-            OnlineTrainingDetails, Usage,
+            ChatChoice, ChatCompletionRequest, ChatCompletionResponse, ChatMessage,
+            CompletionChoice, CompletionRequest, CompletionResponse, EmbeddingRequest,
+            ListModelsResponse, Model, OnlineTrainingDetails, Usage,
         },
         tools,
     },
     archetypes::capabilities::Infer,
     auth::Operation,
-    runtime::GenerationRequest,
     runtime::CacheOwner,
+    runtime::GenerationRequest,
     server::{state::ServerState, AuthenticatedUser},
     services::generated::model_client::ModelClient,
 };
-
 
 /// RAII guard for metrics cleanup
 struct MetricsGuard<'a> {
@@ -84,7 +83,6 @@ impl ErrorResponse {
             },
         }
     }
-
 }
 
 /// Result of collecting a stream into a single response.
@@ -118,11 +116,10 @@ async fn collect_stream_to_result(
                 }
                 StreamPayload::Complete(meta) => {
                     let stats: crate::services::rpc_types::InferenceComplete =
-                        serde_json::from_slice(&meta)
-                            .unwrap_or_else(|e| {
-                                tracing::warn!("Failed to parse InferenceComplete: {e}");
-                                crate::services::rpc_types::InferenceComplete::empty()
-                            });
+                        serde_json::from_slice(&meta).unwrap_or_else(|e| {
+                            tracing::warn!("Failed to parse InferenceComplete: {e}");
+                            crate::services::rpc_types::InferenceComplete::empty()
+                        });
                     return Ok(CollectedResult { text, stats });
                 }
                 StreamPayload::Error(msg) => {
@@ -177,22 +174,33 @@ fn extract_cache_owner(headers: &HeaderMap) -> CacheOwner {
     }
 }
 
-/// Extract auth info: (username, jwt_token, jwt_exp)
-fn extract_auth(auth_user: Option<&AuthenticatedUser>) -> (String, Option<String>, Option<i64>) {
-    if let Some(user) = auth_user {
-        trace!("Using authenticated user: {}", user.user);
-        (user.user.clone(), user.token.clone(), user.exp)
-    } else {
-        trace!("No authentication provided, using anonymous identity");
-        ("anonymous".to_owned(), None, None)
-    }
+/// Extract auth info, including the authority-verified hosted-account tenant.
+fn extract_auth(
+    auth_user: Option<&AuthenticatedUser>,
+) -> Result<(String, String, Option<String>, Option<i64>), &'static str> {
+    let user = auth_user.ok_or("authenticated identity missing")?;
+    trace!("Using authenticated user: {}", user.user);
+    Ok((
+        user.user.clone(),
+        user.authorization_domain()?,
+        user.token.clone(),
+        user.exp,
+    ))
 }
 
 /// Build Claims from auth info, using the JWT's real exp for timeout enforcement.
-fn claims_from_auth(user: &str, jwt_token: Option<&str>, jwt_exp: Option<i64>) -> hyprstream_rpc::auth::Claims {
+fn claims_from_auth(
+    user: &str,
+    domain: &str,
+    jwt_token: Option<&str>,
+    jwt_exp: Option<i64>,
+) -> hyprstream_rpc::auth::Claims {
     let now = chrono::Utc::now().timestamp();
     let exp = jwt_exp.unwrap_or(now + 3600);
     let mut claims = hyprstream_rpc::auth::Claims::new(user.to_owned(), now, exp);
+    if domain != "*" {
+        claims = claims.with_tenant(domain.to_owned());
+    }
     if let Some(token) = jwt_token {
         claims = claims.with_token(token.to_owned());
     }
@@ -235,7 +243,8 @@ async fn resolve_model_path(
         // Derive path locally
         let storage_paths = crate::storage::StoragePaths::new()?;
         storage_paths.worktree_path(model_ref.name(), &branch)
-    }.await;
+    }
+    .await;
 
     match path_result {
         Ok(path) => {
@@ -281,10 +290,7 @@ fn add_no_cache_headers(response: &mut axum::response::Response) {
         header::CACHE_CONTROL,
         HeaderValue::from_static("no-cache, no-store, must-revalidate"),
     );
-    headers.insert(
-        header::PRAGMA,
-        HeaderValue::from_static("no-cache"),
-    );
+    headers.insert(header::PRAGMA, HeaderValue::from_static("no-cache"));
 }
 
 /// Create OpenAI API router
@@ -304,7 +310,21 @@ async fn chat_completions(
     Json(request): Json<ChatCompletionRequest>,
 ) -> impl IntoResponse {
     // Extract user identity from JWT (via middleware)
-    let (user, jwt_token, jwt_exp) = extract_auth(auth_user.as_ref().map(|Extension(u)| u));
+    let (user, domain, jwt_token, jwt_exp) =
+        match extract_auth(auth_user.as_ref().map(|Extension(u)| u)) {
+            Ok(identity) => identity,
+            Err(_) => {
+                return (
+                    StatusCode::FORBIDDEN,
+                    Json(ErrorResponse::new(
+                        "Verified hosted-account tenant binding required",
+                        "permission_denied",
+                        "missing_tenant",
+                    )),
+                )
+                    .into_response();
+            }
+        };
 
     // Check permission for inference on this model via ZMQ
     let resource = format!("model:{}", request.model);
@@ -312,7 +332,7 @@ async fn chat_completions(
         .policy_client
         .check(&crate::services::generated::policy_client::PolicyCheck {
             subject: user.clone(),
-            domain: user.clone(),
+            domain: domain.clone(),
             resource: resource.clone(),
             operation: Operation::Infer.as_str().to_owned(),
         })
@@ -322,7 +342,10 @@ async fn chat_completions(
             return (
                 StatusCode::FORBIDDEN,
                 Json(ErrorResponse::new(
-                    format!("Permission denied: user '{}' cannot infer on '{}'", user, request.model),
+                    format!(
+                        "Permission denied: user '{}' cannot infer on '{}'",
+                        user, request.model
+                    ),
                     "permission_denied",
                     "insufficient_permissions",
                 )),
@@ -365,7 +388,9 @@ async fn chat_completions(
 
     if is_streaming {
         info!("Handling streaming request");
-        return stream_chat(state, headers, request, user, jwt_token, jwt_exp).await.into_response();
+        return stream_chat(state, headers, request, user, domain, jwt_token, jwt_exp)
+            .await
+            .into_response();
     }
     info!("Handling non-streaming request");
 
@@ -406,20 +431,23 @@ async fn chat_completions(
     };
 
     let rpc_messages = to_rpc_messages(&request.messages);
-    let tools_str = tools_json.as_ref()
+    let tools_str = tools_json
+        .as_ref()
         .map(|t| serde_json::to_string(t).unwrap_or_default())
         .unwrap_or_default();
     let templated_prompt = match state
         .model_client
         .infer(&request.model)
-        .apply_chat_template(&crate::services::generated::model_client::ChatTemplateRequest {
-            messages: rpc_messages.clone(),
-            add_generation_prompt: true,
-            tools_json: Some(tools_str.clone()).filter(|s| !s.is_empty()),
-            max_tokens: request.max_tokens.map(|v| v as u32),
-            enable_thinking: None,
-            template_vars_json: None,
-        })
+        .apply_chat_template(
+            &crate::services::generated::model_client::ChatTemplateRequest {
+                messages: rpc_messages.clone(),
+                add_generation_prompt: true,
+                tools_json: Some(tools_str.clone()).filter(|s| !s.is_empty()),
+                max_tokens: request.max_tokens.map(|v| v as u32),
+                enable_thinking: None,
+                template_vars_json: None,
+            },
+        )
         .await
     {
         Ok(prompt_str) => crate::config::TemplatedPrompt::new(prompt_str),
@@ -439,12 +467,20 @@ async fn chat_completions(
     info!(
         "Template applied, prompt length: {}, preview: {}",
         templated_prompt.len(),
-        &templated_prompt.as_str().chars().take(200).collect::<String>()
+        &templated_prompt
+            .as_str()
+            .chars()
+            .take(200)
+            .collect::<String>()
     );
 
     // Build generation request with templated prompt
     let gen_params = crate::config::SamplingParams::from(&state.config.sampling_defaults)
-        .merge(crate::config::SamplingParams::from_model_path(&model_path).await.unwrap_or_default())
+        .merge(
+            crate::config::SamplingParams::from_model_path(&model_path)
+                .await
+                .unwrap_or_default(),
+        )
         .merge((&request).into());
     let gen_request = gen_params.into_generation_request(templated_prompt.into_inner());
 
@@ -466,7 +502,7 @@ async fn chat_completions(
             return (StatusCode::INTERNAL_SERVER_ERROR, "Client creation failed").into_response();
         }
     };
-    let _claims = claims_from_auth(&user, jwt_token.as_deref(), jwt_exp);
+    let _claims = claims_from_auth(&user, &domain, jwt_token.as_deref(), jwt_exp);
     // Note: OAI adapter currently creates a fresh client per request.
     // For bearer delegation, use: model_client.request().delegated_bearer(jwt).call(payload)
     let result = collect_stream_to_result(&model_client, &request.model, &gen_request).await;
@@ -488,24 +524,43 @@ async fn chat_completions(
             let finish_reason_str = &collected.stats.finish_reason;
 
             // Parse tool calls from response using format-aware detection
-            let (content, tool_calls, finish_reason) = if tools::has_tool_calls_for_format(tool_call_format, &collected.text) {
-                info!("Detected tool calls in response (format: {:?})", tool_call_format);
-                match tools::parse_tool_calls_for_format(tool_call_format, &collected.text) {
-                    Ok(parsed_tool_calls) if !parsed_tool_calls.is_empty() => {
-                        let content_text = tools::extract_text_content_for_format(tool_call_format, &collected.text);
-                        let content = if content_text.is_empty() { None } else { Some(content_text) };
-                        info!("Parsed {} tool calls", parsed_tool_calls.len());
-                        (content, Some(parsed_tool_calls), "tool_calls")
+            let (content, tool_calls, finish_reason) =
+                if tools::has_tool_calls_for_format(tool_call_format, &collected.text) {
+                    info!(
+                        "Detected tool calls in response (format: {:?})",
+                        tool_call_format
+                    );
+                    match tools::parse_tool_calls_for_format(tool_call_format, &collected.text) {
+                        Ok(parsed_tool_calls) if !parsed_tool_calls.is_empty() => {
+                            let content_text = tools::extract_text_content_for_format(
+                                tool_call_format,
+                                &collected.text,
+                            );
+                            let content = if content_text.is_empty() {
+                                None
+                            } else {
+                                Some(content_text)
+                            };
+                            info!("Parsed {} tool calls", parsed_tool_calls.len());
+                            (content, Some(parsed_tool_calls), "tool_calls")
+                        }
+                        Ok(_) | Err(_) => {
+                            let fr = if finish_reason_str == "max_tokens" {
+                                "length"
+                            } else {
+                                "stop"
+                            };
+                            (Some(collected.text), None, fr)
+                        }
                     }
-                    Ok(_) | Err(_) => {
-                        let fr = if finish_reason_str == "max_tokens" { "length" } else { "stop" };
-                        (Some(collected.text), None, fr)
-                    }
-                }
-            } else {
-                let fr = if finish_reason_str == "max_tokens" { "length" } else { "stop" };
-                (Some(collected.text), None, fr)
-            };
+                } else {
+                    let fr = if finish_reason_str == "max_tokens" {
+                        "length"
+                    } else {
+                        "stop"
+                    };
+                    (Some(collected.text), None, fr)
+                };
 
             let response = ChatCompletionResponse {
                 id: format!("chatcmpl-{}", uuid::Uuid::new_v4()),
@@ -526,7 +581,11 @@ async fn chat_completions(
                     prompt_tokens: 0,
                     completion_tokens: tokens_generated,
                     total_tokens: tokens_generated,
-                    online_training_details: collected.stats.ttt_metrics.as_ref().map(OnlineTrainingDetails::from),
+                    online_training_details: collected
+                        .stats
+                        .ttt_metrics
+                        .as_ref()
+                        .map(OnlineTrainingDetails::from),
                 }),
             };
 
@@ -552,7 +611,15 @@ async fn chat_completions(
 }
 
 /// Handle streaming chat completions via ZMQ PUB/SUB
-async fn stream_chat(state: ServerState, _headers: HeaderMap, request: ChatCompletionRequest, user: String, jwt_token: Option<String>, jwt_exp: Option<i64>) -> impl IntoResponse {
+async fn stream_chat(
+    state: ServerState,
+    _headers: HeaderMap,
+    request: ChatCompletionRequest,
+    user: String,
+    domain: String,
+    jwt_token: Option<String>,
+    jwt_exp: Option<i64>,
+) -> impl IntoResponse {
     // Create channel for SSE events
     let (tx, rx) = mpsc::channel::<Result<serde_json::Value, anyhow::Error>>(100);
 
@@ -580,7 +647,9 @@ async fn stream_chat(state: ServerState, _headers: HeaderMap, request: ChatCompl
         let model_ref = match crate::storage::ModelRef::parse(&model_name) {
             Ok(r) => r,
             Err(e) => {
-                let _ = tx.send(Err(anyhow::anyhow!("Invalid model reference: {}", e))).await;
+                let _ = tx
+                    .send(Err(anyhow::anyhow!("Invalid model reference: {}", e)))
+                    .await;
                 return;
             }
         };
@@ -600,10 +669,14 @@ async fn stream_chat(state: ServerState, _headers: HeaderMap, request: ChatCompl
             // Derive path locally
             let storage_paths = crate::storage::StoragePaths::new()?;
             storage_paths.worktree_path(model_ref.name(), &branch)
-        }.await {
+        }
+        .await
+        {
             Ok(path) => path,
             Err(e) => {
-                let _ = tx.send(Err(anyhow::anyhow!("Could not get model path: {}", e))).await;
+                let _ = tx
+                    .send(Err(anyhow::anyhow!("Could not get model path: {}", e)))
+                    .await;
                 return;
             }
         };
@@ -626,36 +699,49 @@ async fn stream_chat(state: ServerState, _headers: HeaderMap, request: ChatCompl
         // Apply chat template via ZMQ ModelService (tools passed to template)
         info!("Applying chat template for streaming...");
         let rpc_messages = to_rpc_messages(&messages);
-        let tools_str = tools_json.as_ref()
+        let tools_str = tools_json
+            .as_ref()
             .map(|t| serde_json::to_string(t).unwrap_or_default())
             .unwrap_or_default();
-        let templated_prompt = match state.model_client
+        let templated_prompt = match state
+            .model_client
             .infer(&model_name)
-            .apply_chat_template(&crate::services::generated::model_client::ChatTemplateRequest {
-                messages: rpc_messages.clone(),
-                add_generation_prompt: true,
-                tools_json: Some(tools_str.clone()).filter(|s| !s.is_empty()),
-                max_tokens: request.max_tokens.map(|v| v as u32),
-                enable_thinking: None,
-                template_vars_json: None,
-            })
+            .apply_chat_template(
+                &crate::services::generated::model_client::ChatTemplateRequest {
+                    messages: rpc_messages.clone(),
+                    add_generation_prompt: true,
+                    tools_json: Some(tools_str.clone()).filter(|s| !s.is_empty()),
+                    max_tokens: request.max_tokens.map(|v| v as u32),
+                    enable_thinking: None,
+                    template_vars_json: None,
+                },
+            )
             .await
         {
             Ok(prompt_str) => {
                 let prompt = crate::config::TemplatedPrompt::new(prompt_str);
-                info!("Streaming template applied, prompt length: {}", prompt.len());
+                info!(
+                    "Streaming template applied, prompt length: {}",
+                    prompt.len()
+                );
                 prompt
             }
             Err(e) => {
                 error!("Template formatting failed in streaming: {}", e);
-                let _ = tx.send(Err(anyhow::anyhow!("Template formatting failed: {}", e))).await;
+                let _ = tx
+                    .send(Err(anyhow::anyhow!("Template formatting failed: {}", e)))
+                    .await;
                 return;
             }
         };
 
         // Build generation request
         let mut gen_params = crate::config::SamplingParams::from(&defaults)
-            .merge(crate::config::SamplingParams::from_model_path(&model_path).await.unwrap_or_default())
+            .merge(
+                crate::config::SamplingParams::from_model_path(&model_path)
+                    .await
+                    .unwrap_or_default(),
+            )
             .merge((&request).into());
         if !stop_sequences.is_empty() {
             gen_params.stop_tokens = Some(stop_sequences);
@@ -664,7 +750,11 @@ async fn stream_chat(state: ServerState, _headers: HeaderMap, request: ChatCompl
 
         info!(
             "Streaming: max_tokens={:?}, temp={:?}, top_p={:?}, top_k={:?}, repeat_penalty={:?}",
-            gen_request.max_tokens, gen_request.temperature, gen_request.top_p, gen_request.top_k, gen_request.repeat_penalty
+            gen_request.max_tokens,
+            gen_request.temperature,
+            gen_request.top_p,
+            gen_request.top_k,
+            gen_request.repeat_penalty
         );
 
         // Start ZMQ stream with per-request client (preserves caller identity for TTT delta routing)
@@ -672,21 +762,26 @@ async fn stream_chat(state: ServerState, _headers: HeaderMap, request: ChatCompl
             Ok(c) => c,
             Err(e) => {
                 error!("Failed to create ModelClient: {}", e);
-                let _ = tx.send(Err(anyhow::anyhow!("Client creation failed: {}", e))).await;
+                let _ = tx
+                    .send(Err(anyhow::anyhow!("Client creation failed: {}", e)))
+                    .await;
                 return;
             }
         };
-        let _claims = claims_from_auth(&user, jwt_token.as_deref(), jwt_exp);
+        let _claims = claims_from_auth(&user, &domain, jwt_token.as_deref(), jwt_exp);
         // Note: For bearer delegation, use: model_client.request().delegated_bearer(jwt).call(payload)
         use crate::services::generated::model_client::InferRpc;
-        let mut stream_handle = match InferRpc::generate_stream(&model_client.infer(&model_name), &gen_request).await {
-            Ok(h) => h,
-            Err(e) => {
-                error!("Failed to start ZMQ stream: {}", e);
-                let _ = tx.send(Err(anyhow::anyhow!("Generation failed: {}", e))).await;
-                return;
-            }
-        };
+        let mut stream_handle =
+            match InferRpc::generate_stream(&model_client.infer(&model_name), &gen_request).await {
+                Ok(h) => h,
+                Err(e) => {
+                    error!("Failed to start ZMQ stream: {}", e);
+                    let _ = tx
+                        .send(Err(anyhow::anyhow!("Generation failed: {}", e)))
+                        .await;
+                    return;
+                }
+            };
 
         // OpenAI-style stream ID for SSE responses
         let sse_stream_id = format!("chatcmpl-{}", uuid::Uuid::new_v4());
@@ -710,7 +805,7 @@ async fn stream_chat(state: ServerState, _headers: HeaderMap, request: ChatCompl
 
         // ZMQ receive loop - forward StreamBlock payloads to SSE
         info!("Starting ZMQ streaming receive loop (StreamBlock format)...");
-        
+
         // Accumulate full response text for tool call parsing
         let mut accumulated_text = String::new();
 
@@ -879,10 +974,7 @@ async fn stream_chat(state: ServerState, _headers: HeaderMap, request: ChatCompl
     add_no_cache_headers(&mut response);
     response
         .headers_mut()
-        .insert(
-            header::EXPIRES,
-            axum::http::HeaderValue::from_static("0"),
-        );
+        .insert(header::EXPIRES, axum::http::HeaderValue::from_static("0"));
 
     response
 }
@@ -895,7 +987,21 @@ async fn completions(
     Json(request): Json<CompletionRequest>,
 ) -> impl IntoResponse {
     // Extract user identity from JWT (via middleware)
-    let (user, jwt_token, jwt_exp) = extract_auth(auth_user.as_ref().map(|Extension(u)| u));
+    let (user, domain, jwt_token, jwt_exp) =
+        match extract_auth(auth_user.as_ref().map(|Extension(u)| u)) {
+            Ok(identity) => identity,
+            Err(_) => {
+                return (
+                    StatusCode::FORBIDDEN,
+                    Json(ErrorResponse::new(
+                        "Verified hosted-account tenant binding required",
+                        "permission_denied",
+                        "missing_tenant",
+                    )),
+                )
+                    .into_response();
+            }
+        };
 
     // Check permission for inference on this model
     let resource = format!("model:{}", request.model);
@@ -903,7 +1009,7 @@ async fn completions(
         .policy_client
         .check(&crate::services::generated::policy_client::PolicyCheck {
             subject: user.clone(),
-            domain: user.clone(),
+            domain: domain.clone(),
             resource: resource.clone(),
             operation: Operation::Infer.as_str().to_owned(),
         })
@@ -913,7 +1019,10 @@ async fn completions(
             return (
                 StatusCode::FORBIDDEN,
                 Json(ErrorResponse::new(
-                    format!("Permission denied: user '{}' cannot infer on '{}'", user, request.model),
+                    format!(
+                        "Permission denied: user '{}' cannot infer on '{}'",
+                        user, request.model
+                    ),
                     "permission_denied",
                     "insufficient_permissions",
                 )),
@@ -964,14 +1073,16 @@ async fn completions(
     let templated_prompt = match state
         .model_client
         .infer(&request.model)
-        .apply_chat_template(&crate::services::generated::model_client::ChatTemplateRequest {
-            messages: rpc_messages.clone(),
-            add_generation_prompt: true,
-            tools_json: None,
-            max_tokens: request.max_tokens.map(|v| v as u32),
-            enable_thinking: None,
-            template_vars_json: None,
-        })
+        .apply_chat_template(
+            &crate::services::generated::model_client::ChatTemplateRequest {
+                messages: rpc_messages.clone(),
+                add_generation_prompt: true,
+                tools_json: None,
+                max_tokens: request.max_tokens.map(|v| v as u32),
+                enable_thinking: None,
+                template_vars_json: None,
+            },
+        )
         .await
     {
         Ok(prompt_str) => crate::config::TemplatedPrompt::new(prompt_str),
@@ -990,13 +1101,21 @@ async fn completions(
     };
 
     let gen_params = crate::config::SamplingParams::from(&state.config.sampling_defaults)
-        .merge(crate::config::SamplingParams::from_model_path(&model_path).await.unwrap_or_default())
+        .merge(
+            crate::config::SamplingParams::from_model_path(&model_path)
+                .await
+                .unwrap_or_default(),
+        )
         .merge((&request).into());
     let gen_request = gen_params.into_generation_request(templated_prompt.into_inner());
 
     info!(
         "Completions: max_tokens={:?}, temp={:?}, top_p={:?}, top_k={:?}, repeat_penalty={:?}",
-        gen_request.max_tokens, gen_request.temperature, gen_request.top_p, gen_request.top_k, gen_request.repeat_penalty
+        gen_request.max_tokens,
+        gen_request.temperature,
+        gen_request.top_p,
+        gen_request.top_k,
+        gen_request.repeat_penalty
     );
 
     // Call inference via collect-stream (per-request ZMQ client preserves caller identity for TTT delta routing)
@@ -1007,7 +1126,7 @@ async fn completions(
             return (StatusCode::INTERNAL_SERVER_ERROR, "Client creation failed").into_response();
         }
     };
-    let _claims = claims_from_auth(&user, jwt_token.as_deref(), jwt_exp);
+    let _claims = claims_from_auth(&user, &domain, jwt_token.as_deref(), jwt_exp);
     let result = collect_stream_to_result(&model_client, &request.model, &gen_request).await;
 
     // Metrics automatically decremented by MetricsGuard on drop
@@ -1023,13 +1142,24 @@ async fn completions(
                     text: collected.text,
                     index: 0,
                     logprobs: None,
-                    finish_reason: Some(if collected.stats.finish_reason == "max_tokens" { "length" } else { "stop" }.to_owned()),
+                    finish_reason: Some(
+                        if collected.stats.finish_reason == "max_tokens" {
+                            "length"
+                        } else {
+                            "stop"
+                        }
+                        .to_owned(),
+                    ),
                 }],
                 usage: Some(Usage {
                     prompt_tokens: request.prompt.len() / 4, // Rough estimate: 4 chars per token
                     completion_tokens: collected.stats.tokens_generated,
                     total_tokens: request.prompt.len() / 4 + collected.stats.tokens_generated,
-                    online_training_details: collected.stats.ttt_metrics.as_ref().map(OnlineTrainingDetails::from),
+                    online_training_details: collected
+                        .stats
+                        .ttt_metrics
+                        .as_ref()
+                        .map(OnlineTrainingDetails::from),
                 }),
             };
 
@@ -1037,19 +1167,17 @@ async fn completions(
             add_no_cache_headers(&mut response);
             response
         }
-        Err(e) => {
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(serde_json::json!({
-                    "error": {
-                        "message": format!("Generation failed: {}", e),
-                        "type": "generation_error",
-                        "code": "internal_error"
-                    }
-                })),
-            )
-                .into_response()
-        }
+        Err(e) => (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(serde_json::json!({
+                "error": {
+                    "message": format!("Generation failed: {}", e),
+                    "type": "generation_error",
+                    "code": "internal_error"
+                }
+            })),
+        )
+            .into_response(),
     }
 }
 
@@ -1075,19 +1203,62 @@ async fn embeddings(
 ///
 /// Returns all worktrees as model:branch references.
 /// Models are only accessible via their worktree branches.
-async fn list_models(State(state): State<ServerState>) -> impl IntoResponse {
+async fn list_models(
+    State(state): State<ServerState>,
+    auth_user: Option<Extension<AuthenticatedUser>>,
+) -> impl IntoResponse {
+    let (user, domain, _, _) = match extract_auth(auth_user.as_ref().map(|Extension(u)| u)) {
+        Ok(identity) => identity,
+        Err(_) => {
+            return (
+                StatusCode::FORBIDDEN,
+                Json(ErrorResponse::new(
+                    "Verified hosted-account tenant binding required",
+                    "permission_denied",
+                    "missing_tenant",
+                )),
+            )
+                .into_response();
+        }
+    };
+    if !state
+        .policy_client
+        .check(&crate::services::generated::policy_client::PolicyCheck {
+            subject: user,
+            domain,
+            resource: "registry:*".to_owned(),
+            operation: Operation::Query.as_str().to_owned(),
+        })
+        .await
+        .unwrap_or(false)
+    {
+        return (
+            StatusCode::FORBIDDEN,
+            Json(ErrorResponse::new(
+                "Permission denied: cannot query registry",
+                "permission_denied",
+                "insufficient_permissions",
+            )),
+        )
+            .into_response();
+    }
+
     let mut models = vec![];
 
     // Get all worktrees from registry (formatted as model:branch)
     let result: Result<(), anyhow::Error> = async {
         let repos = state.registry.list().await?;
         for repo in repos {
-            if repo.name.is_empty() { continue; }
+            if repo.name.is_empty() {
+                continue;
+            }
             let name = &repo.name;
             match state.registry.repo(&repo.id).list_worktrees().await {
                 Ok(worktrees) => {
                     for wt in worktrees {
-                        if wt.branch_name.is_empty() { continue; }
+                        if wt.branch_name.is_empty() {
+                            continue;
+                        }
                         let display = format!("{}:{}", name, wt.branch_name);
                         models.push(Model {
                             id: display,
@@ -1103,7 +1274,8 @@ async fn list_models(State(state): State<ServerState>) -> impl IntoResponse {
             }
         }
         Ok(())
-    }.await;
+    }
+    .await;
 
     if let Err(e) = result {
         error!("Failed to list models from storage: {}", e);
@@ -1127,15 +1299,12 @@ fn to_rpc_messages(
     msgs: &[ChatMessage],
 ) -> Vec<crate::services::generated::inference_client::ChatMessage> {
     use crate::services::generated::inference_client::ChatMessage as RpcMsg;
-    msgs.iter().map(|m| RpcMsg {
-        role: m.role.clone(),
-        content: m.content.as_deref().unwrap_or("").to_owned(),
-        tool_calls: m.tool_calls.clone().unwrap_or_default(),
-        tool_call_id: m.tool_call_id.as_deref().unwrap_or("").to_owned(),
-    }).collect()
+    msgs.iter()
+        .map(|m| RpcMsg {
+            role: m.role.clone(),
+            content: m.content.as_deref().unwrap_or("").to_owned(),
+            tool_calls: m.tool_calls.clone().unwrap_or_default(),
+            tool_call_id: m.tool_call_id.as_deref().unwrap_or("").to_owned(),
+        })
+        .collect()
 }
-
-
-
-
-

--- a/crates/hyprstream/src/services/factories.rs
+++ b/crates/hyprstream/src/services/factories.rs
@@ -32,8 +32,8 @@ use hyprstream_service::{ServiceContext, Spawnable};
 use tokio::sync::RwLock;
 use tracing::info;
 
-use crate::auth::PolicyManager;
 use crate::auth::identity_store::credentials_dir;
+use crate::auth::PolicyManager;
 use crate::config::{HyprConfig, TokenConfig};
 use crate::services::generated::policy_client::{RefreshServiceTokenRequest, RegisterServiceKey};
 use crate::services::{
@@ -49,7 +49,9 @@ fn load_config() -> HyprConfig {
 /// Get the JWT bound to this service instance's exact signing key.
 fn service_token(signing_key: &SigningKey) -> Option<String> {
     let trust = hyprstream_service::global_trust_store();
-    trust.get(&signing_key.verifying_key()).and_then(|att| att.jwt)
+    trust
+        .get(&signing_key.verifying_key())
+        .and_then(|att| att.jwt)
 }
 
 /// Shared Git2DB registry instance. Lazily initialized by the first factory
@@ -216,8 +218,7 @@ fn register_service_key(
             .get(&signing_key.verifying_key())
             .and_then(|att| att.jwt.clone())
     };
-    let jwt =
-        resolve_registration_jwt(service_name, &creds_dir, secrets_profile, from_trust)?;
+    let jwt = resolve_registration_jwt(service_name, &creds_dir, secrets_profile, from_trust)?;
 
     // Seed the loaded JWT into the trust store so that peer-client construction
     // (`service_token`) and the background renewal task can read it. Bind it to
@@ -281,8 +282,8 @@ fn register_service_key(
 /// Used for local-disk JWTs that we issued ourselves — signature is verified
 /// by PolicyService; here we only need the expiry to decide whether to renew.
 fn decode_jwt_exp(jwt: &str) -> Option<i64> {
-    use base64::Engine as _;
     use base64::engine::general_purpose::URL_SAFE_NO_PAD;
+    use base64::Engine as _;
     let payload_b64 = jwt.split('.').nth(1)?;
     let payload = URL_SAFE_NO_PAD.decode(payload_b64).ok()?;
     let value: serde_json::Value = serde_json::from_slice(&payload).ok()?;
@@ -783,13 +784,15 @@ fn create_registry_service(ctx: &ServiceContext) -> anyhow::Result<Box<dyn Spawn
             audit_pq,
         )?;
         let node_did = hyprstream_rpc::did_key::ed25519_to_did_key(&ctx.verifying_key().to_bytes());
-        Ok(crate::services::discovery::PdsPublisher::with_generation_source(
-            store,
-            node_did,
-            generation_source,
+        Ok(
+            crate::services::discovery::PdsPublisher::with_generation_source(
+                store,
+                node_did,
+                generation_source,
+            )
+            .with_at9p_state_ingest(at9p_state)
+            .with_es256_store(es256_store),
         )
-        .with_at9p_state_ingest(at9p_state)
-        .with_es256_store(es256_store))
     })()
     .map_err(|e| tracing::warn!("PDS publish disabled: {e}"))
     .ok();
@@ -1039,7 +1042,7 @@ fn create_worker_service(ctx: &ServiceContext) -> anyhow::Result<Box<dyn Spawnab
     use hyprstream_workers::config::PoolConfig;
     #[cfg(feature = "oci-image")]
     use hyprstream_workers::image::RafsStore;
-    use hyprstream_workers::{BackendCtx, SandboxBackend, WorkerService, resolve_backend};
+    use hyprstream_workers::{resolve_backend, BackendCtx, SandboxBackend, WorkerService};
 
     let config = load_config();
     let sk = ctx.service_signing_key("worker");
@@ -1170,8 +1173,8 @@ fn create_oai_service(ctx: &ServiceContext) -> anyhow::Result<Box<dyn Spawnable>
     info!("Creating OAIService");
 
     use crate::server::state::ServerState;
-    use crate::services::OAIService;
     use crate::services::generated::model_client::ModelClient;
+    use crate::services::OAIService;
 
     // Load full config for OAI settings
     let config = load_config();
@@ -1359,7 +1362,7 @@ fn create_at9p_verify_service(_ctx: &ServiceContext) -> anyhow::Result<Box<dyn S
 ///
 /// This service provides Flight SQL protocol for dataset queries.
 /// It optionally uses RegistryClient for dataset lookup.
-#[service_factory("flight", depends_on = ["registry", "discovery"])]
+#[service_factory("flight", depends_on = ["policy", "registry", "discovery"])]
 fn create_flight_service(ctx: &ServiceContext) -> anyhow::Result<Box<dyn Spawnable>> {
     info!("Creating FlightService");
 
@@ -1371,6 +1374,31 @@ fn create_flight_service(ctx: &ServiceContext) -> anyhow::Result<Box<dyn Spawnab
 
     // Register this service's verifying key with PolicyService
     register_service_key(ctx, "flight", &sk)?;
+
+    let policy_vk = hyprstream_service::global_trust_store()
+        .resolve_one("policy")
+        .ok_or_else(|| anyhow::anyhow!("trust store has no policy key"))?;
+    let policy_client =
+        PolicyClient::for_local_bootstrap(sk.clone(), policy_vk, service_token(&sk))?;
+    let federation_resolver = Arc::new(
+        crate::auth::FederationKeyResolver::new(&config.oauth.trusted_issuers)
+            .with_policy_client(Arc::new(policy_client.clone())),
+    );
+    let jti_blocklist = SHARED_JTI_BLOCKLIST
+        .get()
+        .map(Arc::clone)
+        .context("PolicyService did not publish the shared JTI blocklist before Flight startup")?;
+    let auth = crate::server::state::ResourceAuthState::new(
+        ctx.jwt_verifying_key(),
+        config.flight.resource_url(),
+        config.oauth.issuer_url(),
+        federation_resolver,
+        jti_blocklist,
+    );
+    let authorizer = Arc::new(crate::services::flight::TenantFlightAuthorizer::new(
+        auth,
+        policy_client,
+    ));
 
     // Create registry client for dataset lookup (if default_dataset is configured)
     // RegistryClient already implements hyprstream_metrics::RegistryClient
@@ -1388,6 +1416,7 @@ fn create_flight_service(ctx: &ServiceContext) -> anyhow::Result<Box<dyn Spawnab
         registry_client,
         ctx.transport("flight", SocketKind::Rep),
         ctx.verifying_key(),
+        authorizer,
     );
 
     Ok(Box::new(flight_service))
@@ -1572,7 +1601,7 @@ fn create_mcp_service(ctx: &ServiceContext) -> anyhow::Result<Box<dyn Spawnable>
                     move |mut req: axum::extract::Request, next: axum::middleware::Next| {
                         let www_authenticate = www_authenticate.clone();
                         let mcp_resource_url = mcp_resource_url.clone();
-                        let _mcp_oauth_issuer = mcp_oauth_issuer_clone.clone();
+                        let mcp_oauth_issuer = mcp_oauth_issuer_clone.clone();
                         let federation_resolver = mcp_federation_resolver.clone();
                         let jwt_key_source = jwt_key_source.clone();
                         let jti_blocklist = mcp_jti_blocklist.clone();
@@ -1669,7 +1698,7 @@ fn create_mcp_service(ctx: &ServiceContext) -> anyhow::Result<Box<dyn Spawnable>
                                     }
                                 }
                             };
-                            let claims = match result {
+                            let mut claims = match result {
                                 Ok(c) => c,
                                 Err(e) => {
                                     tracing::warn!(%method, %uri, error = %e, "MCP auth REJECTED");
@@ -1680,6 +1709,19 @@ fn create_mcp_service(ctx: &ServiceContext) -> anyhow::Result<Box<dyn Spawnable>
                                     return res;
                                 }
                             };
+                            let atproto_issuer =
+                                crate::services::oauth::state::canonical_issuer_origin(
+                                    &mcp_oauth_issuer,
+                                )
+                                .unwrap_or_else(|| mcp_oauth_issuer.clone());
+                            let local_issuers =
+                                [mcp_oauth_issuer.as_str(), atproto_issuer.as_str()];
+                            claims.strip_federated_tenant(&local_issuers);
+                            let subject = claims.subject(&local_issuers);
+                            if subject.validate().is_err() || subject.name().is_none() {
+                                tracing::warn!(%method, %uri, "MCP auth rejected: invalid subject");
+                                return (StatusCode::UNAUTHORIZED, "Authentication failed").into_response();
+                            }
                             // JTI revocation check (RFC 7009)
                             if let Some(ref jti) = claims.jti {
                                 let revoked = jti_blocklist.as_ref().map(|bl| bl.is_revoked(jti)).unwrap_or(false);
@@ -1762,11 +1804,17 @@ fn create_mcp_service(ctx: &ServiceContext) -> anyhow::Result<Box<dyn Spawnable>
                             }
                             tracing::debug!(%method, %uri, sub = %claims.sub, "MCP auth OK");
                             // Insert AuthenticatedUser so MCP handlers see validated identity
-                            req.extensions_mut().insert(crate::server::middleware::AuthenticatedUser {
-                                user: claims.sub.clone(),
+                            let authenticated = crate::server::middleware::AuthenticatedUser {
+                                user: subject.name().unwrap_or_default().to_owned(),
+                                verified_tenant: claims.tenant.clone(),
                                 token: Some(t.clone()),
                                 exp: Some(claims.exp),
-                            });
+                            };
+                            if authenticated.authorization_domain().is_err() {
+                                tracing::warn!(%method, %uri, sub = %claims.sub, "MCP auth rejected: no valid hosted-account tenant binding");
+                                return (StatusCode::FORBIDDEN, "Verified hosted-account tenant binding required").into_response();
+                            }
+                            req.extensions_mut().insert(authenticated);
                             next.run(req).await
                         }
                     }
@@ -1859,7 +1907,7 @@ fn create_mcp_service(ctx: &ServiceContext) -> anyhow::Result<Box<dyn Spawnable>
 fn create_tui_service(ctx: &ServiceContext) -> anyhow::Result<Box<dyn Spawnable>> {
     info!("Creating TuiService");
 
-    use crate::tui::{TuiState, service::TuiService};
+    use crate::tui::{service::TuiService, TuiState};
 
     // TUI publishes terminal frames (stdin/stdout) over moq via
     // StreamChannel::publisher(), and returns its per-PID moq UDS path to the
@@ -2064,9 +2112,9 @@ fn create_metrics_service(ctx: &ServiceContext) -> anyhow::Result<Box<dyn Spawna
     init_local_moq_stream_plane("metrics");
 
     use crate::services::MetricsService;
-    use hyprstream_metrics::StorageBackend as _;
     use hyprstream_metrics::query::QueryOrchestrator;
     use hyprstream_metrics::storage::duckdb::DuckDbBackend;
+    use hyprstream_metrics::StorageBackend as _;
 
     let config = load_config();
     let mc = &config.metrics;

--- a/crates/hyprstream/src/services/flight.rs
+++ b/crates/hyprstream/src/services/flight.rs
@@ -33,14 +33,106 @@ use crate::config::FlightConfig as HyprFlightConfig;
 use anyhow::Result;
 use hyprstream_rpc::prelude::*;
 use hyprstream_rpc::registry::SocketKind;
-use hyprstream_service::Spawnable;
 use hyprstream_rpc::transport::TransportConfig;
+use hyprstream_service::Spawnable;
 use std::sync::Arc;
 use tokio::sync::Notify;
 use tracing::{error, info};
 
 /// Service name for registry and logging
 pub const SERVICE_NAME: &str = "flight";
+
+/// Flight's gRPC authentication and tenant-policy adapter.
+pub struct TenantFlightAuthorizer {
+    auth: crate::server::state::ResourceAuthState,
+    policy_client: crate::services::PolicyClient,
+}
+
+impl TenantFlightAuthorizer {
+    pub fn new(
+        auth: crate::server::state::ResourceAuthState,
+        policy_client: crate::services::PolicyClient,
+    ) -> Self {
+        Self {
+            auth,
+            policy_client,
+        }
+    }
+}
+
+#[tonic::async_trait]
+impl hyprstream_flight::FlightAuthorizer for TenantFlightAuthorizer {
+    async fn authorize(
+        &self,
+        authorization: Option<&str>,
+        resource: &str,
+        operation: &str,
+    ) -> Result<(), hyprstream_flight::FlightAuthError> {
+        let authorization = authorization.ok_or_else(|| {
+            hyprstream_flight::FlightAuthError::Unauthenticated("Bearer token required".to_owned())
+        })?;
+        let token = authorization.strip_prefix("Bearer ").ok_or_else(|| {
+            hyprstream_flight::FlightAuthError::Unauthenticated("Bearer token required".to_owned())
+        })?;
+        let claims = crate::server::middleware::verify_resource_token_claims(&self.auth, token)
+            .await
+            .map_err(|_| {
+                hyprstream_flight::FlightAuthError::Unauthenticated(
+                    "Invalid access token".to_owned(),
+                )
+            })?;
+        if claims.cnf_jkt().is_some() {
+            return Err(hyprstream_flight::FlightAuthError::Unauthenticated(
+                "DPoP-bound tokens are not accepted on Flight without a proof transport".to_owned(),
+            ));
+        }
+        let atproto_issuer =
+            crate::services::oauth::state::canonical_issuer_origin(
+                &self.auth.oauth_issuer_url,
+            )
+            .unwrap_or_else(|| self.auth.oauth_issuer_url.clone());
+        let local_issuers =
+            [self.auth.oauth_issuer_url.as_str(), atproto_issuer.as_str()];
+        let subject = claims.subject(&local_issuers);
+        subject.validate().map_err(|_| {
+            hyprstream_flight::FlightAuthError::Unauthenticated(
+                "Invalid access-token subject".to_owned(),
+            )
+        })?;
+        let identity = crate::server::middleware::AuthenticatedUser {
+            user: subject.name().ok_or_else(|| {
+                hyprstream_flight::FlightAuthError::Unauthenticated(
+                    "Invalid access-token subject".to_owned(),
+                )
+            })?.to_owned(),
+            verified_tenant: claims.tenant,
+            token: Some(token.to_owned()),
+            exp: Some(claims.exp),
+        };
+        let domain = identity.authorization_domain().map_err(|_| {
+            hyprstream_flight::FlightAuthError::Forbidden(
+                "Verified hosted-account tenant binding required".to_owned(),
+            )
+        })?;
+        let allowed = self
+            .policy_client
+            .check(&crate::services::generated::policy_client::PolicyCheck {
+                subject: identity.user,
+                domain,
+                resource: resource.to_owned(),
+                operation: operation.to_owned(),
+            })
+            .await
+            .unwrap_or(false);
+        if allowed {
+            Ok(())
+        } else {
+            Err(hyprstream_flight::FlightAuthError::Forbidden(
+                "Flight request denied by tenant policy".to_owned(),
+            ))
+        }
+    }
+}
 
 /// FlightService - Arrow Flight SQL with RPC control channel
 ///
@@ -63,6 +155,9 @@ pub struct FlightService {
     /// Verifying key for envelope verification
     #[allow(dead_code)]
     verifying_key: VerifyingKey,
+
+    /// Mandatory JWT + hosted-tenant + Casbin boundary for the gRPC data plane.
+    authorizer: Arc<dyn hyprstream_flight::FlightAuthorizer>,
 }
 
 impl FlightService {
@@ -79,12 +174,14 @@ impl FlightService {
         registry_client: Option<Arc<dyn hyprstream_metrics::RegistryClient>>,
         control_transport: TransportConfig,
         verifying_key: VerifyingKey,
+        authorizer: Arc<dyn hyprstream_flight::FlightAuthorizer>,
     ) -> Self {
         Self {
             config,
             registry_client,
             control_transport,
             verifying_key,
+            authorizer,
         }
     }
 }
@@ -123,7 +220,11 @@ impl Spawnable for FlightService {
                 "FlightService starting on {}:{} (dataset: {})",
                 self.config.host,
                 self.config.port,
-                if dataset_name.is_empty() { "<in-memory>" } else { dataset_name }
+                if dataset_name.is_empty() {
+                    "<in-memory>"
+                } else {
+                    dataset_name
+                }
             );
 
             // Signal ready before starting server
@@ -147,10 +248,11 @@ impl Spawnable for FlightService {
                     // It will be terminated when the runtime drops
                 }
 
-                result = hyprstream_flight::start_flight_server(
+                result = hyprstream_flight::start_flight_server_with_authorizer(
                     self.registry_client.clone(),
                     dataset_name,
                     flight_config,
+                    Arc::clone(&self.authorizer),
                 ) => {
                     match result {
                         Ok(()) => info!("FlightService stopped normally"),

--- a/crates/hyprstream/src/services/mcp_service.rs
+++ b/crates/hyprstream/src/services/mcp_service.rs
@@ -19,30 +19,29 @@
 //! 2. Token expiration
 //! 3. Backend services enforce authorization via Casbin policies
 
-use async_trait::async_trait;
-use crate::services::{RegistryClient, PolicyClient};
-use crate::services::generated::model_client::ModelClient;
-use crate::services::generated::tui_client::TuiClient;
-use http::header::AUTHORIZATION;
 use crate::services::generated::mcp_client::{
-    McpHandler, McpResponseVariant, ToolDefinition, ServiceStatus,
-    ToolList, ServiceMetrics, CallTool, dispatch_mcp, serialize_response,
-    ErrorInfo,
+    dispatch_mcp, serialize_response, CallTool, ErrorInfo, McpHandler, McpResponseVariant,
+    ServiceMetrics, ServiceStatus, ToolDefinition, ToolList,
 };
+use crate::services::generated::model_client::ModelClient;
 use crate::services::generated::policy_client::PolicyCheck;
+use crate::services::generated::tui_client::TuiClient;
+use crate::services::{PolicyClient, RegistryClient};
+use async_trait::async_trait;
 use ed25519_dalek::{SigningKey, VerifyingKey};
 use futures::future::BoxFuture;
+use http::header::AUTHORIZATION;
 use hyprstream_rpc::auth::jwt;
-use hyprstream_service::ServiceContext;
-use hyprstream_rpc::service::RequestService;
 use hyprstream_rpc::moq_stream::MoqStreamHandle;
+use hyprstream_rpc::service::RequestService;
 use hyprstream_rpc::streaming::StreamPayload;
 use hyprstream_rpc::transport::TransportConfig;
+use hyprstream_service::ServiceContext;
+use parking_lot::RwLock;
 use rmcp::{
     model::{
-        CallToolRequestParams, CallToolResult, Content, ErrorCode, JsonObject,
-        ListToolsResult, PaginatedRequestParams, ServerCapabilities, ServerInfo, Tool,
-        ToolAnnotations,
+        CallToolRequestParams, CallToolResult, Content, ErrorCode, JsonObject, ListToolsResult,
+        PaginatedRequestParams, ServerCapabilities, ServerInfo, Tool, ToolAnnotations,
     },
     service::RequestContext,
     ErrorData, RoleServer, ServerHandler,
@@ -51,7 +50,6 @@ use serde_json::Value;
 use std::borrow::Cow;
 use std::collections::HashMap;
 use std::sync::Arc;
-use parking_lot::RwLock;
 use tracing::{trace, warn};
 use uuid::Uuid;
 
@@ -64,14 +62,12 @@ pub const SERVICE_NAME: &str = "mcp";
 
 /// UUID v5 namespace for deterministic tool UUIDs
 const MCP_NS: Uuid = Uuid::from_bytes([
-    0x6b, 0xa7, 0xb8, 0x10, 0x9d, 0xad, 0x11, 0xd1,
-    0x80, 0xb4, 0x00, 0xc0, 0x4f, 0xd4, 0x30, 0xc8,
+    0x6b, 0xa7, 0xb8, 0x10, 0x9d, 0xad, 0x11, 0xd1, 0x80, 0xb4, 0x00, 0xc0, 0x4f, 0xd4, 0x30, 0xc8,
 ]);
 
 // b07676df-be7f-56eb-9cd8-e91cfd689158 = UUID v5(MCP_NS, "mcp.refresh_tools")
 const REFRESH_TOOLS_UUID: Uuid = Uuid::from_bytes([
-    0xb0, 0x76, 0x76, 0xdf, 0xbe, 0x7f, 0x56, 0xeb,
-    0x9c, 0xd8, 0xe9, 0x1c, 0xfd, 0x68, 0x91, 0x58,
+    0xb0, 0x76, 0x76, 0xdf, 0xbe, 0x7f, 0x56, 0xeb, 0x9c, 0xd8, 0xe9, 0x1c, 0xfd, 0x68, 0x91, 0x58,
 ]);
 
 /// JSON-RPC error code returned when MCP authentication fails.
@@ -102,8 +98,12 @@ fn normalize_mcp_args(value: Value) -> Value {
         Value::Array(arr) => Value::Array(arr.into_iter().map(normalize_mcp_args).collect()),
         Value::String(ref s) if s.is_empty() => value,
         Value::String(ref s) => {
-            if s == "true" { return Value::Bool(true); }
-            if s == "false" { return Value::Bool(false); }
+            if s == "true" {
+                return Value::Bool(true);
+            }
+            if s == "false" {
+                return Value::Bool(false);
+            }
             if let Ok(n) = s.parse::<u64>() {
                 return Value::Number(n.into());
             }
@@ -179,13 +179,16 @@ pub struct ToolCallContext {
     pub signing_key: SigningKey,
     /// Authenticated user string propagated to backend services
     pub user: String,
+    /// Authority-verified hosted-account tenant used for the HTTP-face PEP.
+    pub domain: String,
     /// ServiceContext for typed_client() / client() access (optional for backward compat)
     pub ctx: Option<Arc<ServiceContext>>,
     /// Bootstrap Policy client used only for Policy operations.
     pub policy_client: PolicyClient,
 }
 
-type ToolHandler = Arc<dyn Fn(ToolCallContext) -> BoxFuture<'static, anyhow::Result<ToolResult>> + Send + Sync>;
+type ToolHandler =
+    Arc<dyn Fn(ToolCallContext) -> BoxFuture<'static, anyhow::Result<ToolResult>> + Send + Sync>;
 
 /// A registered tool
 #[allow(dead_code)]
@@ -224,6 +227,35 @@ impl ToolRegistry {
     }
 }
 
+/// Expand the schema's bare `$scope(action)` annotation into the Casbin
+/// action/resource pair used at the HTTP boundary.
+///
+/// Generated RPC authorization receives the bare action separately from its
+/// service resource. MCP metadata preserves only that annotation, so normalize
+/// it once during tool registration instead of rejecting every annotated tool
+/// at dispatch time.
+fn mcp_policy_scope(scope: &str, service_name: &str, method_name: &str) -> String {
+    let operation = if scope.is_empty() { "query" } else { scope };
+    if operation.contains(':') {
+        return operation.to_owned();
+    }
+    let variant = method_name
+        .split('_')
+        .filter(|part| !part.is_empty())
+        .map(|part| {
+            let mut chars = part.chars();
+            chars
+                .next()
+                .map(char::to_uppercase)
+                .into_iter()
+                .flatten()
+                .chain(chars)
+                .collect::<String>()
+        })
+        .collect::<String>();
+    format!("{operation}:{service_name}:{variant}")
+}
+
 // ═══════════════════════════════════════════════════════════════════════════════
 // Tool Registration
 // ═══════════════════════════════════════════════════════════════════════════════
@@ -234,9 +266,7 @@ impl ToolRegistry {
 /// Scoped tools are discovered by recursively walking `scoped_client_tree()`.
 /// Scope and streaming flags are read from MethodSchema.
 fn register_schema_tools(reg: &mut ToolRegistry) {
-    use crate::services::generated::{
-        model_client, registry_client, policy_client, tui_client,
-    };
+    use crate::services::generated::{model_client, policy_client, registry_client, tui_client};
     // Each service generates its own MethodSchema type, so we use a macro
     // to iterate each service's methods with the correct type.
     macro_rules! register_top_level {
@@ -244,9 +274,13 @@ fn register_schema_tools(reg: &mut ToolRegistry) {
             let (service_name, methods) = $schema_fn;
             for method in methods {
                 // FIX-7: respect $cliHidden — don't expose internal methods as MCP tools
-                if method.hidden { continue; }
+                if method.hidden {
+                    continue;
+                }
                 let tool_name = format!("{service_name}.{}", method.name);
-                let params: Vec<(&str, &str, bool, &str)> = method.params.iter()
+                let params: Vec<(&str, &str, bool, &str)> = method
+                    .params
+                    .iter()
                     .map(|p| (p.name, p.type_name, p.required, p.description))
                     .collect();
                 let json_schema = params_to_json_schema(&params);
@@ -257,16 +291,29 @@ fn register_schema_tools(reg: &mut ToolRegistry) {
                 } else {
                     method.description.to_string()
                 };
-                let required_scope = if !method.scope.is_empty() {
-                    method.scope.to_string()
-                } else {
-                    format!("query:{service_name}:*")
-                };
+                let required_scope =
+                    mcp_policy_scope(method.scope, &service_name, &method_name);
 
                 if method.is_streaming {
-                    register_streaming_tool($reg, &tool_name, description, json_schema, required_scope, service_name, method_name);
+                    register_streaming_tool(
+                        $reg,
+                        &tool_name,
+                        description,
+                        json_schema,
+                        required_scope,
+                        service_name,
+                        method_name,
+                    );
                 } else {
-                    register_sync_tool($reg, &tool_name, description, json_schema, required_scope, service_name, method_name);
+                    register_sync_tool(
+                        $reg,
+                        &tool_name,
+                        description,
+                        json_schema,
+                        required_scope,
+                        service_name,
+                        method_name,
+                    );
                 }
             }
         }};
@@ -277,8 +324,20 @@ fn register_schema_tools(reg: &mut ToolRegistry) {
     register_top_level!(reg, policy_client::schema_metadata());
     register_top_level!(reg, tui_client::schema_metadata());
     // Scoped tools: recursive tree walk for all services with nested scopes
-    register_scoped_tools_recursive(reg, "registry", registry_client::scoped_client_tree(), "registry", &[]);
-    register_scoped_tools_recursive(reg, "model", model_client::scoped_client_tree(), "model", &[]);
+    register_scoped_tools_recursive(
+        reg,
+        "registry",
+        registry_client::scoped_client_tree(),
+        "registry",
+        &[],
+    );
+    register_scoped_tools_recursive(
+        reg,
+        "model",
+        model_client::scoped_client_tree(),
+        "model",
+        &[],
+    );
 }
 
 /// Accumulated scope info: (scope_name, field_name, capnp_type) for building the
@@ -313,16 +372,21 @@ fn register_scoped_tools_recursive(
 
         for method in methods {
             // FIX-7: respect $cliHidden — don't expose internal methods as MCP tools
-            if method.hidden { continue; }
+            if method.hidden {
+                continue;
+            }
             let tool_name = format!("{}.{}", new_prefix, method.name);
 
             // Build JSON schema: method params + all scope fields from ancestors
-            let params: Vec<(&str, &str, bool, &str)> = method.params.iter()
+            let params: Vec<(&str, &str, bool, &str)> = method
+                .params
+                .iter()
                 .map(|p| (p.name, p.type_name, p.required, p.description))
                 .collect();
             let mut json_schema = params_to_json_schema(&params);
             if let Value::Object(ref mut map) = json_schema {
-                let existing_props: Vec<String> = map.get("properties")
+                let existing_props: Vec<String> = map
+                    .get("properties")
                     .and_then(|p| p.as_object())
                     .map(|p| p.keys().cloned().collect())
                     .unwrap_or_default();
@@ -334,16 +398,19 @@ fn register_scoped_tools_recursive(
                             continue;
                         }
                         let json_type = match field_type {
-                            "UInt8" | "UInt16" | "UInt32" | "UInt64" |
-                            "Int8" | "Int16" | "Int32" | "Int64" => "integer",
+                            "UInt8" | "UInt16" | "UInt32" | "UInt64" | "Int8" | "Int16"
+                            | "Int32" | "Int64" => "integer",
                             "Float32" | "Float64" => "number",
                             "Bool" => "boolean",
                             _ => "string",
                         };
-                        props.insert(field_name.into(), serde_json::json!({
-                            "type": json_type,
-                            "description": field_name,
-                        }));
+                        props.insert(
+                            field_name.into(),
+                            serde_json::json!({
+                                "type": json_type,
+                                "description": field_name,
+                            }),
+                        );
                     }
                 }
                 if let Some(Value::Array(ref mut req)) = map.get_mut("required") {
@@ -364,14 +431,11 @@ fn register_scoped_tools_recursive(
             } else {
                 method.description.to_owned()
             };
-            let required_scope = if !method.scope.is_empty() {
-                method.scope.to_owned()
-            } else {
-                format!("query:{}:*", service_name)
-            };
+            let required_scope = mcp_policy_scope(method.scope, service_name, &method_name);
 
             // Capture (scope_name, field_name) pairs for the handler closure
-            let scope_pairs: Vec<(String, String)> = scopes.iter()
+            let scope_pairs: Vec<(String, String)> = scopes
+                .iter()
                 .map(|&(scope_name, field_name, _)| (scope_name.to_owned(), field_name.to_owned()))
                 .collect();
 
@@ -391,10 +455,13 @@ fn register_scoped_tools_recursive(
                         Box::pin(async move {
                             // Build scope chain from args BEFORE moving ctx fields
                             // Args are already normalized to camelCase by normalize_mcp_args()
-                            let scope_chain: Vec<(String, String)> = scope_pairs.iter()
+                            let scope_chain: Vec<(String, String)> = scope_pairs
+                                .iter()
                                 .map(|(scope_name, field_name)| {
                                     let camel_key = snake_to_camel(field_name);
-                                    let val_str = ctx.args.get(camel_key.as_str())
+                                    let val_str = ctx
+                                        .args
+                                        .get(camel_key.as_str())
                                         .map(|v| match v {
                                             Value::String(s) => s.clone(),
                                             Value::Number(n) => n.to_string(),
@@ -405,40 +472,72 @@ fn register_scoped_tools_recursive(
                                 })
                                 .collect();
 
-                            let scope_refs: Vec<(&str, &str)> = scope_chain.iter()
+                            let scope_refs: Vec<(&str, &str)> = scope_chain
+                                .iter()
                                 .map(|(s, v)| (s.as_str(), v.as_str()))
                                 .collect();
 
-                            let (client_secret, client_pubkey) = hyprstream_rpc::generate_ephemeral_keypair();
+                            let (client_secret, client_pubkey) =
+                                hyprstream_rpc::generate_ephemeral_keypair();
                             let client_pubkey_bytes: [u8; 32] = client_pubkey.to_bytes();
 
                             // #468: the streaming-method client returns the VERIFIED-capnp
                             // StreamInfo library type directly (no serde_json::Value round-trip).
-                            let stream_info: hyprstream_rpc::stream_info::StreamInfo = match service.as_str() {
+                            let stream_info: hyprstream_rpc::stream_info::StreamInfo = match service
+                                .as_str()
+                            {
                                 "registry" => {
-                                    let client: RegistryClient = RegistryClient::from_resolver(
-                                        ctx.signing_key, None,
-                                    )?;
-                                    client.call_scoped_streaming_method(&scope_refs, &method, &ctx.args, client_pubkey_bytes).await?
+                                    let client: RegistryClient =
+                                        RegistryClient::from_resolver(ctx.signing_key, None)?;
+                                    client
+                                        .call_scoped_streaming_method(
+                                            &scope_refs,
+                                            &method,
+                                            &ctx.args,
+                                            client_pubkey_bytes,
+                                        )
+                                        .await?
                                 }
                                 "model" => {
                                     let client = ModelClient::from_resolver(ctx.signing_key, None)?;
-                                    client.call_scoped_streaming_method(&scope_refs, &method, &ctx.args, client_pubkey_bytes).await?
+                                    client
+                                        .call_scoped_streaming_method(
+                                            &scope_refs,
+                                            &method,
+                                            &ctx.args,
+                                            client_pubkey_bytes,
+                                        )
+                                        .await?
                                 }
-                                _ => anyhow::bail!("No scoped streaming dispatch for service: {service}"),
+                                _ => anyhow::bail!(
+                                    "No scoped streaming dispatch for service: {service}"
+                                ),
                             };
 
                             // #356: single networked reach shape (UDS-only resolves
                             // to the same-host fast path inside `networked`).
-                            let DecodedStreamReach { dh_public, reach, broadcast_path } =
-                                decode_stream_reach(stream_info)?;
+                            let DecodedStreamReach {
+                                dh_public,
+                                reach,
+                                broadcast_path,
+                            } = decode_stream_reach(stream_info)?;
                             // #321: derive_client_stream_keys yields the AEAD enc_key.
-                            let (mac_key, enc_key, topic) = hyprstream_rpc::derive_client_stream_keys(
-                                &client_secret, &client_pubkey_bytes, &dh_public,
-                            )?;
+                            let (mac_key, enc_key, topic) =
+                                hyprstream_rpc::derive_client_stream_keys(
+                                    &client_secret,
+                                    &client_pubkey_bytes,
+                                    &dh_public,
+                                )?;
                             // #358: MCP tool stream consumed live → direct-first; selection only reorders advertised reaches.
                             let qos = hyprstream_rpc::stream_info::StreamOpt::default();
-                            let handle = MoqStreamHandle::networked(reach, &qos, broadcast_path, mac_key, enc_key, topic);
+                            let handle = MoqStreamHandle::networked(
+                                reach,
+                                &qos,
+                                broadcast_path,
+                                mac_key,
+                                enc_key,
+                                topic,
+                            );
 
                             Ok(ToolResult::Stream(Box::new(handle)))
                         })
@@ -460,10 +559,13 @@ fn register_scoped_tools_recursive(
                         Box::pin(async move {
                             // Build scope chain from args: [("repo", repo_id_val), ("worktree", name_val), ...]
                             // Args are already normalized to camelCase by normalize_mcp_args()
-                            let scope_chain: Vec<(String, String)> = scope_pairs.iter()
+                            let scope_chain: Vec<(String, String)> = scope_pairs
+                                .iter()
                                 .map(|(scope_name, field_name)| {
                                     let camel_key = snake_to_camel(field_name);
-                                    let val_str = ctx.args.get(camel_key.as_str())
+                                    let val_str = ctx
+                                        .args
+                                        .get(camel_key.as_str())
                                         .map(|v| match v {
                                             Value::String(s) => s.clone(),
                                             Value::Number(n) => n.to_string(),
@@ -474,7 +576,8 @@ fn register_scoped_tools_recursive(
                                 })
                                 .collect();
 
-                            let scope_refs: Vec<(&str, &str)> = scope_chain.iter()
+                            let scope_refs: Vec<(&str, &str)> = scope_chain
+                                .iter()
                                 .map(|(s, v)| (s.as_str(), v.as_str()))
                                 .collect();
 
@@ -502,9 +605,8 @@ async fn dispatch_scoped_call(
 ) -> anyhow::Result<ToolResult> {
     let result = match service {
         "registry" => {
-            let client: RegistryClient = RegistryClient::from_resolver(
-                ctx.signing_key.clone(), None,
-            )?;
+            let client: RegistryClient =
+                RegistryClient::from_resolver(ctx.signing_key.clone(), None)?;
             client.call_scoped_method(scopes, method, &ctx.args).await?
         }
         "model" => {
@@ -569,33 +671,50 @@ fn register_streaming_tool(
                 // #468: verified-capnp StreamInfo returned directly (no serde_json round-trip).
                 let stream_info: hyprstream_rpc::stream_info::StreamInfo = match service.as_str() {
                     "registry" => {
-                        let client: RegistryClient = RegistryClient::from_resolver(
-                            ctx.signing_key, None,
-                        )?;
-                        client.call_streaming_method(&method, &ctx.args, client_pubkey_bytes).await?
+                        let client: RegistryClient =
+                            RegistryClient::from_resolver(ctx.signing_key, None)?;
+                        client
+                            .call_streaming_method(&method, &ctx.args, client_pubkey_bytes)
+                            .await?
                     }
                     "model" => {
                         let client = ModelClient::from_resolver(ctx.signing_key, None)?;
-                        client.call_streaming_method(&method, &ctx.args, client_pubkey_bytes).await?
+                        client
+                            .call_streaming_method(&method, &ctx.args, client_pubkey_bytes)
+                            .await?
                     }
                     "tui" => {
                         let client = TuiClient::from_resolver(ctx.signing_key, None)?;
-                        client.call_streaming_method(&method, &ctx.args, client_pubkey_bytes).await?
+                        client
+                            .call_streaming_method(&method, &ctx.args, client_pubkey_bytes)
+                            .await?
                     }
                     _ => anyhow::bail!("No streaming support for service: {}", service),
                 };
 
                 // #356: single networked reach shape (UDS-only resolves to the
                 // same-host fast path inside `networked`).
-                let DecodedStreamReach { dh_public, reach, broadcast_path } =
-                    decode_stream_reach(stream_info)?;
+                let DecodedStreamReach {
+                    dh_public,
+                    reach,
+                    broadcast_path,
+                } = decode_stream_reach(stream_info)?;
                 // #321: derive_client_stream_keys yields the AEAD enc_key.
                 let (mac_key, enc_key, topic) = hyprstream_rpc::derive_client_stream_keys(
-                    &client_secret, &client_pubkey_bytes, &dh_public,
+                    &client_secret,
+                    &client_pubkey_bytes,
+                    &dh_public,
                 )?;
                 // #358: MCP tool stream consumed live → direct-first; selection only reorders advertised reaches.
                 let qos = hyprstream_rpc::stream_info::StreamOpt::default();
-                let handle = MoqStreamHandle::networked(reach, &qos, broadcast_path, mac_key, enc_key, topic);
+                let handle = MoqStreamHandle::networked(
+                    reach,
+                    &qos,
+                    broadcast_path,
+                    mac_key,
+                    enc_key,
+                    topic,
+                );
 
                 Ok(ToolResult::Stream(Box::new(handle)))
             })
@@ -615,8 +734,9 @@ fn params_to_json_schema(params: &[(&str, &str, bool, &str)]) -> Value {
         let json_type = match type_name {
             "Text" | "Data" => "string",
             "Bool" => "boolean",
-            "UInt8" | "UInt16" | "UInt32" | "UInt64" |
-            "Int8" | "Int16" | "Int32" | "Int64" => "integer",
+            "UInt8" | "UInt16" | "UInt32" | "UInt64" | "Int8" | "Int16" | "Int32" | "Int64" => {
+                "integer"
+            }
             "Float32" | "Float64" => "number",
             t if t.starts_with("List(") => "array",
             _ => "string",
@@ -625,7 +745,10 @@ fn params_to_json_schema(params: &[(&str, &str, bool, &str)]) -> Value {
         let mut param_schema = serde_json::Map::new();
         param_schema.insert("type".to_owned(), Value::String(json_type.to_owned()));
         if !description.is_empty() {
-            param_schema.insert("description".to_owned(), Value::String(description.to_owned()));
+            param_schema.insert(
+                "description".to_owned(),
+                Value::String(description.to_owned()),
+            );
         }
 
         properties.insert(name.to_owned(), Value::Object(param_schema));
@@ -679,7 +802,11 @@ fn decode_stream_reach(
 }
 
 /// Dispatch a method call to the appropriate generated client.
-async fn dispatch_schema_call(service: &str, method: &str, ctx: &ToolCallContext) -> anyhow::Result<Value> {
+async fn dispatch_schema_call(
+    service: &str,
+    method: &str,
+    ctx: &ToolCallContext,
+) -> anyhow::Result<Value> {
     let signing_key = ctx.signing_key.clone();
 
     match service {
@@ -688,14 +815,10 @@ async fn dispatch_schema_call(service: &str, method: &str, ctx: &ToolCallContext
             client.call_method(method, &ctx.args).await
         }
         "registry" => {
-            let client: RegistryClient = RegistryClient::from_resolver(
-                signing_key, None,
-            )?;
+            let client: RegistryClient = RegistryClient::from_resolver(signing_key, None)?;
             client.call_method(method, &ctx.args).await
         }
-        "policy" => {
-            ctx.policy_client.call_method(method, &ctx.args).await
-        }
+        "policy" => ctx.policy_client.call_method(method, &ctx.args).await,
         "tui" => {
             let client = TuiClient::from_resolver(signing_key, None)?;
             client.call_method(method, &ctx.args).await
@@ -740,19 +863,37 @@ fn stdio_user(
     token: Option<&str>,
     verifying_key: &VerifyingKey,
     expected_audience: Option<&str>,
-) -> Result<String, ErrorData> {
+) -> Result<crate::server::middleware::AuthenticatedUser, ErrorData> {
     match token {
         Some(token) => jwt::decode(token, verifying_key, expected_audience)
-            .map(|claims| claims.sub)
+            .and_then(|claims| {
+                let identity = crate::server::middleware::AuthenticatedUser {
+                    user: claims.sub,
+                    verified_tenant: claims.tenant,
+                    token: Some(token.to_owned()),
+                    exp: Some(claims.exp),
+                };
+                identity
+                    .authorization_domain()
+                    .map(|_| identity)
+                    .map_err(|_| jwt::JwtError::InvalidFormat)
+            })
             .map_err(|e| {
-                warn!("MCP stdio auth: rejecting request, token decode failed ({})", e);
+                warn!(
+                    "MCP stdio auth: rejecting request, token decode failed ({})",
+                    e
+                );
                 ErrorData::new(
                     MCP_AUTH_ERROR,
                     format!("MCP stdio authentication failed: {}", e),
                     None,
                 )
             }),
-        None => Ok("anonymous".to_owned()),
+        None => Err(ErrorData::new(
+            MCP_AUTH_ERROR,
+            "MCP stdio authentication failed: verified tenant token required".to_owned(),
+            None,
+        )),
     }
 }
 
@@ -791,29 +932,32 @@ impl McpService {
     /// Convert registry to rmcp Tool list (includes built-in refresh_tools meta-tool)
     fn tools_list(&self) -> Vec<Tool> {
         let reg = self.registry.read();
-        let mut tools: Vec<Tool> = reg.list().map(|entry| {
-            let schema: JsonObject = match &entry.args_schema {
-                Value::Object(m) => m.clone(),
-                _ => JsonObject::new(),
-            };
-            Tool {
-                name: Cow::Owned(entry.uuid.to_string()),
-                title: Some(entry.name.clone()),
-                description: Some(Cow::Owned(entry.description.clone())),
-                input_schema: Arc::new(schema),
-                output_schema: None,
-                annotations: Some(ToolAnnotations {
+        let mut tools: Vec<Tool> = reg
+            .list()
+            .map(|entry| {
+                let schema: JsonObject = match &entry.args_schema {
+                    Value::Object(m) => m.clone(),
+                    _ => JsonObject::new(),
+                };
+                Tool {
+                    name: Cow::Owned(entry.uuid.to_string()),
                     title: Some(entry.name.clone()),
-                    read_only_hint: Some(entry.required_scope.starts_with("query:")),
-                    destructive_hint: Some(!entry.required_scope.starts_with("query:")),
-                    open_world_hint: Some(false),
-                    // FIX-8: only query-scoped tools are idempotent; write/train/manage ops are not
-                    idempotent_hint: Some(entry.required_scope.starts_with("query:")),
-                }),
-                icons: None,
-                meta: None,
-            }
-        }).collect();
+                    description: Some(Cow::Owned(entry.description.clone())),
+                    input_schema: Arc::new(schema),
+                    output_schema: None,
+                    annotations: Some(ToolAnnotations {
+                        title: Some(entry.name.clone()),
+                        read_only_hint: Some(entry.required_scope.starts_with("query:")),
+                        destructive_hint: Some(!entry.required_scope.starts_with("query:")),
+                        open_world_hint: Some(false),
+                        // FIX-8: only query-scoped tools are idempotent; write/train/manage ops are not
+                        idempotent_hint: Some(entry.required_scope.starts_with("query:")),
+                    }),
+                    icons: None,
+                    meta: None,
+                }
+            })
+            .collect();
 
         tools.push(Tool {
             name: Cow::Owned(REFRESH_TOOLS_UUID.to_string()),
@@ -850,11 +994,27 @@ impl McpService {
     ///
     /// Fails closed (#1095): an undecodable stdio token is a hard rejection,
     /// never an anonymous downgrade.
-    fn extract_user(&self, context: &RequestContext<RoleServer>) -> Result<String, ErrorData> {
+    fn extract_user(
+        &self,
+        context: &RequestContext<RoleServer>,
+    ) -> Result<crate::server::middleware::AuthenticatedUser, ErrorData> {
         if let Some(parts) = context.extensions.get::<http::request::Parts>() {
-            if let Some(auth_user) = parts.extensions.get::<crate::server::middleware::AuthenticatedUser>() {
-                trace!("MCP HTTP auth: using validated identity for {}", auth_user.user);
-                return Ok(auth_user.user.clone());
+            if let Some(auth_user) = parts
+                .extensions
+                .get::<crate::server::middleware::AuthenticatedUser>()
+            {
+                trace!(
+                    "MCP HTTP auth: using validated identity for {}",
+                    auth_user.user
+                );
+                auth_user.authorization_domain().map_err(|_| {
+                    ErrorData::new(
+                        MCP_AUTH_ERROR,
+                        "MCP HTTP authorization failed: verified tenant binding required",
+                        None,
+                    )
+                })?;
+                return Ok(auth_user.clone());
             }
 
             if parts.headers.contains_key(AUTHORIZATION) {
@@ -862,7 +1022,11 @@ impl McpService {
             } else {
                 trace!("MCP HTTP auth: no Authorization header, anonymous access");
             }
-            Ok("anonymous".to_owned())
+            Err(ErrorData::new(
+                MCP_AUTH_ERROR,
+                "MCP HTTP authentication failed: authenticated identity missing",
+                None,
+            ))
         } else {
             trace!("MCP HTTP auth: no http::request::Parts in extensions (stdio/zmq transport)");
             stdio_user(
@@ -874,45 +1038,91 @@ impl McpService {
     }
 
     /// Dispatch a tool call by UUID with a specific identity
-    async fn dispatch_tool(&self, uuid: &Uuid, args: Value, user: String) -> Result<CallToolResult, ErrorData> {
-        let handler = {
+    async fn dispatch_tool(
+        &self,
+        uuid: &Uuid,
+        args: Value,
+        identity: crate::server::middleware::AuthenticatedUser,
+    ) -> Result<CallToolResult, ErrorData> {
+        let (handler, required_scope) = {
             let reg = self.registry.read();
-            let entry = reg.get(uuid)
-                .ok_or_else(|| ErrorData::invalid_request(format!("Unknown tool: {}", uuid), None))?;
-            entry.handler.clone()
+            let entry = reg.get(uuid).ok_or_else(|| {
+                ErrorData::invalid_request(format!("Unknown tool: {}", uuid), None)
+            })?;
+            (entry.handler.clone(), entry.required_scope.clone())
         };
+
+        let domain = identity.authorization_domain().map_err(|_| {
+            ErrorData::new(
+                MCP_AUTH_ERROR,
+                "MCP authorization failed: verified tenant binding required",
+                None,
+            )
+        })?;
+        let (operation, resource) = required_scope.split_once(':').ok_or_else(|| {
+            ErrorData::internal_error(
+                format!("Tool has invalid required scope: {required_scope}"),
+                None,
+            )
+        })?;
+        let allowed = self
+            .policy_client
+            .check(&PolicyCheck {
+                subject: identity.user.clone(),
+                domain: domain.clone(),
+                resource: resource.to_owned(),
+                operation: operation.to_owned(),
+            })
+            .await
+            .unwrap_or(false);
+        if !allowed {
+            tracing::info!(
+                subject = %identity.user,
+                %domain,
+                %resource,
+                %operation,
+                "MCP HTTP tool policy denied"
+            );
+            return Err(ErrorData::new(
+                ErrorCode(-32003),
+                "MCP tool call forbidden by tenant policy",
+                None,
+            ));
+        }
 
         let ctx = ToolCallContext {
             args: normalize_mcp_args(args),
             signing_key: self.signing_key.clone(),
-            user,
+            user: identity.user,
+            domain,
             ctx: self.service_ctx.clone(),
             policy_client: self.policy_client.clone(),
         };
 
-        let result = handler(ctx).await
+        let result = handler(ctx)
+            .await
             .map_err(|e| ErrorData::internal_error(format!("Tool failed: {}", e), None))?;
 
         match result {
-            ToolResult::Sync(value) => {
-                Ok(CallToolResult::success(vec![Content::text(value.to_string())]))
-            }
+            ToolResult::Sync(value) => Ok(CallToolResult::success(vec![Content::text(
+                value.to_string(),
+            )])),
             ToolResult::Stream(mut handle) => {
                 // Consume StreamHandle — DH, SUB, HMAC all handled internally
                 let mut contents = Vec::new();
-                while let Some(payload) = handle.recv_next().await
+                while let Some(payload) = handle
+                    .recv_next()
+                    .await
                     .map_err(|e| ErrorData::internal_error(format!("Stream error: {}", e), None))?
                 {
                     match payload {
                         StreamPayload::Data(data) => {
-                            contents.push(Content::text(
-                                String::from_utf8_lossy(&data).to_string(),
-                            ));
+                            contents
+                                .push(Content::text(String::from_utf8_lossy(&data).to_string()));
                         }
                         StreamPayload::Complete(meta) => {
-                            contents.push(Content::text(
-                                String::from_utf8_lossy(&meta).to_string(),
-                            ));
+                            contents
+                                .push(Content::text(String::from_utf8_lossy(&meta).to_string()));
                             break;
                         }
                         StreamPayload::Error(msg) => {
@@ -995,9 +1205,10 @@ impl ServerHandler for McpService {
                 }
                 let _ = context.peer.notify_tool_list_changed().await;
                 tracing::info!("MCP refresh_tools: {} -> {} tools", old_count, new_count);
-                return Ok(CallToolResult::success(vec![Content::text(
-                    format!("Refreshed tool registry: {} tools (was {})", new_count, old_count),
-                )]));
+                return Ok(CallToolResult::success(vec![Content::text(format!(
+                    "Refreshed tool registry: {} tools (was {})",
+                    new_count, old_count
+                ))]));
             }
 
             let args = match request.arguments {
@@ -1016,27 +1227,57 @@ impl ServerHandler for McpService {
 
 #[async_trait::async_trait(?Send)]
 impl McpHandler for McpService {
-    async fn authorize(&self, ctx: &crate::services::EnvelopeContext, resource: &str, operation: &str) -> anyhow::Result<()> {
+    async fn authorize(
+        &self,
+        ctx: &crate::services::EnvelopeContext,
+        resource: &str,
+        operation: &str,
+    ) -> anyhow::Result<()> {
         let subject = ctx.subject().to_string();
         let domain = ctx.domain()?;
-        let result = self.policy_client.check(&PolicyCheck {
-            subject: subject.clone(),
-            domain,
-            resource: resource.to_owned(),
-            operation: operation.to_owned(),
-        }).await;
+        let result = self
+            .policy_client
+            .check(&PolicyCheck {
+                subject: subject.clone(),
+                domain,
+                resource: resource.to_owned(),
+                operation: operation.to_owned(),
+            })
+            .await;
         match result {
             Ok(allowed) => {
                 if allowed {
                     Ok(())
                 } else {
-                    tracing::info!("MCP policy denied: sub={} obj={} act={}", subject, resource, operation);
-                    anyhow::bail!("Unauthorized: {} cannot {} on {}", subject, operation, resource)
+                    tracing::info!(
+                        "MCP policy denied: sub={} obj={} act={}",
+                        subject,
+                        resource,
+                        operation
+                    );
+                    anyhow::bail!(
+                        "Unauthorized: {} cannot {} on {}",
+                        subject,
+                        operation,
+                        resource
+                    )
                 }
             }
             Err(e) => {
-                tracing::warn!("MCP policy check RPC error: sub={} obj={} act={} err={}", subject, resource, operation, e);
-                anyhow::bail!("Unauthorized: {} cannot {} on {} (policy check error: {})", subject, operation, resource, e)
+                tracing::warn!(
+                    "MCP policy check RPC error: sub={} obj={} act={} err={}",
+                    subject,
+                    resource,
+                    operation,
+                    e
+                );
+                anyhow::bail!(
+                    "Unauthorized: {} cannot {} on {} (policy check error: {})",
+                    subject,
+                    operation,
+                    resource,
+                    e
+                )
             }
         }
     }
@@ -1048,11 +1289,12 @@ impl McpHandler for McpService {
     ) -> anyhow::Result<McpResponseVariant> {
         let loaded_model_count = {
             // Status check uses local identity (internal health check, no user context)
-            let client = ModelClient::from_resolver(
-                self.signing_key.clone(),
-                None,
-            )?;
-            client.status(&crate::services::generated::model_client::StatusRequest { model_ref: String::new() }).await
+            let client = ModelClient::from_resolver(self.signing_key.clone(), None)?;
+            client
+                .status(&crate::services::generated::model_client::StatusRequest {
+                    model_ref: String::new(),
+                })
+                .await
                 .map(|models| models.len() as u32)
                 .unwrap_or(0)
         };
@@ -1061,11 +1303,15 @@ impl McpHandler for McpService {
             is_running: true,
             loaded_model_count,
             is_authenticated: self.stdio_token.is_some(),
-            authenticated_user: self.stdio_token.as_ref()
-                .and_then(|t| jwt::decode(t, &self.verifying_key, self.expected_audience.as_deref()).ok())
+            authenticated_user: self
+                .stdio_token
+                .as_ref()
+                .and_then(|t| {
+                    jwt::decode(t, &self.verifying_key, self.expected_audience.as_deref()).ok()
+                })
                 .map(|c| c.sub)
                 .unwrap_or_default(),
-            scopes: vec![],  // Scopes no longer in JWT; authorization via Casbin
+            scopes: vec![], // Scopes no longer in JWT; authorization via Casbin
         }))
     }
 
@@ -1075,16 +1321,17 @@ impl McpHandler for McpService {
         _request_id: u64,
     ) -> anyhow::Result<McpResponseVariant> {
         let reg = self.registry.read();
-        let tools: Vec<ToolDefinition> = reg.list().map(|entry| {
-            ToolDefinition {
+        let tools: Vec<ToolDefinition> = reg
+            .list()
+            .map(|entry| ToolDefinition {
                 name: entry.uuid.to_string(),
                 description: entry.description.clone(),
                 is_read_only: entry.required_scope.starts_with("query:"),
                 is_destructive: !entry.required_scope.starts_with("query:"),
                 required_scope: entry.required_scope.clone(),
                 argument_schema: entry.args_schema.to_string(),
-            }
-        }).collect();
+            })
+            .collect();
 
         Ok(McpResponseVariant::ListToolsResult(ToolList { tools }))
     }
@@ -1117,32 +1364,41 @@ impl McpHandler for McpService {
             serde_json::from_str(&data.arguments)?
         };
 
-        let user = ctx.user().to_owned();
-        let result = self.dispatch_tool(&uuid, args, user).await;
+        let identity = crate::server::middleware::AuthenticatedUser {
+            user: ctx.subject().to_string(),
+            verified_tenant: ctx.verified_tenant().map(str::to_owned),
+            token: None,
+            exp: None,
+        };
+        let result = self.dispatch_tool(&uuid, args, identity).await;
 
         match result {
             Ok(call_result) => {
                 use rmcp::model::RawContent;
-                let text: String = call_result.content.iter()
+                let text: String = call_result
+                    .content
+                    .iter()
                     .filter_map(|c| match &c.raw {
                         RawContent::Text(t) => Some(t.text.as_str()),
                         _ => None,
                     })
                     .collect::<Vec<_>>()
                     .join("");
-                Ok(McpResponseVariant::CallToolResult(crate::services::generated::mcp_client::ToolResult {
-                    success: true,
-                    result: text,
-                    error_message: String::new(),
-                }))
+                Ok(McpResponseVariant::CallToolResult(
+                    crate::services::generated::mcp_client::ToolResult {
+                        success: true,
+                        result: text,
+                        error_message: String::new(),
+                    },
+                ))
             }
-            Err(e) => {
-                Ok(McpResponseVariant::CallToolResult(crate::services::generated::mcp_client::ToolResult {
+            Err(e) => Ok(McpResponseVariant::CallToolResult(
+                crate::services::generated::mcp_client::ToolResult {
                     success: false,
                     result: "null".to_owned(),
                     error_message: format!("{}", e),
-                }))
-            }
+                },
+            )),
         }
     }
 }
@@ -1153,7 +1409,11 @@ impl McpHandler for McpService {
 
 #[async_trait(?Send)]
 impl RequestService for McpService {
-    async fn handle_request(&self, ctx: &crate::services::EnvelopeContext, payload: &[u8]) -> anyhow::Result<(Vec<u8>, Option<crate::services::Continuation>)> {
+    async fn handle_request(
+        &self,
+        ctx: &crate::services::EnvelopeContext,
+        payload: &[u8],
+    ) -> anyhow::Result<(Vec<u8>, Option<crate::services::Continuation>)> {
         trace!(
             "McpService request from {} (id={})",
             ctx.subject(),
@@ -1206,20 +1466,41 @@ mod tests {
         SigningKey::from_bytes(&[seed; 32])
     }
 
-    /// No token at all is the only path to the anonymous principal.
     #[test]
-    fn stdio_absent_token_is_anonymous() {
-        let vk = signing_key(0x01).verifying_key();
-        assert_eq!(stdio_user(None, &vk, None).unwrap(), "anonymous");
+    fn schema_action_expands_to_tenant_policy_resource() {
+        assert_eq!(
+            mcp_policy_scope("query", "registry", "list"),
+            "query:registry:List"
+        );
+        assert_eq!(
+            mcp_policy_scope("write", "model", "load_model"),
+            "write:model:LoadModel"
+        );
+        assert_eq!(
+            mcp_policy_scope("", "tui", "health_check"),
+            "query:tui:HealthCheck"
+        );
     }
 
-    /// A present, decodable token yields its subject.
+    /// No token cannot establish a tenant and therefore fails closed.
+    #[test]
+    fn stdio_absent_token_is_rejected() {
+        let vk = signing_key(0x01).verifying_key();
+        assert!(stdio_user(None, &vk, None).is_err());
+    }
+
+    /// A present, decodable token yields its subject and verified tenant.
     #[test]
     fn stdio_valid_token_yields_subject() {
         let sk = signing_key(0x02);
-        let token = jwt::encode(&Claims::new("alice".to_owned(), 0, 9_999_999_999), &sk);
+        let token = jwt::encode(
+            &Claims::new("alice".to_owned(), 0, 9_999_999_999)
+                .with_tenant("tenant-a.example".to_owned()),
+            &sk,
+        );
         let user = stdio_user(Some(&token), &sk.verifying_key(), None).unwrap();
-        assert_eq!(user, "alice");
+        assert_eq!(user.user, "alice");
+        assert_eq!(user.authorization_domain().unwrap(), "tenant-a.example");
     }
 
     /// #1095: a present-but-undecodable token must hard-reject (fail closed),
@@ -1260,6 +1541,7 @@ mod tests {
         let sk = signing_key(0x06);
         let token = jwt::encode(
             &Claims::new("erin".to_owned(), 0, 9_999_999_999)
+                .with_tenant("tenant-a.example".to_owned())
                 .with_audience(Some("https://hyprstream.local".to_owned())),
             &sk,
         );
@@ -1269,6 +1551,6 @@ mod tests {
             Some("https://hyprstream.local"),
         )
         .unwrap();
-        assert_eq!(user, "erin");
+        assert_eq!(user.user, "erin");
     }
 }

--- a/crates/hyprstream/src/services/oauth/auth.rs
+++ b/crates/hyprstream/src/services/oauth/auth.rs
@@ -181,12 +181,48 @@ pub async fn require_bearer_token(
         }
     }
 
-    request.extensions_mut().insert(AuthenticatedUser {
+    let user = AuthenticatedUser {
         user: claims.sub,
+        verified_tenant: claims.tenant,
         token: Some(token),
         exp: Some(claims.exp),
-    });
+    };
+    if user.authorization_domain().is_err() {
+        return (
+            StatusCode::FORBIDDEN,
+            axum::Json(serde_json::json!({
+                "error": "insufficient_scope",
+                "error_description": "Verified hosted-account tenant binding required"
+            })),
+        )
+            .into_response();
+    }
+    request.extensions_mut().insert(user);
 
+    next.run(request).await
+}
+
+/// Restrict cross-tenant OAuth administration to a tenantless service authority.
+///
+/// This layer runs inside [`require_bearer_token`], after the verified identity
+/// has been inserted. Tenant-bound users may use self-service OAuth routes, but
+/// cannot enumerate or mutate the global SCIM store or mint service workload
+/// identities. Introspection has its own same-tenant check.
+pub async fn require_global_service_authority(request: Request, next: Next) -> Response {
+    let authorized = request
+        .extensions()
+        .get::<AuthenticatedUser>()
+        .is_some_and(|user| user.authorization_domain().as_deref() == Ok("*"));
+    if !authorized {
+        return (
+            StatusCode::FORBIDDEN,
+            axum::Json(serde_json::json!({
+                "error": "insufficient_scope",
+                "error_description": "global service authority required"
+            })),
+        )
+            .into_response();
+    }
     next.run(request).await
 }
 

--- a/crates/hyprstream/src/services/oauth/introspection.rs
+++ b/crates/hyprstream/src/services/oauth/introspection.rs
@@ -11,7 +11,7 @@
 use std::sync::Arc;
 
 use axum::{
-    extract::State,
+    extract::{Extension, State},
     http::{header, StatusCode},
     response::{IntoResponse, Response},
     Form, Json,
@@ -19,6 +19,7 @@ use axum::{
 use serde::Deserialize;
 
 use super::state::OAuthState;
+use crate::server::middleware::AuthenticatedUser;
 
 #[derive(Deserialize)]
 pub struct IntrospectRequest {
@@ -30,21 +31,38 @@ pub struct IntrospectRequest {
 /// POST /oauth/introspect (RFC 7662)
 pub async fn introspect_token(
     State(state): State<Arc<OAuthState>>,
+    Extension(caller): Extension<AuthenticatedUser>,
     Form(params): Form<IntrospectRequest>,
 ) -> Response {
     // JWT tokens contain dots; opaque tokens do not.
     if params.token.contains('.') {
-        introspect_jwt(&state, &params.token).await
+        introspect_jwt(&state, &caller, &params.token).await
     } else {
-        introspect_refresh(&state, &params.token).await
+        introspect_refresh(&state, &caller, &params.token).await
     }
 }
 
-async fn introspect_jwt(state: &Arc<OAuthState>, token: &str) -> Response {
+fn caller_may_introspect_tenant(caller: &AuthenticatedUser, tenant: Option<&str>) -> bool {
+    match caller.authorization_domain() {
+        Ok(domain) if domain == "*" => true,
+        Ok(domain) => tenant.is_some_and(|tenant| tenant == domain),
+        Err(_) => false,
+    }
+}
+
+async fn introspect_jwt(
+    state: &Arc<OAuthState>,
+    caller: &AuthenticatedUser,
+    token: &str,
+) -> Response {
     let claims = match super::auth::validate_oauth_access_token(state, token).await {
         Ok(c) => c,
         Err(_) => return inactive_response(),
     };
+
+    if !caller_may_introspect_tenant(caller, claims.tenant.as_deref()) {
+        return inactive_response();
+    }
 
     let now = chrono::Utc::now().timestamp();
     if claims.exp < now {
@@ -68,9 +86,24 @@ async fn introspect_jwt(state: &Arc<OAuthState>, token: &str) -> Response {
         .into_response()
 }
 
-async fn introspect_refresh(state: &Arc<OAuthState>, token: &str) -> Response {
+async fn introspect_refresh(
+    state: &Arc<OAuthState>,
+    caller: &AuthenticatedUser,
+    token: &str,
+) -> Response {
     match state.get_refresh_token(token).await {
         Ok(Some(entry)) => {
+            let tenant = super::token::resolve_hosted_account_binding(
+                state,
+                &entry.username,
+            )
+                .await
+                .ok()
+                .map(|(_, tenant)| tenant);
+            if !caller_may_introspect_tenant(caller, tenant.as_deref()) {
+                return inactive_response();
+            }
+
             // Match the mint boundary: generic tokens retain the username,
             // while active atproto-profile tokens report the mapped DID.
             let sub = if super::state::atproto_profile_active(&entry.scopes) {

--- a/crates/hyprstream/src/services/oauth/mod.rs
+++ b/crates/hyprstream/src/services/oauth/mod.rs
@@ -172,20 +172,10 @@ pub fn create_app(state: Arc<OAuthState>, cors_config: &crate::config::CorsConfi
     // ── Protected routes ───────────────────────────────────────────────────────
     // All require a valid Bearer token (validated by require_bearer_token).
     // Inserts AuthenticatedUser into request extensions for downstream handlers.
-    let protected_router = Router::new()
-        .route("/oauth/introspect", post(introspection::introspect_token))
-        .route("/oauth/wit", post(wit_bootstrap::issue_browser_wit))
-        .route(
-            "/oauth/mount-ticket",
-            post(mount_ticket::issue_mount_ticket),
-        )
+    let authority_router = Router::new()
         .route(
             "/oauth/spiffe/service-svid",
             post(spiffe::issue_service_svid),
-        )
-        .route(
-            "/oauth/userinfo",
-            get(userinfo::userinfo).post(userinfo::userinfo),
         )
         // SCIM 2.0 user management (RFC 7644)
         .route(
@@ -206,6 +196,22 @@ pub fn create_app(state: Arc<OAuthState>, cors_config: &crate::config::CorsConfi
             "/scim/v2/Users/:id/keys/:fingerprint",
             axum::routing::delete(scim::remove_user_key),
         )
+        .layer(axum::middleware::from_fn(
+            auth::require_global_service_authority,
+        ));
+
+    let protected_router = Router::new()
+        .route("/oauth/introspect", post(introspection::introspect_token))
+        .route("/oauth/wit", post(wit_bootstrap::issue_browser_wit))
+        .route(
+            "/oauth/mount-ticket",
+            post(mount_ticket::issue_mount_ticket),
+        )
+        .route(
+            "/oauth/userinfo",
+            get(userinfo::userinfo).post(userinfo::userinfo),
+        )
+        .merge(authority_router)
         .layer(axum::middleware::from_fn_with_state(
             Arc::clone(&state),
             auth::require_bearer_token,
@@ -746,6 +752,13 @@ impl Spawnable for OAuthService {
             );
             if let Some(store) = &self.hosted_account_store {
                 oauth_state = oauth_state.with_hosted_account_store(Arc::clone(store));
+            }
+            match self.account_config.resolve_zone() {
+                Ok(zone) => oauth_state = oauth_state.with_hosted_account_zone(zone),
+                Err(error) => tracing::warn!(
+                    %error,
+                    "OAuth user-token minting disabled: no deployment account zone"
+                ),
             }
             if let Some(store) = user_store {
                 oauth_state = oauth_state.with_user_store(store);
@@ -1525,7 +1538,10 @@ mod tests {
         .with_hosted_account_store(hosted_account_store)
         .with_atproto_did_resolver(Arc::new(FixtureAtprotoDidResolver(
             atproto_document,
-        )));
+        )))
+        .with_hosted_account_zone(crate::account::AccountZone::new(
+            "acct.example.test",
+        )?);
         let token_dir = tempfile::TempDir::new()?;
         oauth_state.with_token_store_impl(Arc::new(RocksDbTokenStore::open(
             token_dir.path().join("refresh.db"),
@@ -1949,6 +1965,7 @@ mod tests {
         let claims = jwt_claims(&token_response.access_token);
         assert_eq!(claims["iss"], ISSUER);
         assert_eq!(claims["sub"], MAPPED_DID);
+        assert_eq!(claims["tenant"], HOSTED_TENANT);
         assert_eq!(claims["aud"], ISSUER);
         assert_eq!(claims["scope"], "atproto");
 
@@ -2433,6 +2450,7 @@ mod tests {
         assert!(state.get_refresh_token(&refresh_token).await?.is_none());
         let refreshed_claims = jwt_claims(refreshed_json["access_token"].as_str().unwrap());
         assert_eq!(refreshed_claims["sub"], MAPPED_DID);
+        assert_eq!(refreshed_claims["tenant"], HOSTED_TENANT);
         assert_eq!(refreshed_claims["scope"], "atproto");
 
         // A non-atproto PAR consent cannot be upgraded to the atproto profile
@@ -2569,7 +2587,7 @@ mod tests {
                 user_pub_key: None,
                 dpop_jkt: None,
                 issuer: None,
-                tenant: None,
+                tenant: Some(HOSTED_TENANT.to_owned()),
                 require_clearance: false,
             })
             .await?
@@ -2587,6 +2605,34 @@ mod tests {
             axum::http::StatusCode::OK,
             "the AS must accept its path-bearing default audience alias"
         );
+        assert_eq!(response_json(default_audience_auth).await["active"], true);
+
+        let cross_tenant_token = state
+            .policy_client
+            .issue_token(&IssueToken {
+                requested_scopes: Some(vec!["read:*:*".to_owned()]),
+                ttl: Some(300),
+                audience: Some(ISSUER.to_owned()),
+                subject: Some("cross-tenant-introspector".to_owned()),
+                user_pub_key: None,
+                dpop_jkt: None,
+                issuer: None,
+                tenant: Some("other.example.test".to_owned()),
+                require_clearance: false,
+            })
+            .await?
+            .token;
+        let cross_tenant_introspection = post_form_bearer(
+            &app,
+            "/oauth/introspect",
+            &[("token", &generic_access_token)],
+            &cross_tenant_token,
+        )
+        .await;
+        assert_eq!(
+            response_json(cross_tenant_introspection).await["active"],
+            false
+        );
 
         // Token exchange may only attenuate the verified subject token's signed
         // grant. A caller holding read:*:* cannot write transition:generic into
@@ -2601,7 +2647,7 @@ mod tests {
                 user_pub_key: None,
                 dpop_jkt: None,
                 issuer: None,
-                tenant: None,
+                tenant: Some("example.test".to_owned()),
                 require_clearance: false,
             })
             .await?
@@ -2649,7 +2695,7 @@ mod tests {
                 user_pub_key: None,
                 dpop_jkt: None,
                 issuer: None,
-                tenant: None,
+                tenant: Some("example.test".to_owned()),
                 require_clearance: false,
             })
             .await?

--- a/crates/hyprstream/src/services/oauth/mount_ticket.rs
+++ b/crates/hyprstream/src/services/oauth/mount_ticket.rs
@@ -111,10 +111,23 @@ pub async fn issue_mount_ticket(
     let exp = now + MOUNT_TICKET_TTL;
     let audience = state.issuer_url.clone();
     let capability = ticket_capability(&body.plane, &normalized_path);
-    let claims = hyprstream_rpc::auth::Claims::new(user.user.clone(), now, exp)
+    let domain = match user.authorization_domain() {
+        Ok(domain) => domain,
+        Err(_) => {
+            return oauth_error(
+                StatusCode::FORBIDDEN,
+                "insufficient_scope",
+                Some("Verified hosted-account tenant binding required"),
+            );
+        }
+    };
+    let mut claims = hyprstream_rpc::auth::Claims::new(user.user.clone(), now, exp)
         .with_issuer(state.issuer_url.clone())
         .with_audience(Some(audience.clone()))
         .with_cap(capability.clone());
+    if domain != "*" {
+        claims = claims.with_tenant(domain);
+    }
     let ticket = hyprstream_rpc::auth::jwt::encode(&claims, &key);
 
     tracing::info!(
@@ -188,6 +201,7 @@ mod freeze_tests {
             State(test_state()),
             Extension(AuthenticatedUser {
                 user: "did:web:accounts.example:users:alice".to_owned(),
+                verified_tenant: Some("tenant-a.example".to_owned()),
                 token: None,
                 exp: None,
             }),
@@ -205,6 +219,7 @@ mod freeze_tests {
             State(test_state()),
             Extension(AuthenticatedUser {
                 user: "alice".to_owned(),
+                verified_tenant: Some("tenant-a.example".to_owned()),
                 token: None,
                 exp: None,
             }),
@@ -214,6 +229,17 @@ mod freeze_tests {
         .await;
 
         assert_eq!(response.status(), StatusCode::OK);
+        let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        let claims = crate::auth::jwt::decode(
+            json["ticket"].as_str().unwrap(),
+            &ed25519_dalek::SigningKey::from_bytes(&[0x75; 32]).verifying_key(),
+            None,
+        )
+        .unwrap();
+        assert_eq!(claims.tenant.as_deref(), Some("tenant-a.example"));
     }
 }
 

--- a/crates/hyprstream/src/services/oauth/scim.rs
+++ b/crates/hyprstream/src/services/oauth/scim.rs
@@ -75,6 +75,33 @@ fn user_service(state: &Arc<OAuthState>) -> Result<&Arc<user_service::UserServic
         .ok_or_else(|| Box::new(scim_error_simple(503, "User service not configured")))
 }
 
+fn hosted_account_did_from_body(
+    state: &OAuthState,
+    body: &serde_json::Value,
+) -> Result<Option<String>, Box<axum::response::Response>> {
+    let did = body
+        .get(SCIM_SCHEMA_EXT_HYPRSTREAM)
+        .and_then(|extension| extension.get("hosted_account_did"))
+        .and_then(serde_json::Value::as_str)
+        .map(str::trim)
+        .filter(|did| !did.is_empty())
+        .map(str::to_owned);
+    if let Some(did) = did.as_deref() {
+        super::token::hosted_account_tenant_from_did(
+            did,
+            state.hosted_account_zone.as_ref(),
+        )
+        .map_err(|error| {
+            Box::new(scim_error(
+                400,
+                "invalidValue",
+                &format!("invalid hosted_account_did: {error}"),
+            ))
+        })?;
+    }
+    Ok(did)
+}
+
 fn user_to_scim(
     info: &user_service::UserInfo,
     base_url: &str,
@@ -84,7 +111,9 @@ fn user_to_scim(
     ScimUser {
         schemas: {
             let mut s = vec![SCIM_SCHEMA_USER.to_owned()];
-            if include_pubkey {
+            if include_pubkey
+                && (!info.pubkey_base64.is_empty() || info.atproto_did.is_some())
+            {
                 s.push(SCIM_SCHEMA_EXT_HYPRSTREAM.to_owned());
             }
             s
@@ -108,9 +137,12 @@ fn user_to_scim(
             location: Some(format!("{base_url}/scim/v2/Users/{}", info.sub)),
             version: Some(etag),
         },
-        hyprstream: if include_pubkey && !info.pubkey_base64.is_empty() {
+        hyprstream: if include_pubkey
+            && (!info.pubkey_base64.is_empty() || info.atproto_did.is_some())
+        {
             Some(ScimHyprstreamExtension {
                 pubkey_base64: info.pubkey_base64.clone(),
+                hosted_account_did: info.atproto_did.clone(),
             })
         } else {
             None
@@ -305,6 +337,10 @@ pub async fn create_user(
         .and_then(|v| v.as_str())
         .map(std::borrow::ToOwned::to_owned);
     let external_id = body.get("externalId").and_then(|v| v.as_str()).map(std::borrow::ToOwned::to_owned);
+    let hosted_account_did = match hosted_account_did_from_body(&state, &body) {
+        Ok(did) => did,
+        Err(response) => return *response,
+    };
 
     let _info = match svc.register(&user_name, &pubkey_base64).await {
         Ok(i) => i,
@@ -312,13 +348,17 @@ pub async fn create_user(
     };
 
     // Set optional profile fields
-    if display_name.is_some() || email.is_some() || external_id.is_some() {
+    if display_name.is_some()
+        || email.is_some()
+        || external_id.is_some()
+        || hosted_account_did.is_some()
+    {
         let update = user_service::UserUpdate {
             name: display_name.map(Some),
             email: email.map(Some),
             external_id: external_id.map(Some),
             email_verified: None,
-            atproto_did: None,
+            atproto_did: hosted_account_did.map(Some),
         };
         if let Err(e) = svc.update(&user_name, update).await {
             return scim_error_simple(500, &e.to_string());
@@ -407,13 +447,17 @@ pub async fn replace_user(
         .map(std::borrow::ToOwned::to_owned);
     let external_id = body.get("externalId").and_then(|v| v.as_str()).map(std::borrow::ToOwned::to_owned);
     let active = body.get("active").and_then(serde_json::Value::as_bool);
+    let hosted_account_did = match hosted_account_did_from_body(&state, &body) {
+        Ok(did) => did,
+        Err(response) => return *response,
+    };
 
     let update = user_service::UserUpdate {
         name: display_name.map(Some),
         email: email.map(Some),
         external_id: external_id.map(Some),
         email_verified: None,
-            atproto_did: None,
+        atproto_did: hosted_account_did.map(Some),
     };
 
     match svc.update(&info.username, update).await {

--- a/crates/hyprstream/src/services/oauth/scim_types.rs
+++ b/crates/hyprstream/src/services/oauth/scim_types.rs
@@ -45,10 +45,13 @@ pub struct ScimEmail {
     pub email_type: Option<String>,
 }
 
-/// Hyprstream extension — Ed25519 public key.
+/// Hyprstream extension — account credentials and authority-owned DID binding.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ScimHyprstreamExtension {
+    #[serde(default)]
     pub pubkey_base64: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub hosted_account_did: Option<String>,
 }
 
 /// SCIM metadata (RFC 7643 §3.1).

--- a/crates/hyprstream/src/services/oauth/spiffe.rs
+++ b/crates/hyprstream/src/services/oauth/spiffe.rs
@@ -177,6 +177,14 @@ pub async fn issue_service_svid(
     Extension(user): Extension<AuthenticatedUser>,
     Json(body): Json<ServiceSvidRequest>,
 ) -> Response {
+    let requester_service = user.user.strip_prefix("service:");
+    if requester_service != Some(body.service.as_str()) {
+        return oauth_error(
+            StatusCode::FORBIDDEN,
+            "insufficient_scope",
+            Some("service authority may mint only its own JWT-SVID"),
+        );
+    }
     if !valid_service_name(&body.service) {
         return oauth_error(
             StatusCode::BAD_REQUEST,
@@ -472,6 +480,13 @@ mod tests {
             service_spiffe_id("https://hypr.example.test/oauth", "model"),
             "spiffe://hypr.example.test/service/model"
         );
+    }
+
+    #[test]
+    fn service_svid_requester_binding_is_exact() {
+        let requester = "service:model";
+        assert_eq!(requester.strip_prefix("service:"), Some("model"));
+        assert_ne!(requester.strip_prefix("service:"), Some("policy"));
     }
 
     #[test]

--- a/crates/hyprstream/src/services/oauth/state.rs
+++ b/crates/hyprstream/src/services/oauth/state.rs
@@ -946,6 +946,9 @@ pub struct OAuthState {
     pub discovery_client: DiscoveryClient,
     /// Issuer URL (e.g., "http://localhost:6791")
     pub issuer_url: String,
+    /// Deployment-owned account-zone apex. User tokens may carry only a tenant
+    /// derived from a hosted DID under this exact configured zone.
+    pub hosted_account_zone: Option<crate::account::AccountZone>,
     /// Default scopes for new clients
     pub default_scopes: Vec<String>,
     /// Access token TTL in seconds
@@ -1153,6 +1156,7 @@ impl OAuthState {
             policy_client,
             discovery_client,
             issuer_url: config.issuer_url(),
+            hosted_account_zone: None,
             default_scopes: config.default_scopes.clone(),
             token_ttl: config.token_ttl_seconds,
             refresh_token_ttl: config.refresh_token_ttl_seconds,
@@ -1384,6 +1388,12 @@ impl OAuthState {
     /// for SCIM/RPC access and legacy OAuth handler reads.
     pub fn with_user_store(mut self, store: Arc<dyn UserStore>) -> Self {
         self.user_service = Some(Arc::new(UserService::new(store)));
+        self
+    }
+
+    /// Bind token issuance to the account zone this deployment actually hosts.
+    pub fn with_hosted_account_zone(mut self, zone: crate::account::AccountZone) -> Self {
+        self.hosted_account_zone = Some(zone);
         self
     }
 

--- a/crates/hyprstream/src/services/oauth/token.rs
+++ b/crates/hyprstream/src/services/oauth/token.rs
@@ -13,7 +13,7 @@ use std::time::Instant;
 
 use axum::{
     extract::State,
-    http::{HeaderMap, header, StatusCode},
+    http::{header, HeaderMap, StatusCode},
     response::{IntoResponse, Response},
     Form, Json,
 };
@@ -23,9 +23,9 @@ use sha2::{Digest, Sha256};
 use subtle::ConstantTimeEq;
 
 use super::state::{DeviceCodeStatus, OAuthState, RefreshTokenEntry};
-use hyprstream_pds::repo_authority::is_path_form_did_web;
-use hyprstream_rpc::auth::{JwkThumbprintInput, jwk_thumbprint};
 use crate::services::generated::policy_client::IssueToken;
+use hyprstream_pds::repo_authority::is_path_form_did_web;
+use hyprstream_rpc::auth::{jwk_thumbprint, JwkThumbprintInput};
 
 /// Device code grant type URN (RFC 8628).
 const DEVICE_CODE_GRANT_TYPE: &str = "urn:ietf:params:oauth:grant-type:device_code";
@@ -106,7 +106,8 @@ pub async fn exchange_token(
         .and_then(|cookies| {
             cookies.split(';').find_map(|part| {
                 let part = part.trim();
-                part.strip_prefix("__Secure-VaultDevice=").map(str::to_owned)
+                part.strip_prefix("__Secure-VaultDevice=")
+                    .map(str::to_owned)
             })
         });
 
@@ -126,24 +127,69 @@ pub async fn exchange_token(
     };
 
     match params.grant_type.as_str() {
-        "authorization_code" => exchange_authorization_code(state, params, dpop_header, vault_device_cookie, client_assertion_jkt).await,
-        "refresh_token" => exchange_refresh_token(state, params, dpop_header, vault_device_cookie, client_assertion_jkt).await,
-        gt if gt == DEVICE_CODE_GRANT_TYPE => exchange_device_code(state, params, dpop_header, vault_device_cookie, client_assertion_jkt).await,
+        "authorization_code" => {
+            exchange_authorization_code(
+                state,
+                params,
+                dpop_header,
+                vault_device_cookie,
+                client_assertion_jkt,
+            )
+            .await
+        }
+        "refresh_token" => {
+            exchange_refresh_token(
+                state,
+                params,
+                dpop_header,
+                vault_device_cookie,
+                client_assertion_jkt,
+            )
+            .await
+        }
+        gt if gt == DEVICE_CODE_GRANT_TYPE => {
+            exchange_device_code(
+                state,
+                params,
+                dpop_header,
+                vault_device_cookie,
+                client_assertion_jkt,
+            )
+            .await
+        }
         gt if gt == JWT_BEARER_GRANT_TYPE => {
             let assertion = match params.assertion {
                 Some(a) => a,
-                None => return token_error(StatusCode::BAD_REQUEST, "invalid_request", Some("assertion is required")),
+                None => {
+                    return token_error(
+                        StatusCode::BAD_REQUEST,
+                        "invalid_request",
+                        Some("assertion is required"),
+                    )
+                }
             };
             super::jwt_bearer::exchange_jwt_bearer(&state, &params.client_id, &assertion).await
         }
         gt if gt == TOKEN_EXCHANGE_GRANT_TYPE => {
             let subject_token = match params.subject_token {
                 Some(t) => t,
-                None => return token_error(StatusCode::BAD_REQUEST, "invalid_request", Some("subject_token is required")),
+                None => {
+                    return token_error(
+                        StatusCode::BAD_REQUEST,
+                        "invalid_request",
+                        Some("subject_token is required"),
+                    )
+                }
             };
             let subject_token_type = match params.subject_token_type {
                 Some(t) => t,
-                None => return token_error(StatusCode::BAD_REQUEST, "invalid_request", Some("subject_token_type is required")),
+                None => {
+                    return token_error(
+                        StatusCode::BAD_REQUEST,
+                        "invalid_request",
+                        Some("subject_token_type is required"),
+                    )
+                }
             };
             // S6 (#572): the UCAN grant path. Routed on a dedicated
             // `subject_token_type` so it cannot be confused with the OIDC/WIT
@@ -173,7 +219,8 @@ pub async fn exchange_token(
                 params.actor_token.as_deref(),
                 params.requested_token_type.as_deref(),
                 params.tenant.as_deref(),
-            ).await
+            )
+            .await
         }
         _ => token_error(
             StatusCode::BAD_REQUEST,
@@ -185,10 +232,7 @@ pub async fn exchange_token(
 
 /// The immutable scope set of the grant being redeemed, used to derive
 /// the profile-correct issuer for assertion-audience checking.
-async fn bound_grant_scopes(
-    state: &OAuthState,
-    params: &TokenRequest,
-) -> Option<Vec<String>> {
+async fn bound_grant_scopes(state: &OAuthState, params: &TokenRequest) -> Option<Vec<String>> {
     match params.grant_type.as_str() {
         "authorization_code" => {
             let code = params.code.as_deref()?;
@@ -198,7 +242,11 @@ async fn bound_grant_scopes(
         }
         "refresh_token" => {
             let refresh_token = params.refresh_token.as_deref()?;
-            let entry = state.get_refresh_token(refresh_token).await.ok().flatten()?;
+            let entry = state
+                .get_refresh_token(refresh_token)
+                .await
+                .ok()
+                .flatten()?;
             (entry.client_id == params.client_id).then_some(entry.scopes)
         }
         gt if gt == DEVICE_CODE_GRANT_TYPE => {
@@ -214,10 +262,7 @@ async fn bound_grant_scopes(
 /// The client-assertion key thumbprint bound to the grant being redeemed
 /// (#1146 T3.3): PAR-bound for `authorization_code`, issuance-bound for
 /// `refresh_token`. `None` when the grant carries no binding.
-async fn bound_assertion_jkt(
-    state: &OAuthState,
-    params: &TokenRequest,
-) -> Option<String> {
+async fn bound_assertion_jkt(state: &OAuthState, params: &TokenRequest) -> Option<String> {
     match params.grant_type.as_str() {
         "authorization_code" => {
             let code = params.code.as_deref()?;
@@ -229,7 +274,11 @@ async fn bound_assertion_jkt(
         }
         "refresh_token" => {
             let refresh_token = params.refresh_token.as_deref()?;
-            let entry = state.get_refresh_token(refresh_token).await.ok().flatten()?;
+            let entry = state
+                .get_refresh_token(refresh_token)
+                .await
+                .ok()
+                .flatten()?;
             (entry.client_id == params.client_id)
                 .then_some(entry.client_assertion_jkt)
                 .flatten()
@@ -308,8 +357,14 @@ async fn enforce_client_authentication(
     }
 
     if has_assertion {
-        let assertion = params.client_assertion.as_deref().unwrap_or_else(|| unreachable!());
-        let atype = params.client_assertion_type.as_deref().unwrap_or_else(|| unreachable!());
+        let assertion = params
+            .client_assertion
+            .as_deref()
+            .unwrap_or_else(|| unreachable!());
+        let atype = params
+            .client_assertion_type
+            .as_deref()
+            .unwrap_or_else(|| unreachable!());
         // Derive the assertion audience from the immutable grant, not from
         // caller-supplied scopes. atproto grants use the origin-only issuer
         // advertised in RFC 8414 metadata; generic grants preserve the
@@ -329,8 +384,14 @@ async fn enforce_client_authentication(
         };
         let expected_audiences = [issuer];
         match super::client_auth::verify_client_assertion(
-            state, &client, atype, assertion, &expected_audiences,
-        ).await {
+            state,
+            &client,
+            atype,
+            assertion,
+            &expected_audiences,
+        )
+        .await
+        {
             Ok(verified) => {
                 // #1146 T3.3: when the grant was bound to a specific
                 // assertion key (at PAR for authorization_code, at
@@ -404,13 +465,21 @@ async fn verify_dpop_at_token_endpoint(
             // checks (signature, jkt match, htm/htu, alg). Keep them
             // out of the public response; logs carry the detail.
             tracing::warn!("DPoP proof verification failed: {e}");
-            return Some(Err(token_error(StatusCode::BAD_REQUEST, "invalid_dpop_proof", None)));
+            return Some(Err(token_error(
+                StatusCode::BAD_REQUEST,
+                "invalid_dpop_proof",
+                None,
+            )));
         }
     };
     // JTI replay check.
     if !state.check_and_record_dpop_jti(&proof.jti, proof.iat) {
         tracing::warn!(jti = %proof.jti, "DPoP JTI replay detected");
-        return Some(Err(token_error(StatusCode::BAD_REQUEST, "invalid_dpop_proof", Some("DPoP proof jti already used"))));
+        return Some(Err(token_error(
+            StatusCode::BAD_REQUEST,
+            "invalid_dpop_proof",
+            Some("DPoP proof jti already used"),
+        )));
     }
 
     // RFC 9449 §8 nonce enforcement.
@@ -421,7 +490,10 @@ async fn verify_dpop_at_token_endpoint(
             let fresh = state.issue_dpop_nonce().await;
             state.mark_dpop_client_nonced(&proof.jkt).await;
             tracing::warn!(jkt = %proof.jkt, "DPoP nonce required but proof omitted it");
-            return Some(Err(use_dpop_nonce_error(&fresh, "DPoP proof must include a server-issued nonce")));
+            return Some(Err(use_dpop_nonce_error(
+                &fresh,
+                "DPoP proof must include a server-issued nonce",
+            )));
         }
         (_, Some(presented)) => {
             // Whether bootstrap or subsequent: a presented nonce must be one
@@ -430,7 +502,10 @@ async fn verify_dpop_at_token_endpoint(
                 let fresh = state.issue_dpop_nonce().await;
                 state.mark_dpop_client_nonced(&proof.jkt).await;
                 tracing::warn!(jkt = %proof.jkt, "DPoP nonce invalid or expired");
-                return Some(Err(use_dpop_nonce_error(&fresh, "DPoP nonce invalid or expired")));
+                return Some(Err(use_dpop_nonce_error(
+                    &fresh,
+                    "DPoP nonce invalid or expired",
+                )));
             }
         }
         (false, None) => {
@@ -472,15 +547,33 @@ async fn exchange_authorization_code(
 ) -> Response {
     let code = match params.code {
         Some(c) => c,
-        None => return token_error(StatusCode::BAD_REQUEST, "invalid_request", Some("code is required")),
+        None => {
+            return token_error(
+                StatusCode::BAD_REQUEST,
+                "invalid_request",
+                Some("code is required"),
+            )
+        }
     };
     let redirect_uri = match params.redirect_uri {
         Some(r) => r,
-        None => return token_error(StatusCode::BAD_REQUEST, "invalid_request", Some("redirect_uri is required")),
+        None => {
+            return token_error(
+                StatusCode::BAD_REQUEST,
+                "invalid_request",
+                Some("redirect_uri is required"),
+            )
+        }
     };
     let code_verifier = match params.code_verifier {
         Some(v) => v,
-        None => return token_error(StatusCode::BAD_REQUEST, "invalid_request", Some("code_verifier is required")),
+        None => {
+            return token_error(
+                StatusCode::BAD_REQUEST,
+                "invalid_request",
+                Some("code_verifier is required"),
+            )
+        }
     };
 
     // Look up and remove pending code (single-use)
@@ -530,7 +623,12 @@ async fn exchange_authorization_code(
         URL_SAFE_NO_PAD.encode(digest)
     };
 
-    if computed_challenge.as_bytes().ct_eq(pending.code_challenge.as_bytes()).unwrap_u8() == 0 {
+    if computed_challenge
+        .as_bytes()
+        .ct_eq(pending.code_challenge.as_bytes())
+        .unwrap_u8()
+        == 0
+    {
         return token_error(
             StatusCode::BAD_REQUEST,
             "invalid_grant",
@@ -540,11 +638,12 @@ async fn exchange_authorization_code(
 
     // Verify DPoP if present.
     let token_issuer = state.issuer_for_scopes(&pending.scopes);
-    let dpop_jkt = match verify_dpop_at_token_endpoint(&state, dpop_header.as_deref(), &token_issuer).await {
-        None => None,
-        Some(Ok(jkt)) => Some(jkt),
-        Some(Err(resp)) => return resp,
-    };
+    let dpop_jkt =
+        match verify_dpop_at_token_endpoint(&state, dpop_header.as_deref(), &token_issuer).await {
+            None => None,
+            Some(Ok(jkt)) => Some(jkt),
+            Some(Err(resp)) => return resp,
+        };
 
     // #1113 rev2 finding 3 + 6: the atproto profile (granted scope set
     // includes `atproto`) is a STRICT path — DPoP is mandatory and the proof
@@ -574,7 +673,20 @@ async fn exchange_authorization_code(
     tracing::info!(client_id = %params.client_id, username = %pending.username, "PKCE verified, issuing token");
     let sub = pending.username.clone();
     let vk_ref = pending.verifying_key.as_ref();
-    issue_token_with_refresh(&state, &params.client_id, pending.scopes, pending.resource, &sub, pending.oidc_nonce, true, vk_ref, dpop_jkt, client_assertion_jkt, vault_device_cookie).await
+    issue_token_with_refresh(
+        &state,
+        &params.client_id,
+        pending.scopes,
+        pending.resource,
+        &sub,
+        pending.oidc_nonce,
+        true,
+        vk_ref,
+        dpop_jkt,
+        client_assertion_jkt,
+        vault_device_cookie,
+    )
+    .await
 }
 
 /// Handle refresh_token grant type (OAuth 2.1 with rotation).
@@ -587,7 +699,13 @@ async fn exchange_refresh_token(
 ) -> Response {
     let refresh_token = match params.refresh_token {
         Some(rt) => rt,
-        None => return token_error(StatusCode::BAD_REQUEST, "invalid_request", Some("refresh_token is required")),
+        None => {
+            return token_error(
+                StatusCode::BAD_REQUEST,
+                "invalid_request",
+                Some("refresh_token is required"),
+            )
+        }
     };
 
     let entry = match state.get_refresh_token(&refresh_token).await {
@@ -664,11 +782,12 @@ async fn exchange_refresh_token(
     // Verify DPoP before consuming the refresh token. A use_dpop_nonce
     // response must leave the credential available for the RFC 9449 retry.
     let token_issuer = state.issuer_for_scopes(&entry.scopes);
-    let dpop_jkt = match verify_dpop_at_token_endpoint(&state, dpop_header.as_deref(), &token_issuer).await {
-        None => None,
-        Some(Ok(jkt)) => Some(jkt),
-        Some(Err(resp)) => return resp,
-    };
+    let dpop_jkt =
+        match verify_dpop_at_token_endpoint(&state, dpop_header.as_deref(), &token_issuer).await {
+            None => None,
+            Some(Ok(jkt)) => Some(jkt),
+            Some(Err(resp)) => return resp,
+        };
 
     // A sender-constrained token cannot be refreshed by another key or without
     // a proof.
@@ -695,6 +814,24 @@ async fn exchange_refresh_token(
         }
     }
 
+    // Validate the authority-controlled binding before atomically consuming
+    // the single-use credential. An operator-repairable mapping failure must
+    // fail closed without destroying the existing session.
+    if !is_path_form_did_web(&entry.username) {
+        if let Err(error) = resolve_hosted_account_binding(&state, &entry.username).await {
+            tracing::warn!(
+                username = %entry.username,
+                %error,
+                "refresh rejected before claim: hosted account binding unavailable"
+            );
+            return token_error(
+                StatusCode::BAD_REQUEST,
+                "invalid_grant",
+                Some("account has no valid hosted DID tenant binding"),
+            );
+        }
+    }
+
     // Atomically claim only after all retryable DPoP validation succeeds.
     // A successful claim prevents every other OAuth replica from minting with
     // this single-use refresh credential.
@@ -714,17 +851,34 @@ async fn exchange_refresh_token(
     };
 
     // Reconstruct verifying key from the atomically claimed record (cnf continuity across refreshes).
-    let stored_vk: Option<ed25519_dalek::VerifyingKey> = claimed.verifying_key_bytes
+    let stored_vk: Option<ed25519_dalek::VerifyingKey> = claimed
+        .verifying_key_bytes
         .and_then(|b| ed25519_dalek::VerifyingKey::from_bytes(&b).ok());
 
     // #1146 T3.3: carry the assertion-key binding forward across rotation.
     // enforce_client_authentication already verified the presented
     // assertion against this binding; for a legacy entry without one,
     // ratchet onto the key that just verified.
-    let carried_assertion_jkt = claimed.client_assertion_jkt.clone().or(client_assertion_jkt);
+    let carried_assertion_jkt = claimed
+        .client_assertion_jkt
+        .clone()
+        .or(client_assertion_jkt);
 
     // Issue new access token + rotated refresh token. No id_token on refresh (OIDC Core § 12.2).
-    issue_token_with_refresh(&state, &claimed.client_id, claimed.scopes, claimed.resource, &claimed.username, None, false, stored_vk.as_ref(), dpop_jkt, carried_assertion_jkt, vault_device_cookie).await
+    issue_token_with_refresh(
+        &state,
+        &claimed.client_id,
+        claimed.scopes,
+        claimed.resource,
+        &claimed.username,
+        None,
+        false,
+        stored_vk.as_ref(),
+        dpop_jkt,
+        carried_assertion_jkt,
+        vault_device_cookie,
+    )
+    .await
 }
 
 /// Handle urn:ietf:params:oauth:grant-type:device_code grant type (RFC 8628 Section 3.4).
@@ -737,7 +891,13 @@ async fn exchange_device_code(
 ) -> Response {
     let device_code = match params.device_code {
         Some(dc) => dc,
-        None => return token_error(StatusCode::BAD_REQUEST, "invalid_request", Some("device_code is required")),
+        None => {
+            return token_error(
+                StatusCode::BAD_REQUEST,
+                "invalid_request",
+                Some("device_code is required"),
+            )
+        }
     };
 
     let mut device_codes = state.pending_device_codes.write().await;
@@ -759,7 +919,11 @@ async fn exchange_device_code(
         device_codes.remove(&device_code);
         let mut user_code_map = state.device_code_by_user_code.write().await;
         user_code_map.remove(&user_code);
-        return token_error(StatusCode::BAD_REQUEST, "expired_token", Some("The device code has expired"));
+        return token_error(
+            StatusCode::BAD_REQUEST,
+            "expired_token",
+            Some("The device code has expired"),
+        );
     }
 
     // Validate client_id
@@ -775,20 +939,32 @@ async fn exchange_device_code(
     let now = Instant::now();
     if let Some(last) = pending.last_polled {
         if now.duration_since(last).as_secs() < pending.interval {
-            return token_error(StatusCode::BAD_REQUEST, "slow_down", Some("Polling too frequently"));
+            return token_error(
+                StatusCode::BAD_REQUEST,
+                "slow_down",
+                Some("Polling too frequently"),
+            );
         }
     }
     match pending.status {
         DeviceCodeStatus::Pending => {
             pending.last_polled = Some(now);
-            token_error(StatusCode::BAD_REQUEST, "authorization_pending", Some("The authorization request is still pending"))
+            token_error(
+                StatusCode::BAD_REQUEST,
+                "authorization_pending",
+                Some("The authorization request is still pending"),
+            )
         }
         DeviceCodeStatus::Denied => {
             let user_code = pending.user_code.clone();
             device_codes.remove(&device_code);
             let mut user_code_map = state.device_code_by_user_code.write().await;
             user_code_map.remove(&user_code);
-            token_error(StatusCode::BAD_REQUEST, "access_denied", Some("The user denied the authorization request"))
+            token_error(
+                StatusCode::BAD_REQUEST,
+                "access_denied",
+                Some("The user denied the authorization request"),
+            )
         }
         DeviceCodeStatus::Approved => {
             let client_id = pending.client_id.clone();
@@ -805,11 +981,7 @@ async fn exchange_device_code(
                         device_code_prefix = %&device_code[..8.min(device_code.len())],
                         "Device code approved but no approver identity recorded"
                     );
-                    return token_error(
-                        StatusCode::INTERNAL_SERVER_ERROR,
-                        "server_error",
-                        None,
-                    );
+                    return token_error(StatusCode::INTERNAL_SERVER_ERROR, "server_error", None);
                 }
             };
             let device_vk = pending.verifying_key;
@@ -818,11 +990,14 @@ async fn exchange_device_code(
             // Verify DPoP before consuming the device code. A
             // `use_dpop_nonce` response must leave it available for retry.
             let token_issuer = state.issuer_for_scopes(&scopes);
-            let dpop_jkt = match verify_dpop_at_token_endpoint(&state, dpop_header.as_deref(), &token_issuer).await {
-                None => None,
-                Some(Ok(jkt)) => Some(jkt),
-                Some(Err(resp)) => return resp,
-            };
+            let dpop_jkt =
+                match verify_dpop_at_token_endpoint(&state, dpop_header.as_deref(), &token_issuer)
+                    .await
+                {
+                    None => None,
+                    Some(Ok(jkt)) => Some(jkt),
+                    Some(Err(resp)) => return resp,
+                };
 
             // A PDS attachment client records the host's iroh did:key at
             // registration. Its token request must demonstrate possession of
@@ -833,10 +1008,7 @@ async fn exchange_device_code(
                     .get(&client_id)
                     .and_then(|client| client.hyprstream_node_did.clone())
             };
-            if !registered_host_dpop_matches(
-                registered_node_did.as_deref(),
-                dpop_jkt.as_deref(),
-            ) {
+            if !registered_host_dpop_matches(registered_node_did.as_deref(), dpop_jkt.as_deref()) {
                 tracing::warn!(%client_id, "PDS host DID and DPoP key do not match");
                 return token_error(
                     StatusCode::BAD_REQUEST,
@@ -884,7 +1056,20 @@ async fn exchange_device_code(
             drop(user_code_map);
 
             // Device flow: no OIDC nonce and not initial OIDC auth.
-            issue_token_with_refresh(&state, &client_id, scopes, resource, &approved_by, None, false, device_vk.as_ref(), dpop_jkt, client_assertion_jkt, vault_device_cookie).await
+            issue_token_with_refresh(
+                &state,
+                &client_id,
+                scopes,
+                resource,
+                &approved_by,
+                None,
+                false,
+                device_vk.as_ref(),
+                dpop_jkt,
+                client_assertion_jkt,
+                vault_device_cookie,
+            )
+            .await
         }
     }
 }
@@ -924,6 +1109,57 @@ fn generate_refresh_token() -> String {
 ///
 /// `initial_auth`: true for authorization_code exchange (may issue id_token),
 /// false for refresh_token and device_code (never issues id_token per OIDC Core § 12.2).
+/// Resolve the PDS/Casbin tenant bound into a hosted account DID.
+///
+/// Hosted accounts are permanent host-form `did:web` identities:
+/// `did:web:{account-label}.{account-zone}`. The account label selects the
+/// record below `/pds/{tenant}/accounts`; the validated zone suffix is the
+/// tenant. PLC and path-form DIDs have no hosted-zone binding and fail closed.
+pub(super) fn hosted_account_tenant_from_did(
+    did: &str,
+    configured_zone: Option<&crate::account::AccountZone>,
+) -> anyhow::Result<String> {
+    let host = did
+        .strip_prefix("did:web:")
+        .ok_or_else(|| anyhow::anyhow!("hosted account DID must use did:web"))?;
+    anyhow::ensure!(
+        !host.contains(':'),
+        "hosted account DID must be host-form, not path-form"
+    );
+    let (label, zone) = host
+        .split_once('.')
+        .ok_or_else(|| anyhow::anyhow!("hosted account DID has no account-zone suffix"))?;
+    anyhow::ensure!(!label.is_empty(), "hosted account DID has an empty label");
+    let tenant = crate::account::AccountZone::new(zone)?;
+    let configured_zone = configured_zone
+        .ok_or_else(|| anyhow::anyhow!("deployment account zone is not configured"))?;
+    anyhow::ensure!(
+        tenant == *configured_zone,
+        "hosted account DID zone is not owned by this deployment"
+    );
+    Ok(tenant.apex().to_owned())
+}
+
+pub(super) async fn resolve_hosted_account_binding(
+    state: &OAuthState,
+    sub: &str,
+) -> anyhow::Result<(String, String)> {
+    let did = state
+        .check_atproto_account_eligibility(sub)
+        .await
+        .map_err(|error| anyhow::anyhow!("{error}"))?;
+    // The DID's host form must be owned by this deployment, but the Casbin/PDS
+    // tenant is the signed account-record binding, not a caller-supplied value
+    // and not an inference from the DID text.
+    hosted_account_tenant_from_did(&did, state.hosted_account_zone.as_ref())?;
+    let tenant = state
+        .hosted_account_tenant(&did)
+        .await
+        .map_err(anyhow::Error::msg)?
+        .ok_or_else(|| anyhow::anyhow!("hosted DID has no signed local account binding"))?;
+    Ok((did, tenant))
+}
+
 async fn issue_token_with_refresh(
     state: &OAuthState,
     client_id: &str,
@@ -993,18 +1229,24 @@ async fn issue_token_with_refresh(
     // with a mapped atproto DID gets that DID as `sub`; an account without a
     // mapped DID fails closed (#1124). The returned DID is already form-
     // validated by evaluate_atproto_eligibility → subject_did_for.
-    let jwt_sub = if atproto_profile {
-        match state.check_atproto_account_eligibility(sub).await {
-            Ok(mapped_did) => mapped_did,
-            Err(e) => {
-                tracing::warn!(local_subject = %sub, error = %e, "rejecting atproto token issuance: account not eligible");
-                return token_error(
-                    StatusCode::BAD_REQUEST,
-                    "invalid_request",
-                    Some("account has no atproto identity; provisioning tracked in #1124"),
-                );
-            }
+    // The mapped host-form DID is the binding authority for every user token,
+    // regardless of whether the client requested the atproto profile. Its
+    // account-zone suffix is the PDS/Casbin tenant; the full DID is an account
+    // identity and is not a valid `/pds/{tenant}` path component.
+    let (hosted_account_did, hosted_account_tenant) =
+        match resolve_hosted_account_binding(state, sub).await {
+        Ok(binding) => binding,
+        Err(e) => {
+            tracing::warn!(local_subject = %sub, error = %e, "rejecting token issuance: account has no hosted DID tenant binding");
+            return token_error(
+                StatusCode::BAD_REQUEST,
+                "invalid_request",
+                Some("account has no hosted DID tenant binding"),
+            );
         }
+    };
+    let jwt_sub = if atproto_profile {
+        hosted_account_did
     } else {
         sub.to_owned()
     };
@@ -1020,7 +1262,7 @@ async fn issue_token_with_refresh(
             user_pub_key: user_pub_key_b64,
             dpop_jkt: dpop_jkt.clone(),
             issuer: Some(token_issuer.clone()),
-            tenant: None,
+            tenant: Some(hosted_account_tenant.clone()),
             require_clearance: false,
         })
         .await;
@@ -1030,9 +1272,11 @@ async fn issue_token_with_refresh(
             tracing::info!(client_id = %client_id, "Token issued successfully");
 
             // Silently link device → user when __Secure-VaultDevice cookie accompanies the request.
-            if let (Some(cookie_val), Some(ref ds), Some(ref sk)) =
-                (&vault_device_cookie, &state.device_store, &state.signing_key)
-            {
+            if let (Some(cookie_val), Some(ref ds), Some(ref sk)) = (
+                &vault_device_cookie,
+                &state.device_store,
+                &state.signing_key,
+            ) {
                 let sk_bytes = sk.to_bytes();
                 if let Some(pubkey) =
                     crate::auth::device_challenge::verify_vault_device_cookie(&sk_bytes, cookie_val)
@@ -1077,7 +1321,10 @@ async fn issue_token_with_refresh(
                     client_assertion_jkt: client_assertion_jkt.clone(),
                     ucan_grant: None, // generic OAuth refresh; not a UCAN grant (MAC #547 B1)
                 };
-                if let Err(e) = state.put_refresh_token(&refresh_token, &entry, state.refresh_token_ttl as u64).await {
+                if let Err(e) = state
+                    .put_refresh_token(&refresh_token, &entry, state.refresh_token_ttl as u64)
+                    .await
+                {
                     tracing::error!(error = %e, "Failed to persist refresh token");
                 }
             }
@@ -1095,7 +1342,8 @@ async fn issue_token_with_refresh(
                     id_exp,
                 )
                 .with_nonce(oidc_nonce)
-                .with_auth_time(now);
+                .with_auth_time(now)
+                .with_tenant(hosted_account_tenant.clone());
 
                 // Add profile claims based on requested scopes.
                 if let Some(user_store) = state.user_store_reader() {
@@ -1116,8 +1364,11 @@ async fn issue_token_with_refresh(
                 }
 
                 // SAFETY: signing_key.is_some() checked in the outer condition.
-                let Some(ref sk) = state.signing_key else { unreachable!() };
-                let jwt_key = hyprstream_rpc::node_identity::derive_purpose_key(sk, "hyprstream-jwt-v1");
+                let Some(ref sk) = state.signing_key else {
+                    unreachable!()
+                };
+                let jwt_key =
+                    hyprstream_rpc::node_identity::derive_purpose_key(sk, "hyprstream-jwt-v1");
                 let id_token_jwt = hyprstream_rpc::auth::jwt::encode_id_token(&id_claims, &jwt_key);
                 Some(id_token_jwt)
             } else {
@@ -1154,11 +1405,7 @@ async fn issue_token_with_refresh(
         }
         Err(e) => {
             tracing::error!(client_id = %client_id, error = %e, "Token issuance failed");
-            token_error(
-                StatusCode::INTERNAL_SERVER_ERROR,
-                "server_error",
-                None,
-            )
+            token_error(StatusCode::INTERNAL_SERVER_ERROR, "server_error", None)
         }
     }
 }
@@ -1221,7 +1468,8 @@ fn token_error(status: StatusCode, error: &str, description: Option<&str>) -> Re
             (header::PRAGMA, "no-cache"),
         ],
         Json(token_error_body(error, description)),
-    ).into_response()
+    )
+        .into_response()
 }
 
 /// Pure JSON-body construction for `token_error`. Split out so unit
@@ -1230,7 +1478,10 @@ fn token_error(status: StatusCode, error: &str, description: Option<&str>) -> Re
 /// as `null`).
 fn token_error_body(error: &str, description: Option<&str>) -> serde_json::Value {
     let mut body = serde_json::Map::new();
-    body.insert("error".to_owned(), serde_json::Value::String(error.to_owned()));
+    body.insert(
+        "error".to_owned(),
+        serde_json::Value::String(error.to_owned()),
+    );
     if let Some(d) = description {
         body.insert(
             "error_description".to_owned(),
@@ -1246,10 +1497,34 @@ mod tests {
     use super::*;
 
     #[test]
+    fn hosted_account_tenant_is_zone_bound_into_host_form_did() {
+        let zone = crate::account::AccountZone::new("acct.example.com").unwrap();
+        assert_eq!(
+            hosted_account_tenant_from_did("did:web:alice.acct.example.com", Some(&zone)).unwrap(),
+            "acct.example.com"
+        );
+        for unbound in [
+            "did:plc:abcdefghijklmnqrstuvwx2p",
+            "did:web:example.com:users:alice",
+            "did:web:alice",
+        ] {
+            assert!(hosted_account_tenant_from_did(unbound, Some(&zone)).is_err());
+        }
+        assert!(
+            hosted_account_tenant_from_did("did:web:alice.other.example.com", Some(&zone))
+                .is_err()
+        );
+        assert!(hosted_account_tenant_from_did("did:web:alice.acct.example.com", None).is_err());
+    }
+
+    #[test]
     fn token_error_body_omits_description_when_none() {
         let body = token_error_body("invalid_client", None);
         let obj = body.as_object().unwrap();
-        assert_eq!(obj.get("error").and_then(|v| v.as_str()), Some("invalid_client"));
+        assert_eq!(
+            obj.get("error").and_then(|v| v.as_str()),
+            Some("invalid_client")
+        );
         assert!(
             !obj.contains_key("error_description"),
             "description field MUST be absent when None — leaks happen via null/empty too"
@@ -1261,7 +1536,10 @@ mod tests {
     fn token_error_body_includes_description_when_some() {
         let body = token_error_body("invalid_request", Some("code is required"));
         let obj = body.as_object().unwrap();
-        assert_eq!(obj.get("error_description").and_then(|v| v.as_str()), Some("code is required"));
+        assert_eq!(
+            obj.get("error_description").and_then(|v| v.as_str()),
+            Some("code is required")
+        );
     }
 
     #[test]
@@ -1278,7 +1556,10 @@ mod tests {
         ));
         assert!(!registered_host_dpop_matches(Some(&did), None));
         assert!(!registered_host_dpop_matches(Some(&did), Some("other-key")));
-        assert!(!registered_host_dpop_matches(Some("did:key:zinvalid"), Some(&matching_jkt)));
+        assert!(!registered_host_dpop_matches(
+            Some("did:key:zinvalid"),
+            Some(&matching_jkt)
+        ));
         assert!(registered_host_dpop_matches(None, None));
     }
 
@@ -1333,7 +1614,9 @@ mod tests {
         let resp = use_dpop_nonce_error(&nonce, "DPoP proof must include a server-issued nonce");
         assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
         assert_eq!(
-            resp.headers().get("DPoP-Nonce").and_then(|v| v.to_str().ok()),
+            resp.headers()
+                .get("DPoP-Nonce")
+                .and_then(|v| v.to_str().ok()),
             Some(nonce.as_str()),
             "DPoP-Nonce header MUST carry the fresh nonce for client retry"
         );
@@ -1395,7 +1678,10 @@ mod tests {
             "atproto sub must be did:plc or host-form did:web (no path), got {sub}"
         );
         let scope = json["scope"].as_str().expect("scope required");
-        assert!(scope.split_whitespace().any(|s| s == "atproto"), "scope missing atproto");
+        assert!(
+            scope.split_whitespace().any(|s| s == "atproto"),
+            "scope missing atproto"
+        );
         assert_eq!(json["access_token"].as_str(), Some("access-jwt"));
         assert_eq!(json["refresh_token"].as_str(), Some("rt"));
     }
@@ -1405,14 +1691,7 @@ mod tests {
     /// top-level `sub` — existing principals are byte-for-byte unchanged.
     #[test]
     fn non_atproto_token_response_is_bearer_without_sub() {
-        let json = build_token_response_json(
-            false,
-            "access-jwt",
-            "alice",
-            "read:*:*",
-            3600,
-            "rt",
-        );
+        let json = build_token_response_json(false, "access-jwt", "alice", "read:*:*", 3600, "rt");
         assert_eq!(json["token_type"].as_str(), Some("Bearer"));
         assert!(
             json.get("sub").is_none(),
@@ -1471,7 +1750,12 @@ mod tests {
 
     #[async_trait::async_trait]
     impl crate::services::oauth::token_store::TokenStore for RecordingTokenStore {
-        async fn put(&self, token: &str, entry: &RefreshTokenEntry, _ttl: u64) -> anyhow::Result<()> {
+        async fn put(
+            &self,
+            token: &str,
+            entry: &RefreshTokenEntry,
+            _ttl: u64,
+        ) -> anyhow::Result<()> {
             self.puts.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
             self.inner.lock().insert(token.to_owned(), entry.clone());
             Ok(())
@@ -1516,7 +1800,9 @@ mod tests {
             DiscoveryClient::new(mk_client()),
             [0x76; 32],
         );
-        state.with_token_store_impl(store as Arc<dyn crate::services::oauth::token_store::TokenStore>);
+        state.with_token_store_impl(
+            store as Arc<dyn crate::services::oauth::token_store::TokenStore>,
+        );
         Arc::new(state)
     }
 
@@ -1624,8 +1910,65 @@ mod tests {
             "refresh must not persist a rotated refresh token for a path-form subject",
         );
         assert!(
-            state.get_refresh_token("legacy-refresh").await.unwrap().is_none(),
+            state
+                .get_refresh_token("legacy-refresh")
+                .await
+                .unwrap()
+                .is_none(),
             "the path-form refresh token must be consumed (taken), not left reusable",
+        );
+    }
+
+    #[tokio::test]
+    async fn missing_hosted_binding_does_not_consume_refresh_token() {
+        let store = RecordingTokenStore::new();
+        let state = freeze_test_state(Arc::clone(&store)).await;
+        let entry = RefreshTokenEntry {
+            client_id: "client-1".to_owned(),
+            username: "alice".to_owned(),
+            scopes: vec!["openid".to_owned()],
+            resource: None,
+            expires_at_unix: chrono::Utc::now().timestamp() + 3600,
+            verifying_key_bytes: None,
+            dpop_jkt: None,
+            client_assertion_jkt: None,
+            ucan_grant: None,
+        };
+        state
+            .put_refresh_token("repairable-refresh", &entry, 3600)
+            .await
+            .unwrap();
+
+        let params = TokenRequest {
+            grant_type: "refresh_token".to_owned(),
+            refresh_token: Some("repairable-refresh".to_owned()),
+            client_id: entry.client_id,
+            code: None,
+            redirect_uri: None,
+            code_verifier: None,
+            device_code: None,
+            assertion: None,
+            client_assertion: None,
+            client_assertion_type: None,
+            subject_token: None,
+            subject_token_type: None,
+            requested_token_type: None,
+            actor_token: None,
+            scope: None,
+            audience: None,
+            tenant: None,
+        };
+        let response =
+            exchange_refresh_token(Arc::clone(&state), params, None, None, None).await;
+
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+        assert!(
+            state
+                .get_refresh_token("repairable-refresh")
+                .await
+                .unwrap()
+                .is_some(),
+            "an operator-repairable hosted binding failure must not consume the session"
         );
     }
 
@@ -1679,10 +2022,21 @@ mod tests {
         let body = axum::body::to_bytes(resp.into_body(), 4096).await.unwrap();
         let value: serde_json::Value = serde_json::from_slice(&body).unwrap();
         assert_eq!(value["error"].as_str(), Some("invalid_grant"));
-        assert!(value["error_description"].as_str().unwrap().contains("frozen"));
-        assert_eq!(store.put_count(), 1, "UCAN refresh must not persist a replacement");
+        assert!(value["error_description"]
+            .as_str()
+            .unwrap()
+            .contains("frozen"));
+        assert_eq!(
+            store.put_count(),
+            1,
+            "UCAN refresh must not persist a replacement"
+        );
         assert!(
-            state.get_refresh_token("legacy-ucan-refresh").await.unwrap().is_none(),
+            state
+                .get_refresh_token("legacy-ucan-refresh")
+                .await
+                .unwrap()
+                .is_none(),
             "the legacy UCAN refresh must be consumed, not left reusable",
         );
     }

--- a/crates/hyprstream/src/services/oauth/token_exchange.rs
+++ b/crates/hyprstream/src/services/oauth/token_exchange.rs
@@ -19,9 +19,9 @@ use serde::Deserialize;
 use sha2::{Digest, Sha256};
 
 use super::state::OAuthState;
-use hyprstream_pds::repo_authority::is_path_form_did_web;
 use crate::mac::exchange::{GrantDecision, GrantError, GrantRequest, GrantedAccess};
 use crate::services::generated::policy_client::IssueToken;
+use hyprstream_pds::repo_authority::is_path_form_did_web;
 
 const TOKEN_TYPE_ID_TOKEN: &str = "urn:ietf:params:oauth:token-type:id_token";
 const TOKEN_TYPE_ACCESS_TOKEN: &str = "urn:ietf:params:oauth:token-type:access_token";
@@ -94,11 +94,7 @@ pub async fn exchange_token_exchange(
     let requested_scopes = match attenuate_exchange_scopes(&verified, scope) {
         Ok(scopes) => scopes,
         Err(description) => {
-            return tx_error(
-                StatusCode::BAD_REQUEST,
-                "invalid_scope",
-                description,
-            );
+            return tx_error(StatusCode::BAD_REQUEST, "invalid_scope", description);
         }
     };
 
@@ -117,6 +113,19 @@ pub async fn exchange_token_exchange(
             StatusCode::BAD_REQUEST,
             "invalid_grant",
             "path-form did:web account subjects are frozen; host-form account minting is not available yet (#1159)",
+        );
+    }
+    let subject_identity = crate::server::middleware::AuthenticatedUser {
+        user: verified.sub.clone(),
+        verified_tenant: tenant.clone(),
+        token: None,
+        exp: None,
+    };
+    if subject_identity.authorization_domain().is_err() {
+        return tx_error(
+            StatusCode::UNAUTHORIZED,
+            "invalid_grant",
+            "subject token has no valid verified hosted-account tenant binding",
         );
     }
 
@@ -220,7 +229,10 @@ async fn verify_id_token(state: &Arc<OAuthState>, token: &str) -> Result<Verifie
     }
 
     Ok(VerifiedSubject {
-        sub: claims.sub,
+        sub: hyprstream_rpc::Subject::federated(&iss, &claims.sub)
+            .name()
+            .ok_or_else(|| "id_token subject is empty".to_owned())?
+            .to_owned(),
         cnf_key_bytes: None, // ID tokens carry no key binding
         iat: claims.iat,
         granted_scopes: None,
@@ -289,8 +301,9 @@ async fn verify_jwt(state: &Arc<OAuthState>, token: &str) -> Result<VerifiedSubj
 
     let (claims, service_signing_key) = if sub.starts_with("service:") {
         let svc_name = sub.trim_start_matches("service:");
-        let (claims, vk) = super::jwt_bearer::decode_with_any_local_service_key(token, svc_name, &token_endpoint)
-            .ok_or_else(|| format!("JWT verification failed for service: {svc_name}"))?;
+        let (claims, vk) =
+            super::jwt_bearer::decode_with_any_local_service_key(token, svc_name, &token_endpoint)
+                .ok_or_else(|| format!("JWT verification failed for service: {svc_name}"))?;
         (claims, Some(vk.to_bytes()))
     } else {
         let cfg = state
@@ -306,13 +319,24 @@ async fn verify_jwt(state: &Arc<OAuthState>, token: &str) -> Result<VerifiedSubj
         (claims, None)
     };
 
+    let mut claims = claims;
+    let atproto_issuer = state.atproto_issuer_url();
+    let local_issuers = [atproto_issuer.as_str(), state.issuer_url.as_str()];
+    claims.strip_federated_tenant(&local_issuers);
+    let subject = claims.subject(&local_issuers);
+    subject
+        .validate()
+        .map_err(|error| format!("invalid JWT subject: {error}"))?;
     let cnf_key_bytes = service_signing_key.or_else(|| claims.cnf_key_bytes());
     Ok(VerifiedSubject {
-        sub: claims.sub,
+        sub: subject
+            .name()
+            .ok_or_else(|| "JWT subject is empty".to_owned())?
+            .to_owned(),
         cnf_key_bytes,
         iat: claims.iat,
         granted_scopes: None,
-        verified_tenant: None,
+        verified_tenant: claims.tenant,
         atproto_replay: None,
         require_clearance: false,
         ttl_ceiling: None,
@@ -1038,7 +1062,15 @@ pub async fn exchange_ucan_grant(
     // met context from resolve_grant_subject — its clearance is the
     // authority-assigned label the enrollment table holds for this subject.
     let subject_clearance = subject_ctx.map(|c| *c.clearance());
-    mint_grant_token(state, &granted, &dpop_jkt, Some(grant_refresh), principals, subject_clearance).await
+    mint_grant_token(
+        state,
+        &granted,
+        &dpop_jkt,
+        Some(grant_refresh),
+        principals,
+        subject_clearance,
+    )
+    .await
 }
 
 /// Re-evaluate a UCAN grant on refresh and re-mint (MAC #547 / B1 #673).
@@ -1177,7 +1209,15 @@ pub(crate) async fn exchange_ucan_grant_refresh(
     // #698: same clearance threading as mint — refresh must not be more
     // permissive (B1/#673).
     let subject_clearance = subject_ctx.map(|c| *c.clearance());
-    mint_grant_token(state, &granted, &dpop_jkt, Some(ucan_grant.clone()), principals, subject_clearance).await
+    mint_grant_token(
+        state,
+        &granted,
+        &dpop_jkt,
+        Some(ucan_grant.clone()),
+        principals,
+        subject_clearance,
+    )
+    .await
 }
 
 /// Map an S6 [`GrantError`] to a concrete OAuth 2.1 error response. Every variant
@@ -1205,9 +1245,11 @@ fn grant_error_response(e: GrantError) -> Response {
         // B2 (#674): a would-be Permit that could not be durably audited.
         // Fail-closed, not the client's fault — surfaced as server_error
         // (matches the "audit trail not configured" preflight response).
-        GrantError::AuditUnavailable => {
-            (StatusCode::INTERNAL_SERVER_ERROR, "server_error", e.to_string())
-        }
+        GrantError::AuditUnavailable => (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "server_error",
+            e.to_string(),
+        ),
     };
     tx_error(status, code, &desc)
 }
@@ -1343,16 +1385,18 @@ async fn mint_grant_token(
         Ok(snapshot) => snapshot,
         Err(error) => {
             tracing::error!("composite authority unavailable or stale; refusing to mint: {error}");
-            return tx_error(StatusCode::INTERNAL_SERVER_ERROR, "server_error", "hybrid token authority is not current");
+            return tx_error(
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "server_error",
+                "hybrid token authority is not current",
+            );
         }
     };
     let signing = snapshot
         .active_signing_pair(hyprstream_rpc::auth::CompositePairRole::OAuth)
         .and_then(hyprstream_rpc::auth::CompositeKeyPair::signing_keys);
     let token = match signing {
-        Some((pq, ed)) => crate::auth::jwt::encode_composite_ml_dsa_65_ed25519(
-            &claims, &pq, &ed,
-        ),
+        Some((pq, ed)) => crate::auth::jwt::encode_composite_ml_dsa_65_ed25519(&claims, &pq, &ed),
         None => {
             tracing::error!(
                 "no authorized active OAuth composite pair; refusing to mint (fail-closed)"
@@ -1540,13 +1584,16 @@ mod tests {
 
         let key = ed25519_dalek::SigningKey::from_bytes(&[0x65; 32]);
         let dummy = std::path::PathBuf::from("/dev/null/path-form-mint-test.sock");
-        let mk_client = || Arc::new(
-            RpcClientImpl::new(
-                LocalSigner::new(key.clone()),
-                LazyUdsTransport::new(dummy.clone()),
-                Some(key.verifying_key()),
-            ).with_response_verify_policy(hyprstream_rpc::crypto::CryptoPolicy::Classical),
-        );
+        let mk_client = || {
+            Arc::new(
+                RpcClientImpl::new(
+                    LocalSigner::new(key.clone()),
+                    LazyUdsTransport::new(dummy.clone()),
+                    Some(key.verifying_key()),
+                )
+                .with_response_verify_policy(hyprstream_rpc::crypto::CryptoPolicy::Classical),
+            )
+        };
         Arc::new(OAuthState::new(
             &OAuthConfig::default(),
             PolicyClient::new(mk_client()),
@@ -1574,13 +1621,19 @@ mod tests {
             },
             // No clearance — this test checks the path-form freeze, not MAC.
             None,
-        ).await;
+        )
+        .await;
 
         assert_eq!(response.status(), StatusCode::BAD_REQUEST);
-        let body = axum::body::to_bytes(response.into_body(), 4096).await.unwrap();
+        let body = axum::body::to_bytes(response.into_body(), 4096)
+            .await
+            .unwrap();
         let value: serde_json::Value = serde_json::from_slice(&body).unwrap();
         assert_eq!(value["error"].as_str(), Some("invalid_grant"));
-        assert!(value["error_description"].as_str().unwrap().contains("frozen"));
+        assert!(value["error_description"]
+            .as_str()
+            .unwrap()
+            .contains("frozen"));
         assert!(value.get("access_token").is_none());
         assert!(value.get("refresh_token").is_none());
     }
@@ -1689,18 +1742,13 @@ mod tests {
     // infrastructure (which is orthogonal — the Claims construction is what
     // carries the clearance, and it happens before signing).
 
-    use crate::mac::{
-        CompiledPolicy, EnrollmentSubjectContextResolver, TeMatrix,
-    };
+    use crate::mac::{CompiledPolicy, EnrollmentSubjectContextResolver, TeMatrix};
     use hyprstream_rpc::auth::mac::{Lattice as LatticeType, LatticeVersion};
     use std::collections::BTreeMap;
     use std::sync::Arc;
 
     /// Build a compiled policy with one enrolled DID at the given clearance.
-    fn policy_with_enrollment(
-        did: &str,
-        clearance: SecurityLabel,
-    ) -> Arc<CompiledPolicy> {
+    fn policy_with_enrollment(did: &str, clearance: SecurityLabel) -> Arc<CompiledPolicy> {
         let lattice = LatticeType::new(LatticeVersion(1), []);
         let policy = CompiledPolicy::new(TeMatrix::default(), &lattice)
             .with_enrollment(BTreeMap::from([(did.to_owned(), clearance)]));
@@ -1716,8 +1764,7 @@ mod tests {
     #[test]
     fn issuer_path_stamps_clearance_readable_by_pep_resolver() {
         let did = "did:key:z6MkpTHR8VNsBxYAAHWutMGeQ4hz2FV6B14xd9CZpkmS5i5o";
-        let enrolled =
-            SecurityLabel::new(Level::Secret, Assurance::PqHybrid, comps(&[0, 1]));
+        let enrolled = SecurityLabel::new(Level::Secret, Assurance::PqHybrid, comps(&[0, 1]));
 
         // Step 1: enrollment resolver derives the clearance (what the grant
         // path does via `exchange_enrollment_resolver()`).
@@ -1801,8 +1848,10 @@ mod tests {
             SecurityLabel::new(Level::Confidential, Assurance::Classical, comps(&[1]));
 
         // Both enrolled in their own resolver (simulating two enrollment entries).
-        let user_ctx = SecurityContext::from_clearance(user_clearance, VerifiedKeyMaterial::Classical);
-        let mcp_ctx = SecurityContext::from_clearance(mcp_clearance, VerifiedKeyMaterial::Classical);
+        let user_ctx =
+            SecurityContext::from_clearance(user_clearance, VerifiedKeyMaterial::Classical);
+        let mcp_ctx =
+            SecurityContext::from_clearance(mcp_clearance, VerifiedKeyMaterial::Classical);
         let met = SecurityContext::delegated(Some(&user_ctx), Some(&mcp_ctx))
             .expect("both principals resolved");
 
@@ -1820,7 +1869,11 @@ mod tests {
             .expect("met clearance resolves");
 
         // It's the meet (Confidential / {1}), NOT the delegator's Secret / {0,1}.
-        assert_eq!(pep_ctx.level(), Level::Confidential, "met level, not delegator's");
+        assert_eq!(
+            pep_ctx.level(),
+            Level::Confidential,
+            "met level, not delegator's"
+        );
         assert_eq!(
             pep_ctx.compartments(),
             comps(&[1]),
@@ -1875,7 +1928,10 @@ mod tests {
         let back: super::super::state::RefreshTokenEntry = serde_json::from_str(&json).unwrap();
         let ug = back.ucan_grant.expect("ucan_grant survives round-trip");
         assert_eq!(ug.grant_cbor_b64, "Zm9vYmFy");
-        assert_eq!(ug.grant_cid, blake3::hash(b"the-grant").to_hex().to_string());
+        assert_eq!(
+            ug.grant_cid,
+            blake3::hash(b"the-grant").to_hex().to_string()
+        );
         assert_eq!(ug.requested_scope.as_deref(), Some("read:model:llama"));
     }
 
@@ -1979,13 +2035,21 @@ mod tests {
         // meet = min level (Confidential) ∩ compartments ({1}).
         let context = context.expect("both principals resolved ⇒ Some");
         assert_eq!(context.level(), Level::Confidential, "min level");
-        assert_eq!(context.compartments(), comps(&[1]), "compartment intersection");
+        assert_eq!(
+            context.compartments(),
+            comps(&[1]),
+            "compartment intersection"
+        );
         // The audit `on_behalf_of` carries the DELEGATOR (the user's own
         // clearance), distinct from the met `subject` context above — this is
         // the two-principal attribution (#445/#681): the met context is what the
         // gates saw, the delegator is who the actor acted for.
         let obo = on_behalf_of.expect("a delegated grant records its delegator");
-        assert_eq!(obo.level(), Level::Secret, "on_behalf_of is the delegator's own level");
+        assert_eq!(
+            obo.level(),
+            Level::Secret,
+            "on_behalf_of is the delegator's own level"
+        );
         assert_eq!(
             obo.compartments(),
             comps(&[0, 1]),
@@ -2021,7 +2085,10 @@ mod tests {
         assert!(principals.act.is_some());
         // The delegator resolved, so it is still available for audit even though
         // the decision itself fails closed on the unresolved actor.
-        assert!(on_behalf_of.is_some(), "the resolved delegator is still recorded");
+        assert!(
+            on_behalf_of.is_some(),
+            "the resolved delegator is still recorded"
+        );
     }
 
     /// Multi-hop delegation roots the delegator at the CHAIN ROOT issuer, not
@@ -2037,7 +2104,9 @@ mod tests {
         // No clearances resolved — we only assert the principal identities.
         let resolver = MapResolver(HashMap::new());
         let ResolvedGrantSubject {
-            on_behalf_of, principals, ..
+            on_behalf_of,
+            principals,
+            ..
         } = resolve_grant_subject(&leaf, &resolver);
         assert!(
             on_behalf_of.is_none(),

--- a/crates/hyprstream/src/services/oauth/wit_bootstrap.rs
+++ b/crates/hyprstream/src/services/oauth/wit_bootstrap.rs
@@ -102,9 +102,26 @@ pub async fn issue_browser_wit(
     let now = chrono::Utc::now().timestamp();
     let expires_at = now + BROWSER_WIT_TTL;
 
-    let claims = hyprstream_rpc::auth::Claims::new(sub.clone(), now, expires_at)
+    let domain = match user.authorization_domain() {
+        Ok(domain) => domain,
+        Err(_) => {
+            return (
+                StatusCode::FORBIDDEN,
+                [(header::CACHE_CONTROL, "no-store"), (header::PRAGMA, "no-cache")],
+                Json(serde_json::json!({
+                    "error": "insufficient_scope",
+                    "error_description": "Verified hosted-account tenant binding required",
+                })),
+            )
+                .into_response();
+        }
+    };
+    let mut claims = hyprstream_rpc::auth::Claims::new(sub.clone(), now, expires_at)
         .with_issuer(state.issuer_url.clone())
         .with_cnf_jwk(&pubkey_bytes);
+    if domain != "*" {
+        claims = claims.with_tenant(domain);
+    }
 
     let wit = hyprstream_rpc::auth::jwt::encode_service_jwt(&claims, ca_key);
 
@@ -166,6 +183,7 @@ mod tests {
             State(test_state()),
             Extension(AuthenticatedUser {
                 user: "did:web:accounts.example:users:alice".to_owned(),
+                verified_tenant: Some("tenant-a.example".to_owned()),
                 token: None,
                 exp: None,
             }),
@@ -182,6 +200,7 @@ mod tests {
             State(test_state()),
             Extension(AuthenticatedUser {
                 user: "alice".to_owned(),
+                verified_tenant: Some("tenant-a.example".to_owned()),
                 token: None,
                 exp: None,
             }),
@@ -190,5 +209,16 @@ mod tests {
         .await;
 
         assert_eq!(response.status(), StatusCode::OK);
+        let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        let claims = crate::auth::jwt::decode(
+            json["wit"].as_str().unwrap(),
+            &ed25519_dalek::SigningKey::from_bytes(&[0x73; 32]).verifying_key(),
+            None,
+        )
+        .unwrap();
+        assert_eq!(claims.tenant.as_deref(), Some("tenant-a.example"));
     }
 }

--- a/crates/hyprstream/src/services/registry.rs
+++ b/crates/hyprstream/src/services/registry.rs
@@ -1790,6 +1790,7 @@ impl RegistryHandler for RegistryService {
         };
 
         let subject = ctx.subject().to_string();
+        let domain = ctx.domain()?;
         let mut result = Vec::with_capacity(repos.len());
 
         for repo in &repos {
@@ -1799,7 +1800,7 @@ impl RegistryHandler for RegistryService {
             // Policy gate: only include repos the caller has at least query access to
             let resource = format!("model:{}", name);
             let permitted = self.policy_client
-                .check(&PolicyCheck { subject: subject.clone(), domain: "*".to_owned(), resource: resource.clone(), operation: "query".to_owned() })
+                .check(&PolicyCheck { subject: subject.clone(), domain: domain.clone(), resource: resource.clone(), operation: "query".to_owned() })
                 .await
                 .unwrap_or_else(|e| {
                     warn!("Policy check RPC error while filtering {}: {} - denying access", resource, e);

--- a/crates/hyprstream/src/services/xet.rs
+++ b/crates/hyprstream/src/services/xet.rs
@@ -45,17 +45,17 @@
 use crate::config::{TlsConfig, XetConfig};
 use crate::server::state::ResourceAuthState;
 use crate::server::tls::{resolve_rustls_config, serve_app};
-use crate::server::{AuthenticatedUser, middleware as server_middleware};
+use crate::server::{middleware as server_middleware, AuthenticatedUser};
 use crate::services::RegistryClient;
 use crate::storage::cas::{CasMount, CasMountAuthorizer, CasSubstrate, DedupDomain};
 use anyhow::Result;
 use axum::{
-    Json, Router,
     extract::{Path, State},
-    http::{HeaderMap, StatusCode, header},
+    http::{header, HeaderMap, StatusCode},
     middleware,
     response::{IntoResponse, Response},
     routing::{get, post},
+    Json, Router,
 };
 use hyprstream_rpc::prelude::*;
 use hyprstream_rpc::registry::SocketKind;
@@ -185,12 +185,17 @@ async fn get_xorb_handler(
     headers: HeaderMap,
     axum::extract::Extension(user): axum::extract::Extension<AuthenticatedUser>,
 ) -> Response {
+    let domain = match user.authorization_domain() {
+        Ok(domain) if domain != "*" => domain,
+        _ => return (StatusCode::FORBIDDEN, "tenant binding required").into_response(),
+    };
     let subject = Subject::new(user.user);
     let mount = CasMount::with_shared_authorizer(
         state.store.clone(),
         DedupDomain::local_default(),
         Arc::clone(&state.cas_authorizer),
-    );
+    )
+    .with_verified_tenant(domain);
     let mut fid = match mount.walk(&["xorb", hash.as_str()], &subject).await {
         Ok(fid) => fid,
         Err(e) => return mount_error_response(e, "get_xorb: mount walk failed"),
@@ -480,6 +485,7 @@ mod tests {
             let now = chrono::Utc::now().timestamp();
             let mut claims = crate::auth::jwt::Claims::new("alice".to_owned(), now, now + 3600)
                 .with_issuer(ISSUER.to_owned())
+                .with_tenant("tenant-a.example".to_owned())
                 .with_audience(Some(audience.to_owned()));
             claims.jti = Some(jti.to_owned());
             crate::auth::jwt::encode_composite_ml_dsa_65_ed25519(
@@ -575,6 +581,7 @@ mod tests {
             HeaderMap::new(),
             axum::extract::Extension(AuthenticatedUser {
                 user: "alice".to_owned(),
+                verified_tenant: Some("tenant-a.example".to_owned()),
                 token: None,
                 exp: None,
             }),
@@ -602,6 +609,7 @@ mod tests {
             headers,
             axum::extract::Extension(AuthenticatedUser {
                 user: "alice".to_owned(),
+                verified_tenant: Some("tenant-a.example".to_owned()),
                 token: None,
                 exp: None,
             }),

--- a/crates/hyprstream/src/storage/cas/mount.rs
+++ b/crates/hyprstream/src/storage/cas/mount.rs
@@ -33,14 +33,14 @@
 //! transient only and is never admitted to the CAS.
 
 use std::collections::HashMap;
+use std::sync::atomic::{AtomicU64, AtomicU8, Ordering};
 use std::sync::Arc;
-use std::sync::atomic::{AtomicU8, AtomicU64, Ordering};
 
 use async_trait::async_trait;
 use cas_serve::StoreError;
-use hyprstream_rpc::Subject;
 use hyprstream_rpc::auth::mac::{Assurance, CompartmentSet, Lattice, Level, SecurityLabel};
-use hyprstream_vfs::{DirEntry, Fid, Mount, MountError, ORDWR, OREAD, OTRUNC, OWRITE, Stat};
+use hyprstream_rpc::Subject;
+use hyprstream_vfs::{DirEntry, Fid, Mount, MountError, Stat, ORDWR, OREAD, OTRUNC, OWRITE};
 use parking_lot::Mutex;
 use tokio::sync::Notify;
 use tracing::{debug, warn};
@@ -78,6 +78,10 @@ pub struct CasMountAuthzRequest<'a> {
     pub address: &'a str,
     /// Dedup domain the mount is serving.
     pub domain: &'a DedupDomain,
+    /// Authority-verified hosted-account tenant for the caller, when the
+    /// transport has one. This is transport context, never an object/path
+    /// field supplied by the caller.
+    pub verified_tenant: Option<&'a str>,
     /// Operation name for policy/audit (e.g. `open`, `read`, `stat`,
     /// `stage:create`, `stage:label`, `stage:commit`).
     pub operation: &'static str,
@@ -615,6 +619,7 @@ fn owner_key(owner: &Subject) -> String {
 pub struct CasMount {
     substrate: CasSubstrate,
     domain: DedupDomain,
+    verified_tenant: Option<String>,
     authorizer: Arc<dyn CasMountAuthorizer>,
     staging: Arc<StagingRegistry>,
     staging_cfg: StagingConfig,
@@ -661,6 +666,7 @@ impl CasMount {
         Self {
             substrate,
             domain,
+            verified_tenant: None,
             authorizer,
             staging: Arc::new(StagingRegistry::new()),
             staging_cfg: StagingConfig::default(),
@@ -680,10 +686,20 @@ impl CasMount {
         Self {
             substrate,
             domain,
+            verified_tenant: None,
             authorizer: Arc::new(authorizer),
             staging: Arc::new(StagingRegistry::new()),
             staging_cfg,
         }
+    }
+
+    /// Bind this request-scoped mount to a transport-verified tenant.
+    ///
+    /// Only HTTP/RPC authentication adapters should call this. The value is
+    /// passed to the MAC clearance source and is not used for object routing.
+    pub(crate) fn with_verified_tenant(mut self, verified_tenant: String) -> Self {
+        self.verified_tenant = Some(verified_tenant);
+        self
     }
 
     fn authorize(
@@ -699,6 +715,7 @@ impl CasMount {
                 kind,
                 address,
                 domain: &self.domain,
+                verified_tenant: self.verified_tenant.as_deref(),
                 operation,
                 requested_label: None,
             },
@@ -717,6 +734,7 @@ impl CasMount {
                 kind: CasMountObjectKind::Stage,
                 address,
                 domain: &self.domain,
+                verified_tenant: self.verified_tenant.as_deref(),
                 operation: "stage:label",
                 requested_label: Some(requested_label),
             },
@@ -833,10 +851,7 @@ impl CasMount {
                 return Err(MountError::PermissionDenied(msg));
             }
         };
-        let put_result = self
-            .substrate
-            .put(&self.domain, &bytes, Some(joined))
-            .await;
+        let put_result = self.substrate.put(&self.domain, &bytes, Some(joined)).await;
 
         match put_result {
             Ok(manifest) => {
@@ -1744,6 +1759,7 @@ mod tests {
             kind: CasMountObjectKind::Xorb,
             address: "aa00",
             domain: &domain,
+            verified_tenant: None,
             operation: "read",
             requested_label: None,
         };
@@ -1775,6 +1791,7 @@ mod tests {
             kind: CasMountObjectKind::Stage,
             address: "1",
             domain: &domain,
+            verified_tenant: None,
             operation: "stage:label",
             requested_label: Some(&requested_label),
         };
@@ -2152,11 +2169,9 @@ mod tests {
             .await
             .unwrap_err();
         assert!(matches!(err, MountError::PermissionDenied(_)));
-        assert!(
-            ctl_str(&mount, &ctl, &caller)
-                .await
-                .contains("state=staging")
-        );
+        assert!(ctl_str(&mount, &ctl, &caller)
+            .await
+            .contains("state=staging"));
 
         declare_test_label(&mount, &ctl, &caller).await;
         mount.write(&ctl, 0, b"commit\n", &caller).await.unwrap();


### PR DESCRIPTION
## Summary

- Enforces the verified tenant as the Casbin domain on the OAI, models, Xet/CAS, MCP, Flight, and protected OAuth HTTP faces.
- Derives user tenants from the authority-controlled signed hosted-account binding for the user's `did:web` identity, with an authority-only SCIM provisioning seam and exact deployment-zone validation.
- Preserves the global domain only for tenantless local `service:*` authorities; federated tenant and forged federated service assertions fail closed.
- Propagates the binding into WIT/mount credentials, same-tenant introspection, MCP tool policy checks, Flight authorization, and MAC-enforcing CAS clearance checks.
- Keeps Xet/CAS MAC enforcing: missing tenant/clearance denies; there is no permissive fallback.

## Security notes

- Cross-tenant replay and subject/tenant confusion have regression coverage.
- Normal refresh tokens are not consumed when a hosted binding is temporarily unavailable.
- SPIFFE JWT-SVID minting is bound to the authenticated service's own name.
- Kimi K3 reviewed the rebased 28-file logic patch and returned **PASS** with no blocking/high/medium findings.

## Validation

- `cargo metadata --all-features --format-version 1` — passed
- Repository pre-commit release Clippy hook — passed
- `buildq -- cargo nextest run --release --profile ci -p hyprstream -p hyprstream-rpc --no-fail-fast` — **2288 passed, 0 failed, 9 skipped**

Closes #1204
Refs #1156
