### PR TITLE
ci: gate the full browser WASM surface

### DIFF
--- a/.github/scripts/browser-wasm-check.sh
+++ b/.github/scripts/browser-wasm-check.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+# Compile the complete Rust surface consumed by www's browser WASM build.
+#
+# Keep this as the single source of truth for both the fast PR WASM job and the
+# required merge-group build. scripts/build-wasm.sh in www uses wasm-pack for
+# hyprstream-rpc and hyprstream-rpc-std; rpc-std currently pulls in
+# hyprstream-vfs transitively. All three packages remain explicit here so a
+# future dependency refactor cannot silently remove VFS from the required gate.
+set -euo pipefail
+
+append_rustflag() {
+  local flag="$1"
+  if [[ " ${RUSTFLAGS:-} " != *" ${flag} "* ]]; then
+    RUSTFLAGS="${RUSTFLAGS:+${RUSTFLAGS} }${flag}"
+  fi
+}
+
+# Match www/scripts/build-wasm.sh. WebTransport needs the unstable web-sys API
+# cfg, while moq-net's rand/getrandom 0.3 graph needs the browser WebCrypto
+# backend selected explicitly.
+append_rustflag '--cfg=web_sys_unstable_apis'
+append_rustflag '--cfg=getrandom_backend="wasm_js"'
+export RUSTFLAGS
+
+readonly -a BROWSER_WASM_PACKAGES=(
+  hyprstream-rpc
+  hyprstream-vfs
+  hyprstream-rpc-std
+)
+
+package_args=()
+for package in "${BROWSER_WASM_PACKAGES[@]}"; do
+  package_args+=( -p "$package" )
+done
+
+cargo check --locked \
+  --target wasm32-unknown-unknown \
+  "${package_args[@]}"

--- a/.github/scripts/graviton-build-test.sh
+++ b/.github/scripts/graviton-build-test.sh
@@ -42,11 +42,10 @@ run_phase() {
 }
 
 # Fail fast on browser-only composition regressions in the required merge-gate
-# job. Keep the WebTransport cfg scoped to this command so it cannot leak into
-# the native release/test phases below. This reuses the same checkout, target,
-# sccache process, and container instead of consuming another runner slot.
-run_phase "browser WASM check" env RUSTFLAGS=--cfg=web_sys_unstable_apis \
-  cargo check --target wasm32-unknown-unknown -p hyprstream-rpc
+# job. The child script scopes both browser cfgs to its own process so they
+# cannot leak into native release/test phases below. It checks the exact
+# browser-facing rpc + vfs + rpc-std package set used by www.
+run_phase "browser WASM check" bash .github/scripts/browser-wasm-check.sh
 
 # Default features (parity with the former x86 gate); libtorch is the image's
 # aarch64 wheel at /opt/libtorch, so NO download-libtorch feature here.

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -132,6 +132,7 @@ jobs:
       # NOT add `|| true`.
       run: |
         python3 scripts/check_rust_workflow_matrix.py
