### PR TITLE
feat(9p): thread aname to attach authorizer + deny unknown export (EACCES) — #877 fix-forward (board-approved P0)

### DIFF
--- a/crates/hyprstream-9p/src/backend.rs
+++ b/crates/hyprstream-9p/src/backend.rs
@@ -62,17 +62,22 @@ pub struct StatResult {
 #[async_trait]
 pub trait Backend: Send + Sync {
     /// Establish the session at `Tattach`, given the `uname` the client
-    /// presented. The default is a no-op: backends whose caller identity is
-    /// fixed at construction (the UDS/vsock listeners) ignore `uname`.
+    /// presented and the `aname` export selector it requested. The default is a
+    /// no-op: backends whose caller identity is fixed at construction
+    /// (the UDS/vsock listeners) ignore both.
     ///
     /// A backend that resolves its caller identity from the attach itself
     /// (the H1b `/9p` WebTransport plane carries a mount ticket in
     /// `Tattach.uname` — the browser `WebSocket` can't set headers and the
     /// cert-pinned WT session has no URL query) validates it here and binds
-    /// the session `Subject`. Returning `Err` fails the attach; the translator
-    /// maps it to an `Rlerror` errno (a `hyprstream_vfs::MountError` in the
-    /// cause chain picks the errno — e.g. `PermissionDenied → EACCES`).
-    async fn attach(&self, _uname: &str) -> anyhow::Result<()> {
+    /// the session `Subject`. `aname` is the requested export (the 9P attach
+    /// name); an authorizing backend validates it against the ticket's granted
+    /// namespace and **denies an unknown/forbidden/malformed selector** rather
+    /// than falling back to a default export (#877/#1071 fail-closed contract).
+    /// Returning `Err` fails the attach; the translator maps it to an `Rlerror`
+    /// errno (a `hyprstream_vfs::MountError` in the cause chain picks the errno
+    /// — e.g. `PermissionDenied → EACCES`).
+    async fn attach(&self, _uname: &str, _aname: &str) -> anyhow::Result<()> {
         Ok(())
     }
 

--- a/crates/hyprstream-9p/src/mount_backend.rs
+++ b/crates/hyprstream-9p/src/mount_backend.rs
@@ -55,8 +55,17 @@ use crate::msg::{self, Qid, ReaddirEntry};
 /// errno (e.g. [`MountError::PermissionDenied`] → `EACCES`).
 #[async_trait]
 pub trait AttachAuthorizer: Send + Sync {
-    /// Validate the `uname` ticket and return the narrowed session [`Subject`].
-    async fn authorize(&self, uname: &str) -> Result<Subject, MountError>;
+    /// Validate the `uname` ticket and the requested `aname` export selector,
+    /// and return the narrowed session [`Subject`].
+    ///
+    /// `aname` is the 9P attach name — the export the client requested. The
+    /// authorizer validates it against the ticket's granted namespace and
+    /// **denies an unknown/forbidden/malformed selector** (returning a
+    /// [`MountError::PermissionDenied`] → `EACCES`) rather than falling back to
+    /// a default export (#877/#1071 fail-closed contract). Selection and the
+    /// `Subject` bind happen in this one authorization so a future
+    /// `ExportResolver` cannot split them.
+    async fn authorize(&self, uname: &str, aname: &str) -> Result<Subject, MountError>;
 }
 
 /// Max bytes a single read/write returns. Kept below the translator's `MSG_SIZE`
@@ -145,15 +154,18 @@ impl MountBackend {
 
 #[async_trait]
 impl Backend for MountBackend {
-    async fn attach(&self, uname: &str) -> Result<()> {
+    async fn attach(&self, uname: &str, aname: &str) -> Result<()> {
         // Fixed-subject listeners have no authorizer; the Subject is already
-        // bound and `uname` is advisory (ignored, as on the UDS/vsock paths).
+        // bound and `uname`/`aname` are advisory (ignored, as on the UDS/vsock
+        // paths).
         let Some(authorizer) = self.authorizer.as_ref() else {
             return Ok(());
         };
-        // Attach-time ticket path (H1b): resolve+narrow. A MountError here maps
-        // to an Rlerror errno (PermissionDenied → EACCES) via the translator.
-        let subject = authorizer.authorize(uname).await.map_err(anyhow::Error::new)?;
+        // Attach-time ticket path (H1b): resolve+narrow the Subject AND validate
+        // the requested `aname` export against the ticket's namespace grant in
+        // one authorization. A MountError here maps to an Rlerror errno
+        // (PermissionDenied → EACCES) via the translator, before any fid exists.
+        let subject = authorizer.authorize(uname, aname).await.map_err(anyhow::Error::new)?;
         let attempted_subject = subject.clone();
         // First attach wins; a second attach on the same connection must not
         // silently re-scope the session. Ignore a redundant identical set,
@@ -428,8 +440,9 @@ mod tests {
         let mount = Arc::new(TrackedMount { clunks: AtomicUsize::new(0) });
         let backend = MountBackend::new(mount.clone(), Subject::new("tenant"));
 
-        // Attach (empty walk) binds fid 0 to the root.
-        backend.attach("tenant").await.unwrap();
+        // Attach (empty walk) binds fid 0 to the root. `MountBackend::new`
+        // fixes the Subject, so `uname`/`aname` are advisory here.
+        backend.attach("tenant", "").await.unwrap();
         backend.fids.insert(
             0,
             Arc::new(MountFidEntry { path: vec![], handle: Mutex::new(Some(Fid::new(0usize))) }),

--- a/crates/hyprstream-9p/src/translator.rs
+++ b/crates/hyprstream-9p/src/translator.rs
@@ -479,9 +479,12 @@ impl Translator {
         };
 
         // Only an attach that cleared monitor authorization may bind a backend
-        // subject. Walk the empty path to materialize
-        // a root qid from the backend, then record it.
-        self.backend.attach(uname).await?;
+        // subject. Forward BOTH `uname` and `aname` so the backend's
+        // authorizer can validate the requested export against the ticket's
+        // granted namespace and deny an unknown/forbidden selector with EACCES
+        // before any fid exists. Walk the empty path to materialize a root qid
+        // from the backend, then record it.
+        self.backend.attach(uname, aname).await?;
         let walk = self.backend.walk(fid, fid, &[]).await?;
         if let Some(session) = &session {
             self.bind_attach_session(session)?;
@@ -1883,7 +1886,7 @@ mod tests {
         struct PartialWalkBackend;
         #[async_trait]
         impl Backend for PartialWalkBackend {
-            async fn attach(&self, _uname: &str) -> anyhow::Result<()> {
+            async fn attach(&self, _uname: &str, _aname: &str) -> anyhow::Result<()> {
                 Ok(())
             }
             async fn walk(
@@ -2195,19 +2198,33 @@ mod tests {
     // ── Attach-time mount ticket (H1b / #765) ───────────────────────────
 
     /// A fake [`AttachAuthorizer`] mirroring the H1b `Tattach.uname` ticket
-    /// check: one fixed ticket string maps to a narrowed Subject; anything else
-    /// is denied with `PermissionDenied` (→ `EACCES`).
+    /// check PLUS the `aname` export-selection gate: one fixed ticket string
+    /// maps to a narrowed Subject, and only the default export (empty `aname`)
+    /// is granted; anything else is denied with `PermissionDenied` (→ `EACCES`).
     struct FakeTicketAuth;
     #[async_trait::async_trait]
     impl crate::mount_backend::AttachAuthorizer for FakeTicketAuth {
         async fn authorize(
             &self,
             uname: &str,
+            aname: &str,
         ) -> std::result::Result<hyprstream_rpc::Subject, hyprstream_vfs::MountError> {
-            match uname {
-                "good-ticket" => Ok(hyprstream_rpc::Subject::new("alice")),
-                "other-ticket" => Ok(hyprstream_rpc::Subject::new("bob")),
-                _ => Err(hyprstream_vfs::MountError::PermissionDenied("bad ticket".into())),
+            let subject = match uname {
+                "good-ticket" => hyprstream_rpc::Subject::new("alice"),
+                "other-ticket" => hyprstream_rpc::Subject::new("bob"),
+                _ => {
+                    return Err(hyprstream_vfs::MountError::PermissionDenied("bad ticket".into()))
+                }
+            };
+            // Export-selection gate (#877 fail-closed contract): only the
+            // default export is granted today; an explicit `aname` selecting any
+            // other export denies — there is NO fallback to the default.
+            if aname.is_empty() {
+                Ok(subject)
+            } else {
+                Err(hyprstream_vfs::MountError::PermissionDenied(format!(
+                    "export {aname:?} not granted by ticket"
+                )))
             }
         }
     }
@@ -2289,6 +2306,32 @@ mod tests {
             .await
             .unwrap_err();
         assert_eq!(errno_from_error(&err), EACCES, "conflicting attach must be EACCES");
+    }
+
+    /// A valid ticket presenting an `aname` for an export it did not grant fails
+    /// the attach; the authorizer's `PermissionDenied` maps to an `Rlerror`
+    /// `EACCES` before any fid or mount handle is ever created. Fail-closed:
+    /// there is NO fallback to a default export after an explicit selector
+    /// (#877/#1071 contract).
+    #[tokio::test]
+    async fn attach_aname_denied_returns_eacces() {
+        let t = authorized_translator();
+        let err = t
+            .handle_message(&msg::tattach(
+                1,
+                0,
+                u32::MAX,
+                "good-ticket",
+                "forbidden-export",
+            ))
+            .await
+            .unwrap_err();
+        assert_eq!(errno_from_error(&err), EACCES, "denied aname must be EACCES");
+        // The root fid (fid 0, the attach target) must not exist after a denied
+        // attach — the deny happened in `backend.attach` before the translator
+        // bound any fid (the fail-closed contract: no fid leak on a denied
+        // export).
+        assert!(t.fids.qtype(0).is_none(), "no fid may be created for a denied aname");
     }
 
     /// Fail-closed: an op arriving before a successful attach binds the Subject

--- a/crates/hyprstream/src/server/routes/ninep.rs
+++ b/crates/hyprstream/src/server/routes/ninep.rs
@@ -523,21 +523,56 @@ struct TicketAttachAuthorizer {
 
 #[async_trait]
 impl AttachAuthorizer for TicketAttachAuthorizer {
-    async fn authorize(&self, uname: &str) -> Result<Subject, MountError> {
+    async fn authorize(&self, uname: &str, aname: &str) -> Result<Subject, MountError> {
         if uname.is_empty() {
             return Err(MountError::PermissionDenied(
                 "missing mount ticket".to_owned(),
             ));
         }
-        match verify_mount_ticket(&self.state, uname, PLANE_WEBTRANSPORT, ROOT_NAMESPACE_PATH).await
-        {
+        // Resolve the requested export (`aname`) to the namespace path the
+        // ticket must grant, then let the ticket capability check decide. An
+        // empty `aname` selects the default (root) export; an explicit selector
+        // is normalized as an absolute, `..`-free path so the accept-side
+        // canonical form agrees with the capability a ticket encodes. A
+        // malformed `aname` denies here; an otherwise well-formed but ungranted
+        // one denies inside `verify_mount_ticket` (the ticket capability won't
+        // match). Either way this is EACCES before any fid exists, and there is
+        // NO fallback to a default export after an explicit selector
+        // (#877/#1071 fail-closed contract).
+        let requested_ns = aname_to_namespace_path(aname)?;
+        match verify_mount_ticket(&self.state, uname, PLANE_WEBTRANSPORT, &requested_ns).await {
             Ok(subject) => Ok(subject),
             Err(reason) => {
-                warn!(reason, "9P WT attach rejected: invalid mount ticket");
+                warn!(reason, aname = %aname, "9P WT attach rejected: invalid mount ticket or export");
                 Err(MountError::PermissionDenied(reason.to_owned()))
             }
         }
     }
+}
+
+/// Normalize the 9P `aname` (export selector) a client presents at `Tattach`
+/// into the namespace path the mount ticket must grant.
+///
+/// An empty `aname` selects the default (root) export → [`ROOT_NAMESPACE_PATH`].
+/// An explicit selector is normalized as an absolute, `..`-free path (a bare
+/// name is anchored at the root) by reusing the mint-side normalizer so the
+/// accept-side canonical form agrees byte-for-byte with the capability a ticket
+/// encodes. A malformed selector (`..`, non-normalizable) denies — it is never
+/// silently coerced to the default.
+///
+/// Today mount tickets are minted only for `/` (`mount_ticket.rs`), so the only
+/// `aname` that can match a grant is one normalizing to `/` (empty or `/`
+/// itself); any other selector denies with `EACCES`. Widening this to real
+/// per-export grants is the `ExportResolver` (#877/#1071) — out of scope here,
+/// where the seam is made `aname`-aware and fail-closed.
+fn aname_to_namespace_path(aname: &str) -> Result<String, MountError> {
+    if aname.is_empty() {
+        return Ok(ROOT_NAMESPACE_PATH.to_owned());
+    }
+    let anchored = if aname.starts_with('/') { aname.to_owned() } else { format!("/{aname}") };
+    crate::services::oauth::mount_ticket::normalize_namespace_path(&anchored).ok_or_else(|| {
+        MountError::PermissionDenied(format!("malformed aname (export selector): {aname:?}"))
+    })
 }
 
 /// The injected 9P-over-WebTransport handler (H1b / #765).

--- a/crates/hyprstream/src/services/oauth/mount_ticket.rs
+++ b/crates/hyprstream/src/services/oauth/mount_ticket.rs
@@ -246,7 +246,7 @@ fn valid_plane(value: &str) -> bool {
             .all(|c| c.is_ascii_alphanumeric() || matches!(c, '.' | '_' | '-'))
 }
 
-fn normalize_namespace_path(value: &str) -> Option<String> {
+pub(crate) fn normalize_namespace_path(value: &str) -> Option<String> {
     if !value.starts_with('/') {
         return None;
     }


### PR DESCRIPTION
## Summary

Board-approved **P0 fix-forward for #877**: thread the 9P attach `aname` (export selector) through to the attach authorizer on `main`, and make `TicketAttachAuthorizer` **deny an unknown / forbidden / malformed export with `EACCES` before any fid exists**. No fallback to a default export after an explicit selector.

Closes the #877/#1071 fail-closed contract and unblocks #817 (`load_model` walks a `Mount`).

Reviewed/approved: 3-reviewer security board (sol/fable/kimi-k3) + the #1267 MAC-lane owner. Synthesis: `877-board-synthesis.md`.

## What changed (5 files, ~130 lines)

- **`hyprstream-9p/src/backend.rs`** — `Backend::attach(_uname)` → `attach(_uname, _aname)`; default no-op kept, doc updated.
- **`hyprstream-9p/src/mount_backend.rs`** — `AttachAuthorizer::authorize(uname)` → `authorize(uname, aname)`; `MountBackend::attach` forwards **both** so export selection + `Subject` bind happen in one authorization.
- **`hyprstream-9p/src/translator.rs`** — `handle_attach` forwards `aname` to `backend.attach` (it was in scope, handed to the monitor, then dropped before the backend). Adds `attach_aname_denied_returns_eacces` (fail-closed contract) and makes `FakeTicketAuth` aname-aware.
- **`hyprstream/src/server/routes/ninep.rs`** — `TicketAttachAuthorizer::authorize` gains `aname`; validates the requested export against the ticket's namespace grant (`aname` → namespace path via the mint-side normalizer). Unknown/forbidden/malformed → `PermissionDenied` → `EACCES`.
- **`hyprstream/src/services/oauth/mount_ticket.rs`** — `normalize_namespace_path` widened to `pub(crate)` so the accept side agrees byte-for-byte with the capability a ticket encodes.

## Out of scope (separate, MAC-lane-owned PRs)

- The unified `VerifiedAttach { identity, subject, session }` bundle (the dual-derivation fix) — **T8-activation scope**.
- The `ExportResolver` `(authority, aname) → Mount` itself — lands later under #877/#1071; this P0 only makes the seam aname-aware and fail-closed.

## Notes

- Mines **only** the aname-threading delta from branch `22bce760b` (which predates `mac_seam`, has no MAC, and shares fids across connections). It does **not** adopt that branch wholesale; main's connection-scoped fid regression is preserved.
- `aname` semantics today: only the root export (`/`) is granted (tickets are minted for `/` only), so the only accepted `aname` is empty / `/`; everything else denies. Widening is the resolver's job.
- Local validation: `hyprstream-9p` build + full test suite green (incl. new test); `hyprstream` crate compiles (`--no-default-features --features gittorrent,xet,otel` — env lacks `systemd-devel`); clippy clean on `hyprstream-9p`. Remaining/full CI via GHA.

## Commit 2 — CI housekeeping (unrelated to the aname logic)

`ba69908e2` banks a **pre-existing main** loopback-burn-down shrink so the #1152 W4 merge-queue gate stops failing every PR off main. `main` already removed 4 loopback literals from `config/server.rs` (`983331c38`/`f2e9a0b6b`, before this branch) without running `check_loopback_burndown.py --update`, so the baseline (86/32) was stale vs reality (82/31) and the gate fails on an un-banked shrink by design. This PR's own code adds zero loopback literals. Baseline now 82/31; gate passes locally. Called out separately so it doesn't muddy the aname review.

Do not merge — independent review (kimi-k3), then queue.
