### PR TITLE
feat(discovery): AppView inventory read-model (#1342 deliverable D)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3638,7 +3638,7 @@ dependencies = [
  "hex",
  "itertools 0.14.0",
  "log",
- "md-5",
+ "md-5 0.10.6",
  "rand 0.9.2",
  "regex",
  "sha2 0.10.9",
@@ -4419,6 +4419,7 @@ dependencies = [
  "block-buffer 0.12.0",
  "const-oid 0.10.2",
  "crypto-common 0.2.1",
+ "ctutils",
 ]
 
 [[package]]
@@ -4607,7 +4608,7 @@ checksum = "d7eeb487dde618b9f6ab26a451775ad5fac3fabe1ca2b64cbbe90b105f264ccd"
 dependencies = [
  "arrow",
  "cast",
- "fallible-iterator",
+ "fallible-iterator 0.3.0",
  "fallible-streaming-iterator",
  "hashlink 0.10.0",
  "libduckdb-sys",
@@ -5069,6 +5070,12 @@ dependencies = [
  "once_cell",
  "rand 0.8.5",
 ]
+
+[[package]]
+name = "fallible-iterator"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4443176a9f2c162692bd3d352d745ef9413eec5782a80d8fd6f8a1ac692a07f7"
 
 [[package]]
 name = "fallible-iterator"
@@ -6416,6 +6423,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "hmac"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6303bc9732ae41b04cb554b844a762b4115a61bfaa81e3e83050991eeb56863f"
+dependencies = [
+ "digest 0.11.3",
+]
+
+[[package]]
 name = "home"
 version = "0.5.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6909,6 +6925,24 @@ dependencies = [
  "tracing",
  "wasm-bindgen",
  "wasm-bindgen-futures",
+]
+
+[[package]]
+name = "hyprstream-appview"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "axum 0.7.9",
+ "hyprstream-pds-service",
+ "hyprstream-rpc",
+ "pglite-rs",
+ "serde",
+ "serde_json",
+ "tempfile",
+ "tokio",
+ "tower 0.5.2",
+ "tracing",
 ]
 
 [[package]]
@@ -9417,6 +9451,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "md-5"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69b6441f590336821bb897fb28fc622898ccceb1d6cea3fde5ea86b090c4de98"
+dependencies = [
+ "cfg-if 1.0.3",
+ "digest 0.11.3",
+]
+
+[[package]]
 name = "md5"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -11452,6 +11496,69 @@ dependencies = [
 ]
 
 [[package]]
+name = "pglite-rs"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce51c5797f88bf0e5f11764118d5392bef6aae38b668947e3b9dcc0dcd42f047"
+dependencies = [
+ "bytes",
+ "fallible-iterator 0.2.0",
+ "futures",
+ "libc",
+ "pglite-rs-sys",
+ "postgres-protocol",
+ "postgres-types",
+ "ruzstd",
+ "tar",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "pglite-rs-lib-aarch64-apple-darwin"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ba22160e74de33d75cb1209da1fbb5816afd3506a9b47df2c81f54066f6bd97"
+
+[[package]]
+name = "pglite-rs-lib-aarch64-unknown-linux-gnu"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47d2b934381ed7bbde6400034ec7294cb68ec46fb745b478b38de3913328126f"
+
+[[package]]
+name = "pglite-rs-lib-x86_64-apple-darwin"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71a8da533f2f9a82700af976acb573495be5bbdedeef90d1133d882c45128e61"
+
+[[package]]
+name = "pglite-rs-lib-x86_64-pc-windows-gnu"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c84ae5eed7dd28f5d9069b62ddd68ff0ea2ee65b989cfb4e9dea227a5dee2896"
+
+[[package]]
+name = "pglite-rs-lib-x86_64-unknown-linux-gnu"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32f15e7c780aba8873afdb1db6b1cd741f2f03ece5a7996cb83f7d7814e64606"
+
+[[package]]
+name = "pglite-rs-sys"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e8c85cdc379a58bef741624ce9c98786818c1decc5c13bd3691a32d125a59d3"
+dependencies = [
+ "libc",
+ "pglite-rs-lib-aarch64-apple-darwin",
+ "pglite-rs-lib-aarch64-unknown-linux-gnu",
+ "pglite-rs-lib-x86_64-apple-darwin",
+ "pglite-rs-lib-x86_64-pc-windows-gnu",
+ "pglite-rs-lib-x86_64-unknown-linux-gnu",
+ "ruzstd",
+]
+
+[[package]]
 name = "pharos"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -12265,6 +12372,35 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.111",
+]
+
+[[package]]
+name = "postgres-protocol"
+version = "0.6.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08808e3c483c46e999108051c78334f473d5adb59d78bb80a1268c7e6aa6c514"
+dependencies = [
+ "base64 0.22.1",
+ "byteorder",
+ "bytes",
+ "fallible-iterator 0.2.0",
+ "hmac 0.13.0",
+ "md-5 0.11.0",
+ "memchr",
+ "rand 0.10.1",
+ "sha2 0.11.0",
+ "stringprep",
+]
+
+[[package]]
+name = "postgres-types"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "851ca9db4932932d69f3ea811b1abe63087a0f740a47692619dd40d4899b68be"
+dependencies = [
+ "bytes",
+ "fallible-iterator 0.2.0",
+ "postgres-protocol",
 ]
 
 [[package]]
@@ -14207,6 +14343,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ruzstd"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7c1c839d570d835527c9a5e4db7cb2198683a988cb9d7293fc8674e6bd58fc8"
+dependencies = [
+ "twox-hash",
+]
+
+[[package]]
 name = "ryu"
 version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -15324,6 +15469,17 @@ name = "strength_reduce"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fe895eb47f22e2ddd4dabc02bce419d2e643c8e3b585c78158b349195bc24d82"
+
+[[package]]
+name = "stringprep"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b4df3d392d81bd458a8a621b8bffbd2302a12ffe288a9d931670948749463b1"
+dependencies = [
+ "unicode-bidi",
+ "unicode-normalization",
+ "unicode-properties",
+]
 
 [[package]]
 name = "strsim"
@@ -16714,6 +16870,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
 
 [[package]]
+name = "unicode-bidi"
+version = "0.3.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c1cb5db39152898a79168971543b1cb5020dff7fe43c8dc468b0885f5e29df5"
+
+[[package]]
 name = "unicode-bom"
 version = "2.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -16742,6 +16904,12 @@ checksum = "43f613e4fa046e69818dd287fdc4bc78175ff20331479dab6e1b0f98d57062de"
 dependencies = [
  "smallvec",
 ]
