### PR TITLE
ci(rust): gate browser WASM and use ci-test doctests

### DIFF
--- a/.github/scripts/graviton-build-test.sh
+++ b/.github/scripts/graviton-build-test.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
-# Merge-gate build + test for the self-hosted Graviton (arm64) fleet, run INSIDE
-# the rust-builder container as a NON-ROOT user (#1011). rust.yml invokes it as:
+# Merge-gate browser-WASM check + native build/test for the self-hosted Graviton
+# (arm64) fleet, run INSIDE the rust-builder container as a NON-ROOT user
+# (#1011). rust.yml invokes it as:
 #   runuser -u ci -- bash -euo pipefail /build/.github/scripts/graviton-build-test.sh
 # from the bind-mounted workspace (cwd = /build). Root-only setup (cargo-nextest,
 # git-lfs, wasm rustup targets, the ci user + perms) happens in the workflow before
@@ -39,6 +40,13 @@ run_phase() {
   echo "::endgroup::"
   return "${status}"
 }
+
+# Fail fast on browser-only composition regressions in the required merge-gate
+# job. Keep the WebTransport cfg scoped to this command so it cannot leak into
+# the native release/test phases below. This reuses the same checkout, target,
+# sccache process, and container instead of consuming another runner slot.
+run_phase "browser WASM check" env RUSTFLAGS=--cfg=web_sys_unstable_apis \
+  cargo check --target wasm32-unknown-unknown -p hyprstream-rpc
 
 # Default features (parity with the former x86 gate); libtorch is the image's
 # aarch64 wheel at /opt/libtorch, so NO download-libtorch feature here.

--- a/.github/scripts/graviton-build-test.sh
+++ b/.github/scripts/graviton-build-test.sh
@@ -57,8 +57,11 @@ export HYPRSTREAM_FSGUEST_WASM="${PWD}/crates/hyprstream-workers-wasmtime-fsgues
 # nextest ci profile enforces the per-test slow-timeout from .config/nextest.toml;
 # fail-fast (the default) is what the merge gate wants.
 run_phase "nextest" cargo nextest run --cargo-profile ci-test --profile ci
-# nextest does not run doctests; keep them in the merge gate.
-run_phase "doctests" cargo test --release --doc
+# nextest does not run doctests; keep them in the merge gate. Use the ci-test
+# cargo profile (not --release) so doctests skip release ThinLTO — #1010's
+# acceptance criterion: a measured 318s doctest phase was paying release LTO
+# for almost no runtime win on doc examples. Parity with the nextest profile.
+run_phase "doctests" cargo test --profile ci-test --doc
 
 echo "::group::sccache statistics"
 sccache --show-stats

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -137,8 +137,9 @@ jobs:
 
   wasm:
     name: WASM (browser client)
-    # The PR check has already validated this target. Keep the merge queue's
-    # critical path to the full integration build rather than recompiling it.
+    # Preserve fast PR feedback. The synthetic merge candidate is checked again
+    # by the required `build` job, in its existing container, so composition-only
+    # browser regressions cannot pass the merge queue.
     if: github.event_name != 'merge_group'
     runs-on: [self-hosted, linux, arm64, graviton, hyprstream-merge-gate]
     timeout-minutes: 30
@@ -197,7 +198,8 @@ jobs:
     #      served by sccache-S3 + crates.io). It only sets up the non-root ci user.
     runs-on: [self-hosted, linux, arm64, graviton, hyprstream-merge-gate]
     # Do not wait for a duplicate lint pass on merge_group. PR lint/WASM checks
-    # run before enqueueing; this required job validates the merged candidate.
+    # run before enqueueing; this required job validates the merged candidate
+    # and rechecks browser WASM before starting the native release build.
     # Backstop below the fleet's 150-min reaper cap (metal reaper_max_lifetime_
     # minutes) so a genuine hang fails definitively rather than being reaped
     # mid-run. A COLD-cache build+test can approach this; once sccache (S3) is
@@ -221,12 +223,12 @@ jobs:
     - name: Pull builder image
       run: podman pull "$BUILDER_IMAGE"
 
-    # Full merge-gate build + test in ONE container so sccache stays warm and the
-    # bind-mounted target/ persists across build → wasm-guests → nextest →
-    # doctests. Mirrors the clippy/wasm invocation (libtorch + sccache-to-S3 from
-    # the image); AWS creds forward by name (`-e VAR` with no value passes the
-    # host value) so the in-image sccache reaches the same-region S3 bucket.
-    - name: Build + test (release, in rust-builder container)
+    # Browser-WASM preflight + full merge-gate build/test run in ONE container,
+    # so sccache stays warm and the bind-mounted target/ persists across the
+    # browser check → native build → wasm guests → nextest → doctests. AWS creds
+    # forward by name (`-e VAR` with no value passes the host value) so the
+    # in-image sccache reaches the same-region S3 bucket.
+    - name: WASM preflight + build + test (in rust-builder container)
       run: |
         podman run --rm \
           -v "$PWD":/build:Z -w /build \

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -203,7 +203,8 @@ jobs:
     # mid-run. A COLD-cache build+test can approach this; once sccache (S3) is
     # warm, real runs finish well under the merge queue's 120-min
     # check_response_timeout. The nextest ci-test profile avoids release ThinLTO
