### PR TITLE
feat(mac): mediate PDS account record reads (#1319)

### DIFF
--- a/crates/hyprstream-pds-service/src/lib.rs
+++ b/crates/hyprstream-pds-service/src/lib.rs
@@ -13,6 +13,7 @@
 use std::sync::Arc;
 
 use hyprstream_pds::AccountRecord;
+use hyprstream_rpc::auth::mac::{MacDecision, MacDenyReason, SecurityContext};
 use hyprstream_rpc::{EnvelopeContext, Subject};
 use hyprstream_vfs::{Mount, MountError, OREAD};
 use thiserror::Error;
@@ -20,11 +21,14 @@ use thiserror::Error;
 /// Namespace location at which an [`AccountRecordStore`] backing mount is bound.
 pub const PDS_NAMESPACE: &str = "/pds";
 
-const ACCOUNTS_DIRECTORY: &str = "accounts";
-const ACCOUNT_RECORD_FILE: &str = "account-record.cbor";
+/// Directory component containing hosted account records within a tenant.
+pub const PDS_ACCOUNTS_DIRECTORY: &str = "accounts";
+/// Public account-record publication marker.
+pub const PDS_ACCOUNT_RECORD_FILE: &str = "account-record.cbor";
+/// Fixed internal principal allowed to resolve a hosted DID to its tenant.
+pub const OAUTH_ACCOUNT_RESOLVER_SUBJECT: &str = "service:oauth";
 const DEFAULT_MAX_RECORD_BYTES: usize = 64 * 1024;
 const READ_CHUNK_BYTES: usize = 8 * 1024;
-const OAUTH_ACCOUNT_RESOLVER_SUBJECT: &str = "service:oauth";
 
 /// Failure from the mandatory tenant boundary or the PDS record read.
 #[derive(Debug, Error)]
@@ -39,6 +43,12 @@ pub enum AccountReadError {
     InvalidAccountLabel(String),
     #[error("PDS hosted-account tenant resolution denied for {0:?}")]
     UnauthorizedTenantResolver(String),
+    #[error("PDS account read denied for {subject:?} on {object:?}: {reason:?}")]
+    MacDenied {
+        subject: String,
+        object: String,
+        reason: MacDenyReason,
+    },
     #[error("invalid hosted account DID {0:?}")]
     InvalidHostedAccountDid(String),
     #[error("hosted account DID {0:?} is bound to more than one tenant")]
@@ -59,22 +69,52 @@ impl From<MountError> for AccountReadError {
     }
 }
 
+/// Mandatory MAC capability for account-record reads.
+///
+/// Implementations resolve the subject clearance and the trusted label of the
+/// exact canonical `object_id`, apply the lattice floor, and audit every MAC
+/// decision. Input-validation and mount-resolution errors are not policy
+/// decisions; they fail before an object read is attempted. The account store
+/// has no constructor without this capability.
+pub trait AccountRecordReadAuthorizer: Send + Sync {
+    /// Check a read before the store opens or reads the fid bound to
+    /// `object_id`.
+    ///
+    /// `security_context` is derived from the verified request envelope and
+    /// retains its assurance and delegated attenuation. It is `None` only when
+    /// the request had no MAC clearance, or for the fixed OAuth service's
+    /// tenant-index lookup before a hosted-account binding has been resolved.
+    fn check_read(
+        &self,
+        subject: &Subject,
+        verified_tenant: Option<&str>,
+        security_context: Option<&SecurityContext>,
+        object_id: &str,
+    ) -> MacDecision;
+}
+
 /// Read-only account record service over a mount rooted at [`PDS_NAMESPACE`].
 ///
-/// The mount remains responsible for its normal per-operation authorization.
-/// This service adds the cross-tenant invariant: every path begins with the
-/// authority-verified tenant captured by [`Self::scope`].
+/// Every construction requires an [`AccountRecordReadAuthorizer`]. The store
+/// binds the requested canonical name to one fid, MAC-authorizes that exact
+/// name, and only then opens and reads from the same fid.
 #[derive(Clone)]
 pub struct AccountRecordStore {
     pds_mount: Arc<dyn Mount>,
+    read_authorizer: Arc<dyn AccountRecordReadAuthorizer>,
     max_record_bytes: usize,
 }
 
 impl AccountRecordStore {
-    /// Construct a store over the mount bound at `/pds`.
-    pub fn new(pds_mount: Arc<dyn Mount>) -> Self {
+    /// Construct a store over the mount bound at `/pds` and a mandatory MAC
+    /// read capability.
+    pub fn new(
+        pds_mount: Arc<dyn Mount>,
+        read_authorizer: Arc<dyn AccountRecordReadAuthorizer>,
+    ) -> Self {
         Self {
             pds_mount,
+            read_authorizer,
             max_record_bytes: DEFAULT_MAX_RECORD_BYTES,
         }
     }
@@ -97,9 +137,11 @@ impl AccountRecordStore {
 
         Ok(AccountReadScope {
             pds_mount: Arc::clone(&self.pds_mount),
+            read_authorizer: Arc::clone(&self.read_authorizer),
             max_record_bytes: self.max_record_bytes,
             tenant,
             subject,
+            security_context: context.security_context(),
         })
     }
 
@@ -125,20 +167,31 @@ impl AccountRecordStore {
             return Ok(None);
         };
 
-        let tenants = read_directory(self.pds_mount.as_ref(), &[], authority).await?;
+        let tenants = read_directory(
+            self.pds_mount.as_ref(),
+            self.read_authorizer.as_ref(),
+            &[],
+            authority,
+            None,
+            None,
+        )
+        .await?;
         let mut resolved = None;
         for entry in tenants.into_iter().filter(|entry| entry.is_dir) {
             validate_tenant_component(&entry.name)?;
             let components = [
                 entry.name.as_str(),
-                ACCOUNTS_DIRECTORY,
+                PDS_ACCOUNTS_DIRECTORY,
                 label,
-                ACCOUNT_RECORD_FILE,
+                PDS_ACCOUNT_RECORD_FILE,
             ];
             let bytes = match read_file(
                 self.pds_mount.as_ref(),
+                self.read_authorizer.as_ref(),
                 &components,
                 authority,
+                Some(entry.name.as_str()),
+                None,
                 self.max_record_bytes,
             )
             .await
@@ -178,9 +231,11 @@ impl AccountRecordStore {
 /// There is intentionally no method that changes the tenant after creation.
 pub struct AccountReadScope {
     pds_mount: Arc<dyn Mount>,
+    read_authorizer: Arc<dyn AccountRecordReadAuthorizer>,
     max_record_bytes: usize,
     tenant: String,
     subject: Subject,
+    security_context: Option<SecurityContext>,
 }
 
 impl AccountReadScope {
@@ -200,14 +255,17 @@ impl AccountReadScope {
         validate_account_label(label)?;
         let components = [
             self.tenant.as_str(),
-            ACCOUNTS_DIRECTORY,
+            PDS_ACCOUNTS_DIRECTORY,
             label,
-            ACCOUNT_RECORD_FILE,
+            PDS_ACCOUNT_RECORD_FILE,
         ];
         let bytes = match read_file(
             self.pds_mount.as_ref(),
+            self.read_authorizer.as_ref(),
             &components,
             &self.subject,
+            Some(self.tenant.as_str()),
+            self.security_context.as_ref(),
             self.max_record_bytes,
         )
         .await
@@ -278,11 +336,29 @@ fn hosted_account_label(did: &str) -> Result<Option<&str>, AccountReadError> {
 
 async fn read_file(
     mount: &dyn Mount,
+    authorizer: &dyn AccountRecordReadAuthorizer,
     components: &[&str],
     subject: &Subject,
+    verified_tenant: Option<&str>,
+    security_context: Option<&SecurityContext>,
     limit: usize,
 ) -> Result<Vec<u8>, AccountReadError> {
     let mut fid = mount.walk(components, subject).await?;
+    let object_id = canonical_object_id(components);
+    if let MacDecision::Deny(reason) =
+        authorizer.check_read(subject, verified_tenant, security_context, &object_id)
+    {
+        mount.clunk(fid, subject).await;
+        return Err(AccountReadError::MacDenied {
+            subject: subject.to_string(),
+            object: object_id,
+            reason,
+        });
+    }
+
+    // The walk above binds the canonical name to this fid. Authorization is
+    // complete before open/stat/read, and the same fid is consumed below:
+    // there is no partial resolution or post-check re-walk/handle substitution.
     if let Err(error) = mount.open(&mut fid, OREAD, subject).await {
         mount.clunk(fid, subject).await;
         return Err(error.into());
@@ -295,10 +371,24 @@ async fn read_file(
 
 async fn read_directory(
     mount: &dyn Mount,
+    authorizer: &dyn AccountRecordReadAuthorizer,
     components: &[&str],
     subject: &Subject,
+    verified_tenant: Option<&str>,
+    security_context: Option<&SecurityContext>,
 ) -> Result<Vec<hyprstream_vfs::DirEntry>, AccountReadError> {
     let mut fid = mount.walk(components, subject).await?;
+    let object_id = canonical_object_id(components);
+    if let MacDecision::Deny(reason) =
+        authorizer.check_read(subject, verified_tenant, security_context, &object_id)
+    {
+        mount.clunk(fid, subject).await;
+        return Err(AccountReadError::MacDenied {
+            subject: subject.to_string(),
+            object: object_id,
+            reason,
+        });
+    }
     if let Err(error) = mount.open(&mut fid, OREAD, subject).await {
         mount.clunk(fid, subject).await;
         return Err(error.into());
@@ -306,6 +396,13 @@ async fn read_directory(
     let result = mount.readdir(&fid, subject).await.map_err(Into::into);
     mount.clunk(fid, subject).await;
     result
+}
+
+fn canonical_object_id(components: &[&str]) -> String {
+    if components.is_empty() {
+        return PDS_NAMESPACE.to_owned();
+    }
+    format!("{PDS_NAMESPACE}/{}", components.join("/"))
 }
 
 async fn read_open_fid(
@@ -354,6 +451,24 @@ mod tests {
     use hyprstream_vfs::{SyntheticMount, SyntheticNode};
     use rand::rngs::OsRng;
 
+    struct PermitAccountReads;
+
+    impl AccountRecordReadAuthorizer for PermitAccountReads {
+        fn check_read(
+            &self,
+            _subject: &Subject,
+            _verified_tenant: Option<&str>,
+            _security_context: Option<&SecurityContext>,
+            _object_id: &str,
+        ) -> MacDecision {
+            MacDecision::Permit
+        }
+    }
+
+    fn permit_account_reads() -> Arc<dyn AccountRecordReadAuthorizer> {
+        Arc::new(PermitAccountReads)
+    }
+
     fn account_bytes(label: &str, zone: &str) -> Vec<u8> {
         let ed = SigningKey::generate(&mut OsRng);
         let (pq, pq_vk) = ml_dsa_generate_keypair();
@@ -377,10 +492,11 @@ mod tests {
 
     fn tenant_node(label: &str, record: Vec<u8>) -> SyntheticNode {
         SyntheticNode::dir().with_child(
-            ACCOUNTS_DIRECTORY,
+            PDS_ACCOUNTS_DIRECTORY,
             SyntheticNode::dir().with_child(
                 label,
-                SyntheticNode::dir().with_child(ACCOUNT_RECORD_FILE, SyntheticNode::file(record)),
+                SyntheticNode::dir()
+                    .with_child(PDS_ACCOUNT_RECORD_FILE, SyntheticNode::file(record)),
             ),
         )
     }
@@ -395,7 +511,7 @@ mod tests {
                 "beta",
                 tenant_node("alice", account_bytes("alice", "beta.example")),
             );
-        AccountRecordStore::new(Arc::new(SyntheticMount::new(root)))
+        AccountRecordStore::new(Arc::new(SyntheticMount::new(root)), permit_account_reads())
     }
 
     fn context(tenant: &str) -> EnvelopeContext {
@@ -469,10 +585,11 @@ mod tests {
         let root = SyntheticNode::dir()
             .with_child("acme", tenant_node("alice", duplicated.clone()))
             .with_child("beta", tenant_node("alice", duplicated));
-        let ambiguous = AccountRecordStore::new(Arc::new(SyntheticMount::new(root)))
-            .resolve_tenant_for_hosted_did(&oauth_authority(), "did:web:alice.acme.example")
-            .await
-            .unwrap_err();
+        let ambiguous =
+            AccountRecordStore::new(Arc::new(SyntheticMount::new(root)), permit_account_reads())
+                .resolve_tenant_for_hosted_did(&oauth_authority(), "did:web:alice.acme.example")
+                .await
+                .unwrap_err();
         assert!(matches!(
             ambiguous,
             AccountReadError::AmbiguousHostedAccountDid(_)
@@ -522,8 +639,11 @@ mod tests {
     #[tokio::test]
     async fn oversized_and_mislabeled_records_fail_closed() {
         let oversized = SyntheticNode::dir().with_child("acme", tenant_node("alice", vec![0; 32]));
-        let store = AccountRecordStore::new(Arc::new(SyntheticMount::new(oversized)))
-            .with_max_record_bytes(8);
+        let store = AccountRecordStore::new(
+            Arc::new(SyntheticMount::new(oversized)),
+            permit_account_reads(),
+        )
+        .with_max_record_bytes(8);
         let error = store
             .scope(&context("acme"))
             .unwrap()
@@ -536,12 +656,15 @@ mod tests {
             "acme",
             tenant_node("bob", account_bytes("alice", "acme.example")),
         );
-        let error = AccountRecordStore::new(Arc::new(SyntheticMount::new(mislabeled)))
-            .scope(&context("acme"))
-            .unwrap()
-            .get("bob")
-            .await
-            .expect_err("mislabeled record must fail");
+        let error = AccountRecordStore::new(
+            Arc::new(SyntheticMount::new(mislabeled)),
+            permit_account_reads(),
+        )
+        .scope(&context("acme"))
+        .unwrap()
+        .get("bob")
+        .await
+        .expect_err("mislabeled record must fail");
         assert!(matches!(
             error,
             AccountReadError::RecordLabelMismatch { .. }

--- a/crates/hyprstream/src/auth/key_rotation.rs
+++ b/crates/hyprstream/src/auth/key_rotation.rs
@@ -2277,6 +2277,20 @@ mod tests {
     use super::*;
     use tempfile::TempDir;
 
+    struct PermitFixtureAccountReads;
+
+    impl hyprstream_pds_service::AccountRecordReadAuthorizer for PermitFixtureAccountReads {
+        fn check_read(
+            &self,
+            _subject: &hyprstream_rpc::Subject,
+            _verified_tenant: Option<&str>,
+            _security_context: Option<&hyprstream_rpc::auth::mac::SecurityContext>,
+            _object_id: &str,
+        ) -> hyprstream_rpc::auth::mac::MacDecision {
+            hyprstream_rpc::auth::mac::MacDecision::Permit
+        }
+    }
+
     fn hosted_account_store(
         label: &str,
         zone: &str,
@@ -2319,9 +2333,10 @@ mod tests {
             ),
         );
         Ok(Arc::new(
-            hyprstream_pds_service::AccountRecordStore::new(Arc::new(
-                hyprstream_vfs::SyntheticMount::new(root),
-            )),
+            hyprstream_pds_service::AccountRecordStore::new(
+                Arc::new(hyprstream_vfs::SyntheticMount::new(root)),
+                Arc::new(PermitFixtureAccountReads),
+            ),
         ))
     }
 

--- a/crates/hyprstream/src/mac/mod.rs
+++ b/crates/hyprstream/src/mac/mod.rs
@@ -70,6 +70,8 @@ pub mod exchange;
 pub mod genesis;
 pub mod lattice;
 pub mod moq_audit;
+// #1319: audited MAC adapter at the tenant account-record read boundary.
+pub mod pds_pep;
 // #676: the production S3-scope ↔ S5-TE-rule vocabulary (injective + exact;
 // wildcards expand at compile time over a closed registry).
 // #1270: CAS-native MAC PEP — trusted content-bound label at seal +
@@ -120,6 +122,12 @@ pub use genesis::{
     ManifestLabelSource, NamespaceEnumerator, NoManifests, SitePolicy,
 };
 pub use moq_audit::{audited_moq_event_pep, MoqAuditSinkAdapter};
+pub use pds_pep::{
+    production_pds_account_read_authorizer, EnrollmentPdsClearanceSource,
+    PdsAccountObjectLabelResolver, PdsAccountReadPep, PdsClearanceSource,
+};
+#[cfg(not(target_arch = "wasm32"))]
+pub use pds_pep::{production_pds_account_record_store, PdsDirectoryMount};
 // #1270: CAS-native MAC PEP — the shared CAS enforcement contract.
 pub use cas_pep::{
     domain_label, seal_label, CasClearanceSource, CasObjectLabelResolver, CasPep,

--- a/crates/hyprstream/src/mac/pds_pep.rs
+++ b/crates/hyprstream/src/mac/pds_pep.rs
@@ -1,0 +1,1128 @@
+//! Audited MAC adapter for the tenant account-record read store (#1319).
+//!
+//! `AccountRecordStore` operates directly on a subject-carrying `Mount`, below
+//! the network 9P translator. This adapter supplies the equivalent mandatory
+//! gate at that read boundary: authority-backed subject clearance, trusted
+//! path-label resolution, lattice dominance, and the canonical MAC audit sink.
+
+use std::sync::Arc;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+#[cfg(not(target_arch = "wasm32"))]
+use async_trait::async_trait;
+use hyprstream_pds_service::{
+    AccountRecordReadAuthorizer, OAUTH_ACCOUNT_RESOLVER_SUBJECT, PDS_ACCOUNTS_DIRECTORY,
+    PDS_ACCOUNT_RECORD_FILE,
+};
+use hyprstream_rpc::auth::mac::{
+    Assurance, CompartmentSet, Level, MacDecision, MacDenyReason, ObjectLabelResolver, ObjectRef,
+    SecurityContext, SecurityLabel, VerifiedKeyMaterial,
+};
+use hyprstream_rpc::Subject;
+#[cfg(not(target_arch = "wasm32"))]
+use hyprstream_vfs::{DirEntry, Fid, Mount, MountError, Stat};
+#[cfg(not(target_arch = "wasm32"))]
+use parking_lot::Mutex;
+#[cfg(not(target_arch = "wasm32"))]
+use std::fs::File;
+#[cfg(not(target_arch = "wasm32"))]
+use std::io::{Read, Seek, SeekFrom};
+#[cfg(not(target_arch = "wasm32"))]
+use std::path::{Path, PathBuf};
+
+use crate::mac::audit::{AuditRecord, AuditSink, DecisionReason};
+use crate::mac::te::{Action, Decision, ObjectType, ScopeAction, SubjectType};
+
+/// Reserved audit identities for the PDS account-read enforcement plane.
+const PDS_SUBJECT_TYPE: SubjectType = SubjectType(u32::MAX - 4);
+const PDS_OBJECT_TYPE: ObjectType = ObjectType(u32::MAX - 4);
+
+fn pds_account_label() -> SecurityLabel {
+    SecurityLabel::new(
+        Level::Confidential,
+        Assurance::Classical,
+        CompartmentSet::EMPTY,
+    )
+}
+
+/// Trusted structural labels for the two account-store read objects.
+///
+/// The OAuth resolver reads only `/pds` (tenant names), while a scoped caller
+/// reads only the exact publication marker below a validated tenant and
+/// account label. Other paths remain unlabeled and therefore deny.
+#[derive(Debug, Default, Clone, Copy)]
+pub struct PdsAccountObjectLabelResolver;
+
+impl ObjectLabelResolver for PdsAccountObjectLabelResolver {
+    fn resolve(&self, object: ObjectRef<'_>) -> Option<SecurityLabel> {
+        let ObjectRef::Path(components) = object else {
+            return None;
+        };
+        match components {
+            ["pds"] => Some(pds_account_label()),
+            ["pds", tenant, accounts, account, record]
+                if valid_tenant_component(tenant)
+                    && *accounts == PDS_ACCOUNTS_DIRECTORY
+                    && valid_account_component(account)
+                    && *record == PDS_ACCOUNT_RECORD_FILE =>
+            {
+                Some(pds_account_label())
+            }
+            _ => None,
+        }
+    }
+}
+
+fn valid_tenant_component(value: &str) -> bool {
+    !value.is_empty()
+        && value.len() <= 253
+        && value != "."
+        && value != ".."
+        && value != "*"
+        && value
+            .bytes()
+            .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'.' | b'_' | b'-'))
+}
+
+fn valid_account_component(value: &str) -> bool {
+    !value.is_empty()
+        && value.len() <= 63
+        && value
+            .bytes()
+            .all(|byte| byte.is_ascii_lowercase() || byte.is_ascii_digit() || byte == b'-')
+        && !value.starts_with('-')
+        && !value.ends_with('-')
+}
+
+/// Descriptor-bound, read-only production mount for `/pds`.
+///
+/// `walk` opens the named filesystem object without reading its contents and
+/// stores that descriptor in the fid. `open`, `stat`, and `read` consume that
+/// same descriptor, so a rename or symlink swap after authorization cannot
+/// substitute a different record. On Linux, directory enumeration also uses
+/// `/proc/self/fd/{fd}` and therefore stays bound to the walked directory.
+#[cfg(not(target_arch = "wasm32"))]
+pub struct PdsDirectoryMount {
+    root: PathBuf,
+    root_directory: File,
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+impl PdsDirectoryMount {
+    pub fn open(root: impl AsRef<Path>) -> std::io::Result<Self> {
+        #[cfg(not(target_os = "linux"))]
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::Unsupported,
+            "descriptor-bound PDS directory mount requires Linux /proc",
+        ));
+
+        #[cfg(target_os = "linux")]
+        {
+            std::fs::create_dir_all(root.as_ref())?;
+            #[cfg(unix)]
+            {
+                use std::os::unix::fs::PermissionsExt as _;
+                std::fs::set_permissions(root.as_ref(), std::fs::Permissions::from_mode(0o700))?;
+            }
+            let root = std::fs::canonicalize(root)?;
+            let root_directory = File::open(&root)?;
+            Ok(Self {
+                root,
+                root_directory,
+            })
+        }
+    }
+
+    fn relative_path(&self, components: &[&str]) -> Result<String, MountError> {
+        if components
+            .iter()
+            .any(|component| !valid_walk_component(component))
+        {
+            return Err(MountError::InvalidArgument(
+                "PDS path contains an invalid component".to_owned(),
+            ));
+        }
+        Ok(if components.is_empty() {
+            ".".to_owned()
+        } else {
+            components.join("/")
+        })
+    }
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+struct PdsDirectoryFid {
+    handle: File,
+    opened_file: Mutex<Option<File>>,
+    components: Vec<String>,
+    is_dir: bool,
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+fn valid_walk_component(component: &str) -> bool {
+    !component.is_empty()
+        && component != "."
+        && component != ".."
+        && !component.contains(['/', '\\', '\0'])
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+fn mount_io_error(action: &str, path: &Path, error: std::io::Error) -> MountError {
+    let detail = format!("{action} {path:?}: {error}");
+    if matches!(
+        error.raw_os_error(),
+        Some(libc::ELOOP | libc::EXDEV | libc::ENOTDIR)
+    ) {
+        return MountError::PermissionDenied(detail);
+    }
+    match error.kind() {
+        std::io::ErrorKind::NotFound => MountError::NotFound(detail),
+        std::io::ErrorKind::PermissionDenied => MountError::PermissionDenied(detail),
+        _ => MountError::Io(detail),
+    }
+}
+
+#[cfg(target_os = "linux")]
+fn open_beneath_without_symlinks(root: &File, relative: &str) -> std::io::Result<File> {
+    use std::ffi::CString;
+    use std::os::fd::{AsRawFd as _, FromRawFd as _};
+
+    #[repr(C)]
+    struct OpenHow {
+        flags: u64,
+        mode: u64,
+        resolve: u64,
+    }
+
+    const RESOLVE_NO_MAGICLINKS: u64 = 0x02;
+    const RESOLVE_NO_SYMLINKS: u64 = 0x04;
+    const RESOLVE_BENEATH: u64 = 0x08;
+
+    let relative = CString::new(relative)
+        .map_err(|_| std::io::Error::from(std::io::ErrorKind::InvalidInput))?;
+    let how = OpenHow {
+        flags: (libc::O_PATH | libc::O_CLOEXEC) as u64,
+        mode: 0,
+        resolve: RESOLVE_BENEATH | RESOLVE_NO_MAGICLINKS | RESOLVE_NO_SYMLINKS,
+    };
+    // SAFETY: `relative` and `how` remain valid for the duration of the
+    // syscall; `root` owns a live directory fd; and a successful return is a
+    // newly owned descriptor transferred exactly once into `File`.
+    let descriptor = unsafe {
+        libc::syscall(
+            libc::SYS_openat2,
+            root.as_raw_fd(),
+            relative.as_ptr(),
+            &raw const how,
+            std::mem::size_of::<OpenHow>(),
+        )
+    };
+    if descriptor < 0 {
+        return Err(std::io::Error::last_os_error());
+    }
+    // SAFETY: a successful `openat2` returns a fresh owned descriptor.
+    Ok(unsafe { File::from_raw_fd(descriptor as libc::c_int) })
+}
+
+#[cfg(target_os = "linux")]
+fn reopen_bound_handle(handle: &File, is_dir: bool) -> std::io::Result<File> {
+    use std::os::fd::AsRawFd as _;
+    use std::os::unix::fs::OpenOptionsExt as _;
+
+    let mut options = std::fs::OpenOptions::new();
+    options.read(true).custom_flags(
+        libc::O_CLOEXEC | libc::O_NONBLOCK | if is_dir { libc::O_DIRECTORY } else { 0 },
+    );
+    options.open(format!("/proc/self/fd/{}", handle.as_raw_fd()))
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+fn fid_state(fid: &Fid) -> Result<&PdsDirectoryFid, MountError> {
+    fid.downcast_ref::<PdsDirectoryFid>()
+        .ok_or_else(|| MountError::InvalidArgument("PDS mount received a foreign fid".to_owned()))
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+fn fid_state_mut(fid: &mut Fid) -> Result<&mut PdsDirectoryFid, MountError> {
+    fid.downcast_mut::<PdsDirectoryFid>()
+        .ok_or_else(|| MountError::InvalidArgument("PDS mount received a foreign fid".to_owned()))
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+#[async_trait]
+impl Mount for PdsDirectoryMount {
+    async fn walk(&self, components: &[&str], _caller: &Subject) -> Result<Fid, MountError> {
+        let relative = self.relative_path(components)?;
+        let display_path = self.root.join(&relative);
+        #[cfg(not(target_os = "linux"))]
+        return Err(MountError::NotSupported(
+            "descriptor-bound PDS walk requires Linux openat2".to_owned(),
+        ));
+        #[cfg(target_os = "linux")]
+        {
+            let handle = open_beneath_without_symlinks(&self.root_directory, &relative)
+                .map_err(|error| mount_io_error("resolve during walk", &display_path, error))?;
+            let metadata = handle
+                .metadata()
+                .map_err(|error| mount_io_error("stat walked descriptor", &display_path, error))?;
+            if !metadata.is_dir() && !metadata.is_file() {
+                return Err(MountError::PermissionDenied(format!(
+                    "PDS walk accepts only ordinary files and directories: {display_path:?}"
+                )));
+            }
+            Ok(Fid::new(PdsDirectoryFid {
+                handle,
+                opened_file: Mutex::new(None),
+                components: components
+                    .iter()
+                    .map(|component| (*component).to_owned())
+                    .collect(),
+                is_dir: metadata.is_dir(),
+            }))
+        }
+    }
+
+    async fn open(&self, fid: &mut Fid, mode: u8, _caller: &Subject) -> Result<(), MountError> {
+        if mode & 0x03 != 0 {
+            return Err(MountError::PermissionDenied(
+                "PDS account mount is read-only".to_owned(),
+            ));
+        }
+        let state = fid_state_mut(fid)?;
+        #[cfg(not(target_os = "linux"))]
+        return Err(MountError::NotSupported(
+            "descriptor-bound PDS open requires Linux /proc".to_owned(),
+        ));
+        #[cfg(target_os = "linux")]
+        {
+            let file = reopen_bound_handle(&state.handle, state.is_dir).map_err(|error| {
+                MountError::Io(format!("open walked PDS descriptor for reading: {error}"))
+            })?;
+            *state.opened_file.lock() = Some(file);
+        }
+        Ok(())
+    }
+
+    async fn read(
+        &self,
+        fid: &Fid,
+        offset: u64,
+        count: u32,
+        _caller: &Subject,
+    ) -> Result<Vec<u8>, MountError> {
+        let state = fid_state(fid)?;
+        if state.is_dir {
+            return Err(MountError::IsDirectory(state.components.join("/")));
+        }
+        let mut opened_file = state.opened_file.lock();
+        let file = opened_file
+            .as_mut()
+            .ok_or_else(|| MountError::InvalidArgument("PDS fid is not open".to_owned()))?;
+        file.seek(SeekFrom::Start(offset))
+            .map_err(|error| MountError::Io(format!("seek PDS record: {error}")))?;
+        let mut bytes = vec![0; count as usize];
+        let read = file
+            .read(&mut bytes)
+            .map_err(|error| MountError::Io(format!("read PDS record: {error}")))?;
+        bytes.truncate(read);
+        Ok(bytes)
+    }
+
+    async fn write(
+        &self,
+        _fid: &Fid,
+        _offset: u64,
+        _data: &[u8],
+        _caller: &Subject,
+    ) -> Result<u32, MountError> {
+        Err(MountError::PermissionDenied(
+            "PDS account mount is read-only".to_owned(),
+        ))
+    }
+
+    async fn readdir(&self, fid: &Fid, _caller: &Subject) -> Result<Vec<DirEntry>, MountError> {
+        let state = fid_state(fid)?;
+        if !state.is_dir {
+            return Err(MountError::NotDirectory(state.components.join("/")));
+        }
+
+        #[cfg(not(target_os = "linux"))]
+        return Err(MountError::NotSupported(
+            "descriptor-bound PDS readdir requires Linux /proc".to_owned(),
+        ));
+
+        #[cfg(target_os = "linux")]
+        {
+            use std::os::fd::AsRawFd as _;
+            let opened_file = state.opened_file.lock();
+            let file = opened_file
+                .as_ref()
+                .ok_or_else(|| MountError::InvalidArgument("PDS fid is not open".to_owned()))?;
+            let descriptor = PathBuf::from(format!("/proc/self/fd/{}", file.as_raw_fd()));
+            let entries = std::fs::read_dir(&descriptor)
+                .map_err(|error| mount_io_error("read PDS directory", &descriptor, error))?;
+            let mut result = Vec::new();
+            for entry in entries {
+                let entry = entry.map_err(|error| {
+                    mount_io_error("read PDS directory entry", &descriptor, error)
+                })?;
+                let name = entry.file_name().into_string().map_err(|_| {
+                    MountError::InvalidArgument(
+                        "PDS directory contains a non-UTF-8 name".to_owned(),
+                    )
+                })?;
+                let file_type = entry.file_type().map_err(|error| {
+                    mount_io_error("type PDS directory entry", &entry.path(), error)
+                })?;
+                let metadata = std::fs::symlink_metadata(entry.path()).map_err(|error| {
+                    mount_io_error("stat PDS directory entry", &entry.path(), error)
+                })?;
+                result.push(DirEntry {
+                    name,
+                    is_dir: file_type.is_dir(),
+                    size: metadata.len(),
+                    stat: None,
+                });
+            }
+            result.sort_by(|left, right| left.name.cmp(&right.name));
+            Ok(result)
+        }
+    }
+
+    async fn stat(&self, fid: &Fid, _caller: &Subject) -> Result<Stat, MountError> {
+        let state = fid_state(fid)?;
+        let opened_file = state.opened_file.lock();
+        let metadata = opened_file
+            .as_ref()
+            .ok_or_else(|| MountError::InvalidArgument("PDS fid is not open".to_owned()))?
+            .metadata()
+            .map_err(|error| MountError::Io(format!("stat PDS descriptor: {error}")))?;
+        Ok(Stat::unknown_qid(
+            if metadata.is_dir() { 0x80 } else { 0 },
+            metadata.len(),
+            state.components.last().cloned().unwrap_or_default(),
+            0,
+        ))
+    }
+
+    async fn clunk(&self, _fid: Fid, _caller: &Subject) {}
+}
+
+/// Resolve an authority-bound PDS reader to its verified MAC context.
+///
+/// The tenant input is derived by `AccountRecordStore` from the verified
+/// envelope, or from the authority-owned hosted-account index entry while the
+/// OAuth service resolves a DID. `None` must fail closed unless the
+/// implementation explicitly recognizes the fixed OAuth service authority
+/// performing root enumeration.
+pub trait PdsClearanceSource: Send + Sync {
+    fn clearance_for(
+        &self,
+        subject: &Subject,
+        verified_tenant: Option<&str>,
+        request_context: Option<&SecurityContext>,
+    ) -> Option<SecurityContext>;
+}
+
+/// Production clearance source that preserves the verified request context.
+///
+/// Ordinary scoped reads use the exact `SecurityContext` derived from their
+/// verified envelope, including signer assurance and delegated attenuation.
+/// The fixed internal OAuth resolver receives only the narrow PDS lookup
+/// clearance needed to discover an authority-owned tenant binding.
+#[derive(Debug, Default, Clone, Copy)]
+pub struct EnrollmentPdsClearanceSource;
+
+impl PdsClearanceSource for EnrollmentPdsClearanceSource {
+    fn clearance_for(
+        &self,
+        subject: &Subject,
+        verified_tenant: Option<&str>,
+        request_context: Option<&SecurityContext>,
+    ) -> Option<SecurityContext> {
+        let subject_id = subject.name()?;
+        if subject_id == OAUTH_ACCOUNT_RESOLVER_SUBJECT {
+            return Some(SecurityContext::from_clearance(
+                pds_account_label(),
+                VerifiedKeyMaterial::Classical,
+            ));
+        }
+        verified_tenant?;
+        request_context.cloned()
+    }
+}
+
+/// PDS account-record PEP over the trusted object-label resolver and audit WAL.
+pub struct PdsAccountReadPep {
+    clearance: Arc<dyn PdsClearanceSource>,
+    labels: Arc<dyn ObjectLabelResolver + Send + Sync>,
+    sink: Arc<dyn AuditSink>,
+}
+
+impl PdsAccountReadPep {
+    pub fn new(
+        clearance: Arc<dyn PdsClearanceSource>,
+        labels: Arc<dyn ObjectLabelResolver + Send + Sync>,
+        sink: Arc<dyn AuditSink>,
+    ) -> Self {
+        Self {
+            clearance,
+            labels,
+            sink,
+        }
+    }
+
+    fn check(
+        &self,
+        subject: &Subject,
+        verified_tenant: Option<&str>,
+        request_context: Option<&SecurityContext>,
+        object_id: &str,
+    ) -> MacDecision {
+        let components: Vec<&str> = object_id
+            .split('/')
+            .filter(|component| !component.is_empty())
+            .collect();
+        let label = self.labels.resolve(ObjectRef::Path(&components));
+        let Some(ctx) = self
+            .clearance
+            .clearance_for(subject, verified_tenant, request_context)
+        else {
+            return self.audit(
+                subject,
+                object_id,
+                None,
+                label,
+                MacDecision::Deny(MacDenyReason::NoClearance),
+            );
+        };
+        let Some(label) = label else {
+            return self.audit(
+                subject,
+                object_id,
+                Some(&ctx),
+                None,
+                MacDecision::Deny(MacDenyReason::UnlabeledObject),
+            );
+        };
+
+        let decision = if ctx.can_access(&label) {
+            MacDecision::Permit
+        } else {
+            MacDecision::Deny(MacDenyReason::FloorDeny)
+        };
+        self.audit(subject, object_id, Some(&ctx), Some(label), decision)
+    }
+
+    fn audit(
+        &self,
+        subject: &Subject,
+        object_id: &str,
+        ctx: Option<&SecurityContext>,
+        label: Option<SecurityLabel>,
+        decision: MacDecision,
+    ) -> MacDecision {
+        let (audit_decision, reason) = match decision {
+            MacDecision::Permit => (Decision::Permit, DecisionReason::Permit),
+            MacDecision::Deny(MacDenyReason::NoClearance) => {
+                (Decision::Deny, DecisionReason::NoClearance)
+            }
+            MacDecision::Deny(MacDenyReason::UnlabeledObject) => {
+                (Decision::Deny, DecisionReason::UnlabeledObject)
+            }
+            MacDecision::Deny(
+                MacDenyReason::FloorDeny
+                | MacDenyReason::NoPepInstalled
+                | MacDenyReason::StaleAuthority,
+            ) => (Decision::Deny, DecisionReason::FloorDeny),
+        };
+        let policy = crate::mac::compiled_policy();
+        let record = AuditRecord {
+            seq: 0,
+            prev_hash: [0; 32],
+            ts_unix_nanos: SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .map_or(0, |duration| duration.as_nanos()),
+            decision: audit_decision,
+            generation: policy.as_ref().map_or(0, |policy| policy.generation),
+            policy_hash: policy.as_ref().and_then(|policy| policy.policy_hash().ok()),
+            subject_type: PDS_SUBJECT_TYPE,
+            subject_clearance: ctx
+                .map(|context| *context.clearance())
+                .unwrap_or_else(SecurityLabel::bottom),
+            on_behalf_of: None,
+            object_type: PDS_OBJECT_TYPE,
+            object_label: label.unwrap_or_else(SecurityLabel::bottom),
+            action: Action::from_scope_action(ScopeAction::Query),
+            reason,
+            subject_id: Some(subject.to_string()),
+            object_id: Some(object_id.to_owned()),
+        };
+
+        match self.sink.record(&record) {
+            Ok(()) => decision,
+            Err(error) => {
+                let deny_record = AuditRecord {
+                    decision: Decision::Deny,
+                    reason: DecisionReason::AuditFailClosed,
+                    ..record
+                };
+                let _ = self.sink.record(&deny_record);
+                tracing::error!(
+                    target: "hyprstream.mac.pds_pep",
+                    %error,
+                    "PDS account-read decision could not be durably audited; enforcing deny"
+                );
+                MacDecision::Deny(MacDenyReason::FloorDeny)
+            }
+        }
+    }
+}
+
+impl AccountRecordReadAuthorizer for PdsAccountReadPep {
+    fn check_read(
+        &self,
+        subject: &Subject,
+        verified_tenant: Option<&str>,
+        security_context: Option<&SecurityContext>,
+        object_id: &str,
+    ) -> MacDecision {
+        self.check(subject, verified_tenant, security_context, object_id)
+    }
+}
+
+/// Assemble the production account-read adapter from verified request
+/// contexts, trusted PDS structural labels, and the mandatory audit sink.
+pub fn production_pds_account_read_authorizer(
+    sink: Arc<dyn AuditSink>,
+) -> Arc<dyn AccountRecordReadAuthorizer> {
+    Arc::new(PdsAccountReadPep::new(
+        Arc::new(EnrollmentPdsClearanceSource),
+        Arc::new(PdsAccountObjectLabelResolver),
+        sink,
+    ))
+}
+
+/// Production composition for a published account tree: a descriptor-bound
+/// mount plus the real PDS PEP and mandatory audit sink.
+///
+/// The caller supplies the authoritative publication root. Hyprstream does not
+/// manufacture a second empty tree when no durable hosted-account publisher is
+/// configured; in that case OAuth has no account store and performs no record
+/// read. Once installed, there is no constructor path around this PEP.
+#[cfg(not(target_arch = "wasm32"))]
+pub fn production_pds_account_record_store(
+    mount: Arc<PdsDirectoryMount>,
+    sink: Arc<dyn AuditSink>,
+) -> Arc<hyprstream_pds_service::AccountRecordStore> {
+    Arc::new(hyprstream_pds_service::AccountRecordStore::new(
+        mount,
+        production_pds_account_read_authorizer(sink),
+    ))
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)]
+mod tests {
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    use async_trait::async_trait;
+    use ed25519_dalek::SigningKey;
+    use parking_lot::Mutex;
+    use rand::rngs::OsRng;
+
+    use hyprstream_pds_service::{AccountReadError, AccountRecordStore};
+    use hyprstream_rpc::auth::mac::{Assurance, CompartmentSet, Level};
+    use hyprstream_rpc::EnvelopeContext;
+    use hyprstream_vfs::{DirEntry, Fid, Mount, MountError, Stat};
+
+    use super::*;
+    use crate::mac::audit::{AuditError, AuditRecord};
+
+    #[derive(Default)]
+    struct SpySink {
+        records: Mutex<Vec<AuditRecord>>,
+    }
+
+    impl AuditSink for SpySink {
+        fn record(&self, record: &AuditRecord) -> Result<(), AuditError> {
+            self.records.lock().push(record.clone());
+            Ok(())
+        }
+    }
+
+    struct PublicReaders;
+
+    impl PdsClearanceSource for PublicReaders {
+        fn clearance_for(
+            &self,
+            subject: &Subject,
+            verified_tenant: Option<&str>,
+            _request_context: Option<&SecurityContext>,
+        ) -> Option<SecurityContext> {
+            ((subject.name() == Some("alice") && verified_tenant == Some("acme"))
+                || (subject.name() == Some(OAUTH_ACCOUNT_RESOLVER_SUBJECT)
+                    && verified_tenant.is_none()))
+            .then(|| {
+                SecurityContext::from_clearance(
+                    label(Level::Public),
+                    VerifiedKeyMaterial::Classical,
+                )
+            })
+        }
+    }
+
+    struct ConfidentialReaders;
+
+    impl PdsClearanceSource for ConfidentialReaders {
+        fn clearance_for(
+            &self,
+            subject: &Subject,
+            verified_tenant: Option<&str>,
+            _request_context: Option<&SecurityContext>,
+        ) -> Option<SecurityContext> {
+            (subject.name() == Some("alice") && verified_tenant == Some("acme")).then(|| {
+                SecurityContext::from_clearance(
+                    label(Level::Confidential),
+                    VerifiedKeyMaterial::Classical,
+                )
+            })
+        }
+    }
+
+    struct NoClearance;
+
+    impl PdsClearanceSource for NoClearance {
+        fn clearance_for(
+            &self,
+            _subject: &Subject,
+            _verified_tenant: Option<&str>,
+            _request_context: Option<&SecurityContext>,
+        ) -> Option<SecurityContext> {
+            None
+        }
+    }
+
+    struct NoLabels;
+
+    impl ObjectLabelResolver for NoLabels {
+        fn resolve(&self, _object: ObjectRef<'_>) -> Option<SecurityLabel> {
+            None
+        }
+    }
+
+    #[derive(Default)]
+    struct FailingSink {
+        attempts: AtomicUsize,
+        records: Mutex<Vec<AuditRecord>>,
+    }
+
+    impl AuditSink for FailingSink {
+        fn record(&self, record: &AuditRecord) -> Result<(), AuditError> {
+            self.attempts.fetch_add(1, Ordering::SeqCst);
+            self.records.lock().push(record.clone());
+            Err(AuditError::Io("injected PDS audit failure".to_owned()))
+        }
+    }
+
+    struct AccountLabels;
+
+    impl ObjectLabelResolver for AccountLabels {
+        fn resolve(&self, object: ObjectRef<'_>) -> Option<SecurityLabel> {
+            match object {
+                ObjectRef::Path(["pds", "acme", "accounts", "alice", "account-record.cbor"]) => {
+                    Some(label(Level::Secret))
+                }
+                _ => None,
+            }
+        }
+    }
+
+    #[derive(Default)]
+    struct ReadTrapMount {
+        walks: AtomicUsize,
+        opens: AtomicUsize,
+        stats: AtomicUsize,
+        reads: AtomicUsize,
+        readdirs: AtomicUsize,
+    }
+
+    #[async_trait]
+    impl Mount for ReadTrapMount {
+        async fn walk(&self, _components: &[&str], _caller: &Subject) -> Result<Fid, MountError> {
+            self.walks.fetch_add(1, Ordering::SeqCst);
+            Ok(Fid::new(()))
+        }
+
+        async fn open(
+            &self,
+            _fid: &mut Fid,
+            _mode: u8,
+            _caller: &Subject,
+        ) -> Result<(), MountError> {
+            self.opens.fetch_add(1, Ordering::SeqCst);
+            Ok(())
+        }
+
+        async fn read(
+            &self,
+            _fid: &Fid,
+            _offset: u64,
+            _count: u32,
+            _caller: &Subject,
+        ) -> Result<Vec<u8>, MountError> {
+            self.reads.fetch_add(1, Ordering::SeqCst);
+            Ok(b"record bytes must remain unreachable".to_vec())
+        }
+
+        async fn write(
+            &self,
+            _fid: &Fid,
+            _offset: u64,
+            _data: &[u8],
+            _caller: &Subject,
+        ) -> Result<u32, MountError> {
+            Err(MountError::NotSupported("read-only test mount".to_owned()))
+        }
+
+        async fn readdir(
+            &self,
+            _fid: &Fid,
+            _caller: &Subject,
+        ) -> Result<Vec<DirEntry>, MountError> {
+            self.readdirs.fetch_add(1, Ordering::SeqCst);
+            Ok(vec![DirEntry {
+                name: "tenant-bytes-must-remain-unreachable".to_owned(),
+                is_dir: true,
+                size: 0,
+                stat: None,
+            }])
+        }
+
+        async fn stat(&self, _fid: &Fid, _caller: &Subject) -> Result<Stat, MountError> {
+            self.stats.fetch_add(1, Ordering::SeqCst);
+            Ok(Stat::unknown_qid(
+                0,
+                38,
+                "account-record.cbor".to_owned(),
+                0,
+            ))
+        }
+
+        async fn clunk(&self, _fid: Fid, _caller: &Subject) {}
+    }
+
+    fn label(level: Level) -> SecurityLabel {
+        SecurityLabel::new(level, Assurance::Classical, CompartmentSet::EMPTY)
+    }
+
+    #[tokio::test]
+    async fn account_store_denies_before_record_bytes_and_audits_identity() {
+        let mount = Arc::new(ReadTrapMount::default());
+        let sink = Arc::new(SpySink::default());
+        let authorizer = Arc::new(PdsAccountReadPep::new(
+            Arc::new(PublicReaders),
+            Arc::new(AccountLabels),
+            sink.clone(),
+        ));
+        let store = AccountRecordStore::new(mount.clone(), authorizer);
+        let signer = SigningKey::generate(&mut OsRng);
+        let context = EnvelopeContext::for_test_authenticated_subject_in_tenant(
+            Subject::new("alice"),
+            "acme",
+            signer.verifying_key(),
+        );
+
+        let error = store
+            .scope(&context)
+            .unwrap()
+            .get("alice")
+            .await
+            .unwrap_err();
+        assert!(matches!(
+            error,
+            AccountReadError::MacDenied {
+                reason: MacDenyReason::FloorDeny,
+                ..
+            }
+        ));
+
+        assert_eq!(mount.walks.load(Ordering::SeqCst), 1);
+        assert_eq!(mount.opens.load(Ordering::SeqCst), 0);
+        assert_eq!(mount.stats.load(Ordering::SeqCst), 0);
+        assert_eq!(mount.reads.load(Ordering::SeqCst), 0);
+        assert_eq!(mount.readdirs.load(Ordering::SeqCst), 0);
+
+        let records = sink.records.lock();
+        assert_eq!(records.len(), 1);
+        assert_eq!(records[0].decision, Decision::Deny);
+        assert_eq!(records[0].reason, DecisionReason::FloorDeny);
+        assert_eq!(records[0].subject_id.as_deref(), Some("alice"));
+        assert_eq!(
+            records[0].object_id.as_deref(),
+            Some("/pds/acme/accounts/alice/account-record.cbor")
+        );
+        assert_eq!(records[0].subject_clearance, label(Level::Public));
+        assert_eq!(records[0].object_label, label(Level::Secret));
+    }
+
+    #[tokio::test]
+    async fn hosted_directory_deny_precedes_open_and_readdir_and_is_audited() {
+        let mount = Arc::new(ReadTrapMount::default());
+        let sink = Arc::new(SpySink::default());
+        let authorizer = Arc::new(PdsAccountReadPep::new(
+            Arc::new(PublicReaders),
+            Arc::new(PdsAccountObjectLabelResolver),
+            sink.clone(),
+        ));
+        let store = AccountRecordStore::new(mount.clone(), authorizer);
+
+        let error = store
+            .resolve_tenant_for_hosted_did(
+                &Subject::new(OAUTH_ACCOUNT_RESOLVER_SUBJECT),
+                "did:web:alice.example.test",
+            )
+            .await
+            .unwrap_err();
+        assert!(matches!(
+            error,
+            AccountReadError::MacDenied {
+                reason: MacDenyReason::FloorDeny,
+                ..
+            }
+        ));
+        assert_eq!(mount.walks.load(Ordering::SeqCst), 1);
+        assert_eq!(mount.opens.load(Ordering::SeqCst), 0);
+        assert_eq!(mount.readdirs.load(Ordering::SeqCst), 0);
+        assert_eq!(mount.stats.load(Ordering::SeqCst), 0);
+        assert_eq!(mount.reads.load(Ordering::SeqCst), 0);
+
+        let records = sink.records.lock();
+        assert_eq!(records.len(), 1);
+        assert_eq!(records[0].decision, Decision::Deny);
+        assert_eq!(records[0].reason, DecisionReason::FloorDeny);
+        assert_eq!(
+            records[0].subject_id.as_deref(),
+            Some(OAUTH_ACCOUNT_RESOLVER_SUBJECT)
+        );
+        assert_eq!(records[0].object_id.as_deref(), Some("/pds"));
+    }
+
+    #[tokio::test]
+    async fn audit_failure_downgrades_permit_before_record_open() {
+        let mount = Arc::new(ReadTrapMount::default());
+        let sink = Arc::new(FailingSink::default());
+        let authorizer = Arc::new(PdsAccountReadPep::new(
+            Arc::new(ConfidentialReaders),
+            Arc::new(PdsAccountObjectLabelResolver),
+            sink.clone(),
+        ));
+        let store = AccountRecordStore::new(mount.clone(), authorizer);
+        let signer = SigningKey::generate(&mut OsRng);
+        let context = EnvelopeContext::for_test_authenticated_subject_in_tenant(
+            Subject::new("alice"),
+            "acme",
+            signer.verifying_key(),
+        );
+
+        let error = store
+            .scope(&context)
+            .unwrap()
+            .get("alice")
+            .await
+            .unwrap_err();
+        assert!(matches!(
+            error,
+            AccountReadError::MacDenied {
+                reason: MacDenyReason::FloorDeny,
+                ..
+            }
+        ));
+        assert_eq!(mount.walks.load(Ordering::SeqCst), 1);
+        assert_eq!(mount.opens.load(Ordering::SeqCst), 0);
+        assert_eq!(mount.stats.load(Ordering::SeqCst), 0);
+        assert_eq!(mount.reads.load(Ordering::SeqCst), 0);
+        assert_eq!(sink.attempts.load(Ordering::SeqCst), 2);
+        let records = sink.records.lock();
+        assert_eq!(records[0].decision, Decision::Permit);
+        assert_eq!(records[1].decision, Decision::Deny);
+        assert_eq!(records[1].reason, DecisionReason::AuditFailClosed);
+        assert_eq!(records[1].subject_id.as_deref(), Some("alice"));
+        assert_eq!(
+            records[1].object_id.as_deref(),
+            Some("/pds/acme/accounts/alice/account-record.cbor")
+        );
+    }
+
+    #[test]
+    fn missing_clearance_and_label_denials_are_audited_with_identities() {
+        let sink = Arc::new(SpySink::default());
+        let no_clearance = PdsAccountReadPep::new(
+            Arc::new(NoClearance),
+            Arc::new(PdsAccountObjectLabelResolver),
+            sink.clone(),
+        );
+        let object = "/pds/acme/accounts/alice/account-record.cbor";
+        assert_eq!(
+            no_clearance.check_read(&Subject::new("alice"), Some("acme"), None, object),
+            MacDecision::Deny(MacDenyReason::NoClearance)
+        );
+
+        let no_label = PdsAccountReadPep::new(
+            Arc::new(ConfidentialReaders),
+            Arc::new(NoLabels),
+            sink.clone(),
+        );
+        assert_eq!(
+            no_label.check_read(&Subject::new("alice"), Some("acme"), None, object),
+            MacDecision::Deny(MacDenyReason::UnlabeledObject)
+        );
+
+        let records = sink.records.lock();
+        assert_eq!(records.len(), 2);
+        assert_eq!(records[0].reason, DecisionReason::NoClearance);
+        assert_eq!(records[1].reason, DecisionReason::UnlabeledObject);
+        for record in records.iter() {
+            assert_eq!(record.decision, Decision::Deny);
+            assert_eq!(record.subject_id.as_deref(), Some("alice"));
+            assert_eq!(record.object_id.as_deref(), Some(object));
+        }
+    }
+
+    #[test]
+    fn production_sources_label_only_account_reads_and_recognize_oauth() {
+        let resolver = PdsAccountObjectLabelResolver;
+        assert_eq!(
+            resolver.resolve(ObjectRef::Path(&["pds"])),
+            Some(pds_account_label())
+        );
+        assert_eq!(
+            resolver.resolve(ObjectRef::Path(&[
+                "pds",
+                "acme",
+                PDS_ACCOUNTS_DIRECTORY,
+                "alice",
+                PDS_ACCOUNT_RECORD_FILE,
+            ])),
+            Some(pds_account_label())
+        );
+        assert_eq!(
+            resolver.resolve(ObjectRef::Path(&["pds", "acme", "private-key"])),
+            None
+        );
+
+        let source = EnrollmentPdsClearanceSource;
+        let oauth = source
+            .clearance_for(&Subject::new(OAUTH_ACCOUNT_RESOLVER_SUBJECT), None, None)
+            .unwrap();
+        assert!(oauth.can_access(&pds_account_label()));
+        assert!(source
+            .clearance_for(&Subject::new("alice"), None, None)
+            .is_none());
+
+        let attenuated =
+            SecurityContext::from_clearance(label(Level::Public), VerifiedKeyMaterial::Classical);
+        assert_eq!(
+            source
+                .clearance_for(&Subject::new("alice"), Some("acme"), Some(&attenuated))
+                .unwrap(),
+            attenuated
+        );
+    }
+
+    #[tokio::test]
+    async fn production_directory_mount_keeps_the_walked_record_descriptor_bound() {
+        let temporary = tempfile::tempdir().unwrap();
+        let root = temporary.path().join("pds");
+        let record_dir = root.join("acme/accounts/alice");
+        std::fs::create_dir_all(&record_dir).unwrap();
+        let record = record_dir.join(PDS_ACCOUNT_RECORD_FILE);
+        std::fs::write(&record, b"original").unwrap();
+        let mount = PdsDirectoryMount::open(&root).unwrap();
+        let subject = Subject::new("alice");
+        let components = [
+            "acme",
+            PDS_ACCOUNTS_DIRECTORY,
+            "alice",
+            PDS_ACCOUNT_RECORD_FILE,
+        ];
+        let mut fid = mount.walk(&components, &subject).await.unwrap();
+
+        let replaced = record_dir.join("replaced.cbor");
+        std::fs::rename(&record, &replaced).unwrap();
+        std::fs::write(&record, b"substitute").unwrap();
+
+        mount
+            .open(&mut fid, hyprstream_vfs::OREAD, &subject)
+            .await
+            .unwrap();
+        assert_eq!(
+            mount.read(&fid, 0, 64, &subject).await.unwrap(),
+            b"original"
+        );
+        mount.clunk(fid, &subject).await;
+    }
+
+    #[tokio::test]
+    async fn production_directory_mount_rejects_final_and_intermediate_symlinks() {
+        use std::os::unix::fs::symlink;
+
+        let temporary = tempfile::tempdir().unwrap();
+        let root = temporary.path().join("pds");
+        let acme = root.join("acme/accounts/alice");
+        let beta = root.join("beta/accounts/alice");
+        std::fs::create_dir_all(&acme).unwrap();
+        std::fs::create_dir_all(&beta).unwrap();
+        let beta_record = beta.join(PDS_ACCOUNT_RECORD_FILE);
+        std::fs::write(&beta_record, b"beta").unwrap();
+
+        let final_link = acme.join(PDS_ACCOUNT_RECORD_FILE);
+        symlink(&beta_record, &final_link).unwrap();
+        let mount = PdsDirectoryMount::open(&root).unwrap();
+        let subject = Subject::new("alice");
+        let final_components = [
+            "acme",
+            PDS_ACCOUNTS_DIRECTORY,
+            "alice",
+            PDS_ACCOUNT_RECORD_FILE,
+        ];
+        assert!(matches!(
+            mount.walk(&final_components, &subject).await,
+            Err(MountError::PermissionDenied(_))
+        ));
+
+        std::fs::remove_file(&final_link).unwrap();
+        std::fs::remove_dir_all(root.join("acme/accounts")).unwrap();
+        symlink(root.join("beta/accounts"), root.join("acme/accounts")).unwrap();
+        assert!(matches!(
+            mount.walk(&final_components, &subject).await,
+            Err(MountError::PermissionDenied(_))
+        ));
+    }
+
+    #[tokio::test]
+    async fn production_directory_mount_enumerates_only_real_root_directories() {
+        use std::os::unix::fs::symlink;
+
+        let temporary = tempfile::tempdir().unwrap();
+        let root = temporary.path().join("pds");
+        std::fs::create_dir_all(root.join("acme")).unwrap();
+        symlink(root.join("acme"), root.join("alias")).unwrap();
+        let mount = PdsDirectoryMount::open(&root).unwrap();
+        let subject = Subject::new(OAUTH_ACCOUNT_RESOLVER_SUBJECT);
+        let mut fid = mount.walk(&[], &subject).await.unwrap();
+        mount
+            .open(&mut fid, hyprstream_vfs::OREAD, &subject)
+            .await
+            .unwrap();
+        let entries = mount.readdir(&fid, &subject).await.unwrap();
+        assert_eq!(entries.len(), 2);
+        assert!(entries.iter().any(|entry| entry.name == "acme" && entry.is_dir));
+        assert!(
+            entries
+                .iter()
+                .any(|entry| entry.name == "alias" && !entry.is_dir)
+        );
+        mount.clunk(fid, &subject).await;
+    }
+}

--- a/crates/hyprstream/src/services/oauth/mod.rs
+++ b/crates/hyprstream/src/services/oauth/mod.rs
@@ -1356,6 +1356,20 @@ mod tests {
         const REDIRECT_URI: &str = "https://client.example.test/callback";
         const MAPPED_DID: &str = "did:web:alice.acct.example.test";
         const HOSTED_TENANT: &str = "tenant-demo";
+
+        struct PermitFixtureAccountReads;
+
+        impl hyprstream_pds_service::AccountRecordReadAuthorizer for PermitFixtureAccountReads {
+            fn check_read(
+                &self,
+                _subject: &hyprstream_rpc::Subject,
+                _verified_tenant: Option<&str>,
+                _security_context: Option<&hyprstream_rpc::auth::mac::SecurityContext>,
+                _object_id: &str,
+            ) -> hyprstream_rpc::auth::mac::MacDecision {
+                hyprstream_rpc::auth::mac::MacDecision::Permit
+            }
+        }
         const PKCE_VERIFIER: &str = "r5-handler-pkce-verifier-abcdefghijklmnopqrstuvwxyz012345";
         const GENERIC_PKCE_VERIFIER: &str =
             "r7-generic-pkce-verifier-abcdefghijklmnopqrstuvwxyz012345";
@@ -1508,10 +1522,10 @@ mod tests {
                 ),
             ),
         );
-        let hosted_account_store =
-            Arc::new(hyprstream_pds_service::AccountRecordStore::new(Arc::new(
-                SyntheticMount::new(pds_root),
-            )));
+        let hosted_account_store = Arc::new(hyprstream_pds_service::AccountRecordStore::new(
+            Arc::new(SyntheticMount::new(pds_root)),
+            Arc::new(PermitFixtureAccountReads),
+        ));
         let mut oauth_state = OAuthState::new(
             &config,
             policy_client,

--- a/crates/hyprstream/src/services/oauth/state.rs
+++ b/crates/hyprstream/src/services/oauth/state.rs
@@ -1249,7 +1249,9 @@ impl OAuthState {
         };
         store
             .resolve_tenant_for_hosted_did(
-                &hyprstream_rpc::Subject::new("service:oauth"),
+                &hyprstream_rpc::Subject::new(
+                    hyprstream_pds_service::OAUTH_ACCOUNT_RESOLVER_SUBJECT,
+                ),
                 did,
             )
             .await

--- a/crates/hyprstream/tests/mac_enforcing_gate.rs
+++ b/crates/hyprstream/tests/mac_enforcing_gate.rs
@@ -602,9 +602,12 @@ async fn t8_atproto_session_credential() -> Result<T8SessionCredential> {
             ),
         ),
     );
-    let hosted_store = Arc::new(hyprstream_pds_service::AccountRecordStore::new(Arc::new(
-        SyntheticMount::new(pds_root),
-    )));
+    let hosted_store = Arc::new(hyprstream_pds_service::AccountRecordStore::new(
+        Arc::new(SyntheticMount::new(pds_root)),
+        hyprstream_core::mac::production_pds_account_read_authorizer(Arc::new(
+            SpyAudit::default(),
+        )),
+    ));
 
     let mut atproto_multikey = vec![0x80, 0x24];
     atproto_multikey.extend_from_slice(


### PR DESCRIPTION
Closes #1319
Progresses #1267
Relates to #613 and #699

## Summary

- require an `AccountRecordReadAuthorizer` for every `AccountRecordStore`
  construction and carry the exact verified envelope security context into
  tenant-scoped reads
- label and MAC-check canonical PDS account-record object IDs before
  `open`/`stat`/`read`/`readdir`, auditing every permit/deny and failing closed
  if the audit sink fails
- bind resolved names to the served object with Linux `openat2`
  (`RESOLVE_BENEATH|RESOLVE_NO_SYMLINKS|RESOLVE_NO_MAGICLINKS`) and reuse the
  same descriptor across authorization and reads
- preserve authority-derived hosted-DID tenant resolution; when no durable
  authoritative account store is supplied, OAuth performs no local read
- add deny-before-bytes, audited-deny, audit-failure, structural-label,
  symlink, rename-replacement, and directory-enumeration coverage

The change is scoped to the account-record read adapter. `mac/pep.rs` is
untouched.

## Validation

- focused `hyprstream-pds-service` tests: 6 passed, 0 failed
- `buildq -- cargo nextest run --release --profile ci -p hyprstream -p hyprstream-pds -p hyprstream-rpc --no-fail-fast`: 2607 passed, 0 failed, 10 skipped
- rebased SHA `36d7fac01` preserves #1315's sealed hosted-DID document and
  `prepare_genesis(document, ...)` flow, composes with #1296's MoQ PEP, and
  wires #1324's enforcing-gate fixture through the production PDS authorizer
- two independent Kimi K3 / high-thinking reviews of the unchanged MAC logic:
  PASS

No self-merge.