+        python3 scripts/check_browser_wasm_gate.py
 
   loopback-burndown:
     name: Loopback-literal burn-down (#1152 W4)
@@ -180,9 +181,10 @@ jobs:
     - name: Pull builder image
       run: podman pull "$BUILDER_IMAGE"
 
-    # Guards the browser/WebTransport build (#225/#226): getrandom wasm_js (Cargo.toml) +
-    # the web_sys_unstable_apis rustflag for WebTransport. Catches wasm-only breakage the
-    # native clippy/build jobs miss (e.g. the PQ-crypto getrandom regression).
+    # Guards the complete browser-facing Rust surface consumed by www:
+    # hyprstream-rpc, hyprstream-vfs, and hyprstream-rpc-std. The shared script
+    # carries the exact web-sys/getrandom cfgs and is also invoked by the required
+    # merge-group build, preventing the two gates from drifting apart.
     - name: Check wasm32 browser build (in rust-builder container)
       run: |
         podman run --rm \
@@ -191,10 +193,9 @@ jobs:
           -e AWS_ACCESS_KEY_ID -e AWS_SECRET_ACCESS_KEY -e AWS_SESSION_TOKEN \
           -e AWS_REGION -e AWS_DEFAULT_REGION \
           -e CARGO_INCREMENTAL=0 -e CARGO_TERM_COLOR=always \
-          -e RUSTFLAGS='--cfg=web_sys_unstable_apis' \
           "$BUILDER_IMAGE" \
           bash -euo pipefail -c '
-            cargo check --target wasm32-unknown-unknown -p hyprstream-rpc
+            bash /build/.github/scripts/browser-wasm-check.sh
             sccache --show-stats
           '
 

--- a/scripts/check_browser_wasm_gate.py
+++ b/scripts/check_browser_wasm_gate.py
@@ -1,0 +1,197 @@
+#!/usr/bin/env python3
+"""Fail-closed static regression for the browser-WASM CI coverage contract.
+
+The browser gate used to check only hyprstream-rpc. www's real browser build
+also compiles hyprstream-rpc-std and hyprstream-vfs, so VFS-only wasm32
+regressions could pass both PR checks and the required merge-group job.
+
+This zero-build check locks one shared script into both CI paths and proves that
+the script retains the complete package set, target, and browser-only cfgs.
+"""
+
+from __future__ import annotations
+
+import pathlib
+import re
+import sys
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+WORKFLOW = ROOT / ".github" / "workflows" / "rust.yml"
+MERGE_DRIVER = ROOT / ".github" / "scripts" / "graviton-build-test.sh"
+WASM_CHECK = ROOT / ".github" / "scripts" / "browser-wasm-check.sh"
+
+EXPECTED_PACKAGES = {
+    "hyprstream-rpc",
+    "hyprstream-vfs",
+    "hyprstream-rpc-std",
+}
+EXPECTED_CFGS = {
+    "--cfg=web_sys_unstable_apis",
+    '--cfg=getrandom_backend="wasm_js"',
+}
+WORKFLOW_INVOCATION = "bash /build/.github/scripts/browser-wasm-check.sh"
+MERGE_DRIVER_WORKFLOW_INVOCATION = (
+    "runuser -u ci -- bash -euo pipefail "
+    "/build/.github/scripts/graviton-build-test.sh"
+)
+MERGE_INVOCATION = "bash .github/scripts/browser-wasm-check.sh"
+
+
+def _assert(condition: bool, message: str) -> None:
+    if not condition:
+        raise AssertionError(message)
+
+
+def _package_set(script: str) -> set[str]:
+    match = re.search(
+        r"readonly -a BROWSER_WASM_PACKAGES=\(\n(?P<body>.*?)\n\)",
+        script,
+        flags=re.DOTALL,
+    )
+    _assert(match is not None, "browser check package array is missing or malformed")
+    assert match is not None
+    return {
+        line.strip()
+        for line in match.group("body").splitlines()
+        if line.strip() and not line.lstrip().startswith("#")
+    }
+
+
+def _cfg_set(script: str) -> set[str]:
+    return set(re.findall(r"^append_rustflag '([^']+)'$", script, flags=re.MULTILINE))
+
+
+def check(workflow: str, merge_driver: str, wasm_check: str) -> None:
+    _assert(
+        workflow.count(WORKFLOW_INVOCATION) == 1,
+        "rust.yml fast PR WASM job must invoke the shared browser check exactly once",
+    )
+    _assert(
+        workflow.count(MERGE_DRIVER_WORKFLOW_INVOCATION) == 1,
+        "rust.yml required build must invoke the merge driver exactly once",
+    )
+    _assert(
+        merge_driver.count(MERGE_INVOCATION) == 1,
+        "required merge driver must invoke the shared browser check exactly once",
+    )
+    packages = _package_set(wasm_check)
+    _assert(
+        packages == EXPECTED_PACKAGES,
+        "browser check packages must be exactly "
+        f"{sorted(EXPECTED_PACKAGES)}; got {sorted(packages)}",
+    )
+    cfgs = _cfg_set(wasm_check)
+    _assert(
+        cfgs == EXPECTED_CFGS,
+        "browser check cfgs must be exactly "
+        f"{sorted(EXPECTED_CFGS)}; got {sorted(cfgs)}",
+    )
+    _assert(
+        wasm_check.count("--target wasm32-unknown-unknown") == 1,
+        "browser check must target wasm32-unknown-unknown exactly once",
+    )
+    _assert(
+        wasm_check.count("cargo check --locked") == 1,
+        "browser check must use one locked cargo check",
+    )
+
+
+def mutations(
+    workflow: str, merge_driver: str, wasm_check: str
+) -> list[tuple[str, str, str, str]]:
+    cases = [
+        (
+            "remove PR invocation",
+            workflow.replace(WORKFLOW_INVOCATION, "true", 1),
+            merge_driver,
+            wasm_check,
+        ),
+        (
+            "remove merge invocation",
+            workflow,
+            merge_driver.replace(MERGE_INVOCATION, "true", 1),
+            wasm_check,
+        ),
+        (
+            "disconnect merge driver from required workflow",
+            workflow.replace(MERGE_DRIVER_WORKFLOW_INVOCATION, "true", 1),
+            merge_driver,
+            wasm_check,
+        ),
+        (
+            "change wasm target",
+            workflow,
+            merge_driver,
+            wasm_check.replace(
+                "--target wasm32-unknown-unknown",
+                "--target wasm32-wasip1",
+                1,
+            ),
+        ),
+        (
+            "drop web-sys cfg",
+            workflow,
+            merge_driver,
+            wasm_check.replace(
+                "append_rustflag '--cfg=web_sys_unstable_apis'\n",
+                "",
+                1,
+            ),
+        ),
+        (
+            "drop getrandom cfg",
+            workflow,
+            merge_driver,
+            wasm_check.replace(
+                "append_rustflag '--cfg=getrandom_backend=\"wasm_js\"'\n",
+                "",
+                1,
+            ),
+        ),
+    ]
+    for package in sorted(EXPECTED_PACKAGES):
+        cases.append(
+            (
+                f"drop package {package}",
+                workflow,
+                merge_driver,
+                wasm_check.replace(f"  {package}\n", "", 1),
+            )
+        )
+    return cases
+
+
+def main() -> int:
+    workflow = WORKFLOW.read_text()
+    merge_driver = MERGE_DRIVER.read_text()
+    wasm_check = WASM_CHECK.read_text()
+
+    try:
+        check(workflow, merge_driver, wasm_check)
+    except AssertionError as error:
+        print(f"browser-WASM gate regression FAILED: {error}", file=sys.stderr)
+        return 1
+
+    cases = mutations(workflow, merge_driver, wasm_check)
+    escaped: list[str] = []
+    for label, mutated_workflow, mutated_driver, mutated_check in cases:
+        try:
+            check(mutated_workflow, mutated_driver, mutated_check)
+        except AssertionError:
+            continue
+        escaped.append(label)
+
+    if escaped:
+        print(
+            "browser-WASM gate self-test FAILED; mutations escaped: "
+            + ", ".join(escaped),
+            file=sys.stderr,
+        )
+        return 1
+
+    print(f"browser-WASM gate regression: OK ({len(cases)} negative mutations)")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/check_browser_wasm_gate.py
+++ b/scripts/check_browser_wasm_gate.py
@@ -35,6 +35,26 @@ MERGE_DRIVER_WORKFLOW_INVOCATION = (
     "/build/.github/scripts/graviton-build-test.sh"
 )
 MERGE_INVOCATION = "bash .github/scripts/browser-wasm-check.sh"
+EXPECTED_EXECUTION_TAIL = """\
+append_rustflag '--cfg=web_sys_unstable_apis'
+append_rustflag '--cfg=getrandom_backend="wasm_js"'
+export RUSTFLAGS
+
+readonly -a BROWSER_WASM_PACKAGES=(
+  hyprstream-rpc
+  hyprstream-vfs
+  hyprstream-rpc-std
+)
+
+package_args=()
+for package in "${BROWSER_WASM_PACKAGES[@]}"; do
+  package_args+=( -p "$package" )
+done
+
+cargo check --locked \\
+  --target wasm32-unknown-unknown \\
+  "${package_args[@]}"
+"""
 
 
 def _assert(condition: bool, message: str) -> None:
@@ -94,6 +114,11 @@ def check(workflow: str, merge_driver: str, wasm_check: str) -> None:
         wasm_check.count("cargo check --locked") == 1,
         "browser check must use one locked cargo check",
     )
