### PR TITLE
test: install mandatory dispatch PEP fixture across affected tests (#1333 follow-up)

### DIFF
--- a/crates/hyprstream/src/auth/key_rotation.rs
+++ b/crates/hyprstream/src/auth/key_rotation.rs
@@ -2440,7 +2440,11 @@ mod tests {
     }
 
     fn authority_process_dir() -> Option<PathBuf> {
-        std::env::var_os("HYPRSTREAM_COMPOSITE_PRODUCTION_TEST_DIR").map(PathBuf::from)
+        let dir = std::env::var_os("HYPRSTREAM_COMPOSITE_PRODUCTION_TEST_DIR")?;
+        // Each authority role runs in a fresh process, so the dispatch fixture
+        // must be installed here rather than in the parent orchestrator.
+        crate::mac::install_explicit_test_dispatch_pep();
+        Some(PathBuf::from(dir))
     }
 
     fn authority_ca_key() -> Arc<SigningKey> {

--- a/crates/hyprstream/tests/ledger_authenticated_transport.rs
+++ b/crates/hyprstream/tests/ledger_authenticated_transport.rs
@@ -25,6 +25,8 @@ use hyprstream_ledger::{
 };
 use parking_lot::Mutex;
 
+mod support;
+
 fn unit() -> UnitId {
     UnitId {
         issuer: Did("did:web:issuer.test".to_owned()),
@@ -153,6 +155,8 @@ fn signed_authz(
 
 #[tokio::test]
 async fn verified_user_transport_did_admits_its_grant_and_refuses_another_signer() {
+    support::install_explicit_dispatch_pep();
+
     struct AdmissionProbe {
         enforcer: Arc<LocalEnforcer>,
         grant_cid: Cid,


### PR DESCRIPTION
Systemic follow-up to #1333 activation: tests exercising a policy/dispatch path now fail NoPepInstalled unless they install the test dispatch-PEP fixture. Adds the fixture across all affected tests (started from the key_rotation subprocess test the C lane found + the #1330 policy test). NO assertions weakened — only installs the mandatory PEP the production gate now requires. Clears a recurring merge_group hazard for downstream PRs.