+
+[[package]]
+name = "unicode-properties"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7df058c713841ad818f1dc5d3fd88063241cc61f49f5fbea4b951e8cf5a8d71d"
 
 [[package]]
 name = "unicode-reverse"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,7 @@ members = [
     "crates/hyprstream-9p",
     "crates/hyprstream-pds",
     "crates/hyprstream-pds-service",
+    "crates/hyprstream-appview",
     "crates/hyprstream-workers-wasmtime",
     "crates/hyprstream-workers-python",
     "crates/hyprstream-k8s",
@@ -114,6 +115,7 @@ cas_types = { git = "https://github.com/huggingface/xet-core", tag = "git-xet-v0
 chunk_cache = { git = "https://github.com/huggingface/xet-core", tag = "git-xet-v0.2.0" }
 merklehash = { git = "https://github.com/huggingface/xet-core", tag = "git-xet-v0.2.0" }
 async-trait = "0.1"
+pglite-rs = { version = "=0.2.7", default-features = false }
 
 # Optional hyprstream-p2p (formerly gittorrent) transport support
 hyprstream-p2p = { path = "crates/hyprstream-p2p" }

--- a/crates/hyprstream-appview/Cargo.toml
+++ b/crates/hyprstream-appview/Cargo.toml
@@ -1,0 +1,30 @@
+[package]
+name = "hyprstream-appview"
+version = "0.1.0"
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+description = "Derived, clearance-filtered identity inventory AppView"
+
+[features]
+default = []
+pglite = ["dep:pglite-rs"]
+
+[dependencies]
+anyhow = { workspace = true }
+async-trait = { workspace = true }
+axum = { workspace = true }
+hyprstream-pds-service = { path = "../hyprstream-pds-service" }
+hyprstream-rpc = { path = "../hyprstream-rpc" }
+pglite-rs = { workspace = true, optional = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+tracing = { workspace = true }
+
+[dev-dependencies]
+tempfile = { workspace = true }
+tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
+tower = { version = "0.5", features = ["util"] }
+
+[lints]
+workspace = true

--- a/crates/hyprstream-appview/src/http.rs
+++ b/crates/hyprstream-appview/src/http.rs
@@ -1,0 +1,212 @@
+use std::sync::Arc;
+
+use axum::extract::{Extension, Query, State};
+use axum::http::StatusCode;
+use axum::response::{IntoResponse, Response};
+use axum::routing::get;
+use axum::{Json, Router};
+use hyprstream_pds_service::federation_intake::IdentityInventoryReadModel;
+use hyprstream_rpc::auth::mac::{CompartmentSet, Level, SecurityContext, VerifiedKeyMaterial};
+use serde::Deserialize;
+
+const MAX_FILTER_BYTES: usize = 256;
+const MAX_CURSOR_BYTES: usize = 2048;
+const DEFAULT_PAGE_SIZE: usize = 200;
+const MAX_PAGE_SIZE: usize = 200;
+
+#[derive(Clone)]
+struct InventoryHttpState {
+    inventory: Arc<dyn IdentityInventoryReadModel>,
+}
+
+/// Viewer clearance installed by trusted authentication/MAC middleware.
+///
+/// HTTP input cannot construct request extensions. If the extension is absent,
+/// the handler deliberately applies the unauthenticated public floor.
+#[derive(Clone, Debug)]
+pub struct InventoryViewer(SecurityContext);
+
+impl InventoryViewer {
+    /// Wrap a clearance already derived from verified server-side claims.
+    pub fn from_verified_clearance(clearance: SecurityContext) -> Self {
+        Self(clearance)
+    }
+
+    fn unauthenticated_floor() -> Self {
+        Self(SecurityContext::new(
+            Level::Public,
+            CompartmentSet::EMPTY,
+            VerifiedKeyMaterial::Unverified,
+        ))
+    }
+}
+
+#[derive(Debug, Default, Deserialize)]
+struct InventoryQuery {
+    filter: Option<String>,
+    after: Option<String>,
+    limit: Option<usize>,
+}
+
+/// Build a mountable `GET /inventory?filter=...` AppView router.
+///
+/// The response is exactly an `InventoryEntry[]`; it has no envelope in which a
+/// pre-filter total or hidden count could leak. Deployment middleware must
+/// reject an invalid presented credential with 401; only true credential
+/// absence may reach this router without an [`InventoryViewer`] extension.
+pub fn inventory_router(inventory: Arc<dyn IdentityInventoryReadModel>) -> Router {
+    Router::new()
+        .route("/inventory", get(query_inventory))
+        .with_state(InventoryHttpState { inventory })
+}
+
+async fn query_inventory(
+    State(state): State<InventoryHttpState>,
+    Query(query): Query<InventoryQuery>,
+    viewer: Option<Extension<InventoryViewer>>,
+) -> Response {
+    if query
+        .filter
+        .as_deref()
+        .is_some_and(|filter| filter.len() > MAX_FILTER_BYTES)
+        || query
+            .after
+            .as_deref()
+            .is_some_and(|after| after.len() > MAX_CURSOR_BYTES)
+        || query.limit == Some(0)
+    {
+        return (
+            StatusCode::BAD_REQUEST,
+            Json(serde_json::json!({"error": "invalid inventory query"})),
+        )
+            .into_response();
+    }
+    let limit = query.limit.unwrap_or(DEFAULT_PAGE_SIZE).min(MAX_PAGE_SIZE);
+    let viewer = viewer
+        .map(|Extension(viewer)| viewer)
+        .unwrap_or_else(InventoryViewer::unauthenticated_floor);
+    match state
+        .inventory
+        .query_page(
+            &viewer.0,
+            query.filter.as_deref(),
+            query.after.as_deref(),
+            limit,
+        )
+        .await
+    {
+        Ok(entries) => Json(entries).into_response(),
+        Err(error) => {
+            tracing::error!(error = %error, "inventory query failed");
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(serde_json::json!({"error": "inventory unavailable"})),
+            )
+                .into_response()
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #![allow(clippy::expect_used, clippy::unwrap_used)]
+
+    use axum::body::{to_bytes, Body};
+    use axum::http::Request;
+    use hyprstream_pds_service::federation_intake::{InMemoryIdentityInventory, InventoryEntry};
+    use hyprstream_rpc::auth::mac::{Assurance, SecurityLabel};
+    use tower::ServiceExt;
+
+    use super::*;
+
+    #[tokio::test]
+    async fn get_inventory_returns_only_post_clearance_array() {
+        let inventory = Arc::new(InMemoryIdentityInventory::default());
+        inventory
+            .upsert_derived(
+                InventoryEntry::indexed_federated(
+                    "did:web:public.example",
+                    Some("alice.example".to_owned()),
+                    None,
+                )
+                .unwrap(),
+                SecurityLabel::bottom(),
+            )
+            .await
+            .unwrap();
+        inventory
+            .upsert_derived(
+                InventoryEntry::indexed_federated(
+                    "did:web:hidden.example",
+                    Some("hidden.example".to_owned()),
+                    None,
+                )
+                .unwrap(),
+                SecurityLabel::new(
+                    Level::Secret,
+                    Assurance::PqHybrid,
+                    CompartmentSet::single(9),
+                ),
+            )
+            .await
+            .unwrap();
+        let app = inventory_router(inventory);
+
+        let response = app
+            .clone()
+            .oneshot(
+                Request::get("/inventory?filter=example")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+        let body: serde_json::Value =
+            serde_json::from_slice(&to_bytes(response.into_body(), 8192).await.unwrap()).unwrap();
+        let entries = body.as_array().expect("response must be a bare array");
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0]["did"], "did:web:public.example");
+        assert!(body.get("total").is_none());
+        assert!(body.get("hiddenCount").is_none());
+
+        let response = app
+            .clone()
+            .oneshot(
+                Request::get(format!(
+                    "/inventory?filter={}",
+                    "x".repeat(MAX_FILTER_BYTES + 1)
+                ))
+                .body(Body::empty())
+                .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+
+        let privileged = InventoryViewer::from_verified_clearance(SecurityContext::new(
+            Level::Secret,
+            CompartmentSet::single(9),
+            VerifiedKeyMaterial::PqHybrid,
+        ));
+        let mut request = Request::get("/inventory?limit=1")
+            .body(Body::empty())
+            .unwrap();
+        request.extensions_mut().insert(privileged.clone());
+        let response = app.clone().oneshot(request).await.unwrap();
+        let body: serde_json::Value =
+            serde_json::from_slice(&to_bytes(response.into_body(), 8192).await.unwrap()).unwrap();
+        let page = body.as_array().unwrap();
+        assert_eq!(page.len(), 1);
+        let after = page[0]["did"].as_str().unwrap();
+
+        let mut request = Request::get(format!("/inventory?limit=1&after={after}"))
+            .body(Body::empty())
+            .unwrap();
+        request.extensions_mut().insert(privileged);
+        let response = app.oneshot(request).await.unwrap();
+        let body: serde_json::Value =
+            serde_json::from_slice(&to_bytes(response.into_body(), 8192).await.unwrap()).unwrap();
+        assert_eq!(body.as_array().unwrap().len(), 1);
+    }
+}

--- a/crates/hyprstream-appview/src/inventory.rs
+++ b/crates/hyprstream-appview/src/inventory.rs
@@ -1,0 +1,652 @@
+use std::sync::Arc;
+
+#[cfg(feature = "pglite")]
+use std::path::Path;
+
+#[cfg(feature = "pglite")]
+use anyhow::{bail, Context};
+use anyhow::{ensure, Result};
+use async_trait::async_trait;
+use hyprstream_pds_service::federation_intake::{
+    IdentityInventoryReadModel, InventoryEntry, InventoryKind,
+};
+use hyprstream_rpc::auth::mac::SecurityLabel;
+#[cfg(feature = "pglite")]
+use hyprstream_rpc::auth::mac::{Assurance, Level, SecurityContext};
+#[cfg(feature = "pglite")]
+use hyprstream_rpc::identity::UNAUTHENTICATED_DID_SENTINEL;
+#[cfg(feature = "pglite")]
+use pglite::{PGlite, Row};
+
+#[cfg(feature = "pglite")]
+const CREATE_SCHEMA_TEMPLATE: &str = r#"
+CREATE TABLE IF NOT EXISTS appview_inventory (
+    did                 TEXT PRIMARY KEY,
+    handle              TEXT,
+    kind                TEXT NOT NULL,
+    tenant              TEXT,
+    pds_endpoint        TEXT,
+    label_level         SMALLINT NOT NULL,
+    label_assurance     SMALLINT NOT NULL,
+    label_compartments  BIGINT NOT NULL,
+    CHECK (did <> '__UNAUTHENTICATED_DID_SENTINEL__'),
+    CHECK (kind IN ('local', 'federated')),
+    CHECK (
+        (kind = 'local' AND tenant IS NOT NULL AND tenant <> '')
+        OR
+        (kind = 'federated' AND tenant IS NULL)
+    )
+);
+CREATE INDEX IF NOT EXISTS appview_inventory_handle_idx
+    ON appview_inventory (lower(handle));
+"#;
+
+#[cfg(feature = "pglite")]
+const UPSERT: &str = r#"
+INSERT INTO appview_inventory (
+    did, handle, kind, tenant, pds_endpoint,
+    label_level, label_assurance, label_compartments
+)
+VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
+ON CONFLICT (did) DO UPDATE SET
+    handle = EXCLUDED.handle,
+    kind = EXCLUDED.kind,
+    tenant = EXCLUDED.tenant,
+    pds_endpoint = EXCLUDED.pds_endpoint,
+    label_level = EXCLUDED.label_level,
+    label_assurance = EXCLUDED.label_assurance,
+    label_compartments = EXCLUDED.label_compartments
+WHERE appview_inventory.kind = EXCLUDED.kind
+  AND appview_inventory.tenant IS NOT DISTINCT FROM EXCLUDED.tenant
+  AND EXCLUDED.label_level >= appview_inventory.label_level
+  AND EXCLUDED.label_assurance >= appview_inventory.label_assurance
+  AND (
+      appview_inventory.label_compartments & EXCLUDED.label_compartments
+  ) = appview_inventory.label_compartments
+RETURNING did
+"#;
+
+#[cfg(feature = "pglite")]
+const VISIBLE_QUERY: &str = r#"
+SELECT did, handle, kind, tenant, pds_endpoint
+FROM appview_inventory
+WHERE did <> $1
+  AND label_level <= $2
+  AND label_assurance <= $3
+  AND (label_compartments & $4) = label_compartments
+  AND (
+      $5::text IS NULL
+      OR strpos(lower(did), lower($5)) > 0
+      OR strpos(lower(COALESCE(handle, '')), lower($5)) > 0
+      OR strpos(lower(kind), lower($5)) > 0
+      OR strpos(lower(COALESCE(tenant, '')), lower($5)) > 0
+      OR strpos(lower(COALESCE(pds_endpoint, '')), lower($5)) > 0
+  )
+  AND ($6::text IS NULL OR did > $6)
+ORDER BY did
+LIMIT $7
+"#;
+
+#[cfg(feature = "pglite")]
+const VISIBLE_GET: &str = r#"
+SELECT did, handle, kind, tenant, pds_endpoint
+FROM appview_inventory
+WHERE did = $1
+  AND did <> $2
+  AND label_level <= $3
+  AND label_assurance <= $4
+  AND (label_compartments & $5) = label_compartments
+"#;
+
+/// PGlite-backed derived identity inventory.
+///
+/// The schema and queries use PostgreSQL types/operators. A metal deployment
+/// can implement [`IdentityInventoryReadModel`] against its Postgres pool
+/// without changing the projection or HTTP contracts.
+#[cfg(feature = "pglite")]
+#[derive(Clone)]
+pub struct PGliteIdentityInventory {
+    database: Arc<PGlite>,
+}
+
+#[cfg(feature = "pglite")]
+impl PGliteIdentityInventory {
+    /// Open the embedded Postgres data directory and apply the idempotent schema.
+    pub async fn open(data_dir: impl AsRef<Path>) -> Result<Self> {
+        let database = PGlite::open(data_dir)
+            .await
+            .context("opening AppView PGlite database")?;
+        let schema = CREATE_SCHEMA_TEMPLATE.replace(
+            "__UNAUTHENTICATED_DID_SENTINEL__",
+            UNAUTHENTICATED_DID_SENTINEL,
+        );
+        database
+            .exec(&schema)
+            .await
+            .context("creating AppView inventory schema")?;
+        Ok(Self {
+            database: Arc::new(database),
+        })
+    }
+
+    async fn visible_rows(
+        &self,
+        viewer: &SecurityContext,
+        filter: Option<&str>,
+        after: Option<&str>,
+        limit: usize,
+    ) -> Result<Vec<InventoryEntry>> {
+        ensure!(limit > 0, "inventory page limit must be positive");
+        let limit = i64::try_from(limit).context("inventory page limit exceeds BIGINT")?;
+        let clearance = viewer.clearance();
+        let level = level_code(clearance.level);
+        let assurance = assurance_code(clearance.assurance);
+        let compartments = clearance.compartments.0 as i64;
+        let normalized_filter = filter.map(str::trim).filter(|value| !value.is_empty());
+        let rows = self
+            .database
+            .query(
+                VISIBLE_QUERY,
+                &[
+                    &UNAUTHENTICATED_DID_SENTINEL,
+                    &level,
+                    &assurance,
+                    &compartments,
+                    &normalized_filter,
+                    &after,
+                    &limit,
+                ],
+            )
+            .await
+            .context("querying visible AppView inventory")?;
+        rows.iter().map(decode_entry).collect()
+    }
+}
+
+#[cfg(feature = "pglite")]
+#[async_trait]
+impl IdentityInventoryReadModel for PGliteIdentityInventory {
+    async fn upsert_derived(&self, identity: InventoryEntry, label: SecurityLabel) -> Result<()> {
+        identity.validate()?;
+        ensure!(
+            identity.kind() != InventoryKind::Unauthenticated,
+            "the unauthenticated floor is not a listable inventory host"
+        );
+
+        let kind = kind_name(identity.kind());
+        let did = identity.did();
+        let handle = identity.handle();
+        let tenant = identity.tenant();
+        let pds_endpoint = identity.pds_endpoint();
+        let level = level_code(label.level);
+        let assurance = assurance_code(label.assurance);
+        let compartments = label.compartments.0 as i64;
+        let rows = self
+            .database
+            .query(
+                UPSERT,
+                &[
+                    &did,
+                    &handle,
+                    &kind,
+                    &tenant,
+                    &pds_endpoint,
+                    &level,
+                    &assurance,
+                    &compartments,
+                ],
+            )
+            .await
+            .context("upserting derived AppView inventory entry")?;
+        ensure!(
+            rows.len() == 1,
+            "inventory refresh rejected a kind, tenant, or label write-down for {}",
+            identity.did()
+        );
+        Ok(())
+    }
+
+    async fn query_page(
+        &self,
+        viewer: &SecurityContext,
+        filter: Option<&str>,
+        after: Option<&str>,
+        limit: usize,
+    ) -> Result<Vec<InventoryEntry>> {
+        self.visible_rows(viewer, filter, after, limit).await
+    }
+
+    async fn get(
+        &self,
+        viewer: Option<&SecurityContext>,
+        did: &str,
+    ) -> Result<Option<InventoryEntry>> {
+        let Some(viewer) = viewer else {
+            return Ok(None);
+        };
+        if did == UNAUTHENTICATED_DID_SENTINEL {
+            return Ok(None);
+        }
+        let clearance = viewer.clearance();
+        let level = level_code(clearance.level);
+        let assurance = assurance_code(clearance.assurance);
+        let compartments = clearance.compartments.0 as i64;
+        let rows = self
+            .database
+            .query(
+                VISIBLE_GET,
+                &[
+                    &did,
+                    &UNAUTHENTICATED_DID_SENTINEL,
+                    &level,
+                    &assurance,
+                    &compartments,
+                ],
+            )
+            .await
+            .context("fetching visible AppView inventory entry")?;
+        ensure!(
+            rows.len() <= 1,
+            "inventory DID primary key returned duplicates"
+        );
+        rows.first().map(decode_entry).transpose()
+    }
+}
+
+#[cfg(feature = "pglite")]
+fn decode_entry(row: &Row) -> Result<InventoryEntry> {
+    let did: String = row.get(0).context("decoding inventory DID")?;
+    let handle: Option<String> = row.get(1).context("decoding inventory handle")?;
+    let kind: String = row.get(2).context("decoding inventory kind")?;
+    let tenant: Option<String> = row.get(3).context("decoding inventory tenant")?;
+    let pds_endpoint: Option<String> = row.get(4).context("decoding inventory PDS endpoint")?;
+    match kind.as_str() {
+        "local" => InventoryEntry::local(
+            did,
+            handle,
+            tenant.context("stored local inventory entry has no tenant")?,
+            pds_endpoint,
+        ),
+        "federated" => {
+            ensure!(
+                tenant.is_none(),
+                "stored federated inventory entry carries a tenant"
+            );
+            InventoryEntry::indexed_federated(did, handle, pds_endpoint)
+        }
+        _ => bail!("stored inventory entry has invalid kind {kind:?}"),
+    }
+}
+
+#[cfg(feature = "pglite")]
+const fn level_code(level: Level) -> i16 {
+    level as i16
+}
+
+#[cfg(feature = "pglite")]
+const fn assurance_code(assurance: Assurance) -> i16 {
+    assurance as i16
+}
+
+#[cfg(feature = "pglite")]
+const fn kind_name(kind: InventoryKind) -> &'static str {
+    match kind {
+        InventoryKind::Local => "local",
+        InventoryKind::Federated => "federated",
+        InventoryKind::Unauthenticated => "unauthenticated",
+    }
+}
+
+/// One projection emitted by an authority-owned source.
+///
+/// Construction routes through [`InventoryEntry`] invariant checks. The label
+/// is trusted object metadata supplied by the source, not by a client or SQL.
+#[derive(Clone, Debug)]
+pub struct LabeledInventoryEntry {
+    entry: InventoryEntry,
+    label: SecurityLabel,
+}
+
+impl LabeledInventoryEntry {
+    /// Create a projection from the directory/federation authority boundary.
+    pub fn federated(
+        did: impl Into<String>,
+        handle: Option<String>,
+        pds_endpoint: Option<String>,
+        label: SecurityLabel,
+    ) -> Result<Self> {
+        Ok(Self {
+            entry: InventoryEntry::indexed_federated(did, handle, pds_endpoint)?,
+            label,
+        })
+    }
+
+    /// Create a local projection from a hosted-account authority boundary.
+    pub fn local(
+        did: impl Into<String>,
+        handle: Option<String>,
+        tenant: impl Into<String>,
+        pds_endpoint: Option<String>,
+        label: SecurityLabel,
+    ) -> Result<Self> {
+        Ok(Self {
+            entry: InventoryEntry::local(did, handle, tenant, pds_endpoint)?,
+            label,
+        })
+    }
+}
+
+/// Bulk/bootstrap source for directory-derived foreign projections.
+///
+/// Live federation intake writes directly through
+/// [`IdentityInventoryReadModel::upsert_derived`]; this source is the clean seam
+/// for the directory lane's later snapshot/bootstrap adapter.
+#[async_trait]
+pub trait DirectoryInventorySource: Send + Sync {
+    async fn entries(&self) -> Result<Vec<LabeledInventoryEntry>>;
+}
+
+/// Authority-owned source for local hosted-account projections.
+///
+/// Implementations must derive tenant from the hosted-account binding. A
+/// client payload or database column is never an acceptable source.
+#[async_trait]
+pub trait HostedAccountInventorySource: Send + Sync {
+    async fn entries(&self) -> Result<Vec<LabeledInventoryEntry>>;
+}
+
+/// Explicit empty directory adapter used until the directory lane lands.
+#[derive(Clone, Copy, Debug, Default)]
+pub struct StubDirectoryInventorySource;
+
+#[async_trait]
+impl DirectoryInventorySource for StubDirectoryInventorySource {
+    async fn entries(&self) -> Result<Vec<LabeledInventoryEntry>> {
+        Ok(Vec::new())
+    }
+}
+
+/// Explicit empty hosted-account enumeration adapter.
+///
+/// The merged hosted-PDS mint lane has no global, authority-safe listing API,
+/// so the AppView does not infer tenant from its registration response.
+#[derive(Clone, Copy, Debug, Default)]
+pub struct StubHostedAccountInventorySource;
+
+#[async_trait]
+impl HostedAccountInventorySource for StubHostedAccountInventorySource {
+    async fn entries(&self) -> Result<Vec<LabeledInventoryEntry>> {
+        Ok(Vec::new())
+    }
+}
+
+/// Refresh orchestration for separately landing directory/hosted adapters.
+pub struct InventoryIngestor {
+    inventory: Arc<dyn IdentityInventoryReadModel>,
+}
+
+impl InventoryIngestor {
+    pub fn new(inventory: Arc<dyn IdentityInventoryReadModel>) -> Self {
+        Self { inventory }
+    }
+
+    /// Ingest derived snapshots without exposing source totals to query callers.
+    pub async fn refresh(
+        &self,
+        directory: &dyn DirectoryInventorySource,
+        hosted_accounts: &dyn HostedAccountInventorySource,
+    ) -> Result<()> {
+        for projection in directory.entries().await? {
+            ensure!(
+                projection.entry.kind() == InventoryKind::Federated,
+                "directory source emitted a non-federated projection"
+            );
+            self.inventory
+                .upsert_derived(projection.entry, projection.label)
+                .await?;
+        }
+        for projection in hosted_accounts.entries().await? {
+            ensure!(
+                projection.entry.kind() == InventoryKind::Local,
+                "hosted-account source emitted a non-local projection"
+            );
+            self.inventory
+                .upsert_derived(projection.entry, projection.label)
+                .await?;
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #![allow(clippy::expect_used, clippy::unwrap_used)]
+
+    use super::*;
+    use hyprstream_pds_service::federation_intake::InMemoryIdentityInventory;
+    #[cfg(feature = "pglite")]
+    use hyprstream_rpc::auth::mac::Assurance;
+    use hyprstream_rpc::auth::mac::{CompartmentSet, Level, SecurityContext, VerifiedKeyMaterial};
+
+    fn viewer(
+        level: Level,
+        assurance: VerifiedKeyMaterial,
+        compartments: CompartmentSet,
+    ) -> SecurityContext {
+        SecurityContext::new(level, compartments, assurance)
+    }
+
+    #[cfg(feature = "pglite")]
+    #[tokio::test]
+    async fn pglite_prefilters_before_materialization_and_preserves_contract() {
+        let temp = tempfile::tempdir_in(std::env::current_dir().unwrap()).unwrap();
+        let inventory = PGliteIdentityInventory::open(temp.path()).await.unwrap();
+        let public = InventoryEntry::indexed_federated(
+            "did:web:public.example",
+            Some("alice.example".to_owned()),
+            Some("https://pds.public.example".to_owned()),
+        )
+        .unwrap();
+        let secret = InventoryEntry::indexed_federated(
+            "did:web:secret.example",
+            Some("secret.example".to_owned()),
+            None,
+        )
+        .unwrap();
+        let local = InventoryEntry::local(
+            "did:web:bob.accounts.example",
+            Some("bob".to_owned()),
+            "tenant-authority",
+            Some("https://pds.local.example".to_owned()),
+        )
+        .unwrap();
+        inventory
+            .upsert_derived(public.clone(), SecurityLabel::bottom())
+            .await
+            .unwrap();
+        inventory
+            .upsert_derived(
+                secret.clone(),
+                SecurityLabel::new(
+                    Level::Secret,
+                    Assurance::PqHybrid,
+                    CompartmentSet::single(7),
+                ),
+            )
+            .await
+            .unwrap();
+        inventory
+            .upsert_derived(
+                local.clone(),
+                SecurityLabel::new(
+                    Level::Internal,
+                    Assurance::Classical,
+                    CompartmentSet::single(4),
+                ),
+            )
+            .await
+            .unwrap();
+        let demotion = inventory
+            .upsert_derived(
+                InventoryEntry::indexed_federated(
+                    local.did(),
+                    Some("attacker-refresh.example".to_owned()),
+                    None,
+                )
+                .unwrap(),
+                SecurityLabel::bottom(),
+            )
+            .await
+            .unwrap_err();
+        assert!(demotion.to_string().contains("write-down"));
+        let label_write_down = inventory
+            .upsert_derived(secret.clone(), SecurityLabel::bottom())
+            .await
+            .unwrap_err();
+        assert!(label_write_down.to_string().contains("write-down"));
+
+        let floor = viewer(
+            Level::Public,
+            VerifiedKeyMaterial::Unverified,
+            CompartmentSet::EMPTY,
+        );
+        let floor_visible = inventory.query(&floor, None).await.unwrap();
+        assert_eq!(floor_visible, vec![public.clone()]);
+        assert_eq!(
+            inventory.query(&floor, Some("secret")).await.unwrap(),
+            Vec::<InventoryEntry>::new()
+        );
+        assert_eq!(
+            inventory.query(&floor, Some("ALICE")).await.unwrap(),
+            vec![public.clone()]
+        );
+        assert!(
+            inventory.query(&floor, Some("%")).await.unwrap().is_empty(),
+            "SQL filters must treat wildcard characters as literal substrings"
+        );
+        assert_eq!(
+            inventory.get(Some(&floor), secret.did()).await.unwrap(),
+            None
+        );
+        assert_eq!(
+            inventory
+                .get(Some(&floor), "did:web:missing.example")
+                .await
+                .unwrap(),
+            None
+        );
+
+        let privileged = viewer(
+            Level::Secret,
+            VerifiedKeyMaterial::PqHybrid,
+            CompartmentSet::single(4).union(CompartmentSet::single(7)),
+        );
+        assert_eq!(
+            inventory.query(&privileged, None).await.unwrap(),
+            vec![local.clone(), public.clone(), secret.clone()]
+        );
+        assert_eq!(
+            inventory
+                .query_page(&privileged, None, None, 2)
+                .await
+                .unwrap(),
+            vec![local, public.clone()]
+        );
+        assert_eq!(
+            inventory
+                .query_page(&privileged, None, Some(public.did()), 2)
+                .await
+                .unwrap(),
+            vec![secret]
+        );
+
+        let wire = serde_json::to_value(&floor_visible).unwrap();
+        let row = &wire.as_array().unwrap()[0];
+        assert!(row.get("quicUrl").is_none());
+        assert!(row.get("certHash").is_none());
+        assert!(wire.get("total").is_none());
+        assert!(wire.get("hiddenCount").is_none());
+
+        let rejected = InventoryEntry::indexed_federated(UNAUTHENTICATED_DID_SENTINEL, None, None)
+            .unwrap_err();
+        assert!(rejected.to_string().contains("unauthenticated floor"));
+    }
+
+    #[tokio::test]
+    async fn source_stubs_are_explicitly_empty() {
+        assert!(StubDirectoryInventorySource
+            .entries()
+            .await
+            .unwrap()
+            .is_empty());
+        assert!(StubHostedAccountInventorySource
+            .entries()
+            .await
+            .unwrap()
+            .is_empty());
+    }
+
+    struct StaticDirectory(Vec<LabeledInventoryEntry>);
+
+    #[async_trait]
+    impl DirectoryInventorySource for StaticDirectory {
+        async fn entries(&self) -> Result<Vec<LabeledInventoryEntry>> {
+            Ok(self.0.clone())
+        }
+    }
+
+    struct StaticHostedAccounts(Vec<LabeledInventoryEntry>);
+
+    #[async_trait]
+    impl HostedAccountInventorySource for StaticHostedAccounts {
+        async fn entries(&self) -> Result<Vec<LabeledInventoryEntry>> {
+            Ok(self.0.clone())
+        }
+    }
+
+    #[tokio::test]
+    async fn source_refresh_preserves_local_tenant_authority_boundary() {
+        let inventory = Arc::new(InMemoryIdentityInventory::default());
+        let ingestor = InventoryIngestor::new(inventory.clone());
+        let directory = StaticDirectory(vec![LabeledInventoryEntry::federated(
+            "did:web:foreign.example",
+            Some("foreign.example".to_owned()),
+            Some("https://pds.foreign.example".to_owned()),
+            SecurityLabel::bottom(),
+        )
+        .unwrap()]);
+        let hosted = StaticHostedAccounts(vec![LabeledInventoryEntry::local(
+            "did:web:alice.accounts.example",
+            Some("alice".to_owned()),
+            "tenant-authority",
+            Some("https://pds.local.example".to_owned()),
+            SecurityLabel::bottom(),
+        )
+        .unwrap()]);
+
+        ingestor.refresh(&directory, &hosted).await.unwrap();
+        let visible = inventory
+            .list(&viewer(
+                Level::Public,
+                VerifiedKeyMaterial::Unverified,
+                CompartmentSet::EMPTY,
+            ))
+            .await
+            .unwrap();
+        assert_eq!(visible.len(), 2);
+        let local = visible
+            .iter()
+            .find(|entry| entry.kind() == InventoryKind::Local)
+            .unwrap();
+        assert_eq!(local.tenant(), Some("tenant-authority"));
+        let federated = visible
+            .iter()
+            .find(|entry| entry.kind() == InventoryKind::Federated)
+            .unwrap();
+        assert_eq!(federated.tenant(), None);
+        assert!(
+            InventoryEntry::local("did:web:invalid.example", None, "", None).is_err(),
+            "a local projection without an authority tenant must fail closed"
+        );
+    }
+}

--- a/crates/hyprstream-appview/src/lib.rs
+++ b/crates/hyprstream-appview/src/lib.rs
@@ -1,0 +1,19 @@
+//! Derived AppView inventory for local and federated ATProto identities.
+//!
+//! This crate is an index, never identity authority. The default build uses the
+//! in-memory read model supplied by `hyprstream-pds-service`, avoiding native
+//! database dependencies in the demo/CI path. The optional `pglite` feature
+//! supplies a PostgreSQL-compatible PGlite adapter for metal deployments.
+//! Inventory queries apply the MAC dominance predicate before rows reach the
+//! HTTP response.
+
+mod http;
+mod inventory;
+
+pub use http::{inventory_router, InventoryViewer};
+#[cfg(feature = "pglite")]
+pub use inventory::PGliteIdentityInventory;
+pub use inventory::{
+    DirectoryInventorySource, HostedAccountInventorySource, InventoryIngestor,
+    LabeledInventoryEntry, StubDirectoryInventorySource, StubHostedAccountInventorySource,
+};

--- a/crates/hyprstream-pds-service/src/federation_intake.rs
+++ b/crates/hyprstream-pds-service/src/federation_intake.rs
@@ -105,14 +105,81 @@ pub struct InventoryEntry {
 
 impl InventoryEntry {
     fn federated(did: String, document: &Value) -> Result<Self> {
-        ensure_real_identity_did(&did)?;
-        Ok(Self {
+        Self::indexed_federated(
             did,
-            handle: extract_handle(document)?,
+            extract_handle(document)?,
+            extract_pds_endpoint(document)?,
+        )
+    }
+
+    /// Build a local projection from an authority-owned hosted-account source.
+    ///
+    /// This constructor validates the invariant at the read-model boundary:
+    /// only a local entry may carry a tenant, and a local entry must carry one.
+    pub fn local(
+        did: impl Into<String>,
+        handle: Option<String>,
+        tenant: impl Into<String>,
+        pds_endpoint: Option<String>,
+    ) -> Result<Self> {
+        let entry = Self {
+            did: did.into(),
+            handle,
+            kind: InventoryKind::Local,
+            tenant: Some(tenant.into()),
+            pds_endpoint,
+        };
+        entry.validate()?;
+        Ok(entry)
+    }
+
+    /// Build a foreign projection from already-resolved federation intake.
+    pub fn indexed_federated(
+        did: impl Into<String>,
+        handle: Option<String>,
+        pds_endpoint: Option<String>,
+    ) -> Result<Self> {
+        let entry = Self {
+            did: did.into(),
+            handle,
             kind: InventoryKind::Federated,
             tenant: None,
-            pds_endpoint: extract_pds_endpoint(document)?,
-        })
+            pds_endpoint,
+        };
+        entry.validate()?;
+        Ok(entry)
+    }
+
+    /// Revalidate a projection before a derived store accepts it.
+    pub fn validate(&self) -> Result<()> {
+        ensure_real_identity_did(&self.did)?;
+        ensure!(!self.did.is_empty(), "inventory DID must not be empty");
+        ensure!(
+            self.handle.as_deref().is_none_or(|value| !value.is_empty()),
+            "inventory handle must not be empty"
+        );
+        ensure!(
+            self.pds_endpoint
+                .as_deref()
+                .is_none_or(|value| !value.is_empty()),
+            "inventory PDS endpoint must not be empty"
+        );
+        match self.kind {
+            InventoryKind::Local => ensure!(
+                self.tenant
+                    .as_deref()
+                    .is_some_and(|value| !value.is_empty()),
+                "local inventory entry requires an authority-resolved tenant"
+            ),
+            InventoryKind::Federated => ensure!(
+                self.tenant.is_none(),
+                "only a local inventory entry may carry a tenant"
+            ),
+            InventoryKind::Unauthenticated => {
+                bail!("the unauthenticated floor is not a listable inventory host")
+            }
+        }
+        Ok(())
     }
 
     /// The indexed DID.
@@ -228,25 +295,56 @@ struct StoredInventoryEntry {
 ///
 /// A pglite/Postgres implementation can replace the in-memory implementation
 /// without changing resolution or tenant-safety logic.
+#[async_trait]
 pub trait IdentityInventoryReadModel: Send + Sync {
-    /// Insert or refresh one derived foreign-identity projection.
+    /// Insert or refresh one derived projection and its trusted object label.
     ///
-    /// Implementations must reject [`UNAUTHENTICATED_DID_SENTINEL`].
-    fn upsert_federated(&self, identity: InventoryEntry) -> Result<()>;
+    /// The projection must already come from federation intake or an
+    /// authority-owned hosted-account source. Implementations must revalidate
+    /// tenant/kind invariants and reject [`UNAUTHENTICATED_DID_SENTINEL`].
+    async fn upsert_derived(&self, identity: InventoryEntry, label: SecurityLabel) -> Result<()>;
 
-    /// List only entries dominated by the viewer's verified clearance.
+    /// Query only entries dominated by the viewer's verified clearance.
     ///
     /// Filtering happens inside the read model before any response is built.
     /// The return shape intentionally has no total/hidden-count field: callers
     /// can observe only this post-filter vector's length. Implementations must
     /// never return [`UNAUTHENTICATED_DID_SENTINEL`] as a real host.
-    fn list(&self, viewer: &SecurityContext) -> Result<Vec<InventoryEntry>>;
+    async fn query(
+        &self,
+        viewer: &SecurityContext,
+        filter: Option<&str>,
+    ) -> Result<Vec<InventoryEntry>> {
+        self.query_page(viewer, filter, None, 200).await
+    }
+
+    /// Query one deterministic, post-clearance page.
+    ///
+    /// `after` is an exclusive DID cursor over the stable DID ordering. The
+    /// caller must enforce a finite `limit`; implementations apply it after
+    /// clearance and filter predicates and never compute a pre-filter total.
+    async fn query_page(
+        &self,
+        viewer: &SecurityContext,
+        filter: Option<&str>,
+        after: Option<&str>,
+        limit: usize,
+    ) -> Result<Vec<InventoryEntry>>;
+
+    /// List all entries visible to this viewer.
+    async fn list(&self, viewer: &SecurityContext) -> Result<Vec<InventoryEntry>> {
+        self.query(viewer, None).await
+    }
 
     /// Fetch one entry without revealing whether a filtered object exists.
     ///
     /// `None` means absent, no caller clearance, or above caller clearance.
     /// Wire adapters must map every `None` case to the same 404-style result.
-    fn get(&self, viewer: Option<&SecurityContext>, did: &str) -> Result<Option<InventoryEntry>>;
+    async fn get(
+        &self,
+        viewer: Option<&SecurityContext>,
+        did: &str,
+    ) -> Result<Option<InventoryEntry>>;
 }
 
 /// Thin in-memory inventory read model, useful for embedded/demo deployments.
@@ -255,37 +353,51 @@ pub struct InMemoryIdentityInventory {
     identities: RwLock<BTreeMap<String, StoredInventoryEntry>>,
 }
 
+#[async_trait]
 impl IdentityInventoryReadModel for InMemoryIdentityInventory {
-    fn upsert_federated(&self, identity: InventoryEntry) -> Result<()> {
-        ensure_real_identity_did(identity.did())?;
-        ensure!(
-            identity.kind == InventoryKind::Federated && identity.tenant.is_none(),
-            "federation intake inventory entry must be federated with no local tenant"
-        );
+    async fn upsert_derived(&self, identity: InventoryEntry, label: SecurityLabel) -> Result<()> {
+        identity.validate()?;
         let mut identities = self.identities.write();
+        if let Some(existing) = identities.get(identity.did()) {
+            ensure_safe_refresh(existing, &identity, &label)?;
+        }
         identities.insert(
             identity.did.clone(),
             StoredInventoryEntry {
                 entry: identity,
-                label: SecurityLabel::bottom(),
+                label,
             },
         );
         Ok(())
     }
 
-    fn list(&self, viewer: &SecurityContext) -> Result<Vec<InventoryEntry>> {
+    async fn query_page(
+        &self,
+        viewer: &SecurityContext,
+        filter: Option<&str>,
+        after: Option<&str>,
+        limit: usize,
+    ) -> Result<Vec<InventoryEntry>> {
+        ensure!(limit > 0, "inventory page limit must be positive");
         let identities = self.identities.read();
         Ok(identities
             .values()
             .filter(|stored| {
                 stored.entry.did() != UNAUTHENTICATED_DID_SENTINEL
                     && viewer.can_access(&stored.label)
+                    && filter.is_none_or(|filter| matches_filter(&stored.entry, filter))
+                    && after.is_none_or(|after| stored.entry.did() > after)
             })
             .map(|stored| stored.entry.clone())
+            .take(limit)
             .collect())
     }
 
-    fn get(&self, viewer: Option<&SecurityContext>, did: &str) -> Result<Option<InventoryEntry>> {
+    async fn get(
+        &self,
+        viewer: Option<&SecurityContext>,
+        did: &str,
+    ) -> Result<Option<InventoryEntry>> {
         if did == UNAUTHENTICATED_DID_SENTINEL {
             return Ok(None);
         }
@@ -295,6 +407,29 @@ impl IdentityInventoryReadModel for InMemoryIdentityInventory {
             .filter(|stored| viewer.is_some_and(|clearance| clearance.can_access(&stored.label)))
             .map(|stored| stored.entry.clone()))
     }
+}
+
+fn ensure_safe_refresh(
+    existing: &StoredInventoryEntry,
+    incoming: &InventoryEntry,
+    incoming_label: &SecurityLabel,
+) -> Result<()> {
+    ensure!(
+        existing.entry.kind == incoming.kind,
+        "inventory refresh cannot change authority kind for {}",
+        incoming.did()
+    );
+    ensure!(
+        existing.entry.tenant == incoming.tenant,
+        "inventory refresh cannot change authority-resolved tenant for {}",
+        incoming.did()
+    );
+    ensure!(
+        incoming_label.can_access(&existing.label),
+        "inventory refresh cannot lower the security label for {}",
+        incoming.did()
+    );
+    Ok(())
 }
 
 /// Resolve and project foreign identities without granting local authority.
@@ -357,7 +492,7 @@ impl FederationIntake {
         did: &str,
         viewer: Option<&SecurityContext>,
     ) -> Result<ResolvedDiscovery> {
-        if self.inventory.get(viewer, did)?.is_none() {
+        if self.inventory.get(viewer, did).await?.is_none() {
             return Err(IdentityDirectoryReadError::NotFound.into());
         }
         let document = self.resolver.resolve_federated_document(did).await?;
@@ -368,9 +503,35 @@ impl FederationIntake {
         ensure_real_identity_did(did)?;
         let document = self.resolver.resolve_federated_document(did).await?;
         let identity = InventoryEntry::federated(did.to_owned(), &document)?;
-        self.inventory.upsert_federated(identity.clone())?;
+        self.inventory
+            .upsert_derived(identity.clone(), SecurityLabel::bottom())
+            .await?;
         Ok(identity)
     }
+}
+
+fn matches_filter(entry: &InventoryEntry, filter: &str) -> bool {
+    let filter = filter.trim().to_lowercase();
+    filter.is_empty()
+        || entry.did.to_lowercase().contains(&filter)
+        || entry
+            .handle
+            .as_deref()
+            .is_some_and(|value| value.to_lowercase().contains(&filter))
+        || entry
+            .tenant
+            .as_deref()
+            .is_some_and(|value| value.to_lowercase().contains(&filter))
+        || entry
+            .pds_endpoint
+            .as_deref()
+            .is_some_and(|value| value.to_lowercase().contains(&filter))
+        || match entry.kind {
+            InventoryKind::Local => "local",
+            InventoryKind::Federated => "federated",
+            InventoryKind::Unauthenticated => "unauthenticated",
+        }
+        .contains(&filter)
 }
 
 fn extract_handle(document: &Value) -> Result<Option<String>> {
@@ -520,7 +681,7 @@ mod tests {
         assert_eq!(resolved.tenant(), None);
         assert_eq!(resolved.pds_endpoint(), Some("https://pds.alice.example"));
 
-        let listed = inventory.list(&unauthenticated_viewer()).unwrap();
+        let listed = inventory.list(&unauthenticated_viewer()).await.unwrap();
         assert_eq!(listed.len(), 1);
         assert_eq!(listed[0].did(), FEDERATED_DID);
         assert_eq!(listed[0].tenant(), None);
@@ -588,7 +749,7 @@ mod tests {
         assert_eq!(resolved.did(), FEDERATED_WEB_DID);
         assert_eq!(resolved.tenant(), None);
         assert_eq!(
-            inventory.list(&unauthenticated_viewer()).unwrap(),
+            inventory.list(&unauthenticated_viewer()).await.unwrap(),
             vec![resolved]
         );
         let viewer = unauthenticated_viewer();
@@ -604,36 +765,28 @@ mod tests {
         assert!(projected.get("certHashes").is_none());
     }
 
-    #[test]
-    fn inventory_listing_prefilters_above_clearance_without_a_hidden_count() {
+    #[tokio::test]
+    async fn inventory_listing_prefilters_above_clearance_without_a_hidden_count() {
         let inventory = InMemoryIdentityInventory::default();
-        let public = InventoryEntry {
-            did: "did:web:public.example".to_owned(),
-            handle: None,
-            kind: InventoryKind::Federated,
-            tenant: None,
-            pds_endpoint: None,
-        };
-        inventory.upsert_federated(public.clone()).unwrap();
-        inventory.identities.write().insert(
-            "did:web:hidden.example".to_owned(),
-            StoredInventoryEntry {
-                entry: InventoryEntry {
-                    did: "did:web:hidden.example".to_owned(),
-                    handle: None,
-                    kind: InventoryKind::Federated,
-                    tenant: None,
-                    pds_endpoint: None,
-                },
-                label: SecurityLabel::new(
+        let public =
+            InventoryEntry::indexed_federated("did:web:public.example", None, None).unwrap();
+        inventory
+            .upsert_derived(public.clone(), SecurityLabel::bottom())
+            .await
+            .unwrap();
+        inventory
+            .upsert_derived(
+                InventoryEntry::indexed_federated("did:web:hidden.example", None, None).unwrap(),
+                SecurityLabel::new(
                     Level::Secret,
                     hyprstream_rpc::auth::mac::Assurance::Unverified,
                     CompartmentSet::EMPTY,
                 ),
-            },
-        );
+            )
+            .await
+            .unwrap();
 
-        let visible = inventory.list(&unauthenticated_viewer()).unwrap();
+        let visible = inventory.list(&unauthenticated_viewer()).await.unwrap();
         assert_eq!(visible, vec![public]);
         assert_eq!(visible.len(), 1, "only the post-filter count is observable");
     }
@@ -671,9 +824,15 @@ mod tests {
         );
         let viewer = unauthenticated_viewer();
 
-        assert_eq!(inventory.get(Some(&viewer), HIDDEN_DID).unwrap(), None);
-        assert_eq!(inventory.get(Some(&viewer), MISSING_DID).unwrap(), None);
-        assert_eq!(inventory.get(None, HIDDEN_DID).unwrap(), None);
+        assert_eq!(
+            inventory.get(Some(&viewer), HIDDEN_DID).await.unwrap(),
+            None
+        );
+        assert_eq!(
+            inventory.get(Some(&viewer), MISSING_DID).await.unwrap(),
+            None
+        );
+        assert_eq!(inventory.get(None, HIDDEN_DID).await.unwrap(), None);
 
         for did in [HIDDEN_DID, MISSING_DID] {
             let error = intake.resolve(did, Some(&viewer)).await.unwrap_err();
@@ -683,6 +842,66 @@ mod tests {
                 "direct access to {did} must be 404-style, never forbidden: {error:#}"
             );
         }
+    }
+
+    #[tokio::test]
+    async fn federated_intake_cannot_demote_or_declassify_a_local_projection() {
+        let inventory = Arc::new(InMemoryIdentityInventory::default());
+        let local = InventoryEntry::local(
+            FEDERATED_WEB_DID,
+            Some("local.example".to_owned()),
+            "tenant-authority",
+            Some("https://local-pds.example".to_owned()),
+        )
+        .unwrap();
+        inventory
+            .upsert_derived(
+                local.clone(),
+                SecurityLabel::new(
+                    Level::Secret,
+                    hyprstream_rpc::auth::mac::Assurance::PqHybrid,
+                    CompartmentSet::single(3),
+                ),
+            )
+            .await
+            .unwrap();
+        let intake = FederationIntake::new(
+            Arc::new(FederatedDidResolver::new(
+                Arc::new(NeverResolver),
+                Arc::new(FixtureResolver {
+                    expected_did: FEDERATED_WEB_DID,
+                    document: serde_json::json!({
+                        "id": FEDERATED_WEB_DID,
+                        "alsoKnownAs": ["at://foreign.example"],
+                    }),
+                }),
+            )),
+            inventory.clone(),
+            Vec::new(),
+        );
+
+        let error = intake.intake(FEDERATED_WEB_DID).await.unwrap_err();
+        assert!(error.to_string().contains("cannot change authority kind"));
+        assert!(
+            inventory
+                .list(&unauthenticated_viewer())
+                .await
+                .unwrap()
+                .is_empty(),
+            "rejected federation refresh must not declassify the local row"
+        );
+        let privileged = SecurityContext::new(
+            Level::Secret,
+            CompartmentSet::single(3),
+            VerifiedKeyMaterial::PqHybrid,
+        );
+        assert_eq!(
+            inventory
+                .get(Some(&privileged), FEDERATED_WEB_DID)
+                .await
+                .unwrap(),
+            Some(local)
+        );
     }
 
     #[tokio::test]
@@ -704,6 +923,7 @@ mod tests {
         );
         assert!(inventory
             .list(&unauthenticated_viewer())
+            .await
             .unwrap()
             .is_empty());
         let error = intake
@@ -734,6 +954,7 @@ mod tests {
         assert!(
             inventory
                 .list(&unauthenticated_viewer())
+                .await
                 .unwrap()
                 .is_empty(),
             "legacy/corrupt sentinel rows must be filtered from inventory listing"
@@ -763,6 +984,7 @@ mod tests {
         assert!(error.to_string().contains("foreign issuer"));
         assert!(inventory
             .list(&unauthenticated_viewer())
+            .await
             .unwrap()
             .is_empty());
     }


### PR DESCRIPTION
pglite-rs AppView inventory index: InventoryEntry{did,handle,kind,tenant(local-only),pdsEndpoint} + query/filter API + mandatory server-side clearance pre-filter (404-leak-safe, post-filter counts only, did:unknown never listable). Derives federated entries from merged federation_intake; directory(A #1348)/hosted-PDS sources behind a clean stubbed interface until A lands. Self-review: Kimi K3.