### PR TITLE
fix(rpc): emit service CGRs from CPU-only build

### DIFF
--- a/crates/hyprstream-rpc-std/build.rs
+++ b/crates/hyprstream-rpc-std/build.rs
@@ -40,6 +40,16 @@ fn main() {
 
     hyprstream_rpc_build::compile_schemas(schema_dir, out_path, import_paths, &schemas);
 
+    // Copy CGR files to stable codegen-out/ for TypeScript codegen
+    let codegen_dir = Path::new(&manifest_dir).join("../../codegen-out");
+    let _ = std::fs::create_dir_all(&codegen_dir);
+    for name in &schemas {
+        let cgr_path = out_path.join(format!("{name}.cgr"));
+        if cgr_path.exists() {
+            let _ = std::fs::copy(&cgr_path, codegen_dir.join(format!("{name}.cgr")));
+        }
+    }
+
     // Export OUT_DIR so downstream crates (hyprstream) can find our CGR files
     // via the DEP_HYPRSTREAM_RPC_STD_OUT_DIR env var.
     println!("cargo:out_dir={}", out_dir);


### PR DESCRIPTION
Fixes #1337.

Copies the service CGRs produced by hyprstream-rpc-std into the repo-root codegen-out directory, mirroring the existing hyprstream build-script behavior. The existing native copy path remains unchanged.

Validation:
- cargo build -p hyprstream-rpc-std with LIBTORCH, LD_LIBRARY_PATH, and LIBTORCH_BYPASS_VERSION_CHECK unset
- verified all nine service CGRs exist in codegen-out and match OUT_DIR byte-for-byte
- cargo check -p hyprstream -p hyprstream-rpc-std with cached CUDA 13.0 libtorch
- repository pre-commit Clippy hook