### PR TITLE
feat(pds): add tenant-safe federation intake

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7182,12 +7182,15 @@ name = "hyprstream-pds-service"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "async-trait",
  "ed25519-dalek 2.2.0",
  "hyprstream-crypto",
  "hyprstream-pds",
  "hyprstream-rpc",
  "hyprstream-vfs",
+ "parking_lot 0.12.4",
  "rand 0.8.5",
+ "serde_json",
  "thiserror 1.0.69",
  "tokio",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7190,6 +7190,7 @@ dependencies = [
  "hyprstream-vfs",
  "parking_lot 0.12.4",
  "rand 0.8.5",
+ "serde",
  "serde_json",
  "thiserror 1.0.69",
  "tokio",

--- a/crates/hyprstream-pds-service/Cargo.toml
+++ b/crates/hyprstream-pds-service/Cargo.toml
@@ -8,9 +8,12 @@ description = "Tenant-scoped PDS account record service over the Hyprstream 9P m
 
 [dependencies]
 anyhow = { workspace = true }
+async-trait = { workspace = true }
 hyprstream-pds = { path = "../hyprstream-pds" }
 hyprstream-rpc = { path = "../hyprstream-rpc" }
 hyprstream-vfs = { path = "../hyprstream-vfs" }
+parking_lot = { workspace = true }
+serde_json = { workspace = true }
 thiserror = { workspace = true }
 
 [dev-dependencies]

--- a/crates/hyprstream-pds-service/Cargo.toml
+++ b/crates/hyprstream-pds-service/Cargo.toml
@@ -13,6 +13,7 @@ hyprstream-pds = { path = "../hyprstream-pds" }
 hyprstream-rpc = { path = "../hyprstream-rpc" }
 hyprstream-vfs = { path = "../hyprstream-vfs" }
 parking_lot = { workspace = true }
+serde = { workspace = true }
 serde_json = { workspace = true }
 thiserror = { workspace = true }
 

--- a/crates/hyprstream-pds-service/src/federation_intake.rs
+++ b/crates/hyprstream-pds-service/src/federation_intake.rs
@@ -18,6 +18,19 @@ use hyprstream_rpc::identity::UNAUTHENTICATED_DID_SENTINEL;
 use parking_lot::RwLock;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
+use thiserror::Error;
+
+/// Leak-safe failure from a direct identity-directory read.
+///
+/// Wire adapters must map this to HTTP 404 (or the transport's equivalent),
+/// never 403. Missing objects and objects above the caller's clearance are
+/// intentionally indistinguishable.
+#[derive(Clone, Copy, Debug, Error, PartialEq, Eq)]
+pub enum IdentityDirectoryReadError {
+    /// The identity does not exist or is not visible to this caller.
+    #[error("identity not found")]
+    NotFound,
+}
 
 /// Resolver for the two foreign ATProto DID methods accepted by intake.
 ///
@@ -136,7 +149,7 @@ impl InventoryEntry {
 #[serde(rename_all = "camelCase")]
 pub struct ResolvedDiscovery {
     quic_url: Option<String>,
-    cert_hashes: Vec<String>,
+    cert_hash: Option<String>,
 }
 
 impl ResolvedDiscovery {
@@ -144,7 +157,7 @@ impl ResolvedDiscovery {
         let Some(services) = document.get("service").and_then(Value::as_array) else {
             return Ok(Self {
                 quic_url: None,
-                cert_hashes: Vec::new(),
+                cert_hash: None,
             });
         };
         let mut quic_entries = services
@@ -153,7 +166,7 @@ impl ResolvedDiscovery {
         let Some(entry) = quic_entries.next() else {
             return Ok(Self {
                 quic_url: None,
-                cert_hashes: Vec::new(),
+                cert_hash: None,
             });
         };
         ensure!(
@@ -184,9 +197,13 @@ impl ResolvedDiscovery {
             })
             .transpose()?
             .unwrap_or_default();
+        ensure!(
+            cert_hashes.len() <= 1,
+            "DID document contains ambiguous QUIC certificate hashes"
+        );
         Ok(Self {
             quic_url,
-            cert_hashes,
+            cert_hash: cert_hashes.into_iter().next(),
         })
     }
 
@@ -195,9 +212,9 @@ impl ResolvedDiscovery {
         self.quic_url.as_deref()
     }
 
-    /// Current overlapping certificate-pin set.
-    pub fn cert_hashes(&self) -> &[String] {
-        &self.cert_hashes
+    /// Current certificate pin, if the DID document publishes one.
+    pub fn cert_hash(&self) -> Option<&str> {
+        self.cert_hash.as_deref()
     }
 }
 
@@ -224,6 +241,12 @@ pub trait IdentityInventoryReadModel: Send + Sync {
     /// can observe only this post-filter vector's length. Implementations must
     /// never return [`UNAUTHENTICATED_DID_SENTINEL`] as a real host.
     fn list(&self, viewer: &SecurityContext) -> Result<Vec<InventoryEntry>>;
+
+    /// Fetch one entry without revealing whether a filtered object exists.
+    ///
+    /// `None` means absent, no caller clearance, or above caller clearance.
+    /// Wire adapters must map every `None` case to the same 404-style result.
+    fn get(&self, viewer: Option<&SecurityContext>, did: &str) -> Result<Option<InventoryEntry>>;
 }
 
 /// Thin in-memory inventory read model, useful for embedded/demo deployments.
@@ -260,6 +283,17 @@ impl IdentityInventoryReadModel for InMemoryIdentityInventory {
             })
             .map(|stored| stored.entry.clone())
             .collect())
+    }
+
+    fn get(&self, viewer: Option<&SecurityContext>, did: &str) -> Result<Option<InventoryEntry>> {
+        if did == UNAUTHENTICATED_DID_SENTINEL {
+            return Ok(None);
+        }
+        let identities = self.identities.read();
+        Ok(identities
+            .get(did)
+            .filter(|stored| viewer.is_some_and(|clearance| clearance.can_access(&stored.label)))
+            .map(|stored| stored.entry.clone()))
     }
 }
 
@@ -314,9 +348,18 @@ impl FederationIntake {
         self.intake_inner(did).await
     }
 
-    /// Resolve current connect-time discovery without consulting AppView data.
-    pub async fn resolve(&self, did: &str) -> Result<ResolvedDiscovery> {
-        ensure_real_identity_did(did)?;
+    /// Resolve current connect-time discovery for a visible inventory entry.
+    ///
+    /// The inventory lookup happens before resolver I/O. Missing, no-clearance,
+    /// and above-clearance identities all return the same 404-style error.
+    pub async fn resolve(
+        &self,
+        did: &str,
+        viewer: Option<&SecurityContext>,
+    ) -> Result<ResolvedDiscovery> {
+        if self.inventory.get(viewer, did)?.is_none() {
+            return Err(IdentityDirectoryReadError::NotFound.into());
+        }
         let document = self.resolver.resolve_federated_document(did).await?;
         ResolvedDiscovery::from_document(&document)
     }
@@ -548,9 +591,17 @@ mod tests {
             inventory.list(&unauthenticated_viewer()).unwrap(),
             vec![resolved]
         );
-        let discovery = intake.resolve(FEDERATED_WEB_DID).await.unwrap();
+        let viewer = unauthenticated_viewer();
+        let discovery = intake
+            .resolve(FEDERATED_WEB_DID, Some(&viewer))
+            .await
+            .unwrap();
         assert_eq!(discovery.quic_url(), Some("https://alice.example:443"));
-        assert!(discovery.cert_hashes().is_empty());
+        assert_eq!(discovery.cert_hash(), None);
+        let projected = serde_json::to_value(discovery).unwrap();
+        assert!(projected.get("quicUrl").is_some());
+        assert!(projected.get("certHash").is_some());
+        assert!(projected.get("certHashes").is_none());
     }
 
     #[test]
