### PR TITLE
feat(pds): hyprstream-hosted account mint (host-form did:web) (#1158)

### DIFF
--- a/crates/hyprstream-pds-service/src/hosted_account_mint.rs
+++ b/crates/hyprstream-pds-service/src/hosted_account_mint.rs
@@ -1,0 +1,549 @@
+//! Authority-bound hosted PDS account minting.
+//!
+//! The client request carries only a requested handle. The deployment
+//! authority allocates both the permanent host-form DID and the local tenant;
+//! neither value can be asserted in the registration payload. A successful
+//! mint publishes one coherent bundle containing the account record, sealed
+//! DID document, genesis operation-log entry, empty MST, signed repo commit,
+//! and account-specific `#atproto` signing key.
+//!
+//! This module performs no federation intake or resolver network I/O. A later
+//! registration/RPC adapter that invokes did:web intake must authenticate and
+//! rate-limit the caller and constrain the resolvable host set before the
+//! first resolver call. Unauthenticated intake is forbidden.
+
+use std::sync::Arc;
+
+use anyhow::{ensure, Context, Result};
+use hyprstream_pds::{
+    AllocatedAccountName, DidOpSignature, GenesisRepoHead, GenesisRotationKeys, HostedAccountMint,
+    HostedRepoGenesis, SealedHostedAccount, UnsignedGenesisDidOp, DID_DOCUMENT_PATH,
+    DID_OPERATION_LOG_PATH,
+};
+use hyprstream_rpc::service_entry::BrowserQuicReach;
+
+use crate::validate_tenant_component;
+
+/// Client-controlled portion of hosted-account registration.
+///
+/// The registration transport must route any supplied `tenant` member through
+/// [`Self::from_client_fields`], which rejects it before allocation.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct HostedAccountRegistrationRequest {
+    handle: String,
+}
+
+impl HostedAccountRegistrationRequest {
+    fn new(handle: impl Into<String>) -> Self {
+        Self {
+            handle: handle.into(),
+        }
+    }
+
+    /// Construct from transport fields while rejecting client tenant input.
+    pub fn from_client_fields(
+        handle: impl Into<String>,
+        client_asserted_tenant: Option<&str>,
+    ) -> Result<Self> {
+        ensure!(
+            client_asserted_tenant.is_none(),
+            "client-asserted tenant is forbidden for hosted-account registration"
+        );
+        Ok(Self::new(handle))
+    }
+
+    #[must_use]
+    pub fn handle(&self) -> &str {
+        &self.handle
+    }
+}
+
+/// Exact registration result consumed by the browser-facing API.
+///
+/// The wire adapter maps the final three Rust fields to `pdsEndpoint`,
+/// `quicUrl`, and `certHash`.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct HostedAccountRegistrationResult {
+    pub handle: String,
+    pub did: String,
+    pub pds_endpoint: String,
+    pub quic_url: String,
+    pub cert_hash: String,
+}
+
+/// One authority-owned allocation of a local tenant and permanent DID.
+///
+/// The registration client never constructs or supplies this value. It is
+/// returned by the [`HostedAccountAuthority`] installed by the server.
+#[derive(Clone)]
+pub struct AuthorityHostedAccountBinding {
+    tenant: String,
+    name: AllocatedAccountName,
+    rotations: GenesisRotationKeys,
+}
+
+impl AuthorityHostedAccountBinding {
+    /// Construct an allocation in an authority implementation.
+    pub fn new(
+        tenant: impl Into<String>,
+        name: AllocatedAccountName,
+        rotations: GenesisRotationKeys,
+    ) -> Result<Self> {
+        let tenant = tenant.into();
+        validate_tenant_component(&tenant)?;
+        Ok(Self {
+            tenant,
+            name,
+            rotations,
+        })
+    }
+
+    #[must_use]
+    pub fn tenant(&self) -> &str {
+        &self.tenant
+    }
+
+    #[must_use]
+    pub fn name(&self) -> &AllocatedAccountName {
+        &self.name
+    }
+}
+
+/// Deployment authority that allocates local tenant bindings.
+pub trait HostedAccountAuthority: Send + Sync {
+    fn allocate(&self, requested_handle: &str) -> Result<AuthorityHostedAccountBinding>;
+}
+
+/// Request-scoped signer for the user-held priority-zero Hybrid rotation key.
+pub trait HostedAccountGenesisSigner {
+    fn sign(&self, unsigned: &UnsignedGenesisDidOp) -> Result<DidOpSignature>;
+}
+
+/// One live discovery read used atomically for both mint input and response.
+#[derive(Clone, Debug, PartialEq)]
+pub struct LiveHostedPdsDiscovery {
+    pub pds_endpoint: String,
+    pub browser_quic_reach: BrowserQuicReach,
+}
+
+/// Resolver for the currently served PDS and QUIC discovery metadata.
+///
+/// Implementations must derive `browser_quic_reach` from the current
+/// `QuicTransport` service entry with
+/// [`hyprstream_rpc::service_entry::decode_browser_quic_reach`]. They must not
+/// accept a manually supplied transport URL or certificate pin.
+pub trait HostedPdsDiscovery: Send + Sync {
+    fn current(&self) -> Result<LiveHostedPdsDiscovery>;
+}
+
+/// Borrowed, already-verified publication generation.
+///
+/// The publisher must durably commit the whole generation before returning.
+/// The public account record is the publication marker; storage
+/// implementations should therefore make it visible last.
+pub struct HostedPdsAccountPublication<'a> {
+    tenant: &'a str,
+    account: &'a SealedHostedAccount,
+    repo: &'a HostedRepoGenesis,
+}
+
+impl HostedPdsAccountPublication<'_> {
+    #[must_use]
+    pub fn tenant(&self) -> &str {
+        self.tenant
+    }
+
+    #[must_use]
+    pub fn label(&self) -> &str {
+        self.account.record().name().label()
+    }
+
+    #[must_use]
+    pub fn account(&self) -> &SealedHostedAccount {
+        self.account
+    }
+
+    #[must_use]
+    pub fn repo(&self) -> &HostedRepoGenesis {
+        self.repo
+    }
+
+    /// Exact bytes served at [`DID_DOCUMENT_PATH`].
+    #[must_use]
+    pub fn did_document(&self) -> (&'static str, &[u8]) {
+        (DID_DOCUMENT_PATH, self.account.did_document().as_bytes())
+    }
+
+    /// Genesis entry establishing the operation log served at
+    /// [`DID_OPERATION_LOG_PATH`].
+    #[must_use]
+    pub fn did_operation_log_genesis(&self) -> (&'static str, &[u8]) {
+        (DID_OPERATION_LOG_PATH, self.account.genesis_bytes())
+    }
+}
+
+/// Durable publication boundary for hosted PDS account generations.
+pub trait HostedPdsAccountPublisher: Send + Sync {
+    fn publish(&self, publication: HostedPdsAccountPublication<'_>) -> Result<()>;
+}
+
+/// Hosted-account mint service used by the later registration API.
+pub struct HostedPdsAccountMinter {
+    authority: Arc<dyn HostedAccountAuthority>,
+    discovery: Arc<dyn HostedPdsDiscovery>,
+    publisher: Arc<dyn HostedPdsAccountPublisher>,
+}
+
+impl HostedPdsAccountMinter {
+    #[must_use]
+    pub fn new(
+        authority: Arc<dyn HostedAccountAuthority>,
+        discovery: Arc<dyn HostedPdsDiscovery>,
+        publisher: Arc<dyn HostedPdsAccountPublisher>,
+    ) -> Self {
+        Self {
+            authority,
+            discovery,
+            publisher,
+        }
+    }
+
+    /// Mint, sign, and durably publish one local hosted PDS account.
+    pub fn mint(
+        &self,
+        request: &HostedAccountRegistrationRequest,
+        signer: &dyn HostedAccountGenesisSigner,
+    ) -> Result<HostedAccountRegistrationResult> {
+        ensure!(
+            !request.handle.is_empty(),
+            "hosted account handle must not be empty"
+        );
+
+        // Read discovery before allocating a permanent name. A deployment with
+        // no live PDS/QUIC reach must not consume a never-reusable label.
+        let live = self
+            .discovery
+            .current()
+            .context("live hosted-PDS discovery is unavailable")?;
+        ensure!(
+            !live.browser_quic_reach.quic_url.is_empty()
+                && !live.browser_quic_reach.cert_hash.is_empty(),
+            "live hosted-PDS QUIC discovery is incomplete"
+        );
+
+        let binding = self
+            .authority
+            .allocate(&request.handle)
+            .context("hosted-account authority allocation failed")?;
+        ensure!(
+            binding.name.label() == request.handle,
+            "authority allocation does not match the requested handle"
+        );
+
+        let mint = HostedAccountMint::begin(binding.name.clone(), binding.rotations.clone())
+            .context("hosted-account mint initialization failed")?;
+        let document = mint
+            .seal_did_document(&live.pds_endpoint)
+            .context("hosted DID document sealing failed")?;
+        let (pending, repo) = mint
+            .prepare_pds_genesis(document, hyprstream_pds::tid::Tid::now())
+            .context("hosted PDS repo genesis failed")?;
+        let signature = signer
+            .sign(pending.unsigned_genesis())
+            .context("hosted DID genesis signing failed")?;
+        let account = pending
+            .seal(signature)
+            .context("hosted DID genesis signature is invalid")?;
+
+        ensure!(
+            account.genesis().unsigned().head_at_op()
+                == GenesisRepoHead::Existing(repo.commit_cid()),
+            "hosted DID genesis is not bound to the signed PDS repo"
+        );
+        repo.verify(&account.record().atproto_verifying_key()?)
+            .context("hosted PDS repo verification failed")?;
+
+        self.publisher
+            .publish(HostedPdsAccountPublication {
+                tenant: binding.tenant(),
+                account: &account,
+                repo: &repo,
+            })
+            .context("hosted PDS account publication failed")?;
+
+        Ok(registration_result(account, live.browser_quic_reach))
+    }
+}
+
+fn registration_result(
+    account: SealedHostedAccount,
+    browser_reach: BrowserQuicReach,
+) -> HostedAccountRegistrationResult {
+    let document = account.did_document();
+    HostedAccountRegistrationResult {
+        handle: document.handle().to_owned(),
+        did: document.did().to_owned(),
+        pds_endpoint: document.pds_endpoint().to_owned(),
+        quic_url: browser_reach.quic_url,
+        cert_hash: browser_reach.cert_hash,
+    }
+}
+
+#[cfg(all(test, not(target_arch = "wasm32")))]
+mod tests {
+    #![allow(clippy::expect_used, clippy::unwrap_used)]
+
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::sync::OnceLock;
+
+    use ed25519_dalek::SigningKey;
+    use hyprstream_crypto::pq::{ml_dsa_generate_keypair, ml_dsa_vk_bytes, MlDsaSigningKey};
+    use hyprstream_pds::{
+        sign_genesis, AccountRecord, HostKeyEnrollment, HybridRotationKey, RecoveryKeyEnrollment,
+        UserRotationKey,
+    };
+    use hyprstream_rpc::auth::mac::{MacDecision, SecurityContext};
+    use hyprstream_rpc::Subject;
+    use hyprstream_vfs::{SyntheticMount, SyntheticNode};
+    use rand::rngs::OsRng;
+
+    use super::*;
+    use crate::{
+        AccountRecordReadAuthorizer, AccountRecordStore, PDS_ACCOUNTS_DIRECTORY,
+        PDS_ACCOUNT_RECORD_FILE,
+    };
+
+    struct TestAuthority {
+        calls: AtomicUsize,
+        rotations: GenesisRotationKeys,
+    }
+
+    impl HostedAccountAuthority for TestAuthority {
+        fn allocate(&self, requested_handle: &str) -> Result<AuthorityHostedAccountBinding> {
+            self.calls.fetch_add(1, Ordering::SeqCst);
+            AuthorityHostedAccountBinding::new(
+                "tenant-authority",
+                AllocatedAccountName::new(
+                    requested_handle,
+                    format!("did:web:{requested_handle}.accounts.example"),
+                )?,
+                self.rotations.clone(),
+            )
+        }
+    }
+
+    struct TestSigner {
+        ed: SigningKey,
+        pq: MlDsaSigningKey,
+    }
+
+    impl HostedAccountGenesisSigner for TestSigner {
+        fn sign(&self, unsigned: &UnsignedGenesisDidOp) -> Result<DidOpSignature> {
+            sign_genesis(unsigned, &self.ed, &self.pq)
+        }
+    }
+
+    #[derive(Clone)]
+    struct StaticDiscovery;
+
+    impl HostedPdsDiscovery for StaticDiscovery {
+        fn current(&self) -> Result<LiveHostedPdsDiscovery> {
+            Ok(LiveHostedPdsDiscovery {
+                pds_endpoint: "https://pds.example".to_owned(),
+                browser_quic_reach: BrowserQuicReach {
+                    quic_url: "https://pds.example:4433/wt".to_owned(),
+                    cert_hash: "paWlpaWlpaWlpaWlpaWlpaWlpaWlpaWlpaWlpaWlpaU=".to_owned(),
+                },
+            })
+        }
+    }
+
+    #[derive(Clone)]
+    struct Published {
+        tenant: String,
+        label: String,
+        account_record: Vec<u8>,
+        did_document_path: String,
+        did_document: Vec<u8>,
+        operation_log_path: String,
+        operation_log_genesis: Vec<u8>,
+        mst_root: hyprstream_pds::Cid,
+        mst_blocks: Vec<(hyprstream_pds::Cid, Vec<u8>)>,
+        commit: Vec<u8>,
+    }
+
+    #[derive(Default)]
+    struct CapturingPublisher {
+        published: OnceLock<Published>,
+    }
+
+    impl HostedPdsAccountPublisher for CapturingPublisher {
+        fn publish(&self, publication: HostedPdsAccountPublication<'_>) -> Result<()> {
+            let (did_document_path, did_document) = publication.did_document();
+            let (operation_log_path, operation_log_genesis) =
+                publication.did_operation_log_genesis();
+            let published = Published {
+                tenant: publication.tenant().to_owned(),
+                label: publication.label().to_owned(),
+                account_record: publication.account().record_bytes().to_vec(),
+                did_document_path: did_document_path.to_owned(),
+                did_document: did_document.to_vec(),
+                operation_log_path: operation_log_path.to_owned(),
+                operation_log_genesis: operation_log_genesis.to_vec(),
+                mst_root: publication.repo().mst_root(),
+                mst_blocks: publication.repo().mst_blocks().to_vec(),
+                commit: publication.repo().commit_bytes().to_vec(),
+            };
+            self.published
+                .set(published)
+                .map_err(|_| anyhow::anyhow!("account was published more than once"))?;
+            Ok(())
+        }
+    }
+
+    fn fixture() -> (
+        Arc<TestAuthority>,
+        Arc<CapturingPublisher>,
+        TestSigner,
+        HostedPdsAccountMinter,
+    ) {
+        let ed = SigningKey::generate(&mut OsRng);
+        let (pq, pq_vk) = ml_dsa_generate_keypair();
+        let rotation =
+            HybridRotationKey::new(ed.verifying_key().to_bytes(), ml_dsa_vk_bytes(&pq_vk)).unwrap();
+        let authority = Arc::new(TestAuthority {
+            calls: AtomicUsize::new(0),
+            rotations: GenesisRotationKeys::new(
+                UserRotationKey::new(rotation),
+                RecoveryKeyEnrollment::Declined,
+                HostKeyEnrollment::Absent,
+            )
+            .unwrap(),
+        });
+        let publisher = Arc::new(CapturingPublisher::default());
+        let minter = HostedPdsAccountMinter::new(
+            authority.clone(),
+            Arc::new(StaticDiscovery),
+            publisher.clone(),
+        );
+        (authority, publisher, TestSigner { ed, pq }, minter)
+    }
+
+    struct PermitReads;
+
+    impl AccountRecordReadAuthorizer for PermitReads {
+        fn check_read(
+            &self,
+            _subject: &Subject,
+            _verified_tenant: Option<&str>,
+            _security_context: Option<&SecurityContext>,
+            _object_id: &str,
+        ) -> MacDecision {
+            MacDecision::Permit
+        }
+    }
+
+    #[test]
+    fn mint_publishes_did_log_and_signed_repo_and_returns_live_discovery() {
+        let (_authority, publisher, signer, minter) = fixture();
+        let result = minter
+            .mint(&HostedAccountRegistrationRequest::new("alice"), &signer)
+            .unwrap();
+        let published = publisher
+            .published
+            .get()
+            .cloned()
+            .expect("mint must publish");
+
+        assert_eq!(published.did_document_path, DID_DOCUMENT_PATH);
+        assert!(!published.did_document.is_empty());
+        assert_eq!(published.operation_log_path, DID_OPERATION_LOG_PATH);
+        assert!(!published.operation_log_genesis.is_empty());
+        let document =
+            hyprstream_pds::SealedHostedDidDocument::from_canonical_json(&published.did_document)
+                .unwrap();
+        let genesis =
+            hyprstream_pds::GenesisDidOp::from_dag_cbor(&published.operation_log_genesis).unwrap();
+        assert!(published
+            .mst_blocks
+            .iter()
+            .any(|(cid, bytes)| *cid == published.mst_root
+                && hyprstream_pds::Cid::from_dag_cbor(bytes) == *cid));
+        let commit = hyprstream_pds::commit::Commit::from_dag_cbor(&published.commit).unwrap();
+        let record = AccountRecord::from_dag_cbor(&published.account_record).unwrap();
+        commit
+            .verify(&record.atproto_verifying_key().unwrap())
+            .unwrap();
+        assert_eq!(document.did(), record.name().did());
+        assert_eq!(document.cid(), record.doc_cid());
+        assert_eq!(genesis.cid().unwrap(), record.genesis_op());
+        assert_eq!(
+            genesis.unsigned().head_at_op(),
+            GenesisRepoHead::Existing(commit.cid())
+        );
+        assert_eq!(commit.data, published.mst_root);
+
+        assert_eq!(result.handle, "at://alice.accounts.example");
+        assert_eq!(result.did, "did:web:alice.accounts.example");
+        assert_eq!(result.pds_endpoint, "https://pds.example");
+        assert_eq!(result.quic_url, "https://pds.example:4433/wt");
+        assert_eq!(
+            result.cert_hash,
+            "paWlpaWlpaWlpaWlpaWlpaWlpaWlpaWlpaWlpaWlpaU="
+        );
+    }
+
+    #[tokio::test]
+    async fn minted_did_resolves_to_the_authority_owned_tenant() {
+        let (_authority, publisher, signer, minter) = fixture();
+        let result = minter
+            .mint(&HostedAccountRegistrationRequest::new("alice"), &signer)
+            .unwrap();
+        let published = publisher
+            .published
+            .get()
+            .cloned()
+            .expect("mint must publish");
+        let root = SyntheticNode::dir().with_child(
+            published.tenant.clone(),
+            SyntheticNode::dir().with_child(
+                PDS_ACCOUNTS_DIRECTORY,
+                SyntheticNode::dir().with_child(
+                    published.label,
+                    SyntheticNode::dir().with_child(
+                        PDS_ACCOUNT_RECORD_FILE,
+                        SyntheticNode::file(published.account_record),
+                    ),
+                ),
+            ),
+        );
+        let store =
+            AccountRecordStore::new(Arc::new(SyntheticMount::new(root)), Arc::new(PermitReads));
+
+        assert_eq!(
+            store
+                .resolve_tenant_for_hosted_did(
+                    &Subject::new(crate::OAUTH_ACCOUNT_RESOLVER_SUBJECT),
+                    &result.did,
+                )
+                .await
+                .unwrap(),
+            Some("tenant-authority".to_owned())
+        );
+    }
+
+    #[test]
+    fn client_asserted_tenant_is_rejected_before_authority_or_publication() {
+        let (authority, publisher, _signer, _minter) = fixture();
+        let error =
+            HostedAccountRegistrationRequest::from_client_fields("alice", Some("tenant-client"))
+                .unwrap_err();
+
+        assert!(
+            error.to_string().contains("client-asserted tenant"),
+            "{error}"
+        );
+        assert_eq!(authority.calls.load(Ordering::SeqCst), 0);
+        assert!(publisher.published.get().is_none());
+    }
+}

--- a/crates/hyprstream-pds-service/src/lib.rs
+++ b/crates/hyprstream-pds-service/src/lib.rs
@@ -25,6 +25,9 @@ pub const PDS_NAMESPACE: &str = "/pds";
 pub const PDS_ACCOUNTS_DIRECTORY: &str = "accounts";
 /// Public account-record publication marker.
 pub const PDS_ACCOUNT_RECORD_FILE: &str = "account-record.cbor";
+
+pub mod hosted_account_mint;
+
 /// Fixed internal principal allowed to resolve a hosted DID to its tenant.
 pub const OAUTH_ACCOUNT_RESOLVER_SUBJECT: &str = "service:oauth";
 const DEFAULT_MAX_RECORD_BYTES: usize = 64 * 1024;

--- a/crates/hyprstream-pds/src/hosted_account.rs
+++ b/crates/hyprstream-pds/src/hosted_account.rs
@@ -319,6 +319,29 @@ impl HostedAccountMint {
             unsigned,
         })
     }
