### PR TITLE
feat(oauth): atproto session-exchange + whoami (identity auth seam, #1342)

### DIFF
--- a/crates/hyprstream-rpc-std/src/wasm_exports.rs
+++ b/crates/hyprstream-rpc-std/src/wasm_exports.rs
@@ -12,10 +12,46 @@
 use std::sync::Arc;
 
 use js_sys::Function;
+use serde::Serialize as _;
 use wasm_bindgen::prelude::*;
 
 // Re-export low-level WASM API (crypto primitives, ZMTP framing) from hyprstream-rpc.
 pub use hyprstream_rpc::wasm_api::*;
+
+/// Exchange an ATProto service-auth JWT plus DPoP proof for hyprstream's
+/// opaque HttpOnly browser session. The service JWT must target
+/// `ai.hyprstream.identity.exchangeSession`.
+#[wasm_bindgen(js_name = "exchangeBrowserSession")]
+pub async fn exchange_browser_session(
+    exchange_endpoint: &str,
+    service_auth_jwt: &str,
+    dpop_proof: &str,
+) -> Result<JsValue, JsError> {
+    let context = hyprstream_rpc::wasm_token_exchange::fetch_session_exchange(
+        exchange_endpoint,
+        service_auth_jwt,
+        dpop_proof,
+    )
+    .await
+    .map_err(|error| JsError::new(&error.to_string()))?;
+    context
+        .serialize(&serde_wasm_bindgen::Serializer::json_compatible())
+        .map_err(|error| JsError::new(&format!("session context serialization failed: {error}")))
+}
+
+/// Read the current server-derived viewer context from the HttpOnly session.
+#[wasm_bindgen(js_name = "browserSessionWhoami")]
+pub async fn browser_session_whoami(
+    exchange_endpoint: &str,
+) -> Result<JsValue, JsError> {
+    let context =
+        hyprstream_rpc::wasm_token_exchange::fetch_session_context(exchange_endpoint)
+            .await
+            .map_err(|error| JsError::new(&error.to_string()))?;
+    context
+        .serialize(&serde_wasm_bindgen::Serializer::json_compatible())
+        .map_err(|error| JsError::new(&format!("session context serialization failed: {error}")))
+}
 
 // ============================================================================
 // VFS Shell — Tcl + Namespace backed by RpcClient

--- a/crates/hyprstream-rpc/src/wasm_token_exchange.rs
+++ b/crates/hyprstream-rpc/src/wasm_token_exchange.rs
@@ -21,12 +21,34 @@
 //! than extending the server response.
 
 use anyhow::{anyhow, ensure, Result};
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 
 /// The RFC 8693 token-exchange grant type.
 pub const GRANT_TYPE: &str = "urn:ietf:params:oauth:grant-type:token-exchange";
 /// Issued-token type the #1314 endpoint always mints (at+jwt / access_token).
 pub const ISSUED_TOKEN_TYPE: &str = "urn:ietf:params:oauth:token-type:access_token";
+/// Browser session exchange route on the hyprstream OAuth origin.
+pub const SESSION_EXCHANGE_PATH: &str = "/api/session/exchange";
+/// Server-derived viewer context route on the hyprstream OAuth origin.
+pub const WHOAMI_PATH: &str = "/api/session/whoami";
+
+/// Server-derived browser viewer authority.
+#[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct SessionContext {
+    pub did: Option<String>,
+    pub kind: SessionKind,
+    pub tenant: Option<String>,
+    pub can_act_locally: bool,
+}
+
+#[derive(Clone, Copy, Debug, Deserialize, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+pub enum SessionKind {
+    Local,
+    Federated,
+    Unauthenticated,
+}
 
 /// A successfully exchanged short-lived Bearer (at+jwt).
 ///
@@ -118,6 +140,32 @@ pub fn parse_exchange_response(body: &str) -> Result<ExchangedToken> {
     })
 }
 
+/// Parse the exact session-exchange / whoami JSON response.
+pub fn parse_session_context(body: &str) -> Result<SessionContext> {
+    let context: SessionContext = serde_json::from_str(body)
+        .map_err(|e| anyhow!("session context response is not valid JSON: {e}"))?;
+    let valid = match context.kind {
+        SessionKind::Local => {
+            context.did.as_deref().is_some_and(|did| !did.is_empty())
+                && context
+                    .tenant
+                    .as_deref()
+                    .is_some_and(|tenant| !tenant.is_empty())
+                && context.can_act_locally
+        }
+        SessionKind::Federated => {
+            context.did.as_deref().is_some_and(|did| !did.is_empty())
+                && context.tenant.is_none()
+                && !context.can_act_locally
+        }
+        SessionKind::Unauthenticated => {
+            context.did.is_none() && context.tenant.is_none() && !context.can_act_locally
+        }
+    };
+    ensure!(valid, "session context contains inconsistent viewer authority");
+    Ok(context)
+}
+
 /// Decode the `sub` claim from an exchanged at+jwt and build a `Subject`.
 ///
 /// No signature verification (see the module authority note). Returns an error
