### PR TITLE
feat(inference): add standalone CPU MoQ service

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6889,6 +6889,7 @@ dependencies = [
  "walkdir",
  "waxterm",
  "web-transport-iroh",
+ "web-transport-quinn",
  "xdg",
  "zeroize",
 ]

--- a/crates/hyprstream-rpc/src/streaming.rs
+++ b/crates/hyprstream-rpc/src/streaming.rs
@@ -753,6 +753,19 @@ impl StreamChannel {
         self.moq_origin.clone()
     }
 
+    fn selected_moq_origin(&self) -> Result<crate::moq_stream::MoqStreamOrigin> {
+        self.moq_origin
+            .read()
+            .clone()
+            .or_else(|| crate::moq_stream::global_moq_origin().cloned())
+            .ok_or_else(|| anyhow::anyhow!("no moq stream origin — server not initialized"))
+    }
+
+    /// Return the broadcast path on the exact origin this channel publishes to.
+    pub fn broadcast_path(&self, topic: &str) -> Result<String> {
+        Ok(self.selected_moq_origin()?.broadcast_path(topic))
+    }
+
     /// Install the node's persistent ML-DSA-65 signing key, replacing the
     /// auto-generated one. The matching public key must be anchored in the
     /// StreamService verifier's PQ trust store for Hybrid verification to