+
+    /// Create and sign the account's empty initial repo, then bind that commit
+    /// CID into the hosted DID's genesis operation.
+    ///
+    /// The generated `#atproto` key never crosses this boundary: it signs the
+    /// repo commit in place and remains owned by the pending account mint.
+    pub fn prepare_pds_genesis(
+        self,
+        did_document: SealedHostedDidDocument,
+        rev: crate::tid::Tid,
+    ) -> Result<(
+        PendingHostedAccountMint,
+        crate::hosted_repo::HostedRepoGenesis,
+    )> {
+        let repo = crate::hosted_repo::HostedRepoGenesis::seal(
+            self.name.did(),
+            &self.atproto_signing_key,
+            rev,
+        )?;
+        let pending =
+            self.prepare_genesis(did_document, GenesisRepoHead::Existing(repo.commit_cid()))?;
+        Ok((pending, repo))
+    }
 }
 
 /// Mint state waiting for the user-held priority-zero signature.

--- a/crates/hyprstream-pds/src/hosted_repo.rs
+++ b/crates/hyprstream-pds/src/hosted_repo.rs
@@ -1,0 +1,130 @@
+//! Initial atproto repository state for a hosted PDS account.
+//!
+//! A hosted account starts with a real, signed repo head even before it has
+//! application records. The empty MST root and ES256 commit are immutable
+//! blocks; the commit CID is bound into operation zero by
+//! [`HostedAccountMint::prepare_pds_genesis`](crate::HostedAccountMint::prepare_pds_genesis).
+
+use anyhow::{ensure, Result};
+use p256::ecdsa::{SigningKey, VerifyingKey};
+
+use crate::cid::Cid;
+use crate::commit::{Commit, UnsignedCommit};
+use crate::mst::Node;
+use crate::tid::Tid;
+
+/// A verified empty-MST root and signed initial repo commit.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct HostedRepoGenesis {
+    mst_root: Cid,
+    mst_blocks: Vec<(Cid, Vec<u8>)>,
+    commit: Commit,
+    commit_bytes: Vec<u8>,
+}
+
+impl HostedRepoGenesis {
+    pub(crate) fn seal(did: &str, signing_key: &SigningKey, rev: Tid) -> Result<Self> {
+        let tree = Node::empty();
+        let mst_root = tree.root_cid();
+        let mst_blocks = tree
+            .all_blocks()
+            .into_iter()
+            .map(|(cid, block)| (cid, block.encode()))
+            .collect::<Vec<_>>();
+        ensure!(
+            mst_blocks.iter().any(|(cid, _)| *cid == mst_root),
+            "initial hosted repo omits its MST root block"
+        );
+
+        let unsigned = UnsignedCommit::new(did, mst_root, rev, None);
+        let commit = Commit::sign(&unsigned, signing_key);
+        commit.verify(signing_key.verifying_key())?;
+        ensure!(
+            commit.did == did && commit.data == mst_root && commit.prev.is_none(),
+            "initial hosted repo commit does not describe the requested empty repo"
+        );
+        let commit_bytes = commit.to_dag_cbor();
+
+        Ok(Self {
+            mst_root,
+            mst_blocks,
+            commit,
+            commit_bytes,
+        })
+    }
+
+    /// CID of the canonical empty MST root block.
+    #[must_use]
+    pub fn mst_root(&self) -> Cid {
+        self.mst_root
+    }
+
+    /// Every MST block needed to materialize the initial repository.
+    #[must_use]
+    pub fn mst_blocks(&self) -> &[(Cid, Vec<u8>)] {
+        &self.mst_blocks
+    }
+
+    /// Signed ES256 initial commit.
+    #[must_use]
+    pub fn commit(&self) -> &Commit {
+        &self.commit
+    }
+
+    /// Canonical DAG-CBOR bytes of the signed initial commit.
+    #[must_use]
+    pub fn commit_bytes(&self) -> &[u8] {
+        &self.commit_bytes
+    }
+
+    /// CID of the signed initial commit bound into the genesis DID operation.
+    #[must_use]
+    pub fn commit_cid(&self) -> Cid {
+        self.commit.cid()
+    }
+
+    /// Re-verify the stored block linkage and commit signature.
+    pub fn verify(&self, verifying_key: &VerifyingKey) -> Result<()> {
+        ensure!(
+            self.mst_blocks
+                .iter()
+                .any(|(cid, bytes)| *cid == self.mst_root && Cid::from_dag_cbor(bytes) == *cid),
+            "initial hosted repo MST root block is missing or corrupt"
+        );
+        ensure!(
+            self.commit.data == self.mst_root && self.commit.prev.is_none(),
+            "initial hosted repo commit linkage is invalid"
+        );
+        ensure!(
+            self.commit.to_dag_cbor() == self.commit_bytes,
+            "initial hosted repo commit bytes are not canonical"
+        );
+        self.commit.verify(verifying_key)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #![allow(clippy::unwrap_used)]
+
+    use p256::ecdsa::SigningKey;
+
+    use super::*;
+
+    #[test]
+    fn empty_repo_genesis_is_signed_and_contains_its_root_block() {
+        let key = SigningKey::from_slice(&[19; 32]).unwrap();
+        let repo = HostedRepoGenesis::seal(
+            "did:web:alice.accounts.example",
+            &key,
+            Tid::from_micros(7, 1),
+        )
+        .unwrap();
+
+        repo.verify(key.verifying_key()).unwrap();
+        assert_eq!(repo.commit().did, "did:web:alice.accounts.example");
+        assert_eq!(repo.commit().data, repo.mst_root());
+        assert_eq!(repo.mst_blocks().len(), 1);
+        assert_eq!(repo.commit_cid(), Cid::from_dag_cbor(repo.commit_bytes()));
+    }
+}

--- a/crates/hyprstream-pds/src/lib.rs
+++ b/crates/hyprstream-pds/src/lib.rs
@@ -66,6 +66,7 @@ pub mod did_op;
 pub mod event_group;
 pub mod hosted_account;
 pub mod hosted_did_document;
+pub mod hosted_repo;
 pub mod ledger;
 pub mod list_record;
 pub mod mst;
@@ -89,6 +90,7 @@ pub use hosted_account::{
 pub use hosted_did_document::{
     SealedHostedDidDocument, DID_DOCUMENT_MEDIA_TYPE, DID_DOCUMENT_PATH, DID_OPERATION_LOG_PATH,
 };
+pub use hosted_repo::HostedRepoGenesis;
 pub use ledger::{AllocationRecord, CheckpointRecord, GrantClass, ReceiptRecord, StateRoot, Unit};
 pub use name_record::NameRecord;
 pub use placement::{GroupItemRecord, GroupRecord, NodeRecord, WorkloadRecord};

--- a/crates/hyprstream-rpc/src/service_entry.rs
+++ b/crates/hyprstream-rpc/src/service_entry.rs
@@ -34,10 +34,11 @@
 use std::net::{IpAddr, Ipv4Addr, SocketAddr};
 
 use anyhow::{anyhow, bail, Context, Result};
+use base64::Engine as _;
 use serde_json::{json, Value};
 
 use crate::did_key::MULTICODEC_ED25519_PUB;
-use crate::transport::{QuicServerAuth, TransportConfig};
+use crate::transport::{EndpointType, QuicServerAuth, TransportConfig};
 
 /// multihash prefix for `sha2-256` with a 32-byte digest (`0x12` code, `0x20` len).
 const MULTIHASH_SHA2_256: [u8; 2] = [0x12, 0x20];
@@ -47,6 +48,15 @@ const MULTIHASH_SHA2_256: [u8; 2] = [0x12, 0x20];
 pub struct DecodedEntry {
     /// Dial target for [`crate::dial::dial`].
     pub config: TransportConfig,
+}
+
+/// Browser projection of the primary live QUIC reach.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BrowserQuicReach {
+    /// URL copied from the validated live `QuicTransport` entry.
+    pub quic_url: String,
+    /// Standard-base64 SHA-256 leaf-certificate hash for WebTransport.
+    pub cert_hash: String,
 }
 
 // ── multibase helpers ────────────────────────────────────────────────────────
@@ -67,7 +77,11 @@ fn multibase_decode_32(s: &str, prefix: [u8; 2], what: &str) -> Result<[u8; 32]>
         .into_vec()
         .map_err(|e| anyhow!("{what}: invalid base58: {e}"))?;
     if bytes.len() != prefix.len() + 32 {
-        bail!("{what}: expected {} bytes, got {}", prefix.len() + 32, bytes.len());
+        bail!(
+            "{what}: expected {} bytes, got {}",
+            prefix.len() + 32,
+            bytes.len()
+        );
     }
     if bytes[..2] != prefix[..] {
         bail!("{what}: wrong multiformats prefix");
@@ -124,16 +138,48 @@ pub fn decode_service_entry(entry: &Value) -> Result<DecodedEntry> {
     }
 }
 
+/// Validate a live `QuicTransport` service entry and project its certificate
+/// pin into the singular browser registration shape.
+///
+/// Discovery models `certHashes` as a set for rotation overlap, while the
+/// registration contract currently has one `certHash`. Ambiguous overlap
+/// therefore fails closed instead of selecting a pin with no defined primary.
+pub fn decode_browser_quic_reach(entry: &Value) -> Result<BrowserQuicReach> {
+    let decoded = decode_service_entry(entry)?;
+    let EndpointType::Quic { auth, .. } = &decoded.config.endpoint else {
+        bail!("browser QUIC reach requires a QuicTransport service entry");
+    };
+    let [cert_hash] = auth.accept_cert_hashes() else {
+        bail!("browser QUIC reach requires exactly one live certificate hash");
+    };
+    let quic_url = entry
+        .get("serviceEndpoint")
+        .and_then(|endpoint| endpoint.get("uri"))
+        .and_then(Value::as_str)
+        .ok_or_else(|| anyhow!("quic: missing `uri`"))?
+        .to_owned();
+    Ok(BrowserQuicReach {
+        quic_url,
+        cert_hash: base64::engine::general_purpose::STANDARD.encode(cert_hash),
+    })
+}
+
 fn decode_iroh(svc: &Value) -> Result<DecodedEntry> {
     let node_id = multibase_decode_32(
-        svc.get("nodeId").and_then(Value::as_str).ok_or_else(|| anyhow!("iroh: missing `nodeId`"))?,
+        svc.get("nodeId")
+            .and_then(Value::as_str)
+            .ok_or_else(|| anyhow!("iroh: missing `nodeId`"))?,
         MULTICODEC_ED25519_PUB,
         "iroh nodeId",
     )?;
     let relays: Vec<String> = svc
         .get("relays")
         .and_then(Value::as_array)
-        .map(|a| a.iter().filter_map(|v| v.as_str().map(str::to_owned)).collect())
+        .map(|a| {
+            a.iter()
+                .filter_map(|v| v.as_str().map(str::to_owned))
+                .collect()
+        })
         .unwrap_or_default();
     // Direct addresses are not published (privacy + iroh discovery); the resolver
     // supplies a relay and lets iroh discover direct paths.
@@ -144,7 +190,10 @@ fn decode_iroh(svc: &Value) -> Result<DecodedEntry> {
 }
 
 fn decode_quic(svc: &Value) -> Result<DecodedEntry> {
-    let uri = svc.get("uri").and_then(Value::as_str).ok_or_else(|| anyhow!("quic: missing `uri`"))?;
+    let uri = svc
+        .get("uri")
+        .and_then(Value::as_str)
+        .ok_or_else(|| anyhow!("quic: missing `uri`"))?;
     let (host, port) = parse_https_authority(uri)?;
     // Default `webpki` to true (safe-by-default: a CA-fronted public peer).
     let require_web_pki = svc.get("webpki").and_then(Value::as_bool).unwrap_or(true);
@@ -154,7 +203,9 @@ fn decode_quic(svc: &Value) -> Result<DecodedEntry> {
         .map(|a| -> Result<Vec<[u8; 32]>> {
             a.iter()
                 .map(|v| {
-                    let s = v.as_str().ok_or_else(|| anyhow!("quic certHashes: non-string entry"))?;
+                    let s = v
+                        .as_str()
+                        .ok_or_else(|| anyhow!("quic certHashes: non-string entry"))?;
                     multibase_decode_32(s, MULTIHASH_SHA2_256, "quic certHash")
                 })
                 .collect()
@@ -185,7 +236,10 @@ fn decode_quic(svc: &Value) -> Result<DecodedEntry> {
 /// 443 when no port is given.
 fn parse_https_authority(uri: &str) -> Result<(String, u16)> {
     let url = url::Url::parse(uri).with_context(|| format!("quic uri parse: {uri}"))?;
-    let host = url.host_str().ok_or_else(|| anyhow!("quic uri has no host: {uri}"))?.to_owned();
+    let host = url
+        .host_str()
+        .ok_or_else(|| anyhow!("quic uri has no host: {uri}"))?
+        .to_owned();
     let port = url.port().unwrap_or(443);
     Ok((host, port))
 }
@@ -207,7 +261,11 @@ mod tests {
         });
         let decoded = decode_service_entry(&entry).unwrap();
         match &decoded.config.endpoint {
-            EndpointType::Iroh { node_id: n, relay_url, direct_addrs } => {
+            EndpointType::Iroh {
+                node_id: n,
+                relay_url,
+                direct_addrs,
+            } => {
                 assert_eq!(*n, node_id);
                 assert_eq!(relay_url.as_deref(), Some("https://relay.example"));
                 assert!(direct_addrs.is_empty());
@@ -225,7 +283,11 @@ mod tests {
         });
         let decoded = decode_service_entry(&entry).unwrap();
         match &decoded.config.endpoint {
-            EndpointType::Quic { addr, server_name, auth: a } => {
+            EndpointType::Quic {
+                addr,
+                server_name,
+                auth: a,
+            } => {
                 assert_eq!(addr.to_string(), "10.0.0.1:4433");
                 assert_eq!(server_name, "10.0.0.1");
                 assert!(!a.require_web_pki());
@@ -233,6 +295,42 @@ mod tests {
             }
             other => panic!("expected Quic, got {other:?}"),
         }
+    }
+
+    #[test]
+    fn browser_quic_projection_uses_the_live_pin() {
+        let auth = QuicServerAuth::pinned(vec![[3u8; 32]]).unwrap();
+        let entry = json!({
+            "type": "QuicTransport",
+            "serviceEndpoint": encode_quic(
+                "https://pds.example:4433/wt",
+                &auth,
+                &["hyprstream-rpc/1"],
+            ),
+        });
+
+        let browser = decode_browser_quic_reach(&entry).unwrap();
+        assert_eq!(browser.quic_url, "https://pds.example:4433/wt");
+        assert_eq!(
+            browser.cert_hash,
+            base64::engine::general_purpose::STANDARD.encode([3u8; 32])
+        );
+    }
+
+    #[test]
+    fn browser_quic_projection_rejects_rotation_overlap_ambiguity() {
+        let auth = QuicServerAuth::pinned(vec![[3u8; 32], [4u8; 32]]).unwrap();
+        let entry = json!({
+            "type": "QuicTransport",
+            "serviceEndpoint": encode_quic(
+                "https://pds.example:4433/wt",
+                &auth,
+                &["hyprstream-rpc/1"],
+            ),
+        });
+
+        let error = decode_browser_quic_reach(&entry).unwrap_err();
+        assert!(error.to_string().contains("exactly one"), "{error:#}");
     }
 
     #[test]
@@ -244,7 +342,11 @@ mod tests {
         });
         let decoded = decode_service_entry(&entry).unwrap();
         match &decoded.config.endpoint {
-            EndpointType::Quic { addr, server_name, auth } => {
+            EndpointType::Quic {
+                addr,
+                server_name,
+                auth,
+            } => {
                 assert!(auth.require_web_pki());
                 assert!(auth.accept_cert_hashes().is_empty());
                 assert_eq!(server_name, "host.example");


### PR DESCRIPTION
Mints a hosted account: host-form did:web DID doc + op-log + PDS account, tenant bound AUTHORITY-SIDE (never client-asserted), returning {handle,did,pdsEndpoint,quicUrl,certHash} for the browser register flow. Substrate for registration deliverable C of epic #1342.