### PR TITLE
fix(auth): bind policy checks to verified tenants

### DIFF
--- a/crates/hyprstream-discovery/src/service.rs
+++ b/crates/hyprstream-discovery/src/service.rs
@@ -500,6 +500,7 @@ pub trait AuthorizationProvider: Send + Sync {
         domain: &str,
         resource: &str,
         operation: &str,
+        bearer: Option<&str>,
     ) -> Result<bool>;
 }
 
@@ -4214,7 +4215,7 @@ impl DiscoveryHandler for DiscoveryService {
         if let Some(ref auth) = self.auth_provider {
             let subject = ctx.subject().to_string();
             let allowed = auth
-                .check(&subject, "*", resource, operation)
+                .check(&subject, "*", resource, operation, ctx.jwt_token())
                 .await
                 .unwrap_or_else(|e| {
                     tracing::warn!("Discovery auth check failed for {}: {}", subject, e);
@@ -5261,6 +5262,7 @@ mod get_record_tests {
             _domain: &str,
             resource: &str,
             operation: &str,
+            _bearer: Option<&str>,
         ) -> Result<bool> {
             Ok(self
                 .allow
@@ -5560,6 +5562,7 @@ mod query_candidates_tests {
             _domain: &str,
             _resource: &str,
             _operation: &str,
+            _bearer: Option<&str>,
         ) -> Result<bool> {
             Ok(true)
         }
@@ -5576,6 +5579,7 @@ mod query_candidates_tests {
             _domain: &str,
             resource: &str,
             operation: &str,
+            _bearer: Option<&str>,
         ) -> Result<bool> {
             Ok(resource != format!("placement:candidate:{}", self.0) || operation != "query")
         }
@@ -5591,6 +5595,7 @@ mod query_candidates_tests {
             _domain: &str,
             resource: &str,
             operation: &str,
+            _bearer: Option<&str>,
         ) -> Result<bool> {
             Ok(resource != format!("placement:candidate:{}", self.0) || operation != "write")
         }

--- a/crates/hyprstream-rpc/src/resolver.rs
+++ b/crates/hyprstream-rpc/src/resolver.rs
@@ -428,6 +428,37 @@ impl RpcClient for ResolvedRpcClient {
         })
         .await
     }
+
+    async fn call_with_options_for_service_with_method(
+        &self,
+        service: &str,
+        method_discriminator: u16,
+        payload: Vec<u8>,
+        options: CallOptions,
+    ) -> anyhow::Result<Vec<u8>> {
+        anyhow::ensure!(
+            service == self.service_name,
+            "generated service authority mismatch"
+        );
+        let service = service.to_owned();
+        self.attempt(|client| {
+            let payload = payload.clone();
+            let options = options.clone();
+            let service = service.clone();
+            async move {
+                client
+                    .call_with_options_for_service_with_method(
+                        &service,
+                        method_discriminator,
+                        payload,
+                        options,
+                    )
+                    .await
+            }
+        })
+        .await
+    }
+
     async fn call_streaming(
         &self,
         payload: Vec<u8>,

--- a/crates/hyprstream-rpc/src/service/svc.rs
+++ b/crates/hyprstream-rpc/src/service/svc.rs
@@ -32,6 +32,7 @@ pub type AuthorizeFn = Arc<
             String,
             String,
             String,
+            Option<String>,
         ) -> std::pin::Pin<Box<dyn std::future::Future<Output = Result<bool>> + Send>>
         + Send
         + Sync,
@@ -557,9 +558,15 @@ impl EnvelopeContext {
         claims.security_context(key_material)
     }
 
-    /// Get the raw JWT token from the envelope (if present).
+    /// Get the effective verified JWT token from the envelope.
+    ///
+    /// For an authorized relay this is the delegated bearer, allowing a
+    /// downstream service to preserve the original user's verified identity
+    /// across another local service boundary.
     pub fn jwt_token(&self) -> Option<&str> {
-        self.jwt_token.as_deref()
+        self.jwt_token
+            .as_deref()
+            .or(self.delegation_token.as_deref())
     }
 
     /// Check if request has user context
@@ -1579,13 +1586,14 @@ mod empty_iss_gate_tests {
         let token = empty_iss_token(&ca);
         let mut ctx = ctx_with_token(token.clone(), /* is_local_caller */ true);
         ctx.jwt_token = None;
-        ctx.delegation_token = Some(token);
+        ctx.delegation_token = Some(token.clone());
         ctx.cnf = relay;
 
         svc.verify_claims(&mut ctx)
             .await
             .expect("the pinned relay may delegate a bearer for re-verification");
         assert_eq!(ctx.subject().name(), Some("alice"));
+        assert_eq!(ctx.jwt_token(), Some(token.as_str()));
     }
 
     #[tokio::test]

--- a/crates/hyprstream-workers/src/runtime/service.rs
+++ b/crates/hyprstream-workers/src/runtime/service.rs
@@ -34,9 +34,9 @@ use tracing::{debug, info, warn};
 // RPC service infrastructure from hyprstream-rpc: the pluggable Cap'n Proto
 // bridged transport (inproc/UDS/QUIC/iroh) + the moq streaming plane. ZMQ is
 // gone (#138/#167) — this is not a ZMQ socket API.
+use hyprstream_rpc::moq_stream::AnyStreamPublisher;
 use hyprstream_rpc::prelude::SigningKey;
 use hyprstream_rpc::service::{AuthorizeFn, EnvelopeContext, RequestService};
-use hyprstream_rpc::moq_stream::AnyStreamPublisher;
 use hyprstream_rpc::streaming::StreamChannel;
 use hyprstream_rpc::transport::TransportConfig;
 
@@ -1398,11 +1398,18 @@ impl WorkerHandler for WorkerService {
         if let Some(ref auth_fn) = self.authorize_fn {
             let subject = ctx.subject().to_string();
             let domain = ctx.domain()?;
-            let allowed = auth_fn(subject.clone(), domain, resource.to_owned(), operation.to_owned()).await
-                .unwrap_or_else(|e| {
-                    warn!("Policy check failed for {} on {}: {} - denying access", subject, resource, e);
-                    false
-                });
+            let allowed = auth_fn(
+                subject.clone(),
+                domain,
+                resource.to_owned(),
+                operation.to_owned(),
+                ctx.jwt_token().map(str::to_owned),
+            )
+            .await
+            .unwrap_or_else(|e| {
+                warn!("Policy check failed for {} on {}: {} - denying access", subject, resource, e);
+                false
+            });
             if allowed {
                 Ok(())
             } else {

--- a/crates/hyprstream-workers/src/workflow/service.rs
+++ b/crates/hyprstream-workers/src/workflow/service.rs
@@ -630,11 +630,18 @@ impl WorkflowHandler for WorkflowService {
         if let Some(ref auth_fn) = self.authorize_fn {
             let subject = ctx.subject().to_string();
             let domain = ctx.domain()?;
-            let allowed = auth_fn(subject.clone(), domain, resource.to_owned(), operation.to_owned()).await
-                .unwrap_or_else(|e| {
-                    tracing::warn!("Policy check failed for {} on {}: {} - denying access", subject, resource, e);
-                    false
-                });
+            let allowed = auth_fn(
+                subject.clone(),
+                domain,
+                resource.to_owned(),
+                operation.to_owned(),
+                ctx.jwt_token().map(str::to_owned),
+            )
+            .await
+            .unwrap_or_else(|e| {
+                tracing::warn!("Policy check failed for {} on {}: {} - denying access", subject, resource, e);
+                false
+            });
             if allowed {
                 Ok(())
             } else {

--- a/crates/hyprstream/src/auth/federation.rs
+++ b/crates/hyprstream/src/auth/federation.rs
@@ -201,11 +201,12 @@ impl FederationKeyResolver {
             // app.partner.org AND a peer at hyprstream.partner.org.
             let origin = crate::services::oauth::registration::extract_origin(issuer)
                 .ok_or_else(|| anyhow!("Invalid issuer URL: {issuer}"))?;
+            let resource = crate::auth::federation_registration_resource(&origin)?;
             match pc
                 .check(&PolicyCheck {
-                    subject: origin.clone(),
-                    domain: origin.clone(),
-                    resource: "federation:register".to_owned(),
+                    subject: String::new(),
+                    domain: String::new(),
+                    resource,
                     operation: "check".to_owned(),
                 })
                 .await

--- a/crates/hyprstream/src/auth/federation_admission.rs
+++ b/crates/hyprstream/src/auth/federation_admission.rs
@@ -4,8 +4,9 @@
 //! [`hyprstream_rpc::admission`] (lower crate, no `PolicyService` client). This
 //! module supplies the **stage-1 origin-admission decision** over the real
 //! `PolicyService`, reusing the existing unified federation trust gate
-//! (`federation:register`) verbatim — the same Casbin resource checked by CIMD
-//! client registration and [`crate::auth::federation::FederationKeyResolver`].
+//! (`federation:register:<origin>`) — the same origin-scoped Casbin resource
+//! checked by CIMD client registration and
+//! [`crate::auth::federation::FederationKeyResolver`].
 //!
 //! It also exposes a constructor that assembles a ready-to-use
 //! [`hyprstream_rpc::admission::FederationAdmissionGate`] from a `PolicyClient`
@@ -38,10 +39,10 @@ use crate::services::PolicyClient;
 /// Stage-1 origin admission over `PolicyService` `federation:register`.
 ///
 /// Wraps the same decision as [`crate::auth::federation::FederationKeyResolver`]'s
-/// peer trust gate: an origin is admitted iff Casbin returns `allow` for
-/// `(subject = origin, domain = "*", resource = "federation:register", op =
-/// "check")`. Fail-closed on denial **and** on `PolicyService` outage — never
-/// default-allow.
+/// peer trust gate: an origin is admitted iff Casbin returns `allow` for the
+/// origin-scoped `federation:register:<origin>` resource. The RPC subject and
+/// domain remain inert; PolicyService derives those only from the verified
+/// envelope context. Fail-closed on denial **and** on `PolicyService` outage.
 pub struct PolicyOriginAdmission {
     policy_client: Arc<PolicyClient>,
 }
@@ -55,12 +56,13 @@ impl PolicyOriginAdmission {
 impl OriginAdmission for PolicyOriginAdmission {
     async fn admit_origin(&self, origin: &str) -> Result<()> {
         use crate::services::generated::policy_client::PolicyCheck;
+        let resource = crate::auth::federation_registration_resource(origin)?;
         match self
             .policy_client
             .check(&PolicyCheck {
-                subject: origin.to_owned(),
-                domain: origin.to_owned(),
-                resource: "federation:register".to_owned(),
+                subject: String::new(),
+                domain: String::new(),
+                resource,
                 operation: "check".to_owned(),
             })
             .await

--- a/crates/hyprstream/src/auth/mod.rs
+++ b/crates/hyprstream/src/auth/mod.rs
@@ -34,7 +34,10 @@ pub use op_log::{
     FixedGenerationSource, SealedHeadEs256Source, SealedOpLogHead,
 };
 pub use key_rotation::{MlDsaSigningKeyStore, MlDsaKeySlot};
-pub use policy_manager::{PolicyManager, PolicyError, write_policy_file, global_policy_manager, set_global_policy_manager};
+pub use policy_manager::{
+    federation_registration_resource, global_policy_manager, set_global_policy_manager,
+    write_policy_file, PolicyError, PolicyManager,
+};
 pub use policy_migration::migrate_policy_csv;
 pub use policy_templates::{PolicyTemplate, ServicePolicyRule, SERVICE_BASE_POLICIES, get_template, get_templates};
 pub use user_store::{DeviceRecord, DeviceStore, KeyAlgorithm, UserFilter, UserProfile, UserProfilePatch, UserStore, PubkeyEntry, pubkey_fingerprint, decode_pubkey_base64};

--- a/crates/hyprstream/src/auth/policy_manager.rs
+++ b/crates/hyprstream/src/auth/policy_manager.rs
@@ -135,7 +135,8 @@ fn validate_policy_component(component: &str, name: &str) -> Result<(), PolicyEr
 /// - Domain-scoped access control (e.g., HfModel, HfDataset)
 /// - Deny rules via explicit effect column
 /// - Wildcards for domain and action
-/// - Role-based access via g()
+/// - Global-service role access via g() in the explicit `*` domain
+/// - Tenant-scoped role access via g2()
 const DEFAULT_MODEL_CONF: &str = r#"[request_definition]
 r = sub, dom, obj, act
 
@@ -150,7 +151,7 @@ g2 = _, _, _
 e = some(where (p.eft == allow)) && !some(where (p.eft == deny))
 
 [matchers]
-m = (g(r.sub, p.sub) || g2(r.sub, p.sub, r.dom) || keyMatch(r.sub, p.sub)) && \
+m = ((r.dom == "*" && g(r.sub, p.sub)) || g2(r.sub, p.sub, r.dom) || keyMatch(r.sub, p.sub)) && \
     (p.dom == "*" || r.dom == p.dom) && \
     keyMatch(r.obj, p.obj) && \
     (p.act == "*" || keyMatch(r.act, p.act))
@@ -268,8 +269,13 @@ pub async fn write_policy_file(path: &Path, content: impl AsRef<[u8]>) -> Result
 
 async fn ensure_domain_role_model(model_path: &Path) -> Result<(), PolicyError> {
     let content = tokio::fs::read_to_string(model_path).await?;
+    const GLOBAL_ROLE_CALL: &str = "g(r.sub, p.sub)";
+    const GUARDED_ROLE_MATCHER: &str =
+        "m = ((r.dom == \"*\" && g(r.sub, p.sub)) || g2(r.sub, p.sub, r.dom) || keyMatch(r.sub, p.sub))";
+
     if content.contains("g2 = _, _, _")
-        && content.contains("g2(r.sub, p.sub, r.dom)")
+        && content.contains(GUARDED_ROLE_MATCHER)
+        && content.matches(GLOBAL_ROLE_CALL).count() == 1
     {
         return Ok(());
     }
@@ -281,15 +287,21 @@ async fn ensure_domain_role_model(model_path: &Path) -> Result<(), PolicyError> 
             1,
         )
         .replacen(
-            "m = (g(r.sub, p.sub) || keyMatch(r.sub, p.sub))",
             "m = (g(r.sub, p.sub) || g2(r.sub, p.sub, r.dom) || keyMatch(r.sub, p.sub))",
+            GUARDED_ROLE_MATCHER,
+            1,
+        )
+        .replacen(
+            "m = (g(r.sub, p.sub) || keyMatch(r.sub, p.sub))",
+            GUARDED_ROLE_MATCHER,
             1,
         );
     if !migrated.contains("g2 = _, _, _")
-        || !migrated.contains("g2(r.sub, p.sub, r.dom)")
+        || !migrated.contains(GUARDED_ROLE_MATCHER)
+        || migrated.matches(GLOBAL_ROLE_CALL).count() != 1
     {
         return Err(PolicyError::ValidationError(format!(
-            "{} must define domain-scoped g2(user, role, domain) membership",
+            "{} must restrict legacy g(user, role) membership to the global '*' domain and define domain-scoped g2(user, role, domain) membership",
             model_path.display()
         )));
     }
@@ -809,10 +821,39 @@ impl PolicyManager {
                 .map_err(PolicyError::CasbinError)?;
         }
 
-        // Add grouping rules
+        // Add grouping rules. A template whose policies name one concrete
+        // tenant gets g2 memberships in that tenant. Global/role-alias
+        // templates retain g memberships, which the model evaluates only when
+        // the verified request domain itself is `*`.
         if let Some(groupings) = template.groupings {
-            let grouping_vecs: Vec<Vec<String>> = groupings.iter().map(ServiceGrouping::to_vec).collect();
-            if !grouping_vecs.is_empty() {
+            let tenant_domains: std::collections::BTreeSet<&str> = policies
+                .iter()
+                .map(|policy| policy.domain)
+                .filter(|domain| *domain != "*")
+                .collect();
+            if tenant_domains.len() > 1 {
+                return Err(PolicyError::ValidationError(format!(
+                    "template '{}' has role assignments spanning multiple tenant domains",
+                    template.name
+                )));
+            }
+
+            if let Some(domain) = tenant_domains.first() {
+                for grouping in groupings {
+                    enforcer
+                        .add_named_grouping_policy(
+                            "g2",
+                            vec![
+                                grouping.user.to_owned(),
+                                grouping.role.to_owned(),
+                                (*domain).to_owned(),
+                            ],
+                        )
+                        .await
+                        .map_err(PolicyError::CasbinError)?;
+                }
+            } else {
+                let grouping_vecs: Vec<Vec<String>> = groupings.iter().map(ServiceGrouping::to_vec).collect();
                 enforcer
                     .add_grouping_policies(grouping_vecs)
                     .await
@@ -1015,6 +1056,75 @@ mod tests {
             pm.check_with_domain("alice", "tenant-a", "model:test", "infer.generate")
                 .await
         );
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn legacy_global_role_grant_is_inert_in_tenant_domains() -> Result<(), PolicyError> {
+        let pm = PolicyManager::new_in_memory().await?;
+        for tenant in ["tenant-a", "tenant-b"] {
+            pm.add_policy_with_domain(
+                "operator",
+                tenant,
+                "model:*",
+                "ttt.writeback",
+                "allow",
+            )
+            .await?;
+        }
+
+        // Simulate a pre-#1196 g(user, role) row already present in policy.csv.
+        pm.add_role_for_user("alice", "operator").await?;
+
+        for tenant in ["tenant-a", "tenant-b"] {
+            assert!(
+                !pm.check_with_domain("alice", tenant, "model:test", "ttt.writeback")
+                    .await,
+                "legacy global role membership must not authorize tenant {tenant}"
+            );
+        }
+
+        pm.add_role_for_user_in_domain("alice", "operator", "tenant-a")
+            .await?;
+        assert!(
+            pm.check_with_domain("alice", "tenant-a", "model:test", "ttt.writeback")
+                .await
+        );
+        assert!(
+            !pm.check_with_domain("alice", "tenant-b", "model:test", "ttt.writeback")
+                .await
+        );
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn legacy_model_is_migrated_before_global_roles_are_loaded() -> Result<(), PolicyError> {
+        let temp = TempDir::new().map_err(PolicyError::IoError)?;
+        let policies_dir = temp.path().join("policies");
+        tokio::fs::create_dir_all(&policies_dir).await?;
+        let legacy_model = DEFAULT_MODEL_CONF.replace(
+            "m = ((r.dom == \"*\" && g(r.sub, p.sub)) || g2(r.sub, p.sub, r.dom) || keyMatch(r.sub, p.sub))",
+            "m = (g(r.sub, p.sub) || g2(r.sub, p.sub, r.dom) || keyMatch(r.sub, p.sub))",
+        );
+        write_policy_file(&policies_dir.join("model.conf"), legacy_model).await?;
+        write_policy_file(
+            &policies_dir.join("policy.csv"),
+            "p, operator, tenant-a, model:*, ttt.writeback, allow\n\
+             p, operator, tenant-b, model:*, ttt.writeback, allow\n\
+             g, alice, operator\n",
+        )
+        .await?;
+
+        let pm = PolicyManager::new(&policies_dir).await?;
+        let migrated = tokio::fs::read_to_string(policies_dir.join("model.conf")).await?;
+        assert!(migrated.contains("r.dom == \"*\" && g(r.sub, p.sub)"));
+        for tenant in ["tenant-a", "tenant-b"] {
+            assert!(
+                !pm.check_with_domain("alice", tenant, "model:test", "ttt.writeback")
+                    .await,
+                "loaded legacy grant must be inert in tenant {tenant}"
+            );
+        }
         Ok(())
     }
 
@@ -1362,14 +1472,26 @@ mod tests {
     async fn apply_template(pm: &PolicyManager, name: &str) {
         let tmpl = crate::auth::policy_templates::get_template(name)
             .unwrap_or_else(|| panic!("template {name} must exist"));
-        for r in tmpl.expanded_policies() {
+        let policies = tmpl.expanded_policies();
+        let tenant_domains: std::collections::BTreeSet<&str> = policies
+            .iter()
+            .map(|policy| policy.domain)
+            .filter(|domain| *domain != "*")
+            .collect();
+        for r in policies {
             pm.add_policy_with_domain(r.subject, r.domain, r.resource, r.action, r.effect)
                 .await
                 .unwrap();
         }
         if let Some(groupings) = tmpl.groupings {
             for g in groupings {
-                pm.add_role_for_user(g.user, g.role).await.unwrap();
+                if let Some(domain) = tenant_domains.first() {
+                    pm.add_role_for_user_in_domain(g.user, g.role, domain)
+                        .await
+                        .unwrap();
+                } else {
+                    pm.add_role_for_user(g.user, g.role).await.unwrap();
+                }
             }
         }
     }

--- a/crates/hyprstream/src/auth/policy_manager.rs
+++ b/crates/hyprstream/src/auth/policy_manager.rs
@@ -80,6 +80,21 @@ pub enum PolicyError {
 /// Maximum length for policy components (user, resource, operation)
 const MAX_POLICY_COMPONENT_LEN: usize = 256;
 
+/// Resource namespace for the unified third-party/peer federation gate.
+///
+/// The origin is policy data, not an authenticated principal. Keeping it in
+/// the resource means `PolicyCheck.subject` can remain inert while the
+/// decision still varies by the normalized RFC 6454 origin.
+pub const FEDERATION_REGISTER_RESOURCE_PREFIX: &str = "federation:register:";
+
+/// Encode a normalized federation origin as a policy resource.
+pub fn federation_registration_resource(origin: &str) -> Result<String, PolicyError> {
+    validate_policy_component(origin, "federation origin")?;
+    let resource = format!("{FEDERATION_REGISTER_RESOURCE_PREFIX}{origin}");
+    validate_policy_component(&resource, "federation registration resource")?;
+    Ok(resource)
+}
+
 /// Validate a policy component for security
 ///
 /// Rejects:
@@ -310,6 +325,62 @@ async fn ensure_domain_role_model(model_path: &Path) -> Result<(), PolicyError> 
     Ok(())
 }
 
+fn is_legacy_federation_origin_subject(subject: &str) -> bool {
+    subject == "*"
+        || subject.starts_with("https://")
+        || subject.starts_with("http://")
+}
+
+/// Move pre-hardening federation rules from the caller identity slot into the
+/// resource slot. This preserves existing per-origin allow/deny lists without
+/// making an HTTPS origin a trusted envelope subject.
+async fn migrate_federation_origin_policies(
+    enforcer: &mut Enforcer,
+) -> Result<bool, PolicyError> {
+    let legacy: Vec<Vec<String>> = enforcer
+        .get_policy()
+        .into_iter()
+        .filter(|rule| {
+            rule.len() == 5
+                && rule.get(2).is_some_and(|resource| resource == "federation:register")
+                && rule
+                    .first()
+                    .is_some_and(|subject| is_legacy_federation_origin_subject(subject))
+        })
+        .collect();
+
+    if legacy.is_empty() {
+        return Ok(false);
+    }
+
+    for old_rule in legacy {
+        let origin_pattern = old_rule
+            .first()
+            .ok_or_else(|| {
+                PolicyError::ValidationError(
+                    "legacy federation rule is missing its origin subject".to_owned(),
+                )
+            })?
+            .clone();
+        let mut migrated_rule = old_rule.clone();
+        migrated_rule[0] = "*".to_owned();
+        migrated_rule[2] = federation_registration_resource(&origin_pattern)?;
+
+        enforcer
+            .remove_policy(old_rule)
+            .await
+            .map_err(PolicyError::CasbinError)?;
+        if !enforcer.get_policy().contains(&migrated_rule) {
+            enforcer
+                .add_policy(migrated_rule)
+                .await
+                .map_err(PolicyError::CasbinError)?;
+        }
+    }
+
+    Ok(true)
+}
+
 /// Policy manager wrapping Casbin enforcer
 pub struct PolicyManager {
     /// Casbin enforcer
@@ -366,6 +437,12 @@ impl PolicyManager {
         let mut enforcer = Enforcer::new(model, adapter)
             .await
             .map_err(|e| PolicyError::PolicyLoadError(e.to_string()))?;
+        if migrate_federation_origin_policies(&mut enforcer).await? {
+            enforcer
+                .save_policy()
+                .await
+                .map_err(|e| PolicyError::PolicySaveError(e.to_string()))?;
+        }
 
         // Inject SERVICE_BASE_POLICIES into the in-memory enforcer.
         // These are code-defined infrastructure rules (service key resolution,
@@ -583,6 +660,15 @@ impl PolicyManager {
         operation: &str,
         effect: &str,
     ) -> Result<bool, PolicyError> {
+        let migrated_resource;
+        let (user, resource) =
+            if resource == "federation:register" && is_legacy_federation_origin_subject(user) {
+                migrated_resource = federation_registration_resource(user)?;
+                ("*", migrated_resource.as_str())
+            } else {
+                (user, resource)
+            };
+
         // Validate all inputs
         validate_policy_component(user, "user")?;
         validate_policy_component(domain, "domain")?;
@@ -634,6 +720,15 @@ impl PolicyManager {
         operation: &str,
         effect: &str,
     ) -> Result<bool, PolicyError> {
+        let migrated_resource;
+        let (user, resource) =
+            if resource == "federation:register" && is_legacy_federation_origin_subject(user) {
+                migrated_resource = federation_registration_resource(user)?;
+                ("*", migrated_resource.as_str())
+            } else {
+                (user, resource)
+            };
+
         // Validate all inputs
         validate_policy_component(user, "user")?;
         validate_policy_component(domain, "domain")?;
@@ -784,6 +879,12 @@ impl PolicyManager {
             .load_policy()
             .await
             .map_err(|e| PolicyError::PolicyLoadError(e.to_string()))?;
+        if migrate_federation_origin_policies(&mut enforcer).await? {
+            enforcer
+                .save_policy()
+                .await
+                .map_err(|e| PolicyError::PolicySaveError(e.to_string()))?;
+        }
         // Filter out rules already loaded from CSV (Casbin add_policies
         // aborts the entire batch on first duplicate).
         let base = base_policies_to_vec();
@@ -1098,6 +1199,61 @@ mod tests {
             !pm.check_with_domain("alice", "tenant-b", "model:test", "ttt.writeback")
                 .await
         );
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn legacy_federation_origin_rule_is_migrated_to_resource() -> Result<(), PolicyError> {
+        let temp = TempDir::new().map_err(PolicyError::IoError)?;
+        let policies_dir = temp.path().join("policies");
+        tokio::fs::create_dir_all(&policies_dir).await?;
+        write_policy_file(&policies_dir.join("model.conf"), DEFAULT_MODEL_CONF).await?;
+        write_policy_file(
+            &policies_dir.join("policy.csv"),
+            "p, https://allowed.example, *, federation:register, check, allow\n\
+             p, https://*.partner.example, *, federation:register, check, allow\n",
+        )
+        .await?;
+
+        let pm = PolicyManager::new(&policies_dir).await?;
+        let allowed = federation_registration_resource("https://allowed.example")?;
+        let wildcard_allowed =
+            federation_registration_resource("https://app.partner.example")?;
+        let blocked = federation_registration_resource("https://blocked.example")?;
+
+        assert!(
+            pm.check_with_domain("service:oauth", "*", &allowed, "check")
+                .await,
+            "the migrated decision must still admit its configured origin"
+        );
+        assert!(
+            pm.check_with_domain("service:oauth", "*", &wildcard_allowed, "check")
+                .await,
+            "migrated wildcard origin patterns must remain effective"
+        );
+        assert!(
+            !pm.check_with_domain("service:oauth", "*", &blocked, "check")
+                .await,
+            "the decision must vary by origin instead of the deputy service"
+        );
+
+        let policies = pm.get_policy().await;
+        assert!(policies.iter().any(|rule| {
+            rule
+                == &vec![
+                    "*".to_owned(),
+                    "*".to_owned(),
+                    allowed.clone(),
+                    "check".to_owned(),
+                    "allow".to_owned(),
+                ]
+        }));
+        assert!(!policies.iter().any(|rule| {
+            rule.first().is_some_and(|subject| subject.starts_with("https://"))
+                && rule
+                    .get(2)
+                    .is_some_and(|resource| resource == "federation:register")
+        }));
         Ok(())
     }
 

--- a/crates/hyprstream/src/auth/policy_manager.rs
+++ b/crates/hyprstream/src/auth/policy_manager.rs
@@ -809,14 +809,30 @@ impl PolicyManager {
         &self,
         template: &crate::auth::policy_templates::PolicyTemplate,
     ) -> Result<(), PolicyError> {
+        let policies = template.expanded_policies();
+        let tenant_domains: std::collections::BTreeSet<&str> = policies
+            .iter()
+            .map(|policy| policy.domain)
+            .filter(|domain| *domain != "*")
+            .collect();
+        if template.groupings.is_some() && tenant_domains.len() > 1 {
+            return Err(PolicyError::ValidationError(format!(
+                "template '{}' has role assignments spanning multiple tenant domains",
+                template.name
+            )));
+        }
+
+        // Validate the complete template before mutating the enforcer so a
+        // rejected multi-tenant grouping cannot leave partial policy rows.
         let mut enforcer = self.enforcer.write().await;
 
         // Add policy rules
-        let policies = template.expanded_policies();
-        let policy_vecs: Vec<Vec<String>> = policies.iter().map(ServicePolicyRule::to_vec).collect();
+        let policy_vecs: Vec<Vec<String>> = policies
+            .iter()
+            .map(ServicePolicyRule::to_vec)
+            .collect();
         if !policy_vecs.is_empty() {
-            enforcer
-                .add_policies(policy_vecs)
+            enforcer.add_policies(policy_vecs)
                 .await
                 .map_err(PolicyError::CasbinError)?;
         }
@@ -826,18 +842,6 @@ impl PolicyManager {
         // templates retain g memberships, which the model evaluates only when
         // the verified request domain itself is `*`.
         if let Some(groupings) = template.groupings {
-            let tenant_domains: std::collections::BTreeSet<&str> = policies
-                .iter()
-                .map(|policy| policy.domain)
-                .filter(|domain| *domain != "*")
-                .collect();
-            if tenant_domains.len() > 1 {
-                return Err(PolicyError::ValidationError(format!(
-                    "template '{}' has role assignments spanning multiple tenant domains",
-                    template.name
-                )));
-            }
-
             if let Some(domain) = tenant_domains.first() {
                 for grouping in groupings {
                     enforcer

--- a/crates/hyprstream/src/auth/policy_manager.rs
+++ b/crates/hyprstream/src/auth/policy_manager.rs
@@ -33,7 +33,11 @@
 
 use crate::auth::policy_templates::{base_policies_to_csv, base_policies_to_vec, ServiceGrouping, ServicePolicyRule};
 use crate::auth::Operation;
-use casbin::{CoreApi, DefaultModel, Enforcer, FileAdapter, MemoryAdapter, MgmtApi, RbacApi};
+use casbin::function_map::{dynamic_to_str, OperatorFunction};
+use casbin::rhai::Dynamic;
+use casbin::{
+    CoreApi, DefaultModel, Enforcer, FileAdapter, MemoryAdapter, MgmtApi, RbacApi,
+};
 use std::path::{Path, PathBuf};
 use std::sync::{Arc, OnceLock};
 use thiserror::Error;
@@ -93,6 +97,96 @@ pub fn federation_registration_resource(origin: &str) -> Result<String, PolicyEr
     let resource = format!("{FEDERATION_REGISTER_RESOURCE_PREFIX}{origin}");
     validate_policy_component(&resource, "federation registration resource")?;
     Ok(resource)
+}
+
+fn federation_origin_pattern_matches(request_origin: &str, policy_origin: &str) -> bool {
+    if request_origin == policy_origin {
+        return true;
+    }
+    if policy_origin.matches('*').count() != 1 {
+        return false;
+    }
+
+    let Some((scheme, authority_pattern)) = policy_origin.split_once("://") else {
+        return false;
+    };
+    let Some(authority_suffix) = authority_pattern.strip_prefix("*.") else {
+        return false;
+    };
+    if authority_suffix.contains('*') {
+        return false;
+    }
+
+    // Substitute a valid DNS label so URL parsing can validate the scheme,
+    // authority, and optional port without ever evaluating an operator-provided
+    // glob as executable matcher syntax.
+    let Ok(policy_url) = url::Url::parse(&format!("{scheme}://wildcard.{authority_suffix}")) else {
+        return false;
+    };
+    let Ok(request_url) = url::Url::parse(request_origin) else {
+        return false;
+    };
+    if policy_url.path() != "/"
+        || request_url.path() != "/"
+        || policy_url.query().is_some()
+        || request_url.query().is_some()
+        || policy_url.fragment().is_some()
+        || request_url.fragment().is_some()
+        || !policy_url.username().is_empty()
+        || !request_url.username().is_empty()
+        || policy_url.password().is_some()
+        || request_url.password().is_some()
+        || policy_url.scheme() != request_url.scheme()
+        || policy_url.port_or_known_default() != request_url.port_or_known_default()
+    {
+        return false;
+    }
+
+    let Some(policy_host) = policy_url.host_str() else {
+        return false;
+    };
+    let Some(host_suffix) = policy_host.strip_prefix("wildcard.") else {
+        return false;
+    };
+    let Some(request_host) = request_url.host_str() else {
+        return false;
+    };
+    request_host
+        .strip_suffix(host_suffix)
+        .is_some_and(|prefix| !prefix.is_empty() && prefix.ends_with('.'))
+}
+
+fn federation_resource_matches(request_resource: &str, policy_resource: &str) -> bool {
+    if policy_resource == "*" {
+        return true;
+    }
+    let Some(request_origin) = request_resource.strip_prefix(FEDERATION_REGISTER_RESOURCE_PREFIX)
+    else {
+        return false;
+    };
+    let Some(policy_origin) = policy_resource.strip_prefix(FEDERATION_REGISTER_RESOURCE_PREFIX)
+    else {
+        return false;
+    };
+    if policy_origin == "*" {
+        return true;
+    }
+    federation_origin_pattern_matches(request_origin, policy_origin)
+}
+
+fn federation_match_operator(request: Dynamic, policy: Dynamic) -> Dynamic {
+    federation_resource_matches(
+        dynamic_to_str(&request).as_ref(),
+        dynamic_to_str(&policy).as_ref(),
+    )
+    .into()
+}
+
+fn install_policy_functions(enforcer: &mut Enforcer) {
+    enforcer.add_function(
+        "federationMatch",
+        OperatorFunction::Arg2(federation_match_operator),
+    );
 }
 
 /// Validate a policy component for security
@@ -168,7 +262,7 @@ e = some(where (p.eft == allow)) && !some(where (p.eft == deny))
 [matchers]
 m = ((r.dom == "*" && g(r.sub, p.sub)) || g2(r.sub, p.sub, r.dom) || keyMatch(r.sub, p.sub)) && \
     (p.dom == "*" || r.dom == p.dom) && \
-    keyMatch(r.obj, p.obj) && \
+    ((keyMatch(r.obj, "federation:register:*") && federationMatch(r.obj, p.obj)) || (!keyMatch(r.obj, "federation:register:*") && keyMatch(r.obj, p.obj))) && \
     (p.act == "*" || keyMatch(r.act, p.act))
 "#;
 
@@ -287,15 +381,17 @@ async fn ensure_domain_role_model(model_path: &Path) -> Result<(), PolicyError> 
     const GLOBAL_ROLE_CALL: &str = "g(r.sub, p.sub)";
     const GUARDED_ROLE_MATCHER: &str =
         "m = ((r.dom == \"*\" && g(r.sub, p.sub)) || g2(r.sub, p.sub, r.dom) || keyMatch(r.sub, p.sub))";
+    const SAFE_RESOURCE_MATCHER: &str = "((keyMatch(r.obj, \"federation:register:*\") && federationMatch(r.obj, p.obj)) || (!keyMatch(r.obj, \"federation:register:*\") && keyMatch(r.obj, p.obj)))";
 
     if content.contains("g2 = _, _, _")
         && content.contains(GUARDED_ROLE_MATCHER)
+        && content.contains(SAFE_RESOURCE_MATCHER)
         && content.matches(GLOBAL_ROLE_CALL).count() == 1
     {
         return Ok(());
     }
 
-    let migrated = content
+    let mut migrated = content
         .replacen(
             "[role_definition]\ng = _, _",
             "[role_definition]\ng = _, _\ng2 = _, _, _",
@@ -311,12 +407,19 @@ async fn ensure_domain_role_model(model_path: &Path) -> Result<(), PolicyError> 
             GUARDED_ROLE_MATCHER,
             1,
         );
+    if !migrated.contains(SAFE_RESOURCE_MATCHER) {
+        migrated = migrated.replacen("keyMatch(r.obj, p.obj)", SAFE_RESOURCE_MATCHER, 1);
+    }
+    if !migrated.contains(SAFE_RESOURCE_MATCHER) {
+        migrated = migrated.replacen("keyMatch(r.obj,p.obj)", SAFE_RESOURCE_MATCHER, 1);
+    }
     if !migrated.contains("g2 = _, _, _")
         || !migrated.contains(GUARDED_ROLE_MATCHER)
+        || !migrated.contains(SAFE_RESOURCE_MATCHER)
         || migrated.matches(GLOBAL_ROLE_CALL).count() != 1
     {
         return Err(PolicyError::ValidationError(format!(
-            "{} must restrict legacy g(user, role) membership to the global '*' domain and define domain-scoped g2(user, role, domain) membership",
+            "{} must restrict legacy g(user, role) membership to the global '*' domain, define domain-scoped g2(user, role, domain) membership, and use separator-aware matching for federation origins",
             model_path.display()
         )));
     }
@@ -437,6 +540,7 @@ impl PolicyManager {
         let mut enforcer = Enforcer::new(model, adapter)
             .await
             .map_err(|e| PolicyError::PolicyLoadError(e.to_string()))?;
+        install_policy_functions(&mut enforcer);
         if migrate_federation_origin_policies(&mut enforcer).await? {
             enforcer
                 .save_policy()
@@ -490,6 +594,7 @@ impl PolicyManager {
         let mut enforcer = Enforcer::new(model, adapter)
             .await
             .map_err(|e| PolicyError::PolicyLoadError(e.to_string()))?;
+        install_policy_functions(&mut enforcer);
 
         // Add permissive default rule: anyone can do anything in any domain
         enforcer
@@ -523,9 +628,10 @@ impl PolicyManager {
             .map_err(|e| PolicyError::ModelLoadError(e.to_string()))?;
 
         let adapter = MemoryAdapter::default();
-        let enforcer = Enforcer::new(model, adapter)
+        let mut enforcer = Enforcer::new(model, adapter)
             .await
             .map_err(|e| PolicyError::PolicyLoadError(e.to_string()))?;
+        install_policy_functions(&mut enforcer);
 
         Ok(Self {
             enforcer: Arc::new(RwLock::new(enforcer)),
@@ -1200,6 +1306,43 @@ mod tests {
                 .await
         );
         Ok(())
+    }
+
+    #[test]
+    fn federation_origin_wildcards_are_dns_label_scoped_and_fail_closed() {
+        let pattern = "https://*.partner.example";
+        assert!(federation_origin_pattern_matches(
+            "https://app.partner.example",
+            pattern
+        ));
+        assert!(federation_origin_pattern_matches(
+            "https://deep.app.partner.example",
+            pattern
+        ));
+        for denied in [
+            "https://partner.example",
+            "https://blocked.example",
+            "https://app.partner.example.evil",
+            "http://app.partner.example",
+            "https://app.partner.example:8443",
+        ] {
+            assert!(
+                !federation_origin_pattern_matches(denied, pattern),
+                "{denied} must not match {pattern}"
+            );
+        }
+        assert!(!federation_origin_pattern_matches(
+            "https://app.partner.example",
+            "https://*.*.partner.example"
+        ));
+        assert!(federation_origin_pattern_matches(
+            "https://[::1]:8443",
+            "https://[::1]:8443"
+        ));
+        assert!(!federation_resource_matches(
+            "federation:register:https://app.partner.example",
+            "federation:register"
+        ));
     }
 
     #[tokio::test]

--- a/crates/hyprstream/src/auth/policy_templates.rs
+++ b/crates/hyprstream/src/auth/policy_templates.rs
@@ -142,9 +142,9 @@ pub const SERVICE_BASE_POLICIES: &[ServicePolicyRule] = &[
     //
     // Operators opt in by applying the `federation-open` template, or
     // by allowlisting specific origins:
-    //   p, https://app.partner.org,        *, federation:register, check, allow
-    //   p, https://*.partner.org,          *, federation:register, check, allow
-    //   p, https://hyprstream.partner.org, *, federation:register, check, allow
+    //   p, *, *, federation:register:https://app.partner.org,        check, allow
+    //   p, *, *, federation:register:https://*.partner.org,          check, allow
+    //   p, *, *, federation:register:https://hyprstream.partner.org, check, allow
     //
     // The same rule shape covers a CIMD client at app.partner.org and
     // a peer hyprstream instance at hyprstream.partner.org. Wizard may
@@ -239,7 +239,7 @@ pub fn get_templates() -> &'static [PolicyTemplate] {
                 ServicePolicyRule {
                     subject: "*",
                     domain: "*",
-                    resource: "federation:register",
+                    resource: "federation:register:*",
                     action: "check",
                     effect: "allow",
                 },

--- a/crates/hyprstream/src/auth/policy_templates.rs
+++ b/crates/hyprstream/src/auth/policy_templates.rs
@@ -86,6 +86,13 @@ pub const SERVICE_BASE_POLICIES: &[ServicePolicyRule] = &[
     ServicePolicyRule { subject: "service:notification", domain: "*", resource: "policy:*", action: "check", effect: "allow" },
     ServicePolicyRule { subject: "service:metrics", domain: "*", resource: "policy:*", action: "check", effect: "allow" },
     ServicePolicyRule { subject: "service:mcp", domain: "*", resource: "policy:*", action: "*", effect: "allow" },
+    ServicePolicyRule {
+        subject: "service:flight",
+        domain: "*",
+        resource: "policy:*",
+        action: "check",
+        effect: "allow",
+    },
     // Service key resolution: any service can resolve other service keys via policy
     ServicePolicyRule { subject: "service:oauth", domain: "*", resource: "policy:*", action: "query", effect: "allow" },
     ServicePolicyRule { subject: "service:registry", domain: "*", resource: "policy:*", action: "query", effect: "allow" },

--- a/crates/hyprstream/src/server/routes/models.rs
+++ b/crates/hyprstream/src/server/routes/models.rs
@@ -82,8 +82,8 @@ struct ModelListItem {
 #[allow(clippy::result_large_err)]
 fn policy_identity(
     auth_user: Option<&Extension<AuthenticatedUser>>,
-) -> Result<(String, String), axum::response::Response> {
-    server::extract_policy_identity(auth_user).map_err(|_| {
+) -> Result<(String, String, Option<String>), axum::response::Response> {
+    let (user, domain) = server::extract_policy_identity(auth_user).map_err(|_| {
         (
             StatusCode::FORBIDDEN,
             Json(serde_json::json!({
@@ -91,7 +91,12 @@ fn policy_identity(
             })),
         )
             .into_response()
-    })
+    })?;
+    Ok((
+        user,
+        domain,
+        auth_user.and_then(|Extension(identity)| identity.token.clone()),
+    ))
 }
 
 /// List all available models
@@ -99,19 +104,23 @@ async fn list_models(
     State(state): State<ServerState>,
     auth_user: Option<Extension<AuthenticatedUser>>,
 ) -> impl IntoResponse {
-    let (user, domain) = match policy_identity(auth_user.as_ref()) {
+    let (user, domain, bearer) = match policy_identity(auth_user.as_ref()) {
         Ok(identity) => identity,
         Err(response) => return response,
     };
-    if !state
-        .policy_client
-        .check(&crate::services::generated::policy_client::PolicyCheck {
-            subject: user.clone(),
-            domain,
-            resource: "registry:*".to_owned(),
-            operation: Operation::Query.as_str().to_owned(),
-        })
-        .await
+    let request = crate::services::generated::policy_client::PolicyCheck {
+        subject: user.clone(),
+        domain,
+        resource: "registry:*".to_owned(),
+        operation: Operation::Query.as_str().to_owned(),
+    };
+    if !crate::services::policy::check_with_verified_bearer(
+        &state.policy_client,
+        &request,
+        bearer.as_deref(),
+        &hyprstream_rpc::envelope::Subject::new(user.clone()),
+    )
+    .await
         .unwrap_or(false)
     {
         return (
@@ -177,20 +186,24 @@ async fn get_model_info(
     auth_user: Option<Extension<AuthenticatedUser>>,
     Path(id): Path<String>,
 ) -> impl IntoResponse {
-    let (user, domain) = match policy_identity(auth_user.as_ref()) {
+    let (user, domain, bearer) = match policy_identity(auth_user.as_ref()) {
         Ok(identity) => identity,
         Err(response) => return response,
     };
     let resource = format!("model:{id}");
-    if !state
-        .policy_client
-        .check(&crate::services::generated::policy_client::PolicyCheck {
-            subject: user.clone(),
-            domain,
-            resource: resource.clone(),
-            operation: Operation::Query.as_str().to_owned(),
-        })
-        .await
+    let request = crate::services::generated::policy_client::PolicyCheck {
+        subject: user.clone(),
+        domain,
+        resource: resource.clone(),
+        operation: Operation::Query.as_str().to_owned(),
+    };
+    if !crate::services::policy::check_with_verified_bearer(
+        &state.policy_client,
+        &request,
+        bearer.as_deref(),
+        &hyprstream_rpc::envelope::Subject::new(user.clone()),
+    )
+    .await
         .unwrap_or(false)
     {
         return (
@@ -238,19 +251,23 @@ async fn download_model(
     auth_user: Option<Extension<AuthenticatedUser>>,
     Json(request): Json<DownloadModelRequest>,
 ) -> impl IntoResponse {
-    let (user, domain) = match policy_identity(auth_user.as_ref()) {
+    let (user, domain, bearer) = match policy_identity(auth_user.as_ref()) {
         Ok(identity) => identity,
         Err(response) => return response,
     };
-    if !state
-        .policy_client
-        .check(&crate::services::generated::policy_client::PolicyCheck {
-            subject: user.clone(),
-            domain,
-            resource: "registry:*".to_owned(),
-            operation: Operation::Write.as_str().to_owned(),
-        })
-        .await
+    let policy_request = crate::services::generated::policy_client::PolicyCheck {
+        subject: user.clone(),
+        domain,
+        resource: "registry:*".to_owned(),
+        operation: Operation::Write.as_str().to_owned(),
+    };
+    if !crate::services::policy::check_with_verified_bearer(
+        &state.policy_client,
+        &policy_request,
+        bearer.as_deref(),
+        &hyprstream_rpc::envelope::Subject::new(user.clone()),
+    )
+    .await
         .unwrap_or(false)
     {
         return (
@@ -373,20 +390,24 @@ async fn load_model(
     auth_user: Option<Extension<AuthenticatedUser>>,
     Path(id): Path<String>,
 ) -> impl IntoResponse {
-    let (user, domain) = match policy_identity(auth_user.as_ref()) {
+    let (user, domain, bearer) = match policy_identity(auth_user.as_ref()) {
         Ok(identity) => identity,
         Err(response) => return response,
     };
     let resource = format!("model:{id}");
-    if !state
-        .policy_client
-        .check(&crate::services::generated::policy_client::PolicyCheck {
-            subject: user.clone(),
-            domain,
-            resource: resource.clone(),
-            operation: Operation::Manage.as_str().to_owned(),
-        })
-        .await
+    let request = crate::services::generated::policy_client::PolicyCheck {
+        subject: user.clone(),
+        domain,
+        resource: resource.clone(),
+        operation: Operation::Manage.as_str().to_owned(),
+    };
+    if !crate::services::policy::check_with_verified_bearer(
+        &state.policy_client,
+        &request,
+        bearer.as_deref(),
+        &hyprstream_rpc::envelope::Subject::new(user.clone()),
+    )
+    .await
         .unwrap_or(false)
     {
         return (
@@ -441,20 +462,24 @@ async fn unload_model(
     auth_user: Option<Extension<AuthenticatedUser>>,
     Path(id): Path<String>,
 ) -> impl IntoResponse {
-    let (user, domain) = match policy_identity(auth_user.as_ref()) {
+    let (user, domain, bearer) = match policy_identity(auth_user.as_ref()) {
         Ok(identity) => identity,
         Err(response) => return response,
     };
     let resource = format!("model:{id}");
-    if !state
-        .policy_client
-        .check(&crate::services::generated::policy_client::PolicyCheck {
-            subject: user.clone(),
-            domain,
-            resource: resource.clone(),
-            operation: Operation::Manage.as_str().to_owned(),
-        })
-        .await
+    let request = crate::services::generated::policy_client::PolicyCheck {
+        subject: user.clone(),
+        domain,
+        resource: resource.clone(),
+        operation: Operation::Manage.as_str().to_owned(),
+    };
+    if !crate::services::policy::check_with_verified_bearer(
+        &state.policy_client,
+        &request,
+        bearer.as_deref(),
+        &hyprstream_rpc::envelope::Subject::new(user.clone()),
+    )
+    .await
         .unwrap_or(false)
     {
         return (
@@ -478,19 +503,23 @@ async fn refresh_cache(
     State(state): State<ServerState>,
     auth_user: Option<Extension<AuthenticatedUser>>,
 ) -> impl IntoResponse {
-    let (user, domain) = match policy_identity(auth_user.as_ref()) {
+    let (user, domain, bearer) = match policy_identity(auth_user.as_ref()) {
         Ok(identity) => identity,
         Err(response) => return response,
     };
-    if !state
-        .policy_client
-        .check(&crate::services::generated::policy_client::PolicyCheck {
-            subject: user.clone(),
-            domain,
-            resource: "registry:*".to_owned(),
-            operation: Operation::Manage.as_str().to_owned(),
-        })
-        .await
+    let request = crate::services::generated::policy_client::PolicyCheck {
+        subject: user.clone(),
+        domain,
+        resource: "registry:*".to_owned(),
+        operation: Operation::Manage.as_str().to_owned(),
+    };
+    if !crate::services::policy::check_with_verified_bearer(
+        &state.policy_client,
+        &request,
+        bearer.as_deref(),
+        &hyprstream_rpc::envelope::Subject::new(user.clone()),
+    )
+    .await
         .unwrap_or(false)
     {
         return (

--- a/crates/hyprstream/src/server/routes/openai.rs
+++ b/crates/hyprstream/src/server/routes/openai.rs
@@ -343,15 +343,19 @@ async fn chat_completions(
 
     // Check permission for inference on this model via ZMQ
     let resource = format!("model:{}", request.model);
-    match state
-        .policy_client
-        .check(&crate::services::generated::policy_client::PolicyCheck {
-            subject: user.clone(),
-            domain: domain.clone(),
-            resource: resource.clone(),
-            operation: Operation::Infer.as_str().to_owned(),
-        })
-        .await
+    let policy_request = crate::services::generated::policy_client::PolicyCheck {
+        subject: user.clone(),
+        domain: domain.clone(),
+        resource: resource.clone(),
+        operation: Operation::Infer.as_str().to_owned(),
+    };
+    match crate::services::policy::check_with_verified_bearer(
+        &state.policy_client,
+        &policy_request,
+        jwt_token.as_deref(),
+        &hyprstream_rpc::envelope::Subject::new(user.clone()),
+    )
+    .await
     {
         Ok(allowed) if !allowed => {
             return (
@@ -1005,15 +1009,19 @@ async fn completions(
 
     // Check permission for inference on this model
     let resource = format!("model:{}", request.model);
-    match state
-        .policy_client
-        .check(&crate::services::generated::policy_client::PolicyCheck {
-            subject: user.clone(),
-            domain: domain.clone(),
-            resource: resource.clone(),
-            operation: Operation::Infer.as_str().to_owned(),
-        })
-        .await
+    let policy_request = crate::services::generated::policy_client::PolicyCheck {
+        subject: user.clone(),
+        domain: domain.clone(),
+        resource: resource.clone(),
+        operation: Operation::Infer.as_str().to_owned(),
+    };
+    match crate::services::policy::check_with_verified_bearer(
+        &state.policy_client,
+        &policy_request,
+        jwt_token.as_deref(),
+        &hyprstream_rpc::envelope::Subject::new(user.clone()),
+    )
+    .await
     {
         Ok(allowed) if !allowed => {
             return (
@@ -1205,7 +1213,7 @@ async fn list_models(
     State(state): State<ServerState>,
     auth_user: Option<Extension<AuthenticatedUser>>,
 ) -> impl IntoResponse {
-    let (user, domain, _, _) = match extract_auth(auth_user.as_ref().map(|Extension(u)| u)) {
+    let (user, domain, jwt_token, _) = match extract_auth(auth_user.as_ref().map(|Extension(u)| u)) {
         Ok(identity) => identity,
         Err(_) => {
             return (
@@ -1219,15 +1227,19 @@ async fn list_models(
                 .into_response();
         }
     };
-    if !state
-        .policy_client
-        .check(&crate::services::generated::policy_client::PolicyCheck {
-            subject: user,
-            domain,
-            resource: "registry:*".to_owned(),
-            operation: Operation::Query.as_str().to_owned(),
-        })
-        .await
+    let policy_request = crate::services::generated::policy_client::PolicyCheck {
+        subject: user.clone(),
+        domain,
+        resource: "registry:*".to_owned(),
+        operation: Operation::Query.as_str().to_owned(),
+    };
+    if !crate::services::policy::check_with_verified_bearer(
+        &state.policy_client,
+        &policy_request,
+        jwt_token.as_deref(),
+        &hyprstream_rpc::envelope::Subject::new(user),
+    )
+    .await
         .unwrap_or(false)
     {
         return (

--- a/crates/hyprstream/src/services/discovery.rs
+++ b/crates/hyprstream/src/services/discovery.rs
@@ -56,15 +56,21 @@ impl AuthorizationProvider for PolicyAuthProvider {
         domain: &str,
         resource: &str,
         operation: &str,
+        bearer: Option<&str>,
     ) -> anyhow::Result<bool> {
-        self.client
-            .check(&PolicyCheck {
-                subject: subject.to_owned(),
-                domain: domain.to_owned(),
-                resource: resource.to_owned(),
-                operation: operation.to_owned(),
-            })
-            .await
+        let request = PolicyCheck {
+            subject: subject.to_owned(),
+            domain: domain.to_owned(),
+            resource: resource.to_owned(),
+            operation: operation.to_owned(),
+        };
+        crate::services::policy::check_with_verified_bearer(
+            &self.client,
+            &request,
+            bearer,
+            &hyprstream_rpc::envelope::Subject::new(subject),
+        )
+        .await
     }
 }
 

--- a/crates/hyprstream/src/services/flight.rs
+++ b/crates/hyprstream/src/services/flight.rs
@@ -114,16 +114,22 @@ impl hyprstream_flight::FlightAuthorizer for TenantFlightAuthorizer {
                 "Verified hosted-account tenant binding required".to_owned(),
             )
         })?;
-        let allowed = self
-            .policy_client
-            .check(&crate::services::generated::policy_client::PolicyCheck {
-                subject: identity.user,
-                domain,
-                resource: resource.to_owned(),
-                operation: operation.to_owned(),
-            })
-            .await
-            .unwrap_or(false);
+        let upstream_subject =
+            hyprstream_rpc::envelope::Subject::new(identity.user.clone());
+        let request = crate::services::generated::policy_client::PolicyCheck {
+            subject: identity.user,
+            domain,
+            resource: resource.to_owned(),
+            operation: operation.to_owned(),
+        };
+        let allowed = crate::services::policy::check_with_verified_bearer(
+            &self.policy_client,
+            &request,
+            Some(token),
+            &upstream_subject,
+        )
+        .await
+        .unwrap_or(false);
         if allowed {
             Ok(())
         } else {

--- a/crates/hyprstream/src/services/inference.rs
+++ b/crates/hyprstream/src/services/inference.rs
@@ -2250,7 +2250,20 @@ impl InferenceHandler for InferenceService {
         let subject = ctx.subject();
         let domain = self.authorization_domain(ctx)?;
         enforce_inference_mac(ctx, &self.object_label)?;
-        let allowed = self.policy_client.check(&PolicyCheck { subject: subject.to_string(), domain, resource: resource.to_owned(), operation: operation.to_owned() }).await.unwrap_or_else(|e| {
+        let request = PolicyCheck {
+            subject: subject.to_string(),
+            domain,
+            resource: resource.to_owned(),
+            operation: operation.to_owned(),
+        };
+        let allowed = crate::services::policy::check_with_verified_bearer(
+            &self.policy_client,
+            &request,
+            ctx.jwt_token(),
+            &ctx.subject(),
+        )
+        .await
+        .unwrap_or_else(|e| {
             warn!("Policy check failed for {} on {}: {} - denying access", subject, resource, e);
             false
         });

--- a/crates/hyprstream/src/services/mcp_service.rs
+++ b/crates/hyprstream/src/services/mcp_service.rs
@@ -1065,16 +1065,20 @@ impl McpService {
                 None,
             )
         })?;
-        let allowed = self
-            .policy_client
-            .check(&PolicyCheck {
-                subject: identity.user.clone(),
-                domain: domain.clone(),
-                resource: resource.to_owned(),
-                operation: operation.to_owned(),
-            })
-            .await
-            .unwrap_or(false);
+        let request = PolicyCheck {
+            subject: identity.user.clone(),
+            domain: domain.clone(),
+            resource: resource.to_owned(),
+            operation: operation.to_owned(),
+        };
+        let allowed = crate::services::policy::check_with_verified_bearer(
+            &self.policy_client,
+            &request,
+            identity.token.as_deref(),
+            &hyprstream_rpc::envelope::Subject::new(identity.user.clone()),
+        )
+        .await
+        .unwrap_or(false);
         if !allowed {
             tracing::info!(
                 subject = %identity.user,
@@ -1235,15 +1239,19 @@ impl McpHandler for McpService {
     ) -> anyhow::Result<()> {
         let subject = ctx.subject().to_string();
         let domain = ctx.domain()?;
-        let result = self
-            .policy_client
-            .check(&PolicyCheck {
-                subject: subject.clone(),
-                domain,
-                resource: resource.to_owned(),
-                operation: operation.to_owned(),
-            })
-            .await;
+        let request = PolicyCheck {
+            subject: subject.clone(),
+            domain,
+            resource: resource.to_owned(),
+            operation: operation.to_owned(),
+        };
+        let result = crate::services::policy::check_with_verified_bearer(
+            &self.policy_client,
+            &request,
+            ctx.jwt_token(),
+            &ctx.subject(),
+        )
+        .await;
         match result {
             Ok(allowed) => {
                 if allowed {

--- a/crates/hyprstream/src/services/metrics.rs
+++ b/crates/hyprstream/src/services/metrics.rs
@@ -686,6 +686,16 @@ mod tests {
             },
         );
         let (signing_key, _vk) = generate_signing_keypair();
+        hyprstream_service::global_trust_store().insert(
+            signing_key.verifying_key(),
+            hyprstream_service::Attestation {
+                scopes: std::collections::HashSet::new(),
+                subject: Some("service:metrics".to_owned()),
+                jwt: None,
+                expires_at: 0,
+                attested_by: None,
+            },
+        );
 
         // Permissive policy service so authorize() always passes.
         let policy_tag = format!("test-policy-{tag}");

--- a/crates/hyprstream/src/services/metrics.rs
+++ b/crates/hyprstream/src/services/metrics.rs
@@ -192,15 +192,20 @@ impl MetricsHandler for MetricsService {
         // MetricRecord nor view_metadata carries a tenant key. Keep policy
         // checks in the global domain instead of claiming tenant isolation that
         // the storage layer does not provide.
-        let allowed = self.policy_client
-            .check(&PolicyCheck {
-                subject: subject.clone(),
-                domain: "*".to_owned(),
-                resource: resource.to_owned(),
-                operation: operation.to_owned(),
-            })
-            .await
-            .map_err(|e| anyhow::anyhow!("Policy check error for {}: {}", subject, e))?;
+        let request = PolicyCheck {
+            subject: subject.clone(),
+            domain: "*".to_owned(),
+            resource: resource.to_owned(),
+            operation: operation.to_owned(),
+        };
+        let allowed = crate::services::policy::check_with_verified_bearer(
+            &self.policy_client,
+            &request,
+            ctx.jwt_token(),
+            &ctx.subject(),
+        )
+        .await
+        .map_err(|e| anyhow::anyhow!("Policy check error for {}: {}", subject, e))?;
         if allowed {
             Ok(())
         } else {

--- a/crates/hyprstream/src/services/model.rs
+++ b/crates/hyprstream/src/services/model.rs
@@ -1533,7 +1533,20 @@ impl ModelHandler for ModelService {
         let domain = ctx.domain()?;
         let object_label = crate::services::inference::inference_object_label();
         crate::services::inference::enforce_inference_mac(ctx, &object_label)?;
-        let allowed = self.policy_client.check(&PolicyCheck { subject: subject.to_string(), domain, resource: resource.to_owned(), operation: operation.to_owned() }).await.unwrap_or_else(|e| {
+        let request = PolicyCheck {
+            subject: subject.to_string(),
+            domain,
+            resource: resource.to_owned(),
+            operation: operation.to_owned(),
+        };
+        let allowed = crate::services::policy::check_with_verified_bearer(
+            &self.policy_client,
+            &request,
+            ctx.jwt_token(),
+            &ctx.subject(),
+        )
+        .await
+        .unwrap_or_else(|e| {
             warn!("Policy check failed for {} on {}: {} - denying access", subject, resource, e);
             false
         });

--- a/crates/hyprstream/src/services/oauth/registration.rs
+++ b/crates/hyprstream/src/services/oauth/registration.rs
@@ -396,7 +396,7 @@ pub(crate) async fn check_federation_register_for_client_auth(
 ///   - applying the `federation-open` template (any HTTPS origin allowed —
 ///     covers both third-party clients AND remote peer servers), or
 ///   - allowlisting specific origins:
-///     `p, https://*.partner.org, *, federation:register, check, allow`
+///     `p, *, *, federation:register:https://*.partner.org, check, allow`
 ///
 /// The same rule covers a CIMD client at app.partner.org AND a peer
 /// hyprstream instance at hyprstream.partner.org.
@@ -405,12 +405,14 @@ pub(crate) async fn check_federation_register_for_client_auth(
 /// posture is preserved over availability of new federation registrations.
 async fn check_federation_register(state: &OAuthState, origin: &str) -> Result<(), String> {
     use crate::services::generated::policy_client::PolicyCheck;
+    let resource = crate::auth::federation_registration_resource(origin)
+        .map_err(|error| format!("invalid federation origin policy resource: {error}"))?;
     match state
         .policy_client
         .check(&PolicyCheck {
-            subject: origin.to_owned(),
-            domain: origin.to_owned(),
-            resource: "federation:register".to_owned(),
+            subject: String::new(),
+            domain: String::new(),
+            resource,
             operation: "check".to_owned(),
         })
         .await

--- a/crates/hyprstream/src/services/policy.rs
+++ b/crates/hyprstream/src/services/policy.rs
@@ -2215,6 +2215,7 @@ mod tests {
     async fn service_mediated_check_uses_verified_user_not_broad_deputy() {
         use hyprstream_service::{InprocManager, ServiceManager};
 
+        crate::mac::install_explicit_test_dispatch_pep();
         let _ = hyprstream_rpc::envelope::install_verify_config(
             hyprstream_rpc::envelope::EnvelopeVerifyConfig {
                 policy: hyprstream_rpc::crypto::CryptoPolicy::Classical,

--- a/crates/hyprstream/src/services/policy.rs
+++ b/crates/hyprstream/src/services/policy.rs
@@ -2253,6 +2253,22 @@ mod tests {
             )
             .await
             .expect("test: broad deputy grant");
+        let allowed_federation =
+            crate::auth::federation_registration_resource("https://allowed.example")
+                .expect("test: federation resource");
+        let blocked_federation =
+            crate::auth::federation_registration_resource("https://blocked.example")
+                .expect("test: federation resource");
+        manager
+            .add_policy_with_domain(
+                "*",
+                "*",
+                &allowed_federation,
+                "check",
+                "allow",
+            )
+            .await
+            .expect("test: per-origin federation grant");
 
         let endpoint = format!("policy-delegation-{}", rand::random::<u64>());
         let policy_key = SigningKey::from_bytes(&[0x70; 32]);
@@ -2317,6 +2333,31 @@ mod tests {
             None,
         )
         .expect("test: policy client");
+
+        let allowed_origin = client
+            .check(&PolicyCheck {
+                subject: String::new(),
+                domain: String::new(),
+                resource: allowed_federation,
+                operation: "check".to_owned(),
+            })
+            .await
+            .expect("test: allowlisted federation decision");
+        assert!(allowed_origin, "the allowlisted origin must be admitted");
+
+        let blocked_origin = client
+            .check(&PolicyCheck {
+                subject: String::new(),
+                domain: String::new(),
+                resource: blocked_federation,
+                operation: "check".to_owned(),
+            })
+            .await
+            .expect("test: non-allowlisted federation decision");
+        assert!(
+            !blocked_origin,
+            "the decision must vary by origin, not the deputy service"
+        );
 
         let allowed = client
             .clone()

--- a/crates/hyprstream/src/services/policy.rs
+++ b/crates/hyprstream/src/services/policy.rs
@@ -385,25 +385,67 @@ impl PolicyHandler for PolicyService {
 
     async fn handle_check(
         &self,
-        _ctx: &EnvelopeContext,
+        ctx: &EnvelopeContext,
         _request_id: u64,
         data: &PolicyCheck,
     ) -> Result<PolicyResponseVariant> {
+        let subject = ctx.subject();
+        if !ctx.is_authenticated() {
+            warn!(
+                requested_subject = %data.subject,
+                requested_domain = %data.domain,
+                resource = %data.resource,
+                operation = %data.operation,
+                "policy check denied: unauthenticated envelope context"
+            );
+            ctx.audit_authz(&data.resource, &data.operation, false);
+            return Ok(PolicyResponseVariant::CheckResult(false));
+        }
+        let domain = match self.request_domain(ctx) {
+            Ok(domain) => domain,
+            Err(error) => {
+                warn!(
+                    caller = %subject,
+                    requested_subject = %data.subject,
+                    requested_domain = %data.domain,
+                    resource = %data.resource,
+                    operation = %data.operation,
+                    %error,
+                    "policy check denied: no verified authorization domain"
+                );
+                ctx.audit_authz(&data.resource, &data.operation, false);
+                return Ok(PolicyResponseVariant::CheckResult(false));
+            }
+        };
+
         trace!(
-            "Policy check: subject={}, domain={}, resource={}, operation={}",
-            data.subject, data.domain, data.resource, data.operation
+            "Policy check: verified_subject={}, verified_domain={}, resource={}, operation={}",
+            subject, domain, data.resource, data.operation
         );
 
-        // Check authorization — pass the operation string directly so dot-namespaced
-        // actions (e.g. "ttt.writeback") are forwarded verbatim to the Casbin enforcer.
+        // Subject and domain are derived exclusively from the verified envelope.
+        // The request fields remain on the wire for compatibility, but cannot
+        // select another identity or tenant. Pass the operation string directly
+        // so dot-namespaced actions are forwarded verbatim to Casbin.
         let allowed = self.policy_manager.check_with_domain(
-            &data.subject,
-            &data.domain,
+            &subject.to_string(),
+            &domain,
             &data.resource,
             &data.operation,
         ).await;
 
-        debug!("Policy check result: allowed={}", allowed);
+        if allowed {
+            debug!(caller = %subject, %domain, "policy check allowed");
+        } else {
+            warn!(
+                caller = %subject,
+                %domain,
+                resource = %data.resource,
+                operation = %data.operation,
+                "policy check denied by policy"
+            );
+        }
+        ctx.audit_authz(&data.resource, &data.operation, allowed);
         Ok(PolicyResponseVariant::CheckResult(allowed))
     }
 
@@ -2000,6 +2042,134 @@ mod tests {
                 .expect("PolicyService bootstrap authority domain"),
             "*"
         );
+    }
+
+    #[tokio::test]
+    async fn unauthenticated_policy_check_is_denied() {
+        let manager = Arc::new(
+            PolicyManager::new_in_memory()
+                .await
+                .expect("test: policy manager"),
+        );
+        manager
+            .add_policy_with_domain(
+                "alice",
+                "tenant-a",
+                "model:allowed",
+                "infer.generate",
+                "allow",
+            )
+            .await
+            .expect("test: policy grant");
+        let (service, _root) = test_service_with_manager(manager).await;
+        let ctx = EnvelopeContext::for_test_authenticated_subject(
+            Subject::anonymous(),
+            SigningKey::from_bytes(&[0x53; 32]).verifying_key(),
+        );
+        let request = PolicyCheck {
+            subject: "alice".to_owned(),
+            domain: "tenant-a".to_owned(),
+            resource: "model:allowed".to_owned(),
+            operation: "infer.generate".to_owned(),
+        };
+
+        let response = service
+            .handle_check(&ctx, 1, &request)
+            .await
+            .expect("denial is a policy response");
+        assert!(matches!(
+            response,
+            PolicyResponseVariant::CheckResult(false)
+        ));
+    }
+
+    #[tokio::test]
+    async fn policy_check_uses_verified_context_not_requested_identity() {
+        let manager = Arc::new(
+            PolicyManager::new_in_memory()
+                .await
+                .expect("test: policy manager"),
+        );
+        manager
+            .add_policy_with_domain(
+                "alice",
+                "tenant-a",
+                "model:own",
+                "infer.generate",
+                "allow",
+            )
+            .await
+            .expect("test: own-tenant grant");
+        manager
+            .add_policy_with_domain(
+                "victim",
+                "tenant-b",
+                "model:foreign",
+                "infer.generate",
+                "allow",
+            )
+            .await
+            .expect("test: foreign-tenant grant");
+        let (service, _root) = test_service_with_manager(manager).await;
+        let ctx = EnvelopeContext::for_test_authenticated_subject_in_tenant(
+            Subject::new("alice"),
+            "tenant-a",
+            SigningKey::from_bytes(&[0x54; 32]).verifying_key(),
+        );
+
+        let forged_probe = PolicyCheck {
+            subject: "victim".to_owned(),
+            domain: "tenant-b".to_owned(),
+            resource: "model:foreign".to_owned(),
+            operation: "infer.generate".to_owned(),
+        };
+        let denied = service
+            .handle_check(&ctx, 1, &forged_probe)
+            .await
+            .expect("denial is a policy response");
+        assert!(matches!(
+            denied,
+            PolicyResponseVariant::CheckResult(false)
+        ));
+
+        let stale_wire_identity = PolicyCheck {
+            subject: "victim".to_owned(),
+            domain: "tenant-b".to_owned(),
+            resource: "model:own".to_owned(),
+            operation: "infer.generate".to_owned(),
+        };
+        let allowed = service
+            .handle_check(&ctx, 2, &stale_wire_identity)
+            .await
+            .expect("allow is a policy response");
+        assert!(matches!(
+            allowed,
+            PolicyResponseVariant::CheckResult(true)
+        ));
+    }
+
+    #[tokio::test]
+    async fn tenantless_user_policy_check_is_denied() {
+        let (service, _root) = test_service().await;
+        let ctx = EnvelopeContext::for_test_authenticated_subject(
+            Subject::new("alice"),
+            SigningKey::from_bytes(&[0x55; 32]).verifying_key(),
+        );
+        let request = PolicyCheck {
+            subject: "alice".to_owned(),
+            domain: "*".to_owned(),
+            resource: "model:any".to_owned(),
+            operation: "infer.generate".to_owned(),
+        };
+
+        let response = service
+            .handle_check(&ctx, 1, &request)
+            .await
+            .expect("denial is a policy response");
+        assert!(matches!(
+            response,
+            PolicyResponseVariant::CheckResult(false)
+        ));
     }
 
     #[tokio::test]

--- a/crates/hyprstream/src/services/policy.rs
+++ b/crates/hyprstream/src/services/policy.rs
@@ -30,6 +30,37 @@ use std::sync::Arc;
 use tokio::sync::RwLock;
 use tracing::{debug, info, trace, warn};
 
+/// Evaluate a policy check on behalf of an already-verified upstream caller.
+///
+/// The compatibility `PolicyCheck.subject/domain` fields are never identity
+/// evidence. A service that mediates a user request relays the original bearer
+/// in its signed envelope so PolicyService can independently verify both the
+/// user and the hosted-account tenant.
+pub(crate) async fn check_with_verified_bearer(
+    client: &crate::services::PolicyClient,
+    request: &PolicyCheck,
+    bearer: Option<&str>,
+    upstream_subject: &Subject,
+) -> Result<bool> {
+    match bearer {
+        Some(token) => client
+            .clone()
+            .with_delegated_bearer(token.to_owned())
+            .check(request)
+            .await,
+        None => {
+            anyhow::ensure!(
+                !upstream_subject.is_federated()
+                    && upstream_subject
+                        .name()
+                        .is_some_and(|name| { name == "system" || name.starts_with("service:") }),
+                "service-mediated user policy check requires a verified upstream bearer"
+            );
+            client.check(request).await
+        }
+    }
+}
+
 // ============================================================================
 // PolicyService (server-side)
 // ============================================================================
@@ -252,7 +283,8 @@ impl PolicyService {
         let subject = ctx.subject();
         let is_global_service = subject
             .name()
-            .is_some_and(|name| name.starts_with("service:"));
+            .is_some_and(|name| name.starts_with("service:"))
+            && !subject.is_federated();
         let is_policy_authority =
             ctx.cnf == self.signing_key.verifying_key().to_bytes();
         anyhow::ensure!(
@@ -1872,6 +1904,28 @@ impl RequestService for PolicyService {
         });
     }
 
+    fn accept_delegated_bearer(&self, signer_pubkey: &[u8; 32]) -> bool {
+        let Some(actor) =
+            hyprstream_service::global_trust_store().resolve_subject(signer_pubkey)
+        else {
+            return false;
+        };
+        let Some(actor_name) = actor.name() else {
+            return false;
+        };
+        if actor.is_federated() || !actor_name.starts_with("service:") {
+            return false;
+        }
+
+        policy_templates::SERVICE_BASE_POLICIES.iter().any(|rule| {
+            (rule.subject == actor_name || rule.subject == "service:*")
+                && rule.domain == "*"
+                && matches!(rule.resource, "policy:*" | "policy:PolicyCheck")
+                && matches!(rule.action, "*" | "check")
+                && rule.effect == "allow"
+        })
+    }
+
     fn build_error_payload(&self, request_id: u64, error: &str) -> Vec<u8> {
         let variant = PolicyResponseVariant::Error(ErrorInfo {
             message: error.to_owned(),
@@ -2025,6 +2079,15 @@ mod tests {
             EnvelopeContext::for_test_authenticated_subject(Subject::new("alice"), service_signer);
         assert!(service.request_domain(&tenantless_user).is_err());
 
+        let federated_service = EnvelopeContext::for_test_authenticated_subject(
+            Subject::federated("https://peer.example", "service:oauth"),
+            service_signer,
+        );
+        assert!(
+            service.request_domain(&federated_service).is_err(),
+            "a federated subject cannot claim local global-service authority by name"
+        );
+
         let wildcard_service = EnvelopeContext::for_test_authenticated_subject_in_tenant(
             Subject::new("service:oauth"),
             "*",
@@ -2146,6 +2209,159 @@ mod tests {
             allowed,
             PolicyResponseVariant::CheckResult(true)
         ));
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn service_mediated_check_uses_verified_user_not_broad_deputy() {
+        use hyprstream_service::{InprocManager, ServiceManager};
+
+        let _ = hyprstream_rpc::envelope::install_verify_config(
+            hyprstream_rpc::envelope::EnvelopeVerifyConfig {
+                policy: hyprstream_rpc::crypto::CryptoPolicy::Classical,
+                pq_store: None,
+            },
+        );
+        let _ = hyprstream_rpc::envelope::install_response_verify_config(
+            hyprstream_rpc::envelope::ResponseVerifyConfig {
+                policy: hyprstream_rpc::crypto::CryptoPolicy::Classical,
+                pq_store: None,
+            },
+        );
+
+        let manager = Arc::new(
+            PolicyManager::new_in_memory()
+                .await
+                .expect("test: policy manager"),
+        );
+        manager
+            .add_policy_with_domain(
+                "alice",
+                "did:web:tenant-a.example",
+                "model:allowed",
+                "infer.generate",
+                "allow",
+            )
+            .await
+            .expect("test: tenant user grant");
+        manager
+            .add_policy_with_domain(
+                "service:registry",
+                "*",
+                "model:deputy-only",
+                "infer.generate",
+                "allow",
+            )
+            .await
+            .expect("test: broad deputy grant");
+
+        let endpoint = format!("policy-delegation-{}", rand::random::<u64>());
+        let policy_key = SigningKey::from_bytes(&[0x70; 32]);
+        let actor_key = SigningKey::from_bytes(&[0x71; 32]);
+        let actor_verifying_key = actor_key.verifying_key();
+        let user_key = SigningKey::from_bytes(&[0x72; 32]);
+        let other_user_key = SigningKey::from_bytes(&[0x73; 32]);
+        let issuer = "https://policy-delegation.test";
+        let key_source = hyprstream_rpc::auth::ClusterKeySource::new(
+            policy_key.verifying_key(),
+            issuer.to_owned(),
+        );
+        let root = tempfile::tempdir().expect("test: policy git directory");
+        let git2db = Arc::new(RwLock::new(
+            Git2DB::open(root.path())
+                .await
+                .expect("test: open policy git database"),
+        ));
+        let service = PolicyService::new(
+            manager,
+            Arc::new(policy_key.clone()),
+            crate::config::TokenConfig::default(),
+            git2db,
+            TransportConfig::inproc(&endpoint),
+        )
+        .with_jwt_key_source(Arc::new(key_source));
+        let services = InprocManager::new();
+        services
+            .spawn(Box::new(service))
+            .await
+            .expect("test: spawn policy service");
+
+        let now = chrono::Utc::now().timestamp();
+        hyprstream_service::global_trust_store().insert(
+            actor_verifying_key,
+            hyprstream_service::Attestation {
+                scopes: ["registry".to_owned()].into_iter().collect(),
+                subject: None,
+                jwt: None,
+                expires_at: now + 300,
+                attested_by: Some(policy_key.verifying_key().to_bytes()),
+            },
+        );
+        let user_token = hyprstream_rpc::auth::jwt::encode(
+            &hyprstream_rpc::auth::Claims::new("alice".to_owned(), now, now + 300)
+                .with_issuer(issuer.to_owned())
+                .with_tenant("did:web:tenant-a.example".to_owned())
+                .with_cnf_jwk(user_key.verifying_key().as_bytes()),
+            &policy_key,
+        );
+        let other_tenant_token = hyprstream_rpc::auth::jwt::encode(
+            &hyprstream_rpc::auth::Claims::new("bob".to_owned(), now, now + 300)
+                .with_issuer(issuer.to_owned())
+                .with_tenant("did:web:tenant-b.example".to_owned())
+                .with_cnf_jwk(other_user_key.verifying_key().as_bytes()),
+            &policy_key,
+        );
+        let client = crate::services::PolicyClient::for_local_endpoint_bootstrap(
+            &format!("inproc://{endpoint}"),
+            actor_key,
+            policy_key.verifying_key(),
+            None,
+        )
+        .expect("test: policy client");
+
+        let allowed = client
+            .clone()
+            .with_delegated_bearer(user_token.clone())
+            .check(&PolicyCheck {
+                subject: "victim".to_owned(),
+                domain: "did:web:tenant-b.example".to_owned(),
+                resource: "model:allowed".to_owned(),
+                operation: "infer.generate".to_owned(),
+            })
+            .await
+            .expect("test: tenant user decision");
+        assert!(allowed, "verified delegated user grant must be effective");
+
+        let cross_tenant = client
+            .clone()
+            .with_delegated_bearer(other_tenant_token)
+            .check(&PolicyCheck {
+                subject: "alice".to_owned(),
+                domain: "did:web:tenant-a.example".to_owned(),
+                resource: "model:allowed".to_owned(),
+                operation: "infer.generate".to_owned(),
+            })
+            .await
+            .expect("test: cross-tenant decision");
+        assert!(
+            !cross_tenant,
+            "tenant-b's verified bearer must not inherit tenant-a's grant"
+        );
+
+        let denied = client
+            .with_delegated_bearer(user_token)
+            .check(&PolicyCheck {
+                subject: "service:registry".to_owned(),
+                domain: "*".to_owned(),
+                resource: "model:deputy-only".to_owned(),
+                operation: "infer.generate".to_owned(),
+            })
+            .await
+            .expect("test: broad deputy decision");
+        assert!(
+            !denied,
+            "the deputy's broad global grant must not replace the delegated user"
+        );
+        hyprstream_service::global_trust_store().remove(&actor_verifying_key);
     }
 
     #[tokio::test]

--- a/crates/hyprstream/src/services/registry.rs
+++ b/crates/hyprstream/src/services/registry.rs
@@ -3566,6 +3566,16 @@ mod tests {
 
         // Generate keypair for signing/verification
         let (signing_key, _verifying_key) = generate_signing_keypair();
+        hyprstream_service::global_trust_store().insert(
+            signing_key.verifying_key(),
+            hyprstream_service::Attestation {
+                scopes: std::collections::HashSet::new(),
+                subject: Some("service:registry".to_owned()),
+                jwt: None,
+                expires_at: 0,
+                attested_by: None,
+            },
+        );
 
         // Create a permissive policy manager and start PolicyService first
         let policy_manager = Arc::new(PolicyManager::permissive().await.expect("test: create policy manager"));
@@ -3634,6 +3644,16 @@ mod tests {
         let models = root.path().join("models");
         let pds = root.path().join("pds");
         let (key, _) = generate_signing_keypair();
+        hyprstream_service::global_trust_store().insert(
+            key.verifying_key(),
+            hyprstream_service::Attestation {
+                scopes: std::collections::HashSet::new(),
+                subject: Some("service:registry".to_owned()),
+                jwt: None,
+                expires_at: 0,
+                attested_by: None,
+            },
+        );
         let policy_manager = Arc::new(PolicyManager::permissive().await.unwrap());
         let policy_git = Arc::new(RwLock::new(Git2DB::open(&models).await.unwrap()));
         let policy = PolicyService::new(policy_manager, Arc::new(key.clone()),

--- a/crates/hyprstream/src/services/registry.rs
+++ b/crates/hyprstream/src/services/registry.rs
@@ -1779,12 +1779,20 @@ impl RegistryHandler for RegistryService {
         // metadata and paths carry no tenant key. Keep this authorization in
         // the global policy domain rather than claiming storage isolation that
         // the registry does not provide.
-        let allowed = self.policy_client.check(&PolicyCheck {
+        let request = PolicyCheck {
             subject: subject.to_string(),
             domain: "*".to_owned(),
             resource: resource.to_owned(),
             operation: operation.to_owned(),
-        }).await.unwrap_or_else(|e| {
+        };
+        let allowed = crate::services::policy::check_with_verified_bearer(
+            &self.policy_client,
+            &request,
+            ctx.jwt_token(),
+            &ctx.subject(),
+        )
+        .await
+        .unwrap_or_else(|e| {
             warn!("Policy check RPC error: sub={} obj={} act={} err={} - denying access", subject, resource, operation, e);
             false
         });
@@ -1811,13 +1819,23 @@ impl RegistryHandler for RegistryService {
 
             // Policy gate: only include repos the caller has at least query access to
             let resource = format!("model:{}", name);
-            let permitted = self.policy_client
-                .check(&PolicyCheck { subject: subject.clone(), domain: domain.clone(), resource: resource.clone(), operation: "query".to_owned() })
-                .await
-                .unwrap_or_else(|e| {
-                    warn!("Policy check RPC error while filtering {}: {} - denying access", resource, e);
-                    false
-                });
+            let request = PolicyCheck {
+                subject: subject.clone(),
+                domain: domain.clone(),
+                resource: resource.clone(),
+                operation: "query".to_owned(),
+            };
+            let permitted = crate::services::policy::check_with_verified_bearer(
+                &self.policy_client,
+                &request,
+                ctx.jwt_token(),
+                &ctx.subject(),
+            )
+            .await
+            .unwrap_or_else(|e| {
+                warn!("Policy check RPC error while filtering {}: {} - denying access", resource, e);
+                false
+            });
             if !permitted { continue; }
 
             // Collect worktrees with capabilities (holds registry read lock internally)

--- a/crates/hyprstream/src/services/worker.rs
+++ b/crates/hyprstream/src/services/worker.rs
@@ -47,12 +47,32 @@ use crate::services::PolicyClient;
 /// The returned closure is async-compatible (returns a boxed future) so it
 /// works on single-threaded runtimes used by RequestService.
 pub fn build_authorize_fn(policy_client: PolicyClient) -> AuthorizeFn {
-    Arc::new(move |subject: String, domain: String, resource: String, operation: String| {
-        let client = policy_client.clone();
-        Box::pin(async move {
-            client.check(&PolicyCheck { subject, domain, resource, operation }).await
-        })
-    })
+    Arc::new(
+        move |subject: String,
+              domain: String,
+              resource: String,
+              operation: String,
+              bearer: Option<String>| {
+            let client = policy_client.clone();
+            Box::pin(async move {
+                let upstream_subject =
+                    hyprstream_rpc::envelope::Subject::new(subject.clone());
+                let request = PolicyCheck {
+                    subject,
+                    domain,
+                    resource,
+                    operation,
+                };
+                crate::services::policy::check_with_verified_bearer(
+                    &client,
+                    &request,
+                    bearer.as_deref(),
+                    &upstream_subject,
+                )
+                .await
+            })
+        },
+    )
 }
 
 // WorkerZmqClient / attach_container removed — use generated WorkerClient +

--- a/crates/hyprstream/src/tui/service.rs
+++ b/crates/hyprstream/src/tui/service.rs
@@ -248,18 +248,23 @@ impl TuiService {
         let policy_client = self.policy_client.as_ref().ok_or_else(|| {
             anyhow::anyhow!("Authorization denied: no policy client configured")
         })?;
-        let allowed = policy_client
-            .check(&crate::services::generated::policy_client::PolicyCheck {
-                subject: subject.clone(),
-                domain,
-                resource: resource.to_owned(),
-                operation: operation.to_owned(),
-            })
-            .await
-            .unwrap_or_else(|e| {
-                warn!("TUI policy check failed for {}: {}", subject, e);
-                false
-            });
+        let request = crate::services::generated::policy_client::PolicyCheck {
+            subject: subject.clone(),
+            domain,
+            resource: resource.to_owned(),
+            operation: operation.to_owned(),
+        };
+        let allowed = crate::services::policy::check_with_verified_bearer(
+            policy_client,
+            &request,
+            ctx.jwt_token(),
+            &ctx.subject(),
+        )
+        .await
+        .unwrap_or_else(|e| {
+            warn!("TUI policy check failed for {}: {}", subject, e);
+            false
+        });
         if !allowed {
             anyhow::bail!("Unauthorized: {} cannot {} on {}", subject, operation, resource);
         }

--- a/crates/hyprstream/tests/e2e_9p_walk.rs
+++ b/crates/hyprstream/tests/e2e_9p_walk.rs
@@ -208,6 +208,16 @@ struct Services {
 
 async fn spawn_services(repo_dir: &std::path::Path, repo_name: &str) -> Result<Services> {
     let signing_key = generate_signing_keypair().0;
+    hyprstream_service::global_trust_store().insert(
+        signing_key.verifying_key(),
+        hyprstream_service::Attestation {
+            scopes: std::collections::HashSet::new(),
+            subject: Some("service:registry".to_owned()),
+            jwt: None,
+            expires_at: 0,
+            attested_by: None,
+        },
+    );
 
     // ── PolicyService (permissive) ──────────────────────────────────────────
     let policy_temp = TempDir::new()?;

--- a/crates/hyprstream/tests/policy_over_iroh.rs
+++ b/crates/hyprstream/tests/policy_over_iroh.rs
@@ -54,6 +54,7 @@ const CLIENT_SIGNING_SEED: [u8; 32] = [0xC1; 32];
 /// per-subject authorization outcomes over the wire.
 const CLIENT_A_SIGNING_SEED: [u8; 32] = [0xC2; 32];
 const CLIENT_B_SIGNING_SEED: [u8; 32] = [0xC3; 32];
+const SERVICE_CLIENT_SIGNING_SEED: [u8; 32] = [0xC4; 32];
 const TEST_ISSUER: &str = "https://policy.test";
 
 /// Subjects the test trust-store attestations bind to client A / B keys.
@@ -74,6 +75,10 @@ fn policy_client_a_signing_key() -> SigningKey {
 
 fn policy_client_b_signing_key() -> SigningKey {
     SigningKey::from_bytes(&CLIENT_B_SIGNING_SEED)
+}
+
+fn policy_service_client_signing_key() -> SigningKey {
+    SigningKey::from_bytes(&SERVICE_CLIENT_SIGNING_SEED)
 }
 
 /// Bind the fixed-seed client keys to bare user subjects in the global trust
@@ -115,6 +120,7 @@ fn policy_pq_trust_store() -> Arc<dyn PqTrustStore> {
     bind_mesh_anchor(&mut store, &policy_client_signing_key());
     bind_mesh_anchor(&mut store, &policy_client_a_signing_key());
     bind_mesh_anchor(&mut store, &policy_client_b_signing_key());
+    bind_mesh_anchor(&mut store, &policy_service_client_signing_key());
     Arc::new(store)
 }
 
@@ -205,25 +211,18 @@ impl TestTokenAuthority {
             &self.ed25519,
         )
     }
-}
 
-/// Stand up a real `PolicyService` in a fresh tempdir and return it
-/// alongside its signing key and the tempdir guard (which must outlive
-/// the service).
-async fn make_policy_service() -> Result<(PolicyService, SigningKey, TempDir)> {
-    let (service, _manager, signing_key, temp, _authority) =
-        make_policy_service_with_manager_and_authority().await?;
-    Ok((service, signing_key, temp))
-}
-
-/// Like [`make_policy_service`] but also returns the `Arc<PolicyManager>` so
-/// tests can write grants (e.g. per-tenant domain rules for #1128) before
-/// serving.
-async fn make_policy_service_with_manager(
-) -> Result<(PolicyService, Arc<PolicyManager>, SigningKey, TempDir)> {
-    let (service, manager, signing_key, temp, _authority) =
-        make_policy_service_with_manager_and_authority().await?;
-    Ok((service, manager, signing_key, temp))
+    fn service_token(&self, subject: &str, signer: &SigningKey) -> String {
+        let now = chrono::Utc::now().timestamp();
+        let claims = hyprstream_rpc::auth::Claims::new(subject.to_owned(), now, now + 300)
+            .with_issuer(TEST_ISSUER.to_owned())
+            .with_cnf_jwk(signer.verifying_key().as_bytes());
+        hyprstream_core::auth::jwt::encode_composite_ml_dsa_65_ed25519(
+            &claims,
+            &self.ml_dsa,
+            &self.ed25519,
+        )
+    }
 }
 
 async fn make_policy_service_with_manager_and_authority(
@@ -354,44 +353,53 @@ async fn client_for_key_with_jwt(
     Ok((client_substrate, policy_client))
 }
 
-/// Real PolicyService over iroh — verifies the canary path end-to-end with
-/// a representative `check` RPC, including both ALLOW and DENY outcomes
-/// produced by the bootstrap `SERVICE_BASE_POLICIES`.
+/// Real PolicyService over iroh — verifies that `check` uses the authenticated
+/// envelope caller, not the subject/domain fields carried for wire compatibility.
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn policy_check_allow_and_deny_over_iroh() -> Result<()> {
     support::install_explicit_dispatch_pep();
     let pq_store = install_hybrid_verify_config();
 
-    let (service, server_signing, _temp) = make_policy_service().await?;
+    let (service, _manager, server_signing, _temp, authority) =
+        make_policy_service_with_manager_and_authority().await?;
     let server_vk = server_signing.verifying_key();
     let request_kem_store = policy_request_kem_store(&server_signing)?;
 
     let (server, server_addr) = serve_over_iroh(service, &server_signing).await?;
-    let (client_substrate, policy) =
-        client_for(server_addr, server_vk, request_kem_store, pq_store).await?;
+    let client_key = policy_service_client_signing_key();
+    let jwt = authority.service_token("service:oauth", &client_key);
+    let (client_substrate, policy) = client_for_key_with_jwt(
+        server_addr,
+        server_vk,
+        request_kem_store,
+        pq_store,
+        client_key,
+        Some(jwt),
+    )
+    .await?;
 
-    // ALLOW: service:oauth → policy:ResolveServiceKey:query (from
-    // SERVICE_BASE_POLICIES, asserted in policy_manager.rs base-rules test).
+    // The forged wire identity is ignored: the verified service:oauth caller
+    // receives its bootstrap grant in the global domain.
     let allow_resp = policy
         .check(&PolicyCheck {
-            subject: "service:oauth".to_owned(),
-            domain: "*".to_owned(),
+            subject: "service:unknown".to_owned(),
+            domain: "tenant-forged".to_owned(),
             resource: "policy:ResolveServiceKey".to_owned(),
             operation: "query".to_owned(),
         })
         .await?;
     assert!(allow_resp, "service:oauth must be allowed: {allow_resp:?}");
 
-    // DENY: service:unknown is not in the base policies.
+    // A resource outside service:oauth's bootstrap grants is denied.
     let deny_resp = policy
         .check(&PolicyCheck {
-            subject: "service:unknown".to_owned(),
+            subject: "service:policy".to_owned(),
             domain: "*".to_owned(),
-            resource: "policy:ResolveServiceKey".to_owned(),
-            operation: "query".to_owned(),
+            resource: "registry:DeleteEverything".to_owned(),
+            operation: "manage".to_owned(),
         })
         .await?;
-    assert!(!deny_resp, "service:unknown must be denied: {deny_resp:?}");
+    assert!(!deny_resp, "ungranted operation must be denied: {deny_resp:?}");
 
     client_substrate.shutdown().await?;
     server.shutdown().await?;
@@ -406,31 +414,36 @@ async fn policy_concurrent_checks_over_iroh() -> Result<()> {
     support::install_explicit_dispatch_pep();
     let pq_store = install_hybrid_verify_config();
 
-    let (service, server_signing, _temp) = make_policy_service().await?;
+    let (service, _manager, server_signing, _temp, authority) =
+        make_policy_service_with_manager_and_authority().await?;
     let server_vk = server_signing.verifying_key();
     let request_kem_store = policy_request_kem_store(&server_signing)?;
 
     let (server, server_addr) = serve_over_iroh(service, &server_signing).await?;
-    let (client_substrate, policy) =
-        client_for(server_addr, server_vk, request_kem_store, pq_store).await?;
+    let client_key = policy_service_client_signing_key();
+    let jwt = authority.service_token("service:oauth", &client_key);
+    let (client_substrate, policy) = client_for_key_with_jwt(
+        server_addr,
+        server_vk,
+        request_kem_store,
+        pq_store,
+        client_key,
+        Some(jwt),
+    )
+    .await?;
     let policy = Arc::new(policy);
 
-    // Cases chosen so wildcard base rules don't interfere:
-    //   - policy:ResolveServiceKey:query is granted ONLY to specific services
-    //     (service:oauth, service:policy, service:model, service:registry,
-    //     service:worker, service:mcp), so unknown service:* subjects deny.
-    //   - policy:Check:check is similarly per-service.
-    //   - Non-`service:` subjects (e.g. "alice") deny on everything below
-    //     unless explicitly granted.
+    // Every stream carries the same verified service:oauth identity; forged
+    // wire subjects cannot change an outcome.
     let cases: Vec<(&str, &str, &str, bool)> = vec![
         ("service:oauth", "policy:ResolveServiceKey", "query", true),
-        ("service:policy", "policy:ResolveServiceKey", "query", true),
-        ("service:model", "policy:Check", "check", true),
+        ("service:unknown", "policy:ResolveServiceKey", "query", true),
         ("service:oauth", "policy:IssueToken", "manage", true),
-        ("service:bogus0", "policy:ResolveServiceKey", "query", false),
-        ("service:bogus1", "policy:Check", "check", false),
-        ("alice", "policy:ResolveServiceKey", "query", false),
-        ("alice", "policy:IssueToken", "manage", false),
+        ("service:policy", "policy:IssueToken", "manage", true),
+        ("service:oauth", "registry:DeleteEverything", "manage", false),
+        ("service:policy", "registry:DeleteEverything", "manage", false),
+        ("alice", "model:secret", "infer.generate", false),
+        ("alice", "metrics:secret", "write", false),
     ];
     let mut handles = Vec::new();
     for (subject, resource, operation, expect_allow) in cases {
@@ -464,14 +477,10 @@ async fn policy_concurrent_checks_over_iroh() -> Result<()> {
 }
 
 // ============================================================================
-// Issue #1128 spike: tenancy-isolation evidence tests
+// Tenancy-isolation evidence tests
 //
-// These tests document the CURRENT behavior of the PolicyService RPC path
-// with respect to tenants (Casbin domains) and event-prefix ownership.
-// Tests named `*_gap1128` assert behavior that is known-broken for
-// multi-tenancy; they are expected to PASS against today's code and to be
-// inverted when the fix lands. Every gap assertion names the production
-// site responsible.
+// These tests exercise the PolicyService RPC path with authority-verified
+// tenants (Casbin domains), subjects, and event-prefix ownership.
 // ============================================================================
 
 /// Baseline (expected green, not a gap): two clients with distinct signing
@@ -567,20 +576,16 @@ async fn two_subjects_per_subject_isolation_over_rpc() -> Result<()> {
     Ok(())
 }
 
-/// GAP (#1128): a grant written in Casbin domain "tenant-a" is INERT on the
-/// RPC path. The RPC authorize path hardcodes the request domain to "*"
-/// (registry.rs:1701, policy.rs:271 — every `check_with_domain(caller, "*",
-/// ...)` call), and the matcher only fires when `p.dom == "*" || r.dom ==
-/// p.dom` (policy_manager.rs:152-155), so a non-wildcard-domain policy can
-/// never authorize an RPC call. This test asserts the current broken
-/// behavior; a fix must make the first assertion ALLOW.
+/// The authority-verified tenant is effective over the RPC path and cannot be
+/// replaced by the compatibility fields in `PolicyCheck`.
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
-async fn domain_grant_is_inert_over_rpc_gap1128() -> Result<()> {
+async fn verified_domain_grant_is_effective_over_rpc() -> Result<()> {
     support::install_explicit_dispatch_pep();
     let pq_store = install_hybrid_verify_config();
     install_test_key_subjects();
 
-    let (service, manager, server_signing, _temp) = make_policy_service_with_manager().await?;
+    let (service, manager, server_signing, _temp, authority) =
+        make_policy_service_with_manager_and_authority().await?;
     // Grant exists ONLY in domain "tenant-a".
     manager
         .add_policy_with_domain(
@@ -594,44 +599,44 @@ async fn domain_grant_is_inert_over_rpc_gap1128() -> Result<()> {
 
     let server_vk = server_signing.verifying_key();
     let (server, server_addr) = serve_over_iroh(service, &server_signing).await?;
-    let (client_substrate, policy) = client_for_key(
+    let client_key = policy_client_a_signing_key();
+    let jwt = authority.token(TENANT_A_SUBJECT, "tenant-a", &client_key);
+    let (client_substrate, policy) = client_for_key_with_jwt(
         server_addr,
         server_vk,
         policy_request_kem_store(&server_signing)?,
         pq_store,
-        policy_client_a_signing_key(),
+        client_key,
+        Some(jwt),
     )
     .await?;
 
-    // The enforce path used by RPC authorization always passes r.dom="*":
-    // with r.dom="*" the tenant-a grant does not match → DENIED. This is the
-    // gap: the domain-scoped grant cannot take effect over RPC.
-    let denied = policy
-        .check(&PolicyCheck {
-            subject: TENANT_A_SUBJECT.to_owned(),
-            domain: "*".to_owned(),
-            resource: "data:orders".to_owned(),
-            operation: "read".to_owned(),
-        })
-        .await?;
-    assert!(
-        !denied,
-        "GAP #1128: tenant-a domain grant must be inert when r.dom=\"*\" (RPC path)"
-    );
-
-    // Control: the grant itself is real — when the domain is evaluated as
-    // "tenant-a" (which no RPC authorize call ever does today), it allows.
+    // Forged compatibility fields do not displace the verified tenant-a
+    // identity, so the real tenant-a grant is effective.
     let allowed = policy
         .check(&PolicyCheck {
-            subject: TENANT_A_SUBJECT.to_owned(),
-            domain: "tenant-a".to_owned(),
+            subject: TENANT_B_SUBJECT.to_owned(),
+            domain: "tenant-b".to_owned(),
             resource: "data:orders".to_owned(),
             operation: "read".to_owned(),
         })
         .await?;
     assert!(
         allowed,
-        "control: the tenant-a grant must match when the domain is actually evaluated"
+        "verified tenant-a grant must be effective despite forged wire identity"
+    );
+
+    let denied = policy
+        .check(&PolicyCheck {
+            subject: TENANT_A_SUBJECT.to_owned(),
+            domain: "tenant-a".to_owned(),
+            resource: "data:tenant-b-only".to_owned(),
+            operation: "read".to_owned(),
+        })
+        .await?;
+    assert!(
+        !denied,
+        "verified tenant-a caller must not gain an ungranted resource"
     );
 
     client_substrate.shutdown().await?;


### PR DESCRIPTION
## Summary

- bind `PolicyCheck` authorization to the verified envelope subject and authority-resolved hosted-account tenant; caller-supplied subject/domain fields are inert
- fail closed and audit unauthenticated, tenantless, federated-service, and policy-denied checks
- preserve the verified bearer through approved local relay services without inheriting deputy grants
- guard legacy `g(user, role)` membership so it is effective only in the explicit global `*` domain; tenant membership uses `g2(user, role, domain)`
- migrate legacy/unsafe model matchers at load, reject models that cannot be hardened, convert concrete-tenant template groupings to `g2`, and reject multi-tenant templates before mutation
- move federation origin allowlisting into `federation:register:<origin>` resource policy data at all three gates and migrate legacy rules on load, reload, add, and remove
- replace unsafe Casbin prefix wildcard behavior with a fail-closed origin matcher: exact origin or one leading DNS-label `*.`, with scheme and effective-port equality; `federation:register:*` is the sole global-open form

## Step 0: #1303

#1318 already fixed the HTTP-face sites and merged as `c9e99a8c860e8d904a10d9243a67d4b4ddfe3336`. The old `services/oauth/models.rs` and `services/oauth/openai.rs` paths no longer exist; their replacements derive policy domains through the verified hosted-account binding. #1303 was closed as completed, so this PR does not duplicate those changes.

## Rebase and validation

- exact head: `ebd4813557feac6c14ca2a72f668b62fba8619b1`
- base / merge-base: `470dbfa61c3cc7a3d50003d429c79540993c81be`
- GitHub compare: 4 ahead, 0 behind
- pre-commit release clippy mirror: passed
- `buildq -- cargo nextest run --release --profile ci -p hyprstream -p hyprstream-rpc --no-fail-fast`
  - 2,357 passed, 0 failed, 10 skipped
- exact-head Kimi-K3 independent security re-review: **PASS**
  - 27/27 policy-manager, 14/14 PolicyService, and 29/29 RPC delegation focused release tests
  - no blocking findings; one low-severity stale `docs/spiffe.md` legacy example remains safe through migration

Hosted Clippy, CodeQL, cargo-deny, and workers-WASM checks are green. The browser-client WASM job reproduces an inherited failure from this exact main base in untouched `mac/pep.rs` code; this PR does not change `mac/pep.rs` or `translator.rs`.

Closes #1302
Closes #1304
Refs #1303
Refs #1267
