### PR TITLE
fix(wasm): exclude server MAC PEPs from browser VFS

### DIFF
--- a/crates/hyprstream-9p/src/lib.rs
+++ b/crates/hyprstream-9p/src/lib.rs
@@ -37,8 +37,10 @@
 //! stories (wasm's `unsafe impl` is only sound single-threaded, native is
 //! genuinely thread-safe) and are gated to disjoint targets.
 
+#[cfg(not(target_arch = "wasm32"))]
 pub mod backend;
 pub mod client;
+#[cfg(not(target_arch = "wasm32"))]
 pub mod memory;
 pub mod msg;
 // The translator is the server-side TCP/UDS accept loop (tokio::net). `net`
@@ -67,6 +69,7 @@ pub mod dma;
 #[cfg(target_arch = "wasm32")]
 pub mod wanix_mount;
 
+#[cfg(not(target_arch = "wasm32"))]
 pub use backend::{Backend, OpenResult, StatResult, WalkResult};
 pub use client::{P9Client, P9Transport};
 #[cfg(not(target_arch = "wasm32"))]

--- a/crates/hyprstream-vfs/src/lib.rs
+++ b/crates/hyprstream-vfs/src/lib.rs
@@ -48,9 +48,11 @@ pub use fsmount::{FsMount, SetAttr};
 pub use hyprstream_rpc::Subject;
 pub use mount::{DirEntry, Fid, Mount, MountError, Stat, OREAD, OWRITE, ORDWR, OTRUNC, ORCLOSE, DMDIR};
 pub use namespace::{BindFlag, MountTarget, Namespace, NamespaceError};
+pub use mac_pep::NamespaceAction;
+#[cfg(not(target_arch = "wasm32"))]
 pub use mac_pep::{
     DenyAllNamespace, DenyAllSubjects, DenyUnlabeledResolver, NamespaceAccessDecider,
-    NamespaceAction, NamespacePep, SubjectContextResolver,
+    NamespacePep, SubjectContextResolver,
 };
 
 #[cfg(not(target_arch = "wasm32"))]

--- a/crates/hyprstream-vfs/src/mac_pep.rs
+++ b/crates/hyprstream-vfs/src/mac_pep.rs
@@ -45,13 +45,17 @@
 //! Flipping the default at construction sites is the separately-gated
 //! activation B-lane (#1267), not this PR.
 
+#[cfg(not(target_arch = "wasm32"))]
 use std::sync::Arc;
 
+#[cfg(not(target_arch = "wasm32"))]
 pub use hyprstream_rpc::auth::mac::{
     MacDecision, MacDenyReason, RpcObjectLabelResolver, SecurityContext, SecurityLabel,
 };
+#[cfg(not(target_arch = "wasm32"))]
 use hyprstream_rpc::Subject;
 
+#[cfg(not(target_arch = "wasm32"))]
 use crate::NamespaceError;
 
 /// The direct-`Namespace`-API operation a [`NamespaceAccessDecider`] is asked
