### PR TITLE
fix(service): canonicalize at9p verify name

### DIFF
--- a/crates/hyprstream/src/services/at9p_verify.rs
+++ b/crates/hyprstream/src/services/at9p_verify.rs
@@ -82,7 +82,7 @@ use crate::config::{At9pVerifyConfig, TlsConfig};
 use crate::server::tls::{resolve_rustls_config, serve_app};
 
 /// Service name for logging (not registered in the RPC mesh — see module docs).
-pub const SERVICE_NAME: &str = "at9p_verify";
+pub const SERVICE_NAME: &str = "at9p-verify";
 
 /// Default freshness window for a liveness proof (seconds, symmetric skew).
 pub const DEFAULT_MAX_SKEW_SECONDS: u64 = 300;
@@ -359,8 +359,9 @@ impl At9pVerifyService {
 
     fn http_addr(&self) -> Result<SocketAddr, RpcError> {
         let s = format!("{}:{}", self.config.host, self.config.port);
-        s.parse()
-            .map_err(|e| RpcError::SpawnFailed(format!("at9p_verify: invalid bind address: {e}")))
+        s.parse().map_err(|e| {
+            RpcError::SpawnFailed(format!("{SERVICE_NAME}: invalid bind address: {e}"))
+        })
     }
 }
 
@@ -383,7 +384,7 @@ impl Spawnable for At9pVerifyService {
         let rt = tokio::runtime::Builder::new_multi_thread()
             .enable_all()
             .build()
-            .map_err(|e| RpcError::SpawnFailed(format!("at9p_verify runtime: {e}")))?;
+            .map_err(|e| RpcError::SpawnFailed(format!("{SERVICE_NAME} runtime: {e}")))?;
 
         rt.block_on(async move {
             let addr = self.http_addr()?;
@@ -395,7 +396,7 @@ impl Spawnable for At9pVerifyService {
                 self.config.tls_key.as_ref(),
             )
             .await
-            .map_err(|e| RpcError::SpawnFailed(format!("at9p_verify TLS config: {e}")))?;
+            .map_err(|e| RpcError::SpawnFailed(format!("{SERVICE_NAME} TLS config: {e}")))?;
 
             let scheme = if rustls_config.is_some() { "https" } else { "http" };
             let state = VerifyFaceState {
@@ -463,6 +464,16 @@ mod tests {
             max_skew_seconds: 300,
             max_challenge_bytes: 256,
         }
+    }
+
+    #[test]
+    fn service_name_is_dns_safe_and_stable() {
+        assert_eq!(SERVICE_NAME, "at9p-verify");
+        assert!(
+            SERVICE_NAME
+                .bytes()
+                .all(|b| b.is_ascii_lowercase() || b.is_ascii_digit() || b == b'-'),
+        );
     }
 
     /// POST a JSON body to the credential-free router and return (status, body).

--- a/crates/hyprstream/src/services/factories.rs
+++ b/crates/hyprstream/src/services/factories.rs
@@ -1344,7 +1344,7 @@ fn create_xet_service(ctx: &ServiceContext) -> anyhow::Result<Box<dyn Spawnable>
 /// it registers nothing and depends on nothing. `SocketKind` has no `Http`
 /// variant and this face is not announceable — that is the #1135 design
 /// statement made concrete. See `services::at9p_verify` for the full rationale.
-#[service_factory("at9p_verify")]
+#[service_factory("at9p-verify")]
 fn create_at9p_verify_service(_ctx: &ServiceContext) -> anyhow::Result<Box<dyn Spawnable>> {
     use crate::services::At9pVerifyService;
 
@@ -2231,6 +2231,21 @@ fn compute_tls_endorsement(
 #[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn at9p_verify_factory_uses_canonical_service_name() {
+        let factory =
+            hyprstream_service::get_factory(crate::services::at9p_verify::SERVICE_NAME)
+                .expect("at9p-verify factory must be registered");
+        assert_eq!(factory.name, "at9p-verify");
+        assert!(
+            factory
+                .name
+                .bytes()
+                .all(|b| b.is_ascii_lowercase() || b.is_ascii_digit() || b == b'-'),
+        );
+        assert!(hyprstream_service::get_factory("at9p_verify").is_none());
+    }
 
     /// Helper: generate an ECDSA P-256 key pair and return (pkcs8_der, public_key_der)
     fn generate_ecdsa_p256_pair() -> (Vec<u8>, Vec<u8>) {


### PR DESCRIPTION
## Summary
- rename the at9p verification service key from at9p_verify to DNS-safe at9p-verify
- keep Rust identifiers and the at9p_verify TOML config key stable
- pin inventory lookup and DNS-safe naming with regression tests

This is demo-critical: it unblocks the operator activation wizard. T8 #1333 rebases onto this commit after landing.

## Validation
- release build: cargo build --release -p hyprstream
- fresh HOME: hyprstream wizard --non-interactive --bootstrap-only (Directories, Registry, Service keys, Environment all OK)
- cargo nextest run --release --profile ci -p hyprstream --no-fail-fast (1392 passed, 7 skipped)
- pre-commit release clippy passed

No self-merge.