+    _assert(
+        wasm_check.count(EXPECTED_EXECUTION_TAIL) == 1,
+        "browser cfgs, package array/loop, target, and Cargo arguments must remain "
+        "one directly connected execution chain",
+    )
 
 
 def mutations(
@@ -147,6 +172,32 @@ def mutations(
                 "",
                 1,
             ),
+        ),
+        (
+            "disconnect package args from cargo",
+            workflow,
+            merge_driver,
+            wasm_check.replace(
+                '"${package_args[@]}"',
+                "-p hyprstream-rpc",
+                1,
+            ),
+        ),
+        (
+            "disconnect package array from args",
+            workflow,
+            merge_driver,
+            wasm_check.replace(
+                '  package_args+=( -p "$package" )',
+                "  :",
+                1,
+            ),
+        ),
+        (
+            "stop exporting browser cfgs",
+            workflow,
+            merge_driver,
+            wasm_check.replace("export RUSTFLAGS", ": # RUSTFLAGS not exported", 1),
         ),
     ]
     for package in sorted(EXPECTED_PACKAGES):


### PR DESCRIPTION
## Summary

- replace the rpc-only WASM preflight with one shared browser-WASM check for `hyprstream-rpc`, `hyprstream-vfs`, and `hyprstream-rpc-std`
- run the same script in both the fast PR workflow and the required merge-group build driver
- use the exact browser cfgs consumed downstream: `web_sys_unstable_apis` and `getrandom_backend="wasm_js"`
- add a static contract test with nine negative mutations so package, target, cfg, or invocation drift fails CI

## Why

The required gate added for #1336 covered only `hyprstream-rpc`. That allowed the `hyprstream-vfs` wasm32 E0432 fixed by #1357 to reach main even though it broke the browser-facing surface consumed by www. This PR closes that recurring-regression class across all three browser crates.

## Validation

- before #1357: the expanded gate reproduced E0432 in `crates/hyprstream-vfs/src/mac_pep.rs`
- composed with #1357 before merge: PASS in 9.57s
- rebased onto #1357 merge commit `bc0f4d454`: PASS in 9.54s
- `python3 scripts/check_browser_wasm_gate.py`: PASS, 9 negative mutations
- `python3 scripts/check_rust_workflow_matrix.py`: PASS, 11 negative mutations
- shell syntax and `git diff --check`: PASS

Systemic follow-up to #1336 and #1357.