@@ -135,7 +183,10 @@ pub fn subject_from_access_token(token: &str) -> Result<crate::Subject> {
 
 #[cfg(target_arch = "wasm32")]
 mod fetch {
-    use super::{exchange_form_body, parse_exchange_response, ExchangedToken};
+    use super::{
+        exchange_form_body, parse_exchange_response, parse_session_context, ExchangedToken,
+        SessionContext, SESSION_EXCHANGE_PATH, WHOAMI_PATH,
+    };
     use anyhow::{anyhow, ensure, Context, Result};
     use wasm_bindgen::JsCast as _;
     use wasm_bindgen_futures::JsFuture;
@@ -252,10 +303,88 @@ mod fetch {
         }
         parse_exchange_response(&text)
     }
+
+    /// Exchange a one-use ATProto service-auth JWT plus DPoP proof for the
+    /// opaque HttpOnly hyprstream browser session cookie.
+    pub async fn fetch_session_exchange(
+        exchange_endpoint: &str,
+        service_auth_jwt: &str,
+        dpop_proof: &str,
+    ) -> Result<SessionContext> {
+        let mut url = parse_origin(exchange_endpoint)?;
+        url.set_path(SESSION_EXCHANGE_PATH);
+
+        let headers = web_sys::Headers::new()
+            .map_err(|e| anyhow!("session-exchange header construction failed: {e:?}"))?;
+        headers
+            .set("authorization", &format!("Bearer {service_auth_jwt}"))
+            .map_err(|e| anyhow!("session-exchange authorization set failed: {e:?}"))?;
+        headers
+            .set("dpop", dpop_proof)
+            .map_err(|e| anyhow!("session-exchange DPoP set failed: {e:?}"))?;
+        headers
+            .set("accept", "application/json")
+            .map_err(|e| anyhow!("session-exchange accept set failed: {e:?}"))?;
+
+        let init = web_sys::RequestInit::new();
+        init.set_method("POST");
+        init.set_headers(headers.as_ref());
+        init.set_cache(web_sys::RequestCache::NoStore);
+        init.set_credentials(web_sys::RequestCredentials::Include);
+        init.set_redirect(web_sys::RequestRedirect::Error);
+
+        let request = web_sys::Request::new_with_str_and_init(url.as_str(), &init)
+            .map_err(|e| anyhow!("session-exchange request construction failed: {e:?}"))?;
+        session_context_fetch(request, "session-exchange").await
+    }
+
+    /// Fetch the current viewer authority using the opaque session cookie.
+    pub async fn fetch_session_context(exchange_endpoint: &str) -> Result<SessionContext> {
+        let mut url = parse_origin(exchange_endpoint)?;
+        url.set_path(WHOAMI_PATH);
+
+        let headers = web_sys::Headers::new()
+            .map_err(|e| anyhow!("whoami header construction failed: {e:?}"))?;
+        headers
+            .set("accept", "application/json")
+            .map_err(|e| anyhow!("whoami accept set failed: {e:?}"))?;
+        let init = web_sys::RequestInit::new();
+        init.set_method("GET");
+        init.set_headers(headers.as_ref());
+        init.set_cache(web_sys::RequestCache::NoStore);
+        init.set_credentials(web_sys::RequestCredentials::Include);
+        init.set_redirect(web_sys::RequestRedirect::Error);
+
+        let request = web_sys::Request::new_with_str_and_init(url.as_str(), &init)
+            .map_err(|e| anyhow!("whoami request construction failed: {e:?}"))?;
+        session_context_fetch(request, "whoami").await
+    }
+
+    async fn session_context_fetch(
+        request: web_sys::Request,
+        operation: &str,
+    ) -> Result<SessionContext> {
+        let window = web_sys::window().ok_or_else(|| anyhow!("browser window unavailable"))?;
+        let response_value = JsFuture::from(window.fetch_with_request(&request))
+            .await
+            .map_err(|e| anyhow!("{operation} fetch failed: {e:?}"))?;
+        let response: web_sys::Response = response_value
+            .dyn_into()
+            .map_err(|_| anyhow!("{operation} fetch returned a non-Response"))?;
+        let text = read_body_text(&response).await?;
+        if !response.ok() {
+            return Err(anyhow!(
+                "{operation} endpoint returned HTTP {}: {}",
+                response.status(),
+                text.trim()
+            ));
+        }
+        parse_session_context(&text)
+    }
 }
 
 #[cfg(target_arch = "wasm32")]
-pub use fetch::fetch_exchange_token;
+pub use fetch::{fetch_exchange_token, fetch_session_context, fetch_session_exchange};
 
 #[cfg(test)]
 #[allow(clippy::unwrap_used, clippy::expect_used)]
@@ -363,5 +492,37 @@ mod tests {
         );
         assert!(rendered.contains("<redacted>"));
         assert!(rendered.contains("300"));
+    }
+
+    #[test]
+    fn parses_local_session_context() {
+        let context = parse_session_context(
+            r#"{"did":"did:web:alice.example","kind":"local","tenant":"acme","canActLocally":true}"#,
+        )
+        .unwrap();
+        assert_eq!(context.did.as_deref(), Some("did:web:alice.example"));
+        assert_eq!(context.kind, SessionKind::Local);
+        assert_eq!(context.tenant.as_deref(), Some("acme"));
+        assert!(context.can_act_locally);
+    }
+
+    #[test]
+    fn parses_unauthenticated_floor() {
+        let context = parse_session_context(
+            r#"{"did":null,"kind":"unauthenticated","tenant":null,"canActLocally":false}"#,
+        )
+        .unwrap();
+        assert_eq!(context.kind, SessionKind::Unauthenticated);
+        assert!(context.did.is_none());
+        assert!(context.tenant.is_none());
+        assert!(!context.can_act_locally);
+    }
+
+    #[test]
+    fn rejects_inconsistent_session_authority() {
+        assert!(parse_session_context(
+            r#"{"did":"did:web:alice.example","kind":"federated","tenant":"client-asserted","canActLocally":true}"#,
+        )
+        .is_err());
     }
 }