-    # on test binaries to keep the suite bounded.
+    # on test binaries to keep the suite bounded; the merge-gate doctest phase
+    # uses the same ci-test cargo profile for the same reason (#1010).
     timeout-minutes: 140
 
     steps:

--- a/crates/hyprstream-rpc/src/auth/mac/pep.rs
+++ b/crates/hyprstream-rpc/src/auth/mac/pep.rs
@@ -9,6 +9,7 @@
 
 use std::sync::Arc;
 
+#[cfg(not(target_arch = "wasm32"))]
 use super::dispatch_pep::{MacDecision, MacDenyReason, RpcObjectLabelResolver};
 use super::{SecurityContext, SecurityLabel};
 use crate::envelope::Subject;
@@ -41,6 +42,7 @@ pub trait ClearanceSource: Send + Sync {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum MoqMacAuditReason {
     /// A denial returned by the canonical shared MAC contract.
+    #[cfg(not(target_arch = "wasm32"))]
     Mac(MacDenyReason),
     /// An authorizer was installed, but moq-net exposed no per-track callback.
     ///
@@ -86,6 +88,7 @@ pub trait MoqMacAuditSink: Send + Sync {
 /// Dormancy is represented by the caller not installing this PEP. Every check
 /// on an installed instance is fail-closed.
 pub struct MoqEventPep {
+    #[cfg(not(target_arch = "wasm32"))]
     resolver: Arc<dyn RpcObjectLabelResolver>,
     clearance: Arc<dyn ClearanceSource>,
     audit: Arc<dyn MoqMacAuditSink>,
@@ -94,6 +97,7 @@ pub struct MoqEventPep {
 impl MoqEventPep {
     /// Construct an active, fail-closed PEP from the canonical object-label
     /// resolver, verified-subject clearance source, and mandatory audit sink.
+    #[cfg(not(target_arch = "wasm32"))]
     pub fn new(
         resolver: Arc<dyn RpcObjectLabelResolver>,
         clearance: Arc<dyn ClearanceSource>,
@@ -123,10 +127,11 @@ impl MoqEventPep {
             object_label,
             reason,
         };
-        if let Err(error) = self.audit.record_deny(&record) {
+        if let Err(_error) = self.audit.record_deny(&record) {
+            #[cfg(not(target_arch = "wasm32"))]
             tracing::error!(
                 target: "hyprstream.mac.audit",
-                %error,
+                error = %_error,
                 subject = ?record.subject,
                 object = %record.object,
                 action = ?record.action,
@@ -142,6 +147,7 @@ impl MoqEventPep {
     /// coordinate. MoQ/event checks have no browser method discriminator, so
     /// the resolver always receives `None`.
     #[must_use]
+    #[cfg(not(target_arch = "wasm32"))]
     pub fn check(
         &self,
         subject: &Subject,
@@ -205,6 +211,7 @@ impl MoqEventPep {
         );
     }
 
+    #[cfg(not(target_arch = "wasm32"))]
     pub fn resolver(&self) -> &Arc<dyn RpcObjectLabelResolver> {
         &self.resolver
     }
@@ -224,7 +231,7 @@ impl ClearanceSource for DenyAllClearanceSource {
     }
 }
 
-#[cfg(test)]
+#[cfg(all(test, not(target_arch = "wasm32")))]
 #[allow(clippy::unwrap_used)]
 mod tests {
     use super::*;


### PR DESCRIPTION
## Summary

Compose the two merge-gate fixes requested in #1010 and #1336:

- run workspace doctests with the existing `ci-test` profile instead of release ThinLTO;
- run the browser `wasm32-unknown-unknown` check as the first phase of the required `build` job;
- cfg-gate the current-main native-only MAC PEP dependencies that the new gate immediately exposed.

## Queue and runner impact

The WASM check runs inside the existing non-root rust-builder container and existing required `build` job. It reuses the checkout, target directory, and S3 sccache process, and consumes no additional runner slot. The standalone WASM PR check remains for fast feedback.

The required job now validates the synthetic merge candidate in this order: browser WASM check, native release build, guest WASM builds, nextest, then doctests. A browser-only composition regression therefore cannot pass the required merge gate.

## Validation

- `bash -n .github/scripts/graviton-build-test.sh`
- `git diff --check`
- exact browser command: `RUSTFLAGS=--cfg=web_sys_unstable_apis cargo check --target wasm32-unknown-unknown -p hyprstream-rpc` — PASS (4.16s on composed head)
- focused native command: `cargo check -p hyprstream-rpc` — PASS (6.30s on composed head)
- repository pre-commit CI-mirroring release check on the source repair — PASS
- negative proof: before the cfg-only source repair, the new required phase failed on current main at the native-only `dispatch_pep` import and `tracing` call; after repair, the same command passes.

The full local release nextest attempt was intentionally stopped after Commander approved the lighter native proof for this pure cfg repair. No compiler or test diagnostic occurred before the stop.

Supersedes the focused source-only PR #1338; its exact source patch is composed here.

Closes #1010
Closes #1336