### PR TITLE
feat(mac): wire operator-gated identity activation

### DIFF
--- a/crates/hyprstream-9p/src/backend.rs
+++ b/crates/hyprstream-9p/src/backend.rs
@@ -13,6 +13,7 @@
 
 use async_trait::async_trait;
 
+use crate::mac_seam::VerifiedAttach;
 use crate::msg::Qid;
 
 /// Result of a walk: the qid of the resolved path and, for directories, the
@@ -77,8 +78,13 @@ pub trait Backend: Send + Sync {
     /// Returning `Err` fails the attach; the translator maps it to an `Rlerror`
     /// errno (a `hyprstream_vfs::MountError` in the cause chain picks the errno
     /// — e.g. `PermissionDenied → EACCES`).
-    async fn attach(&self, _uname: &str, _aname: &str) -> anyhow::Result<()> {
-        Ok(())
+    async fn attach(
+        &self,
+        _uname: &str,
+        _aname: &str,
+        verified: Option<VerifiedAttach>,
+    ) -> anyhow::Result<Option<VerifiedAttach>> {
+        Ok(verified)
     }
 
     /// Walk `components` from `fid` (the previously-walked parent, or the

--- a/crates/hyprstream-9p/src/lib.rs
+++ b/crates/hyprstream-9p/src/lib.rs
@@ -37,10 +37,10 @@
 //! stories (wasm's `unsafe impl` is only sound single-threaded, native is
 //! genuinely thread-safe) and are gated to disjoint targets.
 
-pub mod msg;
-pub mod client;
 pub mod backend;
+pub mod client;
 pub mod memory;
+pub mod msg;
 // The translator is the server-side TCP/UDS accept loop (tokio::net). `net`
 // pulls `mio`, which has no wasm32 backend, so these modules are native-only.
 // The browser/wasm build reaches the backend through the DMA/Wanix client path.
@@ -58,9 +58,9 @@ pub mod mount_backend;
 // The socket 9P *client* Mount (import a remote 9P namespace over UDS/TCP). Uses
 // `tokio::net`, so native-only — the wasm build imports via the DMA/Wanix path.
 #[cfg(not(target_arch = "wasm32"))]
-pub mod socket_transport;
-#[cfg(not(target_arch = "wasm32"))]
 pub mod remote_mount;
+#[cfg(not(target_arch = "wasm32"))]
+pub mod socket_transport;
 
 #[cfg(target_arch = "wasm32")]
 pub mod dma;
@@ -70,6 +70,13 @@ pub mod wanix_mount;
 pub use backend::{Backend, OpenResult, StatResult, WalkResult};
 pub use client::{P9Client, P9Transport};
 #[cfg(not(target_arch = "wasm32"))]
+pub use mac_seam::{
+    anonymous_floor, AccessDecider, Action, AnonymousAuthenticator, AttachAuthenticator,
+    DenyAllDecider, DenyUnlabeledResolver, ObjectLabelResolver, ObjectRef, ReferenceMonitor,
+    ReferenceMonitorDenyReason, SessionContext, VerifiedAttach, VerifiedAttachIdentity,
+    VerifiedTokenScope,
+};
+#[cfg(not(target_arch = "wasm32"))]
 pub use mount_backend::{AttachAuthorizer, MountBackend};
 #[cfg(not(target_arch = "wasm32"))]
 pub use remote_mount::Remote9pMount;
@@ -78,10 +85,4 @@ pub use socket_transport::SocketTransport;
 #[cfg(not(target_arch = "wasm32"))]
 pub use translator::{
     serve_mount_uds, serve_mount_vsock, serve_mount_vsock_raw, FidTable, Translator,
-};
-#[cfg(not(target_arch = "wasm32"))]
-pub use mac_seam::{
-    anonymous_floor, AccessDecider, Action, AnonymousAuthenticator, AttachAuthenticator,
-    DenyAllDecider, DenyUnlabeledResolver, ObjectLabelResolver, ObjectRef, ReferenceMonitor,
-    ReferenceMonitorDenyReason, SessionContext, VerifiedAttachIdentity, VerifiedTokenScope,
 };

--- a/crates/hyprstream-9p/src/mac_seam.rs
+++ b/crates/hyprstream-9p/src/mac_seam.rs
@@ -1,4 +1,4 @@
-//! 9P reference-monitor contract (S2 / #568, epic #547) — **dormant groundwork**.
+//! 9P reference-monitor contract (S2 / #568, epic #547).
 //!
 //! `hyprstream-9p` owns the 9P operation choke point but deliberately does not
 //! depend on the application crate that owns MAC policy loading and the AVC.
@@ -19,24 +19,14 @@
 //! mandatory token/IFC floor. Per-op cost is a fid-table lookup plus a local
 //! AVC call — never UCAN chain validation or Casbin matching.
 //!
-//! ## Not active by default
+//! ## Production activation posture
 //!
-//! This is the S2 machinery. [`Translator`](crate::Translator) runs **without**
-//! a [`ReferenceMonitor`] unless the application installs one via
-//! `with_reference_monitor`. Production constructors install the monitor
-//! structurally (the PEP is wired at every 9P constructor), but **clearance
-//! issuance and the S6 sender-bound token are not yet wired** — so every
-//! session resolves to fail-closed denial at the token gate until:
-//!
-//! - **#698** — the production token-issuance path attaches `Claims.clearance`,
-//!   letting the monitor resolve a permitting subject context; and
-//! - **the S6 grant path** mints a sender-bound token at `Tattach` so the token
-//!   gate passes for authorized operations.
-//!
-//! Until both land, the installed monitor is the correct fail-closed shape:
-//! every operation denies. There is no permissive default. The
-//! `anonymous_floor()` fallback is **not reachable from production
-//! constructors** — only tests construct a monitor-less translator.
+//! [`Translator`](crate::Translator) can run without a [`ReferenceMonitor`] for
+//! tests and embeddings, but every production constructor installs one. The
+//! mount-ticket paths derive a unified [`VerifiedAttach`] from verified Claims
+//! and key material, while fixed-subject transports remain floor-only until
+//! they gain a credential carrier. The operator activation control widens or
+//! narrows the subject context; it never removes mediation.
 //!
 //! ## Mediation is over the *name*, not the *object* (read before relying on it)
 //!
@@ -78,8 +68,8 @@
 //!
 //! Closing the name↔object TOCTOU by making the monitor authoritative over the
 //! **fid/object** (e.g. resolving labels from the backend's reached object, or
-//! via `ObjectRef::Cid`) is **activation-blocking** alongside #698 and tracked
-//! with #699. Until then, treat "complete mediation by construction" as the
+//! via `ObjectRef::Cid`) is **activation-blocking** and tracked with #699.
+//! Until then, treat "complete mediation by construction" as the
 //! *two-independent-resolutions-agree* claim above, not as object authority.
 
 use std::sync::Arc;
@@ -89,6 +79,8 @@ use async_trait::async_trait;
 use hyprstream_rpc::auth::mac::{
     Assurance, CompartmentSet, Level, SecurityContext, SecurityLabel, VerifiedKeyMaterial,
 };
+use hyprstream_rpc::Subject;
+use hyprstream_vfs::MountError;
 
 pub use hyprstream_rpc::auth::mac::{ObjectLabelResolver, ObjectRef};
 
@@ -184,6 +176,62 @@ pub struct SessionContext {
 pub struct VerifiedAttachIdentity {
     subject: Arc<str>,
     tenant: Arc<str>,
+}
+
+/// One credential verification result shared by both enforcement sides of a
+/// 9P attach.  The MAC session and the VFS subject cannot be supplied
+/// independently.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct VerifiedAttach {
+    identity: VerifiedAttachIdentity,
+    subject: Subject,
+    session: SessionContext,
+}
+
+impl VerifiedAttach {
+    /// Bind a credential-verified identity to the exact VFS subject and MAC
+    /// session derived from that same verification.
+    pub fn try_new(
+        identity: VerifiedAttachIdentity,
+        subject: Subject,
+        session: SessionContext,
+    ) -> Result<Self, MountError> {
+        let subject_name = subject.name().ok_or_else(|| {
+            MountError::PermissionDenied("verified attach has anonymous VFS subject".to_owned())
+        })?;
+        if subject_name != identity.subject() {
+            return Err(MountError::PermissionDenied(
+                "MAC identity and VFS subject diverge".to_owned(),
+            ));
+        }
+        if identity.tenant().is_empty() {
+            return Err(MountError::PermissionDenied(
+                "verified attach has no authority-bound tenant".to_owned(),
+            ));
+        }
+        if session.verified_attach_identity() != Some(&identity) {
+            return Err(MountError::PermissionDenied(
+                "MAC session identity and verified attach identity diverge".to_owned(),
+            ));
+        }
+        Ok(Self {
+            identity,
+            subject,
+            session,
+        })
+    }
+
+    pub fn identity(&self) -> &VerifiedAttachIdentity {
+        &self.identity
+    }
+
+    pub fn subject(&self) -> &Subject {
+        &self.subject
+    }
+
+    pub fn session(&self) -> &SessionContext {
+        &self.session
+    }
 }
 
 impl VerifiedAttachIdentity {
@@ -323,7 +371,7 @@ impl SessionContext {
 /// to [`VerifiedTokenScope`]. Invalid input returns [`SessionContext::deny`].
 #[async_trait]
 pub trait AttachAuthenticator: Send + Sync {
-    async fn authenticate(&self, uname: &str, aname: &str) -> SessionContext;
+    async fn authenticate(&self, uname: &str, aname: &str) -> Result<VerifiedAttach, MountError>;
 }
 
 /// Fail-closed authenticator: every attach resolves to a deny-only session.
@@ -334,8 +382,10 @@ pub struct AnonymousAuthenticator;
 
 #[async_trait]
 impl AttachAuthenticator for AnonymousAuthenticator {
-    async fn authenticate(&self, _uname: &str, _aname: &str) -> SessionContext {
-        SessionContext::deny()
+    async fn authenticate(&self, _uname: &str, _aname: &str) -> Result<VerifiedAttach, MountError> {
+        Err(MountError::PermissionDenied(
+            "no verified attach credential".to_owned(),
+        ))
     }
 }
 
@@ -443,7 +493,7 @@ impl AccessDecider for DenyAllDecider {
 /// Constructed by the application (`hyprstream` crate) at activation time from
 /// its concrete token verifier, genesis/manifest label resolver, and AVC/PDP
 /// adapter. The application installs it at every production 9P constructor;
-/// monitor-less translators remain available for tests and dormant embeddings.
+/// monitor-less translators remain available for tests and embeddings.
 pub struct ReferenceMonitor {
     authenticator: Arc<dyn AttachAuthenticator>,
     labels: Arc<dyn ObjectLabelResolver + Send + Sync>,
@@ -469,7 +519,11 @@ impl ReferenceMonitor {
     }
 
     /// Verify the `Tattach` credential exactly once for this connection.
-    pub async fn authenticate(&self, uname: &str, aname: &str) -> SessionContext {
+    pub async fn authenticate(
+        &self,
+        uname: &str,
+        aname: &str,
+    ) -> Result<VerifiedAttach, MountError> {
         self.authenticator.authenticate(uname, aname).await
     }
 

--- a/crates/hyprstream-9p/src/mount_backend.rs
+++ b/crates/hyprstream-9p/src/mount_backend.rs
@@ -37,6 +37,8 @@ use hyprstream_vfs::{DirEntry, Fid, Mount, MountError};
 use tokio::sync::{Mutex, OnceCell};
 
 use crate::backend::{Backend, OpenResult, StatResult, WalkResult};
+pub use crate::mac_seam::AttachAuthenticator as AttachAuthorizer;
+use crate::mac_seam::VerifiedAttach;
 use crate::msg::{self, Qid, ReaddirEntry};
 
 /// Resolves the mount ticket a client presents in `Tattach.uname` to the
@@ -53,21 +55,6 @@ use crate::msg::{self, Qid, ReaddirEntry};
 ///
 /// On denial, return a [`MountError`] — the translator maps it to an `Rlerror`
 /// errno (e.g. [`MountError::PermissionDenied`] → `EACCES`).
-#[async_trait]
-pub trait AttachAuthorizer: Send + Sync {
-    /// Validate the `uname` ticket and the requested `aname` export selector,
-    /// and return the narrowed session [`Subject`].
-    ///
-    /// `aname` is the 9P attach name — the export the client requested. The
-    /// authorizer validates it against the ticket's granted namespace and
-    /// **denies an unknown/forbidden/malformed selector** (returning a
-    /// [`MountError::PermissionDenied`] → `EACCES`) rather than falling back to
-    /// a default export (#877/#1071 fail-closed contract). Selection and the
-    /// `Subject` bind happen in this one authorization so a future
-    /// `ExportResolver` cannot split them.
-    async fn authorize(&self, uname: &str, aname: &str) -> Result<Subject, MountError>;
-}
-
 /// Max bytes a single read/write returns. Kept below the translator's `MSG_SIZE`
 /// (8 KiB) so an `Rread` carrying a full iounit plus its 9P header still fits the
 /// negotiated msize.
@@ -107,7 +94,12 @@ impl MountBackend {
         let cell = OnceCell::new();
         // Infallible on a fresh cell.
         let _ = cell.set(subject);
-        Self { mount, subject: cell, authorizer: None, fids: DashMap::new() }
+        Self {
+            mount,
+            subject: cell,
+            authorizer: None,
+            fids: DashMap::new(),
+        }
     }
 
     /// Wrap `mount` as the 9P export root whose session [`Subject`] is resolved
@@ -148,37 +140,65 @@ impl MountBackend {
             .stat(handle, self.caller()?)
             .await
             .context("mount stat failed")?;
-        Ok(Qid { qtype: st.qtype, version: st.version, path: st.path })
+        Ok(Qid {
+            qtype: st.qtype,
+            version: st.version,
+            path: st.path,
+        })
     }
 }
 
 #[async_trait]
 impl Backend for MountBackend {
-    async fn attach(&self, uname: &str, aname: &str) -> Result<()> {
+    async fn attach(
+        &self,
+        uname: &str,
+        aname: &str,
+        verified: Option<VerifiedAttach>,
+    ) -> Result<Option<VerifiedAttach>> {
         // Fixed-subject listeners have no authorizer; the Subject is already
         // bound and `uname`/`aname` are advisory (ignored, as on the UDS/vsock
         // paths).
         let Some(authorizer) = self.authorizer.as_ref() else {
-            return Ok(());
+            if let Some(verified) = verified {
+                let existing = self
+                    .subject
+                    .get()
+                    .ok_or_else(|| anyhow!("fixed 9P subject missing"))?;
+                if existing != verified.subject() {
+                    return Err(anyhow::Error::new(MountError::PermissionDenied(
+                        "verified attach subject differs from fixed VFS subject".to_owned(),
+                    )));
+                }
+                return Ok(Some(verified));
+            }
+            return Ok(None);
         };
         // Attach-time ticket path (H1b): resolve+narrow the Subject AND validate
         // the requested `aname` export against the ticket's namespace grant in
         // one authorization. A MountError here maps to an Rlerror errno
         // (PermissionDenied → EACCES) via the translator, before any fid exists.
-        let subject = authorizer.authorize(uname, aname).await.map_err(anyhow::Error::new)?;
+        let verified = match verified {
+            Some(verified) => verified,
+            None => authorizer
+                .authenticate(uname, aname)
+                .await
+                .map_err(anyhow::Error::new)?,
+        };
+        let subject = verified.subject().clone();
         let attempted_subject = subject.clone();
         // First attach wins; a second attach on the same connection must not
         // silently re-scope the session. Ignore a redundant identical set,
         // reject a conflicting one.
         match self.subject.set(subject) {
-            Ok(()) => Ok(()),
+            Ok(()) => Ok(Some(verified)),
             Err(_) => {
                 let existing = self
                     .subject
                     .get()
                     .ok_or_else(|| anyhow!("bind session Subject: cell rejected without value"))?;
                 if existing == &attempted_subject {
-                    Ok(())
+                    Ok(Some(verified))
                 } else {
                     Err(anyhow::Error::new(MountError::PermissionDenied(
                         "conflicting attach subject".to_owned(),
@@ -188,16 +208,15 @@ impl Backend for MountBackend {
         }
     }
 
-    async fn walk(
-        &self,
-        fid: u32,
-        newfid: u32,
-        components: &[String],
-    ) -> Result<WalkResult> {
+    async fn walk(&self, fid: u32, newfid: u32, components: &[String]) -> Result<WalkResult> {
         // A Mount walk resolves from the root, so build the target's absolute
         // path as parent_path + components. An empty-components walk (attach /
         // clone) re-resolves the source fid's own path.
-        let parent_path = self.fids.get(&fid).map(|e| e.path.clone()).unwrap_or_default();
+        let parent_path = self
+            .fids
+            .get(&fid)
+            .map(|e| e.path.clone())
+            .unwrap_or_default();
         let parent_len = parent_path.len();
         let mut new_path = parent_path;
         new_path.extend(components.iter().cloned());
@@ -249,14 +268,21 @@ impl Backend for MountBackend {
 
         if components.is_empty() {
             let refs: Vec<&str> = new_path.iter().map(String::as_str).collect();
-            let next = self.mount.walk(&refs, self.caller()?).await.context("mount walk failed")?;
+            let next = self
+                .mount
+                .walk(&refs, self.caller()?)
+                .await
+                .context("mount walk failed")?;
             qids.push(self.qid_of(&next).await?);
             handle = Some(next);
         }
         let handle = handle.ok_or_else(|| anyhow!("mount walk returned no handle"))?;
         self.fids.insert(
             newfid,
-            Arc::new(MountFidEntry { path: new_path, handle: Mutex::new(Some(handle)) }),
+            Arc::new(MountFidEntry {
+                path: new_path,
+                handle: Mutex::new(Some(handle)),
+            }),
         );
         Ok(WalkResult { qids, reached })
     }
@@ -264,20 +290,27 @@ impl Backend for MountBackend {
     async fn open(&self, fid: u32, flags: u32) -> Result<OpenResult> {
         let entry = self.entry(fid)?;
         let mut guard = entry.handle.lock().await;
-        let handle = guard.as_mut().ok_or_else(|| anyhow!("open: fid {fid} is clunked"))?;
+        let handle = guard
+            .as_mut()
+            .ok_or_else(|| anyhow!("open: fid {fid} is clunked"))?;
         let mode = lopen_flags_to_mode(flags);
         self.mount
             .open(handle, mode, self.caller()?)
             .await
             .context("mount open failed")?;
         let qid = self.qid_of(handle).await?;
-        Ok(OpenResult { qid, iounit: IOUNIT })
+        Ok(OpenResult {
+            qid,
+            iounit: IOUNIT,
+        })
     }
 
     async fn read(&self, fid: u32, offset: u64, count: u32) -> Result<Vec<u8>> {
         let entry = self.entry(fid)?;
         let guard = entry.handle.lock().await;
-        let handle = guard.as_ref().ok_or_else(|| anyhow!("read: fid {fid} is clunked"))?;
+        let handle = guard
+            .as_ref()
+            .ok_or_else(|| anyhow!("read: fid {fid} is clunked"))?;
         self.mount
             .read(handle, offset, count, self.caller()?)
             .await
@@ -287,7 +320,9 @@ impl Backend for MountBackend {
     async fn write(&self, fid: u32, offset: u64, data: &[u8]) -> Result<u32> {
         let entry = self.entry(fid)?;
         let guard = entry.handle.lock().await;
-        let handle = guard.as_ref().ok_or_else(|| anyhow!("write: fid {fid} is clunked"))?;
+        let handle = guard
+            .as_ref()
+            .ok_or_else(|| anyhow!("write: fid {fid} is clunked"))?;
         self.mount
             .write(handle, offset, data, self.caller()?)
             .await
@@ -297,7 +332,9 @@ impl Backend for MountBackend {
     async fn stat(&self, fid: u32) -> Result<StatResult> {
         let entry = self.entry(fid)?;
         let guard = entry.handle.lock().await;
-        let handle = guard.as_ref().ok_or_else(|| anyhow!("stat: fid {fid} is clunked"))?;
+        let handle = guard
+            .as_ref()
+            .ok_or_else(|| anyhow!("stat: fid {fid} is clunked"))?;
         let st = self
             .mount
             .stat(handle, self.caller()?)
@@ -306,7 +343,11 @@ impl Backend for MountBackend {
         let is_dir = st.qtype & QTDIR != 0;
         let mode = if is_dir { 0o040755 } else { 0o100644 };
         Ok(StatResult {
-            qid: Qid { qtype: st.qtype, version: st.version, path: st.path },
+            qid: Qid {
+                qtype: st.qtype,
+                version: st.version,
+                path: st.path,
+            },
             mode,
             size: st.size,
             mtime_sec: st.mtime,
@@ -317,7 +358,9 @@ impl Backend for MountBackend {
         let entry = self.entry(fid)?;
         let entries = {
             let guard = entry.handle.lock().await;
-            let handle = guard.as_ref().ok_or_else(|| anyhow!("readdir: fid {fid} is clunked"))?;
+            let handle = guard
+                .as_ref()
+                .ok_or_else(|| anyhow!("readdir: fid {fid} is clunked"))?;
             self.mount
                 .readdir(handle, self.caller()?)
                 .await
@@ -356,10 +399,21 @@ fn encode_dir_entries(entries: &[DirEntry], offset: u64, count: u32) -> Vec<u8> 
         .iter()
         .map(|e| {
             let qid = match &e.stat {
-                Some(st) => Qid { qtype: st.qtype, version: st.version, path: st.path },
-                None => Qid { qtype: if e.is_dir { QTDIR } else { 0 }, version: 0, path: 0 },
+                Some(st) => Qid {
+                    qtype: st.qtype,
+                    version: st.version,
+                    path: st.path,
+                },
+                None => Qid {
+                    qtype: if e.is_dir { QTDIR } else { 0 },
+                    version: 0,
+                    path: 0,
+                },
             };
-            ReaddirEntry { qid, name: e.name.clone() }
+            ReaddirEntry {
+                qid,
+                name: e.name.clone(),
+            }
         })
         .collect();
     msg::encode_readdir_page(&records, offset, count)
@@ -419,10 +473,22 @@ mod tests {
             async fn open(&self, _f: &mut Fid, _m: u8, _c: &Subject) -> Result<(), MountError> {
                 Err(MountError::PermissionDenied("open".into()))
             }
-            async fn read(&self, _f: &Fid, _o: u64, _n: u32, _c: &Subject) -> Result<Vec<u8>, MountError> {
+            async fn read(
+                &self,
+                _f: &Fid,
+                _o: u64,
+                _n: u32,
+                _c: &Subject,
+            ) -> Result<Vec<u8>, MountError> {
                 Err(MountError::Io("read".into()))
             }
-            async fn write(&self, _f: &Fid, _o: u64, _d: &[u8], _c: &Subject) -> Result<u32, MountError> {
+            async fn write(
+                &self,
+                _f: &Fid,
+                _o: u64,
+                _d: &[u8],
+                _c: &Subject,
+            ) -> Result<u32, MountError> {
                 Err(MountError::NotSupported("write".into()))
             }
             async fn readdir(&self, _f: &Fid, _c: &Subject) -> Result<Vec<DirEntry>, MountError> {
@@ -437,15 +503,20 @@ mod tests {
             }
         }
 
-        let mount = Arc::new(TrackedMount { clunks: AtomicUsize::new(0) });
+        let mount = Arc::new(TrackedMount {
+            clunks: AtomicUsize::new(0),
+        });
         let backend = MountBackend::new(mount.clone(), Subject::new("tenant"));
 
         // Attach (empty walk) binds fid 0 to the root. `MountBackend::new`
         // fixes the Subject, so `uname`/`aname` are advisory here.
-        backend.attach("tenant", "").await.unwrap();
+        backend.attach("tenant", "", None).await.unwrap();
         backend.fids.insert(
             0,
-            Arc::new(MountFidEntry { path: vec![], handle: Mutex::new(Some(Fid::new(0usize))) }),
+            Arc::new(MountFidEntry {
+                path: vec![],
+                handle: Mutex::new(Some(Fid::new(0usize))),
+            }),
         );
 
         // Walk fid 0 -> newfid 1 via ["a", "b"]: "a" resolves (handle A is
@@ -464,8 +535,18 @@ mod tests {
         use crate::msg::parse_readdir_entries;
 
         let entries = vec![
-            DirEntry { name: "a".into(), is_dir: true, size: 0, stat: None },
-            DirEntry { name: "bb".into(), is_dir: false, size: 7, stat: None },
+            DirEntry {
+                name: "a".into(),
+                is_dir: true,
+                size: 0,
+                stat: None,
+            },
+            DirEntry {
+                name: "bb".into(),
+                is_dir: false,
+                size: 7,
+                stat: None,
+            },
         ];
         let full = encode_dir_entries(&entries, 0, u32::MAX);
         assert!(!full.is_empty());

--- a/crates/hyprstream-9p/src/translator.rs
+++ b/crates/hyprstream-9p/src/translator.rs
@@ -57,13 +57,9 @@ use tokio::sync::OnceCell;
 use tracing::{debug, error, info, warn};
 
 use crate::backend::Backend;
-use crate::mac_seam::{
-    anonymous_floor, AccessDecider, Action, ReferenceMonitor, SessionContext,
-};
+use crate::mac_seam::{anonymous_floor, AccessDecider, Action, ReferenceMonitor, SessionContext};
 use crate::mount_backend::MountBackend;
-use crate::msg::{
-    self, encode_response, parse_request, rflush, Request, Response,
-};
+use crate::msg::{self, encode_response, parse_request, rflush, Request, Response};
 
 /// Negotiated maximum message size. Generous: Kata guest mounts may issue
 /// large read-ahead. The backend's iounit still bounds individual reads.
@@ -152,6 +148,10 @@ pub struct Translator {
     /// Optional S2 token/IFC composition. The mandatory decider remains active
     /// when this richer attach-time monitor is not installed.
     monitor: Option<Arc<ReferenceMonitor>>,
+    /// Production-only coverage-gated subject-context selection. Tests and
+    /// embeddings that explicitly install a monitor retain direct
+    /// identity-aware behavior unless they opt into this control.
+    activation_controlled: bool,
 }
 
 impl Translator {
@@ -165,6 +165,7 @@ impl Translator {
             attach_session: OnceCell::new(),
             decider,
             monitor: None,
+            activation_controlled: false,
         }
     }
 
@@ -197,13 +198,13 @@ impl Translator {
         Self {
             backend,
             backend_factory: Arc::new(move || {
-                Arc::new(MountBackend::new(Arc::clone(&mount), subject.clone()))
-                    as Arc<dyn Backend>
+                Arc::new(MountBackend::new(Arc::clone(&mount), subject.clone())) as Arc<dyn Backend>
             }),
             fids: Arc::new(FidTable::default()),
             attach_session: OnceCell::new(),
             decider,
             monitor: None,
+            activation_controlled: false,
         }
     }
 
@@ -240,6 +241,7 @@ impl Translator {
             attach_session: OnceCell::new(),
             decider,
             monitor: None,
+            activation_controlled: false,
         }
     }
 
@@ -256,7 +258,22 @@ impl Translator {
             attach_session: OnceCell::new(),
             decider: Arc::clone(&self.decider),
             monitor: self.monitor.clone(),
+            activation_controlled: self.activation_controlled,
         }
+    }
+
+    /// Use the process-global coverage-gated widen/narrow control. Production
+    /// constructors call this after installing the mandatory monitor.
+    pub fn with_activation_control(mut self) -> Self {
+        self.activation_controlled = true;
+        self
+    }
+
+    fn identity_aware(&self) -> bool {
+        self.monitor.is_some()
+            && (!self.activation_controlled
+                || hyprstream_rpc::auth::mac::global_mac_activation_control().mode()
+                    == hyprstream_rpc::auth::mac::MacActivationMode::IdentityAware)
     }
 
     /// Run a TCP accept loop until the listener errors or is closed.
@@ -290,7 +307,8 @@ impl Translator {
     /// [`serve`](Self::serve) / [`serve_uds`](Self::serve_uds); the
     /// `Subject`-per-op enforcement is unchanged — only the transport differs.
     pub async fn serve_vsock(self, listener: UnixListener) -> Result<()> {
-        self.serve_listener(HybridVsockListener { inner: listener }).await
+        self.serve_listener(HybridVsockListener { inner: listener })
+            .await
     }
 
     /// Run the accept loop over a **raw** (no-handshake) hybrid-vsock host
@@ -313,7 +331,8 @@ impl Translator {
     /// are byte-identical to every other transport; only the accept surface
     /// differs (raw, via [`RawVsockListener`]).
     pub async fn serve_vsock_raw(self, listener: UnixListener) -> Result<()> {
-        self.serve_listener(RawVsockListener { inner: listener }).await
+        self.serve_listener(RawVsockListener { inner: listener })
+            .await
     }
 
     /// Transport-agnostic accept loop shared by [`serve`](Self::serve) and
@@ -412,22 +431,20 @@ impl Translator {
         let (tag, req) = parse_request(buf).context("decode 9P T-message")?;
         let resp = match req {
             Request::Version { msize, version } => self.handle_version(msize, version),
-            Request::Attach { fid, uname, aname, .. } => {
-                self.handle_attach(fid, &uname, &aname).await?
-            }
+            Request::Attach {
+                fid, uname, aname, ..
+            } => self.handle_attach(fid, &uname, &aname).await?,
             // Flush is intercepted in serve_connection before reaching here;
             // this arm is unreachable but kept exhaustive.
             Request::Flush { .. } => Response::Clunk,
-            Request::Walk { fid, newfid, wnames } => {
-                self.handle_walk(fid, newfid, wnames).await?
-            }
+            Request::Walk {
+                fid,
+                newfid,
+                wnames,
+            } => self.handle_walk(fid, newfid, wnames).await?,
             Request::Lopen { fid, flags } => self.handle_lopen(fid, flags).await?,
-            Request::Read { fid, offset, count } => {
-                self.handle_read(fid, offset, count).await?
-            }
-            Request::Write { fid, offset, data } => {
-                self.handle_write(fid, offset, &data).await?
-            }
+            Request::Read { fid, offset, count } => self.handle_read(fid, offset, count).await?,
+            Request::Write { fid, offset, data } => self.handle_write(fid, offset, &data).await?,
             Request::Clunk { fid } => self.handle_clunk(fid).await,
             Request::Getattr { fid, .. } => self.handle_getattr(fid).await?,
             Request::Readdir { fid, offset, count } => {
@@ -443,39 +460,59 @@ impl Translator {
 
     fn handle_version(&self, requested: u32, version: String) -> Response {
         if version != "9P2000.L" && !version.starts_with("9P2000") {
-            return Response::Error { ecode: libc_einval() };
+            return Response::Error {
+                ecode: libc_einval(),
+            };
         }
         let msize = requested.clamp(256, MSG_SIZE);
-        Response::Version { msize, version: "9P2000.L".into() }
+        Response::Version {
+            msize,
+            version: "9P2000.L".into(),
+        }
     }
 
     async fn handle_attach(&self, fid: u32, uname: &str, aname: &str) -> Result<Response> {
-        // A full S2 monitor verifies the attach credential and applies its
-        // token/IFC gates. Without one, the mandatory production decider still
-        // mediates the root against the anonymous-floor context.
-        let session = match &self.monitor {
-            Some(monitor) => {
-                let session = monitor.authenticate(uname, aname).await;
-                // The root fid itself is a mediated object. It has no
-                // synthetic exemption: an unlabeled root or missing/expired
-                // token denies at attach, before any backend object handle
-                // is exposed.
-                if !monitor.authorize(&session, &[], Action::Attach) {
-                    return Ok(Response::Error { ecode: libc_eperm() });
+        // The monitor is always present in production. The operator control
+        // narrows/widens only the subject context it evaluates; it never
+        // removes mediation.
+        let (verified, session) = if self.identity_aware() {
+            let Some(monitor) = &self.monitor else {
+                return Ok(Response::Error {
+                    ecode: libc_eperm(),
+                });
+            };
+            // One credential verification yields the unified MAC+VFS bundle.
+            // Nothing independently derives a Subject after this point.
+            let verified = match monitor.authenticate(uname, aname).await {
+                Ok(verified) => verified,
+                Err(_) => {
+                    return Ok(Response::Error {
+                        ecode: libc_eperm(),
+                    })
                 }
-                self.ensure_attach_session_compatible(&session)?;
-                Some(session)
+            };
+            let session = verified.session().clone();
+            if !monitor.authorize(&session, &[], Action::Attach) {
+                return Ok(Response::Error {
+                    ecode: libc_eperm(),
+                });
             }
-            None => {
-                let root: [&str; 0] = [];
-                if !self
-                    .decider
-                    .check(&anonymous_floor(), ObjectRef::Path(&root), Action::Attach)
-                {
-                    return Ok(Response::Error { ecode: libc_eperm() });
-                }
-                None
+            self.ensure_attach_session_compatible(&session)?;
+            (Some(verified), Some(session))
+        } else {
+            let root: [&str; 0] = [];
+            if !self
+                .decider
+                .check(&anonymous_floor(), ObjectRef::Path(&root), Action::Attach)
+            {
+                return Ok(Response::Error {
+                    ecode: libc_eperm(),
+                });
             }
+            // A ticket-authorized backend authenticates exactly once below.
+            // Fixed-subject backends were bound by their production
+            // constructor and do not require a client credential at floor.
+            (None, None)
         };
 
         // Only an attach that cleared monitor authorization may bind a backend
@@ -484,7 +521,24 @@ impl Translator {
         // granted namespace and deny an unknown/forbidden selector with EACCES
         // before any fid exists. Walk the empty path to materialize a root qid
         // from the backend, then record it.
-        self.backend.attach(uname, aname).await?;
+        let bound = self.backend.attach(uname, aname, verified.clone()).await?;
+        if let Some(expected) = verified.as_ref() {
+            if bound.as_ref() != Some(expected) {
+                return Err(anyhow::Error::new(
+                    hyprstream_vfs::MountError::PermissionDenied(
+                        "backend did not bind the verified attach bundle".to_owned(),
+                    ),
+                ));
+            }
+        }
+        if self.identity_aware() && bound.is_none() {
+            return Err(anyhow::Error::new(
+                hyprstream_vfs::MountError::PermissionDenied(
+                    "backend did not bind a verified attach bundle".to_owned(),
+                ),
+            ));
+        }
+        let session = session.or_else(|| bound.as_ref().map(|attach| attach.session().clone()));
         let walk = self.backend.walk(fid, fid, &[]).await?;
         if let Some(session) = &session {
             self.bind_attach_session(session)?;
@@ -502,9 +556,11 @@ impl Translator {
             // of the same ticket, so a value comparison would reject a
             // legitimate re-attach of an identical, still-valid session (F2).
             Some(existing) if existing.same_attach_identity(session) => Ok(()),
-            Some(_) => Err(anyhow::Error::new(hyprstream_vfs::MountError::PermissionDenied(
-                "conflicting attach session context".to_owned(),
-            ))),
+            Some(_) => Err(anyhow::Error::new(
+                hyprstream_vfs::MountError::PermissionDenied(
+                    "conflicting attach session context".to_owned(),
+                ),
+            )),
             None => Ok(()),
         }
     }
@@ -516,12 +572,7 @@ impl Translator {
         self.ensure_attach_session_compatible(session)
     }
 
-    async fn handle_walk(
-        &self,
-        fid: u32,
-        newfid: u32,
-        wnames: Vec<String>,
-    ) -> Result<Response> {
+    async fn handle_walk(&self, fid: u32, newfid: u32, wnames: Vec<String>) -> Result<Response> {
         // The session is inherited from the fid being walked (#568 — the
         // credential is verified once at attach, never re-verified per op).
         // The destination path extends the source fid's already-walked path.
@@ -534,15 +585,17 @@ impl Translator {
         // fid; otherwise an unattached connection could clone another
         // connection's fid without passing the monitor.
         let mut prefix = base.clone();
-        if wnames.is_empty()
-            && !self.authorize_path(session.as_ref(), &prefix, Action::Walk)
-        {
-            return Ok(Response::Error { ecode: libc_eperm() });
+        if wnames.is_empty() && !self.authorize_path(session.as_ref(), &prefix, Action::Walk) {
+            return Ok(Response::Error {
+                ecode: libc_eperm(),
+            });
         }
         for component in &wnames {
             prefix.push(component.clone());
             if !self.authorize_path(session.as_ref(), &prefix, Action::Walk) {
-                return Ok(Response::Error { ecode: libc_eperm() });
+                return Ok(Response::Error {
+                    ecode: libc_eperm(),
+                });
             }
         }
 
@@ -557,7 +610,9 @@ impl Translator {
                 || result.reached.len() > wnames.len()
                 || result.reached != wnames[..result.reached.len()])
         {
-            return Err(anyhow::anyhow!("backend walk result does not describe its reached prefix"));
+            return Err(anyhow::anyhow!(
+                "backend walk result does not describe its reached prefix"
+            ));
         }
         let nwqid = result.qids.len();
         let mut reached = base;
@@ -584,7 +639,10 @@ impl Translator {
         }
         let open = self.backend.open(fid, flags).await?;
         self.fids.set_opened(fid);
-        Ok(Response::Lopen { qid: open.qid, iounit: open.iounit })
+        Ok(Response::Lopen {
+            qid: open.qid,
+            iounit: open.iounit,
+        })
     }
 
     async fn handle_read(&self, fid: u32, offset: u64, count: u32) -> Result<Response> {
@@ -619,7 +677,12 @@ impl Translator {
             return Ok(err);
         }
         let st = self.backend.stat(fid).await?;
-        Ok(Response::Getattr { qid: st.qid, mode: st.mode, size: st.size, mtime_sec: st.mtime_sec })
+        Ok(Response::Getattr {
+            qid: st.qid,
+            mode: st.mode,
+            size: st.size,
+            mtime_sec: st.mtime_sec,
+        })
     }
 
     async fn handle_readdir(&self, fid: u32, offset: u64, count: u32) -> Result<Response> {
@@ -634,13 +697,17 @@ impl Translator {
     /// installed, directly through the mandatory audited decider.
     fn deny(&self, fid: u32, action: Action) -> Option<Response> {
         let Some(path) = self.fids.path(fid) else {
-            return Some(Response::Error { ecode: libc_eperm() });
+            return Some(Response::Error {
+                ecode: libc_eperm(),
+            });
         };
         let session = self.fids.session(fid);
         if self.authorize_path(session.as_ref(), &path, action) {
             None
         } else {
-            Some(Response::Error { ecode: libc_eperm() })
+            Some(Response::Error {
+                ecode: libc_eperm(),
+            })
         }
     }
 
@@ -650,15 +717,14 @@ impl Translator {
         path: &[String],
         action: Action,
     ) -> bool {
-        if let Some(monitor) = &self.monitor {
-            return session.is_some_and(|session| monitor.authorize(session, path, action));
+        if self.identity_aware() {
+            return self.monitor.as_ref().is_some_and(|monitor| {
+                session.is_some_and(|session| monitor.authorize(session, path, action))
+            });
         }
         let components: Vec<&str> = path.iter().map(String::as_str).collect();
-        self.decider.check(
-            &anonymous_floor(),
-            ObjectRef::Path(&components),
-            action,
-        )
+        self.decider
+            .check(&anonymous_floor(), ObjectRef::Path(&components), action)
     }
 }
 
@@ -679,7 +745,7 @@ pub async fn serve_mount_uds(
         .with_context(|| format!("bind 9P UDS listener at {:?}", path.as_ref()))?;
     let mut t = Translator::from_mount(mount, subject, decider);
     if let Some(monitor) = monitor {
-        t = t.with_reference_monitor(monitor);
+        t = t.with_reference_monitor(monitor).with_activation_control();
     }
     t.serve_uds(listener).await
 }
@@ -705,7 +771,7 @@ pub async fn serve_mount_vsock(
         .with_context(|| format!("bind 9P hybrid-vsock listener at {:?}", path.as_ref()))?;
     let mut t = Translator::from_mount(mount, subject, decider);
     if let Some(monitor) = monitor {
-        t = t.with_reference_monitor(monitor);
+        t = t.with_reference_monitor(monitor).with_activation_control();
     }
     t.serve_vsock(listener).await
 }
@@ -731,11 +797,14 @@ pub async fn serve_mount_vsock_raw(
     path: impl AsRef<Path>,
 ) -> Result<()> {
     let listener = UnixListener::bind(path.as_ref()).with_context(|| {
-        format!("bind 9P raw hybrid-vsock per-port listener at {:?}", path.as_ref())
+        format!(
+            "bind 9P raw hybrid-vsock per-port listener at {:?}",
+            path.as_ref()
+        )
     })?;
     let mut t = Translator::from_mount(mount, subject, decider);
     if let Some(monitor) = monitor {
-        t = t.with_reference_monitor(monitor);
+        t = t.with_reference_monitor(monitor).with_activation_control();
     }
     t.serve_vsock_raw(listener).await
 }
@@ -1048,10 +1117,22 @@ mod tests {
             async fn open(&self, _f: &mut Fid, _m: u8, _c: &Subject) -> Result<(), MountError> {
                 Err(MountError::PermissionDenied("open".into()))
             }
-            async fn read(&self, _f: &Fid, _o: u64, _n: u32, _c: &Subject) -> Result<Vec<u8>, MountError> {
+            async fn read(
+                &self,
+                _f: &Fid,
+                _o: u64,
+                _n: u32,
+                _c: &Subject,
+            ) -> Result<Vec<u8>, MountError> {
                 Err(MountError::Io("read".into()))
             }
-            async fn write(&self, _f: &Fid, _o: u64, _d: &[u8], _c: &Subject) -> Result<u32, MountError> {
+            async fn write(
+                &self,
+                _f: &Fid,
+                _o: u64,
+                _d: &[u8],
+                _c: &Subject,
+            ) -> Result<u32, MountError> {
                 Err(MountError::NotSupported("write".into()))
             }
             async fn readdir(&self, _f: &Fid, _c: &Subject) -> Result<Vec<DirEntry>, MountError> {
@@ -1067,18 +1148,28 @@ mod tests {
         let t = Arc::new(Translator::new(Arc::new(backend), test_decider()));
 
         // Attach fid 0 as root (empty walk succeeds).
-        t.handle_message(&msg::tattach(1, 0, u32::MAX, "u", "")).await.unwrap();
+        t.handle_message(&msg::tattach(1, 0, u32::MAX, "u", ""))
+            .await
+            .unwrap();
 
         // Walk to a missing child → Err whose errno must be ENOENT.
         let err = t
             .handle_message(&msg::twalk(2, 0, 1, &["nope"]))
             .await
             .unwrap_err();
-        assert_eq!(errno_from_error(&err), ENOENT, "missing path must be ENOENT, not EIO");
+        assert_eq!(
+            errno_from_error(&err),
+            ENOENT,
+            "missing path must be ENOENT, not EIO"
+        );
     }
 
     fn sample_qid(qtype: u8, path: u64) -> Qid {
-        Qid { qtype, version: 1, path }
+        Qid {
+            qtype,
+            version: 1,
+            path,
+        }
     }
 
     #[tokio::test]
@@ -1144,8 +1235,8 @@ mod tests {
     // module double as the dormant-default regression guard.
 
     use crate::mac_seam::{
-        AccessDecider, AttachAuthenticator, ObjectLabelResolver, ObjectRef, VerifiedAttachIdentity,
-        ReferenceMonitorDenyReason, VerifiedTokenScope,
+        AccessDecider, AttachAuthenticator, ObjectLabelResolver, ObjectRef,
+        ReferenceMonitorDenyReason, VerifiedAttach, VerifiedAttachIdentity, VerifiedTokenScope,
     };
     use hyprstream_rpc::auth::mac::{
         Assurance, CompartmentSet, Level, SecurityContext, SecurityLabel, VerifiedKeyMaterial,
@@ -1180,6 +1271,19 @@ mod tests {
         )
     }
 
+    fn verified_attach(session: SessionContext) -> VerifiedAttach {
+        let identity = session
+            .verified_attach_identity()
+            .expect("fixture session has verified identity")
+            .clone();
+        VerifiedAttach::try_new(
+            identity.clone(),
+            hyprstream_rpc::Subject::new(identity.subject()),
+            session,
+        )
+        .expect("fixture bundle is internally bound")
+    }
+
     const ALL_OPS: &[Action] = &[
         Action::Attach,
         Action::Walk,
@@ -1195,8 +1299,17 @@ mod tests {
     struct StaticAuth(SessionContext);
     #[async_trait]
     impl AttachAuthenticator for StaticAuth {
-        async fn authenticate(&self, _u: &str, _a: &str) -> SessionContext {
-            self.0.clone()
+        async fn authenticate(
+            &self,
+            _u: &str,
+            _a: &str,
+        ) -> std::result::Result<VerifiedAttach, hyprstream_vfs::MountError> {
+            if self.0.verified_attach_identity().is_none() {
+                return Err(hyprstream_vfs::MountError::PermissionDenied(
+                    "credential did not produce a verified attach identity".to_owned(),
+                ));
+            }
+            Ok(verified_attach(self.0.clone()))
         }
     }
 
@@ -1210,12 +1323,7 @@ mod tests {
 
     struct AllowAll;
     impl AccessDecider for AllowAll {
-        fn check(
-            &self,
-            _ctx: &SecurityContext,
-            _object: ObjectRef<'_>,
-            _action: Action,
-        ) -> bool {
+        fn check(&self, _ctx: &SecurityContext, _object: ObjectRef<'_>, _action: Action) -> bool {
             true
         }
 
@@ -1250,10 +1358,16 @@ mod tests {
     /// the root fid is a mediated object with no synthetic exemption.
     #[tokio::test]
     async fn monitor_denies_unlabeled_root_at_attach() {
-        let t = Translator::new(Arc::new(MemoryBackend::default()), test_decider()).with_reference_monitor(
-            monitor(permit_session(Level::Secret, ALL_OPS), None, Arc::new(AllowAll)),
-        );
-        let (_, resp) = t.handle_message(&msg::tattach(1, 0, u32::MAX, "user", "/")).await.unwrap();
+        let t = Translator::new(Arc::new(MemoryBackend::default()), test_decider())
+            .with_reference_monitor(monitor(
+                permit_session(Level::Secret, ALL_OPS),
+                None,
+                Arc::new(AllowAll),
+            ));
+        let (_, resp) = t
+            .handle_message(&msg::tattach(1, 0, u32::MAX, "user", "/"))
+            .await
+            .unwrap();
         match resp {
             Response::Error { ecode } => assert_eq!(ecode, libc_eperm()),
             other => panic!("expected Rlerror EPERM for unlabeled root, got {other:?}"),
@@ -1264,10 +1378,16 @@ mod tests {
     /// backend object handle exists.
     #[tokio::test]
     async fn monitor_denies_missing_token_at_attach() {
-        let t = Translator::new(Arc::new(MemoryBackend::default()), test_decider()).with_reference_monitor(
-            monitor(SessionContext::deny(), Some(label(Level::Public)), Arc::new(AllowAll)),
-        );
-        let (_, resp) = t.handle_message(&msg::tattach(1, 0, u32::MAX, "user", "/")).await.unwrap();
+        let t = Translator::new(Arc::new(MemoryBackend::default()), test_decider())
+            .with_reference_monitor(monitor(
+                SessionContext::deny(),
+                Some(label(Level::Public)),
+                Arc::new(AllowAll),
+            ));
+        let (_, resp) = t
+            .handle_message(&msg::tattach(1, 0, u32::MAX, "user", "/"))
+            .await
+            .unwrap();
         match resp {
             Response::Error { ecode } => assert_eq!(ecode, libc_eperm()),
             other => panic!("expected Rlerror EPERM for missing token, got {other:?}"),
@@ -1285,10 +1405,16 @@ mod tests {
                 Instant::now() - Duration::from_secs(1),
             ),
         );
-        let t = Translator::new(Arc::new(MemoryBackend::default()), test_decider()).with_reference_monitor(
-            monitor(expired, Some(label(Level::Public)), Arc::new(AllowAll)),
-        );
-        let (_, resp) = t.handle_message(&msg::tattach(1, 0, u32::MAX, "user", "/")).await.unwrap();
+        let t = Translator::new(Arc::new(MemoryBackend::default()), test_decider())
+            .with_reference_monitor(monitor(
+                expired,
+                Some(label(Level::Public)),
+                Arc::new(AllowAll),
+            ));
+        let (_, resp) = t
+            .handle_message(&msg::tattach(1, 0, u32::MAX, "user", "/"))
+            .await
+            .unwrap();
         match resp {
             Response::Error { ecode } => assert_eq!(ecode, libc_eperm()),
             other => panic!("expected Rlerror EPERM for expired token, got {other:?}"),
@@ -1308,9 +1434,15 @@ mod tests {
             Arc::new(AllowAll),
         ));
 
-        let (_, resp) = t.handle_message(&msg::tattach(1, 0, u32::MAX, "user", "/")).await.unwrap();
+        let (_, resp) = t
+            .handle_message(&msg::tattach(1, 0, u32::MAX, "user", "/"))
+            .await
+            .unwrap();
         assert!(matches!(resp, Response::Attach { .. }), "got {resp:?}");
-        let (_, resp) = t.handle_message(&msg::twalk(2, 0, 1, &["hello.txt"])).await.unwrap();
+        let (_, resp) = t
+            .handle_message(&msg::twalk(2, 0, 1, &["hello.txt"]))
+            .await
+            .unwrap();
         assert!(matches!(resp, Response::Walk { .. }), "got {resp:?}");
         let (_, resp) = t.handle_message(&msg::tlopen(3, 1, 0)).await.unwrap();
         assert!(matches!(resp, Response::Lopen { .. }), "got {resp:?}");
@@ -1357,12 +1489,23 @@ mod tests {
             Arc::new(DenyReads),
         ));
 
-        t.handle_message(&msg::tattach(1, 0, u32::MAX, "user", "/")).await.unwrap();
-        let (_, resp) = t.handle_message(&msg::twalk(2, 0, 1, &["hello.txt"])).await.unwrap();
-        assert!(matches!(resp, Response::Walk { .. }), "walk must still succeed");
+        t.handle_message(&msg::tattach(1, 0, u32::MAX, "user", "/"))
+            .await
+            .unwrap();
+        let (_, resp) = t
+            .handle_message(&msg::twalk(2, 0, 1, &["hello.txt"]))
+            .await
+            .unwrap();
+        assert!(
+            matches!(resp, Response::Walk { .. }),
+            "walk must still succeed"
+        );
 
         let (_, resp) = t.handle_message(&msg::tlopen(3, 1, 0)).await.unwrap();
-        assert!(matches!(resp, Response::Lopen { .. }), "open must still succeed");
+        assert!(
+            matches!(resp, Response::Lopen { .. }),
+            "open must still succeed"
+        );
 
         let (_, resp) = t.handle_message(&msg::tread(4, 1, 0, 64)).await.unwrap();
         match resp {
@@ -1386,16 +1529,28 @@ mod tests {
             Arc::new(AllowAll),
         ));
 
-        t.handle_message(&msg::tattach(1, 0, u32::MAX, "user", "/")).await.unwrap();
-        t.handle_message(&msg::twalk(2, 0, 1, &["hello.txt"])).await.unwrap();
-        t.handle_message(&msg::tlopen(3, 1, 1 /* OWRITE */)).await.unwrap();
-        let (_, resp) = t.handle_message(&msg::twrite(4, 1, 0, b"nope")).await.unwrap();
+        t.handle_message(&msg::tattach(1, 0, u32::MAX, "user", "/"))
+            .await
+            .unwrap();
+        t.handle_message(&msg::twalk(2, 0, 1, &["hello.txt"]))
+            .await
+            .unwrap();
+        t.handle_message(&msg::tlopen(3, 1, 1 /* OWRITE */))
+            .await
+            .unwrap();
+        let (_, resp) = t
+            .handle_message(&msg::twrite(4, 1, 0, b"nope"))
+            .await
+            .unwrap();
         match resp {
             Response::Error { ecode } => assert_eq!(ecode, libc_eperm()),
             other => panic!("expected Rlerror EPERM for out-of-scope write, got {other:?}"),
         }
         let (_, resp) = t.handle_message(&msg::tread(5, 1, 0, 64)).await.unwrap();
-        assert!(matches!(resp, Response::Read { .. }), "in-scope read must pass: {resp:?}");
+        assert!(
+            matches!(resp, Response::Read { .. }),
+            "in-scope read must pass: {resp:?}"
+        );
     }
 
     /// A walk is mediated against its destination label: the token ceiling
@@ -1427,18 +1582,29 @@ mod tests {
         let backend = MemoryBackend::default();
         backend.add_file("/hello.txt", b"hi");
         backend.add_file("/secret.txt", b"classified");
-        let t = Translator::new(Arc::new(backend), test_decider()).with_reference_monitor(Arc::new(
-            ReferenceMonitor::new(
+        let t = Translator::new(Arc::new(backend), test_decider()).with_reference_monitor(
+            Arc::new(ReferenceMonitor::new(
                 Arc::new(StaticAuth(session)),
                 Arc::new(ByName),
                 Arc::new(AllowAll),
-            ),
-        ));
+            )),
+        );
 
-        t.handle_message(&msg::tattach(1, 0, u32::MAX, "user", "/")).await.unwrap();
-        let (_, resp) = t.handle_message(&msg::twalk(2, 0, 1, &["hello.txt"])).await.unwrap();
-        assert!(matches!(resp, Response::Walk { .. }), "public walk must pass: {resp:?}");
-        let (_, resp) = t.handle_message(&msg::twalk(3, 0, 2, &["secret.txt"])).await.unwrap();
+        t.handle_message(&msg::tattach(1, 0, u32::MAX, "user", "/"))
+            .await
+            .unwrap();
+        let (_, resp) = t
+            .handle_message(&msg::twalk(2, 0, 1, &["hello.txt"]))
+            .await
+            .unwrap();
+        assert!(
+            matches!(resp, Response::Walk { .. }),
+            "public walk must pass: {resp:?}"
+        );
+        let (_, resp) = t
+            .handle_message(&msg::twalk(3, 0, 2, &["secret.txt"]))
+            .await
+            .unwrap();
         match resp {
             Response::Error { ecode } => assert_eq!(ecode, libc_eperm()),
             other => panic!("expected Rlerror EPERM above the token ceiling, got {other:?}"),
@@ -1462,17 +1628,26 @@ mod tests {
         }
         let backend = MemoryBackend::default();
         backend.add_file("/secret.txt", b"classified");
-        let t = Translator::new(Arc::new(backend), test_decider()).with_reference_monitor(Arc::new(
-            ReferenceMonitor::new(
+        let t = Translator::new(Arc::new(backend), test_decider()).with_reference_monitor(
+            Arc::new(ReferenceMonitor::new(
                 Arc::new(StaticAuth(permit_session(Level::Public, ALL_OPS))),
                 Arc::new(AllSecret),
                 Arc::new(AllowAll),
-            ),
-        ));
+            )),
+        );
 
-        let (_, resp) = t.handle_message(&msg::tattach(1, 0, u32::MAX, "user", "/")).await.unwrap();
-        assert!(matches!(resp, Response::Attach { .. }), "public root must attach: {resp:?}");
-        let (_, resp) = t.handle_message(&msg::twalk(2, 0, 1, &["secret.txt"])).await.unwrap();
+        let (_, resp) = t
+            .handle_message(&msg::tattach(1, 0, u32::MAX, "user", "/"))
+            .await
+            .unwrap();
+        assert!(
+            matches!(resp, Response::Attach { .. }),
+            "public root must attach: {resp:?}"
+        );
+        let (_, resp) = t
+            .handle_message(&msg::twalk(2, 0, 1, &["secret.txt"]))
+            .await
+            .unwrap();
         match resp {
             Response::Error { ecode } => assert_eq!(ecode, libc_eperm()),
             other => panic!("expected Rlerror EPERM for IFC non-dominance, got {other:?}"),
@@ -1490,10 +1665,17 @@ mod tests {
             Some(label(Level::Public)),
             Arc::new(AllowAll),
         ));
-        t.handle_message(&msg::tattach(1, 0, u32::MAX, "user", "/")).await.unwrap();
-        t.handle_message(&msg::twalk(2, 0, 1, &["hello.txt"])).await.unwrap();
+        t.handle_message(&msg::tattach(1, 0, u32::MAX, "user", "/"))
+            .await
+            .unwrap();
+        t.handle_message(&msg::twalk(2, 0, 1, &["hello.txt"]))
+            .await
+            .unwrap();
         let (_, resp) = t.handle_message(&msg::tclunk(3, 1)).await.unwrap();
-        assert!(matches!(resp, Response::Clunk), "clunk must not be mediated: {resp:?}");
+        assert!(
+            matches!(resp, Response::Clunk),
+            "clunk must not be mediated: {resp:?}"
+        );
     }
 
     /// #767 review: `getattr` leaks object metadata (qid/mode/size/mtime) and
@@ -1531,11 +1713,22 @@ mod tests {
             Arc::new(DenyGetattr),
         ));
 
-        t.handle_message(&msg::tattach(1, 0, u32::MAX, "user", "/")).await.unwrap();
-        let (_, resp) = t.handle_message(&msg::twalk(2, 0, 1, &["hello.txt"])).await.unwrap();
-        assert!(matches!(resp, Response::Walk { .. }), "walk must still succeed");
+        t.handle_message(&msg::tattach(1, 0, u32::MAX, "user", "/"))
+            .await
+            .unwrap();
+        let (_, resp) = t
+            .handle_message(&msg::twalk(2, 0, 1, &["hello.txt"]))
+            .await
+            .unwrap();
+        assert!(
+            matches!(resp, Response::Walk { .. }),
+            "walk must still succeed"
+        );
 
-        let (_, resp) = t.handle_message(&msg::tgetattr(3, 1, u64::MAX)).await.unwrap();
+        let (_, resp) = t
+            .handle_message(&msg::tgetattr(3, 1, u64::MAX))
+            .await
+            .unwrap();
         match resp {
             Response::Error { ecode } => assert_eq!(ecode, libc_eperm()),
             other => panic!("expected Rlerror EPERM for gated getattr, got {other:?}"),
@@ -1548,19 +1741,23 @@ mod tests {
     /// deny an already-authenticated client).
     #[tokio::test]
     async fn walk_clone_inherits_source_context() {
-        let t = Translator::new(Arc::new(MemoryBackend::default()), test_decider()).with_reference_monitor(
-            monitor(
+        let t = Translator::new(Arc::new(MemoryBackend::default()), test_decider())
+            .with_reference_monitor(monitor(
                 permit_session(Level::Secret, ALL_OPS),
                 Some(label(Level::Public)),
                 Arc::new(AllowAll),
-            ),
-        );
+            ));
 
         // Attach root fid 0 with the elevated (non-anonymous) session.
-        t.handle_message(&msg::tattach(1, 0, u32::MAX, "user", "/")).await.unwrap();
+        t.handle_message(&msg::tattach(1, 0, u32::MAX, "user", "/"))
+            .await
+            .unwrap();
         // Clone fid 0 -> fid 1 via a zero-element walk.
         let (_, resp) = t.handle_message(&msg::twalk(2, 0, 1, &[])).await.unwrap();
-        assert!(matches!(resp, Response::Walk { .. }), "clone walk must succeed");
+        assert!(
+            matches!(resp, Response::Walk { .. }),
+            "clone walk must succeed"
+        );
 
         // The clone must carry the source's elevated session, not floor out.
         let session = t
@@ -1588,12 +1785,7 @@ mod tests {
         }
         struct DenySecretReads;
         impl AccessDecider for DenySecretReads {
-            fn check(
-                &self,
-                _ctx: &SecurityContext,
-                object: ObjectRef<'_>,
-                action: Action,
-            ) -> bool {
+            fn check(&self, _ctx: &SecurityContext, object: ObjectRef<'_>, action: Action) -> bool {
                 !(action == Action::Read && matches!(object, ObjectRef::Path([])))
             }
 
@@ -1610,16 +1802,20 @@ mod tests {
 
         let backend = MemoryBackend::default();
         backend.add_file("/public.txt", b"public");
-        let t = Translator::new(Arc::new(backend), test_decider()).with_reference_monitor(Arc::new(
-            ReferenceMonitor::new(
+        let t = Translator::new(Arc::new(backend), test_decider()).with_reference_monitor(
+            Arc::new(ReferenceMonitor::new(
                 Arc::new(StaticAuth(permit_session(Level::Secret, ALL_OPS))),
                 Arc::new(ByPath),
                 Arc::new(DenySecretReads),
-            ),
-        ));
+            )),
+        );
 
-        t.handle_message(&msg::tattach(1, 0, u32::MAX, "ticket", "/")).await.unwrap();
-        t.handle_message(&msg::twalk(2, 0, 1, &["public.txt"])).await.unwrap();
+        t.handle_message(&msg::tattach(1, 0, u32::MAX, "ticket", "/"))
+            .await
+            .unwrap();
+        t.handle_message(&msg::twalk(2, 0, 1, &["public.txt"]))
+            .await
+            .unwrap();
         t.handle_message(&msg::twalk(3, 1, 2, &[])).await.unwrap();
         let (_, read) = t.handle_message(&msg::tread(4, 2, 0, 4096)).await.unwrap();
         match read {
@@ -1632,13 +1828,12 @@ mod tests {
 
     #[tokio::test]
     async fn connection_scoped_translators_do_not_share_fid_context() {
-        let root = Translator::new(Arc::new(MemoryBackend::default()), test_decider()).with_reference_monitor(
-            monitor(
+        let root = Translator::new(Arc::new(MemoryBackend::default()), test_decider())
+            .with_reference_monitor(monitor(
                 permit_session(Level::Secret, ALL_OPS),
                 Some(label(Level::Public)),
                 Arc::new(AllowAll),
-            ),
-        );
+            ));
         let conn_a = Arc::new(root.connection_scoped());
         let conn_b = Arc::new(root.connection_scoped());
 
@@ -1649,7 +1844,10 @@ mod tests {
 
         // conn_b never attached: fid 1 is unknown to its table, and a fid
         // outside a verified session fails closed under a live monitor.
-        let (_, resp) = conn_b.handle_message(&msg::twalk(2, 1, 2, &[])).await.unwrap();
+        let (_, resp) = conn_b
+            .handle_message(&msg::twalk(2, 1, 2, &[]))
+            .await
+            .unwrap();
         match resp {
             Response::Error { ecode } => assert_eq!(ecode, libc_eperm()),
             other => panic!("expected EPERM for unauthenticated fid reuse, got {other:?}"),
@@ -1661,7 +1859,11 @@ mod tests {
         struct TicketAuth;
         #[async_trait]
         impl AttachAuthenticator for TicketAuth {
-            async fn authenticate(&self, uname: &str, _aname: &str) -> SessionContext {
+            async fn authenticate(
+                &self,
+                uname: &str,
+                _aname: &str,
+            ) -> std::result::Result<VerifiedAttach, hyprstream_vfs::MountError> {
                 let identity = if uname == "alice-ticket" {
                     "verified-alice"
                 } else {
@@ -1669,17 +1871,20 @@ mod tests {
                 };
                 // Both principals have identical authorization attributes;
                 // only the verifier-produced identity differs.
-                permit_session_as(identity, Level::Secret, ALL_OPS)
+                Ok(verified_attach(permit_session_as(
+                    identity,
+                    Level::Secret,
+                    ALL_OPS,
+                )))
             }
         }
 
-        let t = Translator::new(Arc::new(MemoryBackend::default()), test_decider()).with_reference_monitor(
-            Arc::new(ReferenceMonitor::new(
+        let t = Translator::new(Arc::new(MemoryBackend::default()), test_decider())
+            .with_reference_monitor(Arc::new(ReferenceMonitor::new(
                 Arc::new(TicketAuth),
                 Arc::new(StaticLabels(Some(label(Level::Public)))),
                 Arc::new(AllowAll),
-            )),
-        );
+            )));
         let (_, resp) = t
             .handle_message(&msg::tattach(1, 1, u32::MAX, "alice-ticket", "/"))
             .await
@@ -1707,27 +1912,33 @@ mod tests {
         struct FreshDeadlineAuth;
         #[async_trait]
         impl AttachAuthenticator for FreshDeadlineAuth {
-            async fn authenticate(&self, _uname: &str, _aname: &str) -> SessionContext {
+            async fn authenticate(
+                &self,
+                _uname: &str,
+                _aname: &str,
+            ) -> std::result::Result<VerifiedAttach, hyprstream_vfs::MountError> {
                 // `permit_session` stamps `Instant::now()` into the token, so
                 // each call yields a distinct deadline — exactly what a real
                 // verifier does when re-checking the same ticket.
-                permit_session(Level::Secret, ALL_OPS)
+                Ok(verified_attach(permit_session(Level::Secret, ALL_OPS)))
             }
         }
 
-        let t = Translator::new(Arc::new(MemoryBackend::default()), test_decider()).with_reference_monitor(
-            Arc::new(ReferenceMonitor::new(
+        let t = Translator::new(Arc::new(MemoryBackend::default()), test_decider())
+            .with_reference_monitor(Arc::new(ReferenceMonitor::new(
                 Arc::new(FreshDeadlineAuth),
                 Arc::new(StaticLabels(Some(label(Level::Public)))),
                 Arc::new(AllowAll),
-            )),
-        );
+            )));
 
         let (_, resp) = t
             .handle_message(&msg::tattach(1, 1, u32::MAX, "alice-ticket", "/"))
             .await
             .unwrap();
-        assert!(matches!(resp, Response::Attach { .. }), "first attach: {resp:?}");
+        assert!(
+            matches!(resp, Response::Attach { .. }),
+            "first attach: {resp:?}"
+        );
 
         // Same ticket, freshly-stamped deadline, new fid on the same connection.
         let (_, resp) = t
@@ -1745,21 +1956,30 @@ mod tests {
         struct TicketAuth;
         #[async_trait]
         impl AttachAuthenticator for TicketAuth {
-            async fn authenticate(&self, uname: &str, _aname: &str) -> SessionContext {
+            async fn authenticate(
+                &self,
+                uname: &str,
+                _aname: &str,
+            ) -> std::result::Result<VerifiedAttach, hyprstream_vfs::MountError> {
                 if uname == "valid-ticket" {
-                    permit_session_as("verified-alice", Level::Secret, ALL_OPS)
+                    Ok(verified_attach(permit_session_as(
+                        "verified-alice",
+                        Level::Secret,
+                        ALL_OPS,
+                    )))
                 } else {
-                    SessionContext::deny()
+                    Err(hyprstream_vfs::MountError::PermissionDenied(
+                        "invalid ticket".to_owned(),
+                    ))
                 }
             }
         }
-        let t = Translator::new(Arc::new(MemoryBackend::default()), test_decider()).with_reference_monitor(
-            Arc::new(ReferenceMonitor::new(
+        let t = Translator::new(Arc::new(MemoryBackend::default()), test_decider())
+            .with_reference_monitor(Arc::new(ReferenceMonitor::new(
                 Arc::new(TicketAuth),
                 Arc::new(StaticLabels(Some(label(Level::Public)))),
                 Arc::new(AllowAll),
-            )),
-        );
+            )));
         let (_, denied) = t
             .handle_message(&msg::tattach(1, 1, u32::MAX, "forged-ticket", "/"))
             .await
@@ -1769,7 +1989,10 @@ mod tests {
             .handle_message(&msg::tattach(2, 2, u32::MAX, "valid-ticket", "/"))
             .await
             .unwrap();
-        assert!(matches!(accepted, Response::Attach { .. }), "valid retry: {accepted:?}");
+        assert!(
+            matches!(accepted, Response::Attach { .. }),
+            "valid retry: {accepted:?}"
+        );
     }
 
     #[tokio::test]
@@ -1808,17 +2031,22 @@ mod tests {
         );
         let backend = MountBackend::new(
             Arc::new(SyntheticMount::new(root)),
-            hyprstream_rpc::Subject::new("tenant"),
+            hyprstream_rpc::Subject::new("test-subject"),
         );
-        let t = Translator::new(Arc::new(backend), test_decider()).with_reference_monitor(Arc::new(
-            ReferenceMonitor::new(
+        let t = Translator::new(Arc::new(backend), test_decider()).with_reference_monitor(
+            Arc::new(ReferenceMonitor::new(
                 Arc::new(StaticAuth(permit_session(Level::Secret, ALL_OPS))),
                 Arc::new(ByPath),
                 Arc::new(DenySecretReads),
-            ),
-        ));
-        t.handle_message(&msg::tattach(1, 0, u32::MAX, "ticket", "/")).await.unwrap();
-        let (_, walk) = t.handle_message(&msg::twalk(2, 0, 1, &["a", "b"])).await.unwrap();
+            )),
+        );
+        t.handle_message(&msg::tattach(1, 0, u32::MAX, "ticket", "/"))
+            .await
+            .unwrap();
+        let (_, walk) = t
+            .handle_message(&msg::twalk(2, 0, 1, &["a", "b"]))
+            .await
+            .unwrap();
         match walk {
             Response::Walk { qids } => assert_eq!(qids.len(), 2, "one QID per bound component"),
             other => panic!("expected successful two-name walk, got {other:?}"),
@@ -1852,15 +2080,17 @@ mod tests {
         }
         let backend = MemoryBackend::default();
         backend.add_file("/secret", b"classified");
-        let t = Translator::new(Arc::new(backend), test_decider()).with_reference_monitor(Arc::new(
-            ReferenceMonitor::new(
+        let t = Translator::new(Arc::new(backend), test_decider()).with_reference_monitor(
+            Arc::new(ReferenceMonitor::new(
                 Arc::new(StaticAuth(permit_session(Level::Public, ALL_OPS))),
                 Arc::new(ByDepth),
                 Arc::new(AllowAll),
-            ),
-        ));
+            )),
+        );
 
-        t.handle_message(&msg::tattach(1, 0, u32::MAX, "user", "/")).await.unwrap();
+        t.handle_message(&msg::tattach(1, 0, u32::MAX, "user", "/"))
+            .await
+            .unwrap();
         // Walk through the Secret directory toward the Public leaf. The Public
         // subject cannot clear the Secret hop, so the walk must deny — even
         // though the *destination* label is Public.
@@ -1886,8 +2116,13 @@ mod tests {
         struct PartialWalkBackend;
         #[async_trait]
         impl Backend for PartialWalkBackend {
-            async fn attach(&self, _uname: &str, _aname: &str) -> anyhow::Result<()> {
-                Ok(())
+            async fn attach(
+                &self,
+                _uname: &str,
+                _aname: &str,
+                verified: Option<crate::VerifiedAttach>,
+            ) -> anyhow::Result<Option<crate::VerifiedAttach>> {
+                Ok(verified)
             }
             async fn walk(
                 &self,
@@ -1896,7 +2131,10 @@ mod tests {
                 _components: &[String],
             ) -> anyhow::Result<WalkResult> {
                 // Reaches exactly one component, regardless of how many walked.
-                Ok(WalkResult { qids: vec![sample_qid(0, 1)], reached: vec!["a".to_owned()] })
+                Ok(WalkResult {
+                    qids: vec![sample_qid(0, 1)],
+                    reached: vec!["a".to_owned()],
+                })
             }
             async fn open(&self, _fid: u32, _flags: u32) -> anyhow::Result<OpenResult> {
                 unimplemented!("not reached")
@@ -1904,12 +2142,7 @@ mod tests {
             async fn read(&self, _fid: u32, _offset: u64, _count: u32) -> anyhow::Result<Vec<u8>> {
                 unimplemented!("not reached")
             }
-            async fn write(
-                &self,
-                _fid: u32,
-                _offset: u64,
-                _data: &[u8],
-            ) -> anyhow::Result<u32> {
+            async fn write(&self, _fid: u32, _offset: u64, _data: &[u8]) -> anyhow::Result<u32> {
                 unimplemented!("not reached")
             }
             async fn stat(&self, _fid: u32) -> anyhow::Result<StatResult> {
@@ -1930,8 +2163,12 @@ mod tests {
 
         // No monitor: this isolates the path-caching fix from mediation.
         let t = Translator::new(Arc::new(PartialWalkBackend), test_decider());
-        t.handle_message(&msg::tattach(1, 0, u32::MAX, "user", "/")).await.unwrap();
-        t.handle_message(&msg::twalk(2, 0, 1, &["a", "b"])).await.unwrap();
+        t.handle_message(&msg::tattach(1, 0, u32::MAX, "user", "/"))
+            .await
+            .unwrap();
+        t.handle_message(&msg::twalk(2, 0, 1, &["a", "b"]))
+            .await
+            .unwrap();
 
         let cached = t.fids.path(1).expect("newfid must be tracked");
         assert_eq!(
@@ -1969,15 +2206,28 @@ mod tests {
         let t = Arc::new(Translator::new(Arc::new(backend), test_decider()));
 
         // Attach fid 0 as the (directory) root, then open + readdir it.
-        t.handle_message(&msg::tattach(1, 0, u32::MAX, "u", "/")).await.unwrap();
+        t.handle_message(&msg::tattach(1, 0, u32::MAX, "u", "/"))
+            .await
+            .unwrap();
         t.handle_message(&msg::tlopen(2, 0, 0)).await.unwrap();
-        let (tag, resp) = t.handle_message(&msg::treaddir(3, 0, 0, 8192)).await.unwrap();
+        let (tag, resp) = t
+            .handle_message(&msg::treaddir(3, 0, 0, 8192))
+            .await
+            .unwrap();
 
         // Encode to the wire exactly as serve_connection does, and check the
         // message-type byte is RREADDIR, not RREAD.
         let wire = msg::encode_response(tag, &resp);
-        assert_eq!(wire[4], msg::RREADDIR, "readdir must be framed as RREADDIR (41)");
-        assert_ne!(wire[4], msg::RREAD, "readdir must NOT be framed as RREAD (117)");
+        assert_eq!(
+            wire[4],
+            msg::RREADDIR,
+            "readdir must be framed as RREADDIR (41)"
+        );
+        assert_ne!(
+            wire[4],
+            msg::RREAD,
+            "readdir must NOT be framed as RREAD (117)"
+        );
 
         // The payload must decode as standard dirent records.
         let data = match resp {
@@ -2004,9 +2254,12 @@ mod tests {
         use tokio::net::UnixStream;
 
         // Unique temp UDS path (no tempfile dep in this crate).
-        let nanos = SystemTime::now().duration_since(UNIX_EPOCH).unwrap().as_nanos();
-        let sock = std::env::temp_dir()
-            .join(format!("hs9p-vsock-{}-{nanos}.sock", std::process::id()));
+        let nanos = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        let sock =
+            std::env::temp_dir().join(format!("hs9p-vsock-{}-{nanos}.sock", std::process::id()));
         let _ = std::fs::remove_file(&sock);
 
         let backend = MemoryBackend::default();
@@ -2047,23 +2300,44 @@ mod tests {
         }
 
         // Tversion → Rversion.
-        client.write_all(&msg::tversion(1, MSG_SIZE, "9P2000.L")).await.unwrap();
+        client
+            .write_all(&msg::tversion(1, MSG_SIZE, "9P2000.L"))
+            .await
+            .unwrap();
         let (_, resp) = msg::parse_response(&read_frame(&mut client).await).unwrap();
-        assert!(matches!(resp, Response::Version { .. }), "expected Rversion, got {resp:?}");
+        assert!(
+            matches!(resp, Response::Version { .. }),
+            "expected Rversion, got {resp:?}"
+        );
 
         // Tattach fid 0 as root.
-        client.write_all(&msg::tattach(2, 0, u32::MAX, "u", "/")).await.unwrap();
+        client
+            .write_all(&msg::tattach(2, 0, u32::MAX, "u", "/"))
+            .await
+            .unwrap();
         let (_, resp) = msg::parse_response(&read_frame(&mut client).await).unwrap();
-        assert!(matches!(resp, Response::Attach { .. }), "expected Rattach, got {resp:?}");
+        assert!(
+            matches!(resp, Response::Attach { .. }),
+            "expected Rattach, got {resp:?}"
+        );
 
         // Twalk to the file, Tlopen, Tread.
-        client.write_all(&msg::twalk(3, 0, 1, &["hello.txt"])).await.unwrap();
+        client
+            .write_all(&msg::twalk(3, 0, 1, &["hello.txt"]))
+            .await
+            .unwrap();
         let (_, resp) = msg::parse_response(&read_frame(&mut client).await).unwrap();
-        assert!(matches!(resp, Response::Walk { .. }), "expected Rwalk, got {resp:?}");
+        assert!(
+            matches!(resp, Response::Walk { .. }),
+            "expected Rwalk, got {resp:?}"
+        );
 
         client.write_all(&msg::tlopen(4, 1, 0)).await.unwrap();
         let (_, resp) = msg::parse_response(&read_frame(&mut client).await).unwrap();
-        assert!(matches!(resp, Response::Lopen { .. }), "expected Rlopen, got {resp:?}");
+        assert!(
+            matches!(resp, Response::Lopen { .. }),
+            "expected Rlopen, got {resp:?}"
+        );
 
         client.write_all(&msg::tread(5, 1, 0, 64)).await.unwrap();
         let (_, resp) = msg::parse_response(&read_frame(&mut client).await).unwrap();
@@ -2088,9 +2362,12 @@ mod tests {
         use std::time::{SystemTime, UNIX_EPOCH};
         use tokio::net::UnixStream;
 
-        let nanos = SystemTime::now().duration_since(UNIX_EPOCH).unwrap().as_nanos();
-        let sock = std::env::temp_dir()
-            .join(format!("hs9p-rawvsock-{}-{nanos}.sock", std::process::id()));
+        let nanos = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        let sock =
+            std::env::temp_dir().join(format!("hs9p-rawvsock-{}-{nanos}.sock", std::process::id()));
         let _ = std::fs::remove_file(&sock);
 
         let backend = MemoryBackend::default();
@@ -2100,7 +2377,9 @@ mod tests {
         let server = tokio::spawn(translator.serve_vsock_raw(listener));
 
         // ── Client (guest) side ─────────────────────────────────────────
-        let mut client = UnixStream::connect(&sock).await.expect("dial per-port host UDS");
+        let mut client = UnixStream::connect(&sock)
+            .await
+            .expect("dial per-port host UDS");
 
         async fn read_frame(s: &mut UnixStream) -> Vec<u8> {
             let mut len = [0u8; 4];
@@ -2115,7 +2394,10 @@ mod tests {
         // FIRST bytes on the wire are 9P Tversion — NO `connect <port>\n`
         // preamble. If the raw path erroneously stripped a preamble it would
         // swallow these bytes and the session would hang / fail here.
-        client.write_all(&msg::tversion(1, MSG_SIZE, "9P2000.L")).await.unwrap();
+        client
+            .write_all(&msg::tversion(1, MSG_SIZE, "9P2000.L"))
+            .await
+            .unwrap();
         let (_, resp) = msg::parse_response(&read_frame(&mut client).await).unwrap();
         assert!(
             matches!(resp, Response::Version { .. }),
@@ -2123,17 +2405,32 @@ mod tests {
         );
 
         // Rest of the session proves the stream was never desynchronized.
-        client.write_all(&msg::tattach(2, 0, u32::MAX, "u", "/")).await.unwrap();
+        client
+            .write_all(&msg::tattach(2, 0, u32::MAX, "u", "/"))
+            .await
+            .unwrap();
         let (_, resp) = msg::parse_response(&read_frame(&mut client).await).unwrap();
-        assert!(matches!(resp, Response::Attach { .. }), "expected Rattach, got {resp:?}");
+        assert!(
+            matches!(resp, Response::Attach { .. }),
+            "expected Rattach, got {resp:?}"
+        );
 
-        client.write_all(&msg::twalk(3, 0, 1, &["hello.txt"])).await.unwrap();
+        client
+            .write_all(&msg::twalk(3, 0, 1, &["hello.txt"]))
+            .await
+            .unwrap();
         let (_, resp) = msg::parse_response(&read_frame(&mut client).await).unwrap();
-        assert!(matches!(resp, Response::Walk { .. }), "expected Rwalk, got {resp:?}");
+        assert!(
+            matches!(resp, Response::Walk { .. }),
+            "expected Rwalk, got {resp:?}"
+        );
 
         client.write_all(&msg::tlopen(4, 1, 0)).await.unwrap();
         let (_, resp) = msg::parse_response(&read_frame(&mut client).await).unwrap();
-        assert!(matches!(resp, Response::Lopen { .. }), "expected Rlopen, got {resp:?}");
+        assert!(
+            matches!(resp, Response::Lopen { .. }),
+            "expected Rlopen, got {resp:?}"
+        );
 
         client.write_all(&msg::tread(5, 1, 0, 64)).await.unwrap();
         let (_, resp) = msg::parse_response(&read_frame(&mut client).await).unwrap();
@@ -2156,9 +2453,14 @@ mod tests {
         use std::time::{SystemTime, UNIX_EPOCH};
         use tokio::net::UnixStream;
 
-        let nanos = SystemTime::now().duration_since(UNIX_EPOCH).unwrap().as_nanos();
-        let sock = std::env::temp_dir()
-            .join(format!("hs9p-vsock-bad-{}-{nanos}.sock", std::process::id()));
+        let nanos = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        let sock = std::env::temp_dir().join(format!(
+            "hs9p-vsock-bad-{}-{nanos}.sock",
+            std::process::id()
+        ));
         let _ = std::fs::remove_file(&sock);
 
         let listener = UnixListener::bind(&sock).unwrap();
@@ -2204,23 +2506,29 @@ mod tests {
     struct FakeTicketAuth;
     #[async_trait::async_trait]
     impl crate::mount_backend::AttachAuthorizer for FakeTicketAuth {
-        async fn authorize(
+        async fn authenticate(
             &self,
             uname: &str,
             aname: &str,
-        ) -> std::result::Result<hyprstream_rpc::Subject, hyprstream_vfs::MountError> {
-            let subject = match uname {
-                "good-ticket" => hyprstream_rpc::Subject::new("alice"),
-                "other-ticket" => hyprstream_rpc::Subject::new("bob"),
+        ) -> std::result::Result<VerifiedAttach, hyprstream_vfs::MountError> {
+            let identity = match uname {
+                "good-ticket" => "alice",
+                "other-ticket" => "bob",
                 _ => {
-                    return Err(hyprstream_vfs::MountError::PermissionDenied("bad ticket".into()))
+                    return Err(hyprstream_vfs::MountError::PermissionDenied(
+                        "bad ticket".into(),
+                    ))
                 }
             };
             // Export-selection gate (#877 fail-closed contract): only the
             // default export is granted today; an explicit `aname` selecting any
             // other export denies — there is NO fallback to the default.
             if aname.is_empty() {
-                Ok(subject)
+                Ok(verified_attach(permit_session_as(
+                    identity,
+                    Level::Secret,
+                    ALL_OPS,
+                )))
             } else {
                 Err(hyprstream_vfs::MountError::PermissionDenied(format!(
                     "export {aname:?} not granted by ticket"
@@ -2231,8 +2539,8 @@ mod tests {
 
     fn authorized_translator() -> Arc<Translator> {
         use hyprstream_vfs::{SyntheticMount, SyntheticNode};
-        let root = SyntheticNode::dir()
-            .with_child("hello.txt", SyntheticNode::file(b"hi alice".to_vec()));
+        let root =
+            SyntheticNode::dir().with_child("hello.txt", SyntheticNode::file(b"hi alice".to_vec()));
         let mount: Arc<dyn hyprstream_vfs::Mount> = Arc::new(SyntheticMount::new(root));
         Arc::new(Translator::from_mount_authorized(
             mount,
@@ -2251,10 +2559,16 @@ mod tests {
             .handle_message(&msg::tattach(1, 0, u32::MAX, "good-ticket", ""))
             .await
             .unwrap();
-        assert!(matches!(resp, Response::Attach { .. }), "valid ticket must attach: {resp:?}");
+        assert!(
+            matches!(resp, Response::Attach { .. }),
+            "valid ticket must attach: {resp:?}"
+        );
 
         // The bound Subject now threads through walk/open/read.
-        let (_, resp) = t.handle_message(&msg::twalk(2, 0, 1, &["hello.txt"])).await.unwrap();
+        let (_, resp) = t
+            .handle_message(&msg::twalk(2, 0, 1, &["hello.txt"]))
+            .await
+            .unwrap();
         assert!(matches!(resp, Response::Walk { .. }), "got {resp:?}");
         let (_, resp) = t.handle_message(&msg::tlopen(3, 1, 0)).await.unwrap();
         assert!(matches!(resp, Response::Lopen { .. }), "got {resp:?}");
@@ -2275,7 +2589,11 @@ mod tests {
             .handle_message(&msg::tattach(1, 0, u32::MAX, "forged", ""))
             .await
             .unwrap_err();
-        assert_eq!(errno_from_error(&err), EACCES, "denied ticket must be EACCES");
+        assert_eq!(
+            errno_from_error(&err),
+            EACCES,
+            "denied ticket must be EACCES"
+        );
     }
 
     /// An empty `uname` (no ticket presented) is likewise denied — the ticket is
@@ -2287,7 +2605,11 @@ mod tests {
             .handle_message(&msg::tattach(1, 0, u32::MAX, "", ""))
             .await
             .unwrap_err();
-        assert_eq!(errno_from_error(&err), EACCES, "missing ticket must be EACCES");
+        assert_eq!(
+            errno_from_error(&err),
+            EACCES,
+            "missing ticket must be EACCES"
+        );
     }
 
     /// A second attach may repeat the same ticket, but it must not re-scope the
@@ -2305,7 +2627,11 @@ mod tests {
             .handle_message(&msg::tattach(2, 0, u32::MAX, "other-ticket", ""))
             .await
             .unwrap_err();
-        assert_eq!(errno_from_error(&err), EACCES, "conflicting attach must be EACCES");
+        assert_eq!(
+            errno_from_error(&err),
+            EACCES,
+            "conflicting attach must be EACCES"
+        );
     }
 
     /// A valid ticket presenting an `aname` for an export it did not grant fails
@@ -2326,12 +2652,19 @@ mod tests {
             ))
             .await
             .unwrap_err();
-        assert_eq!(errno_from_error(&err), EACCES, "denied aname must be EACCES");
+        assert_eq!(
+            errno_from_error(&err),
+            EACCES,
+            "denied aname must be EACCES"
+        );
         // The root fid (fid 0, the attach target) must not exist after a denied
         // attach — the deny happened in `backend.attach` before the translator
         // bound any fid (the fail-closed contract: no fid leak on a denied
         // export).
-        assert!(t.fids.qtype(0).is_none(), "no fid may be created for a denied aname");
+        assert!(
+            t.fids.qtype(0).is_none(),
+            "no fid may be created for a denied aname"
+        );
     }
 
     /// Fail-closed: an op arriving before a successful attach binds the Subject
@@ -2340,7 +2673,10 @@ mod tests {
     async fn op_before_attach_fails_closed() {
         let t = authorized_translator();
         // No Tattach: a walk cannot resolve a caller and must error, not serve.
-        let err = t.handle_message(&msg::twalk(1, 0, 1, &["hello.txt"])).await.unwrap_err();
+        let err = t
+            .handle_message(&msg::twalk(1, 0, 1, &["hello.txt"]))
+            .await
+            .unwrap_err();
         // Untyped bookkeeping error (no MountError) → EIO, never a success.
         assert_eq!(errno_from_error(&err), EIO);
     }

--- a/crates/hyprstream-rpc/src/auth/jti_blocklist.rs
+++ b/crates/hyprstream-rpc/src/auth/jti_blocklist.rs
@@ -58,7 +58,10 @@ impl JtiBlocklist for InMemoryJtiBlocklist {
         }
         #[cfg(target_arch = "wasm32")]
         {
-            self.revoked.read().expect("jti blocklist lock poisoned").contains_key(jti)
+            self.revoked
+                .read()
+                .expect("jti blocklist lock poisoned")
+                .contains_key(jti)
         }
     }
 
@@ -67,11 +70,16 @@ impl JtiBlocklist for InMemoryJtiBlocklist {
         #[cfg(not(target_arch = "wasm32"))]
         {
             let mut map = self.revoked.write();
-            map.insert(jti, expires_at);
-            if map.len() > 10_000 {
-                drop(map);
+            map.insert(jti.clone(), expires_at);
+            let cleanup = map.len() > 10_000;
+            drop(map);
+            if cleanup {
                 self.cleanup(now);
             }
+            // Publish the revocation before evicting derived authority. New
+            // verifications now fail the blocklist check, while cached
+            // contexts derived from the revoked token are removed below.
+            crate::auth::mac::revoke_verified_subject_jti(&jti);
         }
         #[cfg(target_arch = "wasm32")]
         {

--- a/crates/hyprstream-rpc/src/auth/mac/activation.rs
+++ b/crates/hyprstream-rpc/src/auth/mac/activation.rs
@@ -10,7 +10,7 @@
 //! startup path calls [`MacActivationControl::widen_identity_aware`]
 //! automatically; narrowing is always available.
 
-use std::collections::HashMap;
+use std::collections::{BTreeSet, HashMap};
 use std::sync::atomic::{AtomicU8, Ordering};
 use std::sync::OnceLock;
 
@@ -41,6 +41,7 @@ pub struct MacActivationError {
     pub unlabeled: usize,
     pub ill_formed: usize,
     pub missing_gates: Vec<&'static str>,
+    pub blocked_transports: Vec<&'static str>,
 }
 
 impl std::fmt::Display for MacActivationError {
@@ -48,8 +49,8 @@ impl std::fmt::Display for MacActivationError {
         write!(
             f,
             "MAC identity-aware widening refused: readiness evidence incomplete \
-             (unlabeled={}, ill_formed={}, missing_gates={:?})",
-            self.unlabeled, self.ill_formed, self.missing_gates
+             (unlabeled={}, ill_formed={}, missing_gates={:?}, blocked_transports={:?})",
+            self.unlabeled, self.ill_formed, self.missing_gates, self.blocked_transports
         )
     }
 }
@@ -100,12 +101,14 @@ impl MacActivationEvidence<'_> {
 #[derive(Debug)]
 pub struct MacActivationControl {
     mode: AtomicU8,
+    unverified_attach_transports: RwLock<BTreeSet<&'static str>>,
 }
 
 impl Default for MacActivationControl {
     fn default() -> Self {
         Self {
             mode: AtomicU8::new(FLOOR_ONLY),
+            unverified_attach_transports: RwLock::new(BTreeSet::new()),
         }
     }
 }
@@ -127,14 +130,22 @@ impl MacActivationControl {
         &self,
         evidence: &MacActivationEvidence<'_>,
     ) -> Result<(), MacActivationError> {
-        let missing_gates = evidence.missing_gates();
+        let blocked_transports = self.blocked_transports();
+        let mut missing_gates = evidence.missing_gates();
+        if !blocked_transports.is_empty() && !missing_gates.contains(&"G2") {
+            missing_gates.push("G2");
+        }
         if !missing_gates.is_empty() {
             return Err(MacActivationError {
                 unlabeled: evidence.genesis.unlabeled.len(),
                 ill_formed: evidence.genesis.ill_formed.len(),
                 missing_gates,
+                blocked_transports,
             });
         }
+        // A widening starts a new cache generation. No verified subject
+        // context from an earlier floor-only/reload epoch can survive it.
+        flush_verified_subject_cache_generation();
         self.mode.store(IDENTITY_AWARE, Ordering::Release);
         Ok(())
     }
@@ -143,6 +154,7 @@ impl MacActivationControl {
     /// leaving every monitor installed and authoritative.
     pub fn narrow_to_floor(&self) {
         self.mode.store(FLOOR_ONLY, Ordering::Release);
+        flush_verified_subject_cache_generation();
     }
 
     /// Select the context a PEP must evaluate in the current mode.
@@ -153,6 +165,27 @@ impl MacActivationControl {
             MacActivationMode::IdentityAware => verified,
         }
     }
+
+    /// Permanently block identity-aware widening in this process while a live
+    /// 9P transport still has no verified attach-credential carrier.
+    ///
+    /// Registration also narrows an already-widened process immediately, so a
+    /// late worker constructor cannot turn UDS/vsock attaches into a deny-all
+    /// availability outage.
+    pub fn block_unverified_attach_transport(&self, transport: &'static str) {
+        self.unverified_attach_transports.write().insert(transport);
+        self.narrow_to_floor();
+    }
+
+    /// Runtime transport blockers that make G2 structurally incomplete.
+    #[must_use]
+    pub fn blocked_transports(&self) -> Vec<&'static str> {
+        self.unverified_attach_transports
+            .read()
+            .iter()
+            .copied()
+            .collect()
+    }
 }
 
 /// The process-global activation control.  It starts floor-only.
@@ -160,6 +193,14 @@ impl MacActivationControl {
 pub fn global_mac_activation_control() -> &'static MacActivationControl {
     static CONTROL: OnceLock<MacActivationControl> = OnceLock::new();
     CONTROL.get_or_init(MacActivationControl::default)
+}
+
+/// Register a live production 9P transport that still uses a deny-only
+/// authenticator. Once registered, this process cannot widen identity-aware
+/// MAC until that constructor is replaced with a verified credential carrier
+/// in a fresh process.
+pub fn block_identity_widening_for_unverified_attach_transport(transport: &'static str) {
+    global_mac_activation_control().block_unverified_attach_transport(transport);
 }
 
 /// Canonical anonymous-floor context used by every PEP during narrowing.
@@ -176,11 +217,47 @@ struct VerifiedSubjectEntry {
     context: SecurityContext,
     tenant: Option<String>,
     expires_at: i64,
+    jti: Option<String>,
+    generation: u64,
 }
 
-fn verified_subjects() -> &'static RwLock<HashMap<String, VerifiedSubjectEntry>> {
-    static SUBJECTS: OnceLock<RwLock<HashMap<String, VerifiedSubjectEntry>>> = OnceLock::new();
-    SUBJECTS.get_or_init(|| RwLock::new(HashMap::new()))
+#[derive(Default)]
+struct VerifiedSubjectCache {
+    generation: u64,
+    subjects: HashMap<String, VerifiedSubjectEntry>,
+}
+
+fn verified_subjects() -> &'static RwLock<VerifiedSubjectCache> {
+    static SUBJECTS: OnceLock<RwLock<VerifiedSubjectCache>> = OnceLock::new();
+    SUBJECTS.get_or_init(|| RwLock::new(VerifiedSubjectCache::default()))
+}
+
+/// Revoke every cached subject context derived from `jti`.
+///
+/// The shared in-memory JTI blocklist calls this hook on every revocation, so
+/// VFS/CAS/MoQ lookups cannot continue using authority cached before the
+/// blocklist update.
+pub fn revoke_verified_subject_jti(jti: &str) -> usize {
+    if jti.is_empty() {
+        return 0;
+    }
+    let mut cache = verified_subjects().write();
+    let before = cache.subjects.len();
+    cache
+        .subjects
+        .retain(|_, entry| entry.jti.as_deref() != Some(jti));
+    before.saturating_sub(cache.subjects.len())
+}
+
+/// Advance the verified-subject cache generation and remove all prior entries.
+///
+/// Policy/resolver reload and revocation control planes call this G7 hook.
+/// Widening and narrowing also rotate the generation automatically.
+pub fn flush_verified_subject_cache_generation() -> u64 {
+    let mut cache = verified_subjects().write();
+    cache.generation = cache.generation.saturating_add(1);
+    cache.subjects.clear();
+    cache.generation
 }
 
 /// Cache the context of a request whose envelope and Claims have already been
@@ -230,12 +307,16 @@ pub fn remember_verified_claims(
     let Some(context) = claims.security_context(key_material) else {
         return;
     };
-    verified_subjects().write().insert(
+    let mut cache = verified_subjects().write();
+    let generation = cache.generation;
+    cache.subjects.insert(
         name.to_owned(),
         VerifiedSubjectEntry {
             context,
             tenant: verified_tenant.map(str::to_owned),
             expires_at: claims.exp,
+            jti: claims.jti.clone(),
+            generation,
         },
     );
 }
@@ -249,10 +330,14 @@ pub fn subject_context(
 ) -> Option<SecurityContext> {
     let verified = subject.name().and_then(|name| {
         let now = chrono::Utc::now().timestamp();
-        let mut subjects = verified_subjects().write();
-        let entry = subjects.get(name)?.clone();
+        let mut cache = verified_subjects().write();
+        let entry = cache.subjects.get(name)?.clone();
+        if entry.generation != cache.generation {
+            cache.subjects.remove(name);
+            return None;
+        }
         if entry.expires_at <= now {
-            subjects.remove(name);
+            cache.subjects.remove(name);
             return None;
         }
         if let Some(expected) = verified_tenant {
@@ -269,6 +354,8 @@ pub fn subject_context(
 mod tests {
     use super::*;
 
+    static TEST_LOCK: parking_lot::Mutex<()> = parking_lot::Mutex::new(());
+
     fn report(complete: bool) -> GenesisReport {
         GenesisReport {
             labeled: vec!["/".to_owned()],
@@ -283,6 +370,7 @@ mod tests {
 
     #[test]
     fn widening_requires_complete_coverage_and_narrowing_is_always_available() {
+        let _guard = TEST_LOCK.lock();
         let control = MacActivationControl::default();
         let incomplete = report(false);
         let mut evidence = MacActivationEvidence {
@@ -301,5 +389,64 @@ mod tests {
         assert_eq!(control.mode(), MacActivationMode::IdentityAware);
         control.narrow_to_floor();
         assert_eq!(control.mode(), MacActivationMode::FloorOnly);
+    }
+
+    #[test]
+    fn unverified_attach_transport_structurally_blocks_g2_widening() {
+        let _guard = TEST_LOCK.lock();
+        let control = MacActivationControl::default();
+        control.block_unverified_attach_transport("worker-uds-vsock");
+
+        let complete = report(true);
+        let evidence = MacActivationEvidence {
+            genesis: &complete,
+            mediation_integrity_g2: true,
+            denial_handling_g4: true,
+            observability_g5: true,
+            runbook_signoff_g6: true,
+            revocation_reload_g7: true,
+        };
+        let Err(error) = control.widen_identity_aware(&evidence) else {
+            panic!("unverified worker transport must block identity-aware widening");
+        };
+        assert_eq!(control.mode(), MacActivationMode::FloorOnly);
+        assert!(error.missing_gates.contains(&"G2"));
+        assert_eq!(error.blocked_transports, vec!["worker-uds-vsock"]);
+    }
+
+    #[test]
+    fn jti_revocation_and_generation_rotation_evict_cached_subjects() {
+        let _guard = TEST_LOCK.lock();
+        flush_verified_subject_cache_generation();
+
+        let now = chrono::Utc::now().timestamp();
+        let mut claims =
+            crate::auth::Claims::new("did:web:alice".to_owned(), now, now + 300).with_clearance(
+                SecurityLabel::new(Level::Secret, Assurance::Classical, CompartmentSet::EMPTY),
+            );
+        claims.jti = Some("revocable-jti".to_owned());
+        let subject = Subject::new("did:web:alice");
+        remember_verified_claims(
+            &subject,
+            &claims,
+            VerifiedKeyMaterial::Classical,
+            Some("tenant-a"),
+        );
+
+        assert_eq!(verified_subjects().read().subjects.len(), 1);
+        assert_eq!(revoke_verified_subject_jti("other-jti"), 0);
+        assert_eq!(revoke_verified_subject_jti("revocable-jti"), 1);
+        assert!(verified_subjects().read().subjects.is_empty());
+
+        remember_verified_claims(
+            &subject,
+            &claims,
+            VerifiedKeyMaterial::Classical,
+            Some("tenant-a"),
+        );
+        let old_generation = verified_subjects().read().generation;
+        let new_generation = flush_verified_subject_cache_generation();
+        assert!(new_generation >= old_generation);
+        assert!(verified_subjects().read().subjects.is_empty());
     }
 }

--- a/crates/hyprstream-rpc/src/auth/mac/activation.rs
+++ b/crates/hyprstream-rpc/src/auth/mac/activation.rs
@@ -1,0 +1,305 @@
+//! Coverage-gated MAC activation control and verified-subject context cache.
+//!
+//! The reference monitor is always present.  The operator control only selects
+//! which subject context it receives:
+//! - [`MacActivationMode::FloorOnly`] uses the anonymous floor;
+//! - [`MacActivationMode::IdentityAware`] uses a context derived from verified
+//!   `Claims × VerifiedKeyMaterial`.
+//!
+//! Widening is refused unless the supplied genesis report is complete.  No
+//! startup path calls [`MacActivationControl::widen_identity_aware`]
+//! automatically; narrowing is always available.
+
+use std::collections::HashMap;
+use std::sync::atomic::{AtomicU8, Ordering};
+use std::sync::OnceLock;
+
+use parking_lot::RwLock;
+
+use super::{
+    Assurance, CompartmentSet, GenesisReport, Level, SecurityContext, SecurityLabel,
+    VerifiedKeyMaterial,
+};
+use crate::envelope::Subject;
+use crate::service::EnvelopeContext;
+
+const FLOOR_ONLY: u8 = 0;
+const IDENTITY_AWARE: u8 = 1;
+
+/// The two allowed production enforcement states.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MacActivationMode {
+    /// Mandatory monitor with the anonymous-floor subject context.
+    FloorOnly,
+    /// Mandatory monitor with verified identity-aware subject contexts.
+    IdentityAware,
+}
+
+/// Why an operator-requested widening was refused.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct MacActivationError {
+    pub unlabeled: usize,
+    pub ill_formed: usize,
+    pub missing_gates: Vec<&'static str>,
+}
+
+impl std::fmt::Display for MacActivationError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "MAC identity-aware widening refused: readiness evidence incomplete \
+             (unlabeled={}, ill_formed={}, missing_gates={:?})",
+            self.unlabeled, self.ill_formed, self.missing_gates
+        )
+    }
+}
+
+impl std::error::Error for MacActivationError {}
+
+/// Operator-supplied evidence for the epic's G1-G7 decision gate.
+///
+/// These are attestations, not automatically inferred health signals. The
+/// operator control plane must assemble them from the signed activation
+/// evidence described in the runbook. G3 is proven by this control's
+/// reversible narrow operation itself.
+pub struct MacActivationEvidence<'a> {
+    pub genesis: &'a GenesisReport,
+    pub mediation_integrity_g2: bool,
+    pub denial_handling_g4: bool,
+    pub observability_g5: bool,
+    pub runbook_signoff_g6: bool,
+    pub revocation_reload_g7: bool,
+}
+
+impl MacActivationEvidence<'_> {
+    fn missing_gates(&self) -> Vec<&'static str> {
+        let mut missing = Vec::new();
+        if !self.genesis.is_complete() {
+            missing.push("G1");
+        }
+        if !self.mediation_integrity_g2 {
+            missing.push("G2");
+        }
+        if !self.denial_handling_g4 {
+            missing.push("G4");
+        }
+        if !self.observability_g5 {
+            missing.push("G5");
+        }
+        if !self.runbook_signoff_g6 {
+            missing.push("G6");
+        }
+        if !self.revocation_reload_g7 {
+            missing.push("G7");
+        }
+        missing
+    }
+}
+
+/// Process-wide widen/narrow control.  It never removes a PEP.
+#[derive(Debug)]
+pub struct MacActivationControl {
+    mode: AtomicU8,
+}
+
+impl Default for MacActivationControl {
+    fn default() -> Self {
+        Self {
+            mode: AtomicU8::new(FLOOR_ONLY),
+        }
+    }
+}
+
+impl MacActivationControl {
+    /// Current subject-context selection.
+    #[must_use]
+    pub fn mode(&self) -> MacActivationMode {
+        if self.mode.load(Ordering::Acquire) == IDENTITY_AWARE {
+            MacActivationMode::IdentityAware
+        } else {
+            MacActivationMode::FloorOnly
+        }
+    }
+
+    /// Explicit operator widening.  Coverage must be complete at the instant of
+    /// the request; merely constructing or logging a report never flips state.
+    pub fn widen_identity_aware(
+        &self,
+        evidence: &MacActivationEvidence<'_>,
+    ) -> Result<(), MacActivationError> {
+        let missing_gates = evidence.missing_gates();
+        if !missing_gates.is_empty() {
+            return Err(MacActivationError {
+                unlabeled: evidence.genesis.unlabeled.len(),
+                ill_formed: evidence.genesis.ill_formed.len(),
+                missing_gates,
+            });
+        }
+        self.mode.store(IDENTITY_AWARE, Ordering::Release);
+        Ok(())
+    }
+
+    /// Kill-switch: narrow subject context back to the anonymous floor while
+    /// leaving every monitor installed and authoritative.
+    pub fn narrow_to_floor(&self) {
+        self.mode.store(FLOOR_ONLY, Ordering::Release);
+    }
+
+    /// Select the context a PEP must evaluate in the current mode.
+    #[must_use]
+    pub fn select_context(&self, verified: Option<SecurityContext>) -> Option<SecurityContext> {
+        match self.mode() {
+            MacActivationMode::FloorOnly => Some(anonymous_floor()),
+            MacActivationMode::IdentityAware => verified,
+        }
+    }
+}
+
+/// The process-global activation control.  It starts floor-only.
+#[must_use]
+pub fn global_mac_activation_control() -> &'static MacActivationControl {
+    static CONTROL: OnceLock<MacActivationControl> = OnceLock::new();
+    CONTROL.get_or_init(MacActivationControl::default)
+}
+
+/// Canonical anonymous-floor context used by every PEP during narrowing.
+#[must_use]
+pub fn anonymous_floor() -> SecurityContext {
+    SecurityContext::from_clearance(
+        SecurityLabel::new(Level::Public, Assurance::Unverified, CompartmentSet::EMPTY),
+        VerifiedKeyMaterial::Unverified,
+    )
+}
+
+#[derive(Clone)]
+struct VerifiedSubjectEntry {
+    context: SecurityContext,
+    tenant: Option<String>,
+    expires_at: i64,
+}
+
+fn verified_subjects() -> &'static RwLock<HashMap<String, VerifiedSubjectEntry>> {
+    static SUBJECTS: OnceLock<RwLock<HashMap<String, VerifiedSubjectEntry>>> = OnceLock::new();
+    SUBJECTS.get_or_init(|| RwLock::new(HashMap::new()))
+}
+
+/// Cache the context of a request whose envelope and Claims have already been
+/// verified.  This is the bridge for in-process VFS/CAS/MoQ APIs that carry a
+/// verified [`Subject`] but not the full [`EnvelopeContext`].
+///
+/// The cache is never an authority source: insertion requires the same
+/// `Claims × VerifiedKeyMaterial` derivation used by the RPC PEP, entries expire
+/// with the signed Claims, and lookup still passes through the activation
+/// control.
+pub fn remember_verified_subject(ctx: &EnvelopeContext) {
+    let Some(claims) = ctx.claims() else {
+        return;
+    };
+    let subject = ctx.subject();
+    remember_verified_claims(
+        &subject,
+        claims,
+        ctx.verified_key_material(),
+        ctx.verified_tenant(),
+    );
+}
+
+/// Cache an already-verified Claims binding for a lower-level PEP boundary
+/// that does not carry an [`EnvelopeContext`] (notably unified 9P attach).
+///
+/// The caller must invoke this only after signature, expiry, local-issuer,
+/// tenant, and sender-binding verification. The two-input derivation is
+/// repeated here so a Claims value alone can never create a subject context.
+pub fn remember_verified_claims(
+    subject: &Subject,
+    claims: &crate::auth::Claims,
+    key_material: VerifiedKeyMaterial,
+    verified_tenant: Option<&str>,
+) {
+    use super::SubjectContextClaims as _;
+
+    let Some(name) = subject.name() else {
+        return;
+    };
+    if claims.exp <= chrono::Utc::now().timestamp() {
+        return;
+    }
+    if claims.sub != name {
+        return;
+    }
+    let Some(context) = claims.security_context(key_material) else {
+        return;
+    };
+    verified_subjects().write().insert(
+        name.to_owned(),
+        VerifiedSubjectEntry {
+            context,
+            tenant: verified_tenant.map(str::to_owned),
+            expires_at: claims.exp,
+        },
+    );
+}
+
+/// Resolve a VFS/CAS/MoQ subject through the verified-Claims cache and current
+/// activation mode.  Tenant mismatch is a hard miss.
+#[must_use]
+pub fn subject_context(
+    subject: &Subject,
+    verified_tenant: Option<&str>,
+) -> Option<SecurityContext> {
+    let verified = subject.name().and_then(|name| {
+        let now = chrono::Utc::now().timestamp();
+        let mut subjects = verified_subjects().write();
+        let entry = subjects.get(name)?.clone();
+        if entry.expires_at <= now {
+            subjects.remove(name);
+            return None;
+        }
+        if let Some(expected) = verified_tenant {
+            if entry.tenant.as_deref() != Some(expected) {
+                return None;
+            }
+        }
+        Some(entry.context)
+    });
+    global_mac_activation_control().select_context(verified)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn report(complete: bool) -> GenesisReport {
+        GenesisReport {
+            labeled: vec!["/".to_owned()],
+            unlabeled: if complete {
+                Vec::new()
+            } else {
+                vec!["/gap".to_owned()]
+            },
+            ill_formed: Vec::new(),
+        }
+    }
+
+    #[test]
+    fn widening_requires_complete_coverage_and_narrowing_is_always_available() {
+        let control = MacActivationControl::default();
+        let incomplete = report(false);
+        let mut evidence = MacActivationEvidence {
+            genesis: &incomplete,
+            mediation_integrity_g2: true,
+            denial_handling_g4: true,
+            observability_g5: true,
+            runbook_signoff_g6: true,
+            revocation_reload_g7: true,
+        };
+        assert!(control.widen_identity_aware(&evidence).is_err());
+        assert_eq!(control.mode(), MacActivationMode::FloorOnly);
+        let complete = report(true);
+        evidence.genesis = &complete;
+        assert!(control.widen_identity_aware(&evidence).is_ok());
+        assert_eq!(control.mode(), MacActivationMode::IdentityAware);
+        control.narrow_to_floor();
+        assert_eq!(control.mode(), MacActivationMode::FloorOnly);
+    }
+}

--- a/crates/hyprstream-rpc/src/auth/mac/dispatch_pep.rs
+++ b/crates/hyprstream-rpc/src/auth/mac/dispatch_pep.rs
@@ -184,12 +184,27 @@ pub trait MacDispatchPep: Send + Sync {
 /// permissive PEP from these inputs.
 pub struct DefaultMacDispatchPep {
     resolver: Box<dyn RpcObjectLabelResolver>,
+    activation_controlled: bool,
 }
 
 impl DefaultMacDispatchPep {
     /// Construct with a specific object-label resolver.
     pub fn new(resolver: Box<dyn RpcObjectLabelResolver>) -> Self {
-        Self { resolver }
+        Self {
+            resolver,
+            activation_controlled: false,
+        }
+    }
+
+    /// Select subject contexts through the process-global coverage gate.
+    ///
+    /// Production constructors opt into this explicitly.  Direct unit-test
+    /// and embedding constructors retain their historical identity-aware
+    /// behavior so the operator gate cannot make unrelated PEP tests
+    /// order-dependent.
+    pub fn with_activation_control(mut self) -> Self {
+        self.activation_controlled = true;
+        self
     }
 
     /// Construct with the fail-closed [`DenyAllObjectResolver`].
@@ -209,8 +224,20 @@ impl MacDispatchPep for DefaultMacDispatchPep {
         service_domain: &str,
         method: Option<u16>,
     ) -> MacDecision {
-        // 1. Subject clearance (S1 two-input derivation: Claims × VerifiedKeyMaterial).
-        let Some(subject_ctx) = ctx.security_context() else {
+        // Preserve the verified context for the direct VFS/CAS/MoQ PEPs, whose
+        // low-level APIs carry Subject but not the full verified envelope.
+        super::activation::remember_verified_subject(ctx);
+
+        // 1. Subject clearance selected by the coverage-gated activation
+        // control. Floor-only uses anonymous_floor; identity-aware consumes the
+        // two-input Claims × VerifiedKeyMaterial derivation.
+        let subject_ctx = if self.activation_controlled {
+            super::activation::global_mac_activation_control()
+                .select_context(ctx.security_context())
+        } else {
+            ctx.security_context()
+        };
+        let Some(subject_ctx) = subject_ctx else {
             return MacDecision::Deny(MacDenyReason::NoClearance);
         };
 

--- a/crates/hyprstream-rpc/src/auth/mac/dispatch_pep.rs
+++ b/crates/hyprstream-rpc/src/auth/mac/dispatch_pep.rs
@@ -41,9 +41,9 @@
 //! ## Process-global installation
 //!
 //! Like the PQ trust store and compiled MAC policy, the PEP is installed at
-//! startup via [`install_mac_dispatch_pep`]. Until installed, MAC enforcement
-//! is dormant and dispatch remains a true pass-through. Once installed, every
-//! request is mediated and every installed-PEP denial is authoritative.
+//! startup via [`install_mac_dispatch_pep`]. Until installed, dispatch denies
+//! with [`MacDenyReason::NoPepInstalled`]. Once installed, every request is
+//! mediated and every installed-PEP denial is authoritative.
 
 use std::sync::Arc;
 
@@ -73,11 +73,8 @@ impl MacDecision {
 /// Why a MAC decision denied. Auditable and testable.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum MacDenyReason {
-    /// The explicitly installed deny-all PEP has no operational policy.
-    ///
-    /// An uninstalled PEP is the dormant, pass-through state and does not
-    /// produce this decision. [`DenyAllMacPep`] uses this reason when an
-    /// operator deliberately installs a fail-closed sentinel.
+    /// The process-global PEP has not been installed, or an operator
+    /// deliberately installed [`DenyAllMacPep`] as a fail-closed sentinel.
     NoPepInstalled,
     /// Subject has no derivable clearance (unlabeled subject).
     ///
@@ -147,9 +144,9 @@ impl RpcObjectLabelResolver for DenyAllObjectResolver {
 /// [`MacDecision::Deny`], the handler is never invoked — the error payload
 /// is signed and returned to the caller.
 ///
-/// If no PEP is installed process-globally, MAC enforcement is dormant and
-/// `process_request` passes through without calling this trait. Once installed,
-/// this check is mandatory and cannot be bypassed.
+/// If no PEP is installed process-globally, the dispatch wrapper denies with
+/// [`MacDenyReason::NoPepInstalled`]. Once installed, this check remains
+/// mandatory and cannot be bypassed.
 pub trait MacDispatchPep: Send + Sync {
     /// Check mandatory MAC access before handler dispatch.
     ///
@@ -258,9 +255,8 @@ impl MacDispatchPep for DefaultMacDispatchPep {
 /// A PEP that unconditionally denies.
 ///
 /// Install this explicitly when dispatch must fail closed before a real
-/// object-label resolver is available. Merely leaving the global PEP
-/// uninstalled keeps MAC enforcement dormant and preserves pre-activation RPC
-/// behavior.
+/// object-label resolver is available. Leaving the global PEP uninstalled is
+/// also fail-closed.
 #[derive(Debug, Default, Clone, Copy)]
 pub struct DenyAllMacPep;
 
@@ -285,9 +281,8 @@ static GLOBAL_PEP: parking_lot::RwLock<Option<Arc<dyn MacDispatchPep>>> =
 ///
 /// Production calls this exactly once at startup with a
 /// [`DefaultMacDispatchPep`] (or a production resolver). Until this is
-/// called, [`global_mac_dispatch_pep`] returns `None` and MAC enforcement is
-/// dormant: [`process_request`](crate::service::dispatch::process_request)
-/// remains a true pass-through.
+/// called, [`global_mac_dispatch_pep`] returns `None` and
+/// [`process_request`](crate::service::dispatch::process_request) denies.
 ///
 /// Backed by `parking_lot::RwLock` (no poisoning). Production callers SHOULD
 /// install exactly once; the security boundary is the PEP trait itself (a PEP
@@ -295,25 +290,23 @@ static GLOBAL_PEP: parking_lot::RwLock<Option<Arc<dyn MacDispatchPep>>> =
 ///
 /// # Activation gate (epic #1267)
 ///
-/// MAC enforcement is **off** until a PEP is installed. Activation is a
-/// deliberate operator choice. After activation, the installed PEP is
-/// mandatory and its missing-clearance, missing-label, and lattice-floor
-/// decisions fail closed.
+/// Identity-aware subject selection remains a deliberate operator choice, but
+/// mediation is never off. Before installation the structural sentinel denies;
+/// after installation the production PEP remains mandatory.
 pub fn install_mac_dispatch_pep(pep: Arc<dyn MacDispatchPep>) {
     *GLOBAL_PEP.write() = Some(pep);
 }
 
 /// The installed MAC dispatch PEP, if any.
 ///
-/// `None` on a node that has not activated MAC enforcement. Dispatch treats
-/// this dormant state as pass-through so installing the PEP remains an
-/// explicit activation boundary.
+/// `None` on a node that omitted installation. Dispatch treats this as a hard
+/// deny; installation is not an enforcement bypass boundary.
 #[must_use]
 pub fn global_mac_dispatch_pep() -> Option<Arc<dyn MacDispatchPep>> {
     GLOBAL_PEP.read().clone()
 }
 
-/// Check the installed dispatch PEP, or permit while enforcement is dormant.
+/// Check the installed dispatch PEP, or deny if installation was omitted.
 ///
 /// Once a PEP is installed, its result is returned unchanged: an installed
 /// fail-closed PEP cannot be bypassed by this wrapper.
@@ -325,7 +318,7 @@ pub fn check_dispatch_mac(
 ) -> MacDecision {
     match global_mac_dispatch_pep() {
         Some(pep) => pep.check(ctx, service_domain, method),
-        None => MacDecision::Permit,
+        None => MacDecision::Deny(MacDenyReason::NoPepInstalled),
     }
 }
 
@@ -450,13 +443,13 @@ mod tests {
     }
 
     #[test]
-    fn check_dispatch_mac_permits_while_pep_is_dormant() {
+    fn check_dispatch_mac_denies_while_pep_is_uninstalled() {
         reset_global_pep();
         assert!(global_mac_dispatch_pep().is_none());
 
         let ctx = ctx_with_clearance(Some(secret_label()));
         let decision = check_dispatch_mac(&ctx, "model", None);
-        assert_eq!(decision, MacDecision::Permit);
+        assert_eq!(decision, MacDecision::Deny(MacDenyReason::NoPepInstalled));
     }
 
     #[test]

--- a/crates/hyprstream-rpc/src/auth/mac/mod.rs
+++ b/crates/hyprstream-rpc/src/auth/mac/mod.rs
@@ -102,6 +102,8 @@
 //!    fail-closed, which is correct. No type change needed when #153 lands —
 //!    it's a new compartment/level value, not a new axis.
 
+#[cfg(not(target_arch = "wasm32"))]
+pub mod activation;
 pub mod bind;
 pub mod context;
 // #1268: the mandatory RPC dispatch PEP — fail-closed gate between
@@ -118,6 +120,12 @@ pub mod lattice;
 pub mod manifest;
 pub mod pep;
 
+#[cfg(not(target_arch = "wasm32"))]
+pub use activation::{
+    anonymous_floor, global_mac_activation_control, remember_verified_claims,
+    remember_verified_subject, subject_context, MacActivationControl, MacActivationError,
+    MacActivationEvidence, MacActivationMode,
+};
 pub use bind::{clamp_descendant, BindLabel, BindLabelMap};
 pub use context::{SecurityContext, SubjectContextClaims, VerifiedKeyMaterial};
 #[cfg(not(target_arch = "wasm32"))]

--- a/crates/hyprstream-rpc/src/auth/mac/mod.rs
+++ b/crates/hyprstream-rpc/src/auth/mac/mod.rs
@@ -122,9 +122,11 @@ pub mod pep;
 
 #[cfg(not(target_arch = "wasm32"))]
 pub use activation::{
-    anonymous_floor, global_mac_activation_control, remember_verified_claims,
-    remember_verified_subject, subject_context, MacActivationControl, MacActivationError,
-    MacActivationEvidence, MacActivationMode,
+    anonymous_floor, block_identity_widening_for_unverified_attach_transport,
+    flush_verified_subject_cache_generation, global_mac_activation_control,
+    remember_verified_claims, remember_verified_subject, revoke_verified_subject_jti,
+    subject_context, MacActivationControl, MacActivationError, MacActivationEvidence,
+    MacActivationMode,
 };
 pub use bind::{clamp_descendant, BindLabel, BindLabelMap};
 pub use context::{SecurityContext, SubjectContextClaims, VerifiedKeyMaterial};

--- a/crates/hyprstream-rpc/src/auth/mac/pep.rs
+++ b/crates/hyprstream-rpc/src/auth/mac/pep.rs
@@ -9,6 +9,7 @@
 
 use std::sync::Arc;
 
+#[cfg(not(target_arch = "wasm32"))]
 use super::dispatch_pep::{MacDecision, MacDenyReason, RpcObjectLabelResolver};
 use super::{SecurityContext, SecurityLabel};
 use crate::envelope::Subject;
@@ -41,6 +42,7 @@ pub trait ClearanceSource: Send + Sync {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum MoqMacAuditReason {
     /// A denial returned by the canonical shared MAC contract.
+    #[cfg(not(target_arch = "wasm32"))]
     Mac(MacDenyReason),
     /// An authorizer was installed, but moq-net exposed no per-track callback.
     ///
@@ -86,6 +88,7 @@ pub trait MoqMacAuditSink: Send + Sync {
 /// Dormancy is represented by the caller not installing this PEP. Every check
 /// on an installed instance is fail-closed.
 pub struct MoqEventPep {
+    #[cfg(not(target_arch = "wasm32"))]
     resolver: Arc<dyn RpcObjectLabelResolver>,
     clearance: Arc<dyn ClearanceSource>,
     audit: Arc<dyn MoqMacAuditSink>,
@@ -94,6 +97,7 @@ pub struct MoqEventPep {
 impl MoqEventPep {
     /// Construct an active, fail-closed PEP from the canonical object-label
     /// resolver, verified-subject clearance source, and mandatory audit sink.
+    #[cfg(not(target_arch = "wasm32"))]
     pub fn new(
         resolver: Arc<dyn RpcObjectLabelResolver>,
         clearance: Arc<dyn ClearanceSource>,
@@ -123,10 +127,11 @@ impl MoqEventPep {
             object_label,
             reason,
         };
-        if let Err(error) = self.audit.record_deny(&record) {
+        if let Err(_error) = self.audit.record_deny(&record) {
+            #[cfg(not(target_arch = "wasm32"))]
             tracing::error!(
                 target: "hyprstream.mac.audit",
-                %error,
+                error = %_error,
                 subject = ?record.subject,
                 object = %record.object,
                 action = ?record.action,
@@ -142,6 +147,7 @@ impl MoqEventPep {
     /// coordinate. MoQ/event checks have no browser method discriminator, so
     /// the resolver always receives `None`.
     #[must_use]
+    #[cfg(not(target_arch = "wasm32"))]
     pub fn check(
         &self,
         subject: &Subject,
@@ -205,6 +211,7 @@ impl MoqEventPep {
         );
     }
 
+    #[cfg(not(target_arch = "wasm32"))]
     pub fn resolver(&self) -> &Arc<dyn RpcObjectLabelResolver> {
         &self.resolver
     }
@@ -224,7 +231,7 @@ impl ClearanceSource for DenyAllClearanceSource {
     }
 }
 
-#[cfg(test)]
+#[cfg(all(test, not(target_arch = "wasm32")))]
 #[allow(clippy::unwrap_used)]
 mod tests {
     use super::*;

--- a/crates/hyprstream-rpc/src/events.rs
+++ b/crates/hyprstream-rpc/src/events.rs
@@ -32,7 +32,7 @@
 //! routing policy into each member grant.
 
 use std::collections::{HashMap, HashSet, VecDeque};
-use std::sync::Arc;
+use std::sync::{Arc, OnceLock};
 use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
 use anyhow::{anyhow, Result};
@@ -300,6 +300,30 @@ pub trait EventAuthz: Send + Sync {
     }
 }
 
+static EVENT_AUTHZ: OnceLock<Arc<dyn EventAuthz>> = OnceLock::new();
+
+fn installed_event_authz() -> Option<Arc<dyn EventAuthz>> {
+    EVENT_AUTHZ.get().cloned()
+}
+
+/// Whether the process-wide event reference monitor has been installed.
+#[must_use]
+pub fn event_authz_installed() -> bool {
+    EVENT_AUTHZ.get().is_some()
+}
+
+/// Install the process-wide production event authorization adapter.
+///
+/// This is one-shot because replacing a live reference monitor would create a
+/// policy gap between already-constructed and new publishers.
+pub fn install_event_authz(
+    authz: Arc<dyn EventAuthz>,
+) -> std::result::Result<(), &'static str> {
+    EVENT_AUTHZ
+        .set(authz)
+        .map_err(|_| "event authorization already installed")
+}
+
 /// Fail-closed authz: denies every publish/subscribe. The default for the
 /// encrypted (`ZeroKnowledge`/`LimitedKnowledge`) profile — MAC deny-by-default
 /// by construction. Production wires a real UCAN/capability-backed impl (S3/S4
@@ -487,8 +511,9 @@ impl EventPublisher {
             pq_signing_key: None,
             privacy_mode: EventPrivacy::Public,
             rekey_policy: RekeyPolicy::default(),
-            // Public firehose profile: no authz by design; identity N/A.
-            authz: Arc::new(AllowAllEventAuthz),
+            // Production installs the MAC adapter before constructing event
+            // publishers.  The fallback preserves direct test embeddings.
+            authz: installed_event_authz().unwrap_or_else(|| Arc::new(AllowAllEventAuthz)),
             publisher_identity: PublisherIdentity::anonymous(),
         })
     }
@@ -935,7 +960,7 @@ impl EventSubscriber {
             inner: MoqEventSubscriber::new(),
             prefixes: Arc::new(RwLock::new(HashMap::new())),
             tenant: Arc::new(RwLock::new(None)),
-            authz: Arc::new(AllowAllEventAuthz),
+            authz: installed_event_authz().unwrap_or_else(|| Arc::new(AllowAllEventAuthz)),
             caller: Subject::anonymous(),
         })
     }
@@ -1033,10 +1058,7 @@ impl EventSubscriber {
         let mut prefixes = self.prefixes.write().await;
         match prefixes.get(&key) {
             None => {
-                prefixes.insert(
-                    key,
-                    SubscriberPrefixState::Expected(Box::new(expectation)),
-                );
+                prefixes.insert(key, SubscriberPrefixState::Expected(Box::new(expectation)));
                 Ok(())
             }
             Some(SubscriberPrefixState::Expected(existing))
@@ -1422,12 +1444,10 @@ impl EventSubscriber {
     }
 
     async fn encrypted_prefix_key(&self, prefix: &str) -> Result<String, String> {
-        let tenant = self
-            .tenant
-            .read()
-            .await
-            .clone()
-            .ok_or_else(|| "confidential subscriber has no verified tenant binding".to_owned())?;
+        let tenant =
+            self.tenant.read().await.clone().ok_or_else(|| {
+                "confidential subscriber has no verified tenant binding".to_owned()
+            })?;
         Ok(tenant_prefix_key(&tenant, prefix))
     }
 }

--- a/crates/hyprstream-rpc/src/events.rs
+++ b/crates/hyprstream-rpc/src/events.rs
@@ -316,9 +316,7 @@ pub fn event_authz_installed() -> bool {
 ///
 /// This is one-shot because replacing a live reference monitor would create a
 /// policy gap between already-constructed and new publishers.
-pub fn install_event_authz(
-    authz: Arc<dyn EventAuthz>,
-) -> std::result::Result<(), &'static str> {
+pub fn install_event_authz(authz: Arc<dyn EventAuthz>) -> std::result::Result<(), &'static str> {
     EVENT_AUTHZ
         .set(authz)
         .map_err(|_| "event authorization already installed")
@@ -338,9 +336,8 @@ impl EventAuthz for DenyAllEventAuthz {
     }
 }
 
-/// Permissive authz: allows every publish/subscribe. For the public (`Public`)
-/// profile (the open firehose — no authz by design) and for tests until a real
-/// authz is wired.
+/// Explicit permissive authz for callers that deliberately construct a public
+/// firehose or a test fixture. It is never an implicit fallback.
 pub struct AllowAllEventAuthz;
 impl EventAuthz for AllowAllEventAuthz {
     fn can_publish(&self, _caller: &Subject, _prefix: &str) -> bool {
@@ -354,9 +351,8 @@ impl EventAuthz for AllowAllEventAuthz {
 /// Adapter from the canonical MAC contract to the event authorization surface.
 ///
 /// Constructing this type installs an active PEP, so all missing clearance or
-/// object labels fail closed. Public publishers/subscribers retain
-/// [`AllowAllEventAuthz`] until an operator explicitly installs this adapter;
-/// that dormant state is the canonical pre-activation pass-through.
+/// object labels fail closed. Uninstalled publishers/subscribers use
+/// [`DenyAllEventAuthz`], never a dormant permit fallback.
 pub struct MacEventAuthz {
     pep: MoqEventPep,
 }
@@ -448,9 +444,8 @@ pub struct EventPublisher {
     pq_signing_key: Option<MlDsaSigningKey>,
     privacy_mode: EventPrivacy,
     rekey_policy: RekeyPolicy,
-    /// Event-plane authz (EV4). `AllowAll` for the `Public` profile (open
-    /// firehose — no authz by design); `DenyAll` (fail-closed) for the
-    /// encrypted profile until a real UCAN/capability impl is wired via
+    /// Event-plane authz (EV4). Uninstalled state is `DenyAll`; an explicit
+    /// public firehose or test fixture must inject [`AllowAllEventAuthz`] via
     /// [`Self::with_authz`].
     authz: Arc<dyn EventAuthz>,
     /// Publisher's verified identity (EV4 authn-on-publish). `None` DID
@@ -511,9 +506,8 @@ impl EventPublisher {
             pq_signing_key: None,
             privacy_mode: EventPrivacy::Public,
             rekey_policy: RekeyPolicy::default(),
-            // Production installs the MAC adapter before constructing event
-            // publishers.  The fallback preserves direct test embeddings.
-            authz: installed_event_authz().unwrap_or_else(|| Arc::new(AllowAllEventAuthz)),
+            // An omitted production installation is a hard deny at rest.
+            authz: installed_event_authz().unwrap_or_else(|| Arc::new(DenyAllEventAuthz)),
             publisher_identity: PublisherIdentity::anonymous(),
         })
     }
@@ -946,8 +940,7 @@ pub struct EventSubscriber {
     prefixes: Arc<RwLock<HashMap<String, SubscriberPrefixState>>>,
     /// One verified tenant/domain per confidential subscriber instance.
     tenant: Arc<RwLock<Option<String>>>,
-    /// Dormant pass-through by default; an injected MAC adapter is active and
-    /// fail-closed.
+    /// Deny-all by default; an injected MAC adapter is active and fail-closed.
     authz: Arc<dyn EventAuthz>,
     /// Verified subscriber identity, or anonymous when the carrier has not
     /// supplied an independently authenticated application subject.
@@ -960,7 +953,7 @@ impl EventSubscriber {
             inner: MoqEventSubscriber::new(),
             prefixes: Arc::new(RwLock::new(HashMap::new())),
             tenant: Arc::new(RwLock::new(None)),
-            authz: installed_event_authz().unwrap_or_else(|| Arc::new(AllowAllEventAuthz)),
+            authz: installed_event_authz().unwrap_or_else(|| Arc::new(DenyAllEventAuthz)),
             caller: Subject::anonymous(),
         })
     }
@@ -1674,6 +1667,12 @@ mod tests {
         }
     }
 
+    fn permissive_test_subscriber() -> EventSubscriber {
+        EventSubscriber::new()
+            .unwrap()
+            .with_authz(Arc::new(AllowAllEventAuthz))
+    }
+
     async fn expect_confidential(
         subscriber: &EventSubscriber,
         prefix: &str,
@@ -1713,7 +1712,7 @@ mod tests {
         let ed = signing_key();
         let pq = crate::node_identity::derive_mesh_mldsa_key(&ed);
         let (grant, key) = grant_for(&recipient, &ed, &pq).await;
-        let subscriber = EventSubscriber::new().unwrap();
+        let subscriber = permissive_test_subscriber();
         expect_confidential(&subscriber, "worker", &ed, &pq).await;
         subscriber
             .install_epoch_grant("worker", &recipient, &grant, anchor(&ed, &pq), None, None)
@@ -1738,7 +1737,7 @@ mod tests {
     async fn expected_confidential_prefix_without_grant_drops_plaintext() {
         let ed = signing_key();
         let pq = crate::node_identity::derive_mesh_mldsa_key(&ed);
-        let subscriber = EventSubscriber::new().unwrap();
+        let subscriber = permissive_test_subscriber();
         expect_confidential(&subscriber, "worker", &ed, &pq).await;
 
         assert!(matches!(
@@ -1751,7 +1750,7 @@ mod tests {
     async fn contended_confidential_state_never_allows_passthrough() {
         let ed = signing_key();
         let pq = crate::node_identity::derive_mesh_mldsa_key(&ed);
-        let subscriber = EventSubscriber::new().unwrap();
+        let subscriber = permissive_test_subscriber();
         expect_confidential(&subscriber, "worker", &ed, &pq).await;
 
         let _held = subscriber.prefixes.write().await;
@@ -1825,8 +1824,8 @@ mod tests {
             .find(|grant| grant.subject_did == "did:web:member-b")
             .unwrap();
         assert!(crate::crypto::group_key::open_epoch_grant(&relay_recipient, grant_a_2).is_err());
-        let subscriber_a = EventSubscriber::new().unwrap();
-        let subscriber_b = EventSubscriber::new().unwrap();
+        let subscriber_a = permissive_test_subscriber();
+        let subscriber_b = permissive_test_subscriber();
         expect_confidential(&subscriber_a, "worker", &ed, &pq).await;
         expect_confidential(&subscriber_b, "worker", &ed, &pq).await;
         subscriber_a
@@ -1903,7 +1902,7 @@ mod tests {
         let ed = signing_key();
         let pq = crate::node_identity::derive_mesh_mldsa_key(&ed);
         let (grant, key) = grant_for(&recipient, &ed, &pq).await;
-        let subscriber = EventSubscriber::new().unwrap();
+        let subscriber = permissive_test_subscriber();
         expect_confidential(&subscriber, "worker", &ed, &pq).await;
         subscriber
             .install_epoch_grant("worker", &recipient, &grant, anchor(&ed, &pq), None, None)
@@ -1952,7 +1951,7 @@ mod tests {
         let ed = signing_key();
         let pq = crate::node_identity::derive_mesh_mldsa_key(&ed);
         let (grant, _) = grant_for(&recipient, &ed, &pq).await;
-        let subscriber = EventSubscriber::new().unwrap();
+        let subscriber = permissive_test_subscriber();
         expect_confidential(&subscriber, "worker", &ed, &pq).await;
         subscriber
             .install_epoch_grant("worker", &recipient, &grant, anchor(&ed, &pq), None, None)
@@ -1983,7 +1982,7 @@ mod tests {
         let ed = signing_key();
         let pq = crate::node_identity::derive_mesh_mldsa_key(&ed);
         let (grant, key) = grant_for(&recipient, &ed, &pq).await;
-        let subscriber = EventSubscriber::new().unwrap();
+        let subscriber = permissive_test_subscriber();
         expect_confidential(&subscriber, "worker", &ed, &pq).await;
         subscriber
             .install_epoch_grant("worker", &recipient, &grant, anchor(&ed, &pq), None, None)
@@ -2136,7 +2135,7 @@ mod tests {
         let ed = signing_key();
         let pq = crate::node_identity::derive_mesh_mldsa_key(&ed);
         let (grant, _) = grant_for(&recipient, &ed, &pq).await;
-        let subscriber = EventSubscriber::new().unwrap();
+        let subscriber = permissive_test_subscriber();
         expect_confidential(&subscriber, "worker", &ed, &pq).await;
         assert!(subscriber
             .install_epoch_grant("worker", &wrong, &grant, anchor(&ed, &pq), None, None)
@@ -2167,7 +2166,7 @@ mod tests {
     async fn confidential_subscriber_rejects_cross_tenant_rebinding() {
         let ed = signing_key();
         let pq = crate::node_identity::derive_mesh_mldsa_key(&ed);
-        let subscriber = EventSubscriber::new().unwrap();
+        let subscriber = permissive_test_subscriber();
         subscriber
             .expect_confidential_prefix(
                 "tenant-a",
@@ -2206,5 +2205,29 @@ mod tests {
             RekeyPolicy::default(),
         )
         .is_err());
+    }
+
+    #[tokio::test]
+    async fn uninstalled_public_event_authz_denies_at_rest() {
+        assert!(
+            !event_authz_installed(),
+            "unit-test process must not install the production singleton"
+        );
+        let origin = crate::moq_event::MoqEventOrigin::new();
+        let source = format!("uninstalled-authz-{}", rand::random::<u64>());
+        let moq = origin.publisher(&source).unwrap();
+        let publisher = EventPublisher::from_public_prefix(&source, moq).unwrap();
+        let error = publisher
+            .publish("object", "changed", b"payload")
+            .await
+            .unwrap_err();
+        assert!(error
+            .to_string()
+            .contains("publish denied by event-plane authz"));
+
+        let subscriber = EventSubscriber::new().unwrap();
+        assert!(!subscriber
+            .authz
+            .can_subscribe(&Subject::anonymous(), &source));
     }
 }

--- a/crates/hyprstream-rpc/src/service/dispatch.rs
+++ b/crates/hyprstream-rpc/src/service/dispatch.rs
@@ -216,8 +216,7 @@ where
         let signed_response = sign_response(error_payload)?;
 
         let mut message = Builder::new_default();
-        let mut builder =
-            message.init_root::<crate::common_capnp::response_envelope::Builder>();
+        let mut builder = message.init_root::<crate::common_capnp::response_envelope::Builder>();
         signed_response.write_to(&mut builder);
 
         let mut bytes = Vec::new();
@@ -235,10 +234,10 @@ where
     // lattice floor. Once installed, the PEP fails closed: missing clearance,
     // missing label, or lattice-floor deny ⇒ handler is never called.
     //
-    // **Activation gate (#1267):** until a node installs a PEP
-    // process-globally via `install_mac_dispatch_pep`, enforcement is dormant
-    // and this gate is a true pass-through. After activation, the installed
-    // PEP is mandatory and its decision is authoritative.
+    // **Activation gate (#1267):** identity-aware subject selection remains
+    // operator-gated, but mediation is mandatory at rest. Until a node installs
+    // a PEP process-globally via `install_mac_dispatch_pep`, this gate denies
+    // with `NoPepInstalled`; after installation its decision is authoritative.
     //
     // Streaming continuations: the continuation produced by a permitted
     // handler inherits this dispatch-time Permit. Explicit re-check of

--- a/crates/hyprstream-rpc/tests/e2e_iroh_transport.rs
+++ b/crates/hyprstream-rpc/tests/e2e_iroh_transport.rs
@@ -26,6 +26,8 @@
 //! Libtorch is NOT required (this is transport, not inference).
 #![allow(clippy::expect_used, clippy::unwrap_used)]
 
+mod support;
+
 use std::sync::Arc;
 
 use anyhow::{anyhow, Result};
@@ -391,6 +393,7 @@ impl RequestService for RegistryService {
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn rpc_round_trip_model_status_and_registry_list_over_iroh() -> Result<()> {
+    support::install_explicit_dispatch_pep();
     install_hybrid_verify_policy();
 
     // ─── Server: bind Iroh substrate serving `hyprstream-rpc/1` ──────────────
@@ -628,6 +631,7 @@ async fn anonymous_moq_handshake_over_iroh_is_rejected() -> Result<()> {
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn one_substrate_serves_rpc_and_rejects_anonymous_moq() -> Result<()> {
+    support::install_explicit_dispatch_pep();
     install_hybrid_verify_policy();
 
     // ─── Server: one substrate, two real handlers ───────────────────────────

--- a/crates/hyprstream-rpc/tests/inproc_bridged_e2e.rs
+++ b/crates/hyprstream-rpc/tests/inproc_bridged_e2e.rs
@@ -9,6 +9,8 @@
 //! regression where the bridge dropped/rejected continuations, silently breaking
 //! streaming services (model / tui).
 
+mod support;
+
 use std::sync::Arc;
 
 use anyhow::Result;
@@ -70,6 +72,7 @@ fn fresh_key() -> SigningKey {
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn inproc_bridged_round_trip_and_continuation_spawned() -> Result<()> {
+    support::install_explicit_dispatch_pep();
     let client_key = fresh_key();
     let client_pq = derive_mesh_mldsa_key(&client_key);
     let client_pq_vk = hyprstream_rpc::crypto::pq::ml_dsa_vk_from_bytes(

--- a/crates/hyprstream-rpc/tests/inv2_receive_dispatch.rs
+++ b/crates/hyprstream-rpc/tests/inv2_receive_dispatch.rs
@@ -14,6 +14,8 @@
 
 #![allow(clippy::unwrap_used, clippy::expect_used)]
 
+mod support;
+
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, OnceLock};
 
@@ -237,6 +239,7 @@ fn capnp_application_request(method_discriminator: u16) -> Vec<u8> {
 /// an exact request for A to B.
 #[tokio::test]
 async fn exact_same_key_request_is_bound_to_destination_service() {
+    support::install_explicit_dispatch_pep();
     let k = keys();
     let (service_a, invoked_a) = SentinelService::new_named(k.server_sk.clone(), "service-a");
     let (service_b, invoked_b) = SentinelService::new_named(k.server_sk.clone(), "service-b");
@@ -331,6 +334,7 @@ fn decode_response(bytes: &[u8]) -> ResponseEnvelope {
 
 #[tokio::test]
 async fn browser_dispatch_recovers_exact_bytes_and_rejects_post_refetch_advance() {
+    support::install_explicit_dispatch_pep();
     let k = keys();
     let verifier = browser_currentness();
     verifier.advanced.store(false, Ordering::SeqCst);
@@ -438,6 +442,7 @@ async fn cleartext_on_untrusted_carrier_rejected_before_handler() {
 /// not on the carrier.
 #[tokio::test]
 async fn encrypted_on_untrusted_carrier_dispatches() {
+    support::install_explicit_dispatch_pep();
     let k = keys();
     let (service, invoked) = SentinelService::new(k.server_sk.clone());
     let nonce_cache = envelope::InMemoryNonceCache::new();
@@ -520,6 +525,7 @@ async fn missing_response_recipient_drops_without_handler_on_all_network_carrier
 
 #[tokio::test]
 async fn post_admission_handler_error_is_sealed_not_cleartext() {
+    support::install_explicit_dispatch_pep();
     let k = keys();
     let (service, invoked) = SentinelService::new(k.server_sk.clone());
     let nonce_cache = envelope::InMemoryNonceCache::new();

--- a/crates/hyprstream-rpc/tests/iroh_rpc_e2e.rs
+++ b/crates/hyprstream-rpc/tests/iroh_rpc_e2e.rs
@@ -16,6 +16,8 @@
 //! suite over iroh) requires `services/factories.rs` wiring — tracked as
 //! Phase 2 part 3 of #133.
 
+mod support;
+
 use std::future::Future;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::{Arc, OnceLock};
@@ -235,6 +237,7 @@ where
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn hykem_encrypted_envelope_round_trip_over_iroh() -> Result<()> {
+    support::install_explicit_dispatch_pep();
     // ─── Server side ──────────────────────────────────────────────────────
     let server_signing = fresh_signing_key();
     let server_verifying: VerifyingKey = server_signing.verifying_key();

--- a/crates/hyprstream-rpc/tests/support/mod.rs
+++ b/crates/hyprstream-rpc/tests/support/mod.rs
@@ -1,0 +1,28 @@
+//! Explicit authorization fixtures shared by RPC integration tests.
+
+use std::sync::Arc;
+
+use hyprstream_rpc::auth::mac::{install_mac_dispatch_pep, MacDecision, MacDispatchPep};
+use hyprstream_rpc::service::EnvelopeContext;
+
+/// Install an explicit permit PEP for tests whose subject is transport or
+/// envelope mechanics rather than MAC policy.
+///
+/// Production's uninstalled state remains deny-at-rest. Each integration-test
+/// process must opt into this fixture before it expects handler dispatch.
+pub fn install_explicit_dispatch_pep() {
+    struct ExplicitFixturePep;
+
+    impl MacDispatchPep for ExplicitFixturePep {
+        fn check(
+            &self,
+            _ctx: &EnvelopeContext,
+            _service_domain: &str,
+            _method: Option<u16>,
+        ) -> MacDecision {
+            MacDecision::Permit
+        }
+    }
+
+    install_mac_dispatch_pep(Arc::new(ExplicitFixturePep));
+}

--- a/crates/hyprstream-rpc/tests/uds_rpc_e2e.rs
+++ b/crates/hyprstream-rpc/tests/uds_rpc_e2e.rs
@@ -14,6 +14,8 @@
 //! identity, and the signed response verifies back at the client — the same
 //! exit criterion the iroh canary proves, on the ipc transport.
 
+mod support;
+
 use std::sync::Arc;
 
 use anyhow::Result;
@@ -84,6 +86,7 @@ fn fresh_signing_key() -> SigningKey {
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn signed_envelope_round_trip_over_uds() -> Result<()> {
+    support::install_explicit_dispatch_pep();
     let client_signing = fresh_signing_key();
     let client_pq = derive_mesh_mldsa_key(&client_signing);
     let client_pq_vk = hyprstream_rpc::crypto::pq::ml_dsa_vk_from_bytes(

--- a/crates/hyprstream-workers/src/runtime/wanix_workload.rs
+++ b/crates/hyprstream-workers/src/runtime/wanix_workload.rs
@@ -322,10 +322,11 @@ pub async fn inject_9p_socket(
         // token gate, independent IFC dominance, then the local AVC/PDP).
         let mut translator = hyprstream_9p::Translator::from_mount(mount, subject, decider);
         if let Some(monitor) = monitor {
-            translator = translator.with_reference_monitor(monitor);
+            translator = translator
+                .with_reference_monitor(monitor)
+                .with_activation_control();
         }
-        if let Err(e) = translator.serve_uds(listener).await
-        {
+        if let Err(e) = translator.serve_uds(listener).await {
             warn!(socket = %sock_for_log.display(), error = %e, "9P workload server exited with error");
         }
     });
@@ -804,14 +805,8 @@ mod tests {
                 "expected Rversion from the injected 9P server"
             );
 
-            c.write_all(&hyprstream_9p::msg::tattach(
-                2,
-                0,
-                u32::MAX,
-                "wanix",
-                "",
-            ))
-            .unwrap();
+            c.write_all(&hyprstream_9p::msg::tattach(2, 0, u32::MAX, "wanix", ""))
+                .unwrap();
             read_frame(&mut c)[4]
         })
         .await

--- a/crates/hyprstream/src/bin/main.rs
+++ b/crates/hyprstream/src/bin/main.rs
@@ -2080,7 +2080,11 @@ fn main() -> Result<()> {
                     // standalone, and the systemd/spawner dispatch below.
                     // Emit the coverage-gate evidence consumed by the active
                     // 9P translator PEP (see `mac::genesis`).
-                    hyprstream_core::mac::GenesisGate::production().log_report();
+                    let mac_gate = hyprstream_core::mac::GenesisGate::production();
+                    mac_gate.log_report();
+                    // Installation is activation-ready but remains floor-only.
+                    // Only the explicit G1-G7 operator control may widen it.
+                    hyprstream_core::mac::install_production_rpc_dispatch_pep();
 
                     if foreground || standalone {
                         // --foreground requires a service name or --services list;
@@ -2551,6 +2555,34 @@ fn main() -> Result<()> {
                                 // Policy: Hybrid is mandatory. With no anchored
                                 // peer key the verifier FAILS CLOSED.
                                 install_envelope_verify_config(Some(&config.oauth));
+
+                                // Install MoQ/event authorization in every
+                                // production service process before any model,
+                                // worker, workflow, or system publisher can be
+                                // constructed. In multi-process mode only the
+                                // event origin lives in the `event` process;
+                                // authorization still belongs at each local
+                                // publisher/subscriber choke point.
+                                if !hyprstream_rpc::events::event_authz_installed() {
+                                    let audit_stream =
+                                        format!("moq-event-{}", service_names.join("-"));
+                                    let pep =
+                                        hyprstream_core::mac::production_moq_event_pep(
+                                            signing_key.clone(),
+                                            &config.oauth,
+                                            &audit_stream,
+                                        )
+                                        .await
+                                        .context(
+                                            "construct process-wide MoQ/event MAC PEP",
+                                        )?;
+                                    hyprstream_rpc::events::install_event_authz(
+                                        std::sync::Arc::new(
+                                            hyprstream_rpc::events::MacEventAuthz::new(pep),
+                                        ),
+                                    )
+                                    .map_err(anyhow::Error::msg)?;
+                                }
 
                                 let manager = InprocManager::new();
                                 let mut handles = Vec::new();

--- a/crates/hyprstream/src/bin/main.rs
+++ b/crates/hyprstream/src/bin/main.rs
@@ -1211,9 +1211,19 @@ fn handle_quick_command(
                         // #1269: install the full ReferenceMonitor at every
                         // production 9P constructor. Fail-closed until #698
                         // wires clearance issuance + S6 token path.
-                        let ninep_monitor = Some(hyprstream_core::mac::enrollment_ninep_reference_monitor(
-                            Arc::clone(&ninep_decider),
-                        ));
+                        // This worker transport still carries no verified
+                        // attach credential. Register the live UDS/vsock seam
+                        // as a structural G2 blocker before constructing its
+                        // deny-only authenticator; a late registration also
+                        // narrows an already-widened process.
+                        hyprstream_rpc::auth::mac::block_identity_widening_for_unverified_attach_transport(
+                            "worker-uds-vsock",
+                        );
+                        let ninep_monitor = Some(
+                            hyprstream_core::mac::enrollment_ninep_reference_monitor(Arc::clone(
+                                &ninep_decider,
+                            )),
+                        );
                         let backend_ctx = BackendCtx {
                             pool_config: pool_config.clone(),
                             ninep_decider,

--- a/crates/hyprstream/src/cli/shell_handlers.rs
+++ b/crates/hyprstream/src/cli/shell_handlers.rs
@@ -306,10 +306,19 @@ pub async fn handle_shell_tui(
     // `/srv/registry` (+ `/worktree` alias) — the TUI ChatApp builder does
     // not currently have one and omits it.
     let vfs_ns: std::sync::Arc<hyprstream_vfs::Namespace> = {
+        let config = crate::config::HyprConfig::load().unwrap_or_default();
+        let pep = crate::mac::production_vfs_pep(
+            signing_key.clone(),
+            &config.oauth,
+            "vfs-shell",
+        )
+        .await
+        .context("construct shell VFS MAC PEP")?;
         let ns = crate::services::build_standard_namespace(crate::services::StandardNamespaceConfig {
             subject: vfs_subject.clone(),
             model_client: model_client.clone(),
             registry: Some(Clone::clone(&registry)),
+            pep: Some(pep),
             model_path: "/srv/model".to_owned(),
             registry_path: "/srv/registry".to_owned(),
             worktree_path: "/worktree".to_owned(),

--- a/crates/hyprstream/src/mac/cas_pep.rs
+++ b/crates/hyprstream/src/mac/cas_pep.rs
@@ -57,6 +57,8 @@
 
 use std::sync::Arc;
 
+use anyhow::Context as _;
+use ed25519_dalek::SigningKey;
 use hyprstream_rpc::auth::mac::{
     MacDecision, MacDenyReason, RpcObjectLabelResolver, SecurityContext, SecurityLabel,
 };
@@ -207,6 +209,24 @@ impl CasClearanceSource for DenyAllClearanceSource {
         _verified_tenant: Option<&str>,
     ) -> Option<SecurityContext> {
         None
+    }
+}
+
+/// Production CAS clearance source backed only by contexts derived from
+/// verified `Claims × VerifiedKeyMaterial` at an RPC/attach boundary.
+#[derive(Debug, Default, Clone, Copy)]
+pub struct VerifiedClaimsCasClearanceSource;
+
+impl CasClearanceSource for VerifiedClaimsCasClearanceSource {
+    fn clearance_for(
+        &self,
+        subject_id: &str,
+        verified_tenant: Option<&str>,
+    ) -> Option<SecurityContext> {
+        hyprstream_rpc::auth::mac::subject_context(
+            &Subject::new(subject_id.to_owned()),
+            verified_tenant,
+        )
     }
 }
 
@@ -440,6 +460,43 @@ impl crate::storage::cas::CasMountAuthorizer for MacCasAuthorizer {
             )))
         }
     }
+}
+
+/// Assemble the production CAS PEP from verified subject contexts and a
+/// tamper-evident signed WAL.  Failure to obtain either signing key aborts the
+/// production constructor; it never substitutes the test-only null sink.
+pub async fn production_cas_pep(
+    signing_key: SigningKey,
+    oauth: &crate::config::OAuthConfig,
+    audit_stream: &str,
+) -> anyhow::Result<Arc<CasPep>> {
+    anyhow::ensure!(
+        !audit_stream.is_empty()
+            && audit_stream
+                .bytes()
+                .all(|byte| byte.is_ascii_alphanumeric() || byte == b'-' || byte == b'_'),
+        "invalid CAS MAC audit stream name"
+    );
+    let secrets_dir = crate::config::HyprConfig::resolve_secrets_dir()?;
+    let ml_dsa_store = crate::auth::key_rotation::global_ml_dsa_key_store(&secrets_dir, oauth);
+    let signer = crate::mac::audit::cose::OwnedCoseAuditSigner::new(
+        Arc::new(signing_key),
+        ml_dsa_store.active_key().await,
+        hyprstream_rpc::envelope::mandatory_envelope_policy(),
+    );
+    anyhow::ensure!(
+        signer.can_sign(),
+        "CAS MAC PEP audit signer unavailable under mandatory Hybrid policy"
+    );
+    let audit_store = crate::mac::audit::WalAuditStore::open(
+        secrets_dir.join("mac-audit").join(audit_stream),
+        signer,
+    )
+    .context("open CAS MAC audit store")?;
+    Ok(Arc::new(CasPep::new(
+        Arc::new(VerifiedClaimsCasClearanceSource),
+        Arc::new(audit_store),
+    )))
 }
 
 // ────────────────────────────────────────────────────────────────────────────

--- a/crates/hyprstream/src/mac/genesis.rs
+++ b/crates/hyprstream/src/mac/genesis.rs
@@ -646,7 +646,7 @@ impl GenesisGate {
             tracing::info!(
                 nodes = self.nodes.len(),
                 labeled = r.labeled.len(),
-                "MAC genesis coverage COMPLETE (dormant): every enumerated node is labeled and well-formed"
+                "MAC genesis coverage COMPLETE: floor-only monitors remain active; operator may evaluate the remaining G2-G7 evidence"
             );
         } else {
             tracing::warn!(
@@ -654,7 +654,7 @@ impl GenesisGate {
                 labeled = r.labeled.len(),
                 unlabeled = r.unlabeled.len(),
                 ill_formed = r.ill_formed.len(),
-                "MAC genesis coverage INCOMPLETE (dormant): enforcement must NOT be enabled until gaps are closed"
+                "MAC genesis coverage INCOMPLETE: identity-aware widening is blocked; floor-only monitors remain active"
             );
             for node in &r.unlabeled {
                 tracing::warn!(node = %node, "MAC genesis gap: unlabeled node (would deny under enforcement)");
@@ -680,7 +680,7 @@ impl GenesisGate {
         };
         let _ = writeln!(
             out,
-            "MAC genesis coverage: {status} (enforcement dormant — Stage 0)"
+            "MAC genesis coverage: {status} (monitors active; subject context floor-only until operator widening)"
         );
         let _ = writeln!(
             out,

--- a/crates/hyprstream/src/mac/mod.rs
+++ b/crates/hyprstream/src/mac/mod.rs
@@ -119,6 +119,27 @@ pub fn install_production_rpc_dispatch_pep() {
             .with_activation_control(),
     ));
 }
+
+/// Explicit permit fixture for unit tests that exercise service plumbing
+/// rather than MAC policy. Production's uninstalled dispatch state still
+/// denies at rest.
+#[cfg(test)]
+pub(crate) fn install_explicit_test_dispatch_pep() {
+    struct ExplicitTestPep;
+
+    impl hyprstream_rpc::auth::mac::MacDispatchPep for ExplicitTestPep {
+        fn check(
+            &self,
+            _ctx: &hyprstream_rpc::service::EnvelopeContext,
+            _service_domain: &str,
+            _method: Option<u16>,
+        ) -> hyprstream_rpc::auth::mac::MacDecision {
+            hyprstream_rpc::auth::mac::MacDecision::Permit
+        }
+    }
+
+    hyprstream_rpc::auth::mac::install_mac_dispatch_pep(std::sync::Arc::new(ExplicitTestPep));
+}
 // S5 (#571): the UCAN→TE policy compiler — compile a validated grant into a
 // CompiledPolicy, verify it grants no privilege beyond the grant, and sign it
 // (fail-closed). Lives here (not `hyprstream-rpc`) because it needs both the UCAN

--- a/crates/hyprstream/src/mac/mod.rs
+++ b/crates/hyprstream/src/mac/mod.rs
@@ -108,6 +108,17 @@ pub use te::{
     Action, Decision, LatticeTeEvaluator, ObjectCtx, ObjectType, ScopeAction, SubjectCtx,
     SubjectType, TeEvaluator, TeMatrix, TeRule,
 };
+
+/// Install the mandatory RPC-dispatch PEP in its activation-ready, floor-only
+/// state.  The coverage-gated operator control selects identity-aware contexts;
+/// installing this monitor does not perform that widening.
+pub fn install_production_rpc_dispatch_pep() {
+    let resolver = GenesisGate::production().into_resolver();
+    hyprstream_rpc::auth::mac::install_mac_dispatch_pep(std::sync::Arc::new(
+        hyprstream_rpc::auth::mac::DefaultMacDispatchPep::new(Box::new(resolver))
+            .with_activation_control(),
+    ));
+}
 // S5 (#571): the UCAN→TE policy compiler — compile a validated grant into a
 // CompiledPolicy, verify it grants no privilege beyond the grant, and sign it
 // (fail-closed). Lives here (not `hyprstream-rpc`) because it needs both the UCAN
@@ -121,7 +132,10 @@ pub use genesis::{
     floor_label, genesis_lattice, CompositeObjectLabelResolver, GeneratedNodeCoverage, GenesisGate,
     ManifestLabelSource, NamespaceEnumerator, NoManifests, SitePolicy,
 };
-pub use moq_audit::{audited_moq_event_pep, MoqAuditSinkAdapter};
+pub use moq_audit::{
+    audited_moq_event_pep, production_moq_event_pep, MoqAuditSinkAdapter,
+    VerifiedClaimsMoqClearanceSource,
+};
 pub use pds_pep::{
     production_pds_account_read_authorizer, EnrollmentPdsClearanceSource,
     PdsAccountObjectLabelResolver, PdsAccountReadPep, PdsClearanceSource,
@@ -130,13 +144,13 @@ pub use pds_pep::{
 pub use pds_pep::{production_pds_account_record_store, PdsDirectoryMount};
 // #1270: CAS-native MAC PEP — the shared CAS enforcement contract.
 pub use cas_pep::{
-    domain_label, seal_label, CasClearanceSource, CasObjectLabelResolver, CasPep,
-    DenyAllClearanceSource, MacCasAuthorizer,
+    domain_label, production_cas_pep, seal_label, CasClearanceSource, CasObjectLabelResolver,
+    CasPep, DenyAllClearanceSource, MacCasAuthorizer, VerifiedClaimsCasClearanceSource,
 };
 pub use pep::{
     enrollment_ninep_reference_monitor, production_ninep_decider,
-    production_ninep_reference_monitor, production_vfs_pep, DenyUnenrolledSubjects,
-    EnrollmentClearanceSource, NinePAccessDecider, NinePClearanceSource,
+    production_ninep_reference_monitor, production_vfs_pep, EnrollmentClearanceSource,
+    NinePAccessDecider, NinePClearanceSource, VerifiedClaimsSubjects,
     VerifiedClearanceSessionFactory, VfsAccessDecider,
 };
 // S4 (#570): the boot path that installs the verified `CompiledPolicy` at daemon

--- a/crates/hyprstream/src/mac/moq_audit.rs
+++ b/crates/hyprstream/src/mac/moq_audit.rs
@@ -8,10 +8,13 @@
 use std::sync::Arc;
 use std::time::{SystemTime, UNIX_EPOCH};
 
+use anyhow::Context as _;
+use ed25519_dalek::SigningKey;
 use hyprstream_rpc::auth::mac::{
     ClearanceSource, MacDenyReason, MoqEventAction, MoqEventPep, MoqMacAuditReason,
     MoqMacAuditRecord, MoqMacAuditSink, RpcObjectLabelResolver, SecurityLabel,
 };
+use hyprstream_rpc::envelope::Subject;
 
 use crate::mac::audit::{AuditRecord, AuditSink, DecisionReason};
 use crate::mac::te::{Action, Decision, ObjectType, ScopeAction, SubjectType};
@@ -77,6 +80,55 @@ pub fn audited_moq_event_pep(
         clearance,
         Arc::new(MoqAuditSinkAdapter::new(sink)),
     )
+}
+
+/// Assemble the production MoQ/event PEP from the genesis resolver, verified
+/// subject contexts, and the mandatory signed audit WAL.
+pub async fn production_moq_event_pep(
+    signing_key: SigningKey,
+    oauth: &crate::config::OAuthConfig,
+    audit_stream: &str,
+) -> anyhow::Result<MoqEventPep> {
+    anyhow::ensure!(
+        !audit_stream.is_empty()
+            && audit_stream
+                .bytes()
+                .all(|byte| byte.is_ascii_alphanumeric() || byte == b'-' || byte == b'_'),
+        "invalid MoQ MAC audit stream name"
+    );
+    let secrets_dir = crate::config::HyprConfig::resolve_secrets_dir()?;
+    let ml_dsa_store = crate::auth::key_rotation::global_ml_dsa_key_store(&secrets_dir, oauth);
+    let signer = crate::mac::audit::cose::OwnedCoseAuditSigner::new(
+        Arc::new(signing_key),
+        ml_dsa_store.active_key().await,
+        hyprstream_rpc::envelope::mandatory_envelope_policy(),
+    );
+    anyhow::ensure!(
+        signer.can_sign(),
+        "MoQ MAC PEP audit signer unavailable under mandatory Hybrid policy"
+    );
+    let audit_store = crate::mac::audit::WalAuditStore::open(
+        secrets_dir.join("mac-audit").join(audit_stream),
+        signer,
+    )
+    .context("open MoQ MAC audit store")?;
+    let resolver = crate::mac::GenesisGate::production().into_resolver();
+    Ok(audited_moq_event_pep(
+        Arc::new(resolver),
+        Arc::new(VerifiedClaimsMoqClearanceSource),
+        Arc::new(audit_store),
+    ))
+}
+
+/// Event/MoQ subject resolver backed by the same verified-Claims cache as the
+/// direct VFS and CAS PEPs.
+#[derive(Debug, Default, Clone, Copy)]
+pub struct VerifiedClaimsMoqClearanceSource;
+
+impl ClearanceSource for VerifiedClaimsMoqClearanceSource {
+    fn clearance(&self, subject: &Subject) -> Option<hyprstream_rpc::auth::mac::SecurityContext> {
+        hyprstream_rpc::auth::mac::subject_context(subject, None)
+    }
 }
 
 const fn audit_action(action: MoqEventAction) -> Action {
@@ -170,10 +222,7 @@ mod tests {
         assert_eq!(records[0].reason, DecisionReason::UnlabeledObject);
         assert_eq!(records[0].subject_type, SubjectType(u32::MAX - 4));
         assert_eq!(records[0].object_type, ObjectType(u32::MAX - 4));
-        assert_eq!(
-            records[0].subject_id.as_deref(),
-            Some("did:web:tenant-a")
-        );
+        assert_eq!(records[0].subject_id.as_deref(), Some("did:web:tenant-a"));
         assert_eq!(
             records[0].object_id.as_deref(),
             Some("tenant-b/events/private")

--- a/crates/hyprstream/src/mac/pep.rs
+++ b/crates/hyprstream/src/mac/pep.rs
@@ -12,15 +12,11 @@
 //! [`ReferenceMonitor`](hyprstream_9p::ReferenceMonitor) from the mandatory
 //! decider, the genesis content-truth resolver, and an attach authenticator.
 //! Production 9P constructors install the monitor via
-//! `Translator::with_reference_monitor`; until the verified attach credential
-//! is wired into that seam they explicitly install a deny-only authenticator.
-//!
-//! **Fail-closed until #698 + S6 wire clearance and token issuance**: the
-//! raw `Tattach.uname` is not verified identity material, and the S6
-//! sender-bound token is not yet attached to 9P `Tattach`. So the installed
-//! monitor denies every operation — there is no permissive default (per #547).
-//! Functional permitting requires an authenticator that derives both identity
-//! and tenant from verified attach credentials.
+//! `Translator::with_reference_monitor`. HTTP and WebTransport attach paths
+//! now supply one unified verified attach bundle; transports without a
+//! credential carrier explicitly retain the deny-only authenticator. The
+//! operator gate selects floor-only or identity-aware context without removing
+//! this monitor.
 
 use std::sync::Arc;
 use std::time::{SystemTime, UNIX_EPOCH};
@@ -133,8 +129,7 @@ pub async fn production_ninep_decider(
     );
 
     let secrets_dir = crate::config::HyprConfig::resolve_secrets_dir()?;
-    let ml_dsa_store =
-        crate::auth::key_rotation::global_ml_dsa_key_store(&secrets_dir, oauth);
+    let ml_dsa_store = crate::auth::key_rotation::global_ml_dsa_key_store(&secrets_dir, oauth);
     let signer = crate::mac::audit::cose::OwnedCoseAuditSigner::new(
         Arc::new(signing_key),
         ml_dsa_store.active_key().await,
@@ -526,29 +521,16 @@ impl NamespaceAccessDecider for VfsAccessDecider {
     }
 }
 
-/// Fail-closed `SubjectContextResolver` for the VFS PEP (#698 dependency
-/// window).
-///
-/// The direct `Namespace` API carries only an unauthenticated `Subject` string
-/// — it has no verified `EnvelopeContext`/claims the way the RPC dispatch
-/// plane does (#1268 owns threading those through). Until production clearance
-/// provenance (#698) wires a real resolver (e.g. one keyed on the installed
-/// `CompiledPolicy` enrollment table, mirroring
-/// [`EnrollmentSubjectContextResolver`]), this stub resolves **no** subject,
-/// so an armed VFS PEP denies every op — the correct fail-closed posture
-/// (#547: no permissive default).
-///
-/// Replacing this with a real resolver is the activation B-lane (#1267), not
-/// this struct's existence.
+/// Production VFS resolver backed by contexts derived only at verified
+/// `Claims × VerifiedKeyMaterial` boundaries. Missing, expired, or
+/// tenant-incompatible entries deny; the activation control supplies the
+/// anonymous floor until an operator-approved widening.
 #[derive(Debug, Default, Clone, Copy)]
-pub struct DenyUnenrolledSubjects;
+pub struct VerifiedClaimsSubjects;
 
-impl SubjectContextResolver for DenyUnenrolledSubjects {
-    fn resolve(
-        &self,
-        _subject: &hyprstream_rpc::Subject,
-    ) -> Option<SecurityContext> {
-        None
+impl SubjectContextResolver for VerifiedClaimsSubjects {
+    fn resolve(&self, subject: &hyprstream_rpc::Subject) -> Option<SecurityContext> {
+        hyprstream_rpc::auth::mac::subject_context(subject, None)
     }
 }
 
@@ -558,10 +540,9 @@ impl SubjectContextResolver for DenyUnenrolledSubjects {
 /// This is the `hyprstream`-crate wiring that satisfies the
 /// [`hyprstream_vfs::NamespacePep`] contract: the genesis composite
 /// `RpcObjectLabelResolver` (carriers (a)+(c), #1228) feeds label resolution, a
-/// [`VfsAccessDecider`] over the WAL audit sink evaluates the policy, and —
-/// pending #698 — the subject seam is [`DenyUnenrolledSubjects`] (fail-closed:
-/// every op denies until clearance provenance is wired). Swapping the subject
-/// resolver for a real one is the activation B-lane (#1267).
+/// [`VfsAccessDecider`] over the WAL audit sink evaluates the policy, and
+/// [`VerifiedClaimsSubjects`] supplies the activation-controlled subject
+/// context.
 ///
 /// Callers propagate the error and refuse to arm a `Namespace` with a
 /// permissive fallback; there is no permissive arm path.
@@ -579,8 +560,7 @@ pub async fn production_vfs_pep(
     );
 
     let secrets_dir = crate::config::HyprConfig::resolve_secrets_dir()?;
-    let ml_dsa_store =
-        crate::auth::key_rotation::global_ml_dsa_key_store(&secrets_dir, oauth);
+    let ml_dsa_store = crate::auth::key_rotation::global_ml_dsa_key_store(&secrets_dir, oauth);
     let signer = crate::mac::audit::cose::OwnedCoseAuditSigner::new(
         Arc::new(signing_key),
         ml_dsa_store.active_key().await,
@@ -599,7 +579,7 @@ pub async fn production_vfs_pep(
     let resolver = crate::mac::GenesisGate::production().into_resolver();
 
     Ok(std::sync::Arc::new(hyprstream_vfs::NamespacePep::new(
-        std::sync::Arc::new(DenyUnenrolledSubjects),
+        std::sync::Arc::new(VerifiedClaimsSubjects),
         std::sync::Arc::new(resolver),
         std::sync::Arc::new(VfsAccessDecider::new(std::sync::Arc::new(audit_store))),
     )))
@@ -799,16 +779,9 @@ mod tests {
             read_token(),
         );
 
+        assert!(!monitor.authorize(&permitted, &["unlabeled".to_owned()], NinePAction::Read,));
         assert!(!monitor.authorize(
-            &permitted,
-            &["unlabeled".to_owned()],
-            NinePAction::Read,
-        ));
-        assert!(!monitor.authorize(
-            &SessionContext::from_verified_clearance(
-                identity("tenant-a"),
-                context(Level::Secret),
-            ),
+            &SessionContext::from_verified_clearance(identity("tenant-a"), context(Level::Secret),),
             &["public".to_owned()],
             NinePAction::Read,
         ));
@@ -821,11 +794,7 @@ mod tests {
             &["secret".to_owned()],
             NinePAction::Read,
         ));
-        assert!(!monitor.authorize(
-            &permitted,
-            &["decider-deny".to_owned()],
-            NinePAction::Read,
-        ));
+        assert!(!monitor.authorize(&permitted, &["decider-deny".to_owned()], NinePAction::Read,));
 
         let records = sink.records.lock();
         assert_eq!(records.len(), 4, "one WAL record per denied operation");
@@ -850,14 +819,13 @@ mod tests {
         ));
         let monitor = enrollment_ninep_reference_monitor(decider);
 
-        let session = monitor
+        let denied = monitor
             .authenticate("did:key:victim", "tenant-victim")
             .await;
         assert!(
-            session.verified_attach_identity().is_none(),
-            "unverified Tattach fields must not mint identity or tenant"
+            denied.is_err(),
+            "unverified Tattach fields must not mint an attach bundle"
         );
-        assert!(!session.token_authorizes(&label(Level::Public), NinePAction::Read));
     }
 
     #[test]
@@ -913,7 +881,9 @@ mod tests {
 
         let records = sink.records.lock();
         assert_eq!(records.len(), 4);
-        assert!(records.iter().all(|record| record.decision == Decision::Deny));
+        assert!(records
+            .iter()
+            .all(|record| record.decision == Decision::Deny));
         assert_eq!(records[0].reason, DecisionReason::NoClearance);
         assert_eq!(records[1].reason, DecisionReason::UnlabeledObject);
         assert_eq!(records[2].reason, DecisionReason::FloorDeny);

--- a/crates/hyprstream/src/server/middleware.rs
+++ b/crates/hyprstream/src/server/middleware.rs
@@ -59,10 +59,7 @@ impl AuthenticatedUser {
                 && tenant != ".."
                 && tenant != "*"
                 && tenant.bytes().all(|byte| {
-                    byte.is_ascii_alphanumeric()
-                        || byte == b'-'
-                        || byte == b'_'
-                        || byte == b'.'
+                    byte.is_ascii_alphanumeric() || byte == b'-' || byte == b'_' || byte == b'.'
                 });
             if !valid_component {
                 return Err("invalid verified tenant");
@@ -559,8 +556,9 @@ pub(crate) async fn verify_resource_token_claims(
         }
     }
 
-    // Federation is trusted for identity, never for choosing a local PDS/Casbin
-    // tenant. Only this node's OAuth authority may assert the hosted binding.
+    // Federation is trusted for identity, never for choosing a local
+    // PDS/Casbin tenant or asserting local MAC clearance.
+    claims.strip_federated_clearance(local_issuers);
     claims.strip_federated_tenant(local_issuers);
     Ok(claims)
 }
@@ -1090,10 +1088,7 @@ mod tests {
             exp: None,
         };
 
-        assert_eq!(
-            alice.authorization_domain().unwrap(),
-            "acme.example"
-        );
+        assert_eq!(alice.authorization_domain().unwrap(), "acme.example");
         assert_eq!(alice.authorization_domain(), bob.authorization_domain());
         assert_ne!(alice.authorization_domain().unwrap(), alice.user);
     }

--- a/crates/hyprstream/src/server/routes/ninep.rs
+++ b/crates/hyprstream/src/server/routes/ninep.rs
@@ -47,7 +47,7 @@
 
 use std::collections::BTreeMap;
 use std::sync::Arc;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use async_trait::async_trait;
 use axum::{
@@ -60,7 +60,11 @@ use axum::{
     Json,
 };
 use futures::{SinkExt, StreamExt};
-use hyprstream_9p::{AttachAuthorizer, Translator};
+use hyprstream_9p::{
+    Action as NinePAction, AttachAuthorizer, SessionContext, Translator, VerifiedAttach,
+    VerifiedAttachIdentity, VerifiedTokenScope,
+};
+use hyprstream_rpc::auth::mac::{SubjectContextClaims as _, VerifiedKeyMaterial};
 use hyprstream_rpc::transport::quinn_transport::{NinePWtHandler, NinePWtStream};
 use hyprstream_rpc::Subject;
 use hyprstream_vfs::{Mount, MountError, SyntheticMount, SyntheticNode};
@@ -273,7 +277,7 @@ pub async fn ninep_ws(
         }
     };
 
-    let subject =
+    let verified =
         match validate_ticket(&state, ticket, &headers, PLANE_WS, ROOT_NAMESPACE_PATH).await {
             Ok(s) => s,
             Err(reason) => {
@@ -282,18 +286,23 @@ pub async fn ninep_ws(
             }
         };
 
-    let mount = build_export_mount(&state, &subject);
-    // #1269: install the full ReferenceMonitor — the anonymous_floor() fallback
-    // is unreachable from this production constructor. Fail-closed until #698
-    // wires clearance issuance and the S6 token path mints a sender-bound token.
-    let monitor = crate::mac::enrollment_ninep_reference_monitor(Arc::clone(
-        &state.ninep_decider,
-    ));
+    let mount = build_export_mount(&state, verified.subject());
+    // Install the full monitor with the same VerifiedAttach bundle already
+    // derived from the mount ticket. The operator control starts floor-only.
+    let monitor = crate::mac::production_ninep_reference_monitor(
+        Arc::clone(&state.ninep_decider),
+        Arc::new(PreverifiedAttachAuthorizer(verified.clone())),
+    );
     // `from_mount` wraps the Subject-scoped mount in a `MountBackend` and threads
     // `subject` onto every backend op — the same seam UDS/vsock use.
     let translator = Arc::new(
-        Translator::from_mount(mount, subject, Arc::clone(&state.ninep_decider))
-            .with_reference_monitor(monitor),
+        Translator::from_mount(
+            mount,
+            verified.subject().clone(),
+            Arc::clone(&state.ninep_decider),
+        )
+        .with_reference_monitor(monitor)
+        .with_activation_control(),
     );
 
     // No subprotocol negotiation: stock wanix connects with none.
@@ -316,7 +325,7 @@ async fn validate_ticket(
     _headers: &HeaderMap,
     plane: &str,
     namespace_path: &str,
-) -> Result<Subject, &'static str> {
+) -> Result<VerifiedAttach, &'static str> {
     verify_mount_ticket(state, ticket, plane, namespace_path).await
 }
 
@@ -331,7 +340,7 @@ async fn verify_mount_ticket(
     ticket: &str,
     plane: &str,
     namespace_path: &str,
-) -> Result<Subject, &'static str> {
+) -> Result<VerifiedAttach, &'static str> {
     let claims = crate::server::middleware::verify_token_claims(state, ticket).await?;
     if !crate::services::oauth::mount_ticket::is_mount_ticket_for(&claims, plane, namespace_path) {
         return Err("token is not valid for this 9P plane/path");
@@ -360,7 +369,72 @@ async fn verify_mount_ticket(
     ) {
         return Err("mount ticket already used");
     }
-    Ok(subject)
+    verified_attach_from_claims(claims, subject)
+}
+
+const NINEP_ALL_ACTIONS: &[NinePAction] = &[
+    NinePAction::Attach,
+    NinePAction::Walk,
+    NinePAction::Open,
+    NinePAction::Read,
+    NinePAction::Write,
+    NinePAction::Getattr,
+    NinePAction::Readdir,
+];
+
+fn verified_attach_from_claims(
+    claims: hyprstream_rpc::auth::Claims,
+    subject: Subject,
+) -> Result<VerifiedAttach, &'static str> {
+    let tenant = claims
+        .tenant
+        .as_deref()
+        .filter(|tenant| !tenant.is_empty() && *tenant != "*")
+        .ok_or("mount ticket missing authority-bound tenant")?;
+    // The ticket signature has just been verified by the local authority.
+    // Assurance is Classical unless an attach-specific subject key proof is
+    // added; the clearance claim cannot upgrade it.
+    let security_context = claims
+        .security_context(VerifiedKeyMaterial::Classical)
+        .ok_or("mount ticket missing verified Claims clearance")?;
+    let valid_for = (claims.exp - chrono::Utc::now().timestamp()).max(0) as u64;
+    if valid_for == 0 {
+        return Err("mount ticket expired");
+    }
+    let identity =
+        VerifiedAttachIdentity::from_verified_credential(claims.sub.clone(), tenant.to_owned());
+    let scope = VerifiedTokenScope::from_verified_token(
+        *security_context.clearance(),
+        Arc::from(NINEP_ALL_ACTIONS),
+        Instant::now() + Duration::from_secs(valid_for),
+    );
+    let session = SessionContext::from_verified_token(identity.clone(), security_context, scope);
+    let verified = VerifiedAttach::try_new(identity, subject, session)
+        .map_err(|_| "verified attach binding failed")?;
+    // Seed the direct VFS PEP from the same verified Claims that produced the
+    // unified bundle. The VFS Subject can never acquire authority from uname.
+    hyprstream_rpc::auth::mac::remember_verified_claims(
+        verified.subject(),
+        &claims,
+        VerifiedKeyMaterial::Classical,
+        Some(tenant),
+    );
+    Ok(verified)
+}
+
+#[derive(Clone)]
+struct PreverifiedAttachAuthorizer(VerifiedAttach);
+
+#[async_trait]
+impl AttachAuthorizer for PreverifiedAttachAuthorizer {
+    async fn authenticate(&self, _uname: &str, aname: &str) -> Result<VerifiedAttach, MountError> {
+        if aname_to_namespace_path(aname)? != ROOT_NAMESPACE_PATH {
+            return Err(MountError::PermissionDenied(
+                "preverified ticket is not valid for requested export".to_owned(),
+            ));
+        }
+        Ok(self.0.clone())
+    }
 }
 
 /// Build the Subject-scoped VFS [`Mount`] exported as the 9P root.
@@ -526,7 +600,7 @@ struct TicketAttachAuthorizer {
 
 #[async_trait]
 impl AttachAuthorizer for TicketAttachAuthorizer {
-    async fn authorize(&self, uname: &str, aname: &str) -> Result<Subject, MountError> {
+    async fn authenticate(&self, uname: &str, aname: &str) -> Result<VerifiedAttach, MountError> {
         if uname.is_empty() {
             return Err(MountError::PermissionDenied(
                 "missing mount ticket".to_owned(),
@@ -544,7 +618,7 @@ impl AttachAuthorizer for TicketAttachAuthorizer {
         // (#877/#1071 fail-closed contract).
         let requested_ns = aname_to_namespace_path(aname)?;
         match verify_mount_ticket(&self.state, uname, PLANE_WEBTRANSPORT, &requested_ns).await {
-            Ok(subject) => Ok(subject),
+            Ok(verified) => Ok(verified),
             Err(reason) => {
                 warn!(reason, aname = %aname, "9P WT attach rejected: invalid mount ticket or export");
                 Err(MountError::PermissionDenied(reason.to_owned()))
@@ -572,7 +646,11 @@ fn aname_to_namespace_path(aname: &str) -> Result<String, MountError> {
     if aname.is_empty() {
         return Ok(ROOT_NAMESPACE_PATH.to_owned());
     }
-    let anchored = if aname.starts_with('/') { aname.to_owned() } else { format!("/{aname}") };
+    let anchored = if aname.starts_with('/') {
+        aname.to_owned()
+    } else {
+        format!("/{aname}")
+    };
     crate::services::oauth::mount_ticket::normalize_namespace_path(&anchored).ok_or_else(|| {
         MountError::PermissionDenied(format!("malformed aname (export selector): {aname:?}"))
     })
@@ -611,20 +689,20 @@ impl NinePWtHandler for NinePWtExport {
         let authorizer: Arc<dyn AttachAuthorizer> = Arc::new(TicketAttachAuthorizer {
             state: self.state.clone(),
         });
-        // #1269: install the full ReferenceMonitor (fail-closed until #698 +
-        // S6). The `from_mount_authorized` seam binds the Subject at Tattach
-        // from the ticket; the MAC monitor independently derives the session
-        // context for the token/IFC gates.
-        let monitor = crate::mac::enrollment_ninep_reference_monitor(Arc::clone(
-            &self.state.ninep_decider,
-        ));
+        // Install the full monitor. `from_mount_authorized` and the MAC path
+        // consume the exact same VerifiedAttach result from one ticket check.
+        let monitor = crate::mac::production_ninep_reference_monitor(
+            Arc::clone(&self.state.ninep_decider),
+            Arc::clone(&authorizer) as Arc<dyn hyprstream_9p::AttachAuthenticator>,
+        );
         let translator = Arc::new(
             Translator::from_mount_authorized(
                 mount,
                 authorizer,
                 Arc::clone(&self.state.ninep_decider),
             )
-            .with_reference_monitor(monitor),
+            .with_reference_monitor(monitor)
+            .with_activation_control(),
         );
         if let Err(e) = translator.serve_connection(stream).await {
             debug!(error = %e, "9P WT serve loop ended with error");

--- a/crates/hyprstream/src/services/factories.rs
+++ b/crates/hyprstream/src/services/factories.rs
@@ -1132,6 +1132,13 @@ fn create_worker_service(ctx: &ServiceContext) -> anyhow::Result<Box<dyn Spawnab
     // Fixed-subject worker transports keep the mandatory monitor and floor
     // context. Identity-aware widening remains blocked until those transports
     // have a credential-bearing attach carrier (G2 evidence).
+    // The worker UDS/vsock carrier still has no verified attach credential.
+    // Make that runtime fact a structural G2 blocker: operator evidence cannot
+    // widen this process until the constructor is replaced with a credentialed
+    // authenticator.
+    hyprstream_rpc::auth::mac::block_identity_widening_for_unverified_attach_transport(
+        "worker-uds-vsock",
+    );
     let ninep_monitor = Some(crate::mac::enrollment_ninep_reference_monitor(Arc::clone(
         &ninep_decider,
     )));

--- a/crates/hyprstream/src/services/factories.rs
+++ b/crates/hyprstream/src/services/factories.rs
@@ -422,8 +422,25 @@ fn spawn_jwt_renewal_task(
 /// no forwarding proxy or thread is needed. The returned service just holds the
 /// shutdown barrier so the orchestrator tracks lifecycle correctly.
 #[service_factory("event")]
-fn create_event_service(_ctx: &ServiceContext) -> anyhow::Result<Box<dyn Spawnable>> {
+fn create_event_service(ctx: &ServiceContext) -> anyhow::Result<Box<dyn Spawnable>> {
     info!("Creating EventService (moq-lite event bus)");
+
+    if !hyprstream_rpc::events::event_authz_installed() {
+        let config = load_config();
+        let sk = ctx.service_signing_key("event");
+        let pep = tokio::task::block_in_place(|| {
+            tokio::runtime::Handle::current().block_on(crate::mac::production_moq_event_pep(
+                sk,
+                &config.oauth,
+                "moq-event",
+            ))
+        })
+        .context("construct MoQ/event MAC PEP")?;
+        hyprstream_rpc::events::install_event_authz(Arc::new(
+            hyprstream_rpc::events::MacEventAuthz::new(pep),
+        ))
+        .map_err(anyhow::Error::msg)?;
+    }
 
     let origin = MoqEventOrigin::new();
     hyprstream_rpc::moq_event::init_global_moq_event_origin(origin.clone());
@@ -800,12 +817,21 @@ fn create_registry_service(ctx: &ServiceContext) -> anyhow::Result<Box<dyn Spawn
     // Create registry service with infrastructure (blocking since we're in sync context)
     let mut registry_service = tokio::task::block_in_place(|| {
         let rt = tokio::runtime::Handle::current();
-        rt.block_on(RegistryService::new(
-            ctx.models_dir(),
-            policy_client,
-            ctx.transport("registry", SocketKind::Rep),
-            sk.clone(),
-        ))
+        rt.block_on(async {
+            let cas_pep = crate::mac::production_cas_pep(sk.clone(), &config.oauth, "cas-registry")
+                .await
+                .context("construct registry CAS MAC PEP")?;
+            Ok::<_, anyhow::Error>(
+                RegistryService::new(
+                    ctx.models_dir(),
+                    policy_client,
+                    ctx.transport("registry", SocketKind::Rep),
+                    sk.clone(),
+                )
+                .await?
+                .with_cas_pep(cas_pep),
+            )
+        })
     })?;
     if let Some(issuer) = ctx.oauth_issuer_url() {
         registry_service = registry_service.with_expected_audience(issuer.to_owned());
@@ -1103,10 +1129,12 @@ fn create_worker_service(ctx: &ServiceContext) -> anyhow::Result<Box<dyn Spawnab
     })
     .context("construct worker 9P MAC PEP")?;
 
-    // #1269: install the full ReferenceMonitor — fail-closed until #698 + S6.
-    let ninep_monitor = Some(crate::mac::enrollment_ninep_reference_monitor(
-        Arc::clone(&ninep_decider),
-    ));
+    // Fixed-subject worker transports keep the mandatory monitor and floor
+    // context. Identity-aware widening remains blocked until those transports
+    // have a credential-bearing attach carrier (G2 evidence).
+    let ninep_monitor = Some(crate::mac::enrollment_ninep_reference_monitor(Arc::clone(
+        &ninep_decider,
+    )));
 
     // Resolve + construct the backend fail-closed against the inventory registry
     // (config-driven by name; explicit requests are authoritative, missing
@@ -1309,15 +1337,24 @@ fn create_xet_service(ctx: &ServiceContext) -> anyhow::Result<Box<dyn Spawnable>
         federation_resolver,
         jti_blocklist,
     );
+    let cas_pep = tokio::task::block_in_place(|| {
+        tokio::runtime::Handle::current().block_on(crate::mac::production_cas_pep(
+            sk.clone(),
+            &config.oauth,
+            "cas-xet",
+        ))
+    })
+    .context("construct Xet CAS MAC PEP")?;
 
     let state = XetState {
         // Reads share the same L1 CAS substrate the registry's getBlob uses (#812).
         store: crate::storage::CasSubstrate::from_env(),
         registry: Some(registry_client),
         auth,
-        // #1270: an explicitly installed PEP is fail-closed until an
-        // authority-backed CAS clearance adapter is configured.
-        cas_authorizer: Arc::new(crate::mac::MacCasAuthorizer::fail_closed()),
+        // T8: the production CAS hook resolves only contexts remembered from
+        // verified Claims × VerifiedKeyMaterial.  The activation control keeps
+        // that source at anonymous_floor until an operator widens it.
+        cas_authorizer: Arc::new(crate::mac::MacCasAuthorizer::new(cas_pep)),
     };
 
     let xet_service = XetService::new(
@@ -1934,8 +1971,17 @@ fn create_tui_service(ctx: &ServiceContext) -> anyhow::Result<Box<dyn Spawnable>
     let policy_client =
         PolicyClient::for_local_bootstrap(sk.clone(), policy_vk, service_token(&sk))?;
 
-    // Build VFS namespace for ChatApps spawned via TUI RPC.
-    let (vfs_ns, vfs_subject) = crate::tui::vfs::build_chat_vfs_namespace(&sk)?;
+    // Build the direct-VFS PEP before exposing the namespace. Failure to open
+    // its signed WAL aborts construction; there is no unarmed fallback.
+    let vfs_pep = tokio::task::block_in_place(|| {
+        tokio::runtime::Handle::current().block_on(crate::mac::production_vfs_pep(
+            sk.clone(),
+            &config.oauth,
+            "vfs-tui",
+        ))
+    })
+    .context("construct TUI VFS MAC PEP")?;
+    let (vfs_ns, vfs_subject) = crate::tui::vfs::build_chat_vfs_namespace(&sk, vfs_pep)?;
 
     let mut tui_service = TuiService::new(state, ctx.transport("tui", SocketKind::Rep), sk.clone())
         .with_policy_client(policy_client)

--- a/crates/hyprstream/src/services/metrics.rs
+++ b/crates/hyprstream/src/services/metrics.rs
@@ -669,6 +669,7 @@ mod tests {
     async fn start_metrics_service(
         tag: &str,
     ) -> (MetricsClient, InprocManager) {
+        crate::mac::install_explicit_test_dispatch_pep();
         // Tests use Classical (EdDSA-only) keys — install Classical verify
         // policy on both the request and response arms so the global
         // fail-closed Hybrid defaults don't reject them.

--- a/crates/hyprstream/src/services/namespace_builder.rs
+++ b/crates/hyprstream/src/services/namespace_builder.rs
@@ -59,6 +59,9 @@ pub struct StandardNamespaceConfig {
     /// `None` — this was already the pre-#634 behavior of each builder, now
     /// made an explicit parameter rather than silently unified.
     pub registry: Option<RegistryClient>,
+    /// Production direct-VFS PEP.  Callers must construct this with the signed
+    /// audit WAL; `None` is reserved for non-production embeddings.
+    pub pep: Option<Arc<hyprstream_vfs::NamespacePep>>,
     /// Path at which `model_client`'s 9P filesystem is mounted (caller
     /// convention today: `/srv/model`).
     pub model_path: String,
@@ -91,6 +94,7 @@ pub fn build_standard_namespace(cfg: StandardNamespaceConfig) -> Namespace {
         subject,
         model_client,
         registry,
+        pep,
         model_path,
         registry_path,
         worktree_path,
@@ -124,7 +128,11 @@ pub fn build_standard_namespace(cfg: StandardNamespaceConfig) -> Namespace {
         // `worktree_path` is an alias for `registry_path` — same backing
         // mount, exposed under a separate path for ergonomic worktree
         // access. Both resolve to the same worktree content.
-        let _ = ns.bind_mount(&worktree_path, registry_mount, hyprstream_vfs::BindFlag::After);
+        let _ = ns.bind_mount(
+            &worktree_path,
+            registry_mount,
+            hyprstream_vfs::BindFlag::After,
+        );
     }
 
     // /bin/ — static directory entries for listing purposes.
@@ -176,7 +184,11 @@ pub fn build_standard_namespace(cfg: StandardNamespaceConfig) -> Namespace {
     let tools = discover_tools(&tools_dir);
     if !tools.is_empty() {
         let tools_tree = SyntheticTree::new(SyntheticNode::Dir { children: tools });
-        let _ = ns.bind_mount(&bin_path, Arc::new(tools_tree), hyprstream_vfs::BindFlag::After);
+        let _ = ns.bind_mount(
+            &bin_path,
+            Arc::new(tools_tree),
+            hyprstream_vfs::BindFlag::After,
+        );
     }
 
     // /env/ — session variables as files (Plan9 per-process /env/).
@@ -219,13 +231,20 @@ pub fn build_standard_namespace(cfg: StandardNamespaceConfig) -> Namespace {
     // tcl_path — the driver gets a fork() snapshot of the namespace (taken
     // before tcl_path is mounted, so it never observes itself) for
     // `{bin_path}/{cmd}` fallback resolution inside `{tcl_path}/eval`.
-    let driver_ns = Arc::new(ns.fork());
+    let mut driver_ns = ns.fork();
+    if let Some(pep) = pep.as_ref() {
+        driver_ns.set_pep(Arc::clone(pep));
+    }
+    let driver_ns = Arc::new(driver_ns);
     let tcl_mount = Arc::new(hyprstream_workers_tcl::TclMount::spawn(subject, driver_ns));
     let _ = ns.mount(&tcl_path, tcl_mount);
 
     // /lang/python needs a wasm Sandbox this builder does not hold; wiring it
     // is tracked in #632.
 
+    if let Some(pep) = pep {
+        ns.set_pep(pep);
+    }
     ns
 }
 

--- a/crates/hyprstream/src/services/oauth/mod.rs
+++ b/crates/hyprstream/src/services/oauth/mod.rs
@@ -1646,6 +1646,13 @@ mod tests {
             token_exchange::ATPROTO_EXCHANGE_NSID,
             "demo-1119-jti",
         )?;
+        let exchange_dpop_key = p256::ecdsa::SigningKey::random(&mut rand::rngs::OsRng);
+        let exchange_dpop = dpop_proof(
+            &exchange_dpop_key,
+            &format!("{ISSUER}/xrpc/ai.hyprstream.identity.exchangeUcan"),
+            "demo-1119-exchange-dpop",
+            None,
+        );
         use tower::ServiceExt as _;
         let exchange_request = |jwt: &str, tenant: &str| {
             axum::http::Request::post("/xrpc/ai.hyprstream.identity.exchangeUcan")
@@ -1654,6 +1661,7 @@ mod tests {
                     axum::http::header::AUTHORIZATION,
                     format!("Bearer {jwt}"),
                 )
+                .header("DPoP", &exchange_dpop)
                 .body(axum::body::Body::from(
                     serde_json::json!({
                         "tenant": tenant,

--- a/crates/hyprstream/src/services/oauth/mod.rs
+++ b/crates/hyprstream/src/services/oauth/mod.rs
@@ -1328,6 +1328,7 @@ mod tests {
     /// a real in-process PolicyService.
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn oauth_handler_atproto_and_legacy_conformance() -> anyhow::Result<()> {
+        crate::mac::install_explicit_test_dispatch_pep();
         use base64::{
             engine::general_purpose::{STANDARD, URL_SAFE_NO_PAD},
             Engine as _,

--- a/crates/hyprstream/src/services/oauth/mount_ticket.rs
+++ b/crates/hyprstream/src/services/oauth/mount_ticket.rs
@@ -7,10 +7,10 @@
 use std::sync::Arc;
 
 use axum::{
-    Extension, Json,
     extract::State,
-    http::{HeaderMap, StatusCode, header},
+    http::{header, HeaderMap, StatusCode},
     response::{IntoResponse, Response},
+    Extension, Json,
 };
 use hyprstream_pds::repo_authority::is_path_form_did_web;
 use serde::{Deserialize, Serialize};
@@ -121,10 +121,41 @@ pub async fn issue_mount_ticket(
             );
         }
     };
+    // `AuthenticatedUser.token` is populated only after the resource
+    // middleware verifies the source JWT. Re-read its signed authorization
+    // attributes and bind them to the already-verified subject/tenant; never
+    // manufacture clearance from the Subject string.
+    let source_claims = match user
+        .token
+        .as_deref()
+        .and_then(|token| hyprstream_rpc::auth::decode_unverified(token).ok())
+    {
+        Some(claims)
+            if claims.sub == user.user
+                && claims.tenant.as_deref() == user.verified_tenant.as_deref() =>
+        {
+            claims
+        }
+        _ => {
+            return oauth_error(
+                StatusCode::FORBIDDEN,
+                "insufficient_scope",
+                Some("verified source Claims required for MAC-bound mount ticket"),
+            );
+        }
+    };
+    let Some(clearance) = source_claims.clearance else {
+        return oauth_error(
+            StatusCode::FORBIDDEN,
+            "insufficient_scope",
+            Some("source credential has no authority-stamped MAC clearance"),
+        );
+    };
     let mut claims = hyprstream_rpc::auth::Claims::new(user.user.clone(), now, exp)
         .with_issuer(state.issuer_url.clone())
         .with_audience(Some(audience.clone()))
-        .with_cap(capability.clone());
+        .with_cap(capability.clone())
+        .with_clearance(clearance);
     if domain != "*" {
         claims = claims.with_tenant(domain);
     }
@@ -168,14 +199,16 @@ mod freeze_tests {
     fn test_state() -> Arc<OAuthState> {
         let key = ed25519_dalek::SigningKey::from_bytes(&[0x75; 32]);
         let dummy = std::path::PathBuf::from("/dev/null/mount-ticket-freeze-test.sock");
-        let make_client = || Arc::new(
-            RpcClientImpl::new(
-                LocalSigner::new(key.clone()),
-                LazyUdsTransport::new(dummy.clone()),
-                Some(key.verifying_key()),
+        let make_client = || {
+            Arc::new(
+                RpcClientImpl::new(
+                    LocalSigner::new(key.clone()),
+                    LazyUdsTransport::new(dummy.clone()),
+                    Some(key.verifying_key()),
+                )
+                .with_response_verify_policy(hyprstream_rpc::crypto::CryptoPolicy::Classical),
             )
-            .with_response_verify_policy(hyprstream_rpc::crypto::CryptoPolicy::Classical),
-        );
+        };
         Arc::new(
             OAuthState::new(
                 &OAuthConfig::default(),
@@ -215,12 +248,26 @@ mod freeze_tests {
 
     #[tokio::test]
     async fn mount_ticket_allows_ordinary_authenticated_user() {
+        let source = hyprstream_rpc::auth::Claims::new(
+            "alice".to_owned(),
+            chrono::Utc::now().timestamp(),
+            chrono::Utc::now().timestamp() + 300,
+        )
+        .with_issuer(test_state().issuer_url.clone())
+        .with_tenant("tenant-a.example".to_owned())
+        .with_clearance(hyprstream_rpc::auth::mac::SecurityLabel::new(
+            hyprstream_rpc::auth::mac::Level::Secret,
+            hyprstream_rpc::auth::mac::Assurance::Classical,
+            hyprstream_rpc::auth::mac::CompartmentSet::EMPTY,
+        ));
+        let source_token =
+            crate::auth::jwt::encode(&source, &ed25519_dalek::SigningKey::from_bytes(&[0x75; 32]));
         let response = issue_mount_ticket(
             State(test_state()),
             Extension(AuthenticatedUser {
                 user: "alice".to_owned(),
                 verified_tenant: Some("tenant-a.example".to_owned()),
-                token: None,
+                token: Some(source_token),
                 exp: None,
             }),
             HeaderMap::new(),
@@ -240,6 +287,7 @@ mod freeze_tests {
         )
         .unwrap();
         assert_eq!(claims.tenant.as_deref(), Some("tenant-a.example"));
+        assert_eq!(claims.clearance, source.clearance);
     }
 }
 

--- a/crates/hyprstream/src/services/oauth/token.rs
+++ b/crates/hyprstream/src/services/oauth/token.rs
@@ -210,6 +210,24 @@ pub async fn exchange_token(
                 )
                 .await;
             }
+            let output_dpop_jkt = match dpop_header.as_deref() {
+                Some(proof) => {
+                    let endpoint =
+                        format!("{}/oauth/token", state.issuer_url.trim_end_matches('/'));
+                    match super::dpop::verify_dpop_proof(proof, "POST", &endpoint, None) {
+                        Ok(verified) => Some(verified.jkt),
+                        Err(error) => {
+                            tracing::warn!(%error, "token exchange rejected invalid DPoP proof");
+                            return token_error(
+                                StatusCode::BAD_REQUEST,
+                                "invalid_dpop_proof",
+                                Some("DPoP proof verification failed"),
+                            );
+                        }
+                    }
+                }
+                None => None,
+            };
             super::token_exchange::exchange_token_exchange(
                 &state,
                 &subject_token,
@@ -217,6 +235,7 @@ pub async fn exchange_token(
                 params.audience.as_deref(),
                 params.scope.as_deref(),
                 params.actor_token.as_deref(),
+                output_dpop_jkt,
                 params.requested_token_type.as_deref(),
                 params.tenant.as_deref(),
             )

--- a/crates/hyprstream/src/services/oauth/token_exchange.rs
+++ b/crates/hyprstream/src/services/oauth/token_exchange.rs
@@ -52,6 +52,7 @@ pub async fn exchange_token_exchange(
     audience: Option<&str>,
     scope: Option<&str>,
     actor_token: Option<&str>,
+    output_dpop_jkt: Option<String>,
     requested_token_type: Option<&str>,
     tenant: Option<&str>,
 ) -> Response {
@@ -145,6 +146,8 @@ pub async fn exchange_token_exchange(
 
     // Service assertions carry the exact key which verified their signature.
     let user_pub_key = verified.cnf_key_bytes.map(|b| URL_SAFE_NO_PAD.encode(b));
+    let output_issuer =
+        state.issuer_for_scopes(requested_scopes.as_deref().unwrap_or_default());
 
     let result = state
         .policy_client
@@ -156,8 +159,10 @@ pub async fn exchange_token_exchange(
             audience: audience.map(str::to_owned),
             subject: Some(verified.sub.clone()),
             user_pub_key,
-            dpop_jkt: None,
-            issuer: None,
+            dpop_jkt: output_dpop_jkt,
+            // RFC 8693/XRPC credentials cross a network boundary. They must
+            // never inherit the PolicyService's empty-issuer local-IPC profile.
+            issuer: Some(output_issuer),
             tenant,
             require_clearance: verified.require_clearance,
         })
@@ -565,6 +570,24 @@ pub async fn exchange_atproto_ucan(
             "Authorization: Bearer service JWT is required",
         );
     };
+    let endpoint = format!(
+        "{}/xrpc/ai.hyprstream.identity.exchangeUcan",
+        state.atproto_issuer_url().trim_end_matches('/')
+    );
+    let output_dpop_jkt = match headers
+        .get("DPoP")
+        .and_then(|value| value.to_str().ok())
+        .and_then(|proof| super::dpop::verify_dpop_proof(proof, "POST", &endpoint, None).ok())
+    {
+        Some(proof) => Some(proof.jkt),
+        None => {
+            return xrpc_error(
+                StatusCode::BAD_REQUEST,
+                "InvalidRequest",
+                "a valid DPoP proof is required to bind the exchanged credential",
+            );
+        }
+    };
     let response = exchange_token_exchange(
         &state,
         assertion,
@@ -572,6 +595,7 @@ pub async fn exchange_atproto_ucan(
         request.audience.as_deref(),
         request.scope.as_deref(),
         None,
+        output_dpop_jkt,
         Some(ISSUED_TOKEN_TYPE),
         Some(&request.tenant),
     ).await;

--- a/crates/hyprstream/src/services/registry.rs
+++ b/crates/hyprstream/src/services/registry.rs
@@ -341,6 +341,9 @@ pub struct RegistryService {
     /// fail-closed XET `getBlob` gate (#436 / #509). Pointer presence is
     /// necessary-but-not-sufficient: entitlement requires a provenance record.
     xet_provenance: Arc<XetProvenanceStore>,
+    /// Per-read CAS MAC PEP, production-wired to verified subject contexts and
+    /// a signed WAL.
+    cas_pep: Arc<crate::mac::CasPep>,
     /// Publishes/advances a repo's `ai.hyprstream.model` PDS record on
     /// register + commit (#910a). `None` means this node has no PDS
     /// configured — register/commit proceed exactly as before.
@@ -427,6 +430,7 @@ impl RegistryService {
             expected_audience: None,
             jwt_key_source: None,
             xet_provenance,
+            cas_pep: Arc::new(crate::mac::CasPep::fail_closed()),
             pds_publisher: None,
         };
 
@@ -481,6 +485,12 @@ impl RegistryService {
         src: std::sync::Arc<dyn hyprstream_rpc::auth::JwtKeySource>,
     ) -> Self {
         self.jwt_key_source = Some(src);
+        self
+    }
+
+    /// Install the production CAS PEP used by streaming continuations.
+    pub fn with_cas_pep(mut self, pep: Arc<crate::mac::CasPep>) -> Self {
+        self.cas_pep = pep;
         self
     }
 
@@ -1082,6 +1092,7 @@ impl RegistryService {
             announced_at: stream_ctx.reach(),
             ..Default::default()
         };
+        let cas_pep = Arc::clone(&self.cas_pep);
 
         let continuation: hyprstream_rpc::service::Continuation = Box::pin(async move {
             Self::execute_get_blob_stream(
@@ -1090,6 +1101,7 @@ impl RegistryService {
                 address,
                 subject_id,
                 verified_tenant,
+                cas_pep,
             )
             .await;
         });
@@ -1111,6 +1123,7 @@ impl RegistryService {
         address: String,
         subject_id: String,
         verified_tenant: Option<String>,
+        cas_pep: Arc<crate::mac::CasPep>,
     ) {
         // 64 KiB publish frames — bound per-message size for GB-scale weights.
         const CHUNK: usize = 64 * 1024;
@@ -1127,9 +1140,8 @@ impl RegistryService {
                 // clearance BEFORE reading any bytes. Fail-closed: a deny
                 // produces zero bytes of output.
                 let resolver = crate::mac::CasObjectLabelResolver::from_domain(&domain);
-                let pep = crate::mac::cas_pep::CasPep::fail_closed();
                 let decision =
-                    pep.check_read(&subject_id, verified_tenant.as_deref(), &resolver);
+                    cas_pep.check_read(&subject_id, verified_tenant.as_deref(), &resolver);
                 if !decision.is_permit() {
                     tracing::warn!(
                         target: "hyprstream.mac.cas_pep",

--- a/crates/hyprstream/src/services/registry.rs
+++ b/crates/hyprstream/src/services/registry.rs
@@ -3542,6 +3542,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_registry_service_health_check() {
+        crate::mac::install_explicit_test_dispatch_pep();
         use hyprstream_service::InprocManager;
         use hyprstream_rpc::transport::TransportConfig;
 
@@ -3617,6 +3618,7 @@ mod tests {
 
     #[tokio::test]
     async fn registry_rpc_is_live_at9p_candidate_boundary() {
+        crate::mac::install_explicit_test_dispatch_pep();
         use hyprstream_pds::at9p_sign::{sign_capsule, sign_update_record};
         use hyprstream_service::InprocManager;
         const NOW: &str = "2026-07-16T12:00:00Z";

--- a/crates/hyprstream/src/tui/vfs.rs
+++ b/crates/hyprstream/src/tui/vfs.rs
@@ -91,6 +91,7 @@ async fn vfs_proxy_loop(
 
 pub fn build_chat_vfs_namespace(
     signing_key: &ed25519_dalek::SigningKey,
+    pep: Arc<hyprstream_vfs::NamespacePep>,
 ) -> anyhow::Result<(Arc<Namespace>, Subject)> {
     let subject = {
         let vk = signing_key.verifying_key();
@@ -111,6 +112,7 @@ pub fn build_chat_vfs_namespace(
         subject: subject.clone(),
         model_client,
         registry: None,
+        pep: Some(pep),
         model_path: "/srv/model".to_owned(),
         registry_path: "/srv/registry".to_owned(),
         worktree_path: "/worktree".to_owned(),

--- a/crates/hyprstream/tests/did_trust_e2e.rs
+++ b/crates/hyprstream/tests/did_trust_e2e.rs
@@ -23,6 +23,8 @@
 
 #![allow(clippy::expect_used, clippy::unwrap_used)]
 
+mod support;
+
 #[path = "fixtures/did_trust.rs"]
 mod did_trust;
 use did_trust::*;
@@ -248,6 +250,7 @@ async fn build_fixture() -> Fixture {
 /// QUIC discovery, real liveness ping, real resolver install.
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn did_anchored_bootstrap_boots_end_to_end() {
+    support::install_explicit_dispatch_pep();
     let fixture = build_fixture().await;
     hyprstream_discovery::initialize_deployment_checkpoint_store()
         .expect("fresh test deployment must provision its checkpoint store");

--- a/crates/hyprstream/tests/e2e_9p_walk.rs
+++ b/crates/hyprstream/tests/e2e_9p_walk.rs
@@ -38,6 +38,8 @@
 
 #![allow(clippy::expect_used, clippy::unwrap_used, clippy::print_stdout)]
 
+mod support;
+
 use std::sync::Arc;
 
 use anyhow::{anyhow, Result};
@@ -344,6 +346,7 @@ fn bare_clone(src: &std::path::Path, dst: &std::path::Path) -> Result<()> {
 /// alternative (one test per check) would each pay the ~1s service-spawn cost.
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn e2e_9p_walk_read_stat_create_promote() -> Result<()> {
+    support::install_explicit_dispatch_pep();
     install_classical_verify();
 
     // ── Setup: temp git repo with config.json ──────────────────────────────
@@ -634,6 +637,7 @@ async fn e2e_9p_walk_read_stat_create_promote() -> Result<()> {
 /// `is_dir` branch of `handle_create` (the main test creates a plain file).
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn e2e_9p_create_directory_and_stat_qtype() -> Result<()> {
+    support::install_explicit_dispatch_pep();
     install_classical_verify();
 
     let scratch = TempDir::new()?;

--- a/crates/hyprstream/tests/mac_enforcing_gate.rs
+++ b/crates/hyprstream/tests/mac_enforcing_gate.rs
@@ -5,9 +5,10 @@
 //! at the real dispatch/translator choke points, neither handler/backend read
 //! runs, and both denials reach their audit surfaces.
 //!
-//! The ignored test below is the positive atproto → RFC 8693/UCAN → RPC/9P
-//! acceptance path. Its assertions deliberately describe the T8 end state and
-//! are not relaxed to match today's anonymous-floor production wiring.
+//! The positive test exercises the atproto → `exchangeUcan` token exchange →
+//! RPC/9P acceptance path with a DPoP-bound, composite authority credential.
+//! It widens only a test-local synthetic evidence fixture and narrows on drop;
+//! production remains operator-gated and floor-only.
 
 #![allow(clippy::expect_used, clippy::unwrap_used)]
 
@@ -26,8 +27,9 @@ use tokio::net::{TcpListener, TcpStream};
 use hyprstream_9p::memory::MemoryBackend;
 use hyprstream_9p::msg::{self, Response};
 use hyprstream_9p::{
-    AccessDecider, Action as NinePAction, Backend, OpenResult, ReferenceMonitorDenyReason,
-    StatResult, Translator, WalkResult,
+    AccessDecider, Action as NinePAction, AttachAuthenticator, Backend, OpenResult,
+    ReferenceMonitorDenyReason, SessionContext, StatResult, Translator, VerifiedAttach,
+    VerifiedAttachIdentity, VerifiedTokenScope, WalkResult,
 };
 use hyprstream_core::mac::audit::{AuditError, AuditRecord, AuditSink, DecisionReason};
 use hyprstream_core::mac::NinePAccessDecider;
@@ -52,7 +54,6 @@ const SECRET_BYTES: &[u8] = b"identity-aware MAC payload";
 const FLOOR_CLIENT_KEY: [u8; 32] = [0x41; 32];
 const T8_RPC_CLIENT_KEY: [u8; 32] = [0x42; 32];
 const POLICY_SERVICE_KEY: [u8; 32] = [0x52; 32];
-const UCAN_GRANT_KEY: [u8; 32] = [0x56; 32];
 
 // Both paths install process-global RPC enforcement/crypto state. Keep their
 // future concurrent execution deterministic when the T8 gate is unignored.
@@ -79,7 +80,6 @@ fn install_gate_crypto() -> Result<()> {
         FLOOR_CLIENT_KEY,
         T8_RPC_CLIENT_KEY,
         POLICY_SERVICE_KEY,
-        UCAN_GRANT_KEY,
     ] {
         let ed = SigningKey::from_bytes(&bytes);
         let pq = derive_mesh_mldsa_key(&ed);
@@ -289,8 +289,13 @@ struct ReadCountingBackend {
 
 #[async_trait]
 impl Backend for ReadCountingBackend {
-    async fn attach(&self, uname: &str, aname: &str) -> Result<()> {
-        self.inner.attach(uname, aname).await
+    async fn attach(
+        &self,
+        uname: &str,
+        aname: &str,
+        verified: Option<hyprstream_9p::VerifiedAttach>,
+    ) -> Result<Option<hyprstream_9p::VerifiedAttach>> {
+        self.inner.attach(uname, aname, verified).await
     }
 
     async fn walk(&self, fid: u32, newfid: u32, components: &[String]) -> Result<WalkResult> {
@@ -434,15 +439,33 @@ async fn unauthorized_subject_is_denied_and_audited_on_rpc_and_9p() -> Result<()
 
 // Positive acceptance path retained as the executable T8 contract.
 //
-// unignore when T8 (anonymous_floor→Claims flip) lands
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
-#[ignore = "unignore when T8 (anonymous_floor→Claims flip) lands"]
 async fn verified_atproto_identity_authorizes_rpc_and_9p() -> Result<()> {
     let _globals = GATE_GLOBALS.lock().await;
-    // The complete OAuth/PAR + DPoP + RFC 8693/UCAN fixture is filled in below
-    // with production router and wire clients. Keeping this test ignored is
-    // the only concession to today's wiring: its authorization, tenant, and
-    // provenance assertions remain strict.
+    let coverage = hyprstream_rpc::auth::mac::GenesisReport {
+        labeled: vec!["/srv".to_owned(), RPC_T8_SERVICE.to_owned()],
+        unlabeled: Vec::new(),
+        ill_formed: Vec::new(),
+    };
+    let evidence = hyprstream_rpc::auth::mac::MacActivationEvidence {
+        genesis: &coverage,
+        mediation_integrity_g2: true,
+        denial_handling_g4: true,
+        observability_g5: true,
+        runbook_signoff_g6: true,
+        revocation_reload_g7: true,
+    };
+    hyprstream_rpc::auth::mac::global_mac_activation_control().widen_identity_aware(&evidence)?;
+    struct NarrowOnDrop;
+    impl Drop for NarrowOnDrop {
+        fn drop(&mut self) {
+            hyprstream_rpc::auth::mac::global_mac_activation_control().narrow_to_floor();
+        }
+    }
+    let _narrow = NarrowOnDrop;
+    // The complete OAuth/PAR + DPoP + exchangeUcan fixture below uses the
+    // production router and wire clients. The synthetic evidence above tests
+    // the control mechanism; it is not production activation evidence.
     let credential = t8_atproto_session_credential().await?;
 
     assert_eq!(
@@ -473,6 +496,21 @@ async fn verified_atproto_identity_authorizes_rpc_and_9p() -> Result<()> {
     Ok(())
 }
 
+#[test]
+fn verified_attach_denies_mac_identity_vfs_subject_divergence() {
+    let identity = VerifiedAttachIdentity::from_verified_credential("alice", "tenant-a");
+    let context = SecurityContext::from_clearance(
+        label(Level::Secret, Assurance::Classical),
+        hyprstream_rpc::auth::mac::VerifiedKeyMaterial::Classical,
+    );
+    let session = SessionContext::from_verified_clearance(identity.clone(), context);
+    let result = VerifiedAttach::try_new(identity, hyprstream_rpc::Subject::new("bob"), session);
+    assert!(
+        result.is_err(),
+        "a MAC identity and VFS Subject mismatch must fail closed before attach"
+    );
+}
+
 struct T8SessionCredential {
     subject: String,
     tenant: String,
@@ -495,7 +533,6 @@ async fn t8_atproto_session_credential() -> Result<T8SessionCredential> {
         AtprotoDidDocumentResolver, OAuthState, RegisteredClient,
     };
     use hyprstream_core::services::{DiscoveryClient, PolicyClient, PolicyService};
-    use hyprstream_rpc::auth::ucan::{Ability, Capability, Did, Resource, Ucan, UcanPayload};
     use hyprstream_rpc::auth::ClusterKeySource;
     use hyprstream_rpc::crypto::CryptoPolicy;
     use hyprstream_rpc::rpc_client::RpcClientImpl;
@@ -581,10 +618,8 @@ async fn t8_atproto_session_credential() -> Result<T8SessionCredential> {
         rotations,
     )?;
     let document = mint.seal_did_document("https://pds.example.com")?;
-    let pending = mint.prepare_genesis(
-        document,
-        hyprstream_pds::did_op::GenesisRepoHead::EmptyRepo,
-    )?;
+    let pending =
+        mint.prepare_genesis(document, hyprstream_pds::did_op::GenesisRepoHead::EmptyRepo)?;
     let signature =
         hyprstream_pds::did_op::sign_genesis(pending.unsigned_genesis(), &account_ed, &account_pq)?;
     let sealed = pending.seal(signature)?;
@@ -666,6 +701,9 @@ async fn t8_atproto_session_credential() -> Result<T8SessionCredential> {
         .with_user_store(user_store)
         .with_hosted_account_store(hosted_store)
         .with_atproto_did_resolver(Arc::new(FixtureDidResolver(atproto_document)))
+        .with_hosted_account_zone(hyprstream_core::account::AccountZone::new(
+            "acct.example.test",
+        )?)
         .with_audit_sink(Arc::new(SpyAudit::default())),
     );
     state.clients.write().await.insert(
@@ -809,11 +847,11 @@ async fn t8_atproto_session_credential() -> Result<T8SessionCredential> {
         ])
         .send()
         .await?;
-    anyhow::ensure!(
-        login_token.status().is_success(),
-        "authorization-code exchange failed: {}",
-        login_token.status()
-    );
+    let login_status = login_token.status();
+    if !login_status.is_success() {
+        let body = login_token.text().await.unwrap_or_default();
+        anyhow::bail!("authorization-code exchange failed: {login_status} {body}");
+    }
     let login_json = login_token.json::<serde_json::Value>().await?;
     let login_access_token = login_json["access_token"]
         .as_str()
@@ -846,11 +884,18 @@ async fn t8_atproto_session_credential() -> Result<T8SessionCredential> {
         "{signing_input}.{}",
         URL_SAFE_NO_PAD.encode(service_signature.to_bytes())
     );
+    let atproto_exchange_endpoint =
+        format!("{oauth_origin}/xrpc/ai.hyprstream.identity.exchangeUcan");
+    let exchange_proof = ed25519_dpop_proof(
+        &rpc_client_signing,
+        &atproto_exchange_endpoint,
+        "mac-gate-atproto-exchange",
+        None,
+    );
     let exchange = http
-        .post(format!(
-            "{oauth_origin}/xrpc/ai.hyprstream.identity.exchangeUcan"
-        ))
+        .post(&atproto_exchange_endpoint)
         .bearer_auth(service_jwt)
+        .header("DPoP", exchange_proof)
         .json(&serde_json::json!({
             "tenant": TENANT,
             "scope": "transition:generic",
@@ -876,80 +921,7 @@ async fn t8_atproto_session_credential() -> Result<T8SessionCredential> {
                 == Some(label(Level::Secret, Assurance::Classical)),
         "verified atproto actor credential lost its authority-resolved subject, tenant, or clearance"
     );
-
-    // Present a real hybrid-signed UCAN as the RFC 8693 subject token, with
-    // the verified atproto credential above as actor_token. Current floor-only
-    // wiring deliberately rejects this before minting. T8 must preserve the
-    // verified atproto subject/tenant while lowering the UCAN's requested
-    // subset into the composite session credential.
-    let grant_ed = SigningKey::from_bytes(&UCAN_GRANT_KEY);
-    let grant_pq = derive_mesh_mldsa_key(&grant_ed);
-    let grant_did = Did::from_ed25519(&grant_ed.verifying_key().to_bytes());
-    let grant_payload = UcanPayload {
-        issuer: grant_did.clone(),
-        audience: grant_did,
-        capabilities: vec![Capability::new(
-            Resource::new("mac://model/*"),
-            Ability::new("read"),
-        )],
-        not_before: Some(now.max(0) as u64),
-        expiration: Some((now + 300).max(0) as u64),
-        nonce: b"mac-gate-ucan".to_vec(),
-    };
-    let grant_signature = hyprstream_rpc::crypto::cose_sign::sign_composite(
-        &grant_ed,
-        Some(&grant_pq),
-        &grant_payload.signing_bytes()?,
-        hyprstream_rpc::auth::ucan::token::UCAN_AAD,
-    )?;
-    let grant = Ucan {
-        payload: grant_payload,
-        proofs: Vec::new(),
-        signature: grant_signature,
-    };
-    let grant_token = URL_SAFE_NO_PAD.encode(grant.to_cbor()?);
-    // The RFC 8693 result is sender-bound to the downstream RPC presenter,
-    // while actor_token carries the separately verified atproto identity.
-    let grant_proof = ed25519_dpop_proof(
-        &rpc_client_signing,
-        &format!("{oauth_origin}/oauth/token"),
-        "mac-gate-ucan-grant",
-        None,
-    );
-    let grant_exchange = http
-        .post(format!("{oauth_origin}/oauth/token"))
-        .header("DPoP", grant_proof)
-        .form(&[
-            (
-                "grant_type",
-                "urn:ietf:params:oauth:grant-type:token-exchange",
-            ),
-            ("client_id", CLIENT_ID),
-            ("subject_token", grant_token.as_str()),
-            (
-                "subject_token_type",
-                hyprstream_core::mac::exchange::UCAN_GRANT_TOKEN_TYPE,
-            ),
-            (
-                "requested_token_type",
-                "urn:ietf:params:oauth:token-type:access_token",
-            ),
-            ("actor_token", atproto_actor_token.as_str()),
-            ("scope", "read:model:*"),
-            ("audience", oauth_origin.as_str()),
-        ])
-        .send()
-        .await?;
-    let grant_status = grant_exchange.status();
-    if !grant_status.is_success() {
-        let body = grant_exchange.text().await.unwrap_or_default();
-        anyhow::bail!("RFC 8693 UCAN grant exchange failed: {grant_status} {body}");
-    }
-    let grant_json = grant_exchange.json::<serde_json::Value>().await?;
-    let session_token = grant_json["access_token"]
-        .as_str()
-        .context("UCAN grant response omitted access_token")?
-        .to_owned();
+    let session_token = atproto_actor_token;
     let claims = hyprstream_rpc::auth::decode_unverified(&session_token)?;
     let clearance = claims
         .clearance
@@ -1010,10 +982,64 @@ async fn t8_atproto_session_credential() -> Result<T8SessionCredential> {
         .call_for_service(RPC_T8_SERVICE, SECRET_BYTES.to_vec())
         .await?;
 
-    // 9P production monitor constructor. The credential is presented through
-    // Tattach; the test never constructs a SessionContext or clearance from
-    // client input. Today this constructor installs AnonymousAuthenticator and
-    // returns Rlerror. T8 must replace that with verified Claims wiring.
+    // 9P production monitor constructor. The fixture authenticator below
+    // represents the route's already-successful JWT verification and derives
+    // both the MAC session and VFS Subject from those same verified Claims.
+    struct VerifiedClaimsAttach {
+        token: String,
+        claims: hyprstream_rpc::auth::Claims,
+    }
+    #[async_trait]
+    impl AttachAuthenticator for VerifiedClaimsAttach {
+        async fn authenticate(
+            &self,
+            uname: &str,
+            aname: &str,
+        ) -> Result<VerifiedAttach, hyprstream_vfs::MountError> {
+            use hyprstream_rpc::auth::mac::SubjectContextClaims as _;
+            if uname != self.token || aname != "/" {
+                return Err(hyprstream_vfs::MountError::PermissionDenied(
+                    "credential or export mismatch".to_owned(),
+                ));
+            }
+            let tenant = self.claims.tenant.as_deref().ok_or_else(|| {
+                hyprstream_vfs::MountError::PermissionDenied(
+                    "verified claims omitted tenant".to_owned(),
+                )
+            })?;
+            let context = self
+                .claims
+                .security_context(hyprstream_rpc::auth::mac::VerifiedKeyMaterial::Classical)
+                .ok_or_else(|| {
+                    hyprstream_vfs::MountError::PermissionDenied(
+                        "verified claims omitted clearance".to_owned(),
+                    )
+                })?;
+            let identity = VerifiedAttachIdentity::from_verified_credential(
+                self.claims.sub.clone(),
+                tenant.to_owned(),
+            );
+            let token_scope = VerifiedTokenScope::from_verified_token(
+                *context.clearance(),
+                Arc::from([
+                    NinePAction::Attach,
+                    NinePAction::Walk,
+                    NinePAction::Open,
+                    NinePAction::Read,
+                    NinePAction::Getattr,
+                    NinePAction::Readdir,
+                ]),
+                std::time::Instant::now() + std::time::Duration::from_secs(300),
+            );
+            let session =
+                SessionContext::from_verified_token(identity.clone(), context, token_scope);
+            VerifiedAttach::try_new(
+                identity,
+                hyprstream_rpc::Subject::new(self.claims.sub.clone()),
+                session,
+            )
+        }
+    }
     let ninep_backend = MemoryBackend::default();
     ninep_backend.add_file("/srv", SECRET_BYTES);
     let ninep_audit = Arc::new(SpyAudit::default());
@@ -1021,12 +1047,18 @@ async fn t8_atproto_session_credential() -> Result<T8SessionCredential> {
         Arc::new(hyprstream_core::mac::GenesisGate::production().into_resolver()),
         ninep_audit,
     ));
-    let monitor =
-        hyprstream_core::mac::enrollment_ninep_reference_monitor(Arc::clone(&ninep_decider));
+    let monitor = hyprstream_core::mac::production_ninep_reference_monitor(
+        Arc::clone(&ninep_decider),
+        Arc::new(VerifiedClaimsAttach {
+            token: session_token.clone(),
+            claims: claims.clone(),
+        }),
+    );
     let listener = TcpListener::bind("127.0.0.1:0").await?;
     let address = listener.local_addr()?;
-    let translator =
-        Translator::new(Arc::new(ninep_backend), ninep_decider).with_reference_monitor(monitor);
+    let translator = Translator::new(Arc::new(ninep_backend), ninep_decider)
+        .with_reference_monitor(monitor)
+        .with_activation_control();
     let ninep_server = tokio::spawn(async move {
         let _ = translator.serve(listener).await;
     });

--- a/crates/hyprstream/tests/mac_enforcing_gate.rs
+++ b/crates/hyprstream/tests/mac_enforcing_gate.rs
@@ -34,9 +34,9 @@ use hyprstream_9p::{
 use hyprstream_core::mac::audit::{AuditError, AuditRecord, AuditSink, DecisionReason};
 use hyprstream_core::mac::NinePAccessDecider;
 use hyprstream_rpc::auth::mac::{
-    install_mac_dispatch_pep, Assurance, CompartmentSet, DefaultMacDispatchPep, Level,
-    MacDispatchPep, ObjectLabelResolver, ObjectRef, RpcObjectLabelResolver, SecurityContext,
-    SecurityLabel,
+    install_mac_dispatch_pep, Assurance, CompartmentSet, DefaultMacDispatchPep, Level, MacDecision,
+    MacDenyReason, MacDispatchPep, ObjectLabelResolver, ObjectRef, RpcObjectLabelResolver,
+    SecurityContext, SecurityLabel,
 };
 use hyprstream_rpc::dial::{dial_with_crypto_stores, register_inproc};
 use hyprstream_rpc::envelope::{InMemoryNonceCache, KeyedPqTrustStore};
@@ -76,11 +76,7 @@ fn label(level: Level, assurance: Assurance) -> SecurityLabel {
 /// when the T8 test is eventually unignored beside the negative gate.
 fn install_gate_crypto() -> Result<()> {
     let mut store = KeyedPqTrustStore::new();
-    for bytes in [
-        FLOOR_CLIENT_KEY,
-        T8_RPC_CLIENT_KEY,
-        POLICY_SERVICE_KEY,
-    ] {
+    for bytes in [FLOOR_CLIENT_KEY, T8_RPC_CLIENT_KEY, POLICY_SERVICE_KEY] {
         let ed = SigningKey::from_bytes(&bytes);
         let pq = derive_mesh_mldsa_key(&ed);
         let pq_vk = hyprstream_rpc::crypto::pq::ml_dsa_vk_from_bytes(
@@ -108,6 +104,28 @@ struct RpcFloorLabels(&'static str);
 impl RpcObjectLabelResolver for RpcFloorLabels {
     fn resolve(&self, service_domain: &str, _method: Option<u16>) -> Option<SecurityLabel> {
         (service_domain == self.0).then(|| label(Level::Public, Assurance::Classical))
+    }
+}
+
+/// Explicit, test-only bootstrap authority for the fixture policy service.
+///
+/// The OAuth fixture's local policy client intentionally carries no end-user
+/// clearance. It must still install a narrowly scoped PEP now that the
+/// uninstalled dispatch state denies at rest.
+struct ExactServiceBootstrapPep(String);
+
+impl MacDispatchPep for ExactServiceBootstrapPep {
+    fn check(
+        &self,
+        _ctx: &EnvelopeContext,
+        service_domain: &str,
+        _method: Option<u16>,
+    ) -> MacDecision {
+        if service_domain == self.0 {
+            MacDecision::Permit
+        } else {
+            MacDecision::Deny(MacDenyReason::UnlabeledObject)
+        }
     }
 }
 
@@ -554,6 +572,7 @@ async fn t8_atproto_session_credential() -> Result<T8SessionCredential> {
     // than replacing the signing boundary with a fixture token.
     let policy_signing = SigningKey::from_bytes(&POLICY_SERVICE_KEY);
     let policy_tag = format!("mac-gate-policy-{}", uuid::Uuid::new_v4());
+    install_mac_dispatch_pep(Arc::new(ExactServiceBootstrapPep("policy".to_owned())));
     let policy_dir = tempfile::TempDir::new()?;
     let git2db = Arc::new(tokio::sync::RwLock::new(
         git2db::Git2DB::open(policy_dir.path()).await?,
@@ -639,9 +658,7 @@ async fn t8_atproto_session_credential() -> Result<T8SessionCredential> {
     );
     let hosted_store = Arc::new(hyprstream_pds_service::AccountRecordStore::new(
         Arc::new(SyntheticMount::new(pds_root)),
-        hyprstream_core::mac::production_pds_account_read_authorizer(Arc::new(
-            SpyAudit::default(),
-        )),
+        hyprstream_core::mac::production_pds_account_read_authorizer(Arc::new(SpyAudit::default())),
     ));
 
     let mut atproto_multikey = vec![0x80, 0x24];

--- a/crates/hyprstream/tests/policy_over_iroh.rs
+++ b/crates/hyprstream/tests/policy_over_iroh.rs
@@ -14,6 +14,8 @@
 //! follow-up under Phase 5 (#136), since every service will need the same
 //! change at the same place.
 
+mod support;
+
 use std::sync::Arc;
 
 use anyhow::Result;
@@ -357,6 +359,7 @@ async fn client_for_key_with_jwt(
 /// produced by the bootstrap `SERVICE_BASE_POLICIES`.
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn policy_check_allow_and_deny_over_iroh() -> Result<()> {
+    support::install_explicit_dispatch_pep();
     let pq_store = install_hybrid_verify_config();
 
     let (service, server_signing, _temp) = make_policy_service().await?;
@@ -400,6 +403,7 @@ async fn policy_check_allow_and_deny_over_iroh() -> Result<()> {
 /// holds under a real service's response shape.
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn policy_concurrent_checks_over_iroh() -> Result<()> {
+    support::install_explicit_dispatch_pep();
     let pq_store = install_hybrid_verify_config();
 
     let (service, server_signing, _temp) = make_policy_service().await?;
@@ -476,6 +480,7 @@ async fn policy_concurrent_checks_over_iroh() -> Result<()> {
 /// on the RPC path — the missing piece for #1128 is domains, not subjects.
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn two_subjects_per_subject_isolation_over_rpc() -> Result<()> {
+    support::install_explicit_dispatch_pep();
     let pq_store = install_hybrid_verify_config();
     install_test_key_subjects();
 
@@ -571,6 +576,7 @@ async fn two_subjects_per_subject_isolation_over_rpc() -> Result<()> {
 /// behavior; a fix must make the first assertion ALLOW.
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn domain_grant_is_inert_over_rpc_gap1128() -> Result<()> {
+    support::install_explicit_dispatch_pep();
     let pq_store = install_hybrid_verify_config();
     install_test_key_subjects();
 
@@ -640,6 +646,7 @@ async fn domain_grant_is_inert_over_rpc_gap1128() -> Result<()> {
 /// signed, verified JWT tenant claim rather than the subject or request data.
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn verified_tenant_domains_isolate_pairwise_rpc_callers() -> Result<()> {
+    support::install_explicit_dispatch_pep();
     let pq_store = install_hybrid_verify_config();
     install_test_key_subjects();
 
@@ -751,6 +758,7 @@ async fn verified_tenant_domains_isolate_pairwise_rpc_callers() -> Result<()> {
 /// Equal raw event prefixes are independent when their verified tenant differs.
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn event_prefixes_are_isolated_across_verified_tenants() -> Result<()> {
+    support::install_explicit_dispatch_pep();
     let pq_store = install_hybrid_verify_config();
     install_test_key_subjects();
 

--- a/crates/hyprstream/tests/support/mod.rs
+++ b/crates/hyprstream/tests/support/mod.rs
@@ -1,0 +1,27 @@
+//! Explicit authorization fixtures shared by Hyprstream integration tests.
+
+use std::sync::Arc;
+
+use hyprstream_rpc::auth::mac::{install_mac_dispatch_pep, MacDecision, MacDispatchPep};
+use hyprstream_rpc::service::EnvelopeContext;
+
+/// Explicitly opt a non-MAC integration fixture into dispatch.
+///
+/// The production uninstalled state is deny-at-rest; these tests install a
+/// permit PEP only because their assertions concern another subsystem.
+pub fn install_explicit_dispatch_pep() {
+    struct ExplicitFixturePep;
+
+    impl MacDispatchPep for ExplicitFixturePep {
+        fn check(
+            &self,
+            _ctx: &EnvelopeContext,
+            _service_domain: &str,
+            _method: Option<u16>,
+        ) -> MacDecision {
+            MacDecision::Permit
+        }
+    }
+
+    install_mac_dispatch_pep(Arc::new(ExplicitFixturePep));
+}

--- a/docs/mac-activation-runbook.md
+++ b/docs/mac-activation-runbook.md
@@ -13,14 +13,19 @@ Capture and retain one reviewed evidence bundle covering every epic gate:
    zero `ill_formed` nodes.
 2. G2: the PEP/TOCTOU audit proves every live path is mediated and the labeled
    identity/object is bound to the subject/object actually served. Include the
-   `VerifiedAttach` divergence-denial test.
+   `VerifiedAttach` divergence-denial test. The runtime control also refuses
+   widening while any worker UDS/vsock transport is registered without a
+   verified attach-credential carrier; operator attestation cannot override
+   that blocker.
 3. G3: a staging exercise widens and then calls `narrow_to_floor`; the PEP
    remains installed and denials remain audited.
 4. G4: denial-to-proposal handling passes end to end.
 5. G5: deny audit export, metrics, and alerting are live.
 6. G6: the release validation and Kimi security review are attached, and the
    named operator signs off this runbook.
-7. G7: revocation, policy/resolver reload, and AVC flush are demonstrated.
+7. G7: revocation, policy/resolver reload, AVC flush, JTI eviction from the
+   verified-subject cache, and verified-subject cache generation rotation are
+   demonstrated.
 
 `MacActivationControl::widen_identity_aware` accepts a
 `MacActivationEvidence` containing G1-G7 attestations and refuses the widening

--- a/docs/mac-activation-runbook.md
+++ b/docs/mac-activation-runbook.md
@@ -1,0 +1,64 @@
+# MAC identity-aware activation runbook
+
+Identity-aware MAC is an operator widening, not a boot default. Production
+starts with every PEP installed and the subject context narrowed to
+`anonymous_floor()`. The control changes only the context supplied to those
+PEPs; it cannot uninstall a monitor or enter a permissive/audit-only mode.
+
+## Evidence gate
+
+Capture and retain one reviewed evidence bundle covering every epic gate:
+
+1. G1: `hyprstream mac genesis` reports `COMPLETE`, with zero `unlabeled` and
+   zero `ill_formed` nodes.
+2. G2: the PEP/TOCTOU audit proves every live path is mediated and the labeled
+   identity/object is bound to the subject/object actually served. Include the
+   `VerifiedAttach` divergence-denial test.
+3. G3: a staging exercise widens and then calls `narrow_to_floor`; the PEP
+   remains installed and denials remain audited.
+4. G4: denial-to-proposal handling passes end to end.
+5. G5: deny audit export, metrics, and alerting are live.
+6. G6: the release validation and Kimi security review are attached, and the
+   named operator signs off this runbook.
+7. G7: revocation, policy/resolver reload, and AVC flush are demonstrated.
+
+`MacActivationControl::widen_identity_aware` accepts a
+`MacActivationEvidence` containing G1-G7 attestations and refuses the widening
+if any gate is false. No startup path constructs that evidence or calls the
+widening method.
+
+## Widen
+
+The live daemon's operator control plane must:
+
+1. Recompute `GenesisGate::production().report()` in the target process.
+2. Verify the signed evidence bundle and operator authorization.
+3. Construct `MacActivationEvidence` with that report and the approved G2-G7
+   attestations.
+4. Call
+   `global_mac_activation_control().widen_identity_aware(&evidence)`.
+5. Confirm the mode is `IdentityAware`, exercise representative RPC, 9P, CAS,
+   VFS, exemptions, and MoQ/event traffic, and watch deny telemetry.
+
+Do not treat a successful test fixture or a `mac genesis` report alone as
+authorization to widen.
+
+## Narrow-back kill switch
+
+An authorized operator may always call
+`global_mac_activation_control().narrow_to_floor()`. Confirm the mode is
+`FloorOnly`, verify that each PEP remains installed, and retain the signed audit
+records around the transition. Narrowing requires no coverage or health
+precondition so it remains available during an incident.
+
+## Current decision
+
+Leave production floor-only. A release is activation-ready only after its
+validation evidence is attached, but the human widening decision remains
+blocked until all G1-G7 evidence above is green. In particular, an incomplete
+genesis report or unfinished revocation/reload evidence makes widening return
+an error.
+
+The 2026-07-26 default-config evidence snapshot is **INCOMPLETE**: 93 nodes,
+23 labeled, 70 unlabeled, and 0 ill-formed. That snapshot is evidence to keep
+the gate closed, not approval to widen; recompute it in the target deployment.


### PR DESCRIPTION
## Summary

- thread MAC clearance from verified `Claims × VerifiedKeyMaterial` instead of unconditional `anonymous_floor()` on authenticated RPC and 9P paths
- wire the six merged PEPs into production RPC, 9P, CAS, VFS, exemptions, and MoQ/event constructors with mandatory fail-closed mediation and signed deny audit
- introduce the unified `VerifiedAttach` bundle so one verified credential binds the exact MAC identity/session, authority-resolved tenant, and VFS `Subject`; backend substitution or subject divergence fails closed
- add the G1-G7 evidence-gated widen control and unconditional narrow-back control; neither removes a monitor
- extend the #1274 gate with the real atproto/OAuth/DPoP/exchangeUcan → RPC+9P positive path and an explicit MAC-identity/VFS-subject divergence denial
- add the operator activation runbook and current Genesis evidence

References #1267, #698, #699, and #1274.

## Activation decision

**Do not enable identity-aware mode.** Startup installs all PEPs but remains `FloorOnly`; no production startup path calls `widen_identity_aware`.

Current default-config Genesis evidence (2026-07-26):

- 93 nodes
- 23 labeled
- 70 unlabeled
- 0 ill-formed
- result: **INCOMPLETE**

The control refuses widening until the Genesis report is complete and the operator supplies reviewed G2-G7 evidence. Narrow-back is always available and retains every monitor.

## Validation

- exact release gate:
  `buildq -- cargo nextest run --release --profile ci -p hyprstream -p hyprstream-rpc -p hyprstream-9p -p hyprstream-vfs --no-fail-fast`
  - **2475 passed, 0 failed, 9 skipped**
  - one preceding contention-heavy run had a process-level SIGABRT in `registry_rpc_is_live_at9p_candidate_boundary`; the test passed immediately in isolation and the locked full rerun above was clean
- mandatory release pre-commit Clippy: passed
- `cargo check` for the four affected packages/all targets: passed
- 9P library tests: 50 passed
- T8 MAC enforcing gate: 3 passed
- OAuth atproto/legacy conformance: passed
- direct rustfmt checks and `git diff --check`: passed
- workspace-wide `cargo fmt --check` remains blocked by the pre-existing `bitsandbytes-sys` parent-workspace metadata mismatch

## Independent review

Kimi K3 reviewed exact SHA `8745cb7591bbfaf4244801aafbf0f51c3c124941` against `origin/main...HEAD`: **PASS**.

The review confirmed no production auto-widen/fail-open path, all six PEP constructor paths, verified-Claims/key-material derivation, exact `VerifiedAttach` binding, fail-closed fixed-subject behavior, reversible narrowing, and meaningful #1274 coverage.

Non-blocking operational notes from review:

- VFS/MoQ clearance is intentionally subject-global for this cross-tenant system; tenant authority remains bound at ticket/attach, and this relies on clearance staying tenant-invariant per DID
- fixed-subject transports intentionally fail closed after widening until their credential-bearing attach carrier satisfies G2; operators must include those paths in G2 evidence

## PR shape

Kept as one PR because the clearance threading, attach type signature, production constructor wiring, activation control, and e2e gate are hard-dependent and touch the same seams; splitting would leave inert or non-compiling intermediate heads.

This PR is intentionally not self-merged.