--- a/crates/hyprstream/src/services/oauth/browser_session.rs
+++ b/crates/hyprstream/src/services/oauth/browser_session.rs
@@ -240,6 +240,35 @@ mod tests {
         }
     }
 
+    struct RejectFederatedResolver;
+
+    #[async_trait::async_trait]
+    impl hyprstream_pds_service::federation_intake::FederatedDidDocumentResolver
+        for RejectFederatedResolver
+    {
+        async fn resolve_federated_document(
+            &self,
+            _did: &str,
+        ) -> anyhow::Result<serde_json::Value> {
+            anyhow::bail!("federation intake is outside the browser-session fixture")
+        }
+    }
+
+    struct RejectIdentityResolver;
+
+    impl super::super::identity_registration::IdentityConnectTimeResolver for RejectIdentityResolver {
+        fn recognizes(&self, _did: &str) -> bool {
+            false
+        }
+
+        fn resolve(
+            &self,
+            _did: &str,
+        ) -> anyhow::Result<hyprstream_discovery::ConnectTimeDiscovery> {
+            anyhow::bail!("identity resolution is outside the browser-session fixture")
+        }
+    }
+
     struct PermitAccountReads;
 
     impl hyprstream_pds_service::AccountRecordReadAuthorizer for PermitAccountReads {
@@ -359,12 +388,14 @@ mod tests {
             relay: String::new(),
         };
         let registration_api =
-            super::super::identity_registration::production_identity_registration_api(
+            super::super::identity_registration::compose_identity_registration_api(
                 &oauth,
                 &account,
                 &quic,
                 signing_key.clone(),
                 storage.path().join("pds"),
+                Arc::new(RejectFederatedResolver),
+                Arc::new(RejectIdentityResolver),
             )
             .unwrap();
 

--- a/crates/hyprstream/src/services/oauth/browser_session.rs
+++ b/crates/hyprstream/src/services/oauth/browser_session.rs
@@ -1,0 +1,635 @@
+//! Browser-facing ATProto session exchange and viewer context.
+//!
+//! The exchange consumes a one-use, DID-signed ATProto service-auth JWT plus
+//! its DPoP proof, resolves any local tenant only from the authority-owned
+//! hosted-account store, and creates the opaque server-side session used by
+//! identity registration and federation intake.
+
+use std::sync::Arc;
+
+use axum::extract::State;
+use axum::http::{header, HeaderMap, StatusCode};
+use axum::response::{IntoResponse, Response};
+use axum::Json;
+use serde::Serialize;
+
+use super::session;
+use super::state::OAuthState;
+use super::token_exchange::{verify_atproto_service_jwt, ATPROTO_SESSION_EXCHANGE_NSID};
+
+pub const SESSION_EXCHANGE_PATH: &str = "/api/session/exchange";
+pub const WHOAMI_PATH: &str = "/api/session/whoami";
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ViewerContext {
+    did: Option<String>,
+    kind: ViewerKind,
+    tenant: Option<String>,
+    can_act_locally: bool,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "lowercase")]
+enum ViewerKind {
+    Local,
+    Federated,
+    Unauthenticated,
+}
+
+impl ViewerContext {
+    fn unauthenticated() -> Self {
+        Self {
+            did: None,
+            kind: ViewerKind::Unauthenticated,
+            tenant: None,
+            can_act_locally: false,
+        }
+    }
+
+    fn atproto(did: String, tenant: Option<String>) -> Self {
+        let kind = if tenant.is_some() {
+            ViewerKind::Local
+        } else {
+            ViewerKind::Federated
+        };
+        Self {
+            did: Some(did),
+            kind,
+            can_act_locally: tenant.is_some(),
+            tenant,
+        }
+    }
+
+    fn from_session(session: session::Session) -> Self {
+        session
+            .atproto_did
+            .map(|did| Self::atproto(did, session.verified_tenant))
+            .unwrap_or_else(Self::unauthenticated)
+    }
+}
+
+/// Consume an ATProto service-auth assertion and establish the HttpOnly cookie
+/// session expected by the self-service identity mutation routes.
+pub async fn exchange(State(state): State<Arc<OAuthState>>, headers: HeaderMap) -> Response {
+    let Some(assertion) = bearer_token(&headers) else {
+        return session_error(
+            StatusCode::UNAUTHORIZED,
+            "invalid_token",
+            "Authorization: Bearer ATProto service-auth JWT is required",
+        );
+    };
+
+    let endpoint = format!(
+        "{}{SESSION_EXCHANGE_PATH}",
+        state.atproto_issuer_url().trim_end_matches('/')
+    );
+    let Some(dpop) = headers.get("DPoP").and_then(|value| value.to_str().ok()) else {
+        return session_error(
+            StatusCode::BAD_REQUEST,
+            "invalid_dpop_proof",
+            "DPoP proof is required",
+        );
+    };
+    let proof = match super::dpop::verify_dpop_proof(dpop, "POST", &endpoint, None) {
+        Ok(proof) => proof,
+        Err(error) => {
+            tracing::warn!(%error, "browser session exchange rejected DPoP proof");
+            return session_error(
+                StatusCode::BAD_REQUEST,
+                "invalid_dpop_proof",
+                "DPoP proof verification failed",
+            );
+        }
+    };
+
+    let verified =
+        match verify_atproto_service_jwt(&state, assertion, ATPROTO_SESSION_EXCHANGE_NSID).await {
+            Ok(verified) => verified,
+            Err(error) => {
+                tracing::warn!(%error, "browser session exchange rejected ATProto assertion");
+                return session_error(StatusCode::UNAUTHORIZED, "invalid_token", &error);
+            }
+        };
+
+    if !state.check_and_record_dpop_jti(&proof.jti, proof.iat) {
+        return session_error(
+            StatusCode::BAD_REQUEST,
+            "invalid_dpop_proof",
+            "DPoP proof already used",
+        );
+    }
+    let Some((issuer, jti, exp)) = verified.atproto_replay.as_ref() else {
+        return session_error(
+            StatusCode::UNAUTHORIZED,
+            "invalid_token",
+            "ATProto assertion has no replay identifier",
+        );
+    };
+    if !state.check_and_record_atproto_service_jti(issuer, jti, *exp) {
+        return session_error(
+            StatusCode::UNAUTHORIZED,
+            "invalid_token",
+            "ATProto service-auth JWT already used",
+        );
+    }
+
+    let context = ViewerContext::atproto(verified.sub.clone(), verified.verified_tenant.clone());
+    let session_id = state
+        .sessions
+        .create_atproto(verified.sub, verified.verified_tenant)
+        .await;
+    let secure = state.atproto_issuer_url().starts_with("https://");
+    (
+        StatusCode::OK,
+        [
+            (
+                header::SET_COOKIE,
+                session::session_cookie(&session_id, secure),
+            ),
+            (header::CACHE_CONTROL, "no-store, max-age=0".to_owned()),
+            (header::PRAGMA, "no-cache".to_owned()),
+        ],
+        Json(context),
+    )
+        .into_response()
+}
+
+/// Return the viewer authority derived from the opaque server-side session.
+/// Missing, invalid, expired, or non-ATProto sessions all collapse to the same
+/// public unauthenticated floor.
+pub async fn whoami(State(state): State<Arc<OAuthState>>, headers: HeaderMap) -> Response {
+    let context = match session::extract_session_id(&headers) {
+        Some(session_id) => state
+            .sessions
+            .get(&session_id)
+            .await
+            .map(ViewerContext::from_session)
+            .unwrap_or_else(ViewerContext::unauthenticated),
+        None => ViewerContext::unauthenticated(),
+    };
+    (
+        StatusCode::OK,
+        [
+            (header::CACHE_CONTROL, "no-store, max-age=0"),
+            (header::PRAGMA, "no-cache"),
+        ],
+        Json(context),
+    )
+        .into_response()
+}
+
+fn bearer_token(headers: &HeaderMap) -> Option<&str> {
+    headers
+        .get(header::AUTHORIZATION)?
+        .to_str()
+        .ok()?
+        .split_once(' ')
+        .filter(|(scheme, token)| {
+            scheme.eq_ignore_ascii_case("Bearer")
+                && !token.is_empty()
+                && !token.chars().any(char::is_whitespace)
+        })
+        .map(|(_, token)| token)
+}
+
+fn session_error(status: StatusCode, error: &str, description: &str) -> Response {
+    (
+        status,
+        [
+            (header::CACHE_CONTROL, "no-store"),
+            (header::PRAGMA, "no-cache"),
+        ],
+        Json(serde_json::json!({
+            "error": error,
+            "error_description": description,
+        })),
+    )
+        .into_response()
+}
+
+#[cfg(test)]
+#[allow(clippy::expect_used, clippy::unwrap_used)]
+mod tests {
+    use super::*;
+    use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine as _};
+    use p256::ecdsa::signature::Signer as _;
+    use tower::ServiceExt as _;
+
+    use hyprstream_rpc::crypto::CryptoPolicy;
+    use hyprstream_rpc::rpc_client::RpcClientImpl;
+    use hyprstream_rpc::signer::LocalSigner;
+    use hyprstream_rpc::transport::lazy_uds::LazyUdsTransport;
+    use hyprstream_vfs::{SyntheticMount, SyntheticNode};
+
+    const ISSUER: &str = "https://pds.example.test";
+    const LOCAL_DID: &str = "did:web:alice.accounts.example.com";
+    const FEDERATED_DID: &str = "did:plc:ar7c4by46qjdydhdevvrndac";
+    const TENANT: &str = "tenant-a";
+
+    struct FixtureDidResolver {
+        did: String,
+        document: serde_json::Value,
+    }
+
+    #[async_trait::async_trait]
+    impl super::super::state::AtprotoDidDocumentResolver for FixtureDidResolver {
+        async fn resolve_document(&self, did: &str) -> anyhow::Result<serde_json::Value> {
+            anyhow::ensure!(did == self.did, "fixture DID mismatch");
+            Ok(self.document.clone())
+        }
+    }
+
+    struct PermitAccountReads;
+
+    impl hyprstream_pds_service::AccountRecordReadAuthorizer for PermitAccountReads {
+        fn check_read(
+            &self,
+            _subject: &hyprstream_rpc::Subject,
+            _verified_tenant: Option<&str>,
+            _security_context: Option<&hyprstream_rpc::auth::mac::SecurityContext>,
+            _object_id: &str,
+        ) -> hyprstream_rpc::auth::mac::MacDecision {
+            hyprstream_rpc::auth::mac::MacDecision::Permit
+        }
+    }
+
+    struct SessionFixture {
+        state: Arc<OAuthState>,
+        cors: crate::config::CorsConfig,
+        did: &'static str,
+        atproto_key: p256::ecdsa::SigningKey,
+        _storage: tempfile::TempDir,
+    }
+
+    fn fixture(local: bool) -> SessionFixture {
+        let storage = tempfile::TempDir::new().unwrap();
+        let signing_key = ed25519_dalek::SigningKey::from_bytes(&[0x71; 32]);
+        let remote_key = ed25519_dalek::SigningKey::from_bytes(&[0x72; 32]).verifying_key();
+        let make_client = || {
+            Arc::new(
+                RpcClientImpl::new(
+                    LocalSigner::new(signing_key.clone()),
+                    LazyUdsTransport::new("/dev/null/browser-session-test.sock".into()),
+                    Some(remote_key),
+                )
+                .with_response_verify_policy(CryptoPolicy::Classical),
+            )
+        };
+        let mut oauth = crate::config::OAuthConfig::default();
+        oauth.external_url = Some(ISSUER.to_owned());
+        let cors = crate::config::CorsConfig {
+            enabled: false,
+            ..oauth.cors.clone()
+        };
+
+        let (did, atproto_key, document, hosted_store) = if local {
+            let account_ed = ed25519_dalek::SigningKey::from_bytes(&[0x73; 32]);
+            let (account_pq, account_pq_vk) = hyprstream_crypto::pq::ml_dsa_generate_keypair();
+            let hybrid = hyprstream_pds::HybridRotationKey::new(
+                account_ed.verifying_key().to_bytes(),
+                hyprstream_crypto::pq::ml_dsa_vk_bytes(&account_pq_vk),
+            )
+            .unwrap();
+            let rotations = hyprstream_pds::GenesisRotationKeys::new(
+                hyprstream_pds::UserRotationKey::new(hybrid),
+                hyprstream_pds::RecoveryKeyEnrollment::Declined,
+                hyprstream_pds::HostKeyEnrollment::Absent,
+            )
+            .unwrap();
+            let mint = hyprstream_pds::HostedAccountMint::begin(
+                hyprstream_pds::AllocatedAccountName::new("alice", LOCAL_DID).unwrap(),
+                rotations,
+            )
+            .unwrap();
+            let account_document = mint.seal_did_document(ISSUER).unwrap();
+            let pending = mint
+                .prepare_genesis(
+                    account_document,
+                    hyprstream_pds::did_op::GenesisRepoHead::EmptyRepo,
+                )
+                .unwrap();
+            let signature =
+                hyprstream_pds::sign_genesis(pending.unsigned_genesis(), &account_ed, &account_pq)
+                    .unwrap();
+            let sealed = pending.seal(signature).unwrap();
+            let atproto_key = sealed.atproto_signing_key().clone();
+            let document = serde_json::from_slice(sealed.did_document().as_bytes()).unwrap();
+            let root = SyntheticNode::dir().with_child(
+                TENANT,
+                SyntheticNode::dir().with_child(
+                    "accounts",
+                    SyntheticNode::dir().with_child(
+                        "alice",
+                        SyntheticNode::dir().with_child(
+                            "account-record.cbor",
+                            SyntheticNode::file(sealed.record_bytes().to_vec()),
+                        ),
+                    ),
+                ),
+            );
+            let store = Arc::new(hyprstream_pds_service::AccountRecordStore::new(
+                Arc::new(SyntheticMount::new(root)),
+                Arc::new(PermitAccountReads),
+            ));
+            (LOCAL_DID, atproto_key, document, Some(store))
+        } else {
+            let atproto_key = p256::ecdsa::SigningKey::random(&mut rand::rngs::OsRng);
+            let document = did_document(FEDERATED_DID, &atproto_key);
+            (FEDERATED_DID, atproto_key, document, None)
+        };
+
+        let certified =
+            rcgen::generate_simple_self_signed(vec!["pds.example.test".to_owned()]).unwrap();
+        let cert_path = storage.path().join("quic-cert.pem");
+        let key_path = storage.path().join("quic-key.pem");
+        std::fs::write(&cert_path, certified.cert.pem()).unwrap();
+        std::fs::write(&key_path, certified.key_pair.serialize_pem()).unwrap();
+        let account = crate::account::AccountZoneConfig {
+            zone: Some("accounts.example.com".to_owned()),
+            ..Default::default()
+        };
+        let quic = crate::config::QuicConfig {
+            enabled: true,
+            bind_addr: "127.0.0.1:4433".to_owned(),
+            server_name: "pds.example.test".to_owned(),
+            cert_path: cert_path.to_string_lossy().into_owned(),
+            key_path: key_path.to_string_lossy().into_owned(),
+            iroh: false,
+            relay: String::new(),
+        };
+        let registration_api =
+            super::super::identity_registration::production_identity_registration_api(
+                &oauth,
+                &account,
+                &quic,
+                signing_key.clone(),
+                storage.path().join("pds"),
+            )
+            .unwrap();
+
+        let mut state = OAuthState::new(
+            &oauth,
+            crate::services::PolicyClient::new(make_client()),
+            crate::services::DiscoveryClient::new(make_client()),
+            signing_key.verifying_key().to_bytes(),
+        )
+        .with_atproto_did_resolver(Arc::new(FixtureDidResolver {
+            did: did.to_owned(),
+            document,
+        }))
+        .with_identity_registration_api(registration_api);
+        if let Some(store) = hosted_store {
+            state = state.with_hosted_account_store(store);
+        }
+        SessionFixture {
+            state: Arc::new(state),
+            cors,
+            did,
+            atproto_key,
+            _storage: storage,
+        }
+    }
+
+    fn did_document(did: &str, key: &p256::ecdsa::SigningKey) -> serde_json::Value {
+        let mut multikey = vec![0x80, 0x24];
+        multikey.extend_from_slice(key.verifying_key().to_encoded_point(true).as_bytes());
+        serde_json::json!({
+            "id": did,
+            "verificationMethod": [{
+                "id": format!("{did}#atproto"),
+                "type": "Multikey",
+                "controller": did,
+                "publicKeyMultibase": format!("z{}", bs58::encode(multikey).into_string()),
+            }]
+        })
+    }
+
+    fn service_jwt(fixture: &SessionFixture, jti: &str) -> String {
+        let header = URL_SAFE_NO_PAD.encode(
+            serde_json::to_vec(&serde_json::json!({
+                "alg": "ES256", "typ": "JWT", "kid": "#atproto"
+            }))
+            .unwrap(),
+        );
+        let now = chrono::Utc::now().timestamp();
+        let payload = URL_SAFE_NO_PAD.encode(
+            serde_json::to_vec(&serde_json::json!({
+                "iss": fixture.did,
+                "aud": fixture.state.atproto_service_did().unwrap(),
+                "iat": now,
+                "exp": now + 60,
+                "lxm": ATPROTO_SESSION_EXCHANGE_NSID,
+                "jti": jti,
+            }))
+            .unwrap(),
+        );
+        let signing_input = format!("{header}.{payload}");
+        let signature: p256::ecdsa::Signature = fixture.atproto_key.sign(signing_input.as_bytes());
+        format!(
+            "{signing_input}.{}",
+            URL_SAFE_NO_PAD.encode(signature.to_bytes())
+        )
+    }
+
+    fn dpop_proof(jti: &str) -> String {
+        let key = p256::ecdsa::SigningKey::random(&mut rand::rngs::OsRng);
+        let point = key.verifying_key().to_encoded_point(false);
+        let header = URL_SAFE_NO_PAD.encode(
+            serde_json::to_vec(&serde_json::json!({
+                "alg": "ES256",
+                "typ": "dpop+jwt",
+                "jwk": {
+                    "kty": "EC",
+                    "crv": "P-256",
+                    "x": URL_SAFE_NO_PAD.encode(point.x().unwrap()),
+                    "y": URL_SAFE_NO_PAD.encode(point.y().unwrap()),
+                }
+            }))
+            .unwrap(),
+        );
+        let payload = URL_SAFE_NO_PAD.encode(
+            serde_json::to_vec(&serde_json::json!({
+                "htm": "POST",
+                "htu": format!("{ISSUER}{SESSION_EXCHANGE_PATH}"),
+                "iat": chrono::Utc::now().timestamp(),
+                "jti": jti,
+            }))
+            .unwrap(),
+        );
+        let signing_input = format!("{header}.{payload}");
+        let signature: p256::ecdsa::Signature = key.sign(signing_input.as_bytes());
+        format!(
+            "{signing_input}.{}",
+            URL_SAFE_NO_PAD.encode(signature.to_bytes())
+        )
+    }
+
+    async fn body(response: Response) -> serde_json::Value {
+        let bytes = axum::body::to_bytes(response.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        serde_json::from_slice(&bytes).unwrap()
+    }
+
+    fn cookie(response: &Response) -> String {
+        response.headers()[header::SET_COOKIE]
+            .to_str()
+            .unwrap()
+            .split(';')
+            .next()
+            .unwrap()
+            .to_owned()
+    }
+
+    async fn exchange_request(
+        fixture: &SessionFixture,
+        service_jti: &str,
+        dpop_jti: &str,
+    ) -> Response {
+        super::super::create_app(Arc::clone(&fixture.state), &fixture.cors)
+            .oneshot(
+                axum::http::Request::post(SESSION_EXCHANGE_PATH)
+                    .header(
+                        header::AUTHORIZATION,
+                        format!("Bearer {}", service_jwt(fixture, service_jti)),
+                    )
+                    .header("DPoP", dpop_proof(dpop_jti))
+                    .body(axum::body::Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap()
+    }
+
+    #[tokio::test]
+    async fn local_atproto_exchange_cookie_whoami_and_register_end_to_end() {
+        let fixture = fixture(true);
+        let exchange = exchange_request(&fixture, "local-service", "local-dpop").await;
+        assert_eq!(exchange.status(), StatusCode::OK);
+        let session_cookie = cookie(&exchange);
+        let context = body(exchange).await;
+        assert_eq!(context["did"], LOCAL_DID);
+        assert_eq!(context["kind"], "local");
+        assert_eq!(context["tenant"], TENANT);
+        assert_eq!(context["canActLocally"], true);
+
+        let app = super::super::create_app(Arc::clone(&fixture.state), &fixture.cors);
+        let whoami = app
+            .clone()
+            .oneshot(
+                axum::http::Request::get(WHOAMI_PATH)
+                    .header(header::COOKIE, &session_cookie)
+                    .body(axum::body::Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(whoami.status(), StatusCode::OK);
+        assert_eq!(body(whoami).await, context);
+
+        let register = app
+            .oneshot(
+                axum::http::Request::post("/api/identity/register")
+                    .header(header::COOKIE, session_cookie)
+                    .header(header::CONTENT_TYPE, "application/json")
+                    .body(axum::body::Body::from(r#"{"handle":"new-account"}"#))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(register.status(), StatusCode::OK);
+        assert_eq!(
+            body(register).await["did"],
+            "did:web:new-account.accounts.example.com"
+        );
+    }
+
+    #[tokio::test]
+    async fn federated_exchange_whoami_has_no_local_authority() {
+        let fixture = fixture(false);
+        let exchange = exchange_request(&fixture, "foreign-service", "foreign-dpop").await;
+        assert_eq!(exchange.status(), StatusCode::OK);
+        let session_cookie = cookie(&exchange);
+        let context = body(exchange).await;
+        assert_eq!(context["did"], FEDERATED_DID);
+        assert_eq!(context["kind"], "federated");
+        assert!(context["tenant"].is_null());
+        assert_eq!(context["canActLocally"], false);
+
+        let whoami = super::super::create_app(Arc::clone(&fixture.state), &fixture.cors)
+            .oneshot(
+                axum::http::Request::get(WHOAMI_PATH)
+                    .header(header::COOKIE, session_cookie)
+                    .body(axum::body::Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(body(whoami).await, context);
+    }
+
+    #[tokio::test]
+    async fn unauthenticated_whoami_is_public_floor() {
+        let fixture = fixture(false);
+        let generic_id = fixture
+            .state
+            .sessions
+            .create(FEDERATED_DID.to_owned(), "atproto".to_owned())
+            .await;
+        let app = super::super::create_app(Arc::clone(&fixture.state), &fixture.cors);
+        for cookie in [
+            None,
+            Some(format!("{}=unknown", session::SESSION_COOKIE_NAME)),
+            Some(format!("{}={generic_id}", session::SESSION_COOKIE_NAME)),
+        ] {
+            let mut request = axum::http::Request::get(WHOAMI_PATH)
+                .body(axum::body::Body::empty())
+                .unwrap();
+            if let Some(cookie) = cookie {
+                request
+                    .headers_mut()
+                    .insert(header::COOKIE, cookie.parse().unwrap());
+            }
+            let response = app.clone().oneshot(request).await.unwrap();
+            assert_eq!(response.status(), StatusCode::OK);
+            assert_eq!(
+                body(response).await,
+                serde_json::json!({
+                    "did": null,
+                    "kind": "unauthenticated",
+                    "tenant": null,
+                    "canActLocally": false,
+                })
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn exchange_requires_dpop_and_consumes_service_assertion_once() {
+        let fixture = fixture(false);
+        let app = super::super::create_app(Arc::clone(&fixture.state), &fixture.cors);
+        let missing_dpop = app
+            .clone()
+            .oneshot(
+                axum::http::Request::post(SESSION_EXCHANGE_PATH)
+                    .header(
+                        header::AUTHORIZATION,
+                        format!("Bearer {}", service_jwt(&fixture, "missing-dpop")),
+                    )
+                    .body(axum::body::Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(missing_dpop.status(), StatusCode::BAD_REQUEST);
+        assert!(!missing_dpop.headers().contains_key(header::SET_COOKIE));
+
+        let first = exchange_request(&fixture, "one-use-service", "first-dpop").await;
+        assert_eq!(first.status(), StatusCode::OK);
+        let replay = exchange_request(&fixture, "one-use-service", "fresh-dpop").await;
+        assert_eq!(replay.status(), StatusCode::UNAUTHORIZED);
+        assert!(!replay.headers().contains_key(header::SET_COOKIE));
+        assert_eq!(body(replay).await["error"], "invalid_token");
+    }
+}

--- a/crates/hyprstream/src/services/oauth/identity_registration.rs
+++ b/crates/hyprstream/src/services/oauth/identity_registration.rs
@@ -122,7 +122,7 @@ pub(crate) fn production_identity_registration_api(
     )
 }
 
-fn compose_identity_registration_api(
+pub(super) fn compose_identity_registration_api(
     oauth: &OAuthConfig,
     account: &AccountZoneConfig,
     quic: &QuicConfig,

--- a/crates/hyprstream/src/services/oauth/mod.rs
+++ b/crates/hyprstream/src/services/oauth/mod.rs
@@ -28,6 +28,7 @@
 
 pub mod auth;
 pub mod authorize;
+pub mod browser_session;
 pub mod challenge;
 pub mod cimd_cache;
 pub mod client_auth;
@@ -147,6 +148,14 @@ pub fn create_app(state: Arc<OAuthState>, cors_config: &crate::config::CorsConfi
         )
         .route("/oauth/revoke", post(revocation::revoke_token))
         .route("/oauth/logout", post(handle_logout))
+        .route(
+            browser_session::SESSION_EXCHANGE_PATH,
+            post(browser_session::exchange),
+        )
+        .route(
+            browser_session::WHOAMI_PATH,
+            get(browser_session::whoami),
+        )
         .route(
             "/oauth/external/authorize/:provider",
             get(oidc_callback::external_authorize),

--- a/crates/hyprstream/src/services/oauth/session.rs
+++ b/crates/hyprstream/src/services/oauth/session.rs
@@ -13,10 +13,14 @@ use tokio::sync::RwLock;
 /// A server-side session for an authenticated user.
 #[derive(Debug, Clone)]
 pub struct Session {
-    /// Authenticated username (local subject or mapped external subject).
+    /// Authenticated subject. ATProto browser sessions store the verified DID.
     pub username: String,
     /// How the user authenticated ("local" or provider slug).
     pub auth_method: String,
+    /// Verified ATProto DID for browser sessions created by the exchange seam.
+    pub atproto_did: Option<String>,
+    /// Authority-owned tenant binding resolved from the verified identity.
+    pub verified_tenant: Option<String>,
     /// When the user authenticated.
     pub authenticated_at: Instant,
     /// When the session expires.
@@ -48,10 +52,33 @@ impl SessionStore {
         let session = Session {
             username,
             auth_method,
+            atproto_did: None,
+            verified_tenant: None,
             authenticated_at: Instant::now(),
             expires_at: Instant::now() + self.ttl,
         };
 
+        self.sessions.write().await.insert(session_id.clone(), session);
+        session_id
+    }
+
+    /// Create a browser session from a server-verified ATProto identity.
+    pub async fn create_atproto(
+        &self,
+        did: String,
+        verified_tenant: Option<String>,
+    ) -> String {
+        let mut id_bytes = [0u8; 32];
+        rand::rngs::OsRng.fill_bytes(&mut id_bytes);
+        let session_id = URL_SAFE_NO_PAD.encode(id_bytes);
+        let session = Session {
+            username: did.clone(),
+            auth_method: "atproto".to_owned(),
+            atproto_did: Some(did),
+            verified_tenant,
+            authenticated_at: Instant::now(),
+            expires_at: Instant::now() + self.ttl,
+        };
         self.sessions.write().await.insert(session_id.clone(), session);
         session_id
     }
@@ -88,6 +115,7 @@ impl Default for SessionStore {
 
 /// Extract session ID from request cookies.
 pub fn extract_session_id(headers: &axum::http::HeaderMap) -> Option<String> {
+    let prefix = format!("{SESSION_COOKIE_NAME}=");
     headers
         .get(axum::http::header::COOKIE)
         .and_then(|v| v.to_str().ok())
@@ -95,8 +123,8 @@ pub fn extract_session_id(headers: &axum::http::HeaderMap) -> Option<String> {
             cookies
                 .split(';')
                 .map(str::trim)
-                .find(|c| c.starts_with(SESSION_COOKIE_NAME))
-                .and_then(|c| c.strip_prefix(&format!("{SESSION_COOKIE_NAME}=")))
+                .find_map(|cookie| cookie.strip_prefix(&prefix))
+                .filter(|session_id| !session_id.is_empty())
                 .map(String::from)
         })
 }

--- a/crates/hyprstream/src/services/oauth/token_exchange.rs
+++ b/crates/hyprstream/src/services/oauth/token_exchange.rs
@@ -28,18 +28,19 @@ const TOKEN_TYPE_ACCESS_TOKEN: &str = "urn:ietf:params:oauth:token-type:access_t
 const TOKEN_TYPE_JWT: &str = "urn:ietf:params:oauth:token-type:jwt";
 const ISSUED_TOKEN_TYPE: &str = "urn:ietf:params:oauth:token-type:access_token";
 pub const ATPROTO_EXCHANGE_NSID: &str = "ai.hyprstream.identity.exchangeUcan";
+pub const ATPROTO_SESSION_EXCHANGE_NSID: &str = "ai.hyprstream.identity.exchangeSession";
 const MAX_ATPROTO_SERVICE_TOKEN_LIFETIME: i64 = 3600;
 pub(super) const MAX_ATPROTO_EXCHANGE_TOKEN_TTL: u32 = 300;
 
-struct VerifiedSubject {
-    sub: String,
+pub(super) struct VerifiedSubject {
+    pub(super) sub: String,
     cnf_key_bytes: Option<[u8; 32]>,
     iat: i64,
     /// Authority from a locally validated OAuth access-token grant. Identity
     /// tokens and generic JWTs do not carry a server-authorized OAuth grant.
     granted_scopes: Option<Vec<String>>,
-    verified_tenant: Option<String>,
-    atproto_replay: Option<(String, String, i64)>,
+    pub(super) verified_tenant: Option<String>,
+    pub(super) atproto_replay: Option<(String, String, i64)>,
     require_clearance: bool,
     ttl_ceiling: Option<u32>,
 }
@@ -287,7 +288,7 @@ async fn verify_jwt(state: &Arc<OAuthState>, token: &str) -> Result<VerifiedSubj
     if issuer_hint.as_deref().is_some_and(|issuer| {
         issuer.starts_with("did:plc:") || issuer.starts_with("did:web:")
     }) {
-        return verify_atproto_service_jwt(state, token).await;
+        return verify_atproto_service_jwt(state, token, ATPROTO_EXCHANGE_NSID).await;
     }
 
     let unverified = hyprstream_rpc::auth::decode_unverified(token)
@@ -367,9 +368,10 @@ struct AtprotoServiceClaims {
     jti: String,
 }
 
-async fn verify_atproto_service_jwt(
+pub(super) async fn verify_atproto_service_jwt(
     state: &Arc<OAuthState>,
     token: &str,
+    expected_lxm: &str,
 ) -> Result<VerifiedSubject, String> {
     let parts: Vec<&str> = token.split('.').collect();
     if parts.len() != 3 || parts.iter().any(|part| part.is_empty()) {
@@ -390,8 +392,8 @@ async fn verify_atproto_service_jwt(
     if claims.aud != expected_audience {
         return Err(format!("ATProto service JWT aud must equal host DID {expected_audience}"));
     }
-    if claims.lxm != ATPROTO_EXCHANGE_NSID {
-        return Err(format!("ATProto service JWT lxm must equal {ATPROTO_EXCHANGE_NSID}"));
+    if claims.lxm != expected_lxm {
+        return Err(format!("ATProto service JWT lxm must equal {expected_lxm}"));
     }
     let now = chrono::Utc::now().timestamp();
     if claims.exp <= now {


### PR DESCRIPTION
Wires the frontend->hyprstream auth seam (operator: defer www backend/, use hyprstream own exchange). atproto/DPoP session -> authenticated hyprstream session (the hyprstream_session cookie C register/intake require); whoami/session-context endpoint returns viewer server-derived {did,kind,tenant,canActLocally} for client gating (unauth->floor). Built on wasm_token_exchange (#1119) + oauth session module + verified_tenant. Exact contracts in .fleet-coord/route-contracts.md.