### PR TITLE
feat(wasm): wire VfsShell::connect through #1314 exchange + browser-provisioning (Lane C) — drop Subject::anonymous

### DIFF
--- a/crates/hyprstream-rpc-std/src/wasm_exports.rs
+++ b/crates/hyprstream-rpc-std/src/wasm_exports.rs
@@ -25,8 +25,20 @@ pub use hyprstream_rpc::wasm_api::*;
 ///
 /// All I/O goes through `RpcClient<JsSigner, WtConnection>` → ZMTP/QUIC → server.
 ///
+/// `connect` first exchanges `subject_token` for a short-lived at+jwt Bearer via
+/// the #1314 token-exchange endpoint (`POST {exchangeEndpoint}/oauth/token`), then
+/// dials the registry + model services through browser-provisioning (the only
+/// working browser dial) and presents that Bearer as the default JWT on every
+/// request. The shell's `Subject` is decoded from the Bearer's `sub` claim.
+///
 /// ```js
-/// const shell = await VfsShell.connect(regUrl, modelUrl, certHash, signerPubkey, signFn);
+/// const shell = await VfsShell.connect(
+///   registryOrigin, modelOrigin,            // https provisioning origins
+///   ed25519Pubkey, ed25519SignFn,            // hybrid signer (Ed25519 arm)
+///   mlDsa65Pubkey, mlDsa65SignFn,            // hybrid signer (PQ arm)
+///   exchangeEndpoint,                        // https origin hosting POST /oauth/token
+///   atprotoJwt, "urn:ietf:params:oauth:token-type:jwt",
+/// );
 /// const result = await shell.eval('ls /srv/registry');
 /// ```
 #[wasm_bindgen]
