### PR TITLE
Network-addressable tenant-bound inference + native arm64 CPU image

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -58,6 +58,12 @@ jobs:
         password: ${{ secrets.DOCKER_PASSWORD }}
     - name: Checkout repository
       uses: actions/checkout@v4
+      with:
+        # workflow_run sets GITHUB_SHA to the current default-branch tip, which
+        # may be newer than the commit that passed Rust. Build the exact tested
+        # commit; tag pushes fall back to the tagged SHA.
+        ref: ${{ github.event.workflow_run.head_sha || github.sha }}
+        persist-credentials: false
 
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v3
@@ -85,6 +91,12 @@ jobs:
           type=semver,pattern={{major}}.{{minor}},suffix=-${{ matrix.tag_suffix }}
           # Latest tag for main branch
           type=raw,value=latest,enable={{is_default_branch}},suffix=-${{ matrix.tag_suffix }}
+          # Architecture-specific CPU staging tags. The manifest job below
+          # combines these with the native arm64 image under the normal CPU tag.
+          type=semver,pattern={{version}},suffix=-cpu-amd64,enable=${{ matrix.variant == 'cpu' }}
+          type=semver,pattern={{major}}.{{minor}},suffix=-cpu-amd64,enable=${{ matrix.variant == 'cpu' }}
+          type=raw,value=edge,suffix=-cpu-amd64,enable=${{ matrix.variant == 'cpu' && github.event_name == 'workflow_run' }}
+          type=raw,value=latest,suffix=-cpu-amd64,enable=${{ matrix.variant == 'cpu' && github.event_name == 'workflow_run' }}
 
     - name: Build and push Docker image
       uses: docker/build-push-action@v6
@@ -174,6 +186,11 @@ jobs:
     permissions:
       contents: read
       packages: write
+    env:
+      # The golden AMI root filesystem is only 29 GB. Put all image layers and
+      # BuildKit cache mounts on the dedicated 196 GB CI-cache volume instead.
+      PODMAN_ROOT: /mnt/hypr-ci-cache/podman-image-${{ github.run_id }}-${{ github.run_attempt }}
+      PODMAN_RUNROOT: /mnt/hypr-ci-cache/podman-run-${{ github.run_id }}-${{ github.run_attempt }}
     # Two concurrence regimes:
     #  - main (workflow_run) builds contend only on the moving edge/latest
     #    tags, so they share ONE per-branch group and the superseded run is
@@ -234,6 +251,7 @@ jobs:
         TAGS: ${{ steps.meta.outputs.tags }}
       run: |
         set -euo pipefail
+        mkdir -p "$PODMAN_ROOT" "$PODMAN_RUNROOT"
         # Turn the newline-separated tag list into repeated `-t` args.
         tag_args=()
         while IFS= read -r t; do
@@ -247,7 +265,7 @@ jobs:
         echo '```' >> "$GITHUB_STEP_SUMMARY"
         printf '  %s\n' "${tag_args[@]}" >> "$GITHUB_STEP_SUMMARY"
         echo '```' >> "$GITHUB_STEP_SUMMARY"
-        podman build \
+        podman --root "$PODMAN_ROOT" --runroot "$PODMAN_RUNROOT" build \
           --target runtime \
           --build-arg VARIANT=cpu-arm64 \
           "${tag_args[@]}" \
@@ -261,14 +279,67 @@ jobs:
       run: |
         set -euo pipefail
         while IFS= read -r t; do
-          [ -n "$t" ] && podman push "$t"
+          [ -n "$t" ] && podman --root "$PODMAN_ROOT" --runroot "$PODMAN_RUNROOT" push "$t"
         done <<< "$TAGS"
 
     - name: Clean up disk space after build
       if: always()
       run: |
         echo "=== Cleaning up after arm64 CPU build ==="
-        podman system prune -af || true
+        podman --root "$PODMAN_ROOT" --runroot "$PODMAN_RUNROOT" system reset --force || true
         rm -rf ~/.cargo/registry/cache ~/.cargo/git 2>/dev/null || true
         echo "=== Disk usage after cleanup ==="
         df -h
+
+  # Publish the normal CPU contract as an OCI index only after both native
+  # builds succeeded. The Graviton target can keep pulling `latest-cpu`; GHCR
+  # selects linux/arm64 while existing x86 hosts receive linux/amd64.
+  publish-cpu-manifest:
+    if: >-
+      github.event_name == 'push' ||
+      (
+        github.event.workflow_run.event == 'push' &&
+        github.event.workflow_run.head_repository.full_name == github.repository &&
+        github.event.workflow_run.conclusion == 'success'
+      )
+    needs: [build-docker, build-docker-arm64]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v3
+
+    - name: Log in to Container Registry
+      env:
+        REGISTRY_USER: ${{ github.actor }}
+        REGISTRY_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        echo "$REGISTRY_TOKEN" | docker login ghcr.io -u "$REGISTRY_USER" --password-stdin
+
+    - name: Extract CPU manifest tags
+      id: meta
+      uses: docker/metadata-action@v5
+      with:
+        images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+        tags: |
+          type=semver,pattern={{version}},suffix=-cpu
+          type=semver,pattern={{major}}.{{minor}},suffix=-cpu
+          type=raw,value=edge,suffix=-cpu,enable=${{ github.event_name == 'workflow_run' }}
+          type=raw,value=latest,suffix=-cpu,enable=${{ github.event_name == 'workflow_run' }}
+
+    - name: Publish multi-arch CPU manifests
+      env:
+        TAGS: ${{ steps.meta.outputs.tags }}
+      run: |
+        set -euo pipefail
+        while IFS= read -r tag; do
+          [ -n "$tag" ] || continue
+          docker buildx imagetools create \
+            --tag "$tag" \
+            "${tag}-amd64" \
+            "${tag}-arm64"
+          docker buildx imagetools inspect "$tag"
+        done <<< "$TAGS"

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -14,12 +14,23 @@ env:
   REGISTRY: ghcr.io
   IMAGE_NAME: hyprstream/hyprstream
 
+# Keep moving main tags ordered as a unit across the amd64 build, arm64 build,
+# and final manifest publication. Release tags are never cancelled mid-push.
+concurrency:
+  group: docker-publish-${{ github.event_name == 'workflow_run' && 'main' || 'release' }}
+  cancel-in-progress: ${{ github.event_name == 'workflow_run' }}
+
 jobs:
   build-docker:
-    # Only run if: tag push OR Rust workflow succeeded
+    # workflow_run carries write-capable credentials, so accept successful
+    # same-repository push runs only. A fork branch named main must not publish.
     if: >-
       github.event_name == 'push' ||
-      github.event.workflow_run.conclusion == 'success'
+      (
+        github.event.workflow_run.event == 'push' &&
+        github.event.workflow_run.head_repository.full_name == github.repository &&
+        github.event.workflow_run.conclusion == 'success'
+      )
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -83,16 +94,17 @@ jobs:
         images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
         tags: |
           # PR builds - tagged as pr-{number}
-          type=ref,event=pr,suffix=-${{ matrix.tag_suffix }},prefix=pr-
+          type=ref,event=pr,suffix=-${{ matrix.tag_suffix }},prefix=pr-,enable=${{ matrix.variant != 'cpu' }}
           # Branch builds (excluding main) - tagged as {branch}
-          type=ref,event=branch,suffix=-${{ matrix.tag_suffix }},enable=${{ github.ref_name != 'main' }}
+          type=ref,event=branch,suffix=-${{ matrix.tag_suffix }},enable=${{ matrix.variant != 'cpu' && github.ref_name != 'main' }}
           # Tag builds (releases) - semantic versioning
-          type=semver,pattern={{version}},suffix=-${{ matrix.tag_suffix }}
-          type=semver,pattern={{major}}.{{minor}},suffix=-${{ matrix.tag_suffix }}
+          type=semver,pattern={{version}},suffix=-${{ matrix.tag_suffix }},enable=${{ matrix.variant != 'cpu' }}
+          type=semver,pattern={{major}}.{{minor}},suffix=-${{ matrix.tag_suffix }},enable=${{ matrix.variant != 'cpu' }}
           # Latest tag for main branch
-          type=raw,value=latest,enable={{is_default_branch}},suffix=-${{ matrix.tag_suffix }}
+          type=raw,value=latest,enable=${{ matrix.variant != 'cpu' && github.event_name == 'workflow_run' }},suffix=-${{ matrix.tag_suffix }}
           # Architecture-specific CPU staging tags. The manifest job below
-          # combines these with the native arm64 image under the normal CPU tag.
+          # is the sole writer of canonical CPU tags, and combines these with
+          # the native arm64 image only after both architecture builds pass.
           type=semver,pattern={{version}},suffix=-cpu-amd64,enable=${{ matrix.variant == 'cpu' }}
           type=semver,pattern={{major}}.{{minor}},suffix=-cpu-amd64,enable=${{ matrix.variant == 'cpu' }}
           type=raw,value=edge,suffix=-cpu-amd64,enable=${{ matrix.variant == 'cpu' && github.event_name == 'workflow_run' }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -280,7 +280,10 @@ ENV LD_LIBRARY_PATH=/opt/libtorch/lib
 RUN --mount=type=cache,target=/root/.cargo/registry \
     --mount=type=cache,target=/root/.cargo/git \
     --mount=type=cache,target=/sccache \
-    OPENSSL_NO_VENDOR=1 cargo build --locked --release --no-default-features --features otel,gittorrent,xet
+    --mount=type=cache,target=/build/target,sharing=locked \
+    OPENSSL_NO_VENDOR=1 cargo build --locked --release --no-default-features --features otel,gittorrent,xet \
+    && mkdir -p /out \
+    && cp /build/target/release/hyprstream /out/hyprstream
 
 #############################################
 # Runtime Stage Selection (Distroless)
@@ -383,8 +386,10 @@ COPY --from=builder /opt/libtorch/lib/ /opt/libtorch/lib/
 
 FROM runtime-${VARIANT} AS runtime
 
-# Copy binary from builder
-COPY --from=builder /build/target/release/hyprstream /hyprstream
+# Copy only the final binary out of the builder. Cargo's target directory is a
+# cache mount, so tens of gigabytes of intermediate objects never enter an OCI
+# layer (critical on the Graviton publisher's small root filesystem).
+COPY --from=builder /out/hyprstream /hyprstream
 
 # Set library paths
 ENV LD_LIBRARY_PATH=/opt/libtorch/lib:/usr/local/cuda/lib64

--- a/crates/hyprstream-discovery/src/service.rs
+++ b/crates/hyprstream-discovery/src/service.rs
@@ -2416,6 +2416,36 @@ impl RpcClient for ProductionRpcClient {
             .await?
             .0)
     }