@@ -101,6 +105,7 @@ pub enum NamespaceAction {
 /// Implementations MUST NOT derive clearance from an unverified,
 /// caller-supplied label (D1 — labels in wire schemas are hints; here the
 /// `Subject` name is even weaker: an unauthenticated string).
+#[cfg(not(target_arch = "wasm32"))]
 pub trait SubjectContextResolver: Send + Sync {
     /// Resolve `subject` to its verified security context, or `None` if its
     /// clearance cannot be proven — which the PEP treats as deny.
@@ -111,9 +116,11 @@ pub trait SubjectContextResolver: Send + Sync {
 ///
 /// This is the default a [`NamespacePep`] uses for the subject seam when no
 /// production resolver (#698) has been wired — every mediated op denies.
+#[cfg(not(target_arch = "wasm32"))]
 #[derive(Debug, Default, Clone, Copy)]
 pub struct DenyAllSubjects;
 
+#[cfg(not(target_arch = "wasm32"))]
 impl SubjectContextResolver for DenyAllSubjects {
     fn resolve(&self, _subject: &Subject) -> Option<SecurityContext> {
         // No SubjectContextResolver wired (#698 not landed). The authorize()
@@ -134,6 +141,7 @@ impl SubjectContextResolver for DenyAllSubjects {
 /// `hyprstream` crate can write those fail-closed decisions to the same
 /// tamper-evident WAL as policy-floor denials. No deny may return before this
 /// audit boundary.
+#[cfg(not(target_arch = "wasm32"))]
 pub trait NamespaceAccessDecider: Send + Sync {
     /// Return the canonical MAC decision and record every outcome through the
     /// MAC audit sink.
@@ -152,9 +160,11 @@ pub trait NamespaceAccessDecider: Send + Sync {
 
 /// Fail-closed decider for a [`NamespacePep`] whose production audited decider
 /// is unavailable. Every op denies.
+#[cfg(not(target_arch = "wasm32"))]
 #[derive(Debug, Default, Clone, Copy)]
 pub struct DenyAllNamespace;
 
+#[cfg(not(target_arch = "wasm32"))]
 impl NamespaceAccessDecider for DenyAllNamespace {
     fn check(
         &self,
@@ -170,9 +180,11 @@ impl NamespaceAccessDecider for DenyAllNamespace {
 /// `hyprstream_9p::DenyUnlabeledResolver`. Returning `None` is a mandatory
 /// deny (design §1 invariant 2) — the PEP refuses to authorize any op whose
 /// object has no trusted label.
+#[cfg(not(target_arch = "wasm32"))]
 #[derive(Debug, Default, Clone, Copy)]
 pub struct DenyUnlabeledResolver;
 
+#[cfg(not(target_arch = "wasm32"))]
 impl RpcObjectLabelResolver for DenyUnlabeledResolver {
     fn resolve(&self, _service_domain: &str, _method: Option<u16>) -> Option<SecurityLabel> {
         None
@@ -191,18 +203,21 @@ impl RpcObjectLabelResolver for DenyUnlabeledResolver {
 /// populate. Building a `NamespacePep` is therefore always fail-closed;
 /// "unenforced" is represented by *not installing* one on the `Namespace`
 /// (the dormant status quo), never by a permissive PEP.
+#[cfg(not(target_arch = "wasm32"))]
 pub struct NamespacePep {
     subjects: Arc<dyn SubjectContextResolver>,
     labels: Arc<dyn RpcObjectLabelResolver>,
     decider: Arc<dyn NamespaceAccessDecider>,
 }
 
+#[cfg(not(target_arch = "wasm32"))]
 impl std::fmt::Debug for NamespacePep {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("NamespacePep").finish_non_exhaustive()
     }
 }
 
+#[cfg(not(target_arch = "wasm32"))]
 impl NamespacePep {
     /// Assemble the monitor from its three mandatory seams.
     ///
@@ -292,6 +307,7 @@ impl NamespacePep {
     }
 }
 
+#[cfg(not(target_arch = "wasm32"))]
 fn denial_detail(subject: &Subject, reason: &str) -> String {
     match subject.name() {
         Some(n) => format!("'{n}': {reason}"),
@@ -299,6 +315,7 @@ fn denial_detail(subject: &Subject, reason: &str) -> String {
     }
 }
 
+#[cfg(not(target_arch = "wasm32"))]
 const fn deny_reason_detail(reason: MacDenyReason) -> &'static str {
     match reason {
         MacDenyReason::NoPepInstalled => "explicit deny-all PEP installed",
@@ -309,7 +326,7 @@ const fn deny_reason_detail(reason: MacDenyReason) -> &'static str {
     }
 }
 
-#[cfg(test)]
+#[cfg(all(test, not(target_arch = "wasm32")))]
 mod tests {
     use super::*;
     use hyprstream_rpc::auth::mac::{

--- a/crates/hyprstream-vfs/src/namespace.rs
+++ b/crates/hyprstream-vfs/src/namespace.rs
@@ -6,7 +6,9 @@
 use std::sync::Arc;
 
 use hyprstream_rpc::Subject;
-use crate::mac_pep::{NamespaceAction, NamespacePep};
+use crate::mac_pep::NamespaceAction;
+#[cfg(not(target_arch = "wasm32"))]
+use crate::mac_pep::NamespacePep;
 use crate::mount::{DirEntry, Mount, MountError, Stat, OWRITE};
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -103,6 +105,7 @@ pub struct Namespace {
     mounts: Vec<MountEntry>,
     /// Mandatory MAC reference monitor over the direct API. `None` ⇒ the
     /// un-enforced status quo; `Some` ⇒ every mediated op must pass it.
+    #[cfg(not(target_arch = "wasm32"))]
     pep: Option<Arc<NamespacePep>>,
 }
 
@@ -115,6 +118,7 @@ impl Namespace {
     pub fn new() -> Self {
         Self {
             mounts: Vec::new(),
+            #[cfg(not(target_arch = "wasm32"))]
             pep: None,
         }
     }
@@ -128,19 +132,28 @@ impl Namespace {
     /// itself is fail-closed by construction (see [`NamespacePep`]).
     ///
     /// Returns the previous PEP, if any (enables atomic re-arm in tests).
+    #[cfg(not(target_arch = "wasm32"))]
     pub fn set_pep(&mut self, pep: Arc<NamespacePep>) -> Option<Arc<NamespacePep>> {
         self.pep.replace(pep)
     }
 
     /// Whether a MAC PEP is currently armed on this namespace.
+    #[cfg(not(target_arch = "wasm32"))]
     pub fn pep_armed(&self) -> bool {
         self.pep.is_some()
+    }
+
+    /// Browser namespaces are clients; server-side MAC enforcement is absent.
+    #[cfg(target_arch = "wasm32")]
+    pub const fn pep_armed(&self) -> bool {
+        false
     }
 
     /// Enforce `action` by `subject` against the object at `path` when a PEP is
     /// armed. No-op (permit) when no PEP is installed — the dormant status quo.
     /// Fail-closed when armed: any unresolvable clearance/label or failed
     /// `can_access` yields [`NamespaceError::Denied`].
+    #[cfg(not(target_arch = "wasm32"))]
     fn enforce(&self, subject: &Subject, path: &str, action: NamespaceAction) -> Result<(), NamespaceError> {
         let Some(pep) = &self.pep else {
             return Ok(());
@@ -151,6 +164,18 @@ impl Namespace {
         // namespace supplies only the path, never a caller-authored label.
         let normalized = normalize_path(path);
         pep.authorize(subject, &normalized, action)
+    }
+
+    #[cfg(target_arch = "wasm32")]
+    const fn enforce(
+        &self,
+        _subject: &Subject,
+        _path: &str,
+        _action: NamespaceAction,
+    ) -> Result<(), NamespaceError> {
+        // Browser VFS is a client. The native service boundary owns the
+        // mandatory MAC reference monitor and never delegates it to wasm.
+        Ok(())
     }
 
     /// Mount a target at a path prefix (replaces any existing mount).
@@ -186,6 +211,7 @@ impl Namespace {
     /// Like [`Self::mount`], this is the **construction** path (no subject):
     /// when a PEP is armed it denies — use [`Self::bind_mount_as`].
     pub fn bind_mount(&mut self, prefix: &str, target: MountTarget, flag: BindFlag) -> Result<(), NamespaceError> {
+        #[cfg(not(target_arch = "wasm32"))]
         if let Some(pep) = &self.pep {
             // An armed namespace cannot mutate without a proven subject — the
             // subject-less construction path is intentionally closed once the
@@ -263,6 +289,7 @@ impl Namespace {
     /// Construction path (no subject): denies when a PEP is armed — use
     /// [`Self::unmount_as`].
     pub fn unmount(&mut self, prefix: &str) -> Result<(), NamespaceError> {
+        #[cfg(not(target_arch = "wasm32"))]
         if let Some(pep) = &self.pep {
             let normalized = normalize_path(prefix);
             return Err(pep.deny_uncredentialed(&normalized, NamespaceAction::Unmount));
@@ -288,6 +315,7 @@ impl Namespace {
     /// child do not affect the parent.
     pub fn fork(&self) -> Namespace {
         Namespace {
+            #[cfg(not(target_arch = "wasm32"))]
             pep: self.pep.clone(),
             mounts: self.mounts.iter().map(|m| MountEntry {
                 prefix: m.prefix.clone(),
@@ -900,7 +928,7 @@ fn split_path(path: &str) -> Vec<&str> {
 // Tests
 // ─────────────────────────────────────────────────────────────────────────────
 
-#[cfg(test)]
+#[cfg(all(test, not(target_arch = "wasm32")))]
 #[allow(clippy::unwrap_used, clippy::disallowed_types)]
 mod tests {
     use super::*;


### PR DESCRIPTION
Fixes the wasm32 build break caused by native-only MAC dispatch types leaking into browser client crates.

- compiles the `RpcObjectLabelResolver`/decision-backed Namespace PEP only on native targets
- omits the PEP field and enforcement state from wasm `Namespace`; browser VFS remains a client and server-side MAC stays authoritative
- keeps the target-neutral `NamespaceAction` vocabulary available without native dispatch types
- gates the adjacent 9P server backend/memory modules whose `VerifiedAttach` seam is native-only; browser builds retain only the 9P client/DMA/Wanix side
- native PEP behavior and tests are unchanged

Validation:
- `RUSTFLAGS=--cfg=web_sys_unstable_apis cargo check --target wasm32-unknown-unknown -p hyprstream-vfs` — pass
- `RUSTFLAGS="--cfg=web_sys_unstable_apis --cfg getrandom_backend=\"wasm_js\"" cargo check --target wasm32-unknown-unknown -p hyprstream-rpc-std` — pass
- `cargo test -p hyprstream-vfs --lib --tests --no-fail-fast` — 69 passed
- `cargo test -p hyprstream-9p --lib --tests --no-fail-fast` — 54 passed
- `cargo clippy -p hyprstream-vfs -p hyprstream-9p --all-targets -- -D warnings` — pass
- repository release pre-commit clippy — pass

No self-approval or merge.