@@ -36,77 +48,94 @@ pub struct VfsShell {
 
 #[wasm_bindgen]
 impl VfsShell {
-    /// Create a new VFS shell by connecting to services.
+    /// Create a new VFS shell by authenticating + connecting to services.
     ///
-    /// Creates its own `RpcClient` instances for the registry and model services.
-    /// Both clients share the same `signer_pubkey` and `sign_fn`.
-    ///
-    /// - `signer_pubkey`: 32-byte Ed25519 public key for every envelope
-    /// - `sign_fn`: async JS callback `(canonicalBytes: Uint8Array) => Promise<Uint8Array>`
+    /// - `registry_origin` / `model_origin`: HTTPS origins serving the
+    ///   `/.well-known/hyprstream/browser-provisioning/{registry,model}`
+    ///   discovery documents. Cert pinning is server-supplied by provisioning
+    ///   (there is no caller `cert_hash` on the resolved path — that is the
+    ///   security model the `dial_wasm` stub deliberately forced us onto).
+    /// - `signer_pubkey` / `sign_fn`: 32-byte Ed25519 pubkey + async JS callback
+    ///   `(canonicalBytes: Uint8Array) => Promise<Uint8Array>` (hybrid Ed25519 arm).
+    /// - `signer_ml_dsa65_pubkey` / `pq_sign_fn`: ML-DSA-65 pubkey + PQ sign
+    ///   callback (hybrid PQ arm; required by the resolved path).
+    /// - `exchange_endpoint`: HTTPS origin hosting the #1314 `POST /oauth/token`.
+    /// - `subject_token` / `subject_token_type`: the credential to exchange
+    ///   (e.g. an atproto JWT, `subject_token_type = urn:ietf:params:oauth:token-type:jwt`).
     pub async fn connect(
-        registry_url: &str,
-        model_url: &str,
-        cert_hash: Option<String>,
+        registry_origin: &str,
+        model_origin: &str,
         signer_pubkey: &[u8],
         sign_fn: Function,
+        signer_ml_dsa65_pubkey: &[u8],
+        pq_sign_fn: Function,
+        exchange_endpoint: &str,
+        subject_token: String,
+        subject_token_type: String,
     ) -> Result<VfsShell, JsError> {
         console_error_panic_hook::set_once();
 
-        use hyprstream_rpc::crypto::VerifyingKey;
-        // #409 Path A: route through the wasm32 `dial()` factory instead of
-        // hand-assembling `RpcClientImpl` here. This is the browser counterpart
-        // to native `dial()` — same `Arc<dyn RpcClient>` return, hiding the
-        // concrete `WtConnection` transport behind the object-safe trait.
-        use hyprstream_rpc::dial_wasm;
-
-        // TODO: Get server verifying key from discovery endpoint
-        let server_key = VerifyingKey::from_bytes(&[0u8; 32]).unwrap_or_else(|_| {
-            VerifyingKey::from_bytes(&[
-                0xd7, 0x5a, 0x98, 0x01, 0x82, 0xb1, 0x0a, 0xb7,
-                0xd5, 0x4b, 0xfe, 0xd3, 0xc9, 0x64, 0x07, 0x3a,
-                0x0e, 0xe1, 0x72, 0xf3, 0xda, 0xa3, 0x23, 0x28,
-                0x27, 0xbf, 0x5c, 0xdc, 0xb3, 0xa0, 0x35, 0x6c,
-            ]).expect("fallback key")
-        });
-
-        // Connect to registry
-        web_sys::console::log_1(&"[VfsShell] Connecting to registry...".into());
-        let reg_signer = hyprstream_rpc::signer::JsSigner::new(signer_pubkey, sign_fn.clone())
-            .map_err(|e| JsError::new(&e.to_string()))?;
-        let reg_client: Arc<dyn hyprstream_rpc::rpc_client::RpcClient> = dial_wasm::dial(
-            registry_url,
-            cert_hash.as_deref(),
-            reg_signer,
-            Some(server_key.clone()),
-            None,
+        // 1) Exchange the atproto/external JWT for a short-lived at+jwt Bearer (#1314).
+        web_sys::console::log_1(&"[VfsShell] Exchanging subject token...".into());
+        let exchanged = hyprstream_rpc::wasm_token_exchange::fetch_exchange_token(
+            exchange_endpoint,
+            &subject_token,
+            &subject_token_type,
         )
         .await
         .map_err(|e| JsError::new(&e.to_string()))?;
+
+        // 2) Derive the display Subject from the freshly-minted Bearer's `sub`.
+        //    The response does not echo `sub` (the mint stamps `sub = verified.sub`),
+        //    so decode it client-side. Authority is re-verified by the server on
+        //    every RPC; this decode is bookkeeping only.
+        let subject = hyprstream_rpc::wasm_token_exchange::subject_from_access_token(
+            &exchanged.access_token,
+        )
+        .map_err(|e| JsError::new(&e.to_string()))?;
+        web_sys::console::log_1(&"[VfsShell] Subject resolved from exchanged token".into());
+
+        // 3) Connect to registry + model through the resolved browser-provisioning
+        //    path (the only working browser dial), presenting the Bearer as the
+        //    default JWT on every request. The `dial_wasm::dial` stub is dropped.
+        let bearer = Some(exchanged.access_token);
+        web_sys::console::log_1(&"[VfsShell] Connecting to registry...".into());
+        let reg_client: Arc<dyn hyprstream_rpc::rpc_client::RpcClient> = Arc::new(
+            crate::wasm_rpc_client::build_resolved_client(
+                registry_origin,
+                "registry",
+                signer_pubkey,
+                sign_fn.clone(),
+                signer_ml_dsa65_pubkey,
+                pq_sign_fn.clone(),
+                bearer.clone(),
+            )
+            .await?,
+        );
         web_sys::console::log_1(&"[VfsShell] Registry connected".into());
 
-        // Connect to model
         web_sys::console::log_1(&"[VfsShell] Connecting to model...".into());
-        let model_signer = hyprstream_rpc::signer::JsSigner::new(signer_pubkey, sign_fn)
-            .map_err(|e| JsError::new(&e.to_string()))?;
-        let model_client: Arc<dyn hyprstream_rpc::rpc_client::RpcClient> = dial_wasm::dial(
-            model_url,
-            cert_hash.as_deref(),
-            model_signer,
-            Some(server_key),
-            None,
-        )
-        .await
-        .map_err(|e| JsError::new(&e.to_string()))?;
+        let model_client: Arc<dyn hyprstream_rpc::rpc_client::RpcClient> = Arc::new(
+            crate::wasm_rpc_client::build_resolved_client(
+                model_origin,
+                "model",
+                signer_pubkey,
+                sign_fn,
+                signer_ml_dsa65_pubkey,
+                pq_sign_fn,
+                bearer,
+            )
+            .await?,
+        );
         web_sys::console::log_1(&"[VfsShell] Model connected".into());
 
-        // Build VFS namespace
+        // 4) Build VFS namespace + Tcl shell with the authenticated subject.
         web_sys::console::log_1(&"[VfsShell] Building namespace...".into());
-        let (ns, _stream_registry) = crate::vfs_mount::build_browser_namespace(reg_client, model_client);
+        let (ns, _stream_registry) =
+            crate::vfs_mount::build_browser_namespace(reg_client, model_client);
         let ns = Arc::new(ns);
         web_sys::console::log_1(&"[VfsShell] Namespace built".into());
 
-        // Create Tcl shell
-        let subject = hyprstream_rpc::Subject::anonymous();
         let shell = hyprstream_workers_tcl::TclShell::new(subject, ns);
 
         Ok(VfsShell {

--- a/crates/hyprstream-rpc-std/src/wasm_rpc_client.rs
+++ b/crates/hyprstream-rpc-std/src/wasm_rpc_client.rs
@@ -113,6 +113,63 @@ fn fixed_ephemeral_pubkey(ephemeral_pubkey: &[u8]) -> Result<[u8; 32], JsError> 
         .map_err(|_| JsError::new("ephemeral_pubkey must be 32 bytes"))
 }
 
+/// Resolve accepted-current browser provisioning for `service_name`, dial the
+/// bound owned WebTransport reach, and build a fully-provisioned client (hybrid
+/// `JsSigner`, KEM/PQ crypto stores, request-binding pre-seal guard, optional
+/// default JWT).
+///
+/// Rust-internal counterpart of [`WasmRpcClient::connect_resolved`]: it returns
+/// the concrete client so callers can either wrap it in `WasmRpcClient` (the JS
+/// export) or erase it behind `Arc<dyn RpcClient>` for a VFS namespace mount
+/// (see `VfsShell::connect`). This is the single working browser dial — the
+/// `dial_wasm::dial` stub is deliberately disabled in favor of this path.
+pub(crate) async fn build_resolved_client(
+    provisioning_origin: &str,
+    service_name: &str,
+    signer_pubkey: &[u8],
+    sign_fn: js_sys::Function,
+    signer_ml_dsa65_pubkey: &[u8],
+    pq_sign_fn: js_sys::Function,
+    jwt: Option<String>,
+) -> Result<RpcClientImpl<JsSigner, WtConnection>, JsError> {
+    let expected = BrowserProvisioningRequest::new(
+        service_name,
+        "hyprstream-rpc/1",
+        service_name,
+        BrowserCarrierProfile::OwnedHybridWebTransport,
+    )
+    .map_err(|error| JsError::new(&error.to_string()))?;
+    let provisioned = fetch_browser_provisioning(provisioning_origin, &expected)
+        .await
+        .map_err(|error| JsError::new(&error.to_string()))?;
+    let transport = WtConnection::connect_with_certificate_hashes(
+        provisioned.webtransport_url(),
+        provisioned.certificate_hashes(),
+    )
+    .await
+    .map_err(|error| JsError::new(&error.to_string()))?;
+    let signer = JsSigner::new_hybrid(signer_pubkey, sign_fn, signer_ml_dsa65_pubkey, pq_sign_fn)
+        .map_err(|error| JsError::new(&error.to_string()))?;
+    let (kem, pq) = provisioned
+        .crypto_stores()
+        .map_err(|error| JsError::new(&error.to_string()))?;
+    let guard = BrowserProvisioningGuard::new(provisioning_origin, expected, provisioned.clone());
+    let binding = provisioned
+        .request_binding()
+        .map_err(|error| JsError::new(&error.to_string()))?;
+    let client = RpcClientImpl::new(signer, transport, Some(provisioned.server_verifying_key()))
+        .with_request_kem_store(kem)
+        .with_response_pq_store(pq)
+        .with_pre_seal_guard(Arc::new(guard))
+        .with_browser_provisioning_binding(binding)
+        .map_err(|error| JsError::new(&error.to_string()))?;
+    let client = match jwt {
+        Some(token) => client.with_default_jwt(token),
+        None => client,
+    };
+    Ok(client)
+}
+
 #[wasm_bindgen(js_class = "RpcClient")]
 impl WasmRpcClient {
     /// Create a new RPC client with a pre-built transport connection.
@@ -176,45 +233,17 @@ impl WasmRpcClient {
         pq_sign_fn: js_sys::Function,
         jwt: Option<String>,
     ) -> Result<WasmRpcClient, JsError> {
-        let expected = BrowserProvisioningRequest::new(
+        let inner = build_resolved_client(
+            provisioning_origin,
             service_name,
-            "hyprstream-rpc/1",
-            service_name,
-            BrowserCarrierProfile::OwnedHybridWebTransport,
+            signer_pubkey,
+            sign_fn,
+            signer_ml_dsa65_pubkey,
+            pq_sign_fn,
+            jwt,
         )
-        .map_err(|error| JsError::new(&error.to_string()))?;
-        let provisioned = fetch_browser_provisioning(provisioning_origin, &expected)
-            .await
-            .map_err(|error| JsError::new(&error.to_string()))?;
-        let transport = WtConnection::connect_with_certificate_hashes(
-            provisioned.webtransport_url(),
-            provisioned.certificate_hashes(),
-        )
-        .await
-        .map_err(|error| JsError::new(&error.to_string()))?;
-        let signer =
-            JsSigner::new_hybrid(signer_pubkey, sign_fn, signer_ml_dsa65_pubkey, pq_sign_fn)
-                .map_err(|error| JsError::new(&error.to_string()))?;
-        let (kem, pq) = provisioned
-            .crypto_stores()
-            .map_err(|error| JsError::new(&error.to_string()))?;
-        let guard =
-            BrowserProvisioningGuard::new(provisioning_origin, expected, provisioned.clone());
-        let binding = provisioned
-            .request_binding()
-            .map_err(|error| JsError::new(&error.to_string()))?;
-        let client =
-            RpcClientImpl::new(signer, transport, Some(provisioned.server_verifying_key()))
-                .with_request_kem_store(kem)
-                .with_response_pq_store(pq)
-                .with_pre_seal_guard(Arc::new(guard))
-                .with_browser_provisioning_binding(binding)
-                .map_err(|error| JsError::new(&error.to_string()))?;
-        let client = match jwt {
-            Some(token) => client.with_default_jwt(token),
-            None => client,
-        };
-        Ok(Self { inner: client })
+        .await?;
+        Ok(Self { inner })
     }
 
     /// Builder: set a dynamic token provider called on every RPC request.

--- a/crates/hyprstream-rpc/src/lib.rs
+++ b/crates/hyprstream-rpc/src/lib.rs
@@ -229,6 +229,10 @@ pub mod web_transport;
 #[cfg(target_arch = "wasm32")]
 pub mod dial_wasm;
 pub mod browser_provisioning;
+/// Browser-side RFC 8693 token-exchange (#1314) for the wasm client. Pure
+/// parsing helpers compile on all targets (unit-tested on native); the browser
+/// `fetch` glue is `wasm32`-only.
+pub mod wasm_token_exchange;
 // Iroh carrier reach + pkarr helpers for wasm32. NodeId is exposed only as an
 // endpoint address/diagnostic; no DID or application-identity conversion exists.
 #[cfg(target_arch = "wasm32")]

--- a/crates/hyprstream-rpc/src/wasm_token_exchange.rs
+++ b/crates/hyprstream-rpc/src/wasm_token_exchange.rs
@@ -1,0 +1,327 @@
+//! Browser-side RFC 8693 token-exchange (#1314) for the wasm client.
+//!
+//! The browser `VfsShell` exchanges an atproto/external JWT for a short-lived
+//! hyprstream at+jwt Bearer, then presents that Bearer as the default JWT on
+//! every RPC. This module holds:
+//!
+//! - **Pure helpers** (`exchange_form_body`, `parse_exchange_response`,
+//!   `subject_from_access_token`) — target-agnostic, unit-tested on native.
+//! - **`fetch_exchange_token`** — the browser `fetch` glue, `wasm32`-only (it
+//!   uses `web_sys`), mirroring `browser_provisioning::fetch_browser_provisioning`.
+//!
+//! # Authority note
+//!
+//! `subject_from_access_token` decodes the at+jwt `sub` **without** signature
+//! verification. This is client-side bookkeeping only: it derives a display
+//! `Subject` from the freshly-exchanged Bearer. The token's authority is never
+//! trusted from this decode — the server re-verifies the bearer on every RPC
+//! (`require_bearer_token` / `validate_oauth_access_token`). The exchange
+//! response does not echo `sub`, and the mint stamps `sub = verified.sub`
+//! (`token_exchange.rs`), so the client decodes it from the minted token rather
+//! than extending the server response.
+
+use anyhow::{anyhow, ensure, Result};
+use serde::Deserialize;
+
+/// The RFC 8693 token-exchange grant type.
+pub const GRANT_TYPE: &str = "urn:ietf:params:oauth:grant-type:token-exchange";
+/// Issued-token type the #1314 endpoint always mints (at+jwt / access_token).
+pub const ISSUED_TOKEN_TYPE: &str = "urn:ietf:params:oauth:token-type:access_token";
+
+/// A successfully exchanged short-lived Bearer (at+jwt).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ExchangedToken {
+    /// The at+jwt `access_token` — presented as the client's default JWT.
+    pub access_token: String,
+    /// Lifetime in seconds, as reported by the endpoint. Informational: Lane C
+    /// uses a static default-JWT; a refresh path (`withTokenProvider`) is the
+    /// future-work follow-on the recon notes.
+    pub expires_in: i64,
+}
+
+#[derive(Deserialize)]
+struct ExchangeResponse {
+    access_token: String,
+    #[serde(default)]
+    expires_in: Option<i64>,
+    #[serde(default)]
+    token_type: Option<String>,
+    #[serde(default)]
+    issued_token_type: Option<String>,
+}
+
+/// Build the `application/x-www-form-urlencoded` body for an RFC 8693 exchange.
+///
+/// `grant_type` and the `subject_token_type` constant are URL-safe; the
+/// `subject_token` (a JWT) is percent-encoded defensively.
+pub fn exchange_form_body(subject_token: &str, subject_token_type: &str) -> String {
+    format!(
+        "grant_type={GRANT_TYPE}&subject_token={}&subject_token_type={}",
+        percent_encode(subject_token),
+        percent_encode(subject_token_type),
+    )
+}
+
+/// Minimal RFC 3986 unreserved percent-encoding.
+fn percent_encode(input: &str) -> String {
+    let mut out = String::with_capacity(input.len());
+    for &byte in input.as_bytes() {
+        if byte.is_ascii_alphanumeric() || matches!(byte, b'-' | b'.' | b'_' | b'~') {
+            out.push(byte as char);
+        } else {
+            out.push_str(&format!("%{:02X}", byte));
+        }
+    }
+    out
+}
+
+/// Parse the JSON body of a successful `POST /oauth/token` exchange.
+///
+/// Validates `access_token` is present and, when the endpoint sets them, that
+/// `token_type` is `Bearer` and `issued_token_type` is the access-token type —
+/// defending against a misrouted/shape-changed response being treated as a
+/// valid Bearer.
+pub fn parse_exchange_response(body: &str) -> Result<ExchangedToken> {
+    let resp: ExchangeResponse = serde_json::from_str(body)
+        .map_err(|e| anyhow!("token-exchange response is not valid JSON: {e}"))?;
+    ensure!(
+        !resp.access_token.is_empty(),
+        "token-exchange response omitted access_token"
+    );
+    if let Some(token_type) = &resp.token_type {
+        ensure!(
+            token_type.eq_ignore_ascii_case("Bearer"),
+            "token-exchange token_type is not Bearer: {token_type}"
+        );
+    }
+    if let Some(issued) = &resp.issued_token_type {
+        ensure!(
+            issued == ISSUED_TOKEN_TYPE,
+            "token-exchange issued_token_type unexpected: {issued}"
+        );
+    }
+    Ok(ExchangedToken {
+        access_token: resp.access_token,
+        expires_in: resp.expires_in.unwrap_or(0).max(0),
+    })
+}
+
+/// Decode the `sub` claim from an exchanged at+jwt and build a `Subject`.
+///
+/// No signature verification (see the module authority note). Returns an error
+/// if the token is not a decodable JWT or has no `sub`.
+pub fn subject_from_access_token(token: &str) -> Result<crate::Subject> {
+    let claims = crate::auth::decode_unverified(token)
+        .map_err(|e| anyhow!("access_token is not a decodable JWT: {e}"))?;
+    ensure!(!claims.sub.is_empty(), "access_token has no sub claim");
+    Ok(crate::Subject::new(claims.sub))
+}
+
+// ============================================================================
+// Browser fetch glue (wasm32 only)
+// ============================================================================
+
+#[cfg(target_arch = "wasm32")]
+mod fetch {
+    use super::{exchange_form_body, parse_exchange_response, ExchangedToken};
+    use anyhow::{anyhow, ensure, Context, Result};
+    use wasm_bindgen::JsCast as _;
+    use wasm_bindgen_futures::JsFuture;
+
+    /// Validate `endpoint` is an absolute, credential-free HTTPS origin.
+    fn parse_origin(endpoint: &str) -> Result<url::Url> {
+        let parsed = url::Url::parse(endpoint).context("invalid exchange endpoint")?;
+        ensure!(
+            parsed.scheme() == "https"
+                && parsed.host_str().is_some()
+                && parsed.username().is_empty()
+                && parsed.password().is_none()
+                && parsed.fragment().is_none()
+                && (parsed.path().is_empty() || parsed.path() == "/")
+                && parsed.query().is_none(),
+            "exchange endpoint must be an absolute credential-free HTTPS origin (no path/query)"
+        );
+        Ok(parsed)
+    }
+
+    /// Read a `Response` body fully into a UTF-8 string via its stream reader.
+    ///
+    /// Mirrors `browser_provisioning::fetch_browser_provisioning`'s reader loop
+    /// (no `content-length` dependency).
+    async fn read_body_text(response: &web_sys::Response) -> Result<String> {
+        let body = response
+            .body()
+            .ok_or_else(|| anyhow!("token-exchange response omitted its body"))?;
+        let reader: web_sys::ReadableStreamDefaultReader = body.get_reader().unchecked_into();
+        let mut bytes = Vec::new();
+        loop {
+            let result = JsFuture::from(reader.read())
+                .await
+                .map_err(|e| anyhow!("token-exchange response read failed: {e:?}"))?;
+            let done = js_sys::Reflect::get(&result, &wasm_bindgen::JsValue::from_str("done"))
+                .map_err(|_| anyhow!("token-exchange chunk omitted done"))?
+                .as_bool()
+                .ok_or_else(|| anyhow!("token-exchange chunk had invalid done"))?;
+            if done {
+                break;
+            }
+            let value = js_sys::Reflect::get(&result, &wasm_bindgen::JsValue::from_str("value"))
+                .map_err(|_| anyhow!("token-exchange chunk omitted value"))?;
+            let chunk: js_sys::Uint8Array = value
+                .dyn_into()
+                .map_err(|_| anyhow!("token-exchange chunk was not a Uint8Array"))?;
+            bytes.extend_from_slice(&chunk.to_vec());
+        }
+        String::from_utf8(bytes).context("token-exchange response was not valid UTF-8")
+    }
+
+    /// POST an RFC 8693 token-exchange grant to `{exchange_endpoint}/oauth/token`
+    /// and return the short-lived at+jwt Bearer.
+    ///
+    /// Form-encoded body, **no DPoP** — the generic exchange path (#1314) is
+    /// bearer-only; only the UCAN-grant path needs DPoP. CORS is open (#1316).
+    pub async fn fetch_exchange_token(
+        exchange_endpoint: &str,
+        subject_token: &str,
+        subject_token_type: &str,
+    ) -> Result<ExchangedToken> {
+        let mut url = parse_origin(exchange_endpoint)?;
+        url.set_path("/oauth/token");
+
+        let body = exchange_form_body(subject_token, subject_token_type);
+
+        let headers = web_sys::Headers::new()
+            .map_err(|e| anyhow!("token-exchange header construction failed: {e:?}"))?;
+        headers
+            .set("content-type", "application/x-www-form-urlencoded")
+            .map_err(|e| anyhow!("token-exchange content-type set failed: {e:?}"))?;
+        headers
+            .set("accept", "application/json")
+            .map_err(|e| anyhow!("token-exchange accept set failed: {e:?}"))?;
+
+        let init = web_sys::RequestInit::new();
+        init.set_method("POST");
+        init.set_body(&js_sys::JsString::from(body.as_str()));
+        init.set_headers(headers.as_ref());
+        init.set_cache(web_sys::RequestCache::NoStore);
+        init.set_credentials(web_sys::RequestCredentials::SameOrigin);
+        init.set_redirect(web_sys::RequestRedirect::Error);
+
+        let request = web_sys::Request::new_with_str_and_init(url.as_str(), &init)
+            .map_err(|e| anyhow!("token-exchange request construction failed: {e:?}"))?;
+        let window = web_sys::window().ok_or_else(|| anyhow!("browser window unavailable"))?;
+        let response_value = JsFuture::from(window.fetch_with_request(&request))
+            .await
+            .map_err(|e| anyhow!("token-exchange fetch failed: {e:?}"))?;
+        let response: web_sys::Response = response_value
+            .dyn_into()
+            .map_err(|_| anyhow!("token-exchange fetch returned a non-Response"))?;
+
+        let text = read_body_text(&response).await?;
+        if !response.ok() {
+            // The body is read first so a streamed OAuth error payload is surfaced.
+            return Err(anyhow!(
+                "token-exchange endpoint returned HTTP {}: {}",
+                response.status(),
+                text.trim()
+            ));
+        }
+        parse_exchange_response(&text)
+    }
+}
+
+#[cfg(target_arch = "wasm32")]
+pub use fetch::fetch_exchange_token;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine as _};
+
+    fn jwt(payload_json: &str) -> String {
+        let header = URL_SAFE_NO_PAD.encode(r#"{"alg":"EdDSA","typ":"at+jwt"}"#);
+        let payload = URL_SAFE_NO_PAD.encode(payload_json);
+        format!("{header}.{payload}.c2ln")
+    }
+
+    #[test]
+    fn form_body_round_trips_safe_constants() {
+        // `:` is not RFC 3986 unreserved, so the caller-supplied URN is encoded;
+        // the server's form parser decodes %3A back to ':'. A valid JWT
+        // (base64url-no-pad + '.') is already unreserved, so it passes through.
+        let body = exchange_form_body("abc.def.ghi", "urn:ietf:params:oauth:token-type:jwt");
+        assert_eq!(
+            body,
+            "grant_type=urn:ietf:params:oauth:grant-type:token-exchange\
+             &subject_token=abc.def.ghi\
+             &subject_token_type=urn%3Aietf%3Aparams%3Aoauth%3Atoken-type%3Ajwt"
+        );
+    }
+
+    #[test]
+    fn form_body_percent_encodes_non_unreserved() {
+        // base64url-no-pad never produces '+', but a tampered/odd token could carry it.
+        let body = exchange_form_body("a+b c", "t/y");
+        assert!(body.contains("subject_token=a%2Bb%20c"), "{body}");
+        assert!(body.contains("subject_token_type=t%2Fy"), "{body}");
+    }
+
+    #[test]
+    fn parse_full_response() {
+        let body = r#"{"access_token":"aaa.bbb.ccc","issued_token_type":"urn:ietf:params:oauth:token-type:access_token","token_type":"Bearer","expires_in":300}"#;
+        let t = parse_exchange_response(body).unwrap();
+        assert_eq!(t.access_token, "aaa.bbb.ccc");
+        assert_eq!(t.expires_in, 300);
+    }
+
+    #[test]
+    fn parse_tolerates_missing_extras() {
+        let body = r#"{"access_token":"x.y.z"}"#;
+        let t = parse_exchange_response(body).unwrap();
+        assert_eq!(t.access_token, "x.y.z");
+        assert_eq!(t.expires_in, 0);
+    }
+
+    #[test]
+    fn parse_rejects_missing_access_token() {
+        let body = r#"{"token_type":"Bearer","expires_in":300}"#;
+        assert!(parse_exchange_response(body).is_err());
+    }
+
+    #[test]
+    fn parse_rejects_non_bearer_token_type() {
+        let body = r#"{"access_token":"x","token_type":"DPoP","expires_in":300}"#;
+        assert!(parse_exchange_response(body).is_err());
+    }
+
+    #[test]
+    fn parse_rejects_wrong_issued_token_type() {
+        let body = r#"{"access_token":"x","issued_token_type":"urn:ietf:params:oauth:token-type:id_token","token_type":"Bearer","expires_in":300}"#;
+        assert!(parse_exchange_response(body).is_err());
+    }
+
+    #[test]
+    fn parse_rejects_non_json() {
+        assert!(parse_exchange_response("not json").is_err());
+    }
+
+    #[test]
+    fn subject_decoded_from_sub_claim() {
+        let token =
+            jwt(r#"{"iss":"https://node.example","sub":"did:plc:abc","exp":9999999999,"iat":1}"#);
+        let sub = subject_from_access_token(&token).unwrap();
+        assert_eq!(sub.name(), Some("did:plc:abc"));
+        assert!(!sub.is_anonymous());
+    }
+
+    #[test]
+    fn subject_rejects_empty_sub() {
+        let token = jwt(r#"{"iss":"x","sub":"","exp":1,"iat":1}"#);
+        assert!(subject_from_access_token(&token).is_err());
+    }
+
+    #[test]
+    fn subject_rejects_non_jwt() {
+        assert!(subject_from_access_token("not-a-jwt").is_err());
+    }
+}

--- a/crates/hyprstream-rpc/src/wasm_token_exchange.rs
+++ b/crates/hyprstream-rpc/src/wasm_token_exchange.rs
@@ -29,7 +29,10 @@ pub const GRANT_TYPE: &str = "urn:ietf:params:oauth:grant-type:token-exchange";
 pub const ISSUED_TOKEN_TYPE: &str = "urn:ietf:params:oauth:token-type:access_token";
 
 /// A successfully exchanged short-lived Bearer (at+jwt).
-#[derive(Debug, Clone, PartialEq, Eq)]
+///
+/// `Debug` is manual and redacts `access_token` so an accidental `{:?}` log
+/// can't leak the Bearer.
+#[derive(Clone, PartialEq, Eq)]
 pub struct ExchangedToken {
     /// The at+jwt `access_token` — presented as the client's default JWT.
     pub access_token: String,
@@ -37,6 +40,15 @@ pub struct ExchangedToken {
     /// uses a static default-JWT; a refresh path (`withTokenProvider`) is the
     /// future-work follow-on the recon notes.
     pub expires_in: i64,
+}
+
+impl std::fmt::Debug for ExchangedToken {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ExchangedToken")
+            .field("access_token", &"<redacted>")
+            .field("expires_in", &self.expires_in)
+            .finish()
+    }
 }
 
 #[derive(Deserialize)]
@@ -128,6 +140,12 @@ mod fetch {
     use wasm_bindgen::JsCast as _;
     use wasm_bindgen_futures::JsFuture;
 
+    /// Cap on a token-exchange response body. An OAuth token response is a few
+    /// hundred bytes; anything larger signals a misconfigured/compromised
+    /// endpoint trying to exhaust the browser tab (mirrors the spirit of
+    /// `browser_provisioning::MAX_PROVISIONING_BYTES`).
+    const MAX_EXCHANGE_RESPONSE_BYTES: usize = 64 * 1024;
+
     /// Validate `endpoint` is an absolute, credential-free HTTPS origin.
     fn parse_origin(endpoint: &str) -> Result<url::Url> {
         let parsed = url::Url::parse(endpoint).context("invalid exchange endpoint")?;
@@ -170,7 +188,13 @@ mod fetch {
             let chunk: js_sys::Uint8Array = value
                 .dyn_into()
                 .map_err(|_| anyhow!("token-exchange chunk was not a Uint8Array"))?;
-            bytes.extend_from_slice(&chunk.to_vec());
+            let chunk_bytes = chunk.to_vec();
+            if bytes.len().saturating_add(chunk_bytes.len()) > MAX_EXCHANGE_RESPONSE_BYTES {
+                return Err(anyhow!(
+                    "token-exchange response exceeds {MAX_EXCHANGE_RESPONSE_BYTES} bytes"
+                ));
+            }
+            bytes.extend_from_slice(&chunk_bytes);
         }
         String::from_utf8(bytes).context("token-exchange response was not valid UTF-8")
     }
@@ -234,6 +258,7 @@ mod fetch {
 pub use fetch::fetch_exchange_token;
 
 #[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {
     use super::*;
     use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine as _};
@@ -323,5 +348,20 @@ mod tests {
     #[test]
     fn subject_rejects_non_jwt() {
         assert!(subject_from_access_token("not-a-jwt").is_err());
+    }
+
+    #[test]
+    fn exchanged_token_debug_redacts_access_token() {
+        let t = ExchangedToken {
+            access_token: "secret-bearer-value".to_owned(),
+            expires_in: 300,
+        };
+        let rendered = format!("{t:?}");
+        assert!(
+            !rendered.contains("secret-bearer-value"),
+            "ExchangedToken Debug leaked the access_token: {rendered}"
+        );
+        assert!(rendered.contains("<redacted>"));
+        assert!(rendered.contains("300"));
     }
 }


### PR DESCRIPTION
## Lane C — wasm browser-client auth wiring

`VfsShell::connect` (the browser client entry) was **non-functional**: it called `dial_wasm::dial` (a deliberate hard-error stub forcing browser-provisioning) and used `Subject::anonymous()`. This rebases it onto the only working browser dial (`connect_resolved` / browser-provisioning) and wires the #1314 identity exchange so the shell actually connects **and** authenticates.

## Changes
- **New `hyprstream_rpc::wasm_token_exchange`** — RFC 8693 token-exchange browser `fetch` (`POST {exchange_endpoint}/oauth/token`, form-encoded, **no DPoP**) returning the short-lived at+jwt Bearer + `expires_in`. Pure helpers (`exchange_form_body`, `parse_exchange_response`, `subject_from_access_token`) are target-agnostic with native unit tests; the `fetch` glue is `wasm32`-only. Endpoint is CORS-open (#1316).
- **`VfsShell::connect`** — new signature (provisioning origins + hybrid Ed25519/ML-DSA-65 signer + identity inputs): exchanges the subject token, decodes the Bearer's `sub` for the `Subject` (replacing `Subject::anonymous()`), and dials registry + model through `build_resolved_client` with the Bearer as the default JWT. `dial_wasm::dial` stub calls dropped (path a, rejected).
- **`build_resolved_client`** — factored from `connect_resolved`'s body (`pub(crate)`) so the JS export and `VfsShell` share the single working browser dial.

## Deviations from the design doc
- **`cert_hash` dropped** from `connect`: browser-provisioning pins the server cert hashes, so a caller-supplied `cert_hash` is contradictory on the resolved path — the security model the `dial_wasm` stub deliberately forced us onto. (Doc said "keep cert_hash"; superseded by the path-b rebase in the same doc's step 4.)
- **Hybrid signer params added** (`signer_ml_dsa65_pubkey`, `pq_sign_fn`): required by the resolved path's `JsSigner::new_hybrid` (doc step 4: "prefer the hybrid signer if connect_resolved uses it").

## Build status
- ✅ `cargo check -p hyprstream-rpc --target wasm32-unknown-unknown` — **green** (this is the CI "WASM (browser client)" job; compiles the new module incl. the browser `fetch` glue).
- ✅ `cargo build -p hyprstream-rpc -p hyprstream-rpc-std` (host) — **green**; non-wasm build intact.
- ✅ `cargo test -p hyprstream-rpc wasm_token_exchange` — 11 unit tests pass (form-body encoding, response parsing incl. rejection cases, at+jwt `sub` decode).
- ⚠️ `cargo build -p hyprstream-rpc-std --target wasm32-unknown-unknown` — **blocked upstream** at `hyprstream-vfs/src/mac_pep.rs`, which imports `MacDecision`/`MacDenyReason`/`RpcObjectLabelResolver` from the wasm-gated `dispatch_pep`. This is **pre-existing on `main`** (from #1272/#1268; #1317's wasm-gate covered `crate::service` but not the `dispatch_pep → mac_pep → namespace` chain) — **not introduced by this PR** (touches none of those files). Resolving it needs a MAC-lane decision on the namespace-PEP contract's wasm behavior (browser does no server-side MAC). Flagged separately for the MAC lane.

Full browser-fetch E2E can't run locally; CI validates.

## Do not merge
Awaiting independent cross-agent review (kimi-k3 / gpt-5.6-sol) + build-green.
