### PR TITLE
ci(rust): drop push-to-main trigger; add workflow_dispatch

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,10 +1,17 @@
 name: Rust
 
+# Triggers (see #1331): pull_request runs the fast PR checks (clippy/wasm/deny/
+# loopback); merge_group runs the sole required heavy `build` against the
+# synthetic merge candidate (the exact landing commit only once the gate passes
+# — it is NOT landed yet at test time); workflow_dispatch lets an operator
+# request full validation of any ref. A push to `main` is intentionally NOT a
+# trigger — once the merge-group gate passes, GitHub performs the landing push,
+# and firing this workflow again on that push would only duplicate the
+# self-hosted build and re-run the fast checks for nothing.
 on:
-  push:
-    branches: [ "main" ]
   pull_request:
   merge_group:
+  workflow_dispatch:
 
 # id-token: write lets jobs mint an OIDC token to assume the sccache S3 role
 # (AWS_SCCACHE_ROLE_ARN). No long-lived AWS secrets live in the repo — the role
@@ -98,6 +105,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
+      # This checkout runs repo-controlled code below (cargo-deny reads deny.toml;
+      # the #1331 matrix gate runs scripts/check_rust_workflow_matrix.py). Do NOT
+      # persist the GITHUB_TOKEN in .git/config — closes the artipacked vector
+      # (zizmor, CodeRabbit), matching the loopback-burndown job.
+      with:
+        persist-credentials: false
     - name: Install cargo-deny
       uses: taiki-e/install-action@v2
       with:
@@ -110,6 +123,15 @@ jobs:
       run: |
         unset RUSTC_WRAPPER
         cargo deny check bans licenses