@@ -911,12 +924,7 @@ impl StreamChannel {
         &self,
         ctx: &StreamContext,
     ) -> Result<crate::moq_stream::AnyStreamPublisher> {
-        let scoped_origin = self.moq_origin.read().clone();
-        let origin = match scoped_origin.as_ref() {
-            Some(origin) => origin,
-            None => crate::moq_stream::global_moq_origin()
-                .ok_or_else(|| anyhow::anyhow!("no moq stream origin — server not initialized"))?,
-        };
+        let origin = self.selected_moq_origin()?;
         // #321: on the DH (mesh) path, sign each StreamBlock with the node's per-host
         // hybrid identity (Ed25519 + the deterministically-derived mesh ML-DSA key)
         // so consumers can attribute blocks to this host (C-PROV / threat T3). The
@@ -1593,6 +1601,7 @@ mod tests {
         let _publisher = channel.publisher(&stream).await?;
 
         let path = scoped_origin.broadcast_path(stream.topic());
+        assert_eq!(channel.broadcast_path(stream.topic())?, path);
         tokio::time::timeout(
             std::time::Duration::from_secs(1),
             scoped_origin.consumer().announced_broadcast(&path),

--- a/crates/hyprstream/Cargo.toml
+++ b/crates/hyprstream/Cargo.toml
@@ -99,6 +99,7 @@ rcgen.workspace = true  # Self-signed TLS cert generation for QUIC
 rustls.workspace = true  # TLS runtime (ring crypto provider for axum-server)
 rustls-pemfile.workspace = true  # PEM file parsing for TLS certs
 rustls-acme.workspace = true  # ACME (Let's Encrypt / step-ca) automatic cert provisioning
+web-transport-quinn.workspace = true
 zeroize.workspace = true  # Zeroing private key material on drop
 time = "0.3"  # Datetime types for certificate validity
 

--- a/crates/hyprstream/src/config/mod.rs
+++ b/crates/hyprstream/src/config/mod.rs
@@ -32,6 +32,10 @@ pub struct HyprConfig {
     #[serde(default)]
     pub model: ModelConfig,
 
+    /// Standalone CPU inference service configuration (#1236/#1247).
+    #[serde(default)]
+    pub inference: InferenceServerConfig,
+
     /// Runtime execution settings
     #[serde(default)]
     pub runtime: RuntimeConfig,
@@ -1840,6 +1844,171 @@ pub struct ModelConfig {
     pub quic_port: Option<u16>,
 }
 
+/// Configuration for one deployable, CPU-only inference process.
+///
+/// The service is opt-in: an empty `model_path` is the unconfigured default.
+/// Metal runs two separate processes with distinct `replica` values and
+/// resource limits, keeping libtorch and KV-cache fault domains isolated.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct InferenceServerConfig {
+    /// Materialized model directory loaded before the service becomes ready.
+    #[serde(default)]
+    pub model_path: PathBuf,
+    /// Authority-facing model reference used for logs and deployment identity.
+    #[serde(default)]
+    pub model_ref: String,
+    /// Authenticated immutable Git object ID for the materialized model.
+    #[serde(default)]
+    pub model_oid: String,
+    /// Verified tenant to which this process is exclusively bound.
+    #[serde(default)]
+    pub tenant: String,
+    /// Replica ordinal. Metal deploys ordinals 0 and 1.
+    #[serde(default)]
+    pub replica: u16,
+    /// Inclusive transformer layer start. Partial ranges remain blocked on #314.
+    #[serde(default)]
+    pub stage_start: u32,
+    /// Exclusive transformer layer end. `None` means the complete model.
+    #[serde(default)]
+    pub stage_end: Option<u32>,
+    /// Browser-addressable QUIC/WebTransport port.
+    #[serde(default)]
+    pub quic_port: Option<u16>,
+    /// Routable address placed in signed `StreamInfo.announcedAt`.
+    #[serde(default)]
+    pub advertise_addr: Option<std::net::SocketAddr>,
+}
+
+impl Default for InferenceServerConfig {
+    fn default() -> Self {
+        Self {
+            model_path: PathBuf::new(),
+            model_ref: String::new(),
+            model_oid: String::new(),
+            tenant: String::new(),
+            replica: 0,
+            stage_start: 0,
+            stage_end: None,
+            quic_port: None,
+            advertise_addr: None,
+        }
+    }
+}
+
+impl InferenceServerConfig {
+    /// Validate the deployable CPU service contract without loading weights.
+    pub fn validate(&self) -> anyhow::Result<()> {
+        anyhow::ensure!(
+            !self.model_path.as_os_str().is_empty(),
+            "inference.model_path is required"
+        );
+        anyhow::ensure!(
+            self.model_path.is_absolute(),
+            "inference.model_path must be absolute"
+        );
+        anyhow::ensure!(
+            self.model_path.is_dir(),
+            "inference.model_path is not a directory: {}",
+            self.model_path.display()
+        );
+        anyhow::ensure!(!self.model_ref.trim().is_empty(), "inference.model_ref is required");
+        anyhow::ensure!(!self.tenant.trim().is_empty(), "inference.tenant is required");
+        let advertise_addr = self.advertise_addr.ok_or_else(|| {
+            anyhow::anyhow!(
+                "inference.advertise_addr is required for network-addressable browser MoQ"
+            )
+        })?;
+        anyhow::ensure!(
+            !advertise_addr.ip().is_unspecified()
+                && !advertise_addr.ip().is_loopback()
+                && advertise_addr.port() != 0,
+            "inference.advertise_addr must be a non-loopback routable IP and non-zero port"
+        );
+        let quic_port = self.quic_port.ok_or_else(|| {
+            anyhow::anyhow!(
+                "inference.quic_port is required and must match inference.advertise_addr"
+            )
+        })?;
+        anyhow::ensure!(
+            quic_port != 0 && quic_port == advertise_addr.port(),
+            "inference.quic_port must be non-zero and match inference.advertise_addr port"
+        );
+        anyhow::ensure!(
+            matches!(self.model_oid.len(), 40 | 64)
+                && self.model_oid.bytes().all(|b| b.is_ascii_hexdigit()),
+            "inference.model_oid must be a 40- or 64-character hexadecimal object ID"
+        );
+        anyhow::ensure!(
+            self.stage_start == 0 && self.stage_end.is_none(),
+            "partial inference stage ranges require the #314 subset loader; configure the complete range as stage_start=0 and omit stage_end"
+        );
+        Ok(())
+    }
+
+    /// Verify that the configured path is inside the checkout at `model_oid`.
+    ///
+    /// A deployment may not pair an arbitrary directory with a claimed OID:
+    /// the immutable Git identity is checked before any weights are loaded.
+    pub fn verify_materialized_oid(&self) -> anyhow::Result<()> {
+        let model_path = self.model_path.canonicalize()?;
+        let repository = git2::Repository::discover(&model_path).map_err(|error| {
+            anyhow::anyhow!(
+                "inference.model_path is not in a Git checkout: {error}"
+            )
+        })?;
+        let checkout = repository
+            .workdir()
+            .ok_or_else(|| anyhow::anyhow!("inference model repository is bare"))?
+            .canonicalize()?;
+        anyhow::ensure!(
+            model_path.starts_with(&checkout),
+            "inference.model_path escapes its discovered checkout"
+        );
+        let actual = repository
+            .head()?
+            .target()
+            .ok_or_else(|| anyhow::anyhow!("inference model checkout has no direct HEAD OID"))?
+            .to_string();
+        anyhow::ensure!(
+            actual.eq_ignore_ascii_case(&self.model_oid),
+            "inference model OID mismatch: configured {}, materialized {}",
+            self.model_oid,
+            actual
+        );
+
+        let model_relative = model_path
+            .strip_prefix(&checkout)
+            .map_err(|_| anyhow::anyhow!("inference model path is outside its checkout"))?;
+        let mut options = git2::StatusOptions::new();
+        options
+            .include_untracked(true)
+            .recurse_untracked_dirs(true)
+            // Ignored bytes under the model subtree are still mutable model
+            // inputs and must not inherit the checkout's authenticated OID.
+            .include_ignored(true)
+            .include_unmodified(false);
+        for entry in repository.statuses(Some(&mut options))?.iter() {
+            let Some(path) = entry.path() else {
+                anyhow::bail!("inference model checkout contains a non-UTF-8 changed path");
+            };
+            if std::path::Path::new(path).starts_with(model_relative) {
+                anyhow::bail!(
+                    "inference model checkout is not immutable at {}: {path} has status {:?}",
+                    self.model_oid,
+                    entry.status()
+                );
+            }
+        }
+        Ok(())
+    }
+
+    /// Stable deployment identity for logs and capacity reporting.
+    pub fn instance_name(&self) -> String {
+        format!("inference-cpu-{}", self.replica)
+    }
+}
+
 impl Default for ModelConfig {
     fn default() -> Self {
         Self {
@@ -2169,6 +2338,7 @@ impl Default for LoraAppConfig {
 pub struct HyprConfigBuilder {
     server_builder: ServerConfigBuilder,
     model: ModelConfig,
+    inference: InferenceServerConfig,
     runtime: RuntimeConfig,
     generation: GenerationConfig,
     lora: LoraAppConfig,
@@ -2203,6 +2373,7 @@ impl HyprConfigBuilder {
         Self {
             server_builder: ServerConfigBuilder::new(),
             model: ModelConfig::default(),
+            inference: InferenceServerConfig::default(),
             runtime: RuntimeConfig::default(),
             generation: GenerationConfig::default(),
             lora: LoraAppConfig::default(),
@@ -2237,6 +2408,7 @@ impl HyprConfigBuilder {
         Self {
             server_builder: config.server.to_builder(),
             model: config.model,
+            inference: config.inference,
             runtime: config.runtime,
             generation: config.generation,
             lora: config.lora,
@@ -2283,6 +2455,7 @@ impl HyprConfigBuilder {
         HyprConfig {
             server: self.server_builder.build(),
             model: self.model,
+            inference: self.inference,
             runtime: self.runtime,
             generation: self.generation,
             lora: self.lora,
@@ -2845,6 +3018,147 @@ impl From<&crate::config::server::SamplingParamDefaults> for SamplingParams {
 
 #[cfg(test)]
 mod tests {
+    #[test]
+    fn standalone_inference_config_rejects_partial_stage_without_subset_loader() {
+        let model = tempfile::TempDir::new().unwrap_or_else(|e| panic!("{e}"));
+        let config = InferenceServerConfig {
+            model_path: model.path().to_path_buf(),
+            model_ref: "demo:main".to_owned(),
+            model_oid: "1".repeat(40),
+            tenant: "demo.example".to_owned(),
+            quic_port: Some(7440),
+            advertise_addr: Some(
+                "192.0.2.10:7440"
+                    .parse()
+                    .unwrap_or_else(|e| panic!("{e}")),
+            ),
+            stage_start: 8,
+            stage_end: Some(16),
+            ..InferenceServerConfig::default()
+        };
+        let error = match config.validate() {
+            Ok(()) => panic!("partial ranges must fail closed until #314"),
+            Err(error) => error,
+        };
+        assert!(error.to_string().contains("#314"));
+    }
+
+    #[test]
+    fn standalone_inference_replicas_have_distinct_runtime_names() {
+        let first = InferenceServerConfig {
+            replica: 0,
+            ..InferenceServerConfig::default()
+        };
+        let second = InferenceServerConfig {
+            replica: 1,
+            ..InferenceServerConfig::default()
+        };
+        assert_eq!(first.instance_name(), "inference-cpu-0");
+        assert_eq!(second.instance_name(), "inference-cpu-1");
+        assert_ne!(first.instance_name(), second.instance_name());
+    }
+
+    #[test]
+    fn standalone_inference_rejects_mismatched_advertised_port() {
+        let model = tempfile::TempDir::new().unwrap_or_else(|e| panic!("{e}"));
+        let config = InferenceServerConfig {
+            model_path: model.path().to_path_buf(),
+            model_ref: "demo:main".to_owned(),
+            model_oid: "1".repeat(40),
+            tenant: "demo.example".to_owned(),
+            quic_port: Some(7441),
+            advertise_addr: Some(
+                "192.0.2.10:7440"
+                    .parse()
+                    .unwrap_or_else(|e| panic!("{e}")),
+            ),
+            ..InferenceServerConfig::default()
+        };
+
+        let error = match config.validate() {
+            Ok(()) => panic!("bound and advertised QUIC ports must agree"),
+            Err(error) => error,
+        };
+        assert!(error.to_string().contains("must be non-zero and match"));
+    }
+
+    #[test]
+    fn standalone_inference_verifies_materialized_git_oid() {
+        let model = tempfile::TempDir::new().unwrap_or_else(|e| panic!("{e}"));
+        let repository =
+            git2::Repository::init(model.path()).unwrap_or_else(|e| panic!("{e}"));
+        std::fs::write(model.path().join("config.json"), b"{}")
+            .unwrap_or_else(|e| panic!("{e}"));
+        std::fs::write(model.path().join(".gitignore"), b"ignored.bin\n")
+            .unwrap_or_else(|e| panic!("{e}"));
+        let mut index = repository.index().unwrap_or_else(|e| panic!("{e}"));
+        index
+            .add_path(std::path::Path::new("config.json"))
+            .unwrap_or_else(|e| panic!("{e}"));
+        index
+            .add_path(std::path::Path::new(".gitignore"))
+            .unwrap_or_else(|e| panic!("{e}"));
+        index.write().unwrap_or_else(|e| panic!("{e}"));
+        let tree_oid = index.write_tree().unwrap_or_else(|e| panic!("{e}"));
+        let tree = repository
+            .find_tree(tree_oid)
+            .unwrap_or_else(|e| panic!("{e}"));
+        let signature =
+            git2::Signature::now("hyprstream-test", "test@hyprstream.local")
+                .unwrap_or_else(|e| panic!("{e}"));
+        let oid = repository
+            .commit(
+                Some("HEAD"),
+                &signature,
+                &signature,
+                "fixture",
+                &tree,
+                &[],
+            )
+            .unwrap_or_else(|e| panic!("{e}"));
+
+        let mut config = InferenceServerConfig {
+            model_path: model.path().to_path_buf(),
+            model_ref: "demo:main".to_owned(),
+            model_oid: oid.to_string(),
+            tenant: "demo.example".to_owned(),
+            quic_port: Some(7440),
+            advertise_addr: Some(
+                "192.0.2.10:7440"
+                    .parse()
+                    .unwrap_or_else(|e| panic!("{e}")),
+            ),
+            ..InferenceServerConfig::default()
+        };
+        config
+            .validate()
+            .unwrap_or_else(|e| panic!("valid fixture rejected: {e}"));
+        config
+            .verify_materialized_oid()
+            .unwrap_or_else(|e| panic!("matching OID rejected: {e}"));
+
+        std::fs::write(model.path().join("config.json"), b"{\"tampered\":true}")
+            .unwrap_or_else(|e| panic!("{e}"));
+        assert!(
+            config.verify_materialized_oid().is_err(),
+            "dirty tracked model bytes must not inherit the HEAD identity"
+        );
+        std::fs::write(model.path().join("config.json"), b"{}")
+            .unwrap_or_else(|e| panic!("{e}"));
+
+        std::fs::write(model.path().join("ignored.bin"), b"mutable weights")
+            .unwrap_or_else(|e| panic!("{e}"));
+        assert!(
+            config.verify_materialized_oid().is_err(),
+            "ignored model bytes must not inherit the HEAD identity"
+        );
+        std::fs::remove_file(model.path().join("ignored.bin"))
+            .unwrap_or_else(|e| panic!("{e}"));
+
+        config.model_oid = "f".repeat(40);
+        assert!(config.verify_materialized_oid().is_err());
+    }
+
     /// #1136 anchors are a PAIR. #905 §2/§6 is bidirectional-or-not-believed, so a
     /// one-sided anchor config can never establish trust and must fail at validation
     /// rather than at `install_process_production_resolver()`.

--- a/crates/hyprstream/src/services/factories.rs
+++ b/crates/hyprstream/src/services/factories.rs
@@ -1052,6 +1052,80 @@ fn create_model_service(ctx: &ServiceContext) -> anyhow::Result<Box<dyn Spawnabl
 }
 
 // ═══════════════════════════════════════════════════════════════════════════════
+// Standalone CPU Inference Service Factory (#1236/#1247)
+// ═══════════════════════════════════════════════════════════════════════════════
+
+/// One model, one tenant, one CPU-only process. Metal starts two independent
+/// copies with replica ordinals 0 and 1; no engine or KV-cache state is shared.
+#[service_factory("inference", schema = "../../../hyprstream-rpc-std/schema/inference.capnp", metadata = crate::services::generated::inference_client::schema_metadata, depends_on = ["policy", "discovery"])]
+fn create_inference_service(ctx: &ServiceContext) -> anyhow::Result<Box<dyn Spawnable>> {
+    info!("Creating standalone CPU InferenceService");
+
+    let config = load_config();
+    config.inference.validate()?;
+    config.inference.verify_materialized_oid()?;
+
+    let sk = ctx.service_signing_key("inference");
+    register_service_key(ctx, "inference", &sk)?;
+    let instance_name = config.inference.instance_name();
+
+    // The standalone image is a CPU fault domain even if a host happens to
+    // expose CUDA. Explicitly clear every GPU selector at the service boundary.
+    let runtime = crate::config::RuntimeConfig {
+        use_gpu: false,
+        gpu_device_id: None,
+        devices: Vec::new(),
+        gpu_layers: None,
+        ..config.runtime.clone()
+    };
+    // Do not announce both replicas under the singleton Discovery key:
+    // Discovery currently replaces, rather than pools, duplicate service
+    // endpoints. Metal #1309 owns the canonical two-backend load-balancer.
+    let quic = ctx
+        .quic_shared()
+        .map(|shared| {
+            shared.for_service(
+                &instance_name,
+                config.inference.quic_port.unwrap_or(0),
+            )
+        })
+        .ok_or_else(|| {
+            anyhow::anyhow!(
+                "standalone inference requires [quic].enabled=true for browser MoQ"
+            )
+        })?;
+
+    let mut service = crate::services::InferenceServiceConfig::new(
+        &config.inference.model_path,
+        runtime,
+        sk.verifying_key(),
+        sk.clone(),
+        ctx.transport(&instance_name, SocketKind::Rep),
+        None,
+    )
+    .with_instance_identity(
+        instance_name.clone(),
+        config.inference.tenant.clone(),
+        sk.verifying_key(),
+    )
+    .with_quic_config(Some(quic))
+    .with_quic_advertise_addr(config.inference.advertise_addr);
+    if let Some(issuer) = ctx.oauth_issuer_url() {
+        service = service.with_expected_audience(issuer.to_owned());
+    }
+    service = service.with_jwt_key_source(ctx.cluster_key_source());
+
+    info!(
+        instance = %config.inference.instance_name(),
+        model_ref = %config.inference.model_ref,
+        model_oid = %config.inference.model_oid,
+        tenant = %config.inference.tenant,
+        "standalone CPU inference configured"
+    );
+    Ok(Box::new(service))
+}
+
+// ═══════════════════════════════════════════════════════════════════════════════
 // Worker Service Factory
 // ═══════════════════════════════════════════════════════════════════════════════
 

--- a/crates/hyprstream/src/services/inference.rs
+++ b/crates/hyprstream/src/services/inference.rs
@@ -51,7 +51,7 @@ use hyprstream_rpc::prelude::*;
 use hyprstream_rpc::StreamChannel;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
-use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use parking_lot::Mutex;
 use tokio::runtime::Handle;
 use tokenizers::Tokenizer;
@@ -186,6 +186,12 @@ pub struct InferenceServiceInner {
     /// Verified key of the ModelService controller allowed to bridge a local
     /// request into this tenant-bound instance.
     controller_pubkey: VerifyingKey,
+    /// True only while the network stream plane is bound and accepting.
+    network_ready: Arc<AtomicBool>,
+    /// Rejects new generation streams once lifecycle drain begins.
+    draining: Arc<AtomicBool>,
+    /// Process/service shutdown notification.
+    shutdown: Arc<tokio::sync::Notify>,
     /// Optional #1264 completion-spend emitter. `None` (default) ⇒ inert: the
     /// completion path posts no spend. Behind a `RwLock` so an operator can
     /// attach it after the service thread constructs the inner (the emitter's
@@ -477,6 +483,11 @@ impl InferenceService {
         fs: Option<WorktreeClient>,
         tenant_domain: String,
         controller_pubkey: VerifyingKey,
+        producer_reach_config: hyprstream_rpc::moq_stream::ProducerReachConfigHandle,
+        moq_origin: hyprstream_rpc::moq_stream::MoqStreamOriginHandle,
+        network_ready: Arc<AtomicBool>,
+        draining: Arc<AtomicBool>,
+        shutdown: Arc<tokio::sync::Notify>,
     ) -> Result<Self> {
         // Capture runtime handle for reuse in handlers
         let runtime_handle = Handle::current();
@@ -603,7 +614,8 @@ impl InferenceService {
 
         // Create StreamChannel upfront.
         let stream_channel = StreamChannel::new(signing_key.clone())
-            .with_reach_config(hyprstream_rpc::moq_stream::ProducerReachConfig::default());
+            .with_reach_config_handle(producer_reach_config)
+            .with_moq_origin_handle(moq_origin);
         let object_label = inference_object_label();
 
         Ok(InferenceService {
@@ -626,6 +638,9 @@ impl InferenceService {
                 lora_generation: Arc::new(AtomicU64::new(0)),
                 tenant_domain,
                 controller_pubkey,
+                network_ready,
+                draining,
+                shutdown,
                 #[cfg(feature = "ledger")]
                 ledger: parking_lot::RwLock::new(None),
                 object_label,
@@ -863,6 +878,10 @@ impl InferenceService {
         Vec<hyprstream_rpc::stream_info::Destination>,
         PendingWork,
     )> {
+        anyhow::ensure!(
+            !self.draining.load(Ordering::Acquire),
+            "inference service is draining and refuses new streams"
+        );
         // TTT adaptation is deferred to execute_stream (runs in continuation after REP
         // is sent) to avoid blocking the ZMQ REQ/REP handler with GPU-intensive work.
 
@@ -887,9 +906,7 @@ impl InferenceService {
 
         let stream_id = stream_ctx.stream_id().to_owned();
         let server_pubkey = *stream_ctx.server_pubkey();
-        let broadcast_path = hyprstream_rpc::moq_stream::global_moq_origin()
-            .map(|o| o.broadcast_path(stream_ctx.topic()))
-            .unwrap_or_default();
+        let broadcast_path = stream_channel.broadcast_path(stream_ctx.topic())?;
         // #384: per-stream reach (server-authored RelayChoice on the ctx);
         // ServerDefault unless set to Only/Override for anonymized/per-tenant.
         let reach = stream_ctx.reach();
@@ -1233,6 +1250,8 @@ impl InferenceService {
     /// Handle is ready request
     async fn handle_is_ready(&self) -> bool {
         self.engine.read().is_loaded()
+            && self.network_ready.load(Ordering::Acquire)
+            && !self.draining.load(Ordering::Acquire)
     }
 
     /// Handle apply chat template
@@ -2455,8 +2474,19 @@ impl InferenceHandler for InferenceService {
 
     async fn handle_health_check(&self, _ctx: &EnvelopeContext, _request_id: u64) -> Result<InferenceResponseVariant> {
         let model_loaded = self.engine.read().is_loaded();
+        let network_ready = self.network_ready.load(Ordering::Acquire);
+        let draining = self.draining.load(Ordering::Acquire);
+        let status = if draining {
+            "draining"
+        } else if !model_loaded {
+            "not_loaded"
+        } else if !network_ready {
+            "stream_plane_unavailable"
+        } else {
+            "ok"
+        };
         Ok(InferenceResponseVariant::HealthCheckResult(HealthStatus {
-            status: if model_loaded { "ok".into() } else { "not_loaded".into() },
+            status: status.into(),
             model_loaded,
             kv_cache_usage_percent: 0.0,
             gpu_memory_used_mb: 0,
@@ -2466,6 +2496,13 @@ impl InferenceHandler for InferenceService {
 
     async fn handle_shutdown(&self, _ctx: &EnvelopeContext, _request_id: u64) -> Result<InferenceResponseVariant> {
         info!("Inference service shutdown requested");
+        self.draining.store(true, Ordering::Release);
+        self.network_ready.store(false, Ordering::Release);
+        let shutdown = Arc::clone(&self.shutdown);
+        tokio::spawn(async move {
+            tokio::task::yield_now().await;
+            shutdown.notify_waiters();
+        });
         Ok(InferenceResponseVariant::Success)
     }
 
@@ -2832,6 +2869,17 @@ pub struct InferenceServiceConfig {
     network_reach: Arc<
         parking_lot::RwLock<Option<hyprstream_rpc::transport::TransportConfig>>,
     >,
+    /// Reach and origin shared with the browser-addressable QUIC/MoQ relay.
+    producer_reach_config: hyprstream_rpc::moq_stream::ProducerReachConfigHandle,
+    moq_origin: hyprstream_rpc::moq_stream::MoqStreamOriginHandle,
+    /// Standalone services own and bind this QUIC/WebTransport endpoint.
+    quic_config: Option<hyprstream_rpc::service::QuicLoopConfig>,
+    /// Explicit externally routable reach advertised for this QUIC bind.
+    quic_advertise_addr: Option<std::net::SocketAddr>,
+    /// False when an outer ModelService owns the advertised stream plane.
+    owns_stream_plane: bool,
+    network_ready: Arc<AtomicBool>,
+    draining: Arc<AtomicBool>,
 }
 
 impl InferenceServiceConfig {
@@ -2866,6 +2914,18 @@ impl InferenceServiceConfig {
             tenant_domain: "local".to_owned(),
             controller_pubkey: server_pubkey,
             network_reach: Arc::new(parking_lot::RwLock::new(None)),
+            producer_reach_config: Arc::new(parking_lot::RwLock::new(
+                hyprstream_rpc::moq_stream::ProducerReachConfig::default(),
+            )),
+            moq_origin: Arc::new(parking_lot::RwLock::new(None)),
+            quic_config: None,
+            quic_advertise_addr: None,
+            owns_stream_plane: true,
+            // Legacy in-process/training services do not attach a browser
+            // stream plane; preserve their model-based readiness until a
+            // network plane is explicitly configured below.
+            network_ready: Arc::new(AtomicBool::new(true)),
+            draining: Arc::new(AtomicBool::new(false)),
         }
     }
 
@@ -2880,6 +2940,46 @@ impl InferenceServiceConfig {
         self.service_name = service_name;
         self.tenant_domain = tenant_domain;
         self.controller_pubkey = controller_pubkey;
+        self
+    }
+
+    /// Publish generated streams through an outer service's QUIC/MoQ relay.
+    #[must_use]
+    pub fn with_stream_plane(
+        mut self,
+        producer_reach_config: hyprstream_rpc::moq_stream::ProducerReachConfigHandle,
+        moq_origin: hyprstream_rpc::moq_stream::MoqStreamOriginHandle,
+    ) -> Self {
+        self.producer_reach_config = producer_reach_config;
+        self.moq_origin = moq_origin;
+        self.owns_stream_plane = false;
+        self.network_ready.store(
+            self.producer_reach_config.read().quic_reach.is_some(),
+            Ordering::Release,
+        );
+        self
+    }
+
+    /// Bind a browser-addressable RPC/MoQ endpoint owned by this process.
+    #[must_use]
+    pub fn with_quic_config(
+        mut self,
+        quic_config: Option<hyprstream_rpc::service::QuicLoopConfig>,
+    ) -> Self {
+        if quic_config.is_some() {
+            self.network_ready.store(false, Ordering::Release);
+        }
+        self.quic_config = quic_config;
+        self
+    }
+
+    /// Set the externally routable address signed into `StreamInfo`.
+    #[must_use]
+    pub fn with_quic_advertise_addr(
+        mut self,
+        advertise_addr: Option<std::net::SocketAddr>,
+    ) -> Self {
+        self.quic_advertise_addr = advertise_addr;
         self
     }
 
@@ -2902,6 +3002,187 @@ impl InferenceServiceConfig {
         &self,
     ) -> Arc<parking_lot::RwLock<Option<hyprstream_rpc::transport::TransportConfig>>> {
         Arc::clone(&self.network_reach)
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+async fn serve_inference_bridged(
+    service_name: &str,
+    transport: &hyprstream_rpc::transport::TransportConfig,
+    processor: Arc<
+        dyn hyprstream_rpc::transport::rpc_session::IrohRequestProcessor,
+    >,
+    signing_key: SigningKey,
+    shutdown: Arc<tokio::sync::Notify>,
+    on_ready: Option<tokio::sync::oneshot::Sender<()>>,
+    quic_config: Option<hyprstream_rpc::service::QuicLoopConfig>,
+    quic_advertise_addr: Option<std::net::SocketAddr>,
+    producer_reach_config: hyprstream_rpc::moq_stream::ProducerReachConfigHandle,
+    moq_origin: hyprstream_rpc::moq_stream::MoqStreamOriginHandle,
+    network_ready: Arc<AtomicBool>,
+    draining: Arc<AtomicBool>,
+) -> hyprstream_rpc::error::Result<()> {
+    let Some(mut qc) = quic_config else {
+        return hyprstream_rpc::service::serve::serve_bridged(
+            transport,
+            processor,
+            signing_key,
+            shutdown,
+            on_ready,
+        )
+        .await
+        .map_err(|e| hyprstream_rpc::error::RpcError::SpawnFailed(e.to_string()));
+    };
+
+    hyprstream_rpc::transport::install_pq_crypto_provider().map_err(|error| {
+        hyprstream_rpc::error::RpcError::SpawnFailed(format!(
+            "QUIC crypto provider: {error}"
+        ))
+    })?;
+    let chain: Vec<rustls::pki_types::CertificateDer<'static>> = qc
+        .cert_chain
+        .iter()
+        .map(|der| rustls::pki_types::CertificateDer::from(der.clone()))
+        .collect();
+    let key = rustls::pki_types::PrivateKeyDer::try_from((*qc.key_der).clone())
+        .map_err(|e| {
+            hyprstream_rpc::error::RpcError::SpawnFailed(format!("QUIC key: {e}"))
+        })?;
+    let wt_server = web_transport_quinn::ServerBuilder::new()
+        .with_addr(qc.bind_addr)
+        .with_certificate(chain, key)
+        .map_err(|e| {
+            hyprstream_rpc::error::RpcError::SpawnFailed(format!("QUIC bind: {e}"))
+        })?;
+    let actual_addr = wt_server.local_addr().map_err(|e| {
+        hyprstream_rpc::error::RpcError::SpawnFailed(format!("QUIC local_addr: {e}"))
+    })?;
+    let advertise_addr = if let Some(advertise_addr) = quic_advertise_addr {
+        advertise_addr
+    } else if actual_addr.ip().is_unspecified() {
+        match actual_addr {
+            std::net::SocketAddr::V4(_) => std::net::SocketAddr::from((
+                std::net::Ipv4Addr::LOCALHOST,
+                actual_addr.port(),
+            )),
+            std::net::SocketAddr::V6(_) => std::net::SocketAddr::from((
+                std::net::Ipv6Addr::LOCALHOST,
+                actual_addr.port(),
+            )),
+        }
+    } else {
+        actual_addr
+    };
+    let pin =
+        hyprstream_rpc::transport::quinn_transport::cert_sha256(&qc.cert_chain[0]);
+    let origin = moq_origin
+        .read()
+        .clone()
+        .or_else(|| hyprstream_rpc::moq_stream::global_moq_origin().cloned())
+        .ok_or_else(|| {
+            hyprstream_rpc::error::RpcError::SpawnFailed(
+                "standalone inference has no MoQ origin".to_owned(),
+            )
+        })?;
+
+    let rpc_server =
+        hyprstream_rpc::transport::quinn_transport::QuinnRpcServer::with_capacity(
+            wt_server,
+            Arc::clone(&processor),
+            signing_key.clone(),
+            hyprstream_rpc::transport::rpc_session::DEFAULT_STREAM_LIMIT,
+        )
+        .with_moq_consumer(origin.consumer().clone());
+
+    if let Some(registry) = hyprstream_rpc::registry::try_global() {
+        registry.register(
+            service_name,
+            hyprstream_rpc::registry::SocketKind::Quic,
+            hyprstream_rpc::transport::TransportConfig::quic_pinned(
+                advertise_addr,
+                &qc.server_name,
+                pin,
+            ),
+            None,
+        );
+    }
+    {
+        let mut reach = producer_reach_config.write();
+        reach.quic_reach = Some(hyprstream_rpc::moq_stream::NodeStreamReach {
+            addr: advertise_addr,
+            server_name: qc.server_name.clone(),
+            cert_hashes: vec![pin],
+        });
+        reach.relay = qc.moq_relay.clone();
+    }
+    network_ready.store(true, Ordering::Release);
+    if let Some(callback) = qc.on_quic_bound.take() {
+        callback(
+            service_name.to_owned(),
+            advertise_addr,
+            qc.server_name.clone(),
+        );
+    }
+    if let Some(relay) = qc.moq_relay.take() {
+        hyprstream_rpc::moq_stream::serve_origin_to_relay_background(
+            origin.producer().clone(),
+            relay,
+        );
+    }
+
+    let drain_limit = rpc_server.stream_limit();
+    let drain_capacity = rpc_server.capacity();
+    let drain_token = rpc_server.shutdown_token();
+    let drain_shutdown = Arc::clone(&shutdown);
+    let drain_state = Arc::clone(&draining);
+    let drain_ready = Arc::clone(&network_ready);
+    tokio::spawn(async move {
+        drain_shutdown.notified().await;
+        drain_state.store(true, Ordering::Release);
+        drain_ready.store(false, Ordering::Release);
+        hyprstream_rpc::transport::quinn_transport::QuinnRpcServer::shutdown(
+            &drain_limit,
+            drain_capacity,
+            &drain_token,
+        )
+        .await;
+    });
+
+    let rep = hyprstream_rpc::service::serve::serve_bridged(
+        transport,
+        Arc::clone(&processor),
+        signing_key,
+        Arc::clone(&shutdown),
+        on_ready,
+    );
+    let mut rep = Box::pin(rep);
+    let mut quic = Box::pin(rpc_server.run());
+    tokio::select! {
+        rep_result = &mut rep => {
+            shutdown.notify_waiters();
+            let quic_result = quic.await;
+            network_ready.store(false, Ordering::Release);
+            if let Err(error) = quic_result {
+                tracing::warn!(%error, "standalone inference QUIC loop ended during drain");
+            }
+            rep_result.map_err(|e| {
+                hyprstream_rpc::error::RpcError::SpawnFailed(e.to_string())
+            })
+        }
+        quic_result = &mut quic => {
+            network_ready.store(false, Ordering::Release);
+            if draining.load(Ordering::Acquire) {
+                return rep.await.map_err(|error| {
+                    hyprstream_rpc::error::RpcError::SpawnFailed(error.to_string())
+                });
+            }
+            shutdown.notify_waiters();
+            let detail = match quic_result {
+                Ok(()) => "QUIC server exited unexpectedly".to_owned(),
+                Err(error) => format!("QUIC server failed: {error}"),
+            };
+            Err(hyprstream_rpc::error::RpcError::SpawnFailed(detail))
+        }
     }
 }
 
@@ -2951,8 +3232,39 @@ impl hyprstream_service::Spawnable for InferenceServiceConfig {
                 tenant_domain,
                 controller_pubkey,
                 network_reach,
+                producer_reach_config,
+                moq_origin,
+                quic_config,
+                quic_advertise_addr,
+                owns_stream_plane,
+                network_ready,
+                draining,
             } = *self;
             let adapter_transport = transport.clone();
+
+            let lifecycle_ready = Arc::clone(&network_ready);
+            let lifecycle_draining = Arc::clone(&draining);
+            let lifecycle_shutdown = Arc::clone(&shutdown);
+            tokio::spawn(async move {
+                lifecycle_shutdown.notified().await;
+                lifecycle_draining.store(true, Ordering::Release);
+                lifecycle_ready.store(false, Ordering::Release);
+            });
+
+            // Standalone instances use an isolated origin so two CPU replicas
+            // in one deployment cannot expose each other's broadcast namespace.
+            if owns_stream_plane && quic_config.is_some() {
+                *moq_origin.write() = Some(
+                    hyprstream_rpc::moq_stream::MoqStreamOrigin::standalone()
+                        .with_prefix(hyprstream_rpc::moq_stream::DEFAULT_PREFIX)
+                        .build(),
+                );
+            }
+            let bridge_reach_config = Arc::clone(&producer_reach_config);
+            let bridge_moq_origin = Arc::clone(&moq_origin);
+            let bridge_network_ready = Arc::clone(&network_ready);
+            let bridge_draining = Arc::clone(&draining);
+            let bridge_shutdown = Arc::clone(&shutdown);
 
             // Build PolicyClient + GPU service + adapter ON the bridge thread.
             let (bridge, ready) = hyprstream_rpc::transport::iroh_rpc::LocalServiceBridge::spawn_with(
@@ -2975,6 +3287,11 @@ impl hyprstream_service::Spawnable for InferenceServiceConfig {
                         fs,
                         tenant_domain,
                         controller_pubkey,
+                        bridge_reach_config,
+                        bridge_moq_origin,
+                        bridge_network_ready,
+                        bridge_draining,
+                        bridge_shutdown,
                     )
                     .await
                     .map_err(|e| anyhow::anyhow!("inference init: {e}"))?;
@@ -3034,15 +3351,21 @@ impl hyprstream_service::Spawnable for InferenceServiceConfig {
                 direct_addrs,
                 None,
             ));
-            let result = hyprstream_rpc::service::serve::serve_bridged(
+            let result = serve_inference_bridged(
+                &service_name,
                 &transport,
                 processor,
                 server_signing_key,
                 shutdown,
                 on_ready,
+                quic_config,
+                quic_advertise_addr,
+                producer_reach_config,
+                moq_origin,
+                network_ready,
+                draining,
             )
-            .await
-            .map_err(|e| hyprstream_rpc::error::RpcError::SpawnFailed(e.to_string()));
+            .await;
             if let Err(error) = substrate.shutdown().await {
                 tracing::warn!(%error, "inference iroh shutdown failed");
             }
@@ -3151,6 +3474,48 @@ mod tenant_binding_tests {
 
     fn key(seed: u8) -> SigningKey {
         SigningKey::from_bytes(&[seed; 32])
+    }
+
+    #[test]
+    fn inference_config_shares_outer_moq_plane_by_identity() {
+        let reach = Arc::new(parking_lot::RwLock::new(
+            hyprstream_rpc::moq_stream::ProducerReachConfig::default(),
+        ));
+        let origin = Arc::new(parking_lot::RwLock::new(None));
+        let signing_key = key(4);
+        let config = InferenceServiceConfig::new(
+            "/model",
+            RuntimeConfig::default(),
+            signing_key.verifying_key(),
+            signing_key.clone(),
+            hyprstream_rpc::transport::TransportConfig::inproc(
+                "inference-stream-plane-test",
+            ),
+            None,
+        )
+        .with_stream_plane(Arc::clone(&reach), Arc::clone(&origin));
+
+        assert!(Arc::ptr_eq(&config.producer_reach_config, &reach));
+        assert!(Arc::ptr_eq(&config.moq_origin, &origin));
+        assert!(!config.owns_stream_plane);
+        assert!(!config.network_ready.load(Ordering::Acquire));
+    }
+
+    #[test]
+    fn legacy_in_process_config_preserves_model_based_readiness() {
+        let signing_key = key(5);
+        let config = InferenceServiceConfig::new(
+            "/model",
+            RuntimeConfig::default(),
+            signing_key.verifying_key(),
+            signing_key,
+            hyprstream_rpc::transport::TransportConfig::inproc(
+                "inference-legacy-readiness-test",
+            ),
+            None,
+        );
+
+        assert!(config.network_ready.load(Ordering::Acquire));
     }
 
     #[test]

--- a/crates/hyprstream/src/services/inference.rs
+++ b/crates/hyprstream/src/services/inference.rs
@@ -3057,22 +3057,22 @@ async fn serve_inference_bridged(
     let actual_addr = wt_server.local_addr().map_err(|e| {
         hyprstream_rpc::error::RpcError::SpawnFailed(format!("QUIC local_addr: {e}"))
     })?;
-    let advertise_addr = if let Some(advertise_addr) = quic_advertise_addr {
-        advertise_addr
-    } else if actual_addr.ip().is_unspecified() {
-        match actual_addr {
-            std::net::SocketAddr::V4(_) => std::net::SocketAddr::from((
-                std::net::Ipv4Addr::LOCALHOST,
-                actual_addr.port(),
-            )),
-            std::net::SocketAddr::V6(_) => std::net::SocketAddr::from((
-                std::net::Ipv6Addr::LOCALHOST,
-                actual_addr.port(),
-            )),
-        }
-    } else {
-        actual_addr
-    };
+    let advertise_addr = quic_advertise_addr.ok_or_else(|| {
+        hyprstream_rpc::error::RpcError::SpawnFailed(
+            "standalone inference requires an explicit routable QUIC advertise address"
+                .to_owned(),
+        )
+    })?;
+    if advertise_addr.ip().is_unspecified()
+        || advertise_addr.ip().is_loopback()
+        || advertise_addr.port() == 0
+        || advertise_addr.port() != actual_addr.port()
+    {
+        return Err(hyprstream_rpc::error::RpcError::SpawnFailed(format!(
+            "standalone inference advertise address {advertise_addr} is not routable or does not match bound QUIC port {}",
+            actual_addr.port()
+        )));
+    }
     let pin =
         hyprstream_rpc::transport::quinn_transport::cert_sha256(&qc.cert_chain[0]);
     let origin = moq_origin

--- a/crates/hyprstream/src/services/model.rs
+++ b/crates/hyprstream/src/services/model.rs
@@ -212,6 +212,13 @@ pub struct ModelServiceInner {
     /// The sole tenant admitted by an in-process deployment. A second tenant
     /// must never share the FFI engine fault radius.
     in_process_tenant: std::sync::OnceLock<String>,
+    /// QUIC/MoQ reach populated by the outer service spawner after bind.
+    ///
+    /// Dynamically loaded inference engines share this handle so their stream
+    /// tokens advertise the ModelService's browser-addressable `/moq` relay.
+    producer_reach_config: hyprstream_rpc::moq_stream::ProducerReachConfigHandle,
+    /// Service-scoped MoQ origin populated by the outer service spawner.
+    moq_origin: hyprstream_rpc::moq_stream::MoqStreamOriginHandle,
 }
 
 /// Model service that manages InferenceService lifecycle.
@@ -360,6 +367,10 @@ impl ModelService {
             load_terminals: TerminalStore::new(),
             load_epoch: AtomicU64::new(0),
             in_process_tenant: std::sync::OnceLock::new(),
+            producer_reach_config: std::sync::Arc::new(parking_lot::RwLock::new(
+                hyprstream_rpc::moq_stream::ProducerReachConfig::default(),
+            )),
+            moq_origin: std::sync::Arc::new(parking_lot::RwLock::new(None)),
         })})
     }
 
@@ -888,6 +899,10 @@ impl ModelService {
             instance.service_name(),
             instance.tenant().to_owned(),
             self.signing_key.verifying_key(),
+        )
+        .with_stream_plane(
+            Arc::clone(&self.producer_reach_config),
+            Arc::clone(&self.moq_origin),
         );
         if let Some(ref aud) = self.expected_audience {
             service_config = service_config.with_expected_audience(aud.clone());
@@ -2023,6 +2038,18 @@ impl crate::services::RequestService for ModelService {
 
     fn jwt_key_source(&self) -> Option<std::sync::Arc<dyn hyprstream_rpc::auth::JwtKeySource>> {
         self.inner.jwt_key_source.clone()
+    }
+
+    fn producer_reach_config_handle(
+        &self,
+    ) -> Option<hyprstream_rpc::moq_stream::ProducerReachConfigHandle> {
+        Some(Arc::clone(&self.producer_reach_config))
+    }
+
+    fn moq_origin_handle(
+        &self,
+    ) -> Option<hyprstream_rpc::moq_stream::MoqStreamOriginHandle> {
+        Some(Arc::clone(&self.moq_origin))
     }
 
     fn build_error_payload(&self, request_id: u64, error: &str) -> Vec<u8> {

--- a/docs/deployment/cpu-inference-service.md
+++ b/docs/deployment/cpu-inference-service.md
@@ -1,0 +1,152 @@
+# CPU inference service deployment contract
+
+This is the handoff from hyprstream #1236/#1247 to metal #1309. A deployment
+runs exactly two independent `inference` service processes. Each process loads
+one immutable model checkout on CPU, owns its libtorch engine and KV cache, and
+publishes encrypted `generateStream` output on its own QUIC/WebTransport `/moq`
+origin.
+
+## Artifact and command
+
+Use the multi-architecture CPU image and pin the release digest in metal:
+
+```text
+ghcr.io/hyprstream/hyprstream@sha256:<release-cpu-index-digest>
+```
+
+`latest-cpu` and `edge-cpu` are discovery tags, not deployment pins. The OCI
+index selects native `linux/amd64` or `linux/arm64`. The container command is:
+
+```text
+/hyprstream service start inference --foreground --ipc
+```
+
+The image is distroless. Do not specify a shell health check or expect CUDA
+tools in the container.
+
+## Two required metal entries
+
+Metal should model these as two named entries, not a scalar replica count:
+
+| Metal entry | `REPLICA` | IPC socket | QUIC UDP port |
+| --- | ---: | --- | ---: |
+| `inference-cpu-0` | 0 | `inference-cpu-0.sock` | 7440 |
+| `inference-cpu-1` | 1 | `inference-cpu-1.sock` | 7441 |
+
+Both may mount the same read-only model checkout and service credential, but
+they must be separate containers/processes with separate writable cache/state
+directories and separate CPU/memory/cgroup budgets. They may share the
+deployment IPC directory with Policy and Discovery; the replica-specific
+socket names prevent bind collisions.
+
+Required per-entry environment:
+
+```text
+HYPRSTREAM__INFERENCE__MODEL_PATH=/models/demo
+HYPRSTREAM__INFERENCE__MODEL_REF=<authority-facing-model-ref>
+HYPRSTREAM__INFERENCE__MODEL_OID=<40-or-64-hex-immutable-object-id>
+HYPRSTREAM__INFERENCE__TENANT=<verified-tenant-domain>
+HYPRSTREAM__INFERENCE__REPLICA=0
+HYPRSTREAM__INFERENCE__STAGE_START=0
+HYPRSTREAM__INFERENCE__QUIC_PORT=7440
+HYPRSTREAM__INFERENCE__ADVERTISE_ADDR=<replica-0-routable-ip>:7440
+HYPRSTREAM__QUIC__ENABLED=true
+HYPRSTREAM__QUIC__BIND_ADDR=0.0.0.0:7440
+HYPRSTREAM__RUNTIME__USE_GPU=false
+```
+
+For replica 1, set `REPLICA=1`, bind/advertise port `7441`, and advertise the
+replica-1 routable address. `QUIC_PORT` must be non-zero and equal to the port
+in `ADVERTISE_ADDR`; startup rejects ephemeral, loopback, unspecified, and
+mismatched advertised reaches. The service itself clears `use_gpu`,
+`gpu_device_id`, `devices`, and `gpu_layers`, even if inherited configuration
+tries to enable a GPU.
+
+Mounts and secrets:
+
+- `/models/demo`: read-only Git worktree. Startup discovers its repository and
+  requires `HEAD == MODEL_OID` before loading weights.
+- deployment IPC directory: read-write, shared with Policy and Discovery.
+- inference service credential and CA/public trust material: secret/credential
+  mounts, never Terraform/OpenTofu state values.
+- per-replica cache/state directory: read-write and not shared with the sibling.
+- TLS key material: secret mount. The certificate/public pin may be deployment
+  output; the private key must not be.
+
+Metal should validate at plan time that entry names, replica ordinals, IPC
+socket names, QUIC ports, and writable state paths are pairwise distinct.
+Enforce CPU and memory limits with the container/cgroup controls. The existing
+`runtime.cpu_threads`, `runtime.kv_cache_size_mb`, and
+`runtime.max_concurrent_generations` fields are not consumed by the inference
+engine and must not be treated as capacity enforcement.
+
+## Network and browser contract
+
+The authenticated inference RPC returns a signed `StreamInfo` containing:
+
+- `broadcastPath`: the service-scoped MoQ broadcast;
+- `announcedAt`: the explicitly configured, pinned QUIC `/moq` reach for that
+  replica;
+- the server DH public key and the declared stream QoS.
+
+This backend branch supplies the authenticated `generateStream` RPC, signed
+reach, and service-scoped `/moq` publisher. `hyprstream-rpc-std` already has a
+raw WASM WebTransport/MoQ worker, but does not yet have the production
+high-level inference subscriber/verifier. Www #13 must select the advertised
+reach and broadcast path, then enforce sequence/QoS, chained-MAC, and AEAD
+verification before exposing token bytes. No green browser E2E is claimed by
+this backend handoff.
+
+`moq_event` remains the lifecycle/event fan-out plane. Per-request generation
+tokens use `moq_stream`; metal does not need to deploy a separate legacy
+StreamService for them.
+
+The `/moq` transport currently accepts anonymous subscribers. Generated token
+payloads remain AEAD-sealed, but connection admission, tenant authorization,
+and subscriber capacity protection are not enforced at the MoQ endpoint. Do
+not expose the two replica ports directly to an untrusted network; place them
+behind the deployment ingress policy until authenticated MoQ CONNECT lands.
+
+## Replica routing
+
+The service deliberately does not announce both processes under the singleton
+`inference` Discovery key: current Discovery replaces duplicate
+`(service-name, socket-kind)` endpoints and cannot represent a two-member pool.
+Metal #1309 must place both named backends behind one canonical
+network-addressable inference route and remove an unhealthy/draining member
+there. Discovery multi-endpoint routing remains follow-up work; deploying two
+processes alone does not create an in-process load-balancing pool.
+
+The initial authenticated RPC may be load-balanced. Its returned
+`StreamInfo.announcedAt` is a second-hop, replica-pinned address and must remain
+sticky to the exact replica that created `broadcastPath`; never round-robin
+that address to the sibling, whose isolated origin does not contain the
+broadcast.
+
+## Readiness, health, and termination
+
+- Readiness is late: the factory verifies the immutable OID before launch; the
+  service signals ready only after CPU model/weights load, RPC bind, and QUIC
+  `/moq` bind.
+- The authoritative health probe is authenticated inference `isReady` followed
+  by `healthCheck`; success requires `modelLoaded=true` and `status="ok"`.
+  Socket existence or a running container is only liveness, not readiness.
+- Before SIGTERM, stop routing new RPCs to the replica and allow a best-effort
+  completion window. Transport shutdown drains RPC/QUIC connections, but
+  detached generation continuations are not counted, cancelled, or awaited;
+  active generation completion is not guaranteed. Process exit is the unload
+  boundary and drops the engine and KV cache. Configure `Restart=on-failure`.
+- New stream admission during the external drain window is a metal/router
+  concern until an explicit capacity/drain RPC lands.
+
+## Fail-closed limitations
+
+Partial transformer ranges `[a,b)` are rejected at startup. The real subset
+loader and range-aware forward path are tracked by #314; a whole-model process
+must not be labeled as a partial pipeline stage.
+
+The backend publisher currently supports the classical ephemeral-DH
+`generateStream` setup. A production browser subscriber, hybrid-KEM browser
+support, authenticated MoQ admission, remote cancellation, enforced
+per-process admission/KV budgets, Discovery multi-endpoint routing, and an
+explicit generation-aware drain/capacity RPC are follow-up acceptance work.


### PR DESCRIPTION
## Scope

Adds the network-addressable, CPU-forced inference backend increment for #1236 and #1247:

- standalone inference factory with immutable model OID verification
- replica-specific engine, IPC socket, QUIC endpoint, and scoped MoQ origin
- generateStream RPC plus signed replica-pinned StreamInfo reach
- ModelService stream-plane reach/origin propagation
- network-aware readiness, health, drain admission, and shutdown state
- exact two-process metal handoff contract

This is an increment toward #1236/#1247, not issue closure. Remaining acceptance gaps are documented: #314 partial range execution, production browser subscriber/E2E, authenticated MoQ CONNECT, enforced admission/KV budgets, generation-aware cancellation/drain, and live two-process reachability.

## Metal contract

See docs/deployment/cpu-inference-service.md. The normal multi-arch CPU publisher supplies linux/amd64 and linux/arm64 from the merged main revision; no new Containerfile or OCI stack is introduced.

## Validation

- cargo test -p hyprstream --lib standalone_inference
- cargo test -p hyprstream --lib tenant_binding_tests::
- cargo test -p hyprstream-rpc --lib stream_channel_uses_service_scoped_moq_origin
- repository pre-commit release clippy hook
- independent adversarial review: no remaining code blocker for this narrow increment
