### PR TITLE
ci(rust): don't run loopback burn-down on merge_group (unblock queue livelock)

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -119,6 +119,11 @@ jobs:
     # shrink. Plain text scan, no build — stays on the free runner. Must be
     # able to fail — do NOT add `|| true`. See
     # scripts/check_loopback_burndown.py for the stated methodology.
+    # Advisory-only on the merge queue: `build` is the sole required merge-group
+    # check (see the note on the preflight build job). Running this ratchet on
+    # merge_group made a non-required shrink fail the group and livelock the queue;
+    # keep it on PR/push where it advises, matching the other non-required jobs.
+    if: github.event_name != 'merge_group'
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4


### PR DESCRIPTION
The `loopback-burndown` job is a **non-required advisory** ratchet but was missing the `if: github.event_name != 'merge_group'` guard its sibling non-required jobs already have. On the merge queue, an un-banked loopback *shrink* in a batched PR (#1318 removes one literal) fails the whole merge_group run → the queue re-forms the group → **livelock** (5 groups in ~20 min, 0 merges).

`build` stays the sole required merge-group check. Keeps loopback on PR/push (where it advises and can still fail — no `|| true`, per the job's own note), just not on merge_group. Matches the preflight-build job's documented design. #1152 W4.

Self-healing: merge_group runs the workflow from the combined ref, so landing this alongside the stuck batch makes the group skip loopback and all land together.