### PR TITLE
ci: publish immutable CPU indexes for every revision

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -346,35 +346,40 @@ jobs:
       run: |
         set -euo pipefail
         if [ "$GITHUB_REF" != "refs/heads/main" ]; then
-          echo "publish=true" >> "$GITHUB_OUTPUT"
+          echo "aliases=false" >> "$GITHUB_OUTPUT"
           exit 0
         fi
-        current_sha="$(
+        if ! current_sha="$(
           git ls-remote "https://github.com/${REPOSITORY}.git" refs/heads/main |
             awk 'NR == 1 { print $1 }'
-        )"
+        )"; then
+          echo "aliases=false" >> "$GITHUB_OUTPUT"
+          echo "::warning::could not resolve current main; publishing immutable index only"
+          exit 0
+        fi
         if [ "$current_sha" = "$EXPECTED_SHA" ]; then
-          echo "publish=true" >> "$GITHUB_OUTPUT"
+          echo "aliases=true" >> "$GITHUB_OUTPUT"
         else
-          echo "publish=false" >> "$GITHUB_OUTPUT"
+          echo "aliases=false" >> "$GITHUB_OUTPUT"
           echo "::notice::not moving canonical CPU tags: ${EXPECTED_SHA} is stale; main is ${current_sha}"
         fi
 
     - name: Extract CPU manifest tags
       id: meta
-      if: steps.freshness.outputs.publish == 'true'
       uses: docker/metadata-action@v5
       with:
         images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
         tags: |
+          # Every validated build gets an immutable, revision-qualified index.
+          type=raw,value=sha-${{ github.sha }},suffix=-cpu
           type=semver,pattern={{version}},suffix=-cpu
           type=semver,pattern={{major}}.{{minor}},suffix=-cpu
-          type=raw,value=edge,suffix=-cpu,enable=${{ github.ref == 'refs/heads/main' }}
-          type=raw,value=latest,suffix=-cpu,enable=${{ github.ref == 'refs/heads/main' }}
+          # Only the current main revision may move canonical aliases.
+          type=raw,value=edge,suffix=-cpu,enable=${{ github.ref == 'refs/heads/main' && steps.freshness.outputs.aliases == 'true' }}
+          type=raw,value=latest,suffix=-cpu,enable=${{ github.ref == 'refs/heads/main' && steps.freshness.outputs.aliases == 'true' }}
 
     - name: Publish multi-arch CPU manifests
       id: publish
-      if: steps.freshness.outputs.publish == 'true'
       env:
         TAGS: ${{ steps.meta.outputs.tags }}
         IMAGE: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
@@ -383,15 +388,16 @@ jobs:
         set -euo pipefail
         while IFS= read -r tag; do
           [ -n "$tag" ] || continue
+          metadata="$(mktemp)"
           docker buildx imagetools create \
+            --metadata-file "$metadata" \
             --tag "$tag" \
             "${IMAGE}:sha-${REVISION}-cpu-amd64" \
             "${IMAGE}:sha-${REVISION}-cpu-arm64"
           docker buildx imagetools inspect "$tag"
-          raw_manifest="$(mktemp)"
-          docker buildx imagetools inspect "$tag" --raw > "$raw_manifest"
-          digest="sha256:$(sha256sum "$raw_manifest" | awk '{ print $1 }')"
-          rm -f "$raw_manifest"
+          digest="$(jq -er '."containerimage.descriptor".digest' "$metadata")"
+          rm -f "$metadata"
+          docker buildx imagetools inspect "${IMAGE}@${digest}"
           echo "${tag}@${digest}" | tee -a "$GITHUB_STEP_SUMMARY"
           echo "digest=${digest}" >> "$GITHUB_OUTPUT"
         done <<< "$TAGS"


### PR DESCRIPTION
## Summary

- always publish a revision-qualified multi-arch `sha-<full-revision>-cpu` index from the exact amd64/arm64 staging manifests
- use freshness only to decide whether a main run may also move `edge-cpu` / `latest-cpu`; transient lookup failure safely disables aliases without suppressing the immutable index
- take the authoritative index digest from `docker buildx imagetools create --metadata-file` and verify the digest-addressed index

## Why

#1358 repaired the normal main-push publisher and exact-SHA platform staging. Under continuous merge traffic, however, a validated run can become stale while the hour-long image matrix runs. Metal #32 still needs an immutable multi-arch index for that exact validated revision even when moving aliases must not be updated.

This remains the existing Dockerfile, GHCR repository, native amd64/arm64 jobs, and canonical publisher—no new image stack.

## Validation / review

- `actionlint` v1.7.7
- repository release-clippy pre-commit hook
- `git diff --check`
- independent adversarial review: **no blocker**; main/stale/release tag matrix, freshness failure behavior, Buildx descriptor digest extraction, and digest-addressed verification checked