+    - name: Static workflow-matrix regression (#1331)
+      # Pure static YAML inspection — no network, no build, no runner. Locks the
+      # Rust workflow to the trigger/job matrix introduced by #1331 (no push-to-
+      # main duplicate run; workflow_dispatch for operator full validation) and
+      # pins the corrected AppImage-trigger comment. Runs on every event this
+      # job sees (PR, merge_group, workflow_dispatch) so a regression cannot
+      # slip past the merge gate. Must be able to fail — do NOT add `|| true`.
+      run: |
+        python3 scripts/check_rust_workflow_matrix.py
 
   loopback-burndown:
     name: Loopback-literal burn-down (#1152 W4)
@@ -122,7 +144,7 @@ jobs:
     # Advisory-only on the merge queue: `build` is the sole required merge-group
     # check (see the note on the preflight build job). Running this ratchet on
     # merge_group made a non-required shrink fail the group and livelock the queue;
-    # keep it on PR/push where it advises, matching the other non-required jobs.
+    # keep it on PR/manual-dispatch where it advises, matching the other non-required jobs.
     if: github.event_name != 'merge_group'
     runs-on: ubuntu-latest
     steps:
@@ -177,11 +199,16 @@ jobs:
 
   build:
     # MERGE GATE — not a per-PR-push check. The heavy build+test runs in the merge
-    # queue (`merge_group`) against latest main + the PR, and on push to `main` — but
-    # NOT on every PR push. PR review keeps the fast jobs (clippy/deny/wasm) for quick
-    # feedback; `build` is the required check enforced by the `protection` ruleset's
-    # merge queue. (Per-PR AppImage artifacts were dropped with the PR build; the
-    # `appimage.yml` workflow still builds the AppImage on push to `main`.)
+    # queue (`merge_group`) against the synthetic merge candidate (latest main + the
+    # PR — the exact landing commit only once this gate passes), and on
+    # `workflow_dispatch` for operator-requested full validation — but NOT on every
+    # PR push, and NOT on a push to `main` either: the post-merge duplicate run was
+    # removed in #1331 because the merge-group gate already validated the candidate
+    # that GitHub then lands. PR review keeps the fast jobs (clippy/deny/wasm) for
+    # quick feedback; `build` is the required check enforced by the `protection`
+    # ruleset's merge queue. AppImage artifacts are produced by `appimage.yml` on a
+    # nightly schedule, on `v*` tags, and on manual dispatch — never on a push to
+    # `main`.
     if: github.event_name != 'pull_request'
     # MERGE GATE runs on the self-hosted Graviton (arm64) fleet, INSIDE the
     # prebuilt rust-builder container via `podman run` — the same layer clippy +

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -128,8 +128,8 @@ jobs:
       # Rust workflow to the trigger/job matrix introduced by #1331 (no push-to-
       # main duplicate run; workflow_dispatch for operator full validation) and
       # pins the corrected AppImage-trigger comment. Runs on every event this
-      # job sees (PR, merge_group, workflow_dispatch) so a regression cannot
-      # slip past the merge gate. Must be able to fail — do NOT add `|| true`.
+      # job sees (PR, merge_group, workflow_dispatch). Must be able to fail — do
+      # NOT add `|| true`.
       run: |
         python3 scripts/check_rust_workflow_matrix.py
 
@@ -144,7 +144,8 @@ jobs:
     # Advisory-only on the merge queue: `build` is the sole required merge-group
     # check (see the note on the preflight build job). Running this ratchet on
     # merge_group made a non-required shrink fail the group and livelock the queue;
-    # keep it on PR/manual-dispatch where it advises, matching the other non-required jobs.
+    # keep it on PR/manual-dispatch where it advises, matching the other
+    # non-required jobs.
     if: github.event_name != 'merge_group'
     runs-on: ubuntu-latest
     steps:

--- a/scripts/check_rust_workflow_matrix.py
+++ b/scripts/check_rust_workflow_matrix.py
@@ -1,0 +1,316 @@
+#!/usr/bin/env python3
+r"""Static regression for the Rust workflow trigger/job matrix (#1331).
+
+WHY THIS EXISTS
+---------------
+The `Rust` workflow used to fire on every push to `main`, which (after a
+merge-queue landing) duplicated the heavy self-hosted build and re-ran the
+fast PR checks for an already-tested commit. #1331 removed the `push` trigger
+and replaced it with `workflow_dispatch` for operator-requested full
+validation of an arbitrary ref.
+
+This gate freezes that decision so a future edit cannot silently reintroduce
+the post-merge duplicate run. It also pins the corrected AppImage-trigger
+comment: `appimage.yml` runs on schedule / tags / `workflow_dispatch` only —
+never on a push to a branch.
+
+METHODOLOGY
+-----------
+Pure Python-stdlib inspection — no third-party YAML parser, no network, no
+runner, no build. A focused line-based parser extracts the top-level `on:`
+triggers (and their nested children) and each job's `if:` expression; the
+assertions then lock the matrix to the shape #1331 introduced. Failures exit
+non-zero so the CI step can fail. Do NOT add `|| true`.
+
+NON-VACUOUS
+-----------
+`--self-test` (run automatically by `main()` when the script is invoked with
+no arguments after the live check) feeds known-bad mutations of the live
+workflow through the same check function and asserts each one is rejected.
+If a mutation slips through, the gate fails — proving the assertions fire.
+"""
+
+from __future__ import annotations
+
+import pathlib
+import re
+import sys
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+RUST_WF = ROOT / ".github" / "workflows" / "rust.yml"
+APPIMAGE_WF = ROOT / ".github" / "workflows" / "appimage.yml"
+
+
+# --------------------------------------------------------------------------
+# Minimal GitHub-Actions-YAML structural parser (stdlib only).
+#
+# We do NOT attempt a general YAML parse. We extract exactly two things the
+# gate needs: (1) the top-level `on:` trigger block as an ordered dict of
+# {trigger_name: nested_subtext}, and (2) each job's `if:` expression under
+# `jobs:`. Both are produced by reading indentation, which is sufficient for
+# the constrained shapes GitHub Actions accepts for these fields.
+# --------------------------------------------------------------------------
+
+
+def _strip_key(token: str) -> str:
+    """Strip surrounding YAML quotes and trailing comment from a key token."""
+    token = token.split("#", 1)[0].strip()
+    if len(token) >= 2 and token[0] in "\"'" and token[-1] == token[0]:
+        token = token[1:-1]
+    return token
+
+
+def _on_blocks(text: str) -> dict[str, str]:
+    """Return {trigger_name: nested_subtext} for each top-level trigger.
+
+    `nested_subtext` is the raw block of lines indented under that trigger
+    (empty string if the trigger has no children, e.g. `pull_request:` with
+    nothing nested). Returns {} if the file has no top-level `on:`.
+
+    Handles the two forms used in this repo:
+      block:      on:\n  pull_request:\n  merge_group:\n
+      inline/map: on: push               (single trigger, no nesting)
+    """
+    lines = text.splitlines()
+    on_idx = None
+    for i, line in enumerate(lines):
+        if not line or line[0] in " \t" or line.lstrip().startswith("#"):
+            continue
+        if _strip_key(line.split(":", 1)[0]) == "on":
+            on_idx = i
+            break
+    if on_idx is None:
+        return {}
+
+    header = lines[on_idx]
+    after_colon = header.split(":", 1)[1] if ":" in header else ""
+    inline = after_colon.split("#", 1)[0].strip()
+    if inline:
+        # inline form: `on: push` or `on: [push, pull_request]`
+        if inline.startswith("[") and inline.endswith("]"):
+            inner = inline[1:-1]
+            return {_strip_key(t): "" for t in inner.split(",") if t.strip()}
+        return {_strip_key(inline): ""}
+
+    # block form: find the indent of the first non-blank/comment line after on:
+    block_indent: int | None = None
+    for line in lines[on_idx + 1:]:
+        if not line.strip() or line.lstrip().startswith("#"):
+            continue
+        block_indent = len(line) - len(line.lstrip())
+        break
+    if block_indent is None:
+        return {}
+
+    blocks: dict[str, str] = {}
+    cur_name: str | None = None
+    buf: list[str] = []
+    for line in lines[on_idx + 1:]:
+        if not line.strip() or line.lstrip().startswith("#"):
+            if cur_name is not None:
+                buf.append(line)
+            continue
+        indent = len(line) - len(line.lstrip())
+        if indent < block_indent:
+            break  # dedent out of on:
+        if indent == block_indent:
+            if cur_name is not None:
+                blocks[cur_name] = "\n".join(buf)
+            stripped = line.strip()
+            if stripped.startswith("- "):
+                cur_name = _strip_key(stripped[2:])
+            elif ":" in stripped:
+                cur_name = _strip_key(stripped.split(":", 1)[0])
+            else:
+                cur_name = _strip_key(stripped)
+            buf = []
+        else:
+            if cur_name is not None:
+                buf.append(line)
+    if cur_name is not None:
+        blocks[cur_name] = "\n".join(buf)
+    return blocks
+
+
+def _jobs_if_map(text: str) -> dict[str, str | None]:
+    """Return {job_name: if_expr_or_None} for top-level entries under `jobs:`.
+
+    `if_expr_or_None` is the literal text after `if:` (comment stripped) for
+    the first `if:` line found directly inside that job, or None if the job
+    has no `if:`. Only direct children of `jobs:` are returned (2-space indent
+    in this repo's files); nested `if:` lines deeper than the job body are
+    ignored once the first `if:` has been recorded.
+    """
+    lines = text.splitlines()
+    in_jobs = False
+    jobs: dict[str, str | None] = {}
+    cur_job: str | None = None
+    cur_job_indent: int | None = None
+    for line in lines:
+        if not line.strip() or line.lstrip().startswith("#"):
+            continue
+        indent = len(line) - len(line.lstrip())
+        if indent == 0:
+            cur_job = None
+            cur_job_indent = None
+            in_jobs = _strip_key(line.split(":", 1)[0]) == "jobs"
+            continue
+        if not in_jobs:
+            continue
+        if indent == 2 and line.rstrip(" \t").endswith(":"):
+            cur_job = _strip_key(line.strip()[:-1])
+            cur_job_indent = indent
+            jobs[cur_job] = None
+            continue
+        if cur_job is None or cur_job_indent is None:
+            continue
+        if jobs.get(cur_job) is None and indent > cur_job_indent:
+            m = re.match(r"\s*if:\s*(.+?)\s*(?:#.*)?$", line)
+            if m:
+                jobs[cur_job] = m.group(1).strip()
+    return jobs
+
+
+# --------------------------------------------------------------------------
+# Assertions
+# --------------------------------------------------------------------------
+
+
+def _assert(cond: bool, msg: str) -> None:
+    if not cond:
+        raise AssertionError(msg)
+
+
+def check_rust_text(text: str) -> None:
+    triggers = list(_on_blocks(text).keys())
+    for required in ("pull_request", "merge_group", "workflow_dispatch"):
+        _assert(
+            required in triggers,
+            f"rust.yml: missing required trigger {required!r}; got {triggers}",
+        )
+    _assert(
+        "push" not in triggers,
+        "rust.yml: 'push' trigger must not be present (reintroduces the #1331 "
+        f"duplicate post-merge run); got {triggers}",
+    )
+
+    jobs = _jobs_if_map(text)
+    for name in ("clippy", "deny", "loopback-burndown", "wasm", "build"):
+        _assert(name in jobs, f"rust.yml: required job {name!r} missing; got {sorted(jobs)}")
+
+    for name in ("clippy", "wasm", "loopback-burndown"):
+        cond = jobs.get(name)
+        _assert(
+            cond is not None and "github.event_name != 'merge_group'" in cond,
+            f"rust.yml: job {name!r} must skip on merge_group (if={cond!r})",
+        )
+
+    build_if = jobs.get("build")
+    _assert(
+        build_if is not None and build_if.strip() == "github.event_name != 'pull_request'",
+        f"rust.yml: 'build' if must be the single 'pull_request' skip (if={build_if!r})",
+    )
+
+
+def check_appimage_text(text: str) -> None:
+    """Pin the corrected rust.yml comment: AppImage is nightly/tag/manual only."""
+    blocks = _on_blocks(text)
+    push = blocks.get("push", "")
+    _assert(
+        "branches" not in push,
+        "appimage.yml: a 'push.branches' trigger is forbidden (the rust.yml "
+        f"comment claims AppImage is nightly/tag/manual only); push block was:\n{push}",
+    )
+
+
+# --------------------------------------------------------------------------
+# Negative mutation fixtures (keep the gate non-vacuous).
+# --------------------------------------------------------------------------
+
+
+def _mutations(rust_text: str) -> list[tuple[str, str]]:
+    """Return (label, mutated_text) pairs that MUST each be rejected."""
+    return [
+        (
+            "re-add push-to-main trigger",
+            rust_text.replace(
+                "on:\n  pull_request:",
+                "on:\n  push:\n    branches: [ \"main\" ]\n  pull_request:",
+                1,
+            ),
+        ),
+        (
+            "drop workflow_dispatch",
+            rust_text.replace("  workflow_dispatch:\n", "", 1),
+        ),
+        (
+            "make build fire on PR",
+            rust_text.replace(
+                "github.event_name != 'pull_request'",
+                "github.event_name == 'pull_request'",
+                1,
+            ),
+        ),
+        (
+            "make clippy run on merge_group",
+            rust_text.replace(
+                "    if: github.event_name != 'merge_group'\n    runs-on: [self-hosted, linux, arm64, graviton, hyprstream-merge-gate]\n    # The last successful run",
+                "    if: github.event_name != 'workflow_dispatch'\n    runs-on: [self-hosted, linux, arm64, graviton, hyprstream-merge-gate]\n    # The last successful run",
+                1,
+            ),
+        ),
+        (
+            "rename build job (removing the required gate)",
+            rust_text.replace("  build:\n", "  build_renamed:\n", 1),
+        ),
+    ]
+
+
+def self_test(rust_text: str) -> list[str]:
+    """Run each negative mutation; return labels that WRONGLY passed check."""
+    escaped: list[str] = []
+    for label, mutated in _mutations(rust_text):
+        if mutated == rust_text:
+            escaped.append(f"{label} (mutation did not apply — fixture is stale)")
+            continue
+        try:
+            check_rust_text(mutated)
+        except AssertionError:
+            continue  # correctly rejected
+        escaped.append(label)
+    return escaped
+
+
+# --------------------------------------------------------------------------
+
+
+def main(argv: list[str]) -> int:
+    rust_text = RUST_WF.read_text()
+    appimage_text = APPIMAGE_WF.read_text()
+
+    failures: list[str] = []
+    for name, fn, arg in (
+        ("check_rust_workflow", check_rust_text, rust_text),
+        ("check_appimage_workflow", check_appimage_text, appimage_text),
+    ):
+        try:
+            fn(arg)
+        except AssertionError as exc:
+            failures.append(f"{name}: {exc}")
+
+    escaped = self_test(rust_text)
+    for label in escaped:
+        failures.append(f"self-test: mutation {label!r} was NOT rejected (gate is vacuous)")
+
+    if failures:
+        print("#1331 workflow-matrix regression FAILED:", file=sys.stderr)
+        for fail in failures:
+            print(f"  - {fail}", file=sys.stderr)
+        return 1
+
+    print("#1331 workflow-matrix regression: OK (incl. 5 negative mutations)")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/scripts/check_rust_workflow_matrix.py
+++ b/scripts/check_rust_workflow_matrix.py
@@ -11,23 +11,26 @@ validation of an arbitrary ref.
 
 This gate freezes that decision so a future edit cannot silently reintroduce
 the post-merge duplicate run. It also pins the corrected AppImage-trigger
-comment: `appimage.yml` runs on schedule / tags / `workflow_dispatch` only —
-never on a push to a branch.
+comment: `appimage.yml` runs on its one nightly schedule, `v*` tags, and manual
+dispatch only — never on a push to a branch.
 
 METHODOLOGY
 -----------
 Pure Python-stdlib inspection — no third-party YAML parser, no network, no
-runner, no build. A focused line-based parser extracts the top-level `on:`
-triggers (and their nested children) and each job's `if:` expression; the
-assertions then lock the matrix to the shape #1331 introduced. Failures exit
-non-zero so the CI step can fail. Do NOT add `|| true`.
+runner, no build. A focused fail-closed line parser extracts the top-level
+`on:` triggers (including inline values), job blocks, and job-level `if:`
+expressions. Assertions lock exact trigger sets, exact normalized conditions,
+and the job identities that implement the #1331 event matrix. Unsupported YAML
+shapes are rejected rather than guessed at. Failures exit non-zero so the CI
+step can fail. Do NOT add `|| true`.
 
 NON-VACUOUS
 -----------
-`--self-test` (run automatically by `main()` when the script is invoked with
-no arguments after the live check) feeds known-bad mutations of the live
-workflow through the same check function and asserts each one is rejected.
-If a mutation slips through, the gate fails — proving the assertions fire.
+The self-test (run automatically after the live check) feeds known-bad
+mutations of both workflows through the same check functions and asserts each
+one is rejected. It includes semantic condition bypasses and alternate trigger
+forms. If a mutation slips through, the gate fails — proving the assertions
+fire.
 """
 
 from __future__ import annotations
@@ -67,9 +70,12 @@ def _on_blocks(text: str) -> dict[str, str]:
     (empty string if the trigger has no children, e.g. `pull_request:` with
     nothing nested). Returns {} if the file has no top-level `on:`.
 
-    Handles the two forms used in this repo:
+    Handles the forms needed to fail closed around this repo:
       block:      on:\n  pull_request:\n  merge_group:\n
-      inline/map: on: push               (single trigger, no nesting)
+      inline/list: on: [pull_request, merge_group]
+
+    A value on an individual trigger is retained in `nested_subtext`, so an
+    inline map such as `push: {branches: [main]}` cannot disappear.
     """
     lines = text.splitlines()
     on_idx = None
@@ -117,19 +123,44 @@ def _on_blocks(text: str) -> dict[str, str]:
             if cur_name is not None:
                 blocks[cur_name] = "\n".join(buf)
             stripped = line.strip()
+            inline_value = ""
             if stripped.startswith("- "):
                 cur_name = _strip_key(stripped[2:])
             elif ":" in stripped:
-                cur_name = _strip_key(stripped.split(":", 1)[0])
+                key, value = stripped.split(":", 1)
+                cur_name = _strip_key(key)
+                inline_value = value.split("#", 1)[0].strip()
             else:
                 cur_name = _strip_key(stripped)
-            buf = []
+            buf = [inline_value] if inline_value else []
         else:
             if cur_name is not None:
                 buf.append(line)
     if cur_name is not None:
         blocks[cur_name] = "\n".join(buf)
     return blocks
+
+
+def _job_blocks(text: str) -> dict[str, str]:
+    """Return raw text for each direct child of the top-level `jobs:` map."""
+    lines = text.splitlines()
+    in_jobs = False
+    blocks: dict[str, list[str]] = {}
+    cur_job: str | None = None
+    for line in lines:
+        if line.strip() and not line.lstrip().startswith("#"):
+            indent = len(line) - len(line.lstrip())
+            if indent == 0:
+                cur_job = None
+                in_jobs = _strip_key(line.split(":", 1)[0]) == "jobs"
+                continue
+            if in_jobs and indent == 2 and line.rstrip(" \t").endswith(":"):
+                cur_job = _strip_key(line.strip()[:-1])
+                blocks[cur_job] = []
+                continue
+        if in_jobs and cur_job is not None:
+            blocks[cur_job].append(line)
+    return {name: "\n".join(lines) for name, lines in blocks.items()}
 
 
 def _jobs_if_map(text: str) -> dict[str, str | None]:
@@ -141,34 +172,50 @@ def _jobs_if_map(text: str) -> dict[str, str | None]:
     in this repo's files); nested `if:` lines deeper than the job body are
     ignored once the first `if:` has been recorded.
     """
-    lines = text.splitlines()
-    in_jobs = False
     jobs: dict[str, str | None] = {}
-    cur_job: str | None = None
-    cur_job_indent: int | None = None
-    for line in lines:
-        if not line.strip() or line.lstrip().startswith("#"):
-            continue
-        indent = len(line) - len(line.lstrip())
-        if indent == 0:
-            cur_job = None
-            cur_job_indent = None
-            in_jobs = _strip_key(line.split(":", 1)[0]) == "jobs"
-            continue
-        if not in_jobs:
-            continue
-        if indent == 2 and line.rstrip(" \t").endswith(":"):
-            cur_job = _strip_key(line.strip()[:-1])
-            cur_job_indent = indent
-            jobs[cur_job] = None
-            continue
-        if cur_job is None or cur_job_indent is None:
-            continue
-        if jobs.get(cur_job) is None and indent > cur_job_indent:
-            m = re.match(r"\s*if:\s*(.+?)\s*(?:#.*)?$", line)
+    for name, block in _job_blocks(text).items():
+        jobs[name] = None
+        for line in block.splitlines():
+            m = re.match(r" {4}if:\s*(.+?)\s*(?:#.*)?$", line)
             if m:
-                jobs[cur_job] = m.group(1).strip()
+                jobs[name] = m.group(1).strip()
+                break
     return jobs
+
+
+def _normalized_condition(expr: str | None) -> str | None:
+    """Normalize only harmless syntax around a GitHub Actions condition.
+
+    Optional expression delimiters, one layer of YAML scalar quotes, quote
+    style, and whitespace are normalized. Operators/parentheses/tokens are not
+    rewritten: semantically broader or negated expressions therefore cannot
+    retain an accepted condition as a substring and escape.
+    """
+    if expr is None:
+        return None
+    value = expr.strip()
+    if len(value) >= 2 and value[0] in "\"'" and value[-1] == value[0]:
+        value = value[1:-1].strip()
+    if value.startswith("${{") and value.endswith("}}"):
+        value = value[3:-2].strip()
+    value = value.replace('"', "'")
+    return re.sub(r"\s+", "", value)
+
+
+def _content_lines(block: str) -> list[str]:
+    """Return stripped non-comment lines from a constrained YAML sub-block."""
+    return [
+        line.split("#", 1)[0].strip()
+        for line in block.splitlines()
+        if line.split("#", 1)[0].strip()
+    ]
+
+
+def _unquote(value: str) -> str:
+    value = value.strip()
+    if len(value) >= 2 and value[0] in "\"'" and value[-1] == value[0]:
+        return value[1:-1]
+    return value
 
 
 # --------------------------------------------------------------------------
@@ -182,44 +229,80 @@ def _assert(cond: bool, msg: str) -> None:
 
 
 def check_rust_text(text: str) -> None:
-    triggers = list(_on_blocks(text).keys())
-    for required in ("pull_request", "merge_group", "workflow_dispatch"):
-        _assert(
-            required in triggers,
-            f"rust.yml: missing required trigger {required!r}; got {triggers}",
-        )
+    trigger_blocks = _on_blocks(text)
+    triggers = set(trigger_blocks)
+    expected_triggers = {"pull_request", "merge_group", "workflow_dispatch"}
     _assert(
-        "push" not in triggers,
-        "rust.yml: 'push' trigger must not be present (reintroduces the #1331 "
-        f"duplicate post-merge run); got {triggers}",
+        triggers == expected_triggers,
+        "rust.yml: triggers must be exactly pull_request, merge_group, and "
+        f"workflow_dispatch; got {sorted(triggers)}",
     )
+    for name, block in trigger_blocks.items():
+        _assert(
+            not _content_lines(block),
+            f"rust.yml: trigger {name!r} must be unfiltered; got {block!r}",
+        )
 
     jobs = _jobs_if_map(text)
     for name in ("clippy", "deny", "loopback-burndown", "wasm", "build"):
         _assert(name in jobs, f"rust.yml: required job {name!r} missing; got {sorted(jobs)}")
 
+    skip_merge_group = "github.event_name!='merge_group'"
     for name in ("clippy", "wasm", "loopback-burndown"):
         cond = jobs.get(name)
         _assert(
-            cond is not None and "github.event_name != 'merge_group'" in cond,
-            f"rust.yml: job {name!r} must skip on merge_group (if={cond!r})",
+            _normalized_condition(cond) == skip_merge_group,
+            f"rust.yml: job {name!r} condition must be exactly the merge_group "
+            f"skip (if={cond!r})",
         )
 
+    _assert(
+        jobs.get("deny") is None,
+        f"rust.yml: 'deny' must run on every supported event (if={jobs.get('deny')!r})",
+    )
     build_if = jobs.get("build")
     _assert(
-        build_if is not None and build_if.strip() == "github.event_name != 'pull_request'",
-        f"rust.yml: 'build' if must be the single 'pull_request' skip (if={build_if!r})",
+        _normalized_condition(build_if) == "github.event_name!='pull_request'",
+        f"rust.yml: 'build' condition must be exactly the pull_request skip "
+        f"(if={build_if!r})",
     )
 
 
 def check_appimage_text(text: str) -> None:
-    """Pin the corrected rust.yml comment: AppImage is nightly/tag/manual only."""
+    """Pin AppImage to one nightly cron, v* tags, and manual dispatch only."""
     blocks = _on_blocks(text)
-    push = blocks.get("push", "")
+    expected_triggers = {"schedule", "workflow_dispatch", "push"}
     _assert(
-        "branches" not in push,
-        "appimage.yml: a 'push.branches' trigger is forbidden (the rust.yml "
-        f"comment claims AppImage is nightly/tag/manual only); push block was:\n{push}",
+        set(blocks) == expected_triggers,
+        "appimage.yml: triggers must be exactly schedule, workflow_dispatch, "
+        f"and push; got {sorted(blocks)}",
+    )
+    _assert(
+        not _content_lines(blocks["workflow_dispatch"]),
+        "appimage.yml: workflow_dispatch must be unfiltered",
+    )
+
+    schedule = _content_lines(blocks["schedule"])
+    _assert(
+        len(schedule) == 1 and schedule[0].startswith("- cron:"),
+        f"appimage.yml: schedule must contain exactly one cron; got {schedule}",
+    )
+    cron = _unquote(schedule[0].split(":", 1)[1])
+    _assert(
+        cron == "30 3 * * *",
+        f"appimage.yml: nightly cron must remain '30 3 * * *'; got {cron!r}",
+    )
+
+    push = _content_lines(blocks["push"])
+    _assert(
+        len(push) == 2 and push[0] == "tags:" and push[1].startswith("-"),
+        "appimage.yml: push must use the fail-closed tags-only block form; "
+        f"got {push}",
+    )
+    tag = _unquote(push[1][1:])
+    _assert(
+        tag == "v*",
+        f"appimage.yml: push must be limited to the single 'v*' tag; got {tag!r}",
     )
 
 
@@ -228,7 +311,7 @@ def check_appimage_text(text: str) -> None:
 # --------------------------------------------------------------------------
 
 
-def _mutations(rust_text: str) -> list[tuple[str, str]]:
+def _rust_mutations(rust_text: str) -> list[tuple[str, str]]:
     """Return (label, mutated_text) pairs that MUST each be rejected."""
     return [
         (
@@ -240,22 +323,56 @@ def _mutations(rust_text: str) -> list[tuple[str, str]]:
             ),
         ),
         (
-            "drop workflow_dispatch",
+            "add Rust schedule trigger",
+            rust_text.replace(
+                "  workflow_dispatch:\n",
+                "  workflow_dispatch:\n  schedule:\n    - cron: '0 0 * * *'\n",
+                1,
+            ),
+        ),
+        (
+            "drop workflow_dispatch trigger",
             rust_text.replace("  workflow_dispatch:\n", "", 1),
         ),
         (
-            "make build fire on PR",
+            "broaden merge_group skip with always",
             rust_text.replace(
-                "github.event_name != 'pull_request'",
-                "github.event_name == 'pull_request'",
+                "if: github.event_name != 'merge_group'",
+                "if: github.event_name != 'merge_group' || always()",
+                1,
+            ),
+        ),
+        (
+            "negate condition retaining expected substring",
+            rust_text.replace(
+                "if: github.event_name != 'merge_group'",
+                "if: ${{ !(github.event_name != 'merge_group') }}",
                 1,
             ),
         ),
         (
             "make clippy run on merge_group",
             rust_text.replace(
-                "    if: github.event_name != 'merge_group'\n    runs-on: [self-hosted, linux, arm64, graviton, hyprstream-merge-gate]\n    # The last successful run",
-                "    if: github.event_name != 'workflow_dispatch'\n    runs-on: [self-hosted, linux, arm64, graviton, hyprstream-merge-gate]\n    # The last successful run",
+                "if: github.event_name != 'merge_group'",
+                "if: github.event_name == 'merge_group'",
+                1,
+            ),
+        ),
+        (
+            "make build run on pull_request",
+            rust_text.replace(
+                "if: github.event_name != 'pull_request'",
+                "if: github.event_name == 'pull_request'",
+                1,
+            ),
+        ),
+        (
+            "make deny skip pull_request",
+            rust_text.replace(
+                "  deny:\n    name: cargo-deny (bans + licenses)\n",
+                "  deny:\n"
+                "    name: cargo-deny (bans + licenses)\n"
+                "    if: github.event_name != 'pull_request'\n",
                 1,
             ),
         ),
@@ -266,18 +383,48 @@ def _mutations(rust_text: str) -> list[tuple[str, str]]:
     ]
 
 
-def self_test(rust_text: str) -> list[str]:
+def _appimage_mutations(appimage_text: str) -> list[tuple[str, str]]:
+    """Return AppImage trigger mutations that MUST each be rejected."""
+    return [
+        (
+            "add AppImage pull_request trigger",
+            appimage_text.replace("on:\n", "on:\n  pull_request:\n", 1),
+        ),
+        (
+            "inline AppImage push branches map",
+            appimage_text.replace(
+                "  push:\n    tags:\n      - 'v*'\n",
+                "  push: {branches: [main], tags: ['v*']}\n",
+                1,
+            ),
+        ),
+    ]
+
+
+def self_test(rust_text: str, appimage_text: str) -> list[str]:
     """Run each negative mutation; return labels that WRONGLY passed check."""
     escaped: list[str] = []
-    for label, mutated in _mutations(rust_text):
-        if mutated == rust_text:
-            escaped.append(f"{label} (mutation did not apply — fixture is stale)")
-            continue
-        try:
-            check_rust_text(mutated)
-        except AssertionError:
-            continue  # correctly rejected
-        escaped.append(label)
+    cases = [
+        ("rust", check_rust_text, rust_text, _rust_mutations(rust_text)),
+        (
+            "appimage",
+            check_appimage_text,
+            appimage_text,
+            _appimage_mutations(appimage_text),
+        ),
+    ]
+    for source, check, original, mutations in cases:
+        for label, mutated in mutations:
+            if mutated == original:
+                escaped.append(
+                    f"{source}: {label} (mutation did not apply — fixture is stale)"
+                )
+                continue
+            try:
+                check(mutated)
+            except AssertionError:
+                continue  # correctly rejected
+            escaped.append(f"{source}: {label}")
     return escaped
 
 
@@ -298,7 +445,7 @@ def main(argv: list[str]) -> int:
         except AssertionError as exc:
             failures.append(f"{name}: {exc}")
 
-    escaped = self_test(rust_text)
+    escaped = self_test(rust_text, appimage_text)
     for label in escaped:
         failures.append(f"self-test: mutation {label!r} was NOT rejected (gate is vacuous)")
 
@@ -308,7 +455,13 @@ def main(argv: list[str]) -> int:
             print(f"  - {fail}", file=sys.stderr)
         return 1
 
-    print("#1331 workflow-matrix regression: OK (incl. 5 negative mutations)")
+    mutation_count = len(_rust_mutations(rust_text)) + len(
+        _appimage_mutations(appimage_text)
+    )
+    print(
+        f"#1331 workflow-matrix regression: OK "
+        f"(incl. {mutation_count} negative mutations)"
+    )
     return 0
 
 


### PR DESCRIPTION
Closes #1331.

## What

The `Rust` workflow currently fires on every push to `main`. After a merge-queue landing, that duplicates the heavy self-hosted `build` and all fast PR checks for a commit the required merge-group gate already validated.

This PR removes the Rust workflow's `push: main` trigger and adds `workflow_dispatch` for operator-requested full validation. It preserves `pull_request` and `merge_group` unchanged.

The branch is rebased onto current main `118ac21862d31d24a4b141026916c183f0f59c4f`, which already contains #1327's required same-container browser-WASM preflight, cfg repair, and `ci-test` doctest profile. This PR does not duplicate or modify those files: the standalone `wasm` job still provides fast PR/manual feedback, while the required merge-group `build` invokes main's unchanged `.github/scripts/graviton-build-test.sh`, whose first phase is the browser-WASM check.

## Event matrix

| event | clippy | standalone wasm | deny + static gate | loopback | required `build` |
|---|---|---|---|---|---|
| `pull_request` | yes | yes | yes | yes | no |
| `merge_group` | no | no | yes | no | yes |
| `workflow_dispatch` | yes | yes | yes | yes | yes |
| `push` to `main` | workflow not triggered | workflow not triggered | workflow not triggered | workflow not triggered | workflow not triggered |

AppImage remains separate and unchanged: its workflow runs at the single nightly schedule, on `v*` tags, and on manual dispatch—never on a branch push.

## Offline matrix regression gate

`scripts/check_rust_workflow_matrix.py` is Python-stdlib-only and network-free. It:

- requires the exact unfiltered Rust trigger set: `pull_request`, `merge_group`, and `workflow_dispatch`;
- requires exact normalized job conditions rather than substring matches;
- preserves the job identities and semantics for Clippy, standalone WASM, cargo-deny, loopback, and the required `build`;
- pins the AppImage trigger claim to its exact schedule/manual/tag-only shape;
- runs 11 built-in negative mutations covering trigger additions/removal, semantic condition escapes, PR/build condition regressions, required-job removal, and AppImage trigger escapes.

The gate runs in the existing cargo-deny job. Its checkout also disables persisted credentials because the job executes repository-controlled policy code.

## Validation

| check | result |
|---|---|
| `python3 scripts/check_rust_workflow_matrix.py` | PASS — 11 built-in negative mutations rejected |
| `python3 -m py_compile scripts/check_rust_workflow_matrix.py` | PASS; generated bytecode removed |
| `bash -n .github/scripts/graviton-build-test.sh` | PASS |
| `git diff --check origin/main...HEAD` | PASS |
| matrix projection | exact triggers and job conditions match the table above |
| main-owned preflight/source/profile diff | clean |
| workflow preflight composition proof | one standalone WASM command; no inline duplicate in `build`; one invocation of main's script; one preflight in that script |

No heavyweight native build, Clippy, or nextest was run locally for this workflow/checker-only rebase.

The naturally triggered exact-head Rust run [30216329984](https://github.com/hyprstream/hyprstream/actions/runs/30216329984) completed successfully without dispatch/retry/cancel: Clippy, standalone WASM, cargo-deny (including the 11-mutation static gate), and loopback all passed; `build` was correctly skipped for the PR event. All exact-head CodeQL analyses also passed, and GitHub reports the PR merge state as `CLEAN`.