@@ -588,6 +639,53 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn above_floor_direct_access_is_not_found_not_forbidden() {
+        const HIDDEN_DID: &str = "did:web:hidden.example";
+        const MISSING_DID: &str = "did:web:missing.example";
+
+        let inventory = Arc::new(InMemoryIdentityInventory::default());
+        inventory.identities.write().insert(
+            HIDDEN_DID.to_owned(),
+            StoredInventoryEntry {
+                entry: InventoryEntry {
+                    did: HIDDEN_DID.to_owned(),
+                    handle: None,
+                    kind: InventoryKind::Federated,
+                    tenant: None,
+                    pds_endpoint: None,
+                },
+                label: SecurityLabel::new(
+                    Level::Secret,
+                    hyprstream_rpc::auth::mac::Assurance::Unverified,
+                    CompartmentSet::EMPTY,
+                ),
+            },
+        );
+        let intake = FederationIntake::new(
+            Arc::new(FederatedDidResolver::new(
+                Arc::new(NeverResolver),
+                Arc::new(NeverResolver),
+            )),
+            inventory.clone(),
+            Vec::new(),
+        );
+        let viewer = unauthenticated_viewer();
+
+        assert_eq!(inventory.get(Some(&viewer), HIDDEN_DID).unwrap(), None);
+        assert_eq!(inventory.get(Some(&viewer), MISSING_DID).unwrap(), None);
+        assert_eq!(inventory.get(None, HIDDEN_DID).unwrap(), None);
+
+        for did in [HIDDEN_DID, MISSING_DID] {
+            let error = intake.resolve(did, Some(&viewer)).await.unwrap_err();
+            assert_eq!(
+                error.downcast_ref::<IdentityDirectoryReadError>(),
+                Some(&IdentityDirectoryReadError::NotFound),
+                "direct access to {did} must be 404-style, never forbidden: {error:#}"
+            );
+        }
+    }
+
+    #[tokio::test]
     async fn unauthenticated_sentinel_is_never_resolved_or_listed() {
         let resolver = Arc::new(FederatedDidResolver::new(
             Arc::new(NeverResolver),
@@ -608,6 +706,17 @@ mod tests {
             .list(&unauthenticated_viewer())
             .unwrap()
             .is_empty());
+        let error = intake
+            .resolve(
+                UNAUTHENTICATED_DID_SENTINEL,
+                Some(&unauthenticated_viewer()),
+            )
+            .await
+            .unwrap_err();
+        assert_eq!(
+            error.downcast_ref::<IdentityDirectoryReadError>(),
+            Some(&IdentityDirectoryReadError::NotFound)
+        );
 
         inventory.identities.write().insert(
             UNAUTHENTICATED_DID_SENTINEL.to_owned(),

--- a/crates/hyprstream-pds-service/src/federation_intake.rs
+++ b/crates/hyprstream-pds-service/src/federation_intake.rs
@@ -12,8 +12,11 @@ use std::sync::Arc;
 use anyhow::{bail, ensure, Result};
 use async_trait::async_trait;
 use hyprstream_rpc::admission::DidDocResolve;
+use hyprstream_rpc::auth::mac::{SecurityContext, SecurityLabel};
 use hyprstream_rpc::auth::Claims;
+use hyprstream_rpc::identity::UNAUTHENTICATED_DID_SENTINEL;
 use parking_lot::RwLock;
+use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
 /// Resolver for the two foreign ATProto DID methods accepted by intake.
@@ -43,6 +46,7 @@ pub trait FederatedDidDocumentResolver: Send + Sync {
 #[async_trait]
 impl FederatedDidDocumentResolver for FederatedDidResolver {
     async fn resolve_federated_document(&self, did: &str) -> Result<Value> {
+        ensure_real_identity_did(did)?;
         let resolver = if hyprstream_rpc::did_plc::is_did_plc(did) {
             &self.plc
         } else if did.starts_with("did:web:") {
@@ -59,79 +63,210 @@ impl FederatedDidDocumentResolver for FederatedDidResolver {
     }
 }
 
-/// A derived, read-only inventory projection for a foreign identity.
-///
-/// `tenant` is retained as an explicit optional field so API consumers can use
-/// the same shape for local and federated inventory entries. Federation intake
-/// constructs records only with `None`; there is no public constructor that can
-/// attach a tenant.
-#[derive(Clone, Debug, PartialEq)]
-pub struct FederatedIdentityRecord {
-    did: String,
-    document: Value,
-    tenant: Option<String>,
+/// Authority class represented by one derived inventory entry.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum InventoryKind {
+    /// A DID with an authority-resolved local hosted-account binding.
+    Local,
+    /// A real foreign DID discovered read-only.
+    Federated,
+    /// The immutable credential-absence floor, never emitted as a real host.
+    Unauthenticated,
 }
 
-impl FederatedIdentityRecord {
-    fn new(did: String, document: Value) -> Self {
-        Self {
+/// Derived AppView projection. It is an index, never identity authority.
+///
+/// Live discovery data is intentionally absent. In particular, this type
+/// cannot carry a QUIC URL or certificate hash; callers obtain rotating reach
+/// through [`FederationIntake::resolve`] at connect time.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct InventoryEntry {
+    did: String,
+    handle: Option<String>,
+    kind: InventoryKind,
+    tenant: Option<String>,
+    pds_endpoint: Option<String>,
+}
+
+impl InventoryEntry {
+    fn federated(did: String, document: &Value) -> Result<Self> {
+        ensure_real_identity_did(&did)?;
+        Ok(Self {
             did,
-            document,
+            handle: extract_handle(document)?,
+            kind: InventoryKind::Federated,
             tenant: None,
-        }
+            pds_endpoint: extract_pds_endpoint(document)?,
+        })
     }
 
-    /// The resolved foreign DID.
+    /// The indexed DID.
     pub fn did(&self) -> &str {
         &self.did
     }
 
-    /// The validated DID document used to derive this projection.
-    pub fn document(&self) -> &Value {
-        &self.document
+    /// Optional ATProto handle derived from `alsoKnownAs`.
+    pub fn handle(&self) -> Option<&str> {
+        self.handle.as_deref()
     }
 
-    /// Always `None` for records produced by federation intake.
+    /// Local, federated, or unauthenticated classification.
+    pub fn kind(&self) -> InventoryKind {
+        self.kind
+    }
+
+    /// Authority-resolved local tenant, always `None` for federation intake.
     pub fn tenant(&self) -> Option<&str> {
         self.tenant.as_deref()
     }
+
+    /// PDS endpoint pointer. This is not live transport reach.
+    pub fn pds_endpoint(&self) -> Option<&str> {
+        self.pds_endpoint.as_deref()
+    }
 }
 
-/// Non-authoritative inventory sink consumed by federation intake.
+/// Live connect-time discovery resolved from current DID authority.
+///
+/// This type is separate from [`InventoryEntry`] so rotating transport
+/// credentials cannot become stale AppView data.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ResolvedDiscovery {
+    quic_url: Option<String>,
+    cert_hashes: Vec<String>,
+}
+
+impl ResolvedDiscovery {
+    fn from_document(document: &Value) -> Result<Self> {
+        let Some(services) = document.get("service").and_then(Value::as_array) else {
+            return Ok(Self {
+                quic_url: None,
+                cert_hashes: Vec::new(),
+            });
+        };
+        let mut quic_entries = services
+            .iter()
+            .filter(|entry| entry.get("type").and_then(Value::as_str) == Some("QuicTransport"));
+        let Some(entry) = quic_entries.next() else {
+            return Ok(Self {
+                quic_url: None,
+                cert_hashes: Vec::new(),
+            });
+        };
+        ensure!(
+            quic_entries.next().is_none(),
+            "DID document contains ambiguous QuicTransport discovery entries"
+        );
+        hyprstream_rpc::service_entry::decode_service_entry(entry)?;
+        let endpoint = entry
+            .get("serviceEndpoint")
+            .and_then(Value::as_object)
+            .ok_or_else(|| anyhow::anyhow!("QuicTransport serviceEndpoint is not an object"))?;
+        let quic_url = endpoint
+            .get("uri")
+            .and_then(Value::as_str)
+            .map(str::to_owned);
+        let cert_hashes = endpoint
+            .get("certHashes")
+            .and_then(Value::as_array)
+            .map(|hashes| {
+                hashes
+                    .iter()
+                    .map(|hash| {
+                        hash.as_str()
+                            .map(str::to_owned)
+                            .ok_or_else(|| anyhow::anyhow!("QUIC cert hash is not a string"))
+                    })
+                    .collect::<Result<Vec<_>>>()
+            })
+            .transpose()?
+            .unwrap_or_default();
+        Ok(Self {
+            quic_url,
+            cert_hashes,
+        })
+    }
+
+    /// Current QUIC URL, if the DID document publishes one.
+    pub fn quic_url(&self) -> Option<&str> {
+        self.quic_url.as_deref()
+    }
+
+    /// Current overlapping certificate-pin set.
+    pub fn cert_hashes(&self) -> &[String] {
+        &self.cert_hashes
+    }
+}
+
+#[derive(Clone)]
+struct StoredInventoryEntry {
+    entry: InventoryEntry,
+    label: SecurityLabel,
+}
+
+/// Non-authoritative inventory read model consumed by federation intake.
 ///
 /// A pglite/Postgres implementation can replace the in-memory implementation
 /// without changing resolution or tenant-safety logic.
-pub trait FederatedIdentityInventory: Send + Sync {
+pub trait IdentityInventoryReadModel: Send + Sync {
     /// Insert or refresh one derived foreign-identity projection.
-    fn upsert(&self, identity: FederatedIdentityRecord) -> Result<()>;
+    ///
+    /// Implementations must reject [`UNAUTHENTICATED_DID_SENTINEL`].
+    fn upsert_federated(&self, identity: InventoryEntry) -> Result<()>;
 
-    /// List the currently indexed foreign identities in deterministic DID order.
-    fn list(&self) -> Result<Vec<FederatedIdentityRecord>>;
+    /// List only entries dominated by the viewer's verified clearance.
+    ///
+    /// Filtering happens inside the read model before any response is built.
+    /// The return shape intentionally has no total/hidden-count field: callers
+    /// can observe only this post-filter vector's length. Implementations must
+    /// never return [`UNAUTHENTICATED_DID_SENTINEL`] as a real host.
+    fn list(&self, viewer: &SecurityContext) -> Result<Vec<InventoryEntry>>;
 }
 
 /// Thin in-memory inventory read model, useful for embedded/demo deployments.
 #[derive(Default)]
-pub struct InMemoryFederatedIdentityInventory {
-    identities: RwLock<BTreeMap<String, FederatedIdentityRecord>>,
+pub struct InMemoryIdentityInventory {
+    identities: RwLock<BTreeMap<String, StoredInventoryEntry>>,
 }
 
-impl FederatedIdentityInventory for InMemoryFederatedIdentityInventory {
-    fn upsert(&self, identity: FederatedIdentityRecord) -> Result<()> {
+impl IdentityInventoryReadModel for InMemoryIdentityInventory {
+    fn upsert_federated(&self, identity: InventoryEntry) -> Result<()> {
+        ensure_real_identity_did(identity.did())?;
+        ensure!(
+            identity.kind == InventoryKind::Federated && identity.tenant.is_none(),
+            "federation intake inventory entry must be federated with no local tenant"
+        );
         let mut identities = self.identities.write();
-        identities.insert(identity.did.clone(), identity);
+        identities.insert(
+            identity.did.clone(),
+            StoredInventoryEntry {
+                entry: identity,
+                label: SecurityLabel::bottom(),
+            },
+        );
         Ok(())
     }
 
-    fn list(&self) -> Result<Vec<FederatedIdentityRecord>> {
+    fn list(&self, viewer: &SecurityContext) -> Result<Vec<InventoryEntry>> {
         let identities = self.identities.read();
-        Ok(identities.values().cloned().collect())
+        Ok(identities
+            .values()
+            .filter(|stored| {
+                stored.entry.did() != UNAUTHENTICATED_DID_SENTINEL
+                    && viewer.can_access(&stored.label)
+            })
+            .map(|stored| stored.entry.clone())
+            .collect())
     }
 }
 
 /// Resolve and project foreign identities without granting local authority.
 pub struct FederationIntake {
     resolver: Arc<dyn FederatedDidDocumentResolver>,
-    inventory: Arc<dyn FederatedIdentityInventory>,
+    inventory: Arc<dyn IdentityInventoryReadModel>,
     local_issuers: Vec<String>,
 }
 
@@ -139,7 +274,7 @@ impl FederationIntake {
     /// Construct an intake service over a resolver and derived inventory sink.
     pub fn new(
         resolver: Arc<dyn FederatedDidDocumentResolver>,
-        inventory: Arc<dyn FederatedIdentityInventory>,
+        inventory: Arc<dyn IdentityInventoryReadModel>,
         local_issuers: Vec<String>,
     ) -> Self {
         Self {
@@ -150,7 +285,7 @@ impl FederationIntake {
     }
 
     /// Resolve and index a foreign DID discovered without identity claims.
-    pub async fn intake(&self, did: &str) -> Result<FederatedIdentityRecord> {
+    pub async fn intake(&self, did: &str) -> Result<InventoryEntry> {
         self.intake_inner(did).await
     }
 
@@ -165,7 +300,7 @@ impl FederationIntake {
         &self,
         did: &str,
         mut claims: Claims,
-    ) -> Result<FederatedIdentityRecord> {
+    ) -> Result<InventoryEntry> {
         let local_issuers: Vec<&str> = self.local_issuers.iter().map(String::as_str).collect();
         ensure!(
             !claims.is_local_to(&local_issuers),
@@ -179,12 +314,70 @@ impl FederationIntake {
         self.intake_inner(did).await
     }
 
-    async fn intake_inner(&self, did: &str) -> Result<FederatedIdentityRecord> {
+    /// Resolve current connect-time discovery without consulting AppView data.
+    pub async fn resolve(&self, did: &str) -> Result<ResolvedDiscovery> {
+        ensure_real_identity_did(did)?;
         let document = self.resolver.resolve_federated_document(did).await?;
-        let identity = FederatedIdentityRecord::new(did.to_owned(), document);
-        self.inventory.upsert(identity.clone())?;
+        ResolvedDiscovery::from_document(&document)
+    }
+
+    async fn intake_inner(&self, did: &str) -> Result<InventoryEntry> {
+        ensure_real_identity_did(did)?;
+        let document = self.resolver.resolve_federated_document(did).await?;
+        let identity = InventoryEntry::federated(did.to_owned(), &document)?;
+        self.inventory.upsert_federated(identity.clone())?;
         Ok(identity)
     }
+}
+
+fn extract_handle(document: &Value) -> Result<Option<String>> {
+    let Some(aliases) = document.get("alsoKnownAs").and_then(Value::as_array) else {
+        return Ok(None);
+    };
+    let handles = aliases
+        .iter()
+        .filter_map(Value::as_str)
+        .filter_map(|alias| alias.strip_prefix("at://"))
+        .filter(|handle| !handle.is_empty() && !handle.contains('/'))
+        .map(str::to_owned)
+        .collect::<Vec<_>>();
+    ensure!(
+        handles.len() <= 1,
+        "DID document contains ambiguous ATProto handles"
+    );
+    Ok(handles.into_iter().next())
+}
+
+fn extract_pds_endpoint(document: &Value) -> Result<Option<String>> {
+    let Some(services) = document.get("service").and_then(Value::as_array) else {
+        return Ok(None);
+    };
+    let endpoints = services
+        .iter()
+        .filter(|entry| {
+            entry.get("type").and_then(Value::as_str) == Some("AtprotoPersonalDataServer")
+        })
+        .map(|entry| {
+            entry
+                .get("serviceEndpoint")
+                .and_then(Value::as_str)
+                .map(str::to_owned)
+                .ok_or_else(|| anyhow::anyhow!("ATProto PDS serviceEndpoint is not a string"))
+        })
+        .collect::<Result<Vec<_>>>()?;
+    ensure!(
+        endpoints.len() <= 1,
+        "DID document contains ambiguous ATProto PDS endpoints"
+    );
+    Ok(endpoints.into_iter().next())
+}
+
+fn ensure_real_identity_did(did: &str) -> Result<()> {
+    ensure!(
+        did != UNAUTHENTICATED_DID_SENTINEL,
+        "{UNAUTHENTICATED_DID_SENTINEL} is reserved for the unauthenticated floor and is not a federated identity"
+    );
+    Ok(())
 }
 
 #[cfg(test)]
@@ -192,7 +385,9 @@ mod tests {
     #![allow(clippy::expect_used, clippy::unwrap_used)]
 
     use super::*;
-    use hyprstream_rpc::auth::mac::{MacDecision, SecurityContext};
+    use hyprstream_rpc::auth::mac::{
+        CompartmentSet, Level, MacDecision, SecurityContext, VerifiedKeyMaterial,
+    };
     use hyprstream_rpc::Subject;
     use hyprstream_vfs::{SyntheticMount, SyntheticNode};
 
@@ -237,6 +432,14 @@ mod tests {
         }
     }
 
+    fn unauthenticated_viewer() -> SecurityContext {
+        SecurityContext::new(
+            Level::Public,
+            CompartmentSet::EMPTY,
+            VerifiedKeyMaterial::Unverified,
+        )
+    }
+
     #[tokio::test]
     async fn federated_did_resolves_lists_and_has_no_hosted_tenant() {
         let resolver = Arc::new(FederatedDidResolver::new(
@@ -244,12 +447,17 @@ mod tests {
                 expected_did: FEDERATED_DID,
                 document: serde_json::json!({
                     "id": FEDERATED_DID,
-                    "alsoKnownAs": ["at://alice.example"]
+                    "alsoKnownAs": ["at://alice.example"],
+                    "service": [{
+                        "id": format!("{FEDERATED_DID}#atproto_pds"),
+                        "type": "AtprotoPersonalDataServer",
+                        "serviceEndpoint": "https://pds.alice.example"
+                    }]
                 }),
             }),
             Arc::new(NeverResolver),
         ));
-        let inventory = Arc::new(InMemoryFederatedIdentityInventory::default());
+        let inventory = Arc::new(InMemoryIdentityInventory::default());
         let intake = FederationIntake::new(
             resolver,
             inventory.clone(),
@@ -264,12 +472,20 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(resolved.did(), FEDERATED_DID);
+        assert_eq!(resolved.handle(), Some("alice.example"));
+        assert_eq!(resolved.kind(), InventoryKind::Federated);
         assert_eq!(resolved.tenant(), None);
+        assert_eq!(resolved.pds_endpoint(), Some("https://pds.alice.example"));
 
-        let listed = inventory.list().unwrap();
+        let listed = inventory.list(&unauthenticated_viewer()).unwrap();
         assert_eq!(listed.len(), 1);
         assert_eq!(listed[0].did(), FEDERATED_DID);
         assert_eq!(listed[0].tenant(), None);
+        let projected = serde_json::to_value(&listed[0]).unwrap();
+        assert!(projected.get("quicUrl").is_none());
+        assert!(projected.get("certHash").is_none());
+        assert!(projected.get("certHashes").is_none());
+        assert!(projected.get("document").is_none());
 
         let account_store = AccountRecordStore::new(
             Arc::new(SyntheticMount::new(SyntheticNode::dir())),
@@ -310,17 +526,109 @@ mod tests {
                 expected_did: FEDERATED_WEB_DID,
                 document: serde_json::json!({
                     "id": FEDERATED_WEB_DID,
-                    "service": []
+                    "service": [{
+                        "id": format!("{FEDERATED_WEB_DID}#quic"),
+                        "type": "QuicTransport",
+                        "serviceEndpoint": {
+                            "uri": "https://alice.example:443",
+                            "webpki": true,
+                            "certHashes": []
+                        }
+                    }]
                 }),
             }),
         ));
-        let inventory = Arc::new(InMemoryFederatedIdentityInventory::default());
+        let inventory = Arc::new(InMemoryIdentityInventory::default());
         let intake = FederationIntake::new(resolver, inventory.clone(), Vec::new());
 
         let resolved = intake.intake(FEDERATED_WEB_DID).await.unwrap();
         assert_eq!(resolved.did(), FEDERATED_WEB_DID);
         assert_eq!(resolved.tenant(), None);
-        assert_eq!(inventory.list().unwrap(), vec![resolved]);
+        assert_eq!(
+            inventory.list(&unauthenticated_viewer()).unwrap(),
+            vec![resolved]
+        );
+        let discovery = intake.resolve(FEDERATED_WEB_DID).await.unwrap();
+        assert_eq!(discovery.quic_url(), Some("https://alice.example:443"));
+        assert!(discovery.cert_hashes().is_empty());
+    }
+
+    #[test]
+    fn inventory_listing_prefilters_above_clearance_without_a_hidden_count() {
+        let inventory = InMemoryIdentityInventory::default();
+        let public = InventoryEntry {
+            did: "did:web:public.example".to_owned(),
+            handle: None,
+            kind: InventoryKind::Federated,
+            tenant: None,
+            pds_endpoint: None,
+        };
+        inventory.upsert_federated(public.clone()).unwrap();
+        inventory.identities.write().insert(
+            "did:web:hidden.example".to_owned(),
+            StoredInventoryEntry {
+                entry: InventoryEntry {
+                    did: "did:web:hidden.example".to_owned(),
+                    handle: None,
+                    kind: InventoryKind::Federated,
+                    tenant: None,
+                    pds_endpoint: None,
+                },
+                label: SecurityLabel::new(
+                    Level::Secret,
+                    hyprstream_rpc::auth::mac::Assurance::Unverified,
+                    CompartmentSet::EMPTY,
+                ),
+            },
+        );
+
+        let visible = inventory.list(&unauthenticated_viewer()).unwrap();
+        assert_eq!(visible, vec![public]);
+        assert_eq!(visible.len(), 1, "only the post-filter count is observable");
+    }
+
+    #[tokio::test]
+    async fn unauthenticated_sentinel_is_never_resolved_or_listed() {
+        let resolver = Arc::new(FederatedDidResolver::new(
+            Arc::new(NeverResolver),
+            Arc::new(NeverResolver),
+        ));
+        let inventory = Arc::new(InMemoryIdentityInventory::default());
+        let intake = FederationIntake::new(resolver, inventory.clone(), Vec::new());
+
+        let error = intake
+            .intake(UNAUTHENTICATED_DID_SENTINEL)
+            .await
+            .unwrap_err();
+        assert!(
+            error.to_string().contains("unauthenticated floor"),
+            "{error:#}"
+        );
+        assert!(inventory
+            .list(&unauthenticated_viewer())
+            .unwrap()
+            .is_empty());
+
+        inventory.identities.write().insert(
+            UNAUTHENTICATED_DID_SENTINEL.to_owned(),
+            StoredInventoryEntry {
+                entry: InventoryEntry {
+                    did: UNAUTHENTICATED_DID_SENTINEL.to_owned(),
+                    handle: None,
+                    kind: InventoryKind::Unauthenticated,
+                    tenant: None,
+                    pds_endpoint: None,
+                },
+                label: SecurityLabel::bottom(),
+            },
+        );
+        assert!(
+            inventory
+                .list(&unauthenticated_viewer())
+                .unwrap()
+                .is_empty(),
+            "legacy/corrupt sentinel rows must be filtered from inventory listing"
+        );
     }
 
     #[tokio::test]
@@ -329,7 +637,7 @@ mod tests {
             Arc::new(NeverResolver),
             Arc::new(NeverResolver),
         ));
-        let inventory = Arc::new(InMemoryFederatedIdentityInventory::default());
+        let inventory = Arc::new(InMemoryIdentityInventory::default());
         let intake = FederationIntake::new(
             resolver,
             inventory.clone(),
@@ -344,6 +652,9 @@ mod tests {
             .await
             .unwrap_err();
         assert!(error.to_string().contains("foreign issuer"));
-        assert!(inventory.list().unwrap().is_empty());
+        assert!(inventory
+            .list(&unauthenticated_viewer())
+            .unwrap()
+            .is_empty());
     }
 }

--- a/crates/hyprstream-pds-service/src/federation_intake.rs
+++ b/crates/hyprstream-pds-service/src/federation_intake.rs
@@ -1,0 +1,349 @@
+//! Read-only intake of foreign ATProto identities into an inventory read model.
+//!
+//! Resolution delegates to the hardened `did:plc` and `did:web` resolvers in
+//! `hyprstream-rpc`. This service adds method dispatch, a final subject-binding
+//! check, and the projection into a queryable inventory. The projection is
+//! deliberately non-authoritative: a federated identity is discoverable but
+//! never acquires a local hosted-account tenant.
+
+use std::collections::BTreeMap;
+use std::sync::Arc;
+
+use anyhow::{bail, ensure, Result};
+use async_trait::async_trait;
+use hyprstream_rpc::admission::DidDocResolve;
+use hyprstream_rpc::auth::Claims;
+use parking_lot::RwLock;
+use serde_json::Value;
+
+/// Resolver for the two foreign ATProto DID methods accepted by intake.
+///
+/// Each arm is an existing resolver implementation. In particular, the PLC arm
+/// remains read-only and retains its configured egress boundary, audit
+/// verification, cache, and response validation.
+pub struct FederatedDidResolver {
+    plc: Arc<dyn DidDocResolve>,
+    web: Arc<dyn DidDocResolve>,
+}
+
+impl FederatedDidResolver {
+    /// Compose the existing `did:plc` and `did:web` document resolvers.
+    pub fn new(plc: Arc<dyn DidDocResolve>, web: Arc<dyn DidDocResolve>) -> Self {
+        Self { plc, web }
+    }
+}
+
+/// Injectable document-resolution boundary for federation intake.
+#[async_trait]
+pub trait FederatedDidDocumentResolver: Send + Sync {
+    /// Resolve a supported foreign DID to its subject-bound document.
+    async fn resolve_federated_document(&self, did: &str) -> Result<Value>;
+}
+
+#[async_trait]
+impl FederatedDidDocumentResolver for FederatedDidResolver {
+    async fn resolve_federated_document(&self, did: &str) -> Result<Value> {
+        let resolver = if hyprstream_rpc::did_plc::is_did_plc(did) {
+            &self.plc
+        } else if did.starts_with("did:web:") {
+            &self.web
+        } else {
+            bail!("unsupported federated DID method: {did}");
+        };
+        let document = resolver.resolve_doc(did).await?;
+        ensure!(
+            document.get("id").and_then(Value::as_str) == Some(did),
+            "resolved DID document id does not match requested DID {did}"
+        );
+        Ok(document)
+    }
+}
+
+/// A derived, read-only inventory projection for a foreign identity.
+///
+/// `tenant` is retained as an explicit optional field so API consumers can use
+/// the same shape for local and federated inventory entries. Federation intake
+/// constructs records only with `None`; there is no public constructor that can
+/// attach a tenant.
+#[derive(Clone, Debug, PartialEq)]
+pub struct FederatedIdentityRecord {
+    did: String,
+    document: Value,
+    tenant: Option<String>,
+}
+
+impl FederatedIdentityRecord {
+    fn new(did: String, document: Value) -> Self {
+        Self {
+            did,
+            document,
+            tenant: None,
+        }
+    }
+
+    /// The resolved foreign DID.
+    pub fn did(&self) -> &str {
+        &self.did
+    }
+
+    /// The validated DID document used to derive this projection.
+    pub fn document(&self) -> &Value {
+        &self.document
+    }
+
+    /// Always `None` for records produced by federation intake.
+    pub fn tenant(&self) -> Option<&str> {
+        self.tenant.as_deref()
+    }
+}
+
+/// Non-authoritative inventory sink consumed by federation intake.
+///
+/// A pglite/Postgres implementation can replace the in-memory implementation
+/// without changing resolution or tenant-safety logic.
+pub trait FederatedIdentityInventory: Send + Sync {
+    /// Insert or refresh one derived foreign-identity projection.
+    fn upsert(&self, identity: FederatedIdentityRecord) -> Result<()>;
+
+    /// List the currently indexed foreign identities in deterministic DID order.
+    fn list(&self) -> Result<Vec<FederatedIdentityRecord>>;
+}
+
+/// Thin in-memory inventory read model, useful for embedded/demo deployments.
+#[derive(Default)]
+pub struct InMemoryFederatedIdentityInventory {
+    identities: RwLock<BTreeMap<String, FederatedIdentityRecord>>,
+}
+
+impl FederatedIdentityInventory for InMemoryFederatedIdentityInventory {
+    fn upsert(&self, identity: FederatedIdentityRecord) -> Result<()> {
+        let mut identities = self.identities.write();
+        identities.insert(identity.did.clone(), identity);
+        Ok(())
+    }
+
+    fn list(&self) -> Result<Vec<FederatedIdentityRecord>> {
+        let identities = self.identities.read();
+        Ok(identities.values().cloned().collect())
+    }
+}
+
+/// Resolve and project foreign identities without granting local authority.
+pub struct FederationIntake {
+    resolver: Arc<dyn FederatedDidDocumentResolver>,
+    inventory: Arc<dyn FederatedIdentityInventory>,
+    local_issuers: Vec<String>,
+}
+
+impl FederationIntake {
+    /// Construct an intake service over a resolver and derived inventory sink.
+    pub fn new(
+        resolver: Arc<dyn FederatedDidDocumentResolver>,
+        inventory: Arc<dyn FederatedIdentityInventory>,
+        local_issuers: Vec<String>,
+    ) -> Self {
+        Self {
+            resolver,
+            inventory,
+            local_issuers,
+        }
+    }
+
+    /// Resolve and index a foreign DID discovered without identity claims.
+    pub async fn intake(&self, did: &str) -> Result<FederatedIdentityRecord> {
+        self.intake_inner(did).await
+    }
+
+    /// Resolve and index a foreign DID carrying already-verified source claims.
+    ///
+    /// These claims describe the foreign identity, not the local caller
+    /// requesting discovery. A local issuer is rejected because it is not a
+    /// federated source. For a foreign issuer, `strip_federated_tenant` runs
+    /// before projection so even a signed tenant assertion cannot become a
+    /// local hosted-account binding.
+    pub async fn intake_with_verified_claims(
+        &self,
+        did: &str,
+        mut claims: Claims,
+    ) -> Result<FederatedIdentityRecord> {
+        let local_issuers: Vec<&str> = self.local_issuers.iter().map(String::as_str).collect();
+        ensure!(
+            !claims.is_local_to(&local_issuers),
+            "federation intake requires claims from a foreign issuer"
+        );
+        claims.strip_federated_tenant(&local_issuers);
+        ensure!(
+            claims.tenant.is_none(),
+            "federated identity retained a local tenant after sanitization"
+        );
+        self.intake_inner(did).await
+    }
+
+    async fn intake_inner(&self, did: &str) -> Result<FederatedIdentityRecord> {
+        let document = self.resolver.resolve_federated_document(did).await?;
+        let identity = FederatedIdentityRecord::new(did.to_owned(), document);
+        self.inventory.upsert(identity.clone())?;
+        Ok(identity)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #![allow(clippy::expect_used, clippy::unwrap_used)]
+
+    use super::*;
+    use hyprstream_rpc::auth::mac::{MacDecision, SecurityContext};
+    use hyprstream_rpc::Subject;
+    use hyprstream_vfs::{SyntheticMount, SyntheticNode};
+
+    use crate::{AccountRecordReadAuthorizer, AccountRecordStore, OAUTH_ACCOUNT_RESOLVER_SUBJECT};
+
+    const FEDERATED_DID: &str = "did:plc:ewvi7nxzyoun6zhxrhs64oiz";
+    const FEDERATED_WEB_DID: &str = "did:web:alice.example";
+
+    struct FixtureResolver {
+        expected_did: &'static str,
+        document: Value,
+    }
+
+    #[async_trait]
+    impl DidDocResolve for FixtureResolver {
+        async fn resolve_doc(&self, did: &str) -> Result<Value> {
+            ensure!(did == self.expected_did, "unexpected DID {did}");
+            Ok(self.document.clone())
+        }
+    }
+
+    struct NeverResolver;
+
+    #[async_trait]
+    impl DidDocResolve for NeverResolver {
+        async fn resolve_doc(&self, did: &str) -> Result<Value> {
+            bail!("wrong resolver arm selected for {did}")
+        }
+    }
+
+    struct PermitAccountReads;
+
+    impl AccountRecordReadAuthorizer for PermitAccountReads {
+        fn check_read(
+            &self,
+            _subject: &Subject,
+            _verified_tenant: Option<&str>,
+            _security_context: Option<&SecurityContext>,
+            _object_id: &str,
+        ) -> MacDecision {
+            MacDecision::Permit
+        }
+    }
+
+    #[tokio::test]
+    async fn federated_did_resolves_lists_and_has_no_hosted_tenant() {
+        let resolver = Arc::new(FederatedDidResolver::new(
+            Arc::new(FixtureResolver {
+                expected_did: FEDERATED_DID,
+                document: serde_json::json!({
+                    "id": FEDERATED_DID,
+                    "alsoKnownAs": ["at://alice.example"]
+                }),
+            }),
+            Arc::new(NeverResolver),
+        ));
+        let inventory = Arc::new(InMemoryFederatedIdentityInventory::default());
+        let intake = FederationIntake::new(
+            resolver,
+            inventory.clone(),
+            vec!["https://local.example".to_owned()],
+        );
+        let foreign_claims = Claims::new(FEDERATED_DID.to_owned(), 1, 2)
+            .with_issuer("https://foreign.example".to_owned())
+            .with_tenant("acme".to_owned());
+
+        let resolved = intake
+            .intake_with_verified_claims(FEDERATED_DID, foreign_claims)
+            .await
+            .unwrap();
+        assert_eq!(resolved.did(), FEDERATED_DID);
+        assert_eq!(resolved.tenant(), None);
+
+        let listed = inventory.list().unwrap();
+        assert_eq!(listed.len(), 1);
+        assert_eq!(listed[0].did(), FEDERATED_DID);
+        assert_eq!(listed[0].tenant(), None);
+
+        let account_store = AccountRecordStore::new(
+            Arc::new(SyntheticMount::new(SyntheticNode::dir())),
+            Arc::new(PermitAccountReads),
+        );
+        let tenant = account_store
+            .resolve_tenant_for_hosted_did(
+                &Subject::new(OAUTH_ACCOUNT_RESOLVER_SUBJECT),
+                FEDERATED_DID,
+            )
+            .await
+            .unwrap();
+        assert_eq!(tenant, None);
+    }
+
+    #[tokio::test]
+    async fn method_dispatch_rejects_document_subject_mismatch() {
+        let resolver = FederatedDidResolver::new(
+            Arc::new(FixtureResolver {
+                expected_did: FEDERATED_DID,
+                document: serde_json::json!({ "id": "did:plc:z23456723456723456723456" }),
+            }),
+            Arc::new(NeverResolver),
+        );
+
+        let error = resolver
+            .resolve_federated_document(FEDERATED_DID)
+            .await
+            .unwrap_err();
+        assert!(error.to_string().contains("does not match"));
+    }
+
+    #[tokio::test]
+    async fn did_web_arm_resolves_and_lists_without_a_tenant() {
+        let resolver = Arc::new(FederatedDidResolver::new(
+            Arc::new(NeverResolver),
+            Arc::new(FixtureResolver {
+                expected_did: FEDERATED_WEB_DID,
+                document: serde_json::json!({
+                    "id": FEDERATED_WEB_DID,
+                    "service": []
+                }),
+            }),
+        ));
+        let inventory = Arc::new(InMemoryFederatedIdentityInventory::default());
+        let intake = FederationIntake::new(resolver, inventory.clone(), Vec::new());
+
+        let resolved = intake.intake(FEDERATED_WEB_DID).await.unwrap();
+        assert_eq!(resolved.did(), FEDERATED_WEB_DID);
+        assert_eq!(resolved.tenant(), None);
+        assert_eq!(inventory.list().unwrap(), vec![resolved]);
+    }
+
+    #[tokio::test]
+    async fn local_identity_claims_cannot_enter_federation_intake() {
+        let resolver = Arc::new(FederatedDidResolver::new(
+            Arc::new(NeverResolver),
+            Arc::new(NeverResolver),
+        ));
+        let inventory = Arc::new(InMemoryFederatedIdentityInventory::default());
+        let intake = FederationIntake::new(
+            resolver,
+            inventory.clone(),
+            vec!["https://local.example".to_owned()],
+        );
+        let local_claims = Claims::new("alice".to_owned(), 1, 2)
+            .with_issuer("https://local.example".to_owned())
+            .with_tenant("acme".to_owned());
+
+        let error = intake
+            .intake_with_verified_claims(FEDERATED_DID, local_claims)
+            .await
+            .unwrap_err();
+        assert!(error.to_string().contains("foreign issuer"));
+        assert!(inventory.list().unwrap().is_empty());
+    }
+}

--- a/crates/hyprstream-pds-service/src/lib.rs
+++ b/crates/hyprstream-pds-service/src/lib.rs
@@ -10,6 +10,8 @@
 //! `verified_tenant`. The tenant is never inferred from the subject, accepted
 //! from a request payload, or supplied as a free-form method argument.
 
+pub mod federation_intake;
+
 use std::sync::Arc;
 
 use hyprstream_pds::AccountRecord;

--- a/crates/hyprstream-pds-service/src/lib.rs
+++ b/crates/hyprstream-pds-service/src/lib.rs
@@ -35,8 +35,8 @@ const READ_CHUNK_BYTES: usize = 8 * 1024;
 /// Failure from the mandatory tenant boundary or the PDS record read.
 #[derive(Debug, Error)]
 pub enum AccountReadError {
-    #[error("PDS account access denied: caller is anonymous")]
-    AnonymousCaller,
+    #[error("PDS account access denied: caller is unauthenticated")]
+    UnauthenticatedCaller,
     #[error("PDS account access denied: no valid verified tenant")]
     MissingVerifiedTenant,
     #[error("PDS account access denied: invalid verified tenant {0:?}")]
@@ -129,7 +129,7 @@ impl AccountRecordStore {
     pub fn scope(&self, context: &EnvelopeContext) -> Result<AccountReadScope, AccountReadError> {
         let subject = context.subject();
         if subject.is_anonymous() {
-            return Err(AccountReadError::AnonymousCaller);
+            return Err(AccountReadError::UnauthenticatedCaller);
         }
 
         let tenant = context
@@ -570,6 +570,16 @@ mod tests {
                 .unwrap(),
             None,
         );
+        assert_eq!(
+            store
+                .resolve_tenant_for_hosted_did(
+                    &oauth_authority(),
+                    hyprstream_rpc::identity::UNAUTHENTICATED_DID_SENTINEL,
+                )
+                .await
+                .unwrap(),
+            None,
+        );
     }
 
     #[tokio::test]
@@ -610,19 +620,19 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn anonymous_and_path_injection_fail_before_mount_access() {
+    async fn unauthenticated_and_path_injection_fail_before_mount_access() {
         let store = store();
         let signer = SigningKey::generate(&mut OsRng);
-        let anonymous = EnvelopeContext::for_test_authenticated_subject_in_tenant(
+        let unauthenticated = EnvelopeContext::for_test_authenticated_subject_in_tenant(
             Subject::anonymous(),
             "acme",
             signer.verifying_key(),
         );
         let error = store
-            .scope(&anonymous)
+            .scope(&unauthenticated)
             .err()
-            .expect("anonymous caller must be denied");
-        assert!(matches!(error, AccountReadError::AnonymousCaller));
+            .expect("unauthenticated caller must be denied");
+        assert!(matches!(error, AccountReadError::UnauthenticatedCaller));
 
         let error = store
             .scope(&context("../acme"))

--- a/crates/hyprstream-pds/src/did_op.rs
+++ b/crates/hyprstream-pds/src/did_op.rs
@@ -52,6 +52,7 @@ use hyprstream_crypto::cose_sign::{
 use hyprstream_crypto::pq::{
     ml_dsa_sk_to_vk_bytes, ml_dsa_vk_bytes, ml_dsa_vk_from_bytes, MlDsaSigningKey,
 };
+use hyprstream_rpc::identity::UNAUTHENTICATED_DID_SENTINEL;
 
 use crate::cid::Cid;
 use crate::dag_cbor::DagCbor;
@@ -442,6 +443,10 @@ impl UnsignedGenesisDidOp {
     }
 
     fn validate(&self) -> Result<()> {
+        ensure!(
+            self.did != UNAUTHENTICATED_DID_SENTINEL,
+            "{UNAUTHENTICATED_DID_SENTINEL} is reserved for the unauthenticated floor and cannot have a genesis operation"
+        );
         validate_host_form_did_web(&self.did)?;
         self.rotation_keys.validate()
     }
@@ -883,6 +888,29 @@ mod tests {
             GenesisRepoHead::EmptyRepo,
         )
         .unwrap()
+    }
+
+    #[test]
+    fn unauthenticated_sentinel_cannot_have_a_genesis_operation() {
+        let user = signer();
+        let rotations = GenesisRotationKeys::new(
+            UserRotationKey::new(user.public),
+            RecoveryKeyEnrollment::Declined,
+            HostKeyEnrollment::Absent,
+        )
+        .unwrap();
+
+        let error = UnsignedGenesisDidOp::new(
+            UNAUTHENTICATED_DID_SENTINEL,
+            Cid::from_raw(b"sentinel must not have a document"),
+            rotations,
+            GenesisRepoHead::EmptyRepo,
+        )
+        .unwrap_err();
+        assert!(
+            error.to_string().contains("unauthenticated floor"),
+            "{error:#}"
+        );
     }
 
     #[test]

--- a/crates/hyprstream-pds/src/hosted_account.rs
+++ b/crates/hyprstream-pds/src/hosted_account.rs
@@ -38,6 +38,7 @@ use crate::did_op::{
     UnsignedGenesisDidOp,
 };
 use crate::hosted_did_document::SealedHostedDidDocument;
+use hyprstream_rpc::identity::UNAUTHENTICATED_DID_SENTINEL;
 
 /// Version of the durable hosted-account record.
 pub const ACCOUNT_RECORD_VERSION: u16 = 1;
@@ -76,6 +77,10 @@ impl AllocatedAccountName {
     }
 
     fn validate(&self) -> Result<()> {
+        ensure!(
+            self.did != UNAUTHENTICATED_DID_SENTINEL,
+            "{UNAUTHENTICATED_DID_SENTINEL} is reserved for the unauthenticated floor and cannot be registered or minted"
+        );
         ensure!(!self.label.is_empty(), "allocated account label is empty");
         ensure!(
             self.label.len() <= 63,
@@ -1022,6 +1027,15 @@ mod tests {
             "did:web:alice.example.acct.example.com"
         )
         .is_err());
+    }
+
+    #[test]
+    fn unauthenticated_sentinel_cannot_be_registered_or_minted() {
+        let error = AllocatedAccountName::new("unknown", UNAUTHENTICATED_DID_SENTINEL).unwrap_err();
+        assert!(
+            error.to_string().contains("cannot be registered or minted"),
+            "{error:#}"
+        );
     }
 
     #[test]

--- a/crates/hyprstream-rpc/src/auth/claims.rs
+++ b/crates/hyprstream-rpc/src/auth/claims.rs
@@ -9,6 +9,7 @@
 
 use crate::capnp::{FromCapnp, ToCapnp};
 use crate::common_capnp;
+use crate::identity::UNAUTHENTICATED_DID_SENTINEL;
 use anyhow::Result;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
@@ -545,8 +546,12 @@ impl Claims {
     /// Local tokens (issued by this node) produce bare subjects (`"alice"`)
     /// matching existing Casbin rules.  Federated tokens produce namespaced
     /// subjects (`"https://other.node:alice"`) to prevent cross-node spoofing.
+    ///
+    /// [`UNAUTHENTICATED_DID_SENTINEL`] is credential absence, not a principal.
+    /// Even a verified token carrying it therefore resolves to the
+    /// unauthenticated floor and can never authenticate as the sentinel.
     pub fn subject(&self, local_issuers: &[&str]) -> crate::envelope::Subject {
-        if self.sub.is_empty() {
+        if self.sub.is_empty() || self.sub == UNAUTHENTICATED_DID_SENTINEL {
             return crate::envelope::Subject::anonymous();
         }
         if self.is_local_to(local_issuers) {
@@ -795,6 +800,9 @@ mod tests {
         use crate::envelope::Subject;
         let claims = Claims::new("alice".to_owned(), 1000, 2000);
         assert_eq!(Subject::from(&claims), Subject::new("alice"));
+
+        let sentinel = Claims::new(UNAUTHENTICATED_DID_SENTINEL.to_owned(), 1000, 2000);
+        assert_eq!(Subject::from(&sentinel), Subject::anonymous());
     }
 
     #[test]
@@ -822,6 +830,8 @@ mod tests {
         let federated = Claims::new("bob".to_owned(), 0, 9999)
             .with_issuer("https://other.example.com".to_owned());
         let no_sub = Claims::new(String::new(), 0, 9999);
+        let sentinel = Claims::new(UNAUTHENTICATED_DID_SENTINEL.to_owned(), 0, 9999)
+            .with_issuer("https://node.example.com".to_owned());
 
         assert_eq!(
             local.subject(&["https://node.example.com"]),
@@ -832,6 +842,10 @@ mod tests {
             Subject::federated("https://other.example.com", "bob")
         );
         assert_eq!(no_sub.subject(&[]), Subject::anonymous());
+        assert_eq!(
+            sentinel.subject(&["https://node.example.com"]),
+            Subject::anonymous()
+        );
     }
 
     #[test]

--- a/crates/hyprstream-rpc/src/envelope.rs
+++ b/crates/hyprstream-rpc/src/envelope.rs
@@ -496,13 +496,11 @@ impl FromStr for Subject {
 
 impl From<&Claims> for Subject {
     fn from(claims: &Claims) -> Self {
-        // Phase 7: Federated subjects use "iss:sub" format so that
-        // "alice@node-a" and local "alice" never collide in Casbin policy.
-        if claims.iss.is_empty() {
-            Subject::new(claims.sub.clone())
-        } else {
-            Subject::federated(&claims.iss, &claims.sub)
-        }
+        // Keep every claims→subject entry point on Claims::subject(), including
+        // its reserved unauthenticated-sentinel handling. With no configured
+        // local issuers, empty `iss` remains local and non-empty `iss` remains
+        // federated, preserving this conversion's prior routing behavior.
+        claims.subject(&[])
     }
 }
 

--- a/crates/hyprstream-rpc/src/identity.rs
+++ b/crates/hyprstream-rpc/src/identity.rs
@@ -51,6 +51,15 @@ pub struct Did(String);
 /// (`at9p_gate`) so the literal cannot drift across the three arms (D2/#964).
 pub const DID_AT9P_PREFIX: &str = "did:at9p:";
 
+/// Reserved sentinel naming the credential-absence floor.
+///
+/// This string is not a DID subject: it has no keys, document, genesis
+/// operation, hosted account, or local tenant. Clients cannot authenticate as
+/// it; servers apply the unauthenticated floor only when no credential is
+/// presented. Identity directories, federation intake, and inventory read
+/// models must reject or omit it rather than treating it as a real identity.
+pub const UNAUTHENTICATED_DID_SENTINEL: &str = "did:unknown";
+
 impl Did {
     /// Wrap a DID string verbatim. **No validation** — strict checks belong at the
     /// admission gate (see the type docs).

--- a/crates/hyprstream-rpc/src/service/svc.rs
+++ b/crates/hyprstream-rpc/src/service/svc.rs
@@ -9,6 +9,7 @@
 //! - Handlers receive `EnvelopeContext` with verified identity
 //! - Services use `ctx.subject()` for policy checks
 
+use crate::identity::UNAUTHENTICATED_DID_SENTINEL;
 use crate::prelude::*;
 use crate::transport::TransportConfig;
 use anyhow::Result;
@@ -885,6 +886,12 @@ pub trait RequestService: 'static {
         let Some(token) = token else {
             // No JWT — try trust store lookup for cached key bindings
             if let Some(subject) = self.resolve_key_subject(&ctx.cnf) {
+                if subject.name() == Some(UNAUTHENTICATED_DID_SENTINEL) {
+                    tracing::warn!(
+                        "Ignored reserved unauthenticated subject from signer-key resolver"
+                    );
+                    return Ok(());
+                }
                 ctx.key_derived_subject = subject;
                 return Ok(());
             }
@@ -1116,6 +1123,12 @@ pub trait RequestService: 'static {
         }
 
         // Store verified claims on context for downstream use
+        if verified.sub == UNAUTHENTICATED_DID_SENTINEL {
+            tracing::warn!("Rejected JWT whose subject is the reserved unauthenticated sentinel");
+            anyhow::bail!(
+                "{UNAUTHENTICATED_DID_SENTINEL} is credential absence and cannot authenticate"
+            );
+        }
         let local_issuers = key_source.local_issuers();
         let local_issuers_refs: Vec<&str> = local_issuers.iter().map(String::as_str).collect();
         // Fu5/#677: MAC clearance is authority-asserted and honored only from
@@ -1160,8 +1173,10 @@ pub trait RequestService: 'static {
                     };
                     let subject_str = claims.subject(&local_issuers_refs);
                     if let Some(subject_name) = subject_str.name() {
-                        self.cache_key_binding(vk, subject_name, &token, claims.exp);
-                        tracing::info!(subject = %subject_name, "Cached key binding in trust store");
+                        if subject_name != UNAUTHENTICATED_DID_SENTINEL {
+                            self.cache_key_binding(vk, subject_name, &token, claims.exp);
+                            tracing::info!(subject = %subject_name, "Cached key binding in trust store");
+                        }
                     }
                 } else if let Some(jkt) = claims.cnf_jkt() {
                     // R2b: DPoP path — JWT has cnf.jkt (thumbprint) instead of cnf.jwk.
@@ -1185,8 +1200,10 @@ pub trait RequestService: 'static {
                     };
                     let subject_str = claims.subject(&local_issuers_refs);
                     if let Some(subject_name) = subject_str.name() {
-                        self.cache_key_binding(vk, subject_name, &token, claims.exp);
-                        tracing::info!(subject = %subject_name, "Cached key binding from cnf.jkt");
+                        if subject_name != UNAUTHENTICATED_DID_SENTINEL {
+                            self.cache_key_binding(vk, subject_name, &token, claims.exp);
+                            tracing::info!(subject = %subject_name, "Cached key binding from cnf.jkt");
+                        }
                     }
                 } else if self.require_cnf_binding() {
                     tracing::warn!("JWT missing cnf binding (jwk or jkt): sub={}", claims.sub);
@@ -1412,6 +1429,7 @@ mod empty_iss_gate_tests {
         key_source: std::sync::Arc<dyn crate::auth::JwtKeySource>,
         policy: crate::crypto::CryptoPolicy,
         relay: Option<[u8; 32]>,
+        cached_subjects: std::sync::Arc<parking_lot::Mutex<Vec<String>>>,
     }
 
     #[async_trait(?Send)]
@@ -1449,6 +1467,15 @@ mod empty_iss_gate_tests {
         }
         fn accept_delegated_bearer(&self, signer_pubkey: &[u8; 32]) -> bool {
             self.relay.as_ref() == Some(signer_pubkey)
+        }
+        fn cache_key_binding(
+            &self,
+            _verifying_key: ed25519_dalek::VerifyingKey,
+            subject: &str,
+            _jwt: &str,
+            _expires_at: i64,
+        ) {
+            self.cached_subjects.lock().push(subject.to_owned());
         }
     }
 
@@ -1489,6 +1516,7 @@ mod empty_iss_gate_tests {
             key_source,
             policy: crate::crypto::CryptoPolicy::Classical,
             relay: None,
+            cached_subjects: std::sync::Arc::default(),
         };
         (svc, ca)
     }
@@ -1555,6 +1583,50 @@ mod empty_iss_gate_tests {
     }
 
     #[tokio::test]
+    async fn verified_local_did_unknown_jwt_cannot_authenticate() {
+        let (svc, ca) = mock_service();
+        let now = chrono::Utc::now().timestamp();
+        let claims = Claims::new(UNAUTHENTICATED_DID_SENTINEL.to_owned(), now, now + 3600)
+            .with_tenant("attacker-tenant".to_owned());
+        let token = crate::auth::jwt::encode(&claims, &ca);
+        let mut ctx = ctx_with_token(token, /* is_local_caller */ true);
+
+        let error = svc
+            .verify_claims(&mut ctx)
+            .await
+            .expect_err("the credential-absence sentinel must not authenticate");
+
+        assert!(
+            error.to_string().contains("cannot authenticate"),
+            "{error:#}"
+        );
+        assert!(ctx.subject().is_anonymous());
+        assert!(ctx.claims().is_none());
+        assert_eq!(ctx.verified_tenant(), None);
+    }
+
+    #[tokio::test]
+    async fn did_unknown_cnf_signer_is_never_cached() {
+        let (svc, ca) = mock_service();
+        let signer = SigningKey::from_bytes(&[0x71; 32]);
+        let now = chrono::Utc::now().timestamp();
+        let claims = Claims::new(UNAUTHENTICATED_DID_SENTINEL.to_owned(), now, now + 3600)
+            .with_cnf_jwk(signer.verifying_key().as_bytes());
+        let token = crate::auth::jwt::encode(&claims, &ca);
+        let mut ctx = ctx_with_token(token, /* is_local_caller */ true);
+        ctx.cnf = signer.verifying_key().to_bytes();
+
+        svc.verify_claims(&mut ctx)
+            .await
+            .expect_err("the sentinel token must be rejected before cnf caching");
+
+        assert!(
+            svc.cached_subjects.lock().is_empty(),
+            "no signer may be cached for did:unknown"
+        );
+    }
+
+    #[tokio::test]
     async fn delegated_bearer_is_denied_by_default() {
         let (svc, ca) = mock_service();
         let token = empty_iss_token(&ca);
@@ -1608,6 +1680,7 @@ mod empty_iss_gate_tests {
             key_source,
             policy: crate::crypto::CryptoPolicy::Classical,
             relay: None,
+            cached_subjects: std::sync::Arc::default(),
         };
         let now = chrono::Utc::now().timestamp();
         let claims = Claims::new("alice".to_owned(), now, now + 3600)
@@ -1643,6 +1716,7 @@ mod empty_iss_gate_tests {
             key_source,
             policy: crate::crypto::CryptoPolicy::Classical,
             relay: None,
+            cached_subjects: std::sync::Arc::default(),
         };
         let now = chrono::Utc::now().timestamp();
         let claims = Claims::new("alice".to_owned(), now, now + 3600)
@@ -1737,6 +1811,7 @@ mod empty_iss_gate_tests {
             key_source,
             policy: crate::crypto::CryptoPolicy::Hybrid,
             relay: None,
+            cached_subjects: std::sync::Arc::default(),
         };
         let now = chrono::Utc::now().timestamp();
         let claims =
@@ -2036,6 +2111,37 @@ mod ipc_key_identity_tests {
         // Fail-closed: no registered binding → anonymous → still denied writes.
         assert!(ctx.subject().is_anonymous());
         assert_eq!(ctx.subject().to_string(), "anonymous");
+    }
+
+    #[tokio::test]
+    async fn no_jwt_recovery_cannot_resurrect_did_unknown() {
+        let _guard = RESOLVER_LOCK.lock().await;
+
+        let caller_pub = SigningKey::from_bytes(&[55u8; 32])
+            .verifying_key()
+            .to_bytes();
+        let mut bindings = HashMap::new();
+        bindings.insert(
+            caller_pub,
+            crate::identity::UNAUTHENTICATED_DID_SENTINEL.to_owned(),
+        );
+        set_key_resolver(std::sync::Arc::new(MapResolver { bindings }));
+
+        let svc = PlainService {
+            signing_key: SigningKey::from_bytes(&[22u8; 32]),
+            transport: TransportConfig::inproc("discovery"),
+        };
+        let mut ctx = ctx_for_signer(caller_pub);
+
+        svc.verify_claims(&mut ctx)
+            .await
+            .expect("reserved recovery binding must collapse to the unauthenticated floor");
+
+        assert!(ctx.subject().is_anonymous());
+        assert_ne!(
+            ctx.subject().name(),
+            Some(crate::identity::UNAUTHENTICATED_DID_SENTINEL)
+        );
     }
 }
 

--- a/crates/hyprstream-service/src/service/trust_store.rs
+++ b/crates/hyprstream-service/src/service/trust_store.rs
@@ -23,6 +23,7 @@
 
 use dashmap::DashMap;
 use ed25519_dalek::VerifyingKey;
+use hyprstream_rpc::identity::UNAUTHENTICATED_DID_SENTINEL;
 use std::collections::HashSet;
 use std::sync::Arc;
 use tracing;
@@ -78,6 +79,13 @@ impl TrustStore {
     /// expires later. Otherwise the existing entry is kept (prevents downgrade).
     /// Logs a warning on equal-expiry discard.
     pub fn insert(&self, key: VerifyingKey, attestation: Attestation) {
+        if attestation.subject.as_deref() == Some(UNAUTHENTICATED_DID_SENTINEL) {
+            tracing::warn!(
+                key = ?key.to_bytes()[..4],
+                "Trust store: rejected reserved unauthenticated subject binding"
+            );
+            return;
+        }
         let subject_debug = attestation.subject.as_deref().unwrap_or("<scope-derived>").to_owned();
         let scopes_debug: Vec<String> = attestation.scopes.iter().cloned().collect();
         let expires_debug = attestation.expires_at;
@@ -209,6 +217,13 @@ impl TrustStore {
         let att = self.get(&vk)?;
         // User keys: explicit subject
         if let Some(ref subject) = att.subject {
+            if subject == UNAUTHENTICATED_DID_SENTINEL {
+                tracing::warn!(
+                    key = ?vk.to_bytes()[..4],
+                    "Trust store: ignored legacy reserved unauthenticated subject binding"
+                );
+                return None;
+            }
             return Some(hyprstream_rpc::envelope::Subject::new(subject.clone()));
         }
         // Service keys: derive from scope
@@ -337,6 +352,25 @@ mod tests {
 
         assert!(store.is_authorized(&key, "model"));
         assert!(!store.is_authorized(&key, "policy"));
+    }
+
+    #[test]
+    fn reserved_unauthenticated_subject_is_neither_cached_nor_recovered() {
+        let store = TrustStore::new();
+        let (_, key) = random_key();
+        let mut sentinel = make_attestation(&[], chrono::Utc::now().timestamp() + 3600);
+        sentinel.subject = Some(UNAUTHENTICATED_DID_SENTINEL.to_owned());
+
+        store.insert(key, sentinel.clone());
+        assert!(
+            store.get(&key).is_none(),
+            "public insertion must reject did:unknown"
+        );
+
+        // Simulate a legacy/corrupt cache entry written before the insertion
+        // guard existed. Resolution must still refuse to resurrect it.
+        store.inner.insert(key, sentinel);
+        assert_eq!(store.resolve_subject(&key.to_bytes()), None);
     }
 
     /// #441 invariant: authoritative service-key resolution.


### PR DESCRIPTION
Part of #1342 deliverable B; extends the merged #1195 read-only resolver into a tenant-safe, leak-safe federation-intake seam.

## What changed
- method-dispatch foreign `did:plc` and `did:web` through the existing hardened resolver implementations
- re-check DID-document subject binding before inventory projection
- call `Claims::strip_federated_tenant` inside verified foreign-claims intake; federated entries structurally carry no local tenant
- reserve `did:unknown` for credential absence: reject it before resolver I/O, inventory insertion, hosted-account mint, and genesis-op construction; filter legacy/corrupt sentinel rows from listing
- define the D-contract `InventoryEntry` projection (`did`, `handle`, `kind`, `tenant`, `pdsEndpoint`) with no DID document, QUIC URL, or cert hash
- require a viewer `SecurityContext` at inventory listing and pre-filter above-clearance entries server-side; the return shape exposes only post-filter entries and no total/hidden count
- make direct inventory lookup and connect-time `resolve(did)` viewer-aware; missing, no-clearance, and above-clearance objects collapse to the same typed `NotFound` result for 404-style wire mapping, before resolver I/O
- resolve rotating discovery through separate connect-time `{ quicUrl, certHash }` output, never AppView storage
- prove a foreign DID resolves and lists while `resolve_tenant_for_hosted_did` returns `Ok(None)`; prove the same tenant result for `did:unknown`
- prove above-floor direct access is not-found-equivalent and indistinguishable from a nonexistent DID, never forbidden

## Validation
- `cargo test -p hyprstream-pds unauthenticated_sentinel --lib -- --nocapture` (2 passed)
- `cargo test -p hyprstream-pds-service unauthenticated --lib -- --nocapture` (2 passed)
- `cargo test -p hyprstream-pds-service above_floor_direct_access_is_not_found_not_forbidden --lib -- --nocapture` (1 passed)
- `cargo test -p hyprstream-pds-service --lib --tests --no-fail-fast` (13 passed)
- `cargo test -p hyprstream-pds --lib --tests --no-fail-fast` (254 unit + 6 integration passed)
- `cargo test -p hyprstream-rpc identity --lib -- --nocapture` (52 passed)
- `cargo clippy -p hyprstream-rpc -p hyprstream-pds -p hyprstream-pds-service --all-targets -- -D warnings`
- repository pre-commit release-profile workspace Clippy gate

Draft only: no merge, self-approval, or queue action performed. Kimi review remains required before queue.

## Rev2 third-door closure
- `Claims::subject` and `Subject::from(&Claims)` floor `did:unknown`; verified sentinel JWTs hard-reject before context installation
- cnf binding cannot cache `did:unknown`; the production trust store rejects new sentinel attestations
- no-JWT recovery ignores sentinel subjects; the trust store also filters legacy/corrupt sentinel bindings
- causal tests: `verified_local_did_unknown_jwt_cannot_authenticate`, `did_unknown_cnf_signer_is_never_cached`, `no_jwt_recovery_cannot_resurrect_did_unknown`
- focused 3/3 passed; full hyprstream-rpc and hyprstream-service suites passed; strict affected Clippy and repository pre-commit release-profile workspace Clippy passed

Fixed head for rev2: `73739edadcea3f27dc9e1cf82064d73b1aab2dbe`. PR remains draft and unqueued.