+    async fn call_with_options_for_service_with_method(
+        &self,
+        service: &str,
+        method_discriminator: u16,
+        payload: Vec<u8>,
+        options: CallOptions,
+    ) -> Result<Vec<u8>> {
+        anyhow::ensure!(
+            service == self.service_name,
+            "generated service authority mismatch"
+        );
+        let service = service.to_owned();
+        Ok(self
+            .attempt(|c| {
+                let p = payload.clone();
+                let o = options.clone();
+                let s = service.clone();
+                async move {
+                    c.call_with_options_for_service_with_method(
+                        &s,
+                        method_discriminator,
+                        p,
+                        o,
+                    )
+                    .await
+                }
+            })
+            .await?
+            .0)
+    }
     async fn call_streaming(&self, payload: Vec<u8>, ephemeral: [u8; 32]) -> Result<Vec<u8>> {
         Ok(self
             .attempt(|c| {
@@ -2445,6 +2475,31 @@ impl RpcClient for ProductionRpcClient {
             .await?
             .0)
     }
+    async fn call_streaming_with_options_for_service(
+        &self,
+        service: &str,
+        payload: Vec<u8>,
+        ephemeral: [u8; 32],
+        options: CallOptions,
+    ) -> Result<Vec<u8>> {
+        anyhow::ensure!(
+            service == self.service_name,
+            "generated service authority mismatch"
+        );
+        let service = service.to_owned();
+        Ok(self
+            .attempt(|c| {
+                let p = payload.clone();
+                let o = options.clone();
+                let s = service.clone();
+                async move {
+                    c.call_streaming_with_options_for_service(&s, p, ephemeral, o)
+                        .await
+                }
+            })
+            .await?
+            .0)
+    }
     async fn call_streaming_for_service_with_method(
         &self,
         service: &str,
@@ -2464,6 +2519,38 @@ impl RpcClient for ProductionRpcClient {
                 async move {
                     c.call_streaming_for_service_with_method(&s, method_discriminator, p, ephemeral)
                         .await
+                }
+            })
+            .await?
+            .0)
+    }
+    async fn call_streaming_with_options_for_service_with_method(
+        &self,
+        service: &str,
+        method_discriminator: u16,
+        payload: Vec<u8>,
+        ephemeral: [u8; 32],
+        options: CallOptions,
+    ) -> Result<Vec<u8>> {
+        anyhow::ensure!(
+            service == self.service_name,
+            "generated service authority mismatch"
+        );
+        let service = service.to_owned();
+        Ok(self
+            .attempt(|c| {
+                let p = payload.clone();
+                let o = options.clone();
+                let s = service.clone();
+                async move {
+                    c.call_streaming_with_options_for_service_with_method(
+                        &s,
+                        method_discriminator,
+                        p,
+                        ephemeral,
+                        o,
+                    )
+                    .await
                 }
             })
             .await?

--- a/crates/hyprstream-rpc-derive/src/codegen/client.rs
+++ b/crates/hyprstream-rpc-derive/src/codegen/client.rs
@@ -897,7 +897,7 @@ pub fn generate_client(
         .map(|sc| sc.factory_name.as_str())
         .collect();
 
-    // Request methods (portable — uses self.client.call(), not CallOptions)
+    // Request methods (portable, carrying immutable per-client call options).
     let request_methods: Vec<TokenStream> = resolved
         .raw
         .request_variants
@@ -941,6 +941,7 @@ pub fn generate_client(
         #[derive(Clone)]
         pub struct #client_name {
             client: std::sync::Arc<dyn hyprstream_rpc::RpcClient>,
+            call_options: hyprstream_rpc::CallOptions,
         }
 
         impl #client_name {
@@ -949,7 +950,12 @@ pub fn generate_client(
 
             /// Create from any RpcClient implementation.
             pub fn new(client: std::sync::Arc<dyn hyprstream_rpc::RpcClient>) -> Self {
-                Self { client }
+                Self { client, call_options: hyprstream_rpc::CallOptions::default() }
+            }
+            #[must_use]
+            pub fn with_delegated_bearer(mut self, token: impl Into<String>) -> Self {
+                self.call_options.delegated_bearer = Some(token.into());
+                self
             }
 
             /// Get the next request ID.
@@ -963,12 +969,18 @@ pub fn generate_client(
             /// context without mutating the shared client. Safe for use with
             /// connection pooling.
             pub fn request(&self) -> hyprstream_rpc::RequestBuilder<'_> {
-                hyprstream_rpc::RequestBuilder::for_service(&self.client, Self::SERVICE_NAME)
+                let builder =
+                    hyprstream_rpc::RequestBuilder::for_service(&self.client, Self::SERVICE_NAME);
+                match &self.call_options.delegated_bearer {
+                    Some(token) => builder.delegated_bearer(token.clone()),
+                    None => builder,
+                }
             }
 
             /// Send a raw request and return the raw response bytes.
             pub async fn call(&self, payload: Vec<u8>) -> anyhow::Result<Vec<u8>> {
-                self.client.call_for_service(Self::SERVICE_NAME, payload).await
+                self.client.call_with_options_for_service(
+                    Self::SERVICE_NAME, payload, self.call_options.clone()).await
             }
 
             /// Send a generated request with its canonical schema method id.
@@ -978,13 +990,17 @@ pub fn generate_client(
                 payload: Vec<u8>,
             ) -> anyhow::Result<Vec<u8>> {
                 self.client
-                    .call_for_service_with_method(Self::SERVICE_NAME, method_discriminator, payload)
+                    .call_with_options_for_service_with_method(
+                        Self::SERVICE_NAME, method_discriminator, payload,
+                        self.call_options.clone())
                     .await
             }
 
             /// Send a streaming request with ephemeral DH pubkey.
             pub async fn call_streaming(&self, payload: Vec<u8>, ephemeral_pubkey: [u8; 32]) -> anyhow::Result<Vec<u8>> {
-                self.client.call_streaming_for_service(Self::SERVICE_NAME, payload, ephemeral_pubkey).await
+                self.client.call_streaming_with_options_for_service(
+                    Self::SERVICE_NAME, payload, ephemeral_pubkey,
+                    self.call_options.clone()).await
             }
 
             /// Send a generated streaming request with its schema method id.
@@ -995,11 +1011,12 @@ pub fn generate_client(
                 ephemeral_pubkey: [u8; 32],
             ) -> anyhow::Result<Vec<u8>> {
                 self.client
-                    .call_streaming_for_service_with_method(
+                    .call_streaming_with_options_for_service_with_method(
                         Self::SERVICE_NAME,
                         method_discriminator,
                         payload,
-                        ephemeral_pubkey,).await
+                        ephemeral_pubkey,
+                        self.call_options.clone(),).await
             }
 
             #(#request_methods)*
@@ -1743,6 +1760,7 @@ fn generate_portable_scoped_factory_method(sc: &ScopedClient) -> TokenStream {
         pub fn #method_name(&self #(, #params)*) -> #client_name_ident {
             #client_name_ident {
                 client: std::sync::Arc::clone(&self.client),
+                call_options: self.call_options.clone(),
                 #(#field_inits,)*
             }
         }

--- a/crates/hyprstream-rpc-derive/src/codegen/scoped.rs
+++ b/crates/hyprstream-rpc-derive/src/codegen/scoped.rs
@@ -343,6 +343,7 @@ fn generate_portable_scoped_client_recursive(
         #[derive(Clone)]
         pub struct #client_name {
             client: std::sync::Arc<dyn hyprstream_rpc::RpcClient>,
+            call_options: hyprstream_rpc::CallOptions,
             #(#all_scope_field_defs,)*
         }
 
@@ -354,7 +355,8 @@ fn generate_portable_scoped_client_recursive(
 
             /// Send a raw request and return the raw response bytes.
             pub async fn call(&self, payload: Vec<u8>) -> anyhow::Result<Vec<u8>> {
-                self.client.call_for_service(#service_name, payload).await
+                self.client.call_with_options_for_service(
+                    #service_name, payload, self.call_options.clone()).await
             }
 
             /// Send a generated request with its canonical root method id.
@@ -364,14 +366,18 @@ fn generate_portable_scoped_client_recursive(
                 payload: Vec<u8>,
             ) -> anyhow::Result<Vec<u8>> {
                 self.client
-                    .call_for_service_with_method(#service_name, method_discriminator, payload)
+                    .call_with_options_for_service_with_method(
+                        #service_name, method_discriminator, payload,
+                        self.call_options.clone())
                     .await
             }
 
             /// Send a streaming request with ephemeral DH pubkey.
             pub async fn call_streaming(&self, payload: Vec<u8>, ephemeral_pubkey: [u8; 32]) -> anyhow::Result<Vec<u8>> {
                 self.client
-                    .call_streaming_for_service(#service_name, payload, ephemeral_pubkey)
+                    .call_streaming_with_options_for_service(
+                        #service_name, payload, ephemeral_pubkey,
+                        self.call_options.clone())
                     .await
             }
 
@@ -383,11 +389,12 @@ fn generate_portable_scoped_client_recursive(
                 ephemeral_pubkey: [u8; 32],
             ) -> anyhow::Result<Vec<u8>> {
                 self.client
-                    .call_streaming_for_service_with_method(
+                    .call_streaming_with_options_for_service_with_method(
                         #service_name,
                         method_discriminator,
                         payload,
                         ephemeral_pubkey,
+                        self.call_options.clone(),
                     )
                     .await
             }
@@ -447,6 +454,7 @@ fn generate_portable_nested_factory_method(
         pub fn #method_name(&self #(, #params)*) -> #client_name_ident {
             #client_name_ident {
                 client: std::sync::Arc::clone(&self.client),
+                call_options: self.call_options.clone(),
                 #(#all_parent_field_inits,)*
                 #(#own_field_inits,)*
             }

--- a/crates/hyprstream-rpc-std/schema/model.capnp
+++ b/crates/hyprstream-rpc-std/schema/model.capnp
@@ -276,9 +276,10 @@ struct UnloadModelRequest {
 # (#320): the typed `TransportConfig` union resolved via the Resolver, replacing
 # the old local-only `endpoint :Text`. Only network-routable arms (Iroh; Quic)
 # are carried — a co-located caller (same process as ModelService) ignores it and
-# uses the in-process dial registry fast path, so an EMPTY list means
-# "co-located only, no remote reach published". The router single-selects ONE
-# reach per request (List is the seam for future replica balancing).
+# uses the in-process dial registry fast path. An EMPTY list means either the
+# accepted load is still pending network readiness or the service is deliberately
+# co-located-only. A loaded network service publishes non-empty reach. The router
+# single-selects ONE reach per request (List is the seam for future balancing).
 struct LoadedModelResponse {
   modelRef @0 :Text;
   reach @1 :List(TransportConfig);
@@ -306,7 +307,7 @@ struct GenerationDefaults {
 struct ModelStatusEntry {
   modelRef   @0 :Text;
   status     @1 :Text;    # "loaded" | "loading"
-  reach      @2 :List(TransportConfig);  # network reach (#320); empty if loading or co-located-only
+  reach      @2 :List(TransportConfig);  # network reach (#320); empty while loading or if co-located-only
   loadedAt   @3 :Int64;   # ms elapsed since load (0 if loading)
   lastUsed   @4 :Int64;   # ms elapsed since last use (0 if loading)
   onlineTrainingConfig @5 :OnlineTrainingConfig;
@@ -331,7 +332,7 @@ struct ModelStatusResponse {
   loaded @0 :Bool;
   memoryBytes @1 :UInt64;
   sessionCount @2 :UInt32;
-  reach @3 :List(TransportConfig);  # network reach (#320); empty if co-located-only / not loaded
+  reach @3 :List(TransportConfig);  # network reach (#320); empty while loading, co-located-only, or not loaded
 
   # Online training configuration (if model loaded)
   onlineTrainingConfig @4 :OnlineTrainingConfig;

--- a/crates/hyprstream-rpc/src/rpc_client.rs
+++ b/crates/hyprstream-rpc/src/rpc_client.rs
@@ -106,9 +106,8 @@ impl PendingResponse {
 /// - `jwt`: Overrides the client's default JWT for this call.
 ///   Used when a service needs to present a specific token.
 /// - `delegated_bearer`: Bearer token relayed on behalf of a user.
-///   Only trusted services (OAI, MCP) may set this. Policy gates which
-///   services can relay bearer tokens. The server resolves the subject
-///   from the bearer token, not the service identity.
+///   Only explicitly pinned service identities may set this. The server
+///   resolves the subject from the verified bearer, not the relay identity.
 #[derive(Debug, Clone, Default)]
 pub struct CallOptions {
     /// Override the client's default JWT for this call.
@@ -510,6 +509,23 @@ impl<S: Signer, T: Transport + 'static> RpcClientImpl<S, T> {
             .await
     }
 
+    /// Send an option-bearing streaming request bound to a canonical destination.
+    pub async fn call_streaming_with_options_for_service(
+        &self,
+        service_domain: &str,
+        payload: Vec<u8>,
+        ephemeral_pubkey: [u8; 32],
+        options: CallOptions,
+    ) -> Result<Vec<u8>> {
+        self.call_streaming_with_options_bound(
+            payload,
+            ephemeral_pubkey,
+            options,
+            Some(service_domain),
+            None,
+        )
+        .await
+    }
 
     /// Send an option-bearing generated streaming request bound to its service and method.
     pub async fn call_streaming_with_options_for_service_with_method(
@@ -1100,6 +1116,17 @@ pub trait RpcClient: Send + Sync {
         payload: Vec<u8>,
         options: CallOptions,
     ) -> Result<Vec<u8>>;
+    async fn call_with_options_for_service_with_method(
+        &self, service_domain: &str, method_discriminator: u16,
+        payload: Vec<u8>, options: CallOptions,
+    ) -> Result<Vec<u8>> {
+        anyhow::ensure!(
+            options.jwt.is_none() && options.delegated_bearer.is_none(),
+            "this RPC client does not support method-bound call options"
+        );
+        self.call_for_service_with_method(service_domain, method_discriminator, payload)
+            .await
+    }
 
     /// Send a streaming request with ephemeral DH pubkey.
     async fn call_streaming(&self, payload: Vec<u8>, ephemeral_pubkey: [u8; 32])
@@ -1112,6 +1139,20 @@ pub trait RpcClient: Send + Sync {
         payload: Vec<u8>,
         ephemeral_pubkey: [u8; 32],
     ) -> Result<Vec<u8>>;
+    async fn call_streaming_with_options_for_service(
+        &self,
+        service_domain: &str,
+        payload: Vec<u8>,
+        ephemeral_pubkey: [u8; 32],
+        options: CallOptions,
+    ) -> Result<Vec<u8>> {
+        anyhow::ensure!(
+            options.jwt.is_none() && options.delegated_bearer.is_none(),
+            "this RPC client does not support streaming call options"
+        );
+        self.call_streaming_for_service(service_domain, payload, ephemeral_pubkey)
+            .await
+    }
 
     /// Send a generated streaming request with an explicit schema method id.
     async fn call_streaming_for_service_with_method(
@@ -1121,6 +1162,22 @@ pub trait RpcClient: Send + Sync {
         payload: Vec<u8>,
         ephemeral_pubkey: [u8; 32],
     ) -> Result<Vec<u8>>;
+    async fn call_streaming_with_options_for_service_with_method(
+        &self, service_domain: &str, method_discriminator: u16,
+        payload: Vec<u8>, ephemeral_pubkey: [u8; 32], options: CallOptions,
+    ) -> Result<Vec<u8>> {
+        anyhow::ensure!(
+            options.jwt.is_none() && options.delegated_bearer.is_none(),
+            "this RPC client does not support method-bound streaming call options"
+        );
+        self.call_streaming_for_service_with_method(
+            service_domain,
+            method_discriminator,
+            payload,
+            ephemeral_pubkey,
+        )
+        .await
+    }
 
     /// Open a verified streaming subscription.
     async fn open_stream(&self, payload: Vec<u8>) -> Result<Box<dyn StreamHandle>>;
@@ -1176,6 +1233,14 @@ impl<S: Signer, T: Transport + 'static> RpcClient for RpcClientImpl<S, T> {
     ) -> Result<Vec<u8>> {
         RpcClientImpl::call_with_options_for_service(self, service_domain, payload, options).await
     }
+    async fn call_with_options_for_service_with_method(
+        &self, service_domain: &str, method_discriminator: u16,
+        payload: Vec<u8>, options: CallOptions,
+    ) -> Result<Vec<u8>> {
+        RpcClientImpl::call_with_options_for_service_with_method(
+            self, service_domain, method_discriminator, payload, options,
+        ).await
+    }
 
     async fn call_streaming(
         &self,
@@ -1194,6 +1259,22 @@ impl<S: Signer, T: Transport + 'static> RpcClient for RpcClientImpl<S, T> {
         RpcClientImpl::call_streaming_for_service(self, service_domain, payload, ephemeral_pubkey)
             .await
     }
+    async fn call_streaming_with_options_for_service(
+        &self,
+        service_domain: &str,
+        payload: Vec<u8>,
+        ephemeral_pubkey: [u8; 32],
+        options: CallOptions,
+    ) -> Result<Vec<u8>> {
+        RpcClientImpl::call_streaming_with_options_for_service(
+            self,
+            service_domain,
+            payload,
+            ephemeral_pubkey,
+            options,
+        )
+        .await
+    }
 
     async fn call_streaming_for_service_with_method(
         &self,
@@ -1210,6 +1291,14 @@ impl<S: Signer, T: Transport + 'static> RpcClient for RpcClientImpl<S, T> {
             ephemeral_pubkey,
         )
         .await
+    }
+    async fn call_streaming_with_options_for_service_with_method(
+        &self, service_domain: &str, method_discriminator: u16,
+        payload: Vec<u8>, ephemeral_pubkey: [u8; 32], options: CallOptions,
+    ) -> Result<Vec<u8>> {
+        RpcClientImpl::call_streaming_with_options_for_service_with_method(
+            self, service_domain, method_discriminator, payload, ephemeral_pubkey, options,
+        ).await
     }
 
     #[cfg(not(feature = "fips"))]

--- a/crates/hyprstream-rpc/src/rpc_client.rs
+++ b/crates/hyprstream-rpc/src/rpc_client.rs
@@ -556,7 +556,17 @@ impl<S: Signer, T: Transport + 'static> RpcClientImpl<S, T> {
     ) -> Result<Vec<u8>> {
         self.ensure_pre_seal_current().await?;
         let request_id = self.next_id();
-        let jwt = options.jwt.or_else(|| self.effective_jwt());
+        anyhow::ensure!(
+            !(options.jwt.is_some() && options.delegated_bearer.is_some()),
+            "an RPC envelope cannot carry both a direct JWT and a delegated bearer"
+        );
+        // Delegation is an explicit principal-selection mode. Do not let a
+        // pooled client's default JWT silently take precedence over it.
+        let jwt = if options.delegated_bearer.is_some() {
+            None
+        } else {
+            options.jwt.or_else(|| self.effective_jwt())
+        };
         let (signed_bytes, pending) = self
             .sign_envelope(
                 request_id,
@@ -625,7 +635,17 @@ impl<S: Signer, T: Transport + 'static> RpcClientImpl<S, T> {
     ) -> Result<Vec<u8>> {
         self.ensure_pre_seal_current().await?;
         let request_id = self.next_id();
-        let jwt = options.jwt.or_else(|| self.effective_jwt());
+        anyhow::ensure!(
+            !(options.jwt.is_some() && options.delegated_bearer.is_some()),
+            "an RPC envelope cannot carry both a direct JWT and a delegated bearer"
+        );
+        // Delegation is an explicit principal-selection mode. Do not let a
+        // pooled client's default JWT silently take precedence over it.
+        let jwt = if options.delegated_bearer.is_some() {
+            None
+        } else {
+            options.jwt.or_else(|| self.effective_jwt())
+        };
         let (signed_bytes, pending) = self
             .sign_envelope(
                 request_id,
@@ -1374,6 +1394,7 @@ mod request_kem_tests {
     struct LifecycleState {
         behavior: AtomicU8,
         recipients: parking_lot::Mutex<Vec<Vec<u8>>>,
+        auth: parking_lot::Mutex<Vec<(Option<String>, Option<String>)>>,
         swap_waiters: Mutex<Vec<(Vec<u8>, oneshot::Sender<Vec<u8>>)>>,
         entered: Notify,
     }
@@ -1398,6 +1419,10 @@ mod request_kem_tests {
                 .as_deref()
                 .ok_or_else(|| anyhow::anyhow!("test request omitted service domain"))?;
             self.state.recipients.lock().push(recipient.encode());
+            self.state.auth.lock().push((
+                request.jwt_token().map(str::to_owned),
+                request.delegation_token.clone(),
+            ));
             let pq_sk = crate::node_identity::derive_mesh_mldsa_key(&self.server_sk);
             let response = crate::envelope::ResponseEnvelope::new_signed_encrypted(
                 request.request_id,
@@ -1483,6 +1508,17 @@ mod request_kem_tests {
         Arc<LifecycleState>,
         Arc<AtomicUsize>,
     ) {
+        lifecycle_client_with_options(browser_binding, None)
+    }
+
+    fn lifecycle_client_with_options(
+        browser_binding: Option<crate::browser_provisioning::BrowserRequestBinding>,
+        default_jwt: Option<String>,
+    ) -> (
+        Arc<RpcClientImpl<LocalSigner, LifecycleTransport>>,
+        Arc<LifecycleState>,
+        Arc<AtomicUsize>,
+    ) {
         let (server_sk, server_vk) = generate_signing_keypair();
         let (client_sk, _client_vk) = generate_signing_keypair();
         let mut kem_store = KeyedKemTrustStore::new();
@@ -1500,6 +1536,7 @@ mod request_kem_tests {
         let state = Arc::new(LifecycleState {
             behavior: AtomicU8::new(LIFECYCLE_SUCCESS),
             recipients: parking_lot::Mutex::new(Vec::new()),
+            auth: parking_lot::Mutex::new(Vec::new()),
             swap_waiters: Mutex::new(Vec::new()),
             entered: Notify::new(),
         });
@@ -1515,6 +1552,10 @@ mod request_kem_tests {
         .with_request_kem_store(Arc::new(kem_store))
         .with_response_pq_store(Arc::new(pq_store))
         .with_response_secret_drop_probe(Arc::clone(&drops));
+        let client = match default_jwt {
+            Some(token) => client.with_default_jwt(token),
+            None => client,
+        };
         let client = match browser_binding {
             Some(binding) => client
                 .with_browser_provisioning_binding(binding)
@@ -1522,6 +1563,60 @@ mod request_kem_tests {
             None => client,
         };
         (Arc::new(client), state, drops)
+    }
+
+    #[tokio::test]
+    async fn delegated_bearer_suppresses_pooled_default_jwt() {
+        let (client, state, _drops) =
+            lifecycle_client_with_options(None, Some("pooled-default".to_owned()));
+
+        client
+            .call_with_options_for_service(
+                "model",
+                b"unary".to_vec(),
+                CallOptions::new().delegated_bearer("delegated-user"),
+            )
+            .await
+            .expect("delegated unary call");
+        client
+            .call_streaming_with_options_for_service(
+                "model",
+                b"streaming".to_vec(),
+                [0x55; 32],
+                CallOptions::new().delegated_bearer("delegated-user"),
+            )
+            .await
+            .expect("delegated streaming call");
+
+        let auth = state.auth.lock();
+        assert_eq!(auth.len(), 2);
+        for (jwt, delegated) in auth.iter() {
+            assert!(jwt.is_none(), "default JWT must not override delegation");
+            assert_eq!(delegated.as_deref(), Some("delegated-user"));
+        }
+    }
+
+    #[tokio::test]
+    async fn explicit_jwt_and_delegated_bearer_are_rejected() {
+        let (client, state, _drops) = lifecycle_client();
+        let error = client
+            .call_with_options_for_service(
+                "model",
+                b"payload".to_vec(),
+                CallOptions::new()
+                    .jwt("direct-user")
+                    .delegated_bearer("delegated-user"),
+            )
+            .await
+            .expect_err("ambiguous principal selection must fail");
+        assert!(
+            error.to_string().contains("both a direct JWT and a delegated bearer"),
+            "unexpected error: {error}"
+        );
+        assert!(
+            state.auth.lock().is_empty(),
+            "ambiguous request must not reach the transport"
+        );
     }
 
     #[async_trait]

--- a/crates/hyprstream-rpc/src/service/svc.rs
+++ b/crates/hyprstream-rpc/src/service/svc.rs
@@ -120,6 +120,8 @@ pub struct EnvelopeContext {
     /// Raw JWT token from the envelope. Server decodes and verifies this.
     /// Preferred over the legacy `claims` field when present.
     jwt_token: Option<String>,
+    /// Bearer relayed by an authenticated service; deny-by-default.
+    delegation_token: Option<String>,
 
     /// Authorization subject derived from the verified Ed25519 signer key.
     ///
@@ -188,6 +190,7 @@ impl EnvelopeContext {
             claims: None,
             verified_tenant: None,
             jwt_token: envelope.envelope.jwt_token().map(ToOwned::to_owned),
+            delegation_token: envelope.envelope.delegation_token.clone(),
             key_derived_subject: Subject::anonymous(),
             jwt_subject: None,
             cnf: envelope.cnf,
@@ -215,6 +218,7 @@ impl EnvelopeContext {
             claims: None,
             verified_tenant: Some("local".to_owned()),
             jwt_token: envelope.envelope.jwt_token().map(ToOwned::to_owned),
+            delegation_token: envelope.envelope.delegation_token.clone(),
             key_derived_subject: Subject::new("system"),
             jwt_subject: None,
             cnf: envelope.cnf,
@@ -246,6 +250,7 @@ impl EnvelopeContext {
             claims: None,
             verified_tenant: Some("local".to_owned()),
             jwt_token: None,
+            delegation_token: None,
             key_derived_subject: Subject::new(format!("service:{service_name}")),
             jwt_subject: None,
             cnf: [0u8; 32],
@@ -291,6 +296,7 @@ impl EnvelopeContext {
             claims,
             verified_tenant: Some("local".to_owned()),
             jwt_token: None,
+            delegation_token: None,
             key_derived_subject: crate::envelope::Subject::anonymous(),
             jwt_subject: None,
             cnf,
@@ -442,6 +448,7 @@ impl EnvelopeContext {
             claims: None,
             verified_tenant: None,
             jwt_token: None,
+            delegation_token: None,
             key_derived_subject: subject,
             jwt_subject: None,
             cnf: signer.to_bytes(),
@@ -837,6 +844,12 @@ pub trait RequestService: 'static {
     ) {
     }
 
+    /// Accept a relayed bearer from this verified envelope signer. Services
+    /// enabling this must pin an independently configured controller key.
+    fn accept_delegated_bearer(&self, _signer_pubkey: &[u8; 32]) -> bool {
+        false
+    }
+
     /// E2E JWT verification with unified key source.
     ///
     /// Called by `process_request` after envelope signature verification.
@@ -850,10 +863,24 @@ pub trait RequestService: 'static {
     /// The legacy `claims` path is kept for backwards compat with older clients.
     async fn verify_claims(&self, ctx: &mut EnvelopeContext) -> anyhow::Result<()> {
         // Prefer jwt_token (new path) over legacy claims
-        let token = ctx
+        let direct_token = ctx
             .jwt_token
             .clone()
             .or_else(|| ctx.claims().and_then(|c| c.token.clone()));
+        let delegated = direct_token.is_none() && ctx.delegation_token.is_some();
+        let token = match direct_token {
+            Some(token) => Some(token),
+            None => match ctx.delegation_token.clone() {
+                Some(token) => {
+                    anyhow::ensure!(
+                        self.accept_delegated_bearer(&ctx.cnf),
+                        "delegated bearer rejected: envelope signer is not an authorized relay"
+                    );
+                    Some(token)
+                }
+                None => None,
+            },
+        };
 
         let Some(token) = token else {
             // No JWT — try trust store lookup for cached key bindings
@@ -1110,58 +1137,63 @@ pub trait RequestService: 'static {
         // R2: Bind JWT cnf.jwk claim to envelope signer (WIMSE WIT key binding).
         // When a JWT carries a cnf.jwk (Ed25519 pubkey), the envelope signer must
         // match. Prevents a valid JWT holder from signing envelopes with a different
-        // key and being attributed the JWT's subject identity.
-        if let Some(ref claims) = ctx.claims {
-            if let Some(expected) = claims.cnf_key_bytes() {
-                use subtle::ConstantTimeEq as _;
-                if expected.ct_ne(&ctx.cnf).into() {
-                    tracing::warn!("JWT cnf.jwk mismatch: sub={}", claims.sub);
-                    anyhow::bail!("JWT cnf.jwk does not match envelope signer");
-                }
-
-                // Cache the (key → subject) binding in the trust store.
-                let vk = match ed25519_dalek::VerifyingKey::from_bytes(&expected) {
-                    Ok(vk) => vk,
-                    Err(_) => {
-                        tracing::warn!("Invalid Ed25519 verifying key in JWT cnf.jwk");
-                        anyhow::bail!("Invalid Ed25519 verifying key in JWT cnf.jwk");
+        // key and being attributed the JWT's subject identity. A pinned relay is
+        // the sole exception: it already verified that binding at ingress, and
+        // the downstream envelope is necessarily signed by the relay instead.
+        // Do not cache a bearer-to-relay binding on this path.
+        if !delegated {
+            if let Some(ref claims) = ctx.claims {
+                if let Some(expected) = claims.cnf_key_bytes() {
+                    use subtle::ConstantTimeEq as _;
+                    if expected.ct_ne(&ctx.cnf).into() {
+                        tracing::warn!("JWT cnf.jwk mismatch: sub={}", claims.sub);
+                        anyhow::bail!("JWT cnf.jwk does not match envelope signer");
                     }
-                };
-                let subject_str = claims.subject(&local_issuers_refs);
-                if let Some(subject_name) = subject_str.name() {
-                    self.cache_key_binding(vk, subject_name, &token, claims.exp);
-                    tracing::info!(subject = %subject_name, "Cached key binding in trust store");
-                }
-            } else if let Some(jkt) = claims.cnf_jkt() {
-                // R2b: DPoP path — JWT has cnf.jkt (thumbprint) instead of cnf.jwk.
-                // Compute the JWK thumbprint of the envelope signer and compare.
-                use subtle::ConstantTimeEq as _;
-                let envelope_jkt =
-                    crate::auth::jwk_thumbprint(&crate::auth::JwkThumbprintInput::Ed25519 {
-                        x: &ctx.cnf,
-                    });
-                if envelope_jkt.as_bytes().ct_ne(jkt.as_bytes()).into() {
-                    tracing::warn!("JWT cnf.jkt mismatch: sub={}", claims.sub);
-                    anyhow::bail!("JWT cnf.jkt does not match envelope signer");
-                }
 
-                let vk = match ed25519_dalek::VerifyingKey::from_bytes(&ctx.cnf) {
-                    Ok(vk) => vk,
-                    Err(_) => {
-                        tracing::warn!("Invalid Ed25519 verifying key in envelope cnf");
-                        anyhow::bail!("Invalid Ed25519 verifying key in envelope cnf");
+                    // Cache the (key → subject) binding in the trust store.
+                    let vk = match ed25519_dalek::VerifyingKey::from_bytes(&expected) {
+                        Ok(vk) => vk,
+                        Err(_) => {
+                            tracing::warn!("Invalid Ed25519 verifying key in JWT cnf.jwk");
+                            anyhow::bail!("Invalid Ed25519 verifying key in JWT cnf.jwk");
+                        }
+                    };
+                    let subject_str = claims.subject(&local_issuers_refs);
+                    if let Some(subject_name) = subject_str.name() {
+                        self.cache_key_binding(vk, subject_name, &token, claims.exp);
+                        tracing::info!(subject = %subject_name, "Cached key binding in trust store");
                     }
-                };
-                let subject_str = claims.subject(&local_issuers_refs);
-                if let Some(subject_name) = subject_str.name() {
-                    self.cache_key_binding(vk, subject_name, &token, claims.exp);
-                    tracing::info!(subject = %subject_name, "Cached key binding from cnf.jkt");
+                } else if let Some(jkt) = claims.cnf_jkt() {
+                    // R2b: DPoP path — JWT has cnf.jkt (thumbprint) instead of cnf.jwk.
+                    // Compute the JWK thumbprint of the envelope signer and compare.
+                    use subtle::ConstantTimeEq as _;
+                    let envelope_jkt =
+                        crate::auth::jwk_thumbprint(&crate::auth::JwkThumbprintInput::Ed25519 {
+                            x: &ctx.cnf,
+                        });
+                    if envelope_jkt.as_bytes().ct_ne(jkt.as_bytes()).into() {
+                        tracing::warn!("JWT cnf.jkt mismatch: sub={}", claims.sub);
+                        anyhow::bail!("JWT cnf.jkt does not match envelope signer");
+                    }
+
+                    let vk = match ed25519_dalek::VerifyingKey::from_bytes(&ctx.cnf) {
+                        Ok(vk) => vk,
+                        Err(_) => {
+                            tracing::warn!("Invalid Ed25519 verifying key in envelope cnf");
+                            anyhow::bail!("Invalid Ed25519 verifying key in envelope cnf");
+                        }
+                    };
+                    let subject_str = claims.subject(&local_issuers_refs);
+                    if let Some(subject_name) = subject_str.name() {
+                        self.cache_key_binding(vk, subject_name, &token, claims.exp);
+                        tracing::info!(subject = %subject_name, "Cached key binding from cnf.jkt");
+                    }
+                } else if self.require_cnf_binding() {
+                    tracing::warn!("JWT missing cnf binding (jwk or jkt): sub={}", claims.sub);
+                    anyhow::bail!(
+                        "JWT must include cnf binding for key binding (required by this service)"
+                    );
                 }
-            } else if self.require_cnf_binding() {
-                tracing::warn!("JWT missing cnf binding (jwk or jkt): sub={}", claims.sub);
-                anyhow::bail!(
-                    "JWT must include cnf binding for key binding (required by this service)"
-                );
             }
         }
 
@@ -1379,6 +1411,7 @@ mod empty_iss_gate_tests {
         transport: TransportConfig,
         key_source: std::sync::Arc<dyn crate::auth::JwtKeySource>,
         policy: crate::crypto::CryptoPolicy,
+        relay: Option<[u8; 32]>,
     }
 
     #[async_trait(?Send)]
@@ -1414,6 +1447,9 @@ mod empty_iss_gate_tests {
         fn jwt_verify_policy(&self) -> crate::crypto::CryptoPolicy {
             self.policy
         }
+        fn accept_delegated_bearer(&self, signer_pubkey: &[u8; 32]) -> bool {
+            self.relay.as_ref() == Some(signer_pubkey)
+        }
     }
 
     /// Build an `EnvelopeContext` carrying `jwt_token`, with the chosen
@@ -1424,6 +1460,7 @@ mod empty_iss_gate_tests {
             claims: None,
             verified_tenant: None,
             jwt_token: Some(token),
+            delegation_token: None,
             key_derived_subject: Subject::anonymous(),
             jwt_subject: None,
             cnf: [0u8; 32],
@@ -1451,6 +1488,7 @@ mod empty_iss_gate_tests {
             transport: TransportConfig::inproc("mock"),
             key_source,
             policy: crate::crypto::CryptoPolicy::Classical,
+            relay: None,
         };
         (svc, ca)
     }
@@ -1517,6 +1555,40 @@ mod empty_iss_gate_tests {
     }
 
     #[tokio::test]
+    async fn delegated_bearer_is_denied_by_default() {
+        let (svc, ca) = mock_service();
+        let token = empty_iss_token(&ca);
+        let relay = [19u8; 32];
+        let mut ctx = ctx_with_token(token.clone(), /* is_local_caller */ true);
+        ctx.jwt_token = None;
+        ctx.delegation_token = Some(token);
+        ctx.cnf = relay;
+
+        let error = svc
+            .verify_claims(&mut ctx)
+            .await
+            .expect_err("services must reject delegated bearers unless explicitly enabled");
+        assert!(error.to_string().contains("not an authorized relay"));
+    }
+
+    #[tokio::test]
+    async fn delegated_bearer_is_verified_for_pinned_relay() {
+        let (mut svc, ca) = mock_service();
+        let relay = [19u8; 32];
+        svc.relay = Some(relay);
+        let token = empty_iss_token(&ca);
+        let mut ctx = ctx_with_token(token.clone(), /* is_local_caller */ true);
+        ctx.jwt_token = None;
+        ctx.delegation_token = Some(token);
+        ctx.cnf = relay;
+
+        svc.verify_claims(&mut ctx)
+            .await
+            .expect("the pinned relay may delegate a bearer for re-verification");
+        assert_eq!(ctx.subject().name(), Some("alice"));
+    }
+
+    #[tokio::test]
     async fn federated_issuer_cannot_assert_local_tenant() {
         let local_ca = SigningKey::from_bytes(&[9u8; 32]);
         let federated_signer = SigningKey::from_bytes(&[10u8; 32]);
@@ -1535,6 +1607,7 @@ mod empty_iss_gate_tests {
             transport: TransportConfig::inproc("mock"),
             key_source,
             policy: crate::crypto::CryptoPolicy::Classical,
+            relay: None,
         };
         let now = chrono::Utc::now().timestamp();
         let claims = Claims::new("alice".to_owned(), now, now + 3600)
@@ -1569,6 +1642,7 @@ mod empty_iss_gate_tests {
             transport: TransportConfig::inproc("mock"),
             key_source,
             policy: crate::crypto::CryptoPolicy::Classical,
+            relay: None,
         };
         let now = chrono::Utc::now().timestamp();
         let claims = Claims::new("alice".to_owned(), now, now + 3600)
@@ -1662,6 +1736,7 @@ mod empty_iss_gate_tests {
             transport: TransportConfig::inproc("mock"),
             key_source,
             policy: crate::crypto::CryptoPolicy::Hybrid,
+            relay: None,
         };
         let now = chrono::Utc::now().timestamp();
         let claims =
@@ -1891,6 +1966,7 @@ mod ipc_key_identity_tests {
             claims: None,
             verified_tenant: None,
             jwt_token: None,
+            delegation_token: None,
             key_derived_subject: Subject::anonymous(),
             jwt_subject: None,
             cnf: signer_pubkey,
@@ -2120,6 +2196,7 @@ mod accounting_audit_tests {
             claims: None,
             verified_tenant: None,
             jwt_token: None,
+            delegation_token: None,
             key_derived_subject: Subject::new(name),
             jwt_subject: None,
             cnf: [0u8; 32],
@@ -2177,6 +2254,7 @@ mod accounting_audit_tests {
             claims: None,
             verified_tenant: None,
             jwt_token: None,
+            delegation_token: None,
             key_derived_subject: Subject::anonymous(),
             jwt_subject: None,
             cnf: [0u8; 32],
@@ -2244,6 +2322,7 @@ mod accounting_audit_tests {
             claims,
             verified_tenant: None,
             jwt_token: None,
+            delegation_token: None,
             key_derived_subject: Subject::anonymous(),
             jwt_subject: None,
             cnf,

--- a/crates/hyprstream/src/runtime/inference_profile.rs
+++ b/crates/hyprstream/src/runtime/inference_profile.rs
@@ -266,6 +266,11 @@ pub struct InferenceInstanceId {
     replica: u16,
 }
 
+/// Domain-separated carrier-key purpose for one opaque service instance.
+pub(crate) fn inference_iroh_key_purpose(service_name: &str) -> String {
+    format!("hyprstream-inference-iroh-v1/{service_name}")
+}
+
 impl InferenceInstanceId {
     pub fn new(verified_tenant: &str, model_ref: &str, replica: u16) -> Result<Self> {
         let tenant = verified_tenant.trim();
@@ -312,6 +317,10 @@ impl InferenceInstanceId {
         let suffix = hex::encode(&digest.finalize()[..12]);
         format!("inference-{suffix}")
     }
+    #[must_use]
+    pub fn iroh_key_purpose(&self) -> String {
+        inference_iroh_key_purpose(&self.service_name())
+    }
 
     /// Same-host cross-process dial target for a subprocess placement.
     #[must_use]
@@ -353,6 +362,7 @@ mod tests {
             first.ipc_transport(Path::new("/run/hyprstream")),
             second.ipc_transport(Path::new("/run/hyprstream"))
         );
+        assert_ne!(first.iroh_key_purpose(), second.iroh_key_purpose());
         assert!(!first.service_name().contains("tenant-a"));
         Ok(())
     }
@@ -380,6 +390,22 @@ mod tests {
             first.ipc_transport(Path::new("/run/hyprstream")),
             second.ipc_transport(Path::new("/run/hyprstream"))
         );
+        let service_key =
+            hyprstream_rpc::prelude::SigningKey::from_bytes(&[31u8; 32]);
+        let first_carrier = hyprstream_rpc::node_identity::derive_purpose_key(
+            &service_key,
+            &first.iroh_key_purpose(),
+        );
+        let second_carrier = hyprstream_rpc::node_identity::derive_purpose_key(
+            &service_key,
+            &second.iroh_key_purpose(),
+        );
+        assert_ne!(
+            first_carrier.verifying_key(),
+            service_key.verifying_key(),
+            "carrier address must not reuse application authority"
+        );
+        assert_ne!(first_carrier.verifying_key(), second_carrier.verifying_key());
         Ok(())
     }
 }

--- a/crates/hyprstream/src/server/routes/openai.rs
+++ b/crates/hyprstream/src/server/routes/openai.rs
@@ -207,6 +207,21 @@ fn claims_from_auth(
     claims
 }
 
+/// Build a request-local ModelService client carrying the HTTP bearer as a
+/// direct JWT. The HTTP middleware already verified this token, and
+/// ModelService re-verifies it before deriving the hosted-account tenant and
+/// MAC clearance. A missing bearer remains missing and therefore fails closed
+/// at the ModelService PEP.
+fn model_client_for_request(
+    state: &ServerState,
+    jwt_token: Option<&str>,
+) -> anyhow::Result<ModelClient> {
+    ModelClient::from_resolver(
+        (*state.signing_key).clone(),
+        jwt_token.map(str::to_owned),
+    )
+}
+
 /// Helper: Resolve model name to filesystem path (also validates inference capability)
 async fn resolve_model_path(
     state: &ServerState,
@@ -414,6 +429,13 @@ async fn chat_completions(
 
     // Apply chat template via ZMQ ModelService
     info!("Applying chat template via ModelService...");
+    let model_client = match model_client_for_request(&state, jwt_token.as_deref()) {
+        Ok(client) => client,
+        Err(e) => {
+            tracing::error!("Failed to create authenticated ModelClient: {e}");
+            return (StatusCode::INTERNAL_SERVER_ERROR, "Client creation failed").into_response();
+        }
+    };
 
     // Serialize tools to JSON Value for the template engine (if provided)
     let tools_json: Option<serde_json::Value> = request.tools.as_ref().map(|t| {
@@ -435,8 +457,7 @@ async fn chat_completions(
         .as_ref()
         .map(|t| serde_json::to_string(t).unwrap_or_default())
         .unwrap_or_default();
-    let templated_prompt = match state
-        .model_client
+    let templated_prompt = match model_client
         .infer(&request.model)
         .apply_chat_template(
             &crate::services::generated::model_client::ChatTemplateRequest {
@@ -486,17 +507,9 @@ async fn chat_completions(
         gen_request.prompt.len()
     );
 
-    // Call inference via collect-stream (per-request ZMQ client preserves caller identity for TTT delta routing)
-    let model_client = match ModelClient::from_resolver((*state.signing_key).clone(), None) {
-        Ok(c) => c,
-        Err(e) => {
-            tracing::error!("Failed to create ModelClient: {e}");
-            return (StatusCode::INTERNAL_SERVER_ERROR, "Client creation failed").into_response();
-        }
-    };
     let _claims = claims_from_auth(&user, &domain, jwt_token.as_deref(), jwt_exp);
-    // Note: OAI adapter currently creates a fresh client per request.
-    // For bearer delegation, use: model_client.request().delegated_bearer(jwt).call(payload)
+    // The request-local client carries the verified HTTP JWT through both
+    // template formatting and inference dispatch.
     let result = collect_stream_to_result(&model_client, &request.model, &gen_request).await;
 
     info!("Generation completed - success: {}", result.is_ok());
@@ -690,13 +703,20 @@ async fn stream_chat(
 
         // Apply chat template via ZMQ ModelService (tools passed to template)
         info!("Applying chat template for streaming...");
+        let model_client = match model_client_for_request(&state, jwt_token.as_deref()) {
+            Ok(client) => client,
+            Err(e) => {
+                error!("Failed to create authenticated ModelClient: {}", e);
+                let _ = tx.send(Err(anyhow::anyhow!("Client creation failed: {}", e))).await;
+                return;
+            }
+        };
         let rpc_messages = to_rpc_messages(&messages);
         let tools_str = tools_json
             .as_ref()
             .map(|t| serde_json::to_string(t).unwrap_or_default())
             .unwrap_or_default();
-        let templated_prompt = match state
-            .model_client
+        let templated_prompt = match model_client
             .infer(&model_name)
             .apply_chat_template(
                 &crate::services::generated::model_client::ChatTemplateRequest {
@@ -749,19 +769,7 @@ async fn stream_chat(
             gen_request.repeat_penalty
         );
 
-        // Start ZMQ stream with per-request client (preserves caller identity for TTT delta routing)
-        let model_client = match ModelClient::from_resolver((*state.signing_key).clone(), None) {
-            Ok(c) => c,
-            Err(e) => {
-                error!("Failed to create ModelClient: {}", e);
-                let _ = tx
-                    .send(Err(anyhow::anyhow!("Client creation failed: {}", e)))
-                    .await;
-                return;
-            }
-        };
         let _claims = claims_from_auth(&user, &domain, jwt_token.as_deref(), jwt_exp);
-        // Note: For bearer delegation, use: model_client.request().delegated_bearer(jwt).call(payload)
         use crate::services::generated::model_client::InferRpc;
         let mut stream_handle =
             match InferRpc::generate_stream(&model_client.infer(&model_name), &gen_request).await {
@@ -1055,6 +1063,13 @@ async fn completions(
 
     // Convert raw prompt to chat format and apply template via ZMQ ModelService
     // The completions endpoint expects raw text, but modern models need templated input
+    let model_client = match model_client_for_request(&state, jwt_token.as_deref()) {
+        Ok(client) => client,
+        Err(e) => {
+            tracing::error!("Failed to create authenticated ModelClient: {e}");
+            return (StatusCode::INTERNAL_SERVER_ERROR, "Client creation failed").into_response();
+        }
+    };
     let rpc_messages = vec![crate::services::generated::inference_client::ChatMessage {
         role: "user".to_owned(),
         content: request.prompt.clone(),
@@ -1062,8 +1077,7 @@ async fn completions(
         tool_call_id: String::new(),
     }];
 
-    let templated_prompt = match state
-        .model_client
+    let templated_prompt = match model_client
         .infer(&request.model)
         .apply_chat_template(
             &crate::services::generated::model_client::ChatTemplateRequest {
@@ -1110,14 +1124,6 @@ async fn completions(
         gen_request.repeat_penalty
     );
 
-    // Call inference via collect-stream (per-request ZMQ client preserves caller identity for TTT delta routing)
-    let model_client = match ModelClient::from_resolver((*state.signing_key).clone(), None) {
-        Ok(c) => c,
-        Err(e) => {
-            tracing::error!("Failed to create ModelClient: {e}");
-            return (StatusCode::INTERNAL_SERVER_ERROR, "Client creation failed").into_response();
-        }
-    };
     let _claims = claims_from_auth(&user, &domain, jwt_token.as_deref(), jwt_exp);
     let result = collect_stream_to_result(&model_client, &request.model, &gen_request).await;
 

--- a/crates/hyprstream/src/services/inference.rs
+++ b/crates/hyprstream/src/services/inference.rs
@@ -193,6 +193,7 @@ pub struct InferenceServiceInner {
     /// is itself a follow-up). Gated behind the `ledger` feature.
     #[cfg(feature = "ledger")]
     ledger: parking_lot::RwLock<Option<Arc<InferenceSpendEmitter>>>,
+    object_label: hyprstream_rpc::auth::mac::SecurityLabel,
 }
 
 /// ZMQ-based inference service
@@ -236,6 +237,29 @@ fn resolve_instance_domain(
     anyhow::bail!(
         "authorization denied: inference instance is bound to a different verified tenant"
     )
+}
+pub(crate) fn enforce_inference_mac(
+    ctx: &EnvelopeContext,
+    object_label: &hyprstream_rpc::auth::mac::SecurityLabel,
+) -> Result<()> {
+    enforce_inference_security_context(ctx.security_context(), object_label)
+}
+/// Canonical content label for the inference engine boundary.
+pub(crate) fn inference_object_label() -> hyprstream_rpc::auth::mac::SecurityLabel {
+    crate::mac::genesis::SitePolicy::conservative().label_for("/srv/inference")
+}
+fn enforce_inference_security_context(
+    security_context: Option<hyprstream_rpc::auth::mac::SecurityContext>,
+    object_label: &hyprstream_rpc::auth::mac::SecurityLabel,
+) -> Result<()> {
+    let security_context = security_context.ok_or_else(|| {
+        anyhow!("authorization denied: inference caller has no verified MAC clearance")
+    })?;
+    anyhow::ensure!(
+        security_context.can_access(object_label),
+        "authorization denied: inference caller clearance does not dominate engine label {object_label}"
+    );
+    Ok(())
 }
 
 // Intermediate response structs (DeltaStatusInfo, SaveAdaptationResult, SnapshotDeltaResult,
@@ -580,6 +604,7 @@ impl InferenceService {
         // Create StreamChannel upfront.
         let stream_channel = StreamChannel::new(signing_key.clone())
             .with_reach_config(hyprstream_rpc::moq_stream::ProducerReachConfig::default());
+        let object_label = inference_object_label();
 
         Ok(InferenceService {
             inner: Arc::new(InferenceServiceInner {
@@ -603,6 +628,7 @@ impl InferenceService {
                 controller_pubkey,
                 #[cfg(feature = "ledger")]
                 ledger: parking_lot::RwLock::new(None),
+                object_label,
             }),
         })
     }
@@ -2223,6 +2249,7 @@ impl InferenceHandler for InferenceService {
     async fn authorize(&self, ctx: &EnvelopeContext, resource: &str, operation: &str) -> Result<()> {
         let subject = ctx.subject();
         let domain = self.authorization_domain(ctx)?;
+        enforce_inference_mac(ctx, &self.object_label)?;
         let allowed = self.policy_client.check(&PolicyCheck { subject: subject.to_string(), domain, resource: resource.to_owned(), operation: operation.to_owned() }).await.unwrap_or_else(|e| {
             warn!("Policy check failed for {} on {}: {} - denying access", subject, resource, e);
             false
@@ -2733,6 +2760,9 @@ impl hyprstream_rpc::service::RequestService for InferenceZmqAdapter {
     fn jwt_key_source(&self) -> Option<std::sync::Arc<dyn hyprstream_rpc::auth::JwtKeySource>> {
         self.jwt_key_source.clone()
     }
+    fn accept_delegated_bearer(&self, signer_pubkey: &[u8; 32]) -> bool {
+        signer_pubkey == &self.service.controller_pubkey.to_bytes()
+    }
 
     /// Resolve a verified mesh-peer signer key to its per-host subject (#328).
     ///
@@ -2785,6 +2815,10 @@ pub struct InferenceServiceConfig {
     tenant_domain: String,
     /// ModelService key allowed to bridge local calls into this tenant.
     controller_pubkey: VerifyingKey,
+    /// Network reach published after the engine and Iroh endpoint are ready.
+    network_reach: Arc<
+        parking_lot::RwLock<Option<hyprstream_rpc::transport::TransportConfig>>,
+    >,
 }
 
 impl InferenceServiceConfig {
@@ -2818,6 +2852,7 @@ impl InferenceServiceConfig {
             jwt_key_source: None,
             tenant_domain: "local".to_owned(),
             controller_pubkey: server_pubkey,
+            network_reach: Arc::new(parking_lot::RwLock::new(None)),
         }
     }
 
@@ -2848,6 +2883,12 @@ impl InferenceServiceConfig {
     ) -> Self {
         self.jwt_key_source = Some(src);
         self
+    }
+    #[must_use]
+    pub fn network_reach_handle(
+        &self,
+    ) -> Arc<parking_lot::RwLock<Option<hyprstream_rpc::transport::TransportConfig>>> {
+        Arc::clone(&self.network_reach)
     }
 }
 
@@ -2884,7 +2925,7 @@ impl hyprstream_service::Spawnable for InferenceServiceConfig {
 
             // Destructure so the (Send) config moves into the on-thread builder.
             let InferenceServiceConfig {
-                service_name: _,
+                service_name,
                 model_path,
                 config,
                 server_pubkey,
@@ -2896,6 +2937,7 @@ impl hyprstream_service::Spawnable for InferenceServiceConfig {
                 jwt_key_source,
                 tenant_domain,
                 controller_pubkey,
+                network_reach,
             } = *self;
             let adapter_transport = transport.clone();
 
@@ -2948,7 +2990,38 @@ impl hyprstream_service::Spawnable for InferenceServiceConfig {
 
             let processor: Arc<dyn hyprstream_rpc::transport::rpc_session::IrohRequestProcessor> =
                 Arc::new(bridge);
-            hyprstream_rpc::service::serve::serve_bridged(
+            let purpose =
+                crate::runtime::inference_profile::inference_iroh_key_purpose(&service_name);
+            let iroh_key =
+                hyprstream_rpc::node_identity::derive_purpose_key(&server_signing_key, &purpose);
+            let rpc_handler =
+                hyprstream_rpc::transport::iroh_rpc::IrohRpcProtocolHandler::with_stream_limit(
+                    Arc::clone(&processor),
+                    server_signing_key.clone(),
+                    hyprstream_rpc::transport::rpc_session::DEFAULT_STREAM_LIMIT,
+                );
+            let substrate =
+                hyprstream_rpc::transport::iroh_substrate::IrohSubstrate::new(
+                    iroh_key.to_bytes(),
+                    hyprstream_rpc::transport::iroh_substrate::RefuseHandler::new(
+                        "inference streaming uses the existing StreamService",
+                    ),
+                    rpc_handler,
+                )
+                .await
+                .map_err(|e| {
+                    hyprstream_rpc::error::RpcError::SpawnFailed(format!(
+                        "inference iroh bind: {e}"
+                    ))
+                })?;
+            let node_id = *substrate.endpoint_id().as_bytes();
+            let direct_addrs = substrate.endpoint().bound_sockets().into_iter().collect();
+            *network_reach.write() = Some(hyprstream_rpc::transport::TransportConfig::iroh(
+                node_id,
+                direct_addrs,
+                None,
+            ));
+            let result = hyprstream_rpc::service::serve::serve_bridged(
                 &transport,
                 processor,
                 server_signing_key,
@@ -2956,7 +3029,11 @@ impl hyprstream_service::Spawnable for InferenceServiceConfig {
                 on_ready,
             )
             .await
-            .map_err(|e| hyprstream_rpc::error::RpcError::SpawnFailed(e.to_string()))
+            .map_err(|e| hyprstream_rpc::error::RpcError::SpawnFailed(e.to_string()));
+            if let Err(error) = substrate.shutdown().await {
+                tracing::warn!(%error, "inference iroh shutdown failed");
+            }
+            result
         })
     }
 }
@@ -3053,6 +3130,10 @@ impl StreamChunkMessage {
 #[cfg(test)]
 mod tenant_binding_tests {
     use super::*;
+    use hyprstream_rpc::auth::mac::{
+        Assurance, CompartmentSet, Level, SecurityContext, SecurityLabel,
+        VerifiedKeyMaterial,
+    };
     use hyprstream_rpc::envelope::Subject;
 
     fn key(seed: u8) -> SigningKey {
@@ -3102,6 +3183,31 @@ mod tenant_binding_tests {
             key(9).verifying_key(),
         );
         assert!(resolve_instance_domain("tenant-a", &controller, &impostor).is_err());
+    }
+
+    #[test]
+    fn mac_denies_missing_clearance() {
+        let object =
+            SecurityLabel::new(Level::Internal, Assurance::Classical, CompartmentSet::EMPTY);
+        assert!(enforce_inference_security_context(None, &object).is_err());
+    }
+
+    #[test]
+    fn mac_denies_insufficient_clearance() {
+        let subject =
+            SecurityContext::new(Level::Public, CompartmentSet::EMPTY, VerifiedKeyMaterial::Classical);
+        let object =
+            SecurityLabel::new(Level::Internal, Assurance::Classical, CompartmentSet::EMPTY);
+        assert!(enforce_inference_security_context(Some(subject), &object).is_err());
+    }
+
+    #[test]
+    fn mac_allows_dominating_clearance() {
+        let subject =
+            SecurityContext::new(Level::Secret, CompartmentSet::EMPTY, VerifiedKeyMaterial::Classical);
+        let object =
+            SecurityLabel::new(Level::Internal, Assurance::Classical, CompartmentSet::EMPTY);
+        assert!(enforce_inference_security_context(Some(subject), &object).is_ok());
     }
 
 }

--- a/crates/hyprstream/src/services/model.rs
+++ b/crates/hyprstream/src/services/model.rs
@@ -112,12 +112,13 @@ pub struct LoadedModel {
     pub instance: InferenceInstanceId,
     /// Model reference string (e.g., "qwen3-small:main")
     pub model_ref: String,
-    /// Resolved transport for this model's InferenceService (#320). For a
-    /// co-located service this is the `Inproc` arm registered in the in-process
-    /// dial registry by the spawner; the cross-host/Iroh reach (when an
-    /// inference service has a network endpoint) is resolved via the Resolver.
-    /// The router single-selects this to talk to the inference service.
+    /// Local transport for this model's InferenceService (#320). This remains
+    /// the `Inproc` arm registered by the spawner and is never advertised as a
+    /// remotely dialable reach.
     pub transport: TransportConfig,
+    /// Advertised network reach for remote callers. Local dispatch continues
+    /// to use `transport` as the in-process fast path.
+    pub network_transport: TransportConfig,
     /// Handle to stop the InferenceService
     pub service_handle: hyprstream_service::SpawnedService,
     /// Client for communicating with the InferenceService (built from
@@ -453,6 +454,8 @@ impl ModelService {
         ctx: &EnvelopeContext,
         model_ref_str: &str,
     ) -> Result<InferenceInstanceId> {
+        let object_label = crate::services::inference::inference_object_label();
+        crate::services::inference::enforce_inference_mac(ctx, &object_label)?;
         InferenceInstanceId::new(&ctx.domain()?, model_ref_str, 0)
     }
 
@@ -478,21 +481,18 @@ impl ModelService {
         registry().endpoint(&instance.service_name(), SocketKind::Rep)
     }
 
-    /// The deterministic InferenceService endpoint *string* for a model ref.
+    /// The deterministic local InferenceService endpoint string for diagnostics.
     ///
-    /// Retained only for human-facing display and the JSON `model.loaded` event
-    /// (`EventPayload::ModelLoaded`); the routable reach is the typed
-    /// [`Self::inference_transport`] / the capnp `reach` list (#320).
+    /// This is never advertised. Loaded status and lifecycle events use the
+    /// separately bound Iroh network reach.
     fn inference_endpoint(instance: &InferenceInstanceId) -> String {
         Self::inference_transport(instance).endpoint_string()
     }
 
     /// The network-routable reach list a remote caller would use to dial this
-    /// model's InferenceService (#320). For a co-located service the transport is
-    /// the `Inproc` arm, which is NEVER advertised on the wire (a remote caller
-    /// can't dial it; a co-located caller uses the in-process fast path), so this
-    /// returns an EMPTY list. A networked (Quic/Iroh) inference reach maps to the
-    /// corresponding wire arm via the single dial→wire reach codec.
+    /// model's InferenceService (#320). An `Inproc` transport is never
+    /// advertised; a networked (Quic/Iroh) reach maps through the single
+    /// dial-to-wire reach codec.
     fn model_reach(transport: &TransportConfig) -> Vec<WireTransportConfig> {
         hyprstream_rpc::moq_stream::dial_transport_to_wire(transport)
             .into_iter()
@@ -769,7 +769,7 @@ impl ModelService {
             if let Some(model) = cache.get_mut(instance) {
                 model.last_used = Instant::now();
                 debug!("Model {} already loaded", model_ref_str);
-                return Ok(Self::inference_endpoint(instance));
+                return Ok(model.network_transport.endpoint_string());
             }
         }
 
@@ -873,9 +873,8 @@ impl ModelService {
         // (#320). For a co-located service this is the `Inproc` arm; the spawner
         // registers it in the in-process dial registry (`register_inproc`) and
         // the same typed transport builds the client below — no string parsing on
-        // the inference client path. (The cross-host/Iroh reach is resolved via
-        // the Resolver when an inference service has a network endpoint; pkarr
-        // auto-discovery stays deferred to #282.)
+        // the inference client path. The service also binds an Iroh endpoint
+        // before readiness and publishes that separate network reach below.
         let transport = Self::inference_transport(instance);
         let mut service_config = crate::services::InferenceServiceConfig::new(
             &model_path,
@@ -896,8 +895,14 @@ impl ModelService {
         if let Some(ref src) = self.jwt_key_source {
             service_config = service_config.with_jwt_key_source(src.clone());
         }
+        let network_reach = service_config.network_reach_handle();
         let service_handle = spawner.spawn(service_config).await
             .map_err(|e| anyhow!("Failed to spawn inference service: {}", e))?;
+        let network_transport = network_reach
+            .read()
+            .clone()
+            .ok_or_else(|| anyhow!("InferenceService became ready without network reach"))?;
+        let endpoint = network_transport.endpoint_string();
 
         // Create client for this service from the typed transport (#320).
         // Inference services share the model service's signing key, so use our
@@ -957,6 +962,7 @@ impl ModelService {
                     instance: instance.clone(),
                     model_ref: model_ref_str.to_owned(),
                     transport: transport.clone(),
+                    network_transport,
                     service_handle,
                     client,
                     // #322 leaf cell-router. v1: single co-located replica. Its
@@ -1052,7 +1058,7 @@ impl ModelService {
             .map(|(_, model)| GenModelStatusEntry {
                 model_ref: model.model_ref.clone(),
                 status: "loaded".to_owned(),
-                reach: Self::model_reach(&model.transport),
+                reach: Self::model_reach(&model.network_transport),
                 loaded_at: model.loaded_at.elapsed().as_millis() as i64,
                 last_used: model.last_used.elapsed().as_millis() as i64,
                 online_training_config: model.ttt_config.as_ref()
@@ -1084,7 +1090,7 @@ impl ModelService {
             return vec![GenModelStatusEntry {
                 model_ref: instance.model_ref().to_owned(),
                 status: "loaded".to_owned(),
-                reach: Self::model_reach(&model.transport),
+                reach: Self::model_reach(&model.network_transport),
                 loaded_at: model.loaded_at.elapsed().as_millis() as i64,
                 last_used: model.last_used.elapsed().as_millis() as i64,
                 online_training_config: model.ttt_config.as_ref()
@@ -1115,7 +1121,7 @@ impl ModelService {
         if let Some(model) = cache.peek(instance) {
             ModelStatusResponse {
                 loaded: true,
-                reach: Self::model_reach(&model.transport),
+                reach: Self::model_reach(&model.network_transport),
                 online_training_config: model.ttt_config.as_ref()
                     .map(Self::ttt_config_to_wire)
                     .unwrap_or_default(),
@@ -1141,11 +1147,10 @@ impl ModelService {
         // subject-keyed, by design.
         let placement_key = ctx.subject().to_string();
         let client = self.select_inference_server(model, &placement_key).await;
-        // TODO: Forward user JWT to worker via per-call builder (delegated_bearer or
-        // request().jwt(token).call(payload)) once inference methods support CallOptions.
-        // The previous with_jwt() call was mutating shared state — unsafe with pooling.
-        let _ = ctx.jwt_token();
-        Ok(client)
+        let bearer = ctx
+            .jwt_token()
+            .ok_or_else(|| anyhow!("inference dispatch requires a verified bearer token"))?;
+        Ok(client.with_delegated_bearer(bearer.to_owned()))
     }
 
     /// Load a LoRA adapter from a file
@@ -1526,6 +1531,8 @@ impl ModelHandler for ModelService {
     async fn authorize(&self, ctx: &EnvelopeContext, resource: &str, operation: &str) -> Result<()> {
         let subject = ctx.subject();
         let domain = ctx.domain()?;
+        let object_label = crate::services::inference::inference_object_label();
+        crate::services::inference::enforce_inference_mac(ctx, &object_label)?;
         let allowed = self.policy_client.check(&PolicyCheck { subject: subject.to_string(), domain, resource: resource.to_owned(), operation: operation.to_owned() }).await.unwrap_or_else(|e| {
             warn!("Policy check failed for {} on {}: {} - denying access", subject, resource, e);
             false
@@ -1546,10 +1553,16 @@ impl ModelHandler for ModelService {
         let model_ref = &data.model_ref;
         let instance = Self::inference_instance(ctx, model_ref)?;
         match self.load_model(&instance, max_ctx, kv_q).await {
-            Ok(_endpoint) => Ok(ModelResponseVariant::LoadResult(LoadedModelResponse {
-                model_ref: model_ref.to_owned(),
-                reach: Self::model_reach(&Self::inference_transport(&instance)),
-            })),
+            Ok(_endpoint) => {
+                let cache = self.loaded_models.read().await;
+                let model = cache
+                    .peek(&instance)
+                    .ok_or_else(|| anyhow!("model missing after successful load"))?;
+                Ok(ModelResponseVariant::LoadResult(LoadedModelResponse {
+                    model_ref: model_ref.to_owned(),
+                    reach: Self::model_reach(&model.network_transport),
+                }))
+            }
             Err(e) => Ok(ModelResponseVariant::Error(ErrorInfo {
                 message: format!("Failed to load model: {e}"),
                 code: "LOAD_FAILED".into(),
@@ -1902,7 +1915,7 @@ impl crate::services::RequestService for ModelService {
                     let response = serialize_response(request_id, &ModelResponseVariant::LoadResult(
                         LoadedModelResponse {
                             model_ref: load_data.model_ref.clone(),
-                            reach: Self::model_reach(&model.transport),
+                            reach: Self::model_reach(&model.network_transport),
                         },
                     ))?;
                     return Ok((response, None));
@@ -1917,7 +1930,7 @@ impl crate::services::RequestService for ModelService {
                     let response = serialize_response(request_id, &ModelResponseVariant::LoadResult(
                         LoadedModelResponse {
                             model_ref: load_data.model_ref.clone(),
-                            reach: Self::model_reach(&Self::inference_transport(&instance)),
+                            reach: Vec::new(),
                         },
                     ))?;
                     return Ok((response, None));
@@ -1931,7 +1944,7 @@ impl crate::services::RequestService for ModelService {
             let response = serialize_response(request_id, &ModelResponseVariant::LoadResult(
                 LoadedModelResponse {
                     model_ref: model_ref.clone(),
-                    reach: Self::model_reach(&Self::inference_transport(&instance)),
+                    reach: Vec::new(),
                 },
             ))?;
 
@@ -2036,6 +2049,20 @@ mod tests {
         assert_eq!(
             config.inference_deployment.isolation,
             InferenceIsolationProfile::InProcess
+        );
+    }
+
+    #[test]
+    fn inference_instance_denies_unlabeled_tenant_before_load() {
+        let signer = SigningKey::from_bytes(&[44u8; 32]).verifying_key();
+        let ctx = EnvelopeContext::for_test_authenticated_subject_in_tenant(
+            hyprstream_rpc::envelope::Subject::new("alice"),
+            "did-hosted-account",
+            signer,
+        );
+        assert!(
+            ModelService::inference_instance(&ctx, "tiny-llama:main").is_err(),
+            "an authority-bound tenant without MAC clearance must not reach engine loading"
         );
     }
 

--- a/scripts/loopback-baseline.txt
+++ b/scripts/loopback-baseline.txt
@@ -29,7 +29,6 @@
 1	crates/hyprstream/src/cli/sign_challenge.rs
 1	crates/hyprstream/src/cli/wizard_handlers.rs
 10	crates/hyprstream/src/config/mod.rs
-4	crates/hyprstream/src/config/server.rs
 5	crates/hyprstream/src/server/middleware.rs
 14	crates/hyprstream/src/services/oauth/authorize.rs
 10	crates/hyprstream/src/services/oauth/mod.rs


### PR DESCRIPTION
## Summary

- bind a purpose-separated Iroh RPC endpoint for every ready tenant/model inference instance while retaining the in-process fast path
- advertise only the network-dialable reach after readiness; pending loads advertise no premature endpoint, and unload shuts the network substrate down
- preserve the verified HTTP bearer through OpenAI routes into ModelService, then relay it immutably to the pinned InferenceService controller hop for re-verification
- reject direct-JWT plus delegated-bearer ambiguity and preserve call options through discovery failover for unary and streaming calls
- enforce the canonical `/srv/inference` MAC label before ModelService touches engine state and again at the InferenceService boundary; tenant identity is only the verified DID hosted-account binding
- publish the CPU inference image for both linux/amd64 and linux/arm64, using native architecture builds and an OCI manifest list for `latest-cpu`/edge/semver CPU tags
- keep CPU arm64 native: Debian Bookworm + the aarch64 PyTorch CPU wheel/libtorch layout; CUDA and ROCm images remain amd64-only
- move native-arm Podman storage onto the large `/mnt` volume and keep Cargo target objects out of the committed image layer, fixing the prior Graviton runner disk exhaustion

## Issue assessment / remaining work

#1313 supplied the CPU deployment profile and tenant-scoped instance identity; #1314 supplied the DID hosted-account token binding. This PR makes those instances independently network-addressable and advances the lifecycle/isolation seam in #1236 and #1247.

It intentionally does not close either issue. True decoder-stage subset loading/range execution and the required two-process stage test remain blocked on #314. Remote replica selection/dialing remains #1237. The per-tenant subprocess/microVM launcher and scheduling-budget enforcement remain in #1247 and continue to fail closed rather than downgrade. The per-device engine pool remains separate in #1235.

## CPU image architecture decision

The existing `latest-cpu` tag was an amd64 image, while the deploy AMI is Rocky/Graviton arm64. The repository already had a valid native arm64 CPU builder/runtime path; a prior native Graviton build completed Rust release compilation and failed only while committing the OCI layer because the 29 GiB root disk filled. The fix therefore uses split native amd64/arm64 builds and `docker buildx imagetools create` only to assemble the manifest list. It does not use QEMU cross-builds and does not introduce GPU dependencies.

## Validation

- `cargo metadata --all-features --format-version 1`
- focused hosted JWT/delegated bearer, inference MAC/tenant binding, registry boundary, and deployment-profile tests
- `buildq -- cargo nextest run --release --profile ci -p hyprstream -p hyprstream-rpc --no-fail-fast` — 2321 passed, 0 failed, 9 skipped
- `buildq -- cargo clippy --workspace --all-targets --release -- -D warnings`
- actionlint + YAML parse for `.github/workflows/docker-build.yml`
- loopback-literal burn-down gate — 82 lines / 31 files

Refs #1236
Refs #1247