### PR TITLE
OAuth-AS cold signup for hosted accounts

### DIFF
--- a/crates/hyprstream-pds-service/src/hosted_account_mint.rs
+++ b/crates/hyprstream-pds-service/src/hosted_account_mint.rs
@@ -112,6 +112,18 @@ impl AuthorityHostedAccountBinding {
 /// Deployment authority that allocates local tenant bindings.
 pub trait HostedAccountAuthority: Send + Sync {
     fn allocate(&self, requested_handle: &str) -> Result<AuthorityHostedAccountBinding>;
+
+    /// Allocate or resume the authority reservation for one authenticated
+    /// transaction. Production implementations bind the permanent label to
+    /// this idempotency key; the default preserves existing test/fake
+    /// authorities while still keeping the client out of tenant/DID choice.
+    fn allocate_for_transaction(
+        &self,
+        requested_handle: &str,
+        _transaction_id: &str,
+    ) -> Result<AuthorityHostedAccountBinding> {
+        self.allocate(requested_handle)
+    }
 }
 
 /// Request-scoped signer for the user-held priority-zero Hybrid rotation key.
@@ -145,6 +157,7 @@ pub struct HostedPdsAccountPublication<'a> {
     tenant: &'a str,
     account: &'a SealedHostedAccount,
     repo: &'a HostedRepoGenesis,
+    transaction_id: Option<&'a str>,
 }
 
 impl HostedPdsAccountPublication<'_> {
@@ -166,6 +179,13 @@ impl HostedPdsAccountPublication<'_> {
     #[must_use]
     pub fn repo(&self) -> &HostedRepoGenesis {
         self.repo
+    }
+
+    /// Authenticated idempotency identity for OAuth cold signup. Manual
+    /// registrations have no transaction identity and remain one-shot.
+    #[must_use]
+    pub fn transaction_id(&self) -> Option<&str> {
+        self.transaction_id
     }
 
     /// Exact bytes served at [`DID_DOCUMENT_PATH`].
@@ -214,6 +234,30 @@ impl HostedPdsAccountMinter {
         request: &HostedAccountRegistrationRequest,
         signer: &dyn HostedAccountGenesisSigner,
     ) -> Result<HostedAccountRegistrationResult> {
+        self.mint_inner(request, signer, None)
+    }
+
+    /// Mint or idempotently resume a cold-signup generation bound to the
+    /// already-verified vault-key fingerprint.
+    pub fn mint_for_transaction(
+        &self,
+        request: &HostedAccountRegistrationRequest,
+        signer: &dyn HostedAccountGenesisSigner,
+        transaction_id: &str,
+    ) -> Result<HostedAccountRegistrationResult> {
+        ensure!(
+            !transaction_id.is_empty(),
+            "hosted-account mint transaction id must not be empty"
+        );
+        self.mint_inner(request, signer, Some(transaction_id))
+    }
+
+    fn mint_inner(
+        &self,
+        request: &HostedAccountRegistrationRequest,
+        signer: &dyn HostedAccountGenesisSigner,
+        transaction_id: Option<&str>,
+    ) -> Result<HostedAccountRegistrationResult> {
         ensure!(
             !request.handle.is_empty(),
             "hosted account handle must not be empty"
@@ -231,10 +275,13 @@ impl HostedPdsAccountMinter {
             "live hosted-PDS QUIC discovery is incomplete"
         );
 
-        let binding = self
-            .authority
-            .allocate(&request.handle)
-            .context("hosted-account authority allocation failed")?;
+        let binding = match transaction_id {
+            Some(transaction_id) => self
+                .authority
+                .allocate_for_transaction(&request.handle, transaction_id),
+            None => self.authority.allocate(&request.handle),
+        }
+        .context("hosted-account authority allocation failed")?;
         ensure!(
             binding.name.label() == request.handle,
             "authority allocation does not match the requested handle"
@@ -268,6 +315,7 @@ impl HostedPdsAccountMinter {
                 tenant: binding.tenant(),
                 account: &account,
                 repo: &repo,
+                transaction_id,
             })
             .context("hosted PDS account publication failed")?;
 

--- a/crates/hyprstream/Cargo.toml
+++ b/crates/hyprstream/Cargo.toml
@@ -145,7 +145,7 @@ libc = "0.2"  # For system calls in overlay2 driver
 reflink-copy = "0.1"  # COW file copying (reflink when available)
 hyprstream-containedfs.workspace = true  # Path-contained filesystem operations
 rocksdb = "0.23"  # User credential store (RocksDbUserStore)
-fred = { version = "9", optional = true }  # Async Redis/Valkey client (ValkeyUserStore, ValkeyTokenStore)
+fred = { version = "9", optional = true, features = ["i-scripts"] }  # Async Redis/Valkey client (ValkeyUserStore, ValkeyTokenStore)
 hyprstream-tui = { path = "../hyprstream-tui" }  # Setup wizard TUI (WizardBackend trait + WizardApp)
 hyprstream-compositor = { path = "../hyprstream-compositor" }  # Pure TUI compositor (chrome state machine)
 waxterm = { path = "../waxterm", features = ["avt"] }  # Terminal abstraction for TUI rendering

--- a/crates/hyprstream/src/auth/mod.rs
+++ b/crates/hyprstream/src/auth/mod.rs
@@ -40,7 +40,11 @@ pub use policy_manager::{
 };
 pub use policy_migration::migrate_policy_csv;
 pub use policy_templates::{PolicyTemplate, ServicePolicyRule, SERVICE_BASE_POLICIES, get_template, get_templates};
-pub use user_store::{DeviceRecord, DeviceStore, KeyAlgorithm, UserFilter, UserProfile, UserProfilePatch, UserStore, PubkeyEntry, pubkey_fingerprint, decode_pubkey_base64};
+pub use user_store::{
+    decode_pubkey_base64, pubkey_fingerprint, AccountKeyCustody, DeviceRecord, DeviceStore,
+    ExternalIdentityBinding, HostedAccountProvisionError, HostedAccountProvisioning, KeyAlgorithm,
+    PubkeyEntry, UserFilter, UserProfile, UserProfilePatch, UserStore,
+};
 pub use rocksdb_store::RocksDbUserStore;
 #[cfg(feature = "valkey")]
 pub use valkey::ValkeyUserStore;

--- a/crates/hyprstream/src/auth/rocksdb_store.rs
+++ b/crates/hyprstream/src/auth/rocksdb_store.rs
@@ -13,13 +13,19 @@ use anyhow::{anyhow, Context, Result};
 use async_trait::async_trait;
 use capnp::message::{Builder, ReaderOptions};
 use ed25519_dalek::VerifyingKey;
+use parking_lot::Mutex;
 use std::io::Cursor;
 use std::path::Path;
 
-use super::user_store::{pubkey_fingerprint, matches_filter, DeviceRecord, DeviceStore, KeyAlgorithm, PubkeyEntry, UserFilter, UserProfile, UserProfilePatch, UserStore};
+use super::user_store::{
+    matches_filter, pubkey_fingerprint, AccountKeyCustody, DeviceRecord, DeviceStore,
+    ExternalIdentityBinding, HostedAccountProvisionError, HostedAccountProvisioning, KeyAlgorithm,
+    PubkeyEntry, UserFilter, UserProfile, UserProfilePatch, UserStore,
+};
 
 const USER_PREFIX: &[u8] = b"user:";
 const PUBKEY_PREFIX: &[u8] = b"pubkey:";
+const ACCOUNT_AUTH_PREFIX: &[u8] = b"account-auth:";
 
 fn user_key(username: &str) -> Vec<u8> {
     let mut key = USER_PREFIX.to_vec();
@@ -33,13 +39,23 @@ fn pubkey_key(fingerprint: &str) -> Vec<u8> {
     key
 }
 
+fn account_auth_key(username: &str) -> Vec<u8> {
+    let mut key = ACCOUNT_AUTH_PREFIX.to_vec();
+    key.extend_from_slice(username.as_bytes());
+    key
+}
+
 fn strip_user_prefix(key: &[u8]) -> Option<&str> {
-    key.strip_prefix(USER_PREFIX).and_then(|s| std::str::from_utf8(s).ok())
+    key.strip_prefix(USER_PREFIX)
+        .and_then(|s| std::str::from_utf8(s).ok())
 }
 
 /// Helper text: reads a capnp Text field, returning None if not set or empty.
 fn text_or_none(reader: capnp::Result<capnp::text::Reader<'_>>) -> Option<String> {
-    reader.ok().filter(|t| !t.is_empty()).and_then(|t| t.to_string().ok())
+    reader
+        .ok()
+        .filter(|t| !t.is_empty())
+        .and_then(|t| t.to_string().ok())
 }
 
 /// Internal representation of a pubkey entry for serialization.
@@ -57,8 +73,24 @@ struct StoredPubkey {
     pq_pubkey: Option<Vec<u8>>,
 }
 
+/// Hosted-account authentication metadata is intentionally a separate record
+/// from the legacy Cap'n Proto user object. This is the persisted seam for
+/// custody flavor and 0..N external identities without widening control-plane
+/// RPC schema. Old accounts have no sidecar and deserialize to the defaults.
+#[derive(Debug, Default, serde::Serialize, serde::Deserialize)]
+struct StoredAccountAuth {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    key_custody: Option<AccountKeyCustody>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    external_identities: Vec<ExternalIdentityBinding>,
+}
+
 pub struct RocksDbUserStore {
     db: rocksdb::DB,
+    /// RocksDB permits only one process to hold the writer lock. This mutex
+    /// additionally serializes conditional user/key inserts inside that
+    /// process so the checks and write batch form one provisioning operation.
+    provisioning_lock: Mutex<()>,
 }
 
 impl RocksDbUserStore {
@@ -73,7 +105,10 @@ impl RocksDbUserStore {
         let db = rocksdb::DB::open(&opts, &db_path)
             .with_context(|| format!("Failed to open RocksDB at {:?}", db_path))?;
 
-        Ok(Self { db })
+        Ok(Self {
+            db,
+            provisioning_lock: Mutex::new(()),
+        })
     }
 
     /// Open the RocksDB user store in read-only mode.
@@ -89,7 +124,10 @@ impl RocksDbUserStore {
         let db = rocksdb::DB::open_for_read_only(&opts, &db_path, false)
             .with_context(|| format!("Failed to open RocksDB (read-only) at {:?}", db_path))?;
 
-        Ok(Self { db })
+        Ok(Self {
+            db,
+            provisioning_lock: Mutex::new(()),
+        })
     }
 
     /// Returns true if this store was opened under the write lock.
@@ -106,7 +144,11 @@ impl RocksDbUserStore {
 
     /// Serialize a `UserProfile` + pubkeys into Cap'n Proto `UserInfo` bytes with a 1-byte
     /// presence prefix for optional Bool fields.
-    fn serialize_profile(sub: &str, profile: &UserProfile, pubkeys: &[StoredPubkey]) -> Result<Vec<u8>> {
+    fn serialize_profile(
+        sub: &str,
+        profile: &UserProfile,
+        pubkeys: &[StoredPubkey],
+    ) -> Result<Vec<u8>> {
         let mut flags: u8 = 0;
         if profile.email_verified.is_some() {
             flags |= Self::FLAG_EMAIL_VERIFIED;
@@ -133,7 +175,6 @@ impl RocksDbUserStore {
             if let Some(ref did) = profile.atproto_did {
                 ui.set_atproto_did(did);
             }
-
             // Serialize pubkeys list
             let mut pk_list = ui.init_pubkeys(pubkeys.len() as u32);
             for (i, pk) in pubkeys.iter().enumerate() {
@@ -194,6 +235,8 @@ impl RocksDbUserStore {
             },
             external_id: text_or_none(ui.get_external_id()),
             atproto_did: text_or_none(ui.get_atproto_did()),
+            key_custody: None,
+            external_identities: Vec::new(),
         };
 
         // Deserialize pubkeys list
@@ -246,19 +289,43 @@ impl RocksDbUserStore {
         let key = user_key(username);
         match self.db.get(&key)? {
             Some(bytes) => {
-                let tuple = Self::deserialize_profile(&bytes)
+                let (sub, mut profile, pubkeys) = Self::deserialize_profile(&bytes)
                     .with_context(|| format!("Failed to deserialize profile for '{}'", username))?;
-                Ok(Some(tuple))
+                if let Some(metadata) = self.db.get(account_auth_key(username))? {
+                    let stored: StoredAccountAuth = serde_json::from_slice(&metadata)
+                        .with_context(|| {
+                            format!(
+                                "Failed to deserialize hosted-account auth metadata for '{}'",
+                                username
+                            )
+                        })?;
+                    profile.key_custody = stored.key_custody;
+                    profile.external_identities = stored.external_identities;
+                }
+                Ok(Some((sub, profile, pubkeys)))
             }
             None => Ok(None),
         }
     }
 
     /// Store the user record and update pubkey reverse indexes.
-    fn put_user(&self, username: &str, sub: &str, profile: &UserProfile, pubkeys: &[StoredPubkey]) -> Result<()> {
+    fn put_user(
+        &self,
+        username: &str,
+        sub: &str,
+        profile: &UserProfile,
+        pubkeys: &[StoredPubkey],
+    ) -> Result<()> {
         let bytes = Self::serialize_profile(sub, profile, pubkeys)?;
         let key = user_key(username);
-        self.db.put(&key, bytes)?;
+        let metadata = serde_json::to_vec(&StoredAccountAuth {
+            key_custody: profile.key_custody,
+            external_identities: profile.external_identities.clone(),
+        })?;
+        let mut batch = rocksdb::WriteBatch::default();
+        batch.put(key, bytes);
+        batch.put(account_auth_key(username), metadata);
+        self.db.write(batch)?;
         Ok(())
     }
 
@@ -303,6 +370,7 @@ impl UserStore for RocksDbUserStore {
                 username
             );
         }
+        let _guard = self.provisioning_lock.lock();
         if self.get_raw(username)?.is_some() {
             tracing::warn!(
                 "Overwriting existing entry for user '{}' in credential store",
@@ -315,8 +383,72 @@ impl UserStore for RocksDbUserStore {
         Ok(sub)
     }
 
+    async fn provision_hosted_account(
+        &self,
+        username: &str,
+        atproto_did: &str,
+        pubkey: VerifyingKey,
+        custody: AccountKeyCustody,
+    ) -> std::result::Result<HostedAccountProvisioning, HostedAccountProvisionError> {
+        use base64::engine::general_purpose::URL_SAFE_NO_PAD;
+        use base64::Engine;
+
+        let _guard = self.provisioning_lock.lock();
+        if self
+            .get_raw(username)
+            .map_err(HostedAccountProvisionError::Backend)?
+            .is_some()
+        {
+            return Err(HostedAccountProvisionError::AccountAlreadyExists);
+        }
+        let fingerprint = pubkey_fingerprint(&pubkey);
+        if self
+            .get_pubkey_index(&fingerprint)
+            .map_err(HostedAccountProvisionError::Backend)?
+            .is_some()
+        {
+            return Err(HostedAccountProvisionError::KeyAlreadyBound);
+        }
+
+        let sub = uuid::Uuid::new_v4().to_string();
+        let profile = UserProfile {
+            sub: Some(sub.clone()),
+            active: Some(true),
+            atproto_did: Some(atproto_did.to_owned()),
+            key_custody: Some(custody),
+            external_identities: Vec::new(),
+            ..Default::default()
+        };
+        let stored_key = StoredPubkey {
+            fingerprint: fingerprint.clone(),
+            pubkey_base64: URL_SAFE_NO_PAD.encode(pubkey.as_bytes()),
+            label: Some("aegis-vault".to_owned()),
+            created_at: chrono::Utc::now().timestamp(),
+            last_used_at: 0,
+            algorithm: KeyAlgorithm::Ed25519,
+            pq_pubkey: None,
+        };
+        let profile_bytes = Self::serialize_profile(&sub, &profile, &[stored_key])
+            .map_err(HostedAccountProvisionError::Backend)?;
+        let metadata_bytes = serde_json::to_vec(&StoredAccountAuth {
+            key_custody: profile.key_custody,
+            external_identities: profile.external_identities.clone(),
+        })
+        .map_err(|error| HostedAccountProvisionError::Backend(error.into()))?;
+        let mut batch = rocksdb::WriteBatch::default();
+        batch.put(user_key(username), profile_bytes);
+        batch.put(account_auth_key(username), metadata_bytes);
+        batch.put(pubkey_key(&fingerprint), username.as_bytes());
+        self.db
+            .write(batch)
+            .map_err(|error| HostedAccountProvisionError::Backend(error.into()))?;
+
+        Ok(HostedAccountProvisioning { sub, fingerprint })
+    }
+
     async fn set_profile(&self, username: &str, update: UserProfilePatch) -> Result<()> {
-        let (mut sub, mut profile, pubkeys) = self.get_raw(username)
+        let (mut sub, mut profile, pubkeys) = self
+            .get_raw(username)
             .with_context(|| format!("User '{}' not found", username))?
             .ok_or_else(|| anyhow!("User '{}' not found", username))?;
 
@@ -341,6 +473,12 @@ impl UserStore for RocksDbUserStore {
         if let Some(value) = update.atproto_did {
             profile.atproto_did = value;
         }
+        if let Some(value) = update.key_custody {
+            profile.key_custody = value;
+        }
+        if let Some(value) = update.external_identities {
+            profile.external_identities = value;
+        }
 
         self.put_user(username, &sub, &profile, &pubkeys)?;
         Ok(())
@@ -354,7 +492,10 @@ impl UserStore for RocksDbUserStore {
                 for pk in &pubkeys {
                     self.delete_pubkey_index(&pk.fingerprint)?;
                 }
-                self.db.delete(&key)?;
+                let mut batch = rocksdb::WriteBatch::default();
+                batch.delete(&key);
+                batch.delete(account_auth_key(username));
+                self.db.write(batch)?;
                 Ok(true)
             }
             None => Ok(false),
@@ -400,7 +541,13 @@ impl UserStore for RocksDbUserStore {
             }
 
             if let Some(ref expr) = filter.filter {
-                if !matches_filter(expr, &username, &profile.sub, &profile.external_id, profile.active) {
+                if !matches_filter(
+                    expr,
+                    &username,
+                    &profile.sub,
+                    &profile.external_id,
+                    profile.active,
+                ) {
                     continue;
                 }
             }
@@ -419,7 +566,11 @@ impl UserStore for RocksDbUserStore {
                     "externalId" => a.1.external_id.cmp(&b.1.external_id),
                     _ => std::cmp::Ordering::Equal,
                 };
-                if descending { cmp.reverse() } else { cmp }
+                if descending {
+                    cmp.reverse()
+                } else {
+                    cmp
+                }
             });
         }
 
@@ -430,7 +581,8 @@ impl UserStore for RocksDbUserStore {
     }
 
     async fn set_active(&self, username: &str, active: bool) -> Result<()> {
-        let (sub, mut profile, pubkeys) = self.get_raw(username)
+        let (sub, mut profile, pubkeys) = self
+            .get_raw(username)
             .with_context(|| format!("User '{}' not found", username))?
             .ok_or_else(|| anyhow!("User '{}' not found", username))?;
         profile.active = Some(active);
@@ -444,14 +596,17 @@ impl UserStore for RocksDbUserStore {
         use base64::engine::general_purpose::URL_SAFE_NO_PAD;
         use base64::Engine;
 
-        let (_, _, stored) = self.get_raw(username)?
+        let (_, _, stored) = self
+            .get_raw(username)?
             .ok_or_else(|| anyhow!("User '{}' not found", username))?;
 
         let mut entries = Vec::with_capacity(stored.len());
         for sp in stored {
-            let pubkey_bytes = URL_SAFE_NO_PAD.decode(&sp.pubkey_base64)
+            let pubkey_bytes = URL_SAFE_NO_PAD
+                .decode(&sp.pubkey_base64)
                 .with_context(|| format!("Invalid base64 for pubkey {}", sp.fingerprint))?;
-            let pubkey_arr: [u8; 32] = pubkey_bytes.try_into()
+            let pubkey_arr: [u8; 32] = pubkey_bytes
+                .try_into()
                 .map_err(|_| anyhow!("Pubkey {} is not 32 bytes", sp.fingerprint))?;
             let pubkey = VerifyingKey::from_bytes(&pubkey_arr)?;
 
@@ -460,7 +615,11 @@ impl UserStore for RocksDbUserStore {
                 pubkey,
                 label: sp.label,
                 created_at: sp.created_at,
-                last_used_at: if sp.last_used_at == 0 { None } else { Some(sp.last_used_at) },
+                last_used_at: if sp.last_used_at == 0 {
+                    None
+                } else {
+                    Some(sp.last_used_at)
+                },
                 algorithm: sp.algorithm,
                 pq_pubkey: sp.pq_pubkey,
             });
@@ -477,14 +636,20 @@ impl UserStore for RocksDbUserStore {
         use base64::engine::general_purpose::URL_SAFE_NO_PAD;
         use base64::Engine;
 
-        let (sub, profile, mut pubkeys) = self.get_raw(username)?
+        let _guard = self.provisioning_lock.lock();
+        let (sub, profile, mut pubkeys) = self
+            .get_raw(username)?
             .ok_or_else(|| anyhow!("User '{}' not found", username))?;
 
         let fingerprint = pubkey_fingerprint(&pubkey);
 
         // Check if this fingerprint already exists for this user
         if pubkeys.iter().any(|pk| pk.fingerprint == fingerprint) {
-            anyhow::bail!("Pubkey with fingerprint {} already exists for user '{}'", fingerprint, username);
+            anyhow::bail!(
+                "Pubkey with fingerprint {} already exists for user '{}'",
+                fingerprint,
+                username
+            );
         }
 
         // Check if fingerprint is already associated with another user
@@ -522,11 +687,13 @@ impl UserStore for RocksDbUserStore {
         use base64::engine::general_purpose::URL_SAFE_NO_PAD;
         use base64::Engine;
 
+        let _guard = self.provisioning_lock.lock();
         if ml_dsa_vk.is_empty() {
             anyhow::bail!("add_pubkey_hybrid: empty ML-DSA-65 verifying key");
         }
 
-        let (sub, profile, mut pubkeys) = self.get_raw(username)?
+        let (sub, profile, mut pubkeys) = self
+            .get_raw(username)?
             .ok_or_else(|| anyhow!("User '{}' not found", username))?;
 
         // Fingerprint is the Ed25519 anchor's (kid) — the PQ vk does not change it.
@@ -570,7 +737,8 @@ impl UserStore for RocksDbUserStore {
     }
 
     async fn remove_pubkey(&self, username: &str, fingerprint: &str) -> Result<bool> {
-        let (sub, profile, mut pubkeys) = self.get_raw(username)?
+        let (sub, profile, mut pubkeys) = self
+            .get_raw(username)?
             .ok_or_else(|| anyhow!("User '{}' not found", username))?;
 
         let original_len = pubkeys.len();
@@ -591,7 +759,8 @@ impl UserStore for RocksDbUserStore {
     }
 
     async fn touch_pubkey(&self, username: &str, fingerprint: &str) -> Result<()> {
-        let (sub, profile, mut pubkeys) = self.get_raw(username)?
+        let (sub, profile, mut pubkeys) = self
+            .get_raw(username)?
             .ok_or_else(|| anyhow!("User '{}' not found", username))?;
 
         let now = chrono::Utc::now().timestamp();
@@ -630,7 +799,9 @@ impl DeviceStore for RocksDbUserStore {
     async fn enroll_device(&self, record: DeviceRecord) -> anyhow::Result<()> {
         let key = device_key(&record.fingerprint);
         // Preserve existing user_sub and label on re-enrollment.
-        let existing: Option<DeviceRecord> = self.db.get(&key)?
+        let existing: Option<DeviceRecord> = self
+            .db
+            .get(&key)?
             .and_then(|v| serde_json::from_slice(&v).ok());
         let to_store = if let Some(existing) = existing {
             DeviceRecord {
@@ -660,12 +831,17 @@ impl DeviceStore for RocksDbUserStore {
 
     async fn get_device(&self, fingerprint: &str) -> anyhow::Result<Option<DeviceRecord>> {
         let key = device_key(fingerprint);
-        Ok(self.db.get(&key)?.and_then(|v| serde_json::from_slice(&v).ok()))
+        Ok(self
+            .db
+            .get(&key)?
+            .and_then(|v| serde_json::from_slice(&v).ok()))
     }
 
     async fn touch_device(&self, fingerprint: &str) -> anyhow::Result<()> {
         let key = device_key(fingerprint);
-        let Some(bytes) = self.db.get(&key)? else { return Ok(()); };
+        let Some(bytes) = self.db.get(&key)? else {
+            return Ok(());
+        };
         let mut record: DeviceRecord = serde_json::from_slice(&bytes)?;
         record.last_seen_at = Some(chrono::Utc::now().timestamp());
         self.db.put(&key, serde_json::to_vec(&record)?)?;
@@ -699,7 +875,9 @@ mod tests {
         let store = make_store(dir.path());
         let sub = store.register("alice").await?;
         assert!(!sub.is_empty(), "sub should be returned on register");
-        let profile = store.get_profile("alice").await?
+        let profile = store
+            .get_profile("alice")
+            .await?
             .ok_or_else(|| anyhow!("alice not found"))?;
         assert_eq!(profile.sub.as_deref(), Some(sub.as_str()));
         Ok(())
@@ -744,7 +922,10 @@ mod tests {
         let store = make_store(dir.path());
         let result = store.register("a:b:c").await;
         assert!(result.is_err());
-        assert!(result.unwrap_err().to_string().contains("must not contain more than one"));
+        assert!(result
+            .unwrap_err()
+            .to_string()
+            .contains("must not contain more than one"));
         Ok(())
     }
 
@@ -764,10 +945,12 @@ mod tests {
         store.register("alice").await?;
         store.register("bob").await?;
 
-        let results = store.search(&UserFilter {
-            filter: Some(r#"userName eq "alice""#.to_owned()),
-            ..Default::default()
-        }).await?;
+        let results = store
+            .search(&UserFilter {
+                filter: Some(r#"userName eq "alice""#.to_owned()),
+                ..Default::default()
+            })
+            .await?;
         assert_eq!(results.len(), 1);
         assert_eq!(results[0].0, "alice");
         Ok(())
@@ -779,17 +962,24 @@ mod tests {
         let store = make_store(dir.path());
         store.register("alice").await?;
 
-        let results = store.search(&UserFilter {
-            filter: Some("userName pr".to_owned()),
-            ..Default::default()
-        }).await?;
+        let results = store
+            .search(&UserFilter {
+                filter: Some("userName pr".to_owned()),
+                ..Default::default()
+            })
+            .await?;
         assert_eq!(results.len(), 1);
 
-        let results = store.search(&UserFilter {
-            filter: Some("active pr".to_owned()),
-            ..Default::default()
-        }).await?;
-        assert!(results.is_empty(), "active is None by default, pr should not match");
+        let results = store
+            .search(&UserFilter {
+                filter: Some("active pr".to_owned()),
+                ..Default::default()
+            })
+            .await?;
+        assert!(
+            results.is_empty(),
+            "active is None by default, pr should not match"
+        );
         Ok(())
     }
 
@@ -801,18 +991,22 @@ mod tests {
             store.register(name).await?;
         }
 
-        let results = store.search(&UserFilter {
-            start_index: Some(1),
-            count: Some(2),
-            ..Default::default()
-        }).await?;
+        let results = store
+            .search(&UserFilter {
+                start_index: Some(1),
+                count: Some(2),
+                ..Default::default()
+            })
+            .await?;
         assert_eq!(results.len(), 2);
 
-        let results = store.search(&UserFilter {
-            start_index: Some(3),
-            count: Some(2),
-            ..Default::default()
-        }).await?;
+        let results = store
+            .search(&UserFilter {
+                start_index: Some(3),
+                count: Some(2),
+                ..Default::default()
+            })
+            .await?;
         assert_eq!(results.len(), 1);
         Ok(())
     }
@@ -825,20 +1019,24 @@ mod tests {
         store.register("alice").await?;
         store.register("bob").await?;
 
-        let results = store.search(&UserFilter {
-            sort_by: Some("userName".to_owned()),
-            sort_order: Some("ascending".to_owned()),
-            ..Default::default()
-        }).await?;
+        let results = store
+            .search(&UserFilter {
+                sort_by: Some("userName".to_owned()),
+                sort_order: Some("ascending".to_owned()),
+                ..Default::default()
+            })
+            .await?;
         assert_eq!(results[0].0, "alice");
         assert_eq!(results[1].0, "bob");
         assert_eq!(results[2].0, "carol");
 
-        let results = store.search(&UserFilter {
-            sort_by: Some("userName".to_owned()),
-            sort_order: Some("descending".to_owned()),
-            ..Default::default()
-        }).await?;
+        let results = store
+            .search(&UserFilter {
+                sort_by: Some("userName".to_owned()),
+                sort_order: Some("descending".to_owned()),
+                ..Default::default()
+            })
+            .await?;
         assert_eq!(results[0].0, "carol");
         assert_eq!(results[1].0, "bob");
         assert_eq!(results[2].0, "alice");
@@ -858,10 +1056,12 @@ mod tests {
         let profile = store.get_profile("alice").await?.unwrap();
         assert_eq!(profile.active, Some(false));
 
-        let results = store.search(&UserFilter {
-            active_only: Some(true),
-            ..Default::default()
-        }).await?;
+        let results = store
+            .search(&UserFilter {
+                active_only: Some(true),
+                ..Default::default()
+            })
+            .await?;
         assert!(results.is_empty());
 
         store.set_active("alice", true).await?;
@@ -876,15 +1076,26 @@ mod tests {
         {
             let store = make_store(dir.path());
             store.register("alice").await?;
-            store.set_profile("alice", UserProfile {
-                sub: None,
-                name: Some("Alice Smith".to_owned()),
-                email: Some("alice@example.com".to_owned()),
-                email_verified: Some(true),
-                active: Some(true),
-                external_id: Some("ext-123".to_owned()),
-                atproto_did: Some("did:plc:abcdefghijklmnqrstuvwx2p".to_owned()),
-            }.into()).await?;
+            store
+                .set_profile(
+                    "alice",
+                    UserProfile {
+                        sub: None,
+                        name: Some("Alice Smith".to_owned()),
+                        email: Some("alice@example.com".to_owned()),
+                        email_verified: Some(true),
+                        active: Some(true),
+                        external_id: Some("ext-123".to_owned()),
+                        atproto_did: Some("did:plc:abcdefghijklmnqrstuvwx2p".to_owned()),
+                        key_custody: Some(AccountKeyCustody::SelfCustody),
+                        external_identities: vec![ExternalIdentityBinding {
+                            issuer: "https://issuer.example".to_owned(),
+                            subject: "alice-123".to_owned(),
+                        }],
+                    }
+                    .into(),
+                )
+                .await?;
         }
         // Open a fresh store instance to verify persistence
         let store2 = RocksDbUserStore::open(dir.path())?;
@@ -897,6 +1108,90 @@ mod tests {
             profile.atproto_did.as_deref(),
             Some("did:plc:abcdefghijklmnqrstuvwx2p")
         );
+        assert_eq!(profile.key_custody, Some(AccountKeyCustody::SelfCustody));
+        assert_eq!(
+            profile.external_identities,
+            vec![ExternalIdentityBinding {
+                issuer: "https://issuer.example".to_owned(),
+                subject: "alice-123".to_owned(),
+            }]
+        );
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn hosted_account_provisioning_is_atomic_and_preserves_future_idp_seam() -> Result<()> {
+        let dir = TempDir::new()?;
+        let store = make_store(dir.path());
+        let alice_key = ed25519_dalek::SigningKey::from_bytes(&[0x71; 32]).verifying_key();
+        let provisioned = store
+            .provision_hosted_account(
+                "alice",
+                "did:web:alice.accounts.example.test",
+                alice_key,
+                AccountKeyCustody::SelfCustody,
+            )
+            .await?;
+        assert_eq!(provisioned.fingerprint, pubkey_fingerprint(&alice_key));
+        let profile = store.get_profile("alice").await?.unwrap();
+        assert_eq!(
+            profile.atproto_did.as_deref(),
+            Some("did:web:alice.accounts.example.test")
+        );
+        assert_eq!(profile.key_custody, Some(AccountKeyCustody::SelfCustody));
+        assert!(profile.external_identities.is_empty());
+        assert_eq!(
+            store.get_pubkey_user(&provisioned.fingerprint).await?,
+            Some("alice".to_owned())
+        );
+        assert!(matches!(
+            store
+                .provision_hosted_account(
+                    "alice",
+                    "did:web:alice.accounts.example.test",
+                    ed25519_dalek::SigningKey::from_bytes(&[0x72; 32]).verifying_key(),
+                    AccountKeyCustody::SelfCustody,
+                )
+                .await,
+            Err(HostedAccountProvisionError::AccountAlreadyExists)
+        ));
+        assert!(matches!(
+            store
+                .provision_hosted_account(
+                    "bob",
+                    "did:web:bob.accounts.example.test",
+                    alice_key,
+                    AccountKeyCustody::SelfCustody,
+                )
+                .await,
+            Err(HostedAccountProvisionError::KeyAlreadyBound)
+        ));
+
+        store
+            .set_profile(
+                "alice",
+                UserProfilePatch {
+                    external_identities: Some(vec![ExternalIdentityBinding {
+                        issuer: "https://issuer.example".to_owned(),
+                        subject: "external-alice".to_owned(),
+                    }]),
+                    ..Default::default()
+                },
+            )
+            .await?;
+        assert_eq!(
+            store
+                .get_external_identity_user("https://issuer.example", "external-alice")
+                .await?,
+            Some("alice".to_owned())
+        );
+        assert_eq!(
+            store.list_external_identities("alice").await?,
+            vec![ExternalIdentityBinding {
+                issuer: "https://issuer.example".to_owned(),
+                subject: "external-alice".to_owned(),
+            }]
+        );
         Ok(())
     }
 
@@ -905,16 +1200,26 @@ mod tests {
         let dir = TempDir::new()?;
         let store = std::sync::Arc::new(make_store(dir.path()));
         store.register("alice").await?;
-        store.set_profile("alice", UserProfilePatch {
-            atproto_did: Some(Some("did:plc:abcdefghijklmnqrstuvwx2p".to_owned())),
-            ..Default::default()
-        }).await?;
+        store
+            .set_profile(
+                "alice",
+                UserProfilePatch {
+                    atproto_did: Some(Some("did:plc:abcdefghijklmnqrstuvwx2p".to_owned())),
+                    ..Default::default()
+                },
+            )
+            .await?;
 
         let service = crate::services::oauth::user_service::UserService::new(store.clone());
-        service.update("alice", crate::services::oauth::user_service::UserUpdate {
-            atproto_did: Some(None),
-            ..Default::default()
-        }).await?;
+        service
+            .update(
+                "alice",
+                crate::services::oauth::user_service::UserUpdate {
+                    atproto_did: Some(None),
+                    ..Default::default()
+                },
+            )
+            .await?;
 
         let profile = store.get_profile("alice").await?.unwrap();
         assert_eq!(profile.atproto_did, None);
@@ -950,7 +1255,9 @@ mod tests {
         let signing_key = SigningKey::generate(&mut rand::thread_rng());
         let pubkey = signing_key.verifying_key();
 
-        let fingerprint = store.add_pubkey("alice", pubkey, Some("laptop".to_owned())).await?;
+        let fingerprint = store
+            .add_pubkey("alice", pubkey, Some("laptop".to_owned()))
+            .await?;
         assert!(!fingerprint.is_empty());
 
         let keys = store.list_pubkeys("alice").await?;
@@ -997,8 +1304,12 @@ mod tests {
         let key1 = SigningKey::generate(&mut rand::thread_rng()).verifying_key();
         let key2 = SigningKey::generate(&mut rand::thread_rng()).verifying_key();
 
-        let fp1 = store.add_pubkey("alice", key1, Some("laptop".to_owned())).await?;
-        let fp2 = store.add_pubkey("alice", key2, Some("phone".to_owned())).await?;
+        let fp1 = store
+            .add_pubkey("alice", key1, Some("laptop".to_owned()))
+            .await?;
+        let fp2 = store
+            .add_pubkey("alice", key2, Some("phone".to_owned()))
+            .await?;
 
         let keys = store.list_pubkeys("alice").await?;
         assert_eq!(keys.len(), 2);
@@ -1039,8 +1350,14 @@ mod tests {
         let alice_fp = store.add_pubkey("alice", alice_key, None).await?;
         let bob_fp = store.add_pubkey("bob", bob_key, None).await?;
 
-        assert_eq!(store.get_pubkey_user(&alice_fp).await?, Some("alice".to_owned()));
-        assert_eq!(store.get_pubkey_user(&bob_fp).await?, Some("bob".to_owned()));
+        assert_eq!(
+            store.get_pubkey_user(&alice_fp).await?,
+            Some("alice".to_owned())
+        );
+        assert_eq!(
+            store.get_pubkey_user(&bob_fp).await?,
+            Some("bob".to_owned())
+        );
         assert_eq!(store.get_pubkey_user("nonexistent").await?, None);
         Ok(())
     }
@@ -1075,7 +1392,10 @@ mod tests {
         let fingerprint = store.add_pubkey("alice", key, None).await?;
 
         // Verify reverse lookup works
-        assert_eq!(store.get_pubkey_user(&fingerprint).await?, Some("alice".to_owned()));
+        assert_eq!(
+            store.get_pubkey_user(&fingerprint).await?,
+            Some("alice".to_owned())
+        );
 
         // Remove user
         store.remove("alice").await?;
@@ -1092,10 +1412,14 @@ mod tests {
         store.register("alice").await?;
 
         let key = SigningKey::generate(&mut rand::thread_rng()).verifying_key();
-        store.add_pubkey("alice", key, Some("first".to_owned())).await?;
+        store
+            .add_pubkey("alice", key, Some("first".to_owned()))
+            .await?;
 
         // Adding same key again should fail
-        let result = store.add_pubkey("alice", key, Some("second".to_owned())).await;
+        let result = store
+            .add_pubkey("alice", key, Some("second".to_owned()))
+            .await;
         assert!(result.is_err());
         assert!(result.unwrap_err().to_string().contains("already exists"));
         Ok(())
@@ -1114,7 +1438,10 @@ mod tests {
         // Adding same key to different user should fail
         let result = store.add_pubkey("bob", key, None).await;
         assert!(result.is_err());
-        assert!(result.unwrap_err().to_string().contains("already associated"));
+        assert!(result
+            .unwrap_err()
+            .to_string()
+            .contains("already associated"));
         Ok(())
     }
 
@@ -1126,7 +1453,9 @@ mod tests {
         {
             let store = make_store(dir.path());
             store.register("alice").await?;
-            fingerprint = store.add_pubkey("alice", key, Some("laptop".to_owned())).await?;
+            fingerprint = store
+                .add_pubkey("alice", key, Some("laptop".to_owned()))
+                .await?;
         }
 
         // Reopen and verify
@@ -1137,7 +1466,10 @@ mod tests {
         assert_eq!(keys[0].label.as_deref(), Some("laptop"));
 
         // Reverse lookup should also work
-        assert_eq!(store2.get_pubkey_user(&fingerprint).await?, Some("alice".to_owned()));
+        assert_eq!(
+            store2.get_pubkey_user(&fingerprint).await?,
+            Some("alice".to_owned())
+        );
         Ok(())
     }
 
@@ -1178,7 +1510,10 @@ mod tests {
         let fp2 = store
             .add_pubkey_hybrid("alice", key, vec![0x11u8; 1952], None)
             .await?;
-        assert_eq!(fp1, fp2, "hybrid upgrade keeps the Ed25519 anchor fingerprint");
+        assert_eq!(
+            fp1, fp2,
+            "hybrid upgrade keeps the Ed25519 anchor fingerprint"
+        );
 
         let keys = store.list_pubkeys("alice").await?;
         assert_eq!(keys.len(), 1, "in-place upgrade, not a second key");
@@ -1244,7 +1579,9 @@ mod tests {
         let err = RocksDbUserStore::deserialize_profile(&bytes)
             .expect_err("unknown algorithm tag must fail the read");
         assert!(
-            err.to_string().to_lowercase().contains("unknown key algorithm"),
+            err.to_string()
+                .to_lowercase()
+                .contains("unknown key algorithm"),
             "error must name the unknown tag: {err}"
         );
     }

--- a/crates/hyprstream/src/auth/rocksdb_store.rs
+++ b/crates/hyprstream/src/auth/rocksdb_store.rs
@@ -394,26 +394,110 @@ impl UserStore for RocksDbUserStore {
         use base64::Engine;
 
         let _guard = self.provisioning_lock.lock();
-        if self
+        let fingerprint = pubkey_fingerprint(&pubkey);
+        let usable_binding = |owner: &str,
+                              raw: &(String, UserProfile, Vec<StoredPubkey>)|
+         -> std::result::Result<bool, HostedAccountProvisionError> {
+            let (sub, profile, keys) = raw;
+            if sub.is_empty()
+                || profile.sub.as_deref() != Some(sub)
+                || profile.active != Some(true)
+                || !profile
+                    .atproto_did
+                    .as_deref()
+                    .is_some_and(|did| did.starts_with("did:web:"))
+                || profile.key_custody.is_none()
+                || keys.is_empty()
+            {
+                return Ok(false);
+            }
+            for key in keys {
+                let valid_key = URL_SAFE_NO_PAD
+                    .decode(&key.pubkey_base64)
+                    .ok()
+                    .and_then(|bytes| <[u8; 32]>::try_from(bytes).ok())
+                    .and_then(|bytes| VerifyingKey::from_bytes(&bytes).ok())
+                    .is_some_and(|key_bytes| pubkey_fingerprint(&key_bytes) == key.fingerprint);
+                if !valid_key {
+                    continue;
+                }
+                if self
+                    .get_pubkey_index(&key.fingerprint)
+                    .map_err(HostedAccountProvisionError::Backend)?
+                    .as_deref()
+                    == Some(owner)
+                {
+                    return Ok(true);
+                }
+            }
+            Ok(false)
+        };
+
+        if let Some(raw) = self
             .get_raw(username)
             .map_err(HostedAccountProvisionError::Backend)?
-            .is_some()
         {
-            return Err(HostedAccountProvisionError::AccountAlreadyExists);
+            let (_, profile, keys) = &raw;
+            let exact_key = keys.iter().any(|key| {
+                key.fingerprint == fingerprint
+                    && key.algorithm == KeyAlgorithm::Ed25519
+                    && key.pq_pubkey.is_none()
+                    && URL_SAFE_NO_PAD
+                        .decode(&key.pubkey_base64)
+                        .is_ok_and(|bytes| bytes.as_slice() == pubkey.as_bytes())
+            });
+            let exact = profile.sub.as_deref() == Some(raw.0.as_str())
+                && profile.active.is_some()
+                && profile.atproto_did.as_deref() == Some(atproto_did)
+                && profile.key_custody == Some(custody)
+                && profile.external_identities.is_empty()
+                && exact_key
+                && self
+                    .get_pubkey_index(&fingerprint)
+                    .map_err(HostedAccountProvisionError::Backend)?
+                    .as_deref()
+                    == Some(username);
+            if exact {
+                return Ok(HostedAccountProvisioning {
+                    sub: raw.0,
+                    fingerprint,
+                    resumed: true,
+                });
+            }
+            if usable_binding(username, &raw)? {
+                return Err(HostedAccountProvisionError::AccountAlreadyExists);
+            }
+            return Err(HostedAccountProvisionError::Backend(anyhow!(
+                "existing hosted-account username has no usable credential binding"
+            )));
         }
-        let fingerprint = pubkey_fingerprint(&pubkey);
-        if self
+
+        if let Some(owner) = self
             .get_pubkey_index(&fingerprint)
             .map_err(HostedAccountProvisionError::Backend)?
-            .is_some()
         {
-            return Err(HostedAccountProvisionError::KeyAlreadyBound);
+            let owner_raw = self
+                .get_raw(&owner)
+                .map_err(HostedAccountProvisionError::Backend)?
+                .ok_or_else(|| {
+                    HostedAccountProvisionError::Backend(anyhow!(
+                        "hosted-account key owner profile is missing"
+                    ))
+                })?;
+            if usable_binding(&owner, &owner_raw)? {
+                return Err(HostedAccountProvisionError::KeyAlreadyBound);
+            }
+            return Err(HostedAccountProvisionError::Backend(anyhow!(
+                "existing hosted-account key owner has no usable credential binding"
+            )));
         }
 
         let sub = uuid::Uuid::new_v4().to_string();
         let profile = UserProfile {
             sub: Some(sub.clone()),
-            active: Some(true),
+            // The OAuth authorize transaction activates this binding only
+            // after durable PDS genesis publication succeeds.
+            active: Some(false),
             atproto_did: Some(atproto_did.to_owned()),
             key_custody: Some(custody),
             external_identities: Vec::new(),
@@ -443,7 +527,69 @@ impl UserStore for RocksDbUserStore {
             .write(batch)
             .map_err(|error| HostedAccountProvisionError::Backend(error.into()))?;
 
-        Ok(HostedAccountProvisioning { sub, fingerprint })
+        Ok(HostedAccountProvisioning {
+            sub,
+            fingerprint,
+            resumed: false,
+        })
+    }
+
+    async fn activate_hosted_account(
+        &self,
+        username: &str,
+        atproto_did: &str,
+        fingerprint: &str,
+        custody: AccountKeyCustody,
+    ) -> std::result::Result<(), HostedAccountProvisionError> {
+        let _guard = self.provisioning_lock.lock();
+        let (sub, mut profile, pubkeys) = self
+            .get_raw(username)
+            .map_err(HostedAccountProvisionError::Backend)?
+            .ok_or_else(|| {
+                HostedAccountProvisionError::Backend(anyhow!(
+                    "staged hosted-account profile is missing"
+                ))
+            })?;
+        use base64::engine::general_purpose::URL_SAFE_NO_PAD;
+        use base64::Engine;
+        let key_matches = pubkeys.iter().any(|key| {
+            key.fingerprint == fingerprint
+                && URL_SAFE_NO_PAD
+                    .decode(&key.pubkey_base64)
+                    .ok()
+                    .and_then(|bytes| <[u8; 32]>::try_from(bytes).ok())
+                    .and_then(|bytes| VerifyingKey::from_bytes(&bytes).ok())
+                    .is_some_and(|key_bytes| pubkey_fingerprint(&key_bytes) == fingerprint)
+        });
+        let reverse_matches = self
+            .get_pubkey_index(fingerprint)
+            .map_err(HostedAccountProvisionError::Backend)?
+            .as_deref()
+            == Some(username);
+        if profile.sub.as_deref() != Some(sub.as_str())
+            || profile.atproto_did.as_deref() != Some(atproto_did)
+            || profile.key_custody != Some(custody)
+            || !key_matches
+            || !reverse_matches
+        {
+            return Err(HostedAccountProvisionError::Backend(anyhow!(
+                "staged hosted-account binding changed before activation"
+            )));
+        }
+        if profile.active == Some(true) {
+            return Ok(());
+        }
+        if profile.active != Some(false) {
+            return Err(HostedAccountProvisionError::Backend(anyhow!(
+                "staged hosted-account binding has an invalid activation state"
+            )));
+        }
+        profile.active = Some(true);
+        let profile_bytes = Self::serialize_profile(&sub, &profile, &pubkeys)
+            .map_err(HostedAccountProvisionError::Backend)?;
+        self.db
+            .put(user_key(username), profile_bytes)
+            .map_err(|error| HostedAccountProvisionError::Backend(error.into()))
     }
 
     async fn set_profile(&self, username: &str, update: UserProfilePatch) -> Result<()> {
@@ -1133,16 +1279,40 @@ mod tests {
             )
             .await?;
         assert_eq!(provisioned.fingerprint, pubkey_fingerprint(&alice_key));
+        assert!(!provisioned.resumed);
         let profile = store.get_profile("alice").await?.unwrap();
         assert_eq!(
             profile.atproto_did.as_deref(),
             Some("did:web:alice.accounts.example.test")
         );
         assert_eq!(profile.key_custody, Some(AccountKeyCustody::SelfCustody));
+        assert_eq!(profile.active, Some(false));
         assert!(profile.external_identities.is_empty());
         assert_eq!(
             store.get_pubkey_user(&provisioned.fingerprint).await?,
             Some("alice".to_owned())
+        );
+        let resumed = store
+            .provision_hosted_account(
+                "alice",
+                "did:web:alice.accounts.example.test",
+                alice_key,
+                AccountKeyCustody::SelfCustody,
+            )
+            .await?;
+        assert!(resumed.resumed);
+        assert_eq!(resumed.sub, provisioned.sub);
+        store
+            .activate_hosted_account(
+                "alice",
+                "did:web:alice.accounts.example.test",
+                &provisioned.fingerprint,
+                AccountKeyCustody::SelfCustody,
+            )
+            .await?;
+        assert_eq!(
+            store.get_profile("alice").await?.unwrap().active,
+            Some(true)
         );
         assert!(matches!(
             store
@@ -1192,6 +1362,71 @@ mod tests {
                 subject: "external-alice".to_owned(),
             }]
         );
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn concurrent_same_key_different_handles_never_reserves_two_accounts() -> Result<()> {
+        let dir = TempDir::new()?;
+        let store = std::sync::Arc::new(make_store(dir.path()));
+        let key = ed25519_dalek::SigningKey::from_bytes(&[0x73; 32]).verifying_key();
+        let barrier = std::sync::Arc::new(tokio::sync::Barrier::new(3));
+
+        let attempt = |handle: &'static str| {
+            let store = store.clone();
+            let barrier = barrier.clone();
+            tokio::spawn(async move {
+                barrier.wait().await;
+                store
+                    .provision_hosted_account(
+                        handle,
+                        &format!("did:web:{handle}.accounts.example.test"),
+                        key,
+                        AccountKeyCustody::SelfCustody,
+                    )
+                    .await
+                    .map(|provisioned| (handle, provisioned))
+            })
+        };
+        let alice = attempt("alice");
+        let bob = attempt("bob");
+        barrier.wait().await;
+        let results = [alice.await?, bob.await?];
+        let winner = results
+            .iter()
+            .find_map(|result| result.as_ref().ok())
+            .expect("one transaction must win");
+        assert_eq!(
+            results.iter().filter(|result| result.is_ok()).count(),
+            1,
+            "the same vault key must never stage two handles"
+        );
+        assert!(results
+            .iter()
+            .any(|result| matches!(result, Err(HostedAccountProvisionError::Backend(_)))));
+        let loser = if winner.0 == "alice" { "bob" } else { "alice" };
+        assert!(store.get_profile(winner.0).await?.is_some());
+        assert!(store.get_profile(loser).await?.is_none());
+
+        store
+            .activate_hosted_account(
+                winner.0,
+                &format!("did:web:{}.accounts.example.test", winner.0),
+                &winner.1.fingerprint,
+                AccountKeyCustody::SelfCustody,
+            )
+            .await?;
+        assert!(matches!(
+            store
+                .provision_hosted_account(
+                    loser,
+                    &format!("did:web:{loser}.accounts.example.test"),
+                    key,
+                    AccountKeyCustody::SelfCustody,
+                )
+                .await,
+            Err(HostedAccountProvisionError::KeyAlreadyBound)
+        ));
         Ok(())
     }
 

--- a/crates/hyprstream/src/auth/rocksdb_store.rs
+++ b/crates/hyprstream/src/auth/rocksdb_store.rs
@@ -396,7 +396,8 @@ impl UserStore for RocksDbUserStore {
         let _guard = self.provisioning_lock.lock();
         let fingerprint = pubkey_fingerprint(&pubkey);
         let usable_binding = |owner: &str,
-                              raw: &(String, UserProfile, Vec<StoredPubkey>)|
+                              raw: &(String, UserProfile, Vec<StoredPubkey>),
+                              required_fingerprint: Option<&str>|
          -> std::result::Result<bool, HostedAccountProvisionError> {
             let (sub, profile, keys) = raw;
             if sub.is_empty()
@@ -412,6 +413,9 @@ impl UserStore for RocksDbUserStore {
                 return Ok(false);
             }
             for key in keys {
+                if required_fingerprint.is_some_and(|required| key.fingerprint != required) {
+                    continue;
+                }
                 let valid_key = URL_SAFE_NO_PAD
                     .decode(&key.pubkey_base64)
                     .ok()
@@ -464,7 +468,7 @@ impl UserStore for RocksDbUserStore {
                     resumed: true,
                 });
             }
-            if usable_binding(username, &raw)? {
+            if usable_binding(username, &raw, None)? {
                 return Err(HostedAccountProvisionError::AccountAlreadyExists);
             }
             return Err(HostedAccountProvisionError::Backend(anyhow!(
@@ -484,7 +488,7 @@ impl UserStore for RocksDbUserStore {
                         "hosted-account key owner profile is missing"
                     ))
                 })?;
-            if usable_binding(&owner, &owner_raw)? {
+            if usable_binding(&owner, &owner_raw, Some(&fingerprint))? {
                 return Err(HostedAccountProvisionError::KeyAlreadyBound);
             }
             return Err(HostedAccountProvisionError::Backend(anyhow!(
@@ -1362,6 +1366,78 @@ mod tests {
                 subject: "external-alice".to_owned(),
             }]
         );
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn corrupt_exact_key_index_never_returns_trusted_key_conflict() -> Result<()> {
+        use base64::engine::general_purpose::URL_SAFE_NO_PAD;
+        use base64::Engine;
+
+        let dir = TempDir::new()?;
+        let store = make_store(dir.path());
+        let alice_key = SigningKey::from_bytes(&[0x74; 32]).verifying_key();
+        let alice = store
+            .provision_hosted_account(
+                "alice",
+                "did:web:alice.accounts.example.test",
+                alice_key,
+                AccountKeyCustody::SelfCustody,
+            )
+            .await?;
+        store
+            .activate_hosted_account(
+                "alice",
+                "did:web:alice.accounts.example.test",
+                &alice.fingerprint,
+                AccountKeyCustody::SelfCustody,
+            )
+            .await?;
+
+        let conflicting_key = SigningKey::from_bytes(&[0x75; 32]).verifying_key();
+        let conflicting_fingerprint = pubkey_fingerprint(&conflicting_key);
+        store
+            .db
+            .put(pubkey_key(&conflicting_fingerprint), b"alice")?;
+
+        let attempt = || {
+            store.provision_hosted_account(
+                "bob",
+                "did:web:bob.accounts.example.test",
+                conflicting_key,
+                AccountKeyCustody::SelfCustody,
+            )
+        };
+        assert!(matches!(
+            attempt().await,
+            Err(HostedAccountProvisionError::Backend(_))
+        ));
+
+        let (sub, profile, mut keys) = store.get_raw("alice")?.unwrap();
+        keys.push(StoredPubkey {
+            fingerprint: conflicting_fingerprint,
+            // The index claims the conflicting fingerprint, but these are
+            // Alice's other key bytes. Recomputing the fingerprint must catch
+            // the mismatch instead of trusting any usable owner key.
+            pubkey_base64: URL_SAFE_NO_PAD.encode(alice_key.as_bytes()),
+            label: Some("corrupt-mismatch".to_owned()),
+            created_at: chrono::Utc::now().timestamp(),
+            last_used_at: 0,
+            algorithm: KeyAlgorithm::Ed25519,
+            pq_pubkey: None,
+        });
+        store.put_user("alice", &sub, &profile, &keys)?;
+        assert!(matches!(
+            attempt().await,
+            Err(HostedAccountProvisionError::Backend(_))
+        ));
+
+        keys.last_mut().unwrap().pubkey_base64 = "not-base64".to_owned();
+        store.put_user("alice", &sub, &profile, &keys)?;
+        assert!(matches!(
+            attempt().await,
+            Err(HostedAccountProvisionError::Backend(_))
+        ));
         Ok(())
     }
 

--- a/crates/hyprstream/src/auth/user_store.rs
+++ b/crates/hyprstream/src/auth/user_store.rs
@@ -8,6 +8,46 @@ use async_trait::async_trait;
 use ed25519_dalek::VerifyingKey;
 use serde::{Deserialize, Serialize};
 
+/// Who controls the account's authentication key material.
+///
+/// Cold signup provisions [`Self::SelfCustody`]. [`Self::Managed`] is the
+/// persisted seam for a later external-IdP-gated account flow; no such flow is
+/// implemented by the OAuth server today.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum AccountKeyCustody {
+    SelfCustody,
+    Managed,
+}
+
+impl AccountKeyCustody {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::SelfCustody => "self_custody",
+            Self::Managed => "managed",
+        }
+    }
+
+    pub fn parse(value: &str) -> Result<Self> {
+        match value {
+            "self_custody" => Ok(Self::SelfCustody),
+            "managed" => Ok(Self::Managed),
+            other => anyhow::bail!("unknown account key custody value '{other}'"),
+        }
+    }
+}
+
+/// One external identity allowed to authenticate as a hosted account.
+///
+/// Demo cold-signup records carry an empty collection. Keeping the normalized
+/// `(issuer, subject)` pair in the account model makes a later OIDC RP additive
+/// instead of requiring a credential-store migration.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ExternalIdentityBinding {
+    pub issuer: String,
+    pub subject: String,
+}
+
 /// User profile data (OIDC standard claims + SCIM-informed fields).
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct UserProfile {
@@ -34,6 +74,13 @@ pub struct UserProfile {
     /// here so the atproto OAuth profile can emit the mapped DID as `sub` (#1113 r5).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub atproto_did: Option<String>,
+    /// Account key custody mode. Absent only on records created before the
+    /// hosted-account model gained an explicit custody discriminator.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub key_custody: Option<AccountKeyCustody>,
+    /// Zero or more external IdP bindings. Empty for vault self-custody signup.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub external_identities: Vec<ExternalIdentityBinding>,
 }
 
 /// Tri-state patch for profile fields: omitted, explicitly cleared, or replaced.
@@ -46,6 +93,8 @@ pub struct UserProfilePatch {
     pub active: Option<Option<bool>>,
     pub external_id: Option<Option<String>>,
     pub atproto_did: Option<Option<String>>,
+    pub key_custody: Option<Option<AccountKeyCustody>>,
+    pub external_identities: Option<Vec<ExternalIdentityBinding>>,
 }
 
 impl From<UserProfile> for UserProfilePatch {
@@ -58,8 +107,30 @@ impl From<UserProfile> for UserProfilePatch {
             active: profile.active.map(Some),
             external_id: profile.external_id.map(Some),
             atproto_did: profile.atproto_did.map(Some),
+            key_custody: profile.key_custody.map(Some),
+            external_identities: (!profile.external_identities.is_empty())
+                .then_some(profile.external_identities),
         }
     }
+}
+
+/// Result of atomically inserting a hosted account into the AS credential
+/// store together with its first authentication key.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct HostedAccountProvisioning {
+    pub sub: String,
+    pub fingerprint: String,
+}
+
+/// Fail-closed conflict/backend distinction for hosted-account provisioning.
+#[derive(Debug, thiserror::Error)]
+pub enum HostedAccountProvisionError {
+    #[error("the requested account already exists")]
+    AccountAlreadyExists,
+    #[error("the supplied key is already bound to another account")]
+    KeyAlreadyBound,
+    #[error("credential-store provisioning failed")]
+    Backend(#[source] anyhow::Error),
 }
 
 /// The public-key algorithm of a stored [`PubkeyEntry`].
@@ -178,6 +249,24 @@ pub trait UserStore: Send + Sync {
     /// Register a new user. Returns the generated subject UUID.
     async fn register(&self, username: &str) -> Result<String>;
 
+    /// Atomically create a hosted AS account and its first authentication key.
+    ///
+    /// Implementations must not overwrite either an existing username or an
+    /// existing key reverse-index entry. The account profile, DID mapping,
+    /// custody discriminator, empty external-binding collection, public key,
+    /// and reverse index become visible together.
+    async fn provision_hosted_account(
+        &self,
+        _username: &str,
+        _atproto_did: &str,
+        _pubkey: VerifyingKey,
+        _custody: AccountKeyCustody,
+    ) -> std::result::Result<HostedAccountProvisioning, HostedAccountProvisionError> {
+        Err(HostedAccountProvisionError::Backend(anyhow::anyhow!(
+            "hosted-account provisioning is unsupported by this credential store"
+        )))
+    }
+
     /// Update a user's profile fields with tri-state patch semantics.
     async fn set_profile(&self, username: &str, patch: UserProfilePatch) -> Result<()>;
 
@@ -237,6 +326,48 @@ pub trait UserStore: Send + Sync {
 
     /// Update last_used_at timestamp for a pubkey.
     async fn touch_pubkey(&self, username: &str, fingerprint: &str) -> Result<()>;
+
+    /// List the normalized external identities bound to one local account.
+    /// Cold signup always returns an empty list.
+    async fn list_external_identities(
+        &self,
+        username: &str,
+    ) -> Result<Vec<ExternalIdentityBinding>> {
+        self.get_profile(username)
+            .await?
+            .map(|profile| profile.external_identities)
+            .ok_or_else(|| anyhow::anyhow!("User '{username}' not found"))
+    }
+
+    /// Resolve a normalized external `(issuer, subject)` identity to its local
+    /// account. The cold-signup demo never populates these bindings; this
+    /// interface is reserved for the later OIDC RP.
+    async fn get_external_identity_user(
+        &self,
+        issuer: &str,
+        subject: &str,
+    ) -> Result<Option<String>> {
+        if issuer.is_empty() || subject.is_empty() {
+            anyhow::bail!("external identity issuer and subject must be non-empty");
+        }
+        let mut match_user = None;
+        for username in self.list_users().await {
+            let Some(profile) = self.get_profile(&username).await? else {
+                continue;
+            };
+            if profile
+                .external_identities
+                .iter()
+                .any(|binding| binding.issuer == issuer && binding.subject == subject)
+            {
+                if match_user.is_some() {
+                    anyhow::bail!("external identity binding is ambiguous for issuer and subject");
+                }
+                match_user = Some(username);
+            }
+        }
+        Ok(match_user)
+    }
 }
 
 /// Compute the SSH fingerprint of a pubkey (matches `ssh-keygen -l -E sha256`).
@@ -328,7 +459,10 @@ impl ScimFilter {
         if let Some(rest) = expr.strip_prefix("userName eq ") {
             return ScimFilter::UserNameEq(unquote(rest).to_owned());
         }
-        if let Some(rest) = expr.strip_prefix("id eq ").or_else(|| expr.strip_prefix("sub eq ")) {
+        if let Some(rest) = expr
+            .strip_prefix("id eq ")
+            .or_else(|| expr.strip_prefix("sub eq "))
+        {
             return ScimFilter::IdEq(unquote(rest).to_owned());
         }
         if let Some(rest) = expr.strip_prefix("externalId eq ") {
@@ -455,14 +589,38 @@ mod tests {
 
     #[test]
     fn test_matches_filter_username_eq() {
-        assert!(matches_filter(r#"userName eq "alice""#, "alice", &None, &None, None));
-        assert!(!matches_filter(r#"userName eq "alice""#, "bob", &None, &None, None));
+        assert!(matches_filter(
+            r#"userName eq "alice""#,
+            "alice",
+            &None,
+            &None,
+            None
+        ));
+        assert!(!matches_filter(
+            r#"userName eq "alice""#,
+            "bob",
+            &None,
+            &None,
+            None
+        ));
     }
 
     #[test]
     fn test_matches_filter_active_eq() {
-        assert!(matches_filter("active eq true", "u", &None, &None, Some(true)));
-        assert!(!matches_filter("active eq true", "u", &None, &None, Some(false)));
+        assert!(matches_filter(
+            "active eq true",
+            "u",
+            &None,
+            &None,
+            Some(true)
+        ));
+        assert!(!matches_filter(
+            "active eq true",
+            "u",
+            &None,
+            &None,
+            Some(false)
+        ));
     }
 
     #[test]
@@ -478,8 +636,14 @@ mod tests {
         assert_eq!(KeyAlgorithm::Ed25519.as_str(), "ed25519");
         assert_eq!(KeyAlgorithm::default(), KeyAlgorithm::Ed25519);
         // Accepts case/whitespace variants.
-        assert_eq!(KeyAlgorithm::parse("ed25519").unwrap(), KeyAlgorithm::Ed25519);
-        assert_eq!(KeyAlgorithm::parse("  Ed25519 ").unwrap(), KeyAlgorithm::Ed25519);
+        assert_eq!(
+            KeyAlgorithm::parse("ed25519").unwrap(),
+            KeyAlgorithm::Ed25519
+        );
+        assert_eq!(
+            KeyAlgorithm::parse("  Ed25519 ").unwrap(),
+            KeyAlgorithm::Ed25519
+        );
         // Unknown tags error (never silently fall back to Ed25519).
         assert!(KeyAlgorithm::parse("ml-dsa-65").is_err());
         assert!(KeyAlgorithm::parse("").is_err());

--- a/crates/hyprstream/src/auth/user_store.rs
+++ b/crates/hyprstream/src/auth/user_store.rs
@@ -120,6 +120,11 @@ impl From<UserProfile> for UserProfilePatch {
 pub struct HostedAccountProvisioning {
     pub sub: String,
     pub fingerprint: String,
+    /// True when this call found the same complete credential binding created
+    /// by an earlier attempt. It may still be staged inactive; callers must
+    /// resume downstream publication/activation instead of treating it as a
+    /// conflict.
+    pub resumed: bool,
 }
 
 /// Fail-closed conflict/backend distinction for hosted-account provisioning.
@@ -254,7 +259,13 @@ pub trait UserStore: Send + Sync {
     /// Implementations must not overwrite either an existing username or an
     /// existing key reverse-index entry. The account profile, DID mapping,
     /// custody discriminator, empty external-binding collection, public key,
-    /// and reverse index become visible together.
+    /// and reverse index become visible together. Repeating the exact same
+    /// `(username, DID, key, custody)` returns `Ok` with `resumed = true`.
+    ///
+    /// Conflict errors are trustworthy recovery signals: implementations may
+    /// return them only when the conflicting profile, key, and reverse index
+    /// form a complete usable hosted-account binding. Partial/corrupt state is
+    /// a backend error and must fail closed.
     async fn provision_hosted_account(
         &self,
         _username: &str,
@@ -264,6 +275,20 @@ pub trait UserStore: Send + Sync {
     ) -> std::result::Result<HostedAccountProvisioning, HostedAccountProvisionError> {
         Err(HostedAccountProvisionError::Backend(anyhow::anyhow!(
             "hosted-account provisioning is unsupported by this credential store"
+        )))
+    }
+
+    /// Atomically mark an exactly matching staged hosted binding active after
+    /// its durable PDS genesis is known to exist.
+    async fn activate_hosted_account(
+        &self,
+        _username: &str,
+        _atproto_did: &str,
+        _fingerprint: &str,
+        _custody: AccountKeyCustody,
+    ) -> std::result::Result<(), HostedAccountProvisionError> {
+        Err(HostedAccountProvisionError::Backend(anyhow::anyhow!(
+            "hosted-account activation is unsupported by this credential store"
         )))
     }
 

--- a/crates/hyprstream/src/auth/valkey.rs
+++ b/crates/hyprstream/src/auth/valkey.rs
@@ -8,6 +8,7 @@
 //!   hs:user:{u}:keys          SET of fingerprints
 //!   hs:key:{fp}               JSON pubkey data (base64, label, timestamps)
 //!   hs:keyowner:{fp}          username string (fingerprint → user reverse index)
+//!   hs:hosted-staged-binding:{u}:{fp} immutable expected hosted-binding bytes
 //!   hs:hosted-binding:{u}:{fp} activated hosted-binding integrity marker
 //!   hs:idx:sub:{sub}          username (sub → username reverse index)
 //!   hs:idx:extid:{extid}      username (externalId → username reverse index)
@@ -41,6 +42,83 @@ struct StoredKey {
     pq_pubkey_base64: Option<String>,
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct HostedBindingMarker {
+    fingerprint: String,
+    did: String,
+    custody: String,
+    pubkey_base64: String,
+}
+
+fn validated_stored_key_base64(
+    fingerprint: &str,
+    key_json: Option<&str>,
+) -> std::result::Result<String, HostedAccountProvisionError> {
+    use base64::engine::general_purpose::STANDARD;
+    use base64::Engine;
+
+    let invalid = || {
+        HostedAccountProvisionError::Backend(anyhow!(
+            "stored hosted-account key does not match its indexed fingerprint"
+        ))
+    };
+    let key: StoredKey =
+        serde_json::from_str(key_json.ok_or_else(invalid)?).map_err(|_| invalid())?;
+    let key_bytes = STANDARD
+        .decode(&key.pubkey_base64)
+        .ok()
+        .and_then(|bytes| <[u8; 32]>::try_from(bytes).ok())
+        .ok_or_else(invalid)?;
+    let verifying_key = VerifyingKey::from_bytes(&key_bytes).map_err(|_| invalid())?;
+    if pubkey_fingerprint(&verifying_key) != fingerprint {
+        return Err(invalid());
+    }
+    Ok(key.pubkey_base64)
+}
+
+fn validate_key_conflict_snapshot(
+    fingerprint: &str,
+    owner: Option<&str>,
+    owner_has_fingerprint: bool,
+    profile_json: Option<&str>,
+    key_json: Option<&str>,
+    marker_json: Option<&str>,
+) -> std::result::Result<(), HostedAccountProvisionError> {
+    let invalid = || {
+        HostedAccountProvisionError::Backend(anyhow!(
+            "existing hosted-account key binding is incomplete or inconsistent"
+        ))
+    };
+    owner
+        .filter(|owner| !owner.is_empty())
+        .ok_or_else(invalid)?;
+    if !owner_has_fingerprint {
+        return Err(invalid());
+    }
+    let profile: UserProfile =
+        serde_json::from_str(profile_json.ok_or_else(invalid)?).map_err(|_| invalid())?;
+    let did = profile
+        .atproto_did
+        .as_deref()
+        .filter(|did| did.starts_with("did:web:"))
+        .ok_or_else(invalid)?;
+    let custody = profile
+        .key_custody
+        .filter(|_| profile.active == Some(true))
+        .ok_or_else(invalid)?;
+    let key_base64 = validated_stored_key_base64(fingerprint, key_json)?;
+    let marker: HostedBindingMarker =
+        serde_json::from_str(marker_json.ok_or_else(invalid)?).map_err(|_| invalid())?;
+    if marker.fingerprint != fingerprint
+        || marker.did != did
+        || marker.custody != custody.as_str()
+        || marker.pubkey_base64 != key_base64
+    {
+        return Err(invalid());
+    }
+    Ok(())
+}
+
 pub struct ValkeyUserStore {
     pool: RedisPool,
 }
@@ -61,6 +139,91 @@ impl ValkeyUserStore {
             None => Ok(None),
             Some(s) => Ok(Some(serde_json::from_str(&s)?)),
         }
+    }
+
+    async fn validate_key_conflict(
+        &self,
+        fingerprint: &str,
+    ) -> std::result::Result<(), HostedAccountProvisionError> {
+        let owner: Option<String> = self
+            .pool
+            .get(format!("hs:keyowner:{fingerprint}"))
+            .await
+            .map_err(|error| HostedAccountProvisionError::Backend(error.into()))?;
+        let profile_json: Option<String> = match owner.as_deref() {
+            Some(owner) => self
+                .pool
+                .get(format!("hs:user:{owner}"))
+                .await
+                .map_err(|error| HostedAccountProvisionError::Backend(error.into()))?,
+            None => None,
+        };
+        let key_json: Option<String> = self
+            .pool
+            .get(format!("hs:key:{fingerprint}"))
+            .await
+            .map_err(|error| HostedAccountProvisionError::Backend(error.into()))?;
+        let marker_json: Option<String> = match owner.as_deref() {
+            Some(owner) => self
+                .pool
+                .get(format!("hs:hosted-binding:{owner}:{fingerprint}"))
+                .await
+                .map_err(|error| HostedAccountProvisionError::Backend(error.into()))?,
+            None => None,
+        };
+        let owner_has_fingerprint = match owner.as_deref() {
+            Some(owner) => self
+                .pool
+                .sismember(format!("hs:user:{owner}:keys"), fingerprint)
+                .await
+                .map_err(|error| HostedAccountProvisionError::Backend(error.into()))?,
+            None => false,
+        };
+        validate_key_conflict_snapshot(
+            fingerprint,
+            owner.as_deref(),
+            owner_has_fingerprint,
+            profile_json.as_deref(),
+            key_json.as_deref(),
+            marker_json.as_deref(),
+        )
+    }
+
+    async fn validated_staged_public_key(
+        &self,
+        username: &str,
+        atproto_did: &str,
+        fingerprint: &str,
+        custody: AccountKeyCustody,
+    ) -> std::result::Result<String, HostedAccountProvisionError> {
+        let key_json: Option<String> = self
+            .pool
+            .get(format!("hs:key:{fingerprint}"))
+            .await
+            .map_err(|error| HostedAccountProvisionError::Backend(error.into()))?;
+        let public_key = validated_stored_key_base64(fingerprint, key_json.as_deref())?;
+        let marker_json: Option<String> = self
+            .pool
+            .get(format!("hs:hosted-staged-binding:{username}:{fingerprint}"))
+            .await
+            .map_err(|error| HostedAccountProvisionError::Backend(error.into()))?;
+        let marker: HostedBindingMarker =
+            serde_json::from_str(marker_json.as_deref().ok_or_else(|| {
+                HostedAccountProvisionError::Backend(anyhow!(
+                    "staged hosted-account key binding marker is missing"
+                ))
+            })?)
+            .map_err(|error| HostedAccountProvisionError::Backend(error.into()))?;
+        if marker.fingerprint != fingerprint
+            || marker.did != atproto_did
+            || marker.custody != custody.as_str()
+            || marker.pubkey_base64 != public_key
+        {
+            return Err(HostedAccountProvisionError::Backend(anyhow!(
+                "staged hosted-account key binding marker is inconsistent"
+            )));
+        }
+        Ok(public_key)
     }
 }
 
@@ -119,6 +282,13 @@ impl UserStore for ValkeyUserStore {
         };
         let key_json = serde_json::to_string(&stored_key)
             .map_err(|error| HostedAccountProvisionError::Backend(error.into()))?;
+        let marker_json = serde_json::to_string(&HostedBindingMarker {
+            fingerprint: fingerprint.clone(),
+            did: atproto_did.to_owned(),
+            custody: custody.as_str().to_owned(),
+            pubkey_base64: base64::engine::general_purpose::STANDARD.encode(pubkey.as_bytes()),
+        })
+        .map_err(|error| HostedAccountProvisionError::Backend(error.into()))?;
 
         // All conflict checks and writes run inside one Valkey script. A
         // conflict status is emitted only after the existing hosted binding
@@ -151,6 +321,7 @@ local function usable(owner, profile, fingerprint)
   if not marker_json then return false end
   local marker_ok, marker = pcall(cjson.decode, marker_json)
   if not marker_ok
+      or marker.fingerprint ~= fingerprint
       or marker.did ~= decoded.atproto_did
       or marker.custody ~= decoded.key_custody
       or marker.pubkey_base64 ~= key.pubkey_base64 then
@@ -173,9 +344,16 @@ if existing_profile then
       and redis.call('GET', KEYS[5]) == ARGV[2]
       and redis.call('SISMEMBER', KEYS[6], ARGV[4]) == 1
   local existing_key = redis.call('GET', KEYS[4])
-  if exact and existing_key then
+  local existing_marker = redis.call('GET', KEYS[7])
+  if exact and existing_key and existing_marker then
     local key_ok, key_decoded = pcall(cjson.decode, existing_key)
-    exact = key_ok and key_decoded.pubkey_base64 == ARGV[7]
+    local marker_ok, marker = pcall(cjson.decode, existing_marker)
+    exact = key_ok and marker_ok
+        and key_decoded.pubkey_base64 == ARGV[7]
+        and marker.fingerprint == ARGV[4]
+        and marker.did == ARGV[5]
+        and marker.custody == ARGV[6]
+        and marker.pubkey_base64 == ARGV[7]
   else
     exact = false
   end
@@ -203,6 +381,7 @@ redis.call('SET', KEYS[3], ARGV[2])
 redis.call('SET', KEYS[4], ARGV[3])
 redis.call('SADD', KEYS[6], ARGV[4])
 redis.call('SET', KEYS[5], ARGV[2])
+redis.call('SET', KEYS[7], ARGV[8])
 return 0
 "#;
         let status: i64 = self
@@ -216,6 +395,7 @@ return 0
                     format!("hs:key:{fingerprint}"),
                     format!("hs:keyowner:{fingerprint}"),
                     format!("hs:user:{username}:keys"),
+                    format!("hs:hosted-staged-binding:{username}:{fingerprint}"),
                 ],
                 vec![
                     profile_json,
@@ -225,6 +405,7 @@ return 0
                     atproto_did.to_owned(),
                     custody.as_str().to_owned(),
                     base64::engine::general_purpose::STANDARD.encode(pubkey.as_bytes()),
+                    marker_json,
                 ],
             )
             .await
@@ -236,7 +417,10 @@ return 0
                 resumed: false,
             }),
             1 => Err(HostedAccountProvisionError::AccountAlreadyExists),
-            2 => Err(HostedAccountProvisionError::KeyAlreadyBound),
+            2 => {
+                self.validate_key_conflict(&fingerprint).await?;
+                Err(HostedAccountProvisionError::KeyAlreadyBound)
+            }
             3 => {
                 let existing = self
                     .get_profile_raw(username)
@@ -278,30 +462,38 @@ return 0
         fingerprint: &str,
         custody: AccountKeyCustody,
     ) -> std::result::Result<(), HostedAccountProvisionError> {
+        let expected_public_key = self
+            .validated_staged_public_key(username, atproto_did, fingerprint, custody)
+            .await?;
         const ACTIVATE_HOSTED_ACCOUNT: &str = r#"
 local profile_json = redis.call('GET', KEYS[1])
 if not profile_json then return 1 end
 local ok, profile = pcall(cjson.decode, profile_json)
 local key_json = redis.call('GET', KEYS[4])
 local key_ok, key = pcall(cjson.decode, key_json or '')
+local marker_json = redis.call('GET', KEYS[5])
+local marker_ok, marker = pcall(cjson.decode, marker_json or '')
 if not ok
     or not key_ok
+    or not marker_ok
     or (profile.active ~= false and profile.active ~= true)
     or profile.atproto_did ~= ARGV[1]
     or profile.key_custody ~= ARGV[4]
     or type(key.pubkey_base64) ~= 'string' or key.pubkey_base64 == ''
+    or marker.fingerprint ~= ARGV[3]
+    or marker.did ~= ARGV[1]
+    or marker.custody ~= ARGV[4]
+    or marker.pubkey_base64 ~= key.pubkey_base64
+    or marker.pubkey_base64 ~= ARGV[5]
     or redis.call('GET', KEYS[2]) ~= ARGV[2]
     or redis.call('SISMEMBER', KEYS[3], ARGV[3]) ~= 1
-    or not key_json then
+    or not key_json
+    or not marker_json then
   return 1
 end
 profile.active = true
 redis.call('SET', KEYS[1], cjson.encode(profile))
-redis.call('SET', KEYS[5], cjson.encode({
-  did = ARGV[1],
-  custody = ARGV[4],
-  pubkey_base64 = key.pubkey_base64
-}))
+redis.call('SET', KEYS[6], marker_json)
 return 0
 "#;
         let status: i64 = self
@@ -313,6 +505,7 @@ return 0
                     format!("hs:keyowner:{fingerprint}"),
                     format!("hs:user:{username}:keys"),
                     format!("hs:key:{fingerprint}"),
+                    format!("hs:hosted-staged-binding:{username}:{fingerprint}"),
                     format!("hs:hosted-binding:{username}:{fingerprint}"),
                 ],
                 vec![
@@ -320,6 +513,7 @@ return 0
                     username.to_owned(),
                     fingerprint.to_owned(),
                     custody.as_str().to_owned(),
+                    expected_public_key,
                 ],
             )
             .await
@@ -417,6 +611,11 @@ return 0
             let _: i64 = self
                 .pool
                 .del(format!("hs:hosted-binding:{username}:{fp}"))
+                .await
+                .unwrap_or(0);
+            let _: i64 = self
+                .pool
+                .del(format!("hs:hosted-staged-binding:{username}:{fp}"))
                 .await
                 .unwrap_or(0);
         }
@@ -746,6 +945,11 @@ return 0
                 .del(format!("hs:hosted-binding:{username}:{fingerprint}"))
                 .await
                 .unwrap_or(0);
+            let _: i64 = self
+                .pool
+                .del(format!("hs:hosted-staged-binding:{username}:{fingerprint}"))
+                .await
+                .unwrap_or(0);
         }
         Ok(removed > 0)
     }
@@ -771,6 +975,119 @@ return 0
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn corrupt_key_conflict_snapshot_never_becomes_trusted_conflict() -> Result<()> {
+        use base64::engine::general_purpose::STANDARD;
+        use base64::Engine;
+
+        let key = ed25519_dalek::SigningKey::from_bytes(&[0x76; 32]).verifying_key();
+        let fingerprint = pubkey_fingerprint(&key);
+        let profile_json = serde_json::to_string(&UserProfile {
+            sub: Some("alice-sub".to_owned()),
+            active: Some(true),
+            atproto_did: Some("did:web:alice.accounts.example.test".to_owned()),
+            key_custody: Some(AccountKeyCustody::SelfCustody),
+            ..Default::default()
+        })?;
+        let key_base64 = STANDARD.encode(key.as_bytes());
+        let key_json = serde_json::to_string(&StoredKey {
+            pubkey_base64: key_base64.clone(),
+            label: Some("aegis-vault".to_owned()),
+            created_at: 1,
+            last_used_at: None,
+            algorithm: crate::auth::KeyAlgorithm::Ed25519,
+            pq_pubkey_base64: None,
+        })?;
+        let marker_json = serde_json::to_string(&HostedBindingMarker {
+            fingerprint: fingerprint.clone(),
+            did: "did:web:alice.accounts.example.test".to_owned(),
+            custody: "self_custody".to_owned(),
+            pubkey_base64: key_base64,
+        })?;
+        assert!(validate_key_conflict_snapshot(
+            &fingerprint,
+            Some("alice"),
+            true,
+            Some(&profile_json),
+            Some(&key_json),
+            Some(&marker_json),
+        )
+        .is_ok());
+
+        for corrupt in [
+            validate_key_conflict_snapshot(
+                &fingerprint,
+                Some("alice"),
+                false,
+                Some(&profile_json),
+                Some(&key_json),
+                Some(&marker_json),
+            ),
+            validate_key_conflict_snapshot(
+                &fingerprint,
+                Some("alice"),
+                true,
+                Some(&profile_json),
+                None,
+                Some(&marker_json),
+            ),
+        ] {
+            assert!(matches!(
+                corrupt,
+                Err(HostedAccountProvisionError::Backend(_))
+            ));
+        }
+
+        let malformed_key_json = serde_json::to_string(&StoredKey {
+            pubkey_base64: "not-base64".to_owned(),
+            label: None,
+            created_at: 1,
+            last_used_at: None,
+            algorithm: crate::auth::KeyAlgorithm::Ed25519,
+            pq_pubkey_base64: None,
+        })?;
+        assert!(matches!(
+            validate_key_conflict_snapshot(
+                &fingerprint,
+                Some("alice"),
+                true,
+                Some(&profile_json),
+                Some(&malformed_key_json),
+                Some(&marker_json),
+            ),
+            Err(HostedAccountProvisionError::Backend(_))
+        ));
+
+        let different_key = ed25519_dalek::SigningKey::from_bytes(&[0x77; 32]).verifying_key();
+        let mismatch_base64 = STANDARD.encode(different_key.as_bytes());
+        let mismatch_key_json = serde_json::to_string(&StoredKey {
+            pubkey_base64: mismatch_base64.clone(),
+            label: None,
+            created_at: 1,
+            last_used_at: None,
+            algorithm: crate::auth::KeyAlgorithm::Ed25519,
+            pq_pubkey_base64: None,
+        })?;
+        let mismatch_marker_json = serde_json::to_string(&HostedBindingMarker {
+            fingerprint: fingerprint.clone(),
+            did: "did:web:alice.accounts.example.test".to_owned(),
+            custody: "self_custody".to_owned(),
+            pubkey_base64: mismatch_base64,
+        })?;
+        assert!(matches!(
+            validate_key_conflict_snapshot(
+                &fingerprint,
+                Some("alice"),
+                true,
+                Some(&profile_json),
+                Some(&mismatch_key_json),
+                Some(&mismatch_marker_json),
+            ),
+            Err(HostedAccountProvisionError::Backend(_))
+        ));
+        Ok(())
+    }
 
     #[tokio::test]
     async fn list_pubkeys_propagates_smembers_read_error() -> Result<()> {

--- a/crates/hyprstream/src/auth/valkey.rs
+++ b/crates/hyprstream/src/auth/valkey.rs
@@ -8,6 +8,7 @@
 //!   hs:user:{u}:keys          SET of fingerprints
 //!   hs:key:{fp}               JSON pubkey data (base64, label, timestamps)
 //!   hs:keyowner:{fp}          username string (fingerprint → user reverse index)
+//!   hs:hosted-binding:{u}:{fp} activated hosted-binding integrity marker
 //!   hs:idx:sub:{sub}          username (sub → username reverse index)
 //!   hs:idx:extid:{extid}      username (externalId → username reverse index)
 
@@ -100,7 +101,7 @@ impl UserStore for ValkeyUserStore {
         let fingerprint = pubkey_fingerprint(&pubkey);
         let profile = UserProfile {
             sub: Some(sub.clone()),
-            active: Some(true),
+            active: Some(false),
             atproto_did: Some(atproto_did.to_owned()),
             key_custody: Some(custody),
             external_identities: Vec::new(),
@@ -119,11 +120,83 @@ impl UserStore for ValkeyUserStore {
         let key_json = serde_json::to_string(&stored_key)
             .map_err(|error| HostedAccountProvisionError::Backend(error.into()))?;
 
-        // All conflict checks and writes run inside one Valkey script. Status:
-        // 0 = inserted, 1 = username exists, 2 = key owner exists.
+        // All conflict checks and writes run inside one Valkey script. A
+        // conflict status is emitted only after the existing hosted binding
+        // has passed profile/key/reverse-index integrity checks.
+        // Status: 0 = inserted, 1 = usable username conflict,
+        // 2 = usable key conflict, 3 = exact resumable binding,
+        // 4 = partial/corrupt state.
         const PROVISION_HOSTED_ACCOUNT: &str = r#"
-if redis.call('EXISTS', KEYS[1]) == 1 then return 1 end
-if redis.call('EXISTS', KEYS[5]) == 1 then return 2 end
+local function usable(owner, profile, fingerprint)
+  if not profile or profile == false then return false end
+  local ok, decoded = pcall(cjson.decode, profile)
+  if not ok or decoded.active ~= true
+      or type(decoded.sub) ~= 'string' or decoded.sub == ''
+      or type(decoded.atproto_did) ~= 'string'
+      or string.sub(decoded.atproto_did, 1, 8) ~= 'did:web:'
+      or type(decoded.key_custody) ~= 'string' then
+    return false
+  end
+  local key_json = redis.call('GET', 'hs:key:' .. fingerprint)
+  if redis.call('SISMEMBER', 'hs:user:' .. owner .. ':keys', fingerprint) ~= 1
+      or redis.call('GET', 'hs:keyowner:' .. fingerprint) ~= owner
+      or not key_json then
+    return false
+  end
+  local key_ok, key = pcall(cjson.decode, key_json)
+  if not key_ok or type(key.pubkey_base64) ~= 'string'
+      or key.pubkey_base64 == '' then return false end
+  local marker_json = redis.call(
+      'GET', 'hs:hosted-binding:' .. owner .. ':' .. fingerprint)
+  if not marker_json then return false end
+  local marker_ok, marker = pcall(cjson.decode, marker_json)
+  if not marker_ok
+      or marker.did ~= decoded.atproto_did
+      or marker.custody ~= decoded.key_custody
+      or marker.pubkey_base64 ~= key.pubkey_base64 then
+    return false
+  end
+  return true
+end
+
+local existing_profile = redis.call('GET', KEYS[1])
+if existing_profile then
+  local ok, decoded = pcall(cjson.decode, existing_profile)
+  local exact = ok
+      and (decoded.active == true or decoded.active == false)
+      and type(decoded.sub) == 'string' and decoded.sub ~= ''
+      and decoded.atproto_did == ARGV[5]
+      and decoded.key_custody == ARGV[6]
+      and (decoded.external_identities == nil
+          or (type(decoded.external_identities) == 'table'
+              and next(decoded.external_identities) == nil))
+      and redis.call('GET', KEYS[5]) == ARGV[2]
+      and redis.call('SISMEMBER', KEYS[6], ARGV[4]) == 1
+  local existing_key = redis.call('GET', KEYS[4])
+  if exact and existing_key then
+    local key_ok, key_decoded = pcall(cjson.decode, existing_key)
+    exact = key_ok and key_decoded.pubkey_base64 == ARGV[7]
+  else
+    exact = false
+  end
+  if exact and (decoded.active == false
+      or usable(ARGV[2], existing_profile, ARGV[4])) then return 3 end
+  if exact then return 4 end
+
+  local fingerprints = redis.call('SMEMBERS', KEYS[6])
+  for _, existing_fingerprint in ipairs(fingerprints) do
+    if usable(ARGV[2], existing_profile, existing_fingerprint) then return 1 end
+  end
+  return 4
+end
+
+local existing_owner = redis.call('GET', KEYS[5])
+if existing_owner then
+  if usable(existing_owner, redis.call('GET', 'hs:user:' .. existing_owner), ARGV[4]) then
+    return 2
+  end
+  return 4
+end
 redis.call('SET', KEYS[1], ARGV[1])
 redis.call('SADD', KEYS[2], ARGV[2])
 redis.call('SET', KEYS[3], ARGV[2])
@@ -149,16 +222,112 @@ return 0
                     username.to_owned(),
                     key_json,
                     fingerprint.clone(),
+                    atproto_did.to_owned(),
+                    custody.as_str().to_owned(),
+                    base64::engine::general_purpose::STANDARD.encode(pubkey.as_bytes()),
                 ],
             )
             .await
             .map_err(|error| HostedAccountProvisionError::Backend(error.into()))?;
         match status {
-            0 => Ok(HostedAccountProvisioning { sub, fingerprint }),
+            0 => Ok(HostedAccountProvisioning {
+                sub,
+                fingerprint,
+                resumed: false,
+            }),
             1 => Err(HostedAccountProvisionError::AccountAlreadyExists),
             2 => Err(HostedAccountProvisionError::KeyAlreadyBound),
+            3 => {
+                let existing = self
+                    .get_profile_raw(username)
+                    .await
+                    .map_err(HostedAccountProvisionError::Backend)?;
+                let existing_sub = existing
+                    .filter(|profile| {
+                        profile.active.is_some()
+                            && profile.atproto_did.as_deref() == Some(atproto_did)
+                            && profile.key_custody == Some(custody)
+                            && profile.external_identities.is_empty()
+                    })
+                    .and_then(|profile| profile.sub)
+                    .filter(|sub| !sub.is_empty())
+                    .ok_or_else(|| {
+                        HostedAccountProvisionError::Backend(anyhow!(
+                            "resumed hosted-account profile has no subject"
+                        ))
+                    })?;
+                Ok(HostedAccountProvisioning {
+                    sub: existing_sub,
+                    fingerprint,
+                    resumed: true,
+                })
+            }
+            4 => Err(HostedAccountProvisionError::Backend(anyhow!(
+                "existing hosted-account state is incomplete or inconsistent"
+            ))),
             other => Err(HostedAccountProvisionError::Backend(anyhow!(
                 "unexpected hosted-account provisioning status {other}"
+            ))),
+        }
+    }
+
+    async fn activate_hosted_account(
+        &self,
+        username: &str,
+        atproto_did: &str,
+        fingerprint: &str,
+        custody: AccountKeyCustody,
+    ) -> std::result::Result<(), HostedAccountProvisionError> {
+        const ACTIVATE_HOSTED_ACCOUNT: &str = r#"
+local profile_json = redis.call('GET', KEYS[1])
+if not profile_json then return 1 end
+local ok, profile = pcall(cjson.decode, profile_json)
+local key_json = redis.call('GET', KEYS[4])
+local key_ok, key = pcall(cjson.decode, key_json or '')
+if not ok
+    or not key_ok
+    or (profile.active ~= false and profile.active ~= true)
+    or profile.atproto_did ~= ARGV[1]
+    or profile.key_custody ~= ARGV[4]
+    or type(key.pubkey_base64) ~= 'string' or key.pubkey_base64 == ''
+    or redis.call('GET', KEYS[2]) ~= ARGV[2]
+    or redis.call('SISMEMBER', KEYS[3], ARGV[3]) ~= 1
+    or not key_json then
+  return 1
+end
+profile.active = true
+redis.call('SET', KEYS[1], cjson.encode(profile))
+redis.call('SET', KEYS[5], cjson.encode({
+  did = ARGV[1],
+  custody = ARGV[4],
+  pubkey_base64 = key.pubkey_base64
+}))
+return 0
+"#;
+        let status: i64 = self
+            .pool
+            .eval(
+                ACTIVATE_HOSTED_ACCOUNT,
+                vec![
+                    format!("hs:user:{username}"),
+                    format!("hs:keyowner:{fingerprint}"),
+                    format!("hs:user:{username}:keys"),
+                    format!("hs:key:{fingerprint}"),
+                    format!("hs:hosted-binding:{username}:{fingerprint}"),
+                ],
+                vec![
+                    atproto_did.to_owned(),
+                    username.to_owned(),
+                    fingerprint.to_owned(),
+                    custody.as_str().to_owned(),
+                ],
+            )
+            .await
+            .map_err(|error| HostedAccountProvisionError::Backend(error.into()))?;
+        match status {
+            0 => Ok(()),
+            _ => Err(HostedAccountProvisionError::Backend(anyhow!(
+                "staged hosted-account binding changed before activation"
             ))),
         }
     }
@@ -243,6 +412,11 @@ return 0
             let _: i64 = self
                 .pool
                 .del(format!("hs:keyowner:{fp}"))
+                .await
+                .unwrap_or(0);
+            let _: i64 = self
+                .pool
+                .del(format!("hs:hosted-binding:{username}:{fp}"))
                 .await
                 .unwrap_or(0);
         }
@@ -565,6 +739,11 @@ return 0
             let _: i64 = self
                 .pool
                 .del(format!("hs:keyowner:{fingerprint}"))
+                .await
+                .unwrap_or(0);
+            let _: i64 = self
+                .pool
+                .del(format!("hs:hosted-binding:{username}:{fingerprint}"))
                 .await
                 .unwrap_or(0);
         }

--- a/crates/hyprstream/src/auth/valkey.rs
+++ b/crates/hyprstream/src/auth/valkey.rs
@@ -13,15 +13,16 @@
 
 #![cfg(feature = "valkey")]
 
-use anyhow::{Context, Result, anyhow};
+use anyhow::{anyhow, Context, Result};
 use async_trait::async_trait;
 use ed25519_dalek::VerifyingKey;
 use fred::prelude::*;
 use serde::{Deserialize, Serialize};
 
 use super::user_store::{
-    matches_filter, pubkey_fingerprint, PubkeyEntry, ScimFilter, UserFilter, UserProfile,
-    UserProfilePatch, UserStore,
+    matches_filter, pubkey_fingerprint, AccountKeyCustody, HostedAccountProvisionError,
+    HostedAccountProvisioning, PubkeyEntry, ScimFilter, UserFilter, UserProfile, UserProfilePatch,
+    UserStore,
 };
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -45,8 +46,7 @@ pub struct ValkeyUserStore {
 
 impl ValkeyUserStore {
     pub async fn connect(url: &str) -> Result<Self> {
-        let config = RedisConfig::from_url(url)
-            .context("invalid Valkey URL")?;
+        let config = RedisConfig::from_url(url).context("invalid Valkey URL")?;
         let pool = Builder::from_config(config).build_pool(8)?;
         pool.connect();
         pool.wait_for_connect().await?;
@@ -77,10 +77,90 @@ impl UserStore for ValkeyUserStore {
             ..Default::default()
         };
         let json = serde_json::to_string(&profile)?;
-        self.pool.set::<(), _, _>(format!("hs:user:{username}"), json, None, None, false).await?;
+        self.pool
+            .set::<(), _, _>(format!("hs:user:{username}"), json, None, None, false)
+            .await?;
         self.pool.sadd::<i64, _, _>("hs:users", username).await?;
-        self.pool.set::<(), _, _>(format!("hs:idx:sub:{sub}"), username, None, None, false).await?;
+        self.pool
+            .set::<(), _, _>(format!("hs:idx:sub:{sub}"), username, None, None, false)
+            .await?;
         Ok(sub)
+    }
+
+    async fn provision_hosted_account(
+        &self,
+        username: &str,
+        atproto_did: &str,
+        pubkey: VerifyingKey,
+        custody: AccountKeyCustody,
+    ) -> std::result::Result<HostedAccountProvisioning, HostedAccountProvisionError> {
+        use base64::Engine;
+
+        let sub = uuid::Uuid::new_v4().to_string();
+        let fingerprint = pubkey_fingerprint(&pubkey);
+        let profile = UserProfile {
+            sub: Some(sub.clone()),
+            active: Some(true),
+            atproto_did: Some(atproto_did.to_owned()),
+            key_custody: Some(custody),
+            external_identities: Vec::new(),
+            ..Default::default()
+        };
+        let profile_json = serde_json::to_string(&profile)
+            .map_err(|error| HostedAccountProvisionError::Backend(error.into()))?;
+        let stored_key = StoredKey {
+            pubkey_base64: base64::engine::general_purpose::STANDARD.encode(pubkey.as_bytes()),
+            label: Some("aegis-vault".to_owned()),
+            created_at: chrono::Utc::now().timestamp(),
+            last_used_at: None,
+            algorithm: crate::auth::KeyAlgorithm::Ed25519,
+            pq_pubkey_base64: None,
+        };
+        let key_json = serde_json::to_string(&stored_key)
+            .map_err(|error| HostedAccountProvisionError::Backend(error.into()))?;
+
+        // All conflict checks and writes run inside one Valkey script. Status:
+        // 0 = inserted, 1 = username exists, 2 = key owner exists.
+        const PROVISION_HOSTED_ACCOUNT: &str = r#"
+if redis.call('EXISTS', KEYS[1]) == 1 then return 1 end
+if redis.call('EXISTS', KEYS[5]) == 1 then return 2 end
+redis.call('SET', KEYS[1], ARGV[1])
+redis.call('SADD', KEYS[2], ARGV[2])
+redis.call('SET', KEYS[3], ARGV[2])
+redis.call('SET', KEYS[4], ARGV[3])
+redis.call('SADD', KEYS[6], ARGV[4])
+redis.call('SET', KEYS[5], ARGV[2])
+return 0
+"#;
+        let status: i64 = self
+            .pool
+            .eval(
+                PROVISION_HOSTED_ACCOUNT,
+                vec![
+                    format!("hs:user:{username}"),
+                    "hs:users".to_owned(),
+                    format!("hs:idx:sub:{sub}"),
+                    format!("hs:key:{fingerprint}"),
+                    format!("hs:keyowner:{fingerprint}"),
+                    format!("hs:user:{username}:keys"),
+                ],
+                vec![
+                    profile_json,
+                    username.to_owned(),
+                    key_json,
+                    fingerprint.clone(),
+                ],
+            )
+            .await
+            .map_err(|error| HostedAccountProvisionError::Backend(error.into()))?;
+        match status {
+            0 => Ok(HostedAccountProvisioning { sub, fingerprint }),
+            1 => Err(HostedAccountProvisionError::AccountAlreadyExists),
+            2 => Err(HostedAccountProvisionError::KeyAlreadyBound),
+            other => Err(HostedAccountProvisionError::Backend(anyhow!(
+                "unexpected hosted-account provisioning status {other}"
+            ))),
+        }
     }
 
     async fn set_profile(&self, username: &str, new: UserProfilePatch) -> Result<()> {
@@ -88,8 +168,16 @@ impl UserStore for ValkeyUserStore {
 
         // Remove stale externalId index if it changed.
         if let Some(ref old_extid) = existing.external_id {
-            if new.external_id.as_ref().is_some_and(|value| value.as_deref() != Some(old_extid)) {
-                let _: i64 = self.pool.del(format!("hs:idx:extid:{old_extid}")).await.unwrap_or(0);
+            if new
+                .external_id
+                .as_ref()
+                .is_some_and(|value| value.as_deref() != Some(old_extid))
+            {
+                let _: i64 = self
+                    .pool
+                    .del(format!("hs:idx:extid:{old_extid}"))
+                    .await
+                    .unwrap_or(0);
             }
         }
 
@@ -102,44 +190,81 @@ impl UserStore for ValkeyUserStore {
             active: new.active.unwrap_or(existing.active),
             external_id: new.external_id.unwrap_or(existing.external_id),
             atproto_did: new.atproto_did.unwrap_or(existing.atproto_did),
+            key_custody: new.key_custody.unwrap_or(existing.key_custody),
+            external_identities: new
+                .external_identities
+                .unwrap_or(existing.external_identities),
         };
 
         // Write new externalId index.
         if let Some(ref extid) = merged.external_id {
-            self.pool.set::<(), _, _>(format!("hs:idx:extid:{extid}"), username, None, None, false).await?;
+            self.pool
+                .set::<(), _, _>(format!("hs:idx:extid:{extid}"), username, None, None, false)
+                .await?;
         }
 
         let json = serde_json::to_string(&merged)?;
-        self.pool.set::<(), _, _>(format!("hs:user:{username}"), json, None, None, false).await?;
+        self.pool
+            .set::<(), _, _>(format!("hs:user:{username}"), json, None, None, false)
+            .await?;
         Ok(())
     }
 
     async fn remove(&self, username: &str) -> Result<bool> {
         let existing = self.get_profile_raw(username).await?;
-        let Some(profile) = existing else { return Ok(false) };
+        let Some(profile) = existing else {
+            return Ok(false);
+        };
 
         // Delete reverse indexes.
         if let Some(ref sub) = profile.sub {
-            let _: i64 = self.pool.del(format!("hs:idx:sub:{sub}")).await.unwrap_or(0);
+            let _: i64 = self
+                .pool
+                .del(format!("hs:idx:sub:{sub}"))
+                .await
+                .unwrap_or(0);
         }
         if let Some(ref extid) = profile.external_id {
-            let _: i64 = self.pool.del(format!("hs:idx:extid:{extid}")).await.unwrap_or(0);
+            let _: i64 = self
+                .pool
+                .del(format!("hs:idx:extid:{extid}"))
+                .await
+                .unwrap_or(0);
         }
 
         // Delete pubkeys.
-        let fps: Vec<String> = self.pool.smembers(format!("hs:user:{username}:keys")).await.unwrap_or_default();
+        let fps: Vec<String> = self
+            .pool
+            .smembers(format!("hs:user:{username}:keys"))
+            .await
+            .unwrap_or_default();
         for fp in &fps {
             let _: i64 = self.pool.del(format!("hs:key:{fp}")).await.unwrap_or(0);
-            let _: i64 = self.pool.del(format!("hs:keyowner:{fp}")).await.unwrap_or(0);
+            let _: i64 = self
+                .pool
+                .del(format!("hs:keyowner:{fp}"))
+                .await
+                .unwrap_or(0);
         }
-        let _: i64 = self.pool.del(format!("hs:user:{username}:keys")).await.unwrap_or(0);
-        let _: i64 = self.pool.del(format!("hs:user:{username}")).await.unwrap_or(0);
+        let _: i64 = self
+            .pool
+            .del(format!("hs:user:{username}:keys"))
+            .await
+            .unwrap_or(0);
+        let _: i64 = self
+            .pool
+            .del(format!("hs:user:{username}"))
+            .await
+            .unwrap_or(0);
         let _: i64 = self.pool.srem("hs:users", username).await.unwrap_or(0);
         Ok(true)
     }
 
     async fn list_users(&self) -> Vec<String> {
-        self.pool.smembers::<Vec<String>, _>("hs:users").await.unwrap_or_default()
+        self.pool
+            .smembers::<Vec<String>, _>("hs:users")
+            .await
+            .unwrap_or_default()
     }
 
     async fn search(&self, filter: &UserFilter) -> Result<Vec<(String, UserProfile)>> {
@@ -155,7 +280,8 @@ impl UserStore for ValkeyUserStore {
                     };
                 }
                 ScimFilter::IdEq(sub) => {
-                    let username: Option<String> = self.pool.get(format!("hs:idx:sub:{sub}")).await?;
+                    let username: Option<String> =
+                        self.pool.get(format!("hs:idx:sub:{sub}")).await?;
                     if let Some(u) = username {
                         if let Some(p) = self.get_profile_raw(&u).await? {
                             return Ok(vec![(u, p)]);
@@ -164,7 +290,8 @@ impl UserStore for ValkeyUserStore {
                     return Ok(vec![]);
                 }
                 ScimFilter::ExternalIdEq(extid) => {
-                    let username: Option<String> = self.pool.get(format!("hs:idx:extid:{extid}")).await?;
+                    let username: Option<String> =
+                        self.pool.get(format!("hs:idx:extid:{extid}")).await?;
                     if let Some(u) = username {
                         if let Some(p) = self.get_profile_raw(&u).await? {
                             return Ok(vec![(u, p)]);
@@ -180,7 +307,9 @@ impl UserStore for ValkeyUserStore {
         let all_usernames: Vec<String> = self.pool.smembers("hs:users").await?;
         let mut results: Vec<(String, UserProfile)> = Vec::new();
         for username in all_usernames {
-            let Some(profile) = self.get_profile_raw(&username).await? else { continue };
+            let Some(profile) = self.get_profile_raw(&username).await? else {
+                continue;
+            };
 
             // Apply active_only shortcut.
             if filter.active_only == Some(true) && profile.active == Some(false) {
@@ -207,7 +336,9 @@ impl UserStore for ValkeyUserStore {
                     ),
                     _ => true, // point-lookup cases already handled above
                 };
-                if !pass { continue; }
+                if !pass {
+                    continue;
+                }
             }
             results.push((username, profile));
         }
@@ -220,7 +351,11 @@ impl UserStore for ValkeyUserStore {
                     "id" | "sub" => a_prof.sub.cmp(&b_prof.sub),
                     _ => a_name.cmp(b_name),
                 };
-                if descending { ord.reverse() } else { ord }
+                if descending {
+                    ord.reverse()
+                } else {
+                    ord
+                }
             });
         }
 
@@ -231,16 +366,21 @@ impl UserStore for ValkeyUserStore {
     }
 
     async fn set_active(&self, username: &str, active: bool) -> Result<()> {
-        let mut profile = self.get_profile_raw(username).await?
+        let mut profile = self
+            .get_profile_raw(username)
+            .await?
             .ok_or_else(|| anyhow!("User '{username}' not found"))?;
         profile.active = Some(active);
         let json = serde_json::to_string(&profile)?;
-        self.pool.set::<(), _, _>(format!("hs:user:{username}"), json, None, None, false).await?;
+        self.pool
+            .set::<(), _, _>(format!("hs:user:{username}"), json, None, None, false)
+            .await?;
         Ok(())
     }
 
     async fn list_pubkeys(&self, username: &str) -> Result<Vec<PubkeyEntry>> {
-        let fps: Vec<String> = self.pool
+        let fps: Vec<String> = self
+            .pool
             .smembers(format!("hs:user:{username}:keys"))
             .await?;
         let mut entries = Vec::new();
@@ -249,7 +389,8 @@ impl UserStore for ValkeyUserStore {
             if let Some(s) = val {
                 let stored: StoredKey = serde_json::from_str(&s)?;
                 use base64::Engine;
-                let raw = base64::engine::general_purpose::STANDARD.decode(&stored.pubkey_base64)?;
+                let raw =
+                    base64::engine::general_purpose::STANDARD.decode(&stored.pubkey_base64)?;
                 let key_bytes: [u8; 32] = raw.try_into().map_err(|_| anyhow!("bad key length"))?;
                 let pubkey = VerifyingKey::from_bytes(&key_bytes)?;
                 // Decode + invariant-check the PQ component (fail closed on a
@@ -288,7 +429,12 @@ impl UserStore for ValkeyUserStore {
         Ok(entries)
     }
 
-    async fn add_pubkey(&self, username: &str, pubkey: VerifyingKey, label: Option<String>) -> Result<String> {
+    async fn add_pubkey(
+        &self,
+        username: &str,
+        pubkey: VerifyingKey,
+        label: Option<String>,
+    ) -> Result<String> {
         use base64::Engine;
         let fp = pubkey_fingerprint(&pubkey);
         let pubkey_base64 = base64::engine::general_purpose::STANDARD.encode(pubkey.as_bytes());
@@ -302,10 +448,33 @@ impl UserStore for ValkeyUserStore {
             pq_pubkey_base64: None,
         };
         let json = serde_json::to_string(&stored)?;
-        self.pool.set::<(), _, _>(format!("hs:key:{fp}"), json, None, None, false).await?;
-        self.pool.sadd::<i64, _, _>(format!("hs:user:{username}:keys"), &fp).await?;
-        self.pool.set::<(), _, _>(format!("hs:keyowner:{fp}"), username, None, None, false).await?;
-        Ok(fp)
+        const ADD_CLASSICAL_KEY: &str = r#"
+local owner = redis.call('GET', KEYS[1])
+if owner and owner ~= ARGV[1] then return 1 end
+if redis.call('SISMEMBER', KEYS[3], ARGV[3]) == 1 then return 2 end
+redis.call('SET', KEYS[2], ARGV[2])
+redis.call('SADD', KEYS[3], ARGV[3])
+redis.call('SET', KEYS[1], ARGV[1])
+return 0
+"#;
+        let status: i64 = self
+            .pool
+            .eval(
+                ADD_CLASSICAL_KEY,
+                vec![
+                    format!("hs:keyowner:{fp}"),
+                    format!("hs:key:{fp}"),
+                    format!("hs:user:{username}:keys"),
+                ],
+                vec![username.to_owned(), json, fp.clone()],
+            )
+            .await?;
+        match status {
+            0 => Ok(fp),
+            1 => anyhow::bail!("Pubkey already associated with another user"),
+            2 => anyhow::bail!("Pubkey with fingerprint {fp} already exists for user '{username}'"),
+            other => anyhow::bail!("unexpected add-pubkey status {other}"),
+        }
     }
 
     async fn add_pubkey_hybrid(
@@ -330,19 +499,21 @@ impl UserStore for ValkeyUserStore {
             }
         }
         let pubkey_base64 = base64::engine::general_purpose::STANDARD.encode(pubkey.as_bytes());
-        let pq_pubkey_base64 =
-            Some(base64::engine::general_purpose::STANDARD.encode(&ml_dsa_vk));
+        let pq_pubkey_base64 = Some(base64::engine::general_purpose::STANDARD.encode(&ml_dsa_vk));
 
         // In-place upgrade (Ed25519 → Hybrid) or idempotent re-bind: preserve
         // the original created_at/last_used_at if a record already exists.
-        let (created_at, last_used_at, existing_label) =
-            match self.pool.get::<Option<String>, _>(format!("hs:key:{fp}")).await? {
-                Some(s) => {
-                    let prev: StoredKey = serde_json::from_str(&s)?;
-                    (prev.created_at, prev.last_used_at, prev.label)
-                }
-                None => (chrono::Utc::now().timestamp(), None, None),
-            };
+        let (created_at, last_used_at, existing_label) = match self
+            .pool
+            .get::<Option<String>, _>(format!("hs:key:{fp}"))
+            .await?
+        {
+            Some(s) => {
+                let prev: StoredKey = serde_json::from_str(&s)?;
+                (prev.created_at, prev.last_used_at, prev.label)
+            }
+            None => (chrono::Utc::now().timestamp(), None, None),
+        };
 
         let stored = StoredKey {
             pubkey_base64,
@@ -353,17 +524,49 @@ impl UserStore for ValkeyUserStore {
             pq_pubkey_base64,
         };
         let json = serde_json::to_string(&stored)?;
-        self.pool.set::<(), _, _>(format!("hs:key:{fp}"), json, None, None, false).await?;
-        self.pool.sadd::<i64, _, _>(format!("hs:user:{username}:keys"), &fp).await?;
-        self.pool.set::<(), _, _>(format!("hs:keyowner:{fp}"), username, None, None, false).await?;
-        Ok(fp)
+        const UPSERT_HYBRID_KEY: &str = r#"
+local owner = redis.call('GET', KEYS[1])
+if owner and owner ~= ARGV[1] then return 1 end
+redis.call('SET', KEYS[2], ARGV[2])
+redis.call('SADD', KEYS[3], ARGV[3])
+redis.call('SET', KEYS[1], ARGV[1])
+return 0
+"#;
+        let status: i64 = self
+            .pool
+            .eval(
+                UPSERT_HYBRID_KEY,
+                vec![
+                    format!("hs:keyowner:{fp}"),
+                    format!("hs:key:{fp}"),
+                    format!("hs:user:{username}:keys"),
+                ],
+                vec![username.to_owned(), json, fp.clone()],
+            )
+            .await?;
+        match status {
+            0 => Ok(fp),
+            1 => anyhow::bail!("Pubkey already associated with another user"),
+            other => anyhow::bail!("unexpected hybrid add-pubkey status {other}"),
+        }
     }
 
     async fn remove_pubkey(&self, username: &str, fingerprint: &str) -> Result<bool> {
-        let removed: i64 = self.pool.srem(format!("hs:user:{username}:keys"), fingerprint).await?;
+        let removed: i64 = self
+            .pool
+            .srem(format!("hs:user:{username}:keys"), fingerprint)
+            .await?;
         if removed > 0 {
-            let _: i64 = self.pool.del(format!("hs:key:{fingerprint}")).await.unwrap_or(0);
-            let _: i64 = self.pool.del(format!("hs:keyowner:{fingerprint}")).await.unwrap_or(0);
+            let _: i64 = self
+                .pool
+                .del(format!("hs:key:{fingerprint}"))
+                .await
+                .unwrap_or(0);
+            let _: i64 = self
+                .pool
+                .del(format!("hs:keyowner:{fingerprint}"))
+                .await
+                .unwrap_or(0);
         }
         Ok(removed > 0)
     }
@@ -378,7 +581,9 @@ impl UserStore for ValkeyUserStore {
             let mut stored: StoredKey = serde_json::from_str(&s)?;
             stored.last_used_at = Some(chrono::Utc::now().timestamp());
             let json = serde_json::to_string(&stored)?;
-            self.pool.set::<(), _, _>(format!("hs:key:{fingerprint}"), json, None, None, false).await?;
+            self.pool
+                .set::<(), _, _>(format!("hs:key:{fingerprint}"), json, None, None, false)
+                .await?;
         }
         Ok(())
     }

--- a/crates/hyprstream/src/auth/valkey.rs
+++ b/crates/hyprstream/src/auth/valkey.rs
@@ -50,29 +50,61 @@ struct HostedBindingMarker {
     pubkey_base64: String,
 }
 
+fn validate_stored_key_record(
+    fingerprint: &str,
+    key_json: &str,
+) -> Result<(StoredKey, VerifyingKey, Option<Vec<u8>>)> {
+    use base64::engine::general_purpose::STANDARD;
+    use base64::Engine;
+
+    let key: StoredKey = serde_json::from_str(key_json)?;
+    let key_bytes: [u8; 32] = STANDARD
+        .decode(&key.pubkey_base64)?
+        .try_into()
+        .map_err(|_| anyhow!("bad key length"))?;
+    let verifying_key = VerifyingKey::from_bytes(&key_bytes)?;
+    if pubkey_fingerprint(&verifying_key) != fingerprint {
+        anyhow::bail!("stored key does not match fingerprint {fingerprint}");
+    }
+
+    // Keep hosted-account activation/conflict classification and ordinary
+    // authentication on one complete-record acceptance policy. A metadata-
+    // corrupt record must never become a recovery-triggering trusted 409.
+    let pq_pubkey = match key.pq_pubkey_base64.as_deref() {
+        Some(b64) if !b64.is_empty() => Some(
+            STANDARD
+                .decode(b64)
+                .with_context(|| format!("invalid base64 ML-DSA-65 key for {fingerprint}"))?,
+        ),
+        _ => None,
+    };
+    match (key.algorithm.is_hybrid(), &pq_pubkey) {
+        (true, Some(_)) | (false, None) => {}
+        (true, None) => anyhow::bail!(
+            "hybrid pubkey record {fingerprint} is missing its ML-DSA-65 key \
+             material (refusing to read — fail closed)"
+        ),
+        (false, Some(_)) => anyhow::bail!(
+            "classical pubkey record {fingerprint} carries unexpected ML-DSA-65 \
+             key material (refusing to read)"
+        ),
+    }
+
+    Ok((key, verifying_key, pq_pubkey))
+}
+
 fn validated_stored_key_base64(
     fingerprint: &str,
     key_json: Option<&str>,
 ) -> std::result::Result<String, HostedAccountProvisionError> {
-    use base64::engine::general_purpose::STANDARD;
-    use base64::Engine;
-
-    let invalid = || {
-        HostedAccountProvisionError::Backend(anyhow!(
-            "stored hosted-account key does not match its indexed fingerprint"
-        ))
-    };
-    let key: StoredKey =
-        serde_json::from_str(key_json.ok_or_else(invalid)?).map_err(|_| invalid())?;
-    let key_bytes = STANDARD
-        .decode(&key.pubkey_base64)
-        .ok()
-        .and_then(|bytes| <[u8; 32]>::try_from(bytes).ok())
-        .ok_or_else(invalid)?;
-    let verifying_key = VerifyingKey::from_bytes(&key_bytes).map_err(|_| invalid())?;
-    if pubkey_fingerprint(&verifying_key) != fingerprint {
-        return Err(invalid());
-    }
+    let key_json = key_json.ok_or_else(|| {
+        HostedAccountProvisionError::Backend(anyhow!("stored hosted-account key is missing"))
+    })?;
+    let (key, _, _) = validate_stored_key_record(fingerprint, key_json).map_err(|error| {
+        HostedAccountProvisionError::Backend(
+            error.context("stored hosted-account key is not authentication-usable"),
+        )
+    })?;
     Ok(key.pubkey_base64)
 }
 
@@ -187,6 +219,27 @@ impl ValkeyUserStore {
             key_json.as_deref(),
             marker_json.as_deref(),
         )
+    }
+
+    async fn validate_account_conflict(
+        &self,
+        username: &str,
+    ) -> std::result::Result<(), HostedAccountProvisionError> {
+        // list_pubkeys applies the same complete-record policy as activation
+        // and trusted key conflicts, and fails the whole account read if any
+        // algorithm/PQ metadata is corrupt.
+        let keys = self
+            .list_pubkeys(username)
+            .await
+            .map_err(HostedAccountProvisionError::Backend)?;
+        for key in keys {
+            if self.validate_key_conflict(&key.fingerprint).await.is_ok() {
+                return Ok(());
+            }
+        }
+        Err(HostedAccountProvisionError::Backend(anyhow!(
+            "existing hosted account has no complete active credential binding"
+        )))
     }
 
     async fn validated_staged_public_key(
@@ -416,7 +469,10 @@ return 0
                 fingerprint,
                 resumed: false,
             }),
-            1 => Err(HostedAccountProvisionError::AccountAlreadyExists),
+            1 => {
+                self.validate_account_conflict(username).await?;
+                Err(HostedAccountProvisionError::AccountAlreadyExists)
+            }
             2 => {
                 self.validate_key_conflict(&fingerprint).await?;
                 Err(HostedAccountProvisionError::KeyAlreadyBound)
@@ -760,34 +816,7 @@ return 0
         for fp in fps {
             let val: Option<String> = self.pool.get(format!("hs:key:{fp}")).await?;
             if let Some(s) = val {
-                let stored: StoredKey = serde_json::from_str(&s)?;
-                use base64::Engine;
-                let raw =
-                    base64::engine::general_purpose::STANDARD.decode(&stored.pubkey_base64)?;
-                let key_bytes: [u8; 32] = raw.try_into().map_err(|_| anyhow!("bad key length"))?;
-                let pubkey = VerifyingKey::from_bytes(&key_bytes)?;
-                // Decode + invariant-check the PQ component (fail closed on a
-                // Hybrid record with no/empty PQ bytes — never a silent
-                // downgrade to Ed25519).
-                let pq_pubkey = match stored.pq_pubkey_base64.as_deref() {
-                    Some(b64) if !b64.is_empty() => Some(
-                        base64::engine::general_purpose::STANDARD
-                            .decode(b64)
-                            .with_context(|| format!("invalid base64 ML-DSA-65 key for {fp}"))?,
-                    ),
-                    _ => None,
-                };
-                match (stored.algorithm.is_hybrid(), &pq_pubkey) {
-                    (true, Some(_)) | (false, None) => {}
-                    (true, None) => anyhow::bail!(
-                        "hybrid pubkey record {fp} is missing its ML-DSA-65 key \
-                         material (refusing to read — fail closed)"
-                    ),
-                    (false, Some(_)) => anyhow::bail!(
-                        "classical pubkey record {fp} carries unexpected ML-DSA-65 \
-                         key material (refusing to read)"
-                    ),
-                }
+                let (stored, pubkey, pq_pubkey) = validate_stored_key_record(&fp, &s)?;
                 entries.push(PubkeyEntry {
                     fingerprint: fp,
                     pubkey,
@@ -1086,6 +1115,84 @@ mod tests {
             ),
             Err(HostedAccountProvisionError::Backend(_))
         ));
+        Ok(())
+    }
+
+    #[test]
+    fn corrupt_algorithm_pq_metadata_never_becomes_trusted_key_conflict() -> Result<()> {
+        use base64::engine::general_purpose::STANDARD;
+        use base64::Engine;
+
+        let key = ed25519_dalek::SigningKey::from_bytes(&[0x78; 32]).verifying_key();
+        let fingerprint = pubkey_fingerprint(&key);
+        let key_base64 = STANDARD.encode(key.as_bytes());
+        let profile_json = serde_json::to_string(&UserProfile {
+            sub: Some("alice-sub".to_owned()),
+            active: Some(true),
+            atproto_did: Some("did:web:alice.accounts.example.test".to_owned()),
+            key_custody: Some(AccountKeyCustody::SelfCustody),
+            ..Default::default()
+        })?;
+        let marker_json = serde_json::to_string(&HostedBindingMarker {
+            fingerprint: fingerprint.clone(),
+            did: "did:web:alice.accounts.example.test".to_owned(),
+            custody: "self_custody".to_owned(),
+            pubkey_base64: key_base64.clone(),
+        })?;
+        let conflict_result = |algorithm: crate::auth::KeyAlgorithm,
+                               pq_pubkey_base64: Option<String>| {
+            let key_json = serde_json::to_string(&StoredKey {
+                pubkey_base64: key_base64.clone(),
+                label: Some("aegis-vault".to_owned()),
+                created_at: 1,
+                last_used_at: None,
+                algorithm,
+                pq_pubkey_base64,
+            })
+            .unwrap();
+            validate_key_conflict_snapshot(
+                &fingerprint,
+                Some("alice"),
+                true,
+                Some(&profile_json),
+                Some(&key_json),
+                Some(&marker_json),
+            )
+        };
+
+        // Hybrid tag without its mandatory ML-DSA-65 component.
+        assert!(matches!(
+            conflict_result(crate::auth::KeyAlgorithm::HybridEd25519MlDsa65, None),
+            Err(HostedAccountProvisionError::Backend(_))
+        ));
+
+        // Classical tag carrying PQ material is inconsistent and must not be
+        // treated as an authentication-usable hosted binding.
+        assert!(matches!(
+            conflict_result(
+                crate::auth::KeyAlgorithm::Ed25519,
+                Some(STANDARD.encode(vec![0x5a; 1952])),
+            ),
+            Err(HostedAccountProvisionError::Backend(_))
+        ));
+
+        // A hybrid record with malformed PQ encoding cannot be read by the
+        // ordinary authentication path, so it cannot justify a trusted 409.
+        assert!(matches!(
+            conflict_result(
+                crate::auth::KeyAlgorithm::HybridEd25519MlDsa65,
+                Some("not-base64".to_owned()),
+            ),
+            Err(HostedAccountProvisionError::Backend(_))
+        ));
+
+        // Preserve the positive side of the invariant: a complete hybrid
+        // record with the same Ed25519 anchor remains accepted.
+        assert!(conflict_result(
+            crate::auth::KeyAlgorithm::HybridEd25519MlDsa65,
+            Some(STANDARD.encode(vec![0x5a; 1952])),
+        )
+        .is_ok());
         Ok(())
     }
 

--- a/crates/hyprstream/src/services/oauth/authorize.rs
+++ b/crates/hyprstream/src/services/oauth/authorize.rs
@@ -576,95 +576,20 @@ pub async fn authorize_post(
             }
         };
 
-        // Fail before consuming an authority label on every conflict the AS
-        // can already observe. The authority reservation remains the final
-        // race-safe handle arbiter.
-        match user_store.get_profile(handle).await {
-            Ok(Some(_)) => {
-                return error_response(
-                    StatusCode::CONFLICT,
-                    "handle_unavailable",
-                    "Requested hosted-account handle is unavailable",
-                );
-            }
-            Ok(None) => {}
-            Err(error) => {
-                tracing::error!(%error, handle, "UserStore availability check failed");
-                return error_response(
-                    StatusCode::INTERNAL_SERVER_ERROR,
-                    "server_error",
-                    "Account availability could not be verified",
-                );
-            }
-        }
-        match user_store.get_pubkey_user(&form.fingerprint).await {
-            Ok(Some(_)) => {
-                return error_response(
-                    StatusCode::CONFLICT,
-                    "key_already_bound",
-                    "Account public key is already bound",
-                );
-            }
-            Ok(None) => {}
-            Err(error) => {
-                tracing::error!(%error, fingerprint = %form.fingerprint, "UserStore key availability check failed");
-                return error_response(
-                    StatusCode::INTERNAL_SERVER_ERROR,
-                    "server_error",
-                    "Account key availability could not be verified",
-                );
-            }
-        }
-
-        let minted =
-            match registration_api.mint_for_oauth_signup(handle, dpop_jkt, &form.fingerprint) {
-                Ok(result) => result,
-                Err(IdentityApiError::RateLimited) => {
-                    return error_response(
-                        StatusCode::TOO_MANY_REQUESTS,
-                        "rate_limited",
-                        "Signup rate limit exceeded",
-                    );
-                }
-                Err(IdentityApiError::HandleUnavailable) => {
-                    return error_response(
-                        StatusCode::CONFLICT,
-                        "handle_unavailable",
-                        "Requested hosted-account handle is unavailable",
-                    );
-                }
-                Err(error) => {
-                    tracing::error!(?error, handle, "Hosted-account signup mint failed");
-                    return error_response(
-                        StatusCode::INTERNAL_SERVER_ERROR,
-                        "server_error",
-                        "Hosted-account minting failed",
-                    );
-                }
-            };
-        if expected_did.as_str() != minted.did {
-            tracing::error!(
-                requested_handle = handle,
-                minted_did = %minted.did,
-                "Authority returned a DID outside the configured host-form account zone"
-            );
-            return error_response(
-                StatusCode::INTERNAL_SERVER_ERROR,
-                "server_error",
-                "Hosted-account authority binding is invalid",
-            );
-        }
-
-        match user_store
+        // The credential store is the first durable uniqueness commit. It
+        // stages the exact handle/DID/key binding inactive, or resumes that
+        // same verified pair. No authority reservation or PDS generation is
+        // published before this succeeds.
+        let provisioned = match user_store
             .provision_hosted_account(
                 handle,
-                &minted.did,
+                &expected_did,
                 verifying_key,
                 AccountKeyCustody::SelfCustody,
             )
             .await
         {
-            Ok(provisioned) if provisioned.fingerprint == form.fingerprint => {}
+            Ok(provisioned) if provisioned.fingerprint == form.fingerprint => provisioned,
             Ok(provisioned) => {
                 tracing::error!(
                     expected = %form.fingerprint,
@@ -700,6 +625,64 @@ pub async fn authorize_post(
                     "Hosted-account credential binding failed",
                 );
             }
+        };
+
+        tracing::debug!(
+            handle,
+            resumed = provisioned.resumed,
+            "Hosted-account credential transaction is staged"
+        );
+
+        let minted =
+            match registration_api.mint_for_oauth_signup(handle, dpop_jkt, &form.fingerprint) {
+                Ok(result) => result,
+                Err(IdentityApiError::RateLimited) => {
+                    return error_response(
+                        StatusCode::TOO_MANY_REQUESTS,
+                        "rate_limited",
+                        "Signup rate limit exceeded",
+                    );
+                }
+                Err(error) => {
+                    // The staged credential binding is intentionally retained:
+                    // an exact retry can resume the authority/PDS transaction.
+                    // Authority conflicts after staging indicate inconsistent
+                    // backend state and are never a client-trusted 409.
+                    tracing::error!(?error, handle, "Hosted-account signup mint failed");
+                    return error_response(
+                        StatusCode::INTERNAL_SERVER_ERROR,
+                        "server_error",
+                        "Hosted-account minting failed",
+                    );
+                }
+            };
+        if expected_did.as_str() != minted.did {
+            tracing::error!(
+                requested_handle = handle,
+                minted_did = %minted.did,
+                "Authority returned a DID outside the configured host-form account zone"
+            );
+            return error_response(
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "server_error",
+                "Hosted-account authority binding is invalid",
+            );
+        }
+        if let Err(error) = user_store
+            .activate_hosted_account(
+                handle,
+                &minted.did,
+                &form.fingerprint,
+                AccountKeyCustody::SelfCustody,
+            )
+            .await
+        {
+            tracing::error!(?error, handle, "Hosted-account final AS activation failed");
+            return error_response(
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "server_error",
+                "Hosted-account activation failed",
+            );
         }
         (handle.to_owned(), verifying_key)
     } else if action == AUTHORIZE_ACTION {
@@ -717,7 +700,35 @@ pub async fn authorize_post(
         )
         .await
         {
-            Ok(pair) => pair,
+            Ok((username, verifying_key)) => match user_store.get_profile(&username).await {
+                Ok(Some(profile)) if profile.active != Some(false) => (username, verifying_key),
+                Ok(Some(_)) => {
+                    return error_response(
+                        StatusCode::FORBIDDEN,
+                        "access_denied",
+                        "Account is not active",
+                    );
+                }
+                Ok(None) => {
+                    tracing::error!(
+                        username,
+                        "Credential reverse index resolved to a missing user profile"
+                    );
+                    return error_response(
+                        StatusCode::INTERNAL_SERVER_ERROR,
+                        "server_error",
+                        "Account credential binding is inconsistent",
+                    );
+                }
+                Err(error) => {
+                    tracing::error!(%error, username, "UserStore activation check failed");
+                    return error_response(
+                        StatusCode::INTERNAL_SERVER_ERROR,
+                        "server_error",
+                        "Account activation could not be verified",
+                    );
+                }
+            },
             Err(e) => {
                 if matches!(e, challenge::ChallengeError::UserStoreError(_)) {
                     tracing::error!(fingerprint = %form.fingerprint, "UserStore lookup error during authorize");
@@ -1294,9 +1305,8 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn signup_action_provisions_account_and_issues_standard_auth_code() -> anyhow::Result<()>
-    {
-        use std::sync::atomic::{AtomicUsize, Ordering};
+    async fn signup_resumes_after_crash_after_genesis_before_activation() -> anyhow::Result<()> {
+        use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 
         use async_trait::async_trait;
         use base64::engine::general_purpose::STANDARD;
@@ -1310,7 +1320,10 @@ mod tests {
             IdentityConnectTimeResolver, IdentityRegistrationApi, RegistrationGenesisSigner,
         };
 
-        struct SignupMint(AtomicUsize);
+        struct SignupMint {
+            calls: AtomicUsize,
+            fail_after_publish_once: AtomicBool,
+        }
         impl HostedRegistrationMint for SignupMint {
             fn mint(
                 &self,
@@ -1319,7 +1332,10 @@ mod tests {
             ) -> anyhow::Result<
                 hyprstream_pds_service::hosted_account_mint::HostedAccountRegistrationResult,
             > {
-                self.0.fetch_add(1, Ordering::SeqCst);
+                self.calls.fetch_add(1, Ordering::SeqCst);
+                if self.fail_after_publish_once.swap(false, Ordering::SeqCst) {
+                    anyhow::bail!("simulated crash after durable PDS genesis publication");
+                }
                 Ok(
                     hyprstream_pds_service::hosted_account_mint::HostedAccountRegistrationResult {
                         handle: format!("at://{}.accounts.example.test", request.handle()),
@@ -1386,7 +1402,10 @@ mod tests {
         config.external_url = Some("https://pds.example.test".to_owned());
         let user_dir = tempfile::TempDir::new()?;
         let user_store = Arc::new(RocksDbUserStore::open(user_dir.path())?);
-        let mint = Arc::new(SignupMint(AtomicUsize::new(0)));
+        let mint = Arc::new(SignupMint {
+            calls: AtomicUsize::new(0),
+            fail_after_publish_once: AtomicBool::new(true),
+        });
         let identity_api = Arc::new(IdentityRegistrationApi::new(
             mint.clone(),
             Arc::new(UnusedSigner),
@@ -1477,14 +1496,75 @@ mod tests {
         )
         .await;
 
-        assert_eq!(response.status(), StatusCode::SEE_OTHER);
-        assert_eq!(mint.0.load(Ordering::SeqCst), 1);
+        assert_eq!(response.status(), StatusCode::INTERNAL_SERVER_ERROR);
+        assert_eq!(mint.calls.load(Ordering::SeqCst), 1);
+        let staged = user_store.get_profile("alice").await?.unwrap();
+        assert_eq!(staged.active, Some(false));
+        assert_eq!(
+            user_store.get_pubkey_user(&fingerprint).await?,
+            Some("alice".to_owned())
+        );
+        assert!(state.pending_codes.read().await.is_empty());
+
+        // A fresh, fully verified OAuth authorize transaction for the exact
+        // same handle/key resumes minting and performs final activation.
+        let retry_nonce = fresh_nonce();
+        let retry_code_challenge = "signup-pkce-challenge-retry".to_owned();
+        let retry_request = AuthorizeParams {
+            client_id: "signup-client".to_owned(),
+            redirect_uri: "https://client.example/callback".to_owned(),
+            code_challenge: retry_code_challenge.clone(),
+            code_challenge_method: "S256".to_owned(),
+            response_type: "code".to_owned(),
+            state: Some("signup-state-retry".to_owned()),
+            scope: Some("atproto".to_owned()),
+            resource: Some("https://pds.example.test".to_owned()),
+            nonce: None,
+            dpop_jkt: Some("par-verified-dpop-thumbprint".to_owned()),
+            client_assertion_jkt: None,
+        };
+        state.pending_nonces.write().await.insert(
+            retry_nonce.clone(),
+            Instant::now() + Duration::from_secs(300),
+        );
+        state.pending_authorize_bindings.write().await.insert(
+            retry_nonce.clone(),
+            super::super::state::AuthorizeBinding {
+                request: retry_request,
+            },
+        );
+        let retry_challenge =
+            signup_proof_challenge("alice", &fingerprint, &retry_nonce, &retry_code_challenge);
+        let retry_signature = STANDARD.encode(vault_key.sign(&retry_challenge).to_bytes());
+        let retry_response = authorize_post(
+            State(state.clone()),
+            Ok(Form(ConsentForm {
+                action: Some(SIGNUP_ACTION.to_owned()),
+                client_id: "signup-client".to_owned(),
+                redirect_uri: "https://client.example/callback".to_owned(),
+                code_challenge: retry_code_challenge,
+                scope: "atproto".to_owned(),
+                state: Some("signup-state-retry".to_owned()),
+                resource: Some("https://pds.example.test".to_owned()),
+                nonce: retry_nonce,
+                fingerprint: fingerprint.clone(),
+                signature: retry_signature,
+                handle: Some("alice".to_owned()),
+                account_public_key: Some(STANDARD.encode(vault_key.verifying_key().as_bytes())),
+                oidc_nonce: None,
+            })),
+        )
+        .await;
+
+        assert_eq!(retry_response.status(), StatusCode::SEE_OTHER);
+        assert_eq!(mint.calls.load(Ordering::SeqCst), 2);
         let profile = user_store.get_profile("alice").await?.unwrap();
         assert_eq!(
             profile.atproto_did.as_deref(),
             Some("did:web:alice.accounts.example.test")
         );
         assert_eq!(profile.key_custody, Some(AccountKeyCustody::SelfCustody));
+        assert_eq!(profile.active, Some(true));
         assert!(profile.external_identities.is_empty());
         assert_eq!(
             user_store.get_pubkey_user(&fingerprint).await?,

--- a/crates/hyprstream/src/services/oauth/authorize.rs
+++ b/crates/hyprstream/src/services/oauth/authorize.rs
@@ -18,7 +18,7 @@ use std::sync::Arc;
 use std::time::{Duration, Instant};
 
 use axum::{
-    extract::{Query, State},
+    extract::{rejection::FormRejection, Query, State},
     http::StatusCode,
     response::{Html, IntoResponse, Redirect, Response},
     Form,
@@ -29,8 +29,14 @@ use serde::Deserialize;
 
 use super::challenge;
 use super::device::html_escape;
+use super::identity_registration::IdentityApiError;
 use super::registration::{resolve_cimd_client, validate_redirect_uri};
 use super::state::{OAuthState, PendingAuthCode};
+use crate::auth::{AccountKeyCustody, HostedAccountProvisionError};
+
+const SIGNUP_ACTION: &str = "signup";
+const AUTHORIZE_ACTION: &str = "authorize";
+const SIGNUP_PROOF_DOMAIN: &[u8] = b"hyprstream-cold-signup-v1\0";
 
 /// Authorization request query parameters
 #[derive(Debug, Clone, Deserialize)]
@@ -100,6 +106,10 @@ pub struct AuthorizeQuery {
 /// `"{fingerprint}:{nonce}:{code_challenge}"`.
 #[derive(Debug, Deserialize)]
 pub struct ConsentForm {
+    /// Omitted/`authorize` authenticates an existing account. `signup`
+    /// provisions a new hosted account inside this same authorize transaction.
+    #[serde(default)]
+    pub action: Option<String>,
     pub client_id: String,
     pub redirect_uri: String,
     pub code_challenge: String,
@@ -114,6 +124,12 @@ pub struct ConsentForm {
     pub fingerprint: String,
     /// Base64-encoded Ed25519 signature
     pub signature: String,
+    /// Requested one-label hosted-account handle. Signup action only.
+    #[serde(default)]
+    pub handle: Option<String>,
+    /// Standard-base64 raw or SSH-wire Ed25519 public key. Signup action only.
+    #[serde(default)]
+    pub account_public_key: Option<String>,
     /// OIDC nonce (passed through from authorize request, stored in auth code)
     #[serde(default)]
     pub oidc_nonce: Option<String>,
@@ -163,7 +179,8 @@ pub async fn authorize_get(
             "Server Not Configured",
             "This server is not configured for local user authentication. \
              Contact your administrator to set up the user credential store.",
-        )).into_response();
+        ))
+        .into_response();
     }
 
     // Resolve client
@@ -171,7 +188,9 @@ pub async fn authorize_get(
         // Client ID Metadata Document flow (cache-aside via cimd_cache).
         match resolve_cimd_client(&state, &params.client_id).await {
             Ok(client) => (
-                client.client_name.unwrap_or_else(|| params.client_id.clone()),
+                client
+                    .client_name
+                    .unwrap_or_else(|| params.client_id.clone()),
                 client.redirect_uris,
             ),
             Err(e) => {
@@ -187,7 +206,10 @@ pub async fn authorize_get(
         let clients = state.clients.read().await;
         match clients.get(&params.client_id) {
             Some(client) => (
-                client.client_name.clone().unwrap_or_else(|| params.client_id.clone()),
+                client
+                    .client_name
+                    .clone()
+                    .unwrap_or_else(|| params.client_id.clone()),
                 client.redirect_uris.clone(),
             ),
             None => {
@@ -210,13 +232,17 @@ pub async fn authorize_get(
     }
 
     // Determine scopes
-    let scopes = params.scope.as_deref().unwrap_or(
-        &state.default_scopes.join(" ")
-    ).to_owned();
+    let scopes = params
+        .scope
+        .as_deref()
+        .unwrap_or(&state.default_scopes.join(" "))
+        .to_owned();
     let mut effective_request = params.clone();
     effective_request.scope = Some(scopes.clone());
     let effective_scopes: Vec<String> = scopes.split_whitespace().map(str::to_owned).collect();
-    if super::state::atproto_profile_active(&effective_scopes) && effective_request.dpop_jkt.is_none() {
+    if super::state::atproto_profile_active(&effective_scopes)
+        && effective_request.dpop_jkt.is_none()
+    {
         return error_response(
             StatusCode::BAD_REQUEST,
             "invalid_request",
@@ -241,13 +267,12 @@ pub async fn authorize_get(
     let nonce = issue_nonce(&state).await;
     // Bind the complete resolved request to the consent nonce. Hidden form
     // fields are transport echoes only and cannot change authority on POST.
-    state
-        .pending_authorize_bindings
-        .write()
-        .await
-        .insert(nonce.clone(), super::state::AuthorizeBinding {
+    state.pending_authorize_bindings.write().await.insert(
+        nonce.clone(),
+        super::state::AuthorizeBinding {
             request: effective_request.clone(),
-        });
+        },
+    );
 
     // Render challenge form
     let html = render_challenge_page(
@@ -282,11 +307,49 @@ fn consent_form_matches_request(form: &ConsentForm, request: &AuthorizeParams) -
         && nonempty(form.oidc_nonce.as_deref()) == nonempty(request.nonce.as_deref())
 }
 
+/// Domain-separated proof signed by the new vault key.
+///
+/// NUL delimiters make the byte contract unambiguous. The fingerprint is
+/// derived again from `account_public_key` before verification, so the proof
+/// binds the actual key as well as handle, single-use authorize nonce, and
+/// PAR/PKCE transaction.
+fn signup_proof_challenge(
+    handle: &str,
+    fingerprint: &str,
+    nonce: &str,
+    code_challenge: &str,
+) -> Vec<u8> {
+    let mut challenge = Vec::with_capacity(
+        SIGNUP_PROOF_DOMAIN.len()
+            + handle.len()
+            + fingerprint.len()
+            + nonce.len()
+            + code_challenge.len()
+            + 4,
+    );
+    challenge.extend_from_slice(SIGNUP_PROOF_DOMAIN);
+    for component in [handle, fingerprint, nonce, code_challenge] {
+        challenge.extend_from_slice(component.as_bytes());
+        challenge.push(0);
+    }
+    challenge
+}
+
 /// POST /oauth/authorize — verify Ed25519 signature, issue auth code
 pub async fn authorize_post(
     State(state): State<Arc<OAuthState>>,
-    Form(form): Form<ConsentForm>,
+    submitted: Result<Form<ConsentForm>, FormRejection>,
 ) -> Response {
+    let Form(form) = match submitted {
+        Ok(form) => form,
+        Err(_) => {
+            return error_response(
+                StatusCode::BAD_REQUEST,
+                "invalid_request",
+                "Authorization form is missing or malformed",
+            );
+        }
+    };
     // Validate and consume the nonce. Rejects forged nonces and enforces the 5-min TTL.
     // Single-use: remove from pending_nonces whether valid or expired.
     let (nonce_valid, authorize_binding) = {
@@ -322,7 +385,8 @@ pub async fn authorize_post(
             return Html(render_error_page(
                 "Invalid Request",
                 "Unknown client or redirect URI. Please restart the authorization flow.",
-            )).into_response();
+            ))
+            .into_response();
         };
         let fresh_nonce = issue_nonce(&state).await;
         // #1113 rev2 F3: re-stash the binding on error-retry so the PAR
@@ -357,84 +421,8 @@ pub async fn authorize_post(
         );
     }
 
-    // Reconstruct challenge: "{fingerprint}:{nonce}:{code_challenge}"
-    // Binds signature to the key identity and the PKCE session. The server
-    // does not trust client-declared usernames — it resolves the username
-    // from the pubkey reverse index keyed by `form.fingerprint`.
-    let challenge_str = format!("{}:{}:{}", form.fingerprint, form.nonce, effective.code_challenge);
-
-    // Get user store
-    let user_store = match state.user_store_reader() {
-        Some(store) => store,
-        None => {
-            return Html(render_error_page(
-                "Server Not Configured",
-                "User credential store not configured on this server.",
-            )).into_response();
-        }
-    };
-
-    // Verify Ed25519 challenge-response. The resolved username comes back
-    // from the reverse index; the client never asserts an identity.
-    let (resolved_username, verifying_key) = match challenge::verify_ed25519_response_by_fingerprint(
-        user_store.as_ref(),
-        &form.fingerprint,
-        &challenge_str,
-        &form.signature,
-    ).await {
-        Ok(pair) => pair,
-        Err(e) => {
-            if matches!(e, challenge::ChallengeError::UserStoreError(_)) {
-                tracing::error!(fingerprint = %form.fingerprint, "UserStore lookup error during authorize");
-            }
-            // Validate redirect_uri and re-derive client display info from the registry.
-            // Never trust the POST body for display values; return an error page if
-            // the client or redirect_uri is no longer valid.
-            let Some((client_name, redirect_host, localhost_warning)) =
-                derive_display_info(&state, &effective.client_id, &effective.redirect_uri).await
-            else {
-                return Html(render_error_page(
-                    "Invalid Request",
-                    "Unknown client or redirect URI. Please restart the authorization flow.",
-                )).into_response();
-            };
-            // Issue a fresh nonce so re-render shows a signable challenge.
-            let fresh_nonce = issue_nonce(&state).await;
-            // #1113 rev2 F3: re-stash the PAR-bound DPoP jkt under the fresh
-            // nonce so one failed consent signature doesn't lose the PAR key
-            // binding (which would break the later token exchange).
-            state
-                .pending_authorize_bindings
-                .write()
-                .await
-                .insert(fresh_nonce.clone(), authorize_binding.clone());
-            let html = render_challenge_page(
-                &client_name,
-                effective.scope.as_deref().unwrap_or(""),
-                &redirect_host,
-                &effective.client_id,
-                &effective.redirect_uri,
-                &effective.code_challenge,
-                effective.state.as_deref().unwrap_or(""),
-                effective.resource.as_deref().unwrap_or(""),
-                &fresh_nonce,
-                effective.nonce.as_deref().unwrap_or(""),
-                Some(e.message()),
-                localhost_warning.as_deref(),
-            );
-            return Html(html).into_response();
-        }
-    };
-
-    // Signature valid — generate auth code
-    let mut code_bytes = [0u8; 32];
-    rand::rngs::OsRng.fill_bytes(&mut code_bytes);
-    let code = URL_SAFE_NO_PAD.encode(code_bytes);
-
-    // #1113 rev2 finding 4: validate the requested scope set against the
-    // server-supported and client-declared scopes BEFORE minting an auth
-    // code. Garbage / undeclared tokens → invalid_scope. The granted set
-    // (intersection) is what the token response will echo (RFC 6749 §3.3).
+    // Validate the complete server-bound request before any irreversible
+    // signup mutation (authority allocation burns a permanent handle).
     let requested_scopes: Vec<String> = effective
         .scope
         .as_deref()
@@ -445,9 +433,6 @@ pub async fn authorize_post(
     let client_declared = match resolve_client_declared_scopes(&state, &effective.client_id).await {
         Some(declared) => declared,
         None => {
-            // #1146 T1.1: the client (and therefore its scope ceiling)
-            // could not be resolved — fail closed rather than silently
-            // validating against the full server-supported set.
             tracing::warn!(
                 client_id = %effective.client_id,
                 "authorize: client unresolvable at scope validation — failing closed"
@@ -463,10 +448,14 @@ pub async fn authorize_post(
     let granted_scopes = match super::state::validate_requested_scopes(
         &requested_scopes,
         &state.server_supported_scopes(),
-        if client_declared.is_empty() { None } else { Some(&client_declared) },
+        if client_declared.is_empty() {
+            None
+        } else {
+            Some(&client_declared)
+        },
         require_atproto,
     ) {
-        Ok(g) => g,
+        Ok(granted) => granted,
         Err(_) => {
             return error_response(
                 StatusCode::BAD_REQUEST,
@@ -475,7 +464,312 @@ pub async fn authorize_post(
             );
         }
     };
-    let resource = effective.resource.as_ref().filter(|s| !s.is_empty()).cloned();
+    let resource = effective
+        .resource
+        .as_ref()
+        .filter(|value| !value.is_empty())
+        .cloned();
+
+    // Get user store
+    let user_store = match state.user_store_reader() {
+        Some(store) => store,
+        None => {
+            return Html(render_error_page(
+                "Server Not Configured",
+                "User credential store not configured on this server.",
+            ))
+            .into_response();
+        }
+    };
+
+    let action = form.action.as_deref().unwrap_or(AUTHORIZE_ACTION);
+    let (resolved_username, verifying_key) = if action == SIGNUP_ACTION {
+        // Cold signup is deliberately reachable only from an ATProto PAR:
+        // `effective` is the server-side snapshot consumed with this nonce,
+        // including the DPoP thumbprint verified by /oauth/par.
+        let Some(dpop_jkt) = effective.dpop_jkt.as_deref() else {
+            return error_response(
+                StatusCode::BAD_REQUEST,
+                "invalid_request",
+                "Signup requires an ATProto Pushed Authorization Request bound to DPoP",
+            );
+        };
+        if !require_atproto {
+            return error_response(
+                StatusCode::BAD_REQUEST,
+                "invalid_scope",
+                "Signup requires the atproto OAuth profile",
+            );
+        }
+        let Some(registration_api) = state.identity_registration_api.as_deref() else {
+            return error_response(
+                StatusCode::SERVICE_UNAVAILABLE,
+                "temporarily_unavailable",
+                "Hosted-account minting is not configured",
+            );
+        };
+        if let Err(error) = registration_api.check_oauth_signup_rate(dpop_jkt) {
+            return match error {
+                IdentityApiError::RateLimited => error_response(
+                    StatusCode::TOO_MANY_REQUESTS,
+                    "rate_limited",
+                    "Signup rate limit exceeded",
+                ),
+                _ => error_response(
+                    StatusCode::BAD_REQUEST,
+                    "invalid_request",
+                    "Signup authorization binding is invalid",
+                ),
+            };
+        }
+        let Some(handle) = form.handle.as_deref().filter(|value| !value.is_empty()) else {
+            return error_response(
+                StatusCode::BAD_REQUEST,
+                "invalid_request",
+                "Signup handle is required",
+            );
+        };
+        let Some(hosted_zone) = state.hosted_account_zone.as_ref() else {
+            return error_response(
+                StatusCode::SERVICE_UNAVAILABLE,
+                "temporarily_unavailable",
+                "Hosted-account zone is not configured",
+            );
+        };
+        let expected_did = match hosted_zone.host_for_label(handle) {
+            Ok(host) => format!("did:web:{host}"),
+            Err(_) => {
+                return error_response(
+                    StatusCode::BAD_REQUEST,
+                    "invalid_request",
+                    "Signup handle is not a valid hosted-account label",
+                );
+            }
+        };
+        let Some(account_public_key) = form
+            .account_public_key
+            .as_deref()
+            .filter(|value| !value.is_empty())
+        else {
+            return error_response(
+                StatusCode::BAD_REQUEST,
+                "invalid_request",
+                "Signup account_public_key is required",
+            );
+        };
+
+        let signup_challenge = signup_proof_challenge(
+            handle,
+            &form.fingerprint,
+            &form.nonce,
+            &effective.code_challenge,
+        );
+        let verifying_key = match challenge::verify_unregistered_ed25519_response(
+            account_public_key,
+            &form.fingerprint,
+            &signup_challenge,
+            &form.signature,
+        ) {
+            Ok(key) => key,
+            Err(error) => {
+                return error_response(StatusCode::BAD_REQUEST, "invalid_proof", error.message());
+            }
+        };
+
+        // Fail before consuming an authority label on every conflict the AS
+        // can already observe. The authority reservation remains the final
+        // race-safe handle arbiter.
+        match user_store.get_profile(handle).await {
+            Ok(Some(_)) => {
+                return error_response(
+                    StatusCode::CONFLICT,
+                    "handle_unavailable",
+                    "Requested hosted-account handle is unavailable",
+                );
+            }
+            Ok(None) => {}
+            Err(error) => {
+                tracing::error!(%error, handle, "UserStore availability check failed");
+                return error_response(
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    "server_error",
+                    "Account availability could not be verified",
+                );
+            }
+        }
+        match user_store.get_pubkey_user(&form.fingerprint).await {
+            Ok(Some(_)) => {
+                return error_response(
+                    StatusCode::CONFLICT,
+                    "key_already_bound",
+                    "Account public key is already bound",
+                );
+            }
+            Ok(None) => {}
+            Err(error) => {
+                tracing::error!(%error, fingerprint = %form.fingerprint, "UserStore key availability check failed");
+                return error_response(
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    "server_error",
+                    "Account key availability could not be verified",
+                );
+            }
+        }
+
+        let minted =
+            match registration_api.mint_for_oauth_signup(handle, dpop_jkt, &form.fingerprint) {
+                Ok(result) => result,
+                Err(IdentityApiError::RateLimited) => {
+                    return error_response(
+                        StatusCode::TOO_MANY_REQUESTS,
+                        "rate_limited",
+                        "Signup rate limit exceeded",
+                    );
+                }
+                Err(IdentityApiError::HandleUnavailable) => {
+                    return error_response(
+                        StatusCode::CONFLICT,
+                        "handle_unavailable",
+                        "Requested hosted-account handle is unavailable",
+                    );
+                }
+                Err(error) => {
+                    tracing::error!(?error, handle, "Hosted-account signup mint failed");
+                    return error_response(
+                        StatusCode::INTERNAL_SERVER_ERROR,
+                        "server_error",
+                        "Hosted-account minting failed",
+                    );
+                }
+            };
+        if expected_did.as_str() != minted.did {
+            tracing::error!(
+                requested_handle = handle,
+                minted_did = %minted.did,
+                "Authority returned a DID outside the configured host-form account zone"
+            );
+            return error_response(
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "server_error",
+                "Hosted-account authority binding is invalid",
+            );
+        }
+
+        match user_store
+            .provision_hosted_account(
+                handle,
+                &minted.did,
+                verifying_key,
+                AccountKeyCustody::SelfCustody,
+            )
+            .await
+        {
+            Ok(provisioned) if provisioned.fingerprint == form.fingerprint => {}
+            Ok(provisioned) => {
+                tracing::error!(
+                    expected = %form.fingerprint,
+                    actual = %provisioned.fingerprint,
+                    handle,
+                    "Credential store returned a mismatched signup key"
+                );
+                return error_response(
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    "server_error",
+                    "Hosted-account credential binding failed",
+                );
+            }
+            Err(HostedAccountProvisionError::AccountAlreadyExists) => {
+                return error_response(
+                    StatusCode::CONFLICT,
+                    "handle_unavailable",
+                    "Requested hosted-account handle is unavailable",
+                );
+            }
+            Err(HostedAccountProvisionError::KeyAlreadyBound) => {
+                return error_response(
+                    StatusCode::CONFLICT,
+                    "key_already_bound",
+                    "Account public key is already bound",
+                );
+            }
+            Err(HostedAccountProvisionError::Backend(error)) => {
+                tracing::error!(%error, handle, "Atomic hosted-account AS provisioning failed");
+                return error_response(
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    "server_error",
+                    "Hosted-account credential binding failed",
+                );
+            }
+        }
+        (handle.to_owned(), verifying_key)
+    } else if action == AUTHORIZE_ACTION {
+        // Existing-account authorize challenge:
+        // "{fingerprint}:{nonce}:{code_challenge}".
+        let challenge_str = format!(
+            "{}:{}:{}",
+            form.fingerprint, form.nonce, effective.code_challenge
+        );
+        match challenge::verify_ed25519_response_by_fingerprint(
+            user_store.as_ref(),
+            &form.fingerprint,
+            &challenge_str,
+            &form.signature,
+        )
+        .await
+        {
+            Ok(pair) => pair,
+            Err(e) => {
+                if matches!(e, challenge::ChallengeError::UserStoreError(_)) {
+                    tracing::error!(fingerprint = %form.fingerprint, "UserStore lookup error during authorize");
+                }
+                // Validate redirect_uri and re-derive client display info from the registry.
+                // Never trust the POST body for display values; return an error page if
+                // the client or redirect_uri is no longer valid.
+                let Some((client_name, redirect_host, localhost_warning)) =
+                    derive_display_info(&state, &effective.client_id, &effective.redirect_uri)
+                        .await
+                else {
+                    return Html(render_error_page(
+                        "Invalid Request",
+                        "Unknown client or redirect URI. Please restart the authorization flow.",
+                    ))
+                    .into_response();
+                };
+                let fresh_nonce = issue_nonce(&state).await;
+                state
+                    .pending_authorize_bindings
+                    .write()
+                    .await
+                    .insert(fresh_nonce.clone(), authorize_binding.clone());
+                let html = render_challenge_page(
+                    &client_name,
+                    effective.scope.as_deref().unwrap_or(""),
+                    &redirect_host,
+                    &effective.client_id,
+                    &effective.redirect_uri,
+                    &effective.code_challenge,
+                    effective.state.as_deref().unwrap_or(""),
+                    effective.resource.as_deref().unwrap_or(""),
+                    &fresh_nonce,
+                    effective.nonce.as_deref().unwrap_or(""),
+                    Some(e.message()),
+                    localhost_warning.as_deref(),
+                );
+                return Html(html).into_response();
+            }
+        }
+    } else {
+        return error_response(
+            StatusCode::BAD_REQUEST,
+            "invalid_request",
+            "Unknown authorize action",
+        );
+    };
+
+    // Signature valid — generate auth code
+    let mut code_bytes = [0u8; 32];
+    rand::rngs::OsRng.fill_bytes(&mut code_bytes);
+    let code = URL_SAFE_NO_PAD.encode(code_bytes);
 
     let pending = PendingAuthCode {
         code: code.clone(),
@@ -495,7 +789,11 @@ pub async fn authorize_post(
         client_assertion_jkt: effective.client_assertion_jkt.clone(),
     };
 
-    state.pending_codes.write().await.insert(code.clone(), pending);
+    state
+        .pending_codes
+        .write()
+        .await
+        .insert(code.clone(), pending);
 
     tracing::info!(
         client_id = %effective.client_id,
@@ -595,7 +893,10 @@ async fn resolve_authorize_query(
     // strict profile (DPoP binding at PAR).
     if let Some(ref scope_str) = query.scope {
         if super::state::atproto_profile_active(
-            &scope_str.split_whitespace().map(str::to_owned).collect::<Vec<_>>(),
+            &scope_str
+                .split_whitespace()
+                .map(str::to_owned)
+                .collect::<Vec<_>>(),
         ) {
             return Err(error_response(
                 StatusCode::BAD_REQUEST,
@@ -647,7 +948,11 @@ async fn issue_nonce(state: &OAuthState) -> String {
     rand::rngs::OsRng.fill_bytes(&mut nonce_bytes);
     let nonce = URL_SAFE_NO_PAD.encode(nonce_bytes);
     let expiry = Instant::now() + Duration::from_secs(300);
-    state.pending_nonces.write().await.insert(nonce.clone(), expiry);
+    state
+        .pending_nonces
+        .write()
+        .await
+        .insert(nonce.clone(), expiry);
     nonce
 }
 
@@ -699,7 +1004,10 @@ async fn derive_display_info(
 /// restriction". Returns `None` (fail closed) when the client cannot be
 /// resolved at all; `Some(vec![])` only when a resolved client declared
 /// no scope ceiling.
-async fn resolve_client_declared_scopes(state: &OAuthState, client_id: &str) -> Option<Vec<String>> {
+async fn resolve_client_declared_scopes(
+    state: &OAuthState,
+    client_id: &str,
+) -> Option<Vec<String>> {
     let client = if client_id.starts_with("https://") {
         match state.cimd_cache.get(client_id).await {
             Some(c) => c,
@@ -771,7 +1079,8 @@ fn error_response(status: StatusCode, error: &str, description: &str) -> Respons
             "error": error,
             "error_description": description,
         })),
-    ).into_response()
+    )
+        .into_response()
 }
 
 /// Render an error page (HTML) for configuration errors.
@@ -877,6 +1186,7 @@ fn render_challenge_page(
     Copy the printed <em>Fingerprint</em> and <em>Signature</em> below.
   </div>
   <form method="post" action="/oauth/authorize">
+    <input type="hidden" name="action" value="authorize">
     <input type="hidden" name="client_id" value="{client_id_val}">
     <input type="hidden" name="redirect_uri" value="{redirect_uri_val}">
     <input type="hidden" name="code_challenge" value="{code_challenge_val}">
@@ -899,7 +1209,8 @@ fn render_challenge_page(
 </body>
 </html>"#,
         client_name_esc = html_escape(client_name),
-        scopes_display = scopes.split_whitespace()
+        scopes_display = scopes
+            .split_whitespace()
             .map(|s| format!("<code>{}</code>", html_escape(s)))
             .collect::<Vec<_>>()
             .join(", "),
@@ -923,6 +1234,7 @@ fn render_challenge_page(
 #[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {
     use super::*;
+    use ed25519_dalek::Signer as _;
 
     #[test]
     fn localhost_warning_fires_when_all_loopback() {
@@ -954,6 +1266,234 @@ mod tests {
     #[test]
     fn localhost_warning_empty_returns_none() {
         assert!(compute_localhost_warning(&[]).is_none());
+    }
+
+    #[test]
+    fn signup_proof_challenge_is_domain_separated_and_transaction_bound() {
+        let challenge =
+            signup_proof_challenge("alice", "SHA256:key", "authorize-nonce", "pkce-challenge");
+        assert!(challenge.starts_with(SIGNUP_PROOF_DOMAIN));
+        assert_ne!(
+            challenge,
+            signup_proof_challenge("bob", "SHA256:key", "authorize-nonce", "pkce-challenge")
+        );
+        assert_ne!(
+            challenge,
+            signup_proof_challenge("alice", "SHA256:key", "other-nonce", "pkce-challenge")
+        );
+        assert_ne!(
+            challenge,
+            signup_proof_challenge("alice", "SHA256:key", "authorize-nonce", "other-pkce")
+        );
+    }
+
+    #[tokio::test]
+    async fn signup_action_provisions_account_and_issues_standard_auth_code() -> anyhow::Result<()>
+    {
+        use std::sync::atomic::{AtomicUsize, Ordering};
+
+        use async_trait::async_trait;
+        use base64::engine::general_purpose::STANDARD;
+        use hyprstream_rpc::rpc_client::RpcClientImpl;
+        use hyprstream_rpc::signer::LocalSigner;
+        use hyprstream_rpc::transport::lazy_uds::LazyUdsTransport;
+
+        use crate::auth::{RocksDbUserStore, UserStore};
+        use crate::services::oauth::identity_registration::{
+            DidWebOriginAllowlist, FederatedIdentityIntake, HostedRegistrationMint,
+            IdentityConnectTimeResolver, IdentityRegistrationApi, RegistrationGenesisSigner,
+        };
+
+        struct SignupMint(AtomicUsize);
+        impl HostedRegistrationMint for SignupMint {
+            fn mint(
+                &self,
+                request: &hyprstream_pds_service::hosted_account_mint::HostedAccountRegistrationRequest,
+                _signer: &dyn hyprstream_pds_service::hosted_account_mint::HostedAccountGenesisSigner,
+            ) -> anyhow::Result<
+                hyprstream_pds_service::hosted_account_mint::HostedAccountRegistrationResult,
+            > {
+                self.0.fetch_add(1, Ordering::SeqCst);
+                Ok(
+                    hyprstream_pds_service::hosted_account_mint::HostedAccountRegistrationResult {
+                        handle: format!("at://{}.accounts.example.test", request.handle()),
+                        did: format!("did:web:{}.accounts.example.test", request.handle()),
+                        pds_endpoint: "https://pds.example.test".to_owned(),
+                        quic_url: "https://pds.example.test:4433".to_owned(),
+                        cert_hash: "fixture-cert-hash".to_owned(),
+                    },
+                )
+            }
+        }
+
+        struct UnusedSigner;
+        impl RegistrationGenesisSigner for UnusedSigner {
+            fn sign_genesis(
+                &self,
+                _caller: &str,
+                _operator_manual: bool,
+                _unsigned: &hyprstream_pds::UnsignedGenesisDidOp,
+            ) -> anyhow::Result<hyprstream_pds::DidOpSignature> {
+                anyhow::bail!("fake mint must not invoke the signer")
+            }
+        }
+
+        struct UnusedIntake;
+        #[async_trait]
+        impl FederatedIdentityIntake for UnusedIntake {
+            async fn intake(
+                &self,
+                _did: &str,
+            ) -> anyhow::Result<hyprstream_pds_service::federation_intake::InventoryEntry>
+            {
+                anyhow::bail!("federation intake is outside this test")
+            }
+        }
+
+        struct UnusedResolver;
+        impl IdentityConnectTimeResolver for UnusedResolver {
+            fn recognizes(&self, _did: &str) -> bool {
+                false
+            }
+
+            fn resolve(
+                &self,
+                _did: &str,
+            ) -> anyhow::Result<hyprstream_discovery::ConnectTimeDiscovery> {
+                anyhow::bail!("connect-time resolution is outside this test")
+            }
+        }
+
+        let signing_key = ed25519_dalek::SigningKey::from_bytes(&[0x51; 32]);
+        let remote_key = ed25519_dalek::SigningKey::from_bytes(&[0x52; 32]).verifying_key();
+        let make_client = || {
+            Arc::new(
+                RpcClientImpl::new(
+                    LocalSigner::new(signing_key.clone()),
+                    LazyUdsTransport::new("/dev/null/oauth-signup-authorize-test.sock".into()),
+                    Some(remote_key),
+                )
+                .with_response_verify_policy(hyprstream_rpc::crypto::CryptoPolicy::Classical),
+            )
+        };
+        let mut config = crate::config::OAuthConfig::default();
+        config.external_url = Some("https://pds.example.test".to_owned());
+        let user_dir = tempfile::TempDir::new()?;
+        let user_store = Arc::new(RocksDbUserStore::open(user_dir.path())?);
+        let mint = Arc::new(SignupMint(AtomicUsize::new(0)));
+        let identity_api = Arc::new(IdentityRegistrationApi::new(
+            mint.clone(),
+            Arc::new(UnusedSigner),
+            Arc::new(UnusedIntake),
+            Arc::new(UnusedResolver),
+            DidWebOriginAllowlist::new(std::iter::empty::<&str>())?,
+            Arc::new(crate::server::middleware::RateLimiter::new(10, 60)),
+        ));
+        let state = Arc::new(
+            OAuthState::new(
+                &config,
+                crate::services::PolicyClient::new(make_client()),
+                crate::services::DiscoveryClient::new(make_client()),
+                signing_key.verifying_key().to_bytes(),
+            )
+            .with_user_store(user_store.clone())
+            .with_identity_registration_api(identity_api)
+            .with_hosted_account_zone(crate::account::AccountZone::new("accounts.example.test")?),
+        );
+        state.clients.write().await.insert(
+            "signup-client".to_owned(),
+            super::super::state::RegisteredClient {
+                client_id: "signup-client".to_owned(),
+                redirect_uris: vec!["https://client.example/callback".to_owned()],
+                client_name: Some("Signup Client".to_owned()),
+                client_uri: None,
+                logo_uri: None,
+                grant_types: vec!["authorization_code".to_owned()],
+                response_types: vec!["code".to_owned()],
+                token_endpoint_auth_method: Some("none".to_owned()),
+                jwks: None,
+                jwks_uri: None,
+                hyprstream_node_did: None,
+                scope: Some("atproto".to_owned()),
+                dpop_bound_access_tokens: Some(true),
+                is_cimd: false,
+                registered_at: Instant::now(),
+            },
+        );
+
+        let nonce = "signup-authorize-nonce".to_owned();
+        let code_challenge = "signup-pkce-challenge".to_owned();
+        let request = AuthorizeParams {
+            client_id: "signup-client".to_owned(),
+            redirect_uri: "https://client.example/callback".to_owned(),
+            code_challenge: code_challenge.clone(),
+            code_challenge_method: "S256".to_owned(),
+            response_type: "code".to_owned(),
+            state: Some("signup-state".to_owned()),
+            scope: Some("atproto".to_owned()),
+            resource: Some("https://pds.example.test".to_owned()),
+            nonce: None,
+            dpop_jkt: Some("par-verified-dpop-thumbprint".to_owned()),
+            client_assertion_jkt: None,
+        };
+        state
+            .pending_nonces
+            .write()
+            .await
+            .insert(nonce.clone(), Instant::now() + Duration::from_secs(300));
+        state.pending_authorize_bindings.write().await.insert(
+            nonce.clone(),
+            super::super::state::AuthorizeBinding { request },
+        );
+
+        let vault_key = ed25519_dalek::SigningKey::from_bytes(&[0x53; 32]);
+        let public_key = STANDARD.encode(vault_key.verifying_key().as_bytes());
+        let fingerprint = crate::auth::pubkey_fingerprint(&vault_key.verifying_key());
+        let challenge = signup_proof_challenge("alice", &fingerprint, &nonce, &code_challenge);
+        let signature = STANDARD.encode(vault_key.sign(&challenge).to_bytes());
+        let response = authorize_post(
+            State(state.clone()),
+            Ok(Form(ConsentForm {
+                action: Some(SIGNUP_ACTION.to_owned()),
+                client_id: "signup-client".to_owned(),
+                redirect_uri: "https://client.example/callback".to_owned(),
+                code_challenge,
+                scope: "atproto".to_owned(),
+                state: Some("signup-state".to_owned()),
+                resource: Some("https://pds.example.test".to_owned()),
+                nonce,
+                fingerprint: fingerprint.clone(),
+                signature,
+                handle: Some("alice".to_owned()),
+                account_public_key: Some(public_key),
+                oidc_nonce: None,
+            })),
+        )
+        .await;
+
+        assert_eq!(response.status(), StatusCode::SEE_OTHER);
+        assert_eq!(mint.0.load(Ordering::SeqCst), 1);
+        let profile = user_store.get_profile("alice").await?.unwrap();
+        assert_eq!(
+            profile.atproto_did.as_deref(),
+            Some("did:web:alice.accounts.example.test")
+        );
+        assert_eq!(profile.key_custody, Some(AccountKeyCustody::SelfCustody));
+        assert!(profile.external_identities.is_empty());
+        assert_eq!(
+            user_store.get_pubkey_user(&fingerprint).await?,
+            Some("alice".to_owned())
+        );
+        let codes = state.pending_codes.read().await;
+        assert_eq!(codes.len(), 1);
+        let pending = codes.values().next().unwrap();
+        assert_eq!(pending.username, "alice");
+        assert_eq!(
+            pending.dpop_jkt.as_deref(),
+            Some("par-verified-dpop-thumbprint")
+        );
+        assert!(state.sessions.get("nonexistent").await.is_none());
+        Ok(())
     }
 
     /// #1113 rev2 F5: the authorization redirect URL MUST include `iss`
@@ -997,7 +1537,10 @@ mod tests {
             .map(|(_, v)| v.to_string())
             .unwrap();
         assert_eq!(iss, "https://pds.example.com");
-        assert!(!iss.ends_with('/'), "iss must be origin (no trailing slash)");
+        assert!(
+            !iss.ends_with('/'),
+            "iss must be origin (no trailing slash)"
+        );
     }
 
     /// #1146 T1.1: `resolve_client_declared_scopes` must re-resolve a CIMD
@@ -1068,11 +1611,10 @@ mod tests {
         );
 
         // DCR registry hit → declared scopes (empty vec = declared no ceiling).
-        state
-            .clients
-            .write()
-            .await
-            .insert("dcr-client".to_owned(), make_registered("dcr-client", Some("atproto"), false));
+        state.clients.write().await.insert(
+            "dcr-client".to_owned(),
+            make_registered("dcr-client", Some("atproto"), false),
+        );
         assert_eq!(
             resolve_client_declared_scopes(&state, "dcr-client").await,
             Some(vec!["atproto".to_owned()])

--- a/crates/hyprstream/src/services/oauth/authorize.rs
+++ b/crates/hyprstream/src/services/oauth/authorize.rs
@@ -942,11 +942,15 @@ async fn resolve_authorize_query(
     })
 }
 
-/// Generate a fresh nonce and record it in `pending_nonces` with a 5-min expiry.
-async fn issue_nonce(state: &OAuthState) -> String {
+fn fresh_nonce() -> String {
     let mut nonce_bytes = [0u8; 32];
     rand::rngs::OsRng.fill_bytes(&mut nonce_bytes);
-    let nonce = URL_SAFE_NO_PAD.encode(nonce_bytes);
+    URL_SAFE_NO_PAD.encode(nonce_bytes)
+}
+
+/// Generate a fresh nonce and record it in `pending_nonces` with a 5-min expiry.
+async fn issue_nonce(state: &OAuthState) -> String {
+    let nonce = fresh_nonce();
     let expiry = Instant::now() + Duration::from_secs(300);
     state
         .pending_nonces
@@ -1270,20 +1274,22 @@ mod tests {
 
     #[test]
     fn signup_proof_challenge_is_domain_separated_and_transaction_bound() {
+        let authorize_nonce = fresh_nonce();
+        let other_nonce = fresh_nonce();
         let challenge =
-            signup_proof_challenge("alice", "SHA256:key", "authorize-nonce", "pkce-challenge");
+            signup_proof_challenge("alice", "SHA256:key", &authorize_nonce, "pkce-challenge");
         assert!(challenge.starts_with(SIGNUP_PROOF_DOMAIN));
         assert_ne!(
             challenge,
-            signup_proof_challenge("bob", "SHA256:key", "authorize-nonce", "pkce-challenge")
+            signup_proof_challenge("bob", "SHA256:key", &authorize_nonce, "pkce-challenge")
         );
         assert_ne!(
             challenge,
-            signup_proof_challenge("alice", "SHA256:key", "other-nonce", "pkce-challenge")
+            signup_proof_challenge("alice", "SHA256:key", &other_nonce, "pkce-challenge")
         );
         assert_ne!(
             challenge,
-            signup_proof_challenge("alice", "SHA256:key", "authorize-nonce", "other-pkce")
+            signup_proof_challenge("alice", "SHA256:key", &authorize_nonce, "other-pkce")
         );
     }
 
@@ -1421,7 +1427,7 @@ mod tests {
             },
         );
 
-        let nonce = "signup-authorize-nonce".to_owned();
+        let nonce = fresh_nonce();
         let code_challenge = "signup-pkce-challenge".to_owned();
         let request = AuthorizeParams {
             client_id: "signup-client".to_owned(),

--- a/crates/hyprstream/src/services/oauth/challenge.rs
+++ b/crates/hyprstream/src/services/oauth/challenge.rs
@@ -10,12 +10,15 @@ use base64::Engine;
 use crate::auth::user_store::UserStore;
 
 /// Error types for Ed25519 challenge-response verification.
+#[derive(Debug)]
 #[allow(dead_code)]
 pub(super) enum ChallengeError {
     /// Username contains ':', which would make the challenge string ambiguous.
     InvalidUsername,
     /// Fingerprint string is malformed (empty, contains ':' delimiter conflict, etc.).
     InvalidFingerprint,
+    /// Presented public key is not a canonical supported Ed25519 encoding.
+    InvalidPublicKey,
     /// Signature is not valid base64.
     InvalidSignatureEncoding,
     /// Signature is not exactly 64 bytes (88 base64 chars).
@@ -39,6 +42,8 @@ impl ChallengeError {
             ChallengeError::InvalidUsername => "Username must not contain ':'",
             ChallengeError::InvalidFingerprint =>
                 "Invalid key fingerprint format. Expected `SHA256:...` from `hyprstream sign-challenge`.",
+            ChallengeError::InvalidPublicKey =>
+                "Invalid account public key (expected base64 Ed25519 key bytes).",
             ChallengeError::InvalidSignatureEncoding =>
                 "Invalid signature encoding (expected base64).",
             ChallengeError::InvalidSignatureLength =>
@@ -55,6 +60,36 @@ impl ChallengeError {
                 "Invalid signature. Ensure you signed the correct challenge string.",
         }
     }
+}
+
+/// Verify proof-of-possession for a not-yet-registered vault key.
+///
+/// Unlike normal authorize, signup cannot resolve the key from a reverse
+/// index. The caller presents the public key; this function derives its
+/// canonical fingerprint, requires the submitted fingerprint to match, and
+/// verifies the domain-separated signup challenge before any account mutation.
+pub(super) fn verify_unregistered_ed25519_response(
+    public_key_b64: &str,
+    fingerprint: &str,
+    challenge: &[u8],
+    sig_b64: &str,
+) -> Result<ed25519_dalek::VerifyingKey, ChallengeError> {
+    let verifying_key = crate::auth::decode_pubkey_base64(public_key_b64)
+        .map_err(|_| ChallengeError::InvalidPublicKey)?;
+    if crate::auth::pubkey_fingerprint(&verifying_key) != fingerprint {
+        return Err(ChallengeError::InvalidFingerprint);
+    }
+    let sig_bytes = STANDARD
+        .decode(sig_b64)
+        .map_err(|_| ChallengeError::InvalidSignatureEncoding)?;
+    let sig_array: [u8; 64] = sig_bytes
+        .try_into()
+        .map_err(|_| ChallengeError::InvalidSignatureLength)?;
+    let signature = ed25519_dalek::Signature::from_bytes(&sig_array);
+    verifying_key
+        .verify_strict(challenge, &signature)
+        .map_err(|_| ChallengeError::SignatureInvalid)?;
+    Ok(verifying_key)
 }
 
 /// Verify an Ed25519 challenge-response.
@@ -78,16 +113,20 @@ pub(super) async fn verify_ed25519_response(
         return Err(ChallengeError::InvalidUsername);
     }
 
-    let sig_bytes = STANDARD.decode(sig_b64)
+    let sig_bytes = STANDARD
+        .decode(sig_b64)
         .map_err(|_| ChallengeError::InvalidSignatureEncoding)?;
 
-    let sig_array: [u8; 64] = sig_bytes.try_into()
+    let sig_array: [u8; 64] = sig_bytes
+        .try_into()
         .map_err(|_| ChallengeError::InvalidSignatureLength)?;
 
     let signature = ed25519_dalek::Signature::from_bytes(&sig_array);
 
     // Get all pubkeys for the user and try each one
-    let pubkeys = user_store.list_pubkeys(username).await
+    let pubkeys = user_store
+        .list_pubkeys(username)
+        .await
         .map_err(ChallengeError::UserStoreError)?;
 
     if pubkeys.is_empty() {
@@ -96,7 +135,11 @@ pub(super) async fn verify_ed25519_response(
 
     // Try to verify against each registered pubkey
     for entry in &pubkeys {
-        if entry.pubkey.verify_strict(challenge.as_bytes(), &signature).is_ok() {
+        if entry
+            .pubkey
+            .verify_strict(challenge.as_bytes(), &signature)
+            .is_ok()
+        {
             // Optionally touch the pubkey to update last_used_at
             let _ = user_store.touch_pubkey(username, &entry.fingerprint).await;
             return Ok(entry.pubkey);
@@ -130,26 +173,36 @@ pub(super) async fn verify_ed25519_response_by_fingerprint(
         return Err(ChallengeError::InvalidFingerprint);
     }
 
-    let sig_bytes = STANDARD.decode(sig_b64)
+    let sig_bytes = STANDARD
+        .decode(sig_b64)
         .map_err(|_| ChallengeError::InvalidSignatureEncoding)?;
-    let sig_array: [u8; 64] = sig_bytes.try_into()
+    let sig_array: [u8; 64] = sig_bytes
+        .try_into()
         .map_err(|_| ChallengeError::InvalidSignatureLength)?;
     let signature = ed25519_dalek::Signature::from_bytes(&sig_array);
 
-    let Some(username) = user_store.get_pubkey_user(fingerprint).await
+    let Some(username) = user_store
+        .get_pubkey_user(fingerprint)
+        .await
         .map_err(ChallengeError::UserStoreError)?
     else {
         return Err(ChallengeError::UnknownFingerprint);
     };
 
-    let pubkeys = user_store.list_pubkeys(&username).await
+    let pubkeys = user_store
+        .list_pubkeys(&username)
+        .await
         .map_err(ChallengeError::UserStoreError)?;
     let Some(entry) = pubkeys.into_iter().find(|e| e.fingerprint == fingerprint) else {
         // Reverse index pointed at this user but the key is gone — treat as unknown.
         return Err(ChallengeError::UnknownFingerprint);
     };
 
-    if entry.pubkey.verify_strict(challenge.as_bytes(), &signature).is_err() {
+    if entry
+        .pubkey
+        .verify_strict(challenge.as_bytes(), &signature)
+        .is_err()
+    {
         return Err(ChallengeError::SignatureInvalid);
     }
 
@@ -164,4 +217,44 @@ pub(crate) fn html_escape(s: &str) -> String {
         .replace('>', "&gt;")
         .replace('"', "&quot;")
         .replace('\'', "&#x27;")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ed25519_dalek::Signer as _;
+
+    #[test]
+    fn unregistered_key_proof_requires_matching_key_fingerprint_and_signature() {
+        let key = ed25519_dalek::SigningKey::from_bytes(&[0x31; 32]);
+        let public_key = STANDARD.encode(key.verifying_key().as_bytes());
+        let fingerprint = crate::auth::pubkey_fingerprint(&key.verifying_key());
+        let challenge = b"hyprstream-cold-signup-v1\0alice\0fingerprint\0nonce\0pkce\0";
+        let signature = STANDARD.encode(key.sign(challenge).to_bytes());
+
+        let Ok(verified) =
+            verify_unregistered_ed25519_response(&public_key, &fingerprint, challenge, &signature)
+        else {
+            panic!("valid signup proof must verify");
+        };
+        assert_eq!(verified, key.verifying_key());
+        assert!(matches!(
+            verify_unregistered_ed25519_response(
+                &public_key,
+                "SHA256:not-the-presented-key",
+                challenge,
+                &signature,
+            ),
+            Err(ChallengeError::InvalidFingerprint)
+        ));
+        assert!(matches!(
+            verify_unregistered_ed25519_response(
+                &public_key,
+                &fingerprint,
+                b"tampered",
+                &signature,
+            ),
+            Err(ChallengeError::SignatureInvalid)
+        ));
+    }
 }

--- a/crates/hyprstream/src/services/oauth/identity_registration.rs
+++ b/crates/hyprstream/src/services/oauth/identity_registration.rs
@@ -28,8 +28,8 @@ use hyprstream_discovery::{
 };
 use hyprstream_pds::{
     sign_genesis, AccountRecord, AllocatedAccountName, DidOpSignature, DirectoryHostedAccountStore,
-    GenesisDidOp, GenesisRotationKeys, HostKeyEnrollment, HybridRotationKey, RecoveryKeyEnrollment,
-    SealedHostedDidDocument, UnsignedGenesisDidOp, UserRotationKey,
+    GenesisDidOp, GenesisRepoHead, GenesisRotationKeys, HostKeyEnrollment, HybridRotationKey,
+    RecoveryKeyEnrollment, SealedHostedDidDocument, UnsignedGenesisDidOp, UserRotationKey,
 };
 use hyprstream_pds_service::federation_intake::{
     FederatedDidDocumentResolver, FederatedDidResolver, FederationIntake,
@@ -61,6 +61,15 @@ const COLD_SIGNUP_GLOBAL_RATE_LIMIT_BUCKET: &str = "oauth-authorize-signup-globa
 const MAX_AUTHORITY_ARTIFACT_BYTES: u64 = 64 * 1024;
 const ACCOUNT_GENESIS_ED25519_PURPOSE: &str = "hyprstream-hosted-account-genesis-ed25519-v1";
 const ACCOUNT_GENESIS_MLDSA65_PURPOSE: &str = "hyprstream-hosted-account-genesis-mldsa65-v1";
+const SIGNUP_TRANSACTION_FILE: &str = "signup-transaction.json";
+
+#[derive(Debug, Deserialize, Serialize)]
+struct HostedAccountReservation {
+    version: u8,
+    did: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    transaction_id: Option<String>,
+}
 
 /// Assemble the production registration face installed by the OAuth factory.
 ///
@@ -172,8 +181,12 @@ struct ProductionHostedAccountAuthority {
     signing_root: ed25519_dalek::SigningKey,
 }
 
-impl HostedAccountAuthority for ProductionHostedAccountAuthority {
-    fn allocate(&self, requested_handle: &str) -> Result<AuthorityHostedAccountBinding> {
+impl ProductionHostedAccountAuthority {
+    fn allocate_inner(
+        &self,
+        requested_handle: &str,
+        transaction_id: Option<&str>,
+    ) -> Result<AuthorityHostedAccountBinding> {
         let zone = self
             .account
             .resolve_zone()
@@ -182,28 +195,98 @@ impl HostedAccountAuthority for ProductionHostedAccountAuthority {
         let name = AllocatedAccountName::new(requested_handle, format!("did:web:{host}"))?;
         let tenant = zone.apex().to_owned();
 
-        // Allocation is a permanent, authority-owned reservation. A failed
-        // post-allocation mint burns the label instead of allowing a different
-        // identity to reuse the permanent DID.
+        // Allocation is a permanent, authority-owned reservation. OAuth
+        // signup binds it to the already-committed AS credential transaction,
+        // allowing only that exact verified pair to resume.
         let reservation_dir = self.pds_root.join(&tenant).join(".allocated");
         create_private_dir_all(&reservation_dir)?;
         let reservation = reservation_dir.join(requested_handle);
-        let mut file = private_create_new(&reservation)
-            .with_context(|| format!("hosted-account label {requested_handle:?} is unavailable"))?;
-        file.write_all(name.did().as_bytes())?;
-        file.sync_all()?;
-        sync_directory(&reservation_dir)?;
-        sync_directory(
-            reservation_dir
-                .parent()
-                .context("hosted-account reservation directory has no tenant parent")?,
-        )?;
+        let reservation_value = HostedAccountReservation {
+            version: 1,
+            did: name.did().to_owned(),
+            transaction_id: transaction_id.map(str::to_owned),
+        };
+        let mut staged_reservation = tempfile::Builder::new()
+            .prefix(".allocation-")
+            .tempfile_in(&reservation_dir)?;
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt as _;
+            std::fs::set_permissions(
+                staged_reservation.path(),
+                std::fs::Permissions::from_mode(0o600),
+            )?;
+        }
+        serde_json::to_writer(staged_reservation.as_file_mut(), &reservation_value)?;
+        staged_reservation.as_file_mut().write_all(b"\n")?;
+        staged_reservation.as_file_mut().sync_all()?;
+        #[cfg(all(target_os = "linux", target_env = "gnu"))]
+        match nix::fcntl::renameat2(
+            None,
+            staged_reservation.path(),
+            None,
+            &reservation,
+            nix::fcntl::RenameFlags::RENAME_NOREPLACE,
+        ) {
+            Ok(()) => {
+                sync_directory(&reservation_dir)?;
+                sync_directory(
+                    reservation_dir
+                        .parent()
+                        .context("hosted-account reservation directory has no tenant parent")?,
+                )?;
+            }
+            Err(nix::errno::Errno::EEXIST) => {
+                let existing: HostedAccountReservation = serde_json::from_slice(
+                    &read_authority_artifact(&reservation)
+                        .context("reading hosted-account reservation")?,
+                )
+                .context("verifying hosted-account reservation")?;
+                ensure!(
+                    existing.version == 1
+                        && existing.did == name.did()
+                        && transaction_id.is_some()
+                        && existing.transaction_id.as_deref() == transaction_id,
+                    std::io::Error::new(
+                        std::io::ErrorKind::AlreadyExists,
+                        format!("hosted-account label {requested_handle:?} is unavailable"),
+                    )
+                );
+                sync_directory(&reservation_dir)?;
+                sync_directory(
+                    reservation_dir
+                        .parent()
+                        .context("hosted-account reservation directory has no tenant parent")?,
+                )?;
+            }
+            Err(error) => return Err(error.into()),
+        }
+        #[cfg(not(all(target_os = "linux", target_env = "gnu")))]
+        anyhow::bail!("atomic hosted-account allocation requires Linux renameat2");
 
         AuthorityHostedAccountBinding::new(
             tenant,
             name,
             account_genesis_rotation_keys(&self.signing_root, requested_handle)?,
         )
+    }
+}
+
+impl HostedAccountAuthority for ProductionHostedAccountAuthority {
+    fn allocate(&self, requested_handle: &str) -> Result<AuthorityHostedAccountBinding> {
+        self.allocate_inner(requested_handle, None)
+    }
+
+    fn allocate_for_transaction(
+        &self,
+        requested_handle: &str,
+        transaction_id: &str,
+    ) -> Result<AuthorityHostedAccountBinding> {
+        ensure!(
+            !transaction_id.is_empty(),
+            "hosted-account reservation transaction id is empty"
+        );
+        self.allocate_inner(requested_handle, Some(transaction_id))
     }
 }
 
@@ -494,26 +577,116 @@ impl HostedPdsAccountPublisher for ProductionHostedAccountPublisher {
         publication.account().write_to(&staging_store)?;
         let staged_account = staging.path().join(publication.label());
         write_repo_genesis(&staged_account, publication.repo())?;
+        if let Some(transaction_id) = publication.transaction_id() {
+            let transaction = serde_json::to_vec(&serde_json::json!({
+                "version": 1,
+                "transaction_id": transaction_id,
+            }))?;
+            write_private_file(&staged_account.join(SIGNUP_TRANSACTION_FILE), &transaction)?;
+            sync_directory(&staged_account)?;
+        }
 
         let final_account = accounts_root.join(publication.label());
         #[cfg(all(target_os = "linux", target_env = "gnu"))]
-        nix::fcntl::renameat2(
+        match nix::fcntl::renameat2(
             None,
             &staged_account,
             None,
             &final_account,
             nix::fcntl::RenameFlags::RENAME_NOREPLACE,
-        )
-        .with_context(|| {
-            format!(
-                "failed to atomically publish hosted account {:?}",
-                publication.label()
-            )
-        })?;
+        ) {
+            Ok(()) => {}
+            Err(nix::errno::Errno::EEXIST) if publication.transaction_id().is_some() => {
+                verify_resumable_signup_publication(&final_account, &publication)?;
+                sync_directory(&accounts_root)?;
+                return Ok(());
+            }
+            Err(error) => {
+                return Err(error).with_context(|| {
+                    format!(
+                        "failed to atomically publish hosted account {:?}",
+                        publication.label()
+                    )
+                });
+            }
+        }
         #[cfg(not(all(target_os = "linux", target_env = "gnu")))]
         anyhow::bail!("atomic hosted-account publication requires Linux renameat2");
         sync_directory(&accounts_root)
     }
+}
+
+fn verify_resumable_signup_publication(
+    account_dir: &Path,
+    expected: &HostedPdsAccountPublication<'_>,
+) -> Result<()> {
+    let transaction: serde_json::Value = serde_json::from_slice(
+        &read_authority_artifact(&account_dir.join(SIGNUP_TRANSACTION_FILE))
+            .context("reading hosted signup transaction marker")?,
+    )
+    .context("verifying hosted signup transaction marker")?;
+    ensure!(
+        transaction
+            .get("version")
+            .and_then(serde_json::Value::as_u64)
+            == Some(1)
+            && transaction
+                .get("transaction_id")
+                .and_then(serde_json::Value::as_str)
+                == expected.transaction_id(),
+        "published hosted account belongs to a different signup transaction"
+    );
+
+    let record_bytes = read_authority_artifact(&account_dir.join("account-record.cbor"))
+        .context("reading published hosted account record")?;
+    let record =
+        AccountRecord::from_dag_cbor(&record_bytes).context("verifying hosted account record")?;
+    let genesis = GenesisDidOp::from_dag_cbor(
+        &read_authority_artifact(&account_dir.join("genesis.didop.cbor"))
+            .context("reading published hosted account genesis")?,
+    )
+    .context("verifying hosted account genesis")?;
+    let document = SealedHostedDidDocument::from_canonical_json(
+        &read_authority_artifact(&account_dir.join("did-document.json"))
+            .context("reading published hosted account DID document")?,
+    )
+    .context("verifying hosted account DID document")?;
+    let expected_name = expected.account().record().name();
+    ensure!(
+        record.name() == expected_name
+            && document.did() == expected_name.did()
+            && document.handle() == expected.account().did_document().handle()
+            && document.pds_endpoint() == expected.account().did_document().pds_endpoint()
+            && record.genesis_op() == genesis.cid()?
+            && record.current_op() == record.genesis_op()
+            && record.doc_cid() == genesis.unsigned().doc_cid()
+            && record.doc_cid() == document.cid()
+            && record.atproto_verifying_key()?.to_encoded_point(true)
+                == document.atproto_verifying_key()?.to_encoded_point(true),
+        "published hosted signup authority artifacts are inconsistent"
+    );
+
+    let commit_bytes = read_authority_artifact(&account_dir.join("repo/commit.cbor"))
+        .context("reading published hosted repo commit")?;
+    let commit = hyprstream_pds::commit::Commit::from_dag_cbor(&commit_bytes)
+        .context("verifying published hosted repo commit")?;
+    commit
+        .verify(&record.atproto_verifying_key()?)
+        .context("published hosted repo signature is invalid")?;
+    let commit_cid = commit.cid();
+    ensure!(
+        commit.did == expected_name.did()
+            && commit.prev.is_none()
+            && genesis.unsigned().head_at_op() == GenesisRepoHead::Existing(commit_cid)
+            && read_authority_artifact(
+                &account_dir.join(format!("repo/blocks/{}.cbor", commit.data))
+            )
+            .is_ok_and(|bytes| hyprstream_pds::Cid::from_dag_cbor(&bytes) == commit.data)
+            && std::fs::read_to_string(account_dir.join("repo/head"))
+                .is_ok_and(|head| head == commit_cid.to_string()),
+        "published hosted signup repo genesis is incomplete or inconsistent"
+    );
+    Ok(())
 }
 
 fn write_repo_genesis(account_dir: &Path, repo: &hyprstream_pds::HostedRepoGenesis) -> Result<()> {
@@ -543,7 +716,7 @@ fn create_private_dir_all(path: &Path) -> Result<()> {
     Ok(())
 }
 
-fn private_create_new(path: &Path) -> Result<File> {
+fn private_create_new(path: &Path) -> std::io::Result<File> {
     let mut options = OpenOptions::new();
     options.write(true).create_new(true);
     #[cfg(unix)]
@@ -551,7 +724,7 @@ fn private_create_new(path: &Path) -> Result<File> {
         use std::os::unix::fs::OpenOptionsExt as _;
         options.mode(0o600);
     }
-    Ok(options.open(path)?)
+    options.open(path)
 }
 
 fn write_private_file(path: &Path, bytes: &[u8]) -> Result<()> {
@@ -660,6 +833,15 @@ pub trait HostedRegistrationMint: Send + Sync {
         request: &HostedAccountRegistrationRequest,
         signer: &dyn HostedAccountGenesisSigner,
     ) -> Result<HostedAccountRegistrationResult>;
+
+    fn mint_for_transaction(
+        &self,
+        request: &HostedAccountRegistrationRequest,
+        signer: &dyn HostedAccountGenesisSigner,
+        _transaction_id: &str,
+    ) -> Result<HostedAccountRegistrationResult> {
+        self.mint(request, signer)
+    }
 }
 
 impl HostedRegistrationMint for HostedPdsAccountMinter {
@@ -669,6 +851,15 @@ impl HostedRegistrationMint for HostedPdsAccountMinter {
         signer: &dyn HostedAccountGenesisSigner,
     ) -> Result<HostedAccountRegistrationResult> {
         HostedPdsAccountMinter::mint(self, request, signer)
+    }
+
+    fn mint_for_transaction(
+        &self,
+        request: &HostedAccountRegistrationRequest,
+        signer: &dyn HostedAccountGenesisSigner,
+        transaction_id: &str,
+    ) -> Result<HostedAccountRegistrationResult> {
+        HostedPdsAccountMinter::mint_for_transaction(self, request, signer, transaction_id)
     }
 }
 
@@ -849,17 +1040,20 @@ impl IdentityRegistrationApi {
             caller: &caller,
             operator_manual: false,
         };
-        let result = self.minter.mint(&mint_request, &signer).map_err(|error| {
-            if error.chain().any(|cause| {
-                cause
-                    .downcast_ref::<std::io::Error>()
-                    .is_some_and(|io| io.kind() == std::io::ErrorKind::AlreadyExists)
-            }) {
-                IdentityApiError::HandleUnavailable
-            } else {
-                IdentityApiError::Backend(error)
-            }
-        })?;
+        let result = self
+            .minter
+            .mint_for_transaction(&mint_request, &signer, fingerprint)
+            .map_err(|error| {
+                if error.chain().any(|cause| {
+                    cause
+                        .downcast_ref::<std::io::Error>()
+                        .is_some_and(|io| io.kind() == std::io::ErrorKind::AlreadyExists)
+                }) {
+                    IdentityApiError::HandleUnavailable
+                } else {
+                    IdentityApiError::Backend(error)
+                }
+            })?;
         if result.did == UNAUTHENTICATED_DID_SENTINEL {
             return Err(IdentityApiError::Backend(anyhow::anyhow!(
                 "hosted-account mint returned the reserved unauthenticated DID"
@@ -1767,6 +1961,35 @@ mod tests {
         assert!(published.join("genesis.didop.cbor").is_file());
         assert!(published.join("did-document.json").is_file());
         assert!(published.join("repo/commit.cbor").is_file());
+    }
+
+    #[test]
+    fn production_cold_signup_mint_resumes_published_genesis_for_exact_transaction() {
+        let fixture = production_router_fixture();
+        let api = fixture.state.identity_registration_api.as_ref().unwrap();
+
+        let first = api
+            .mint_for_oauth_signup("alice", "verified-dpop-jkt", "SHA256:vault-key")
+            .unwrap();
+        let second = api
+            .mint_for_oauth_signup("alice", "verified-dpop-jkt", "SHA256:vault-key")
+            .unwrap();
+
+        assert_eq!(second, first);
+        assert!(matches!(
+            api.mint_for_oauth_signup("alice", "verified-dpop-jkt", "SHA256:different-key"),
+            Err(IdentityApiError::HandleUnavailable)
+        ));
+        let account = fixture
+            .storage
+            .path()
+            .join("pds/accounts.example.com/accounts/alice");
+        assert!(account.join("account-record.cbor").is_file());
+        assert!(account.join("repo/commit.cbor").is_file());
+        let transaction: serde_json::Value =
+            serde_json::from_slice(&std::fs::read(account.join(SIGNUP_TRANSACTION_FILE)).unwrap())
+                .unwrap();
+        assert_eq!(transaction["transaction_id"], "SHA256:vault-key");
     }
 
     #[tokio::test]

--- a/crates/hyprstream/src/services/oauth/identity_registration.rs
+++ b/crates/hyprstream/src/services/oauth/identity_registration.rs
@@ -57,6 +57,7 @@ use crate::server::middleware::RateLimiter;
 const REGISTRATION_RATE_LIMIT_REQUESTS: u32 = 10;
 const REGISTRATION_RATE_LIMIT_WINDOW_SECS: i64 = 60;
 const PUBLIC_RESOLVE_RATE_LIMIT_BUCKET: &str = "identity-resolve-unauthenticated-floor";
+const COLD_SIGNUP_GLOBAL_RATE_LIMIT_BUCKET: &str = "oauth-authorize-signup-global-floor";
 const MAX_AUTHORITY_ARTIFACT_BYTES: u64 = 64 * 1024;
 const ACCOUNT_GENESIS_ED25519_PURPOSE: &str = "hyprstream-hosted-account-genesis-ed25519-v1";
 const ACCOUNT_GENESIS_MLDSA65_PURPOSE: &str = "hyprstream-hosted-account-genesis-mldsa65-v1";
@@ -420,6 +421,13 @@ impl IdentityConnectTimeResolver for HostedConnectTimeResolver {
     fn resolve(&self, did: &str) -> Result<ConnectTimeDiscovery> {
         HostedConnectTimeResolver::resolve(self, did)
     }
+
+    fn hosted_tenant(&self, did: &str) -> Result<Option<String>> {
+        // Verify the authority artifacts before returning the deployment-owned
+        // tenant. Classification by DID suffix alone is not sufficient.
+        HostedConnectTimeResolver::resolve(self, did)?;
+        Ok(Some(self.zone.apex().to_owned()))
+    }
 }
 
 fn read_authority_artifact(path: &Path) -> Result<Vec<u8>> {
@@ -456,6 +464,16 @@ impl IdentityConnectTimeResolver for AuthorityConnectTimeResolver {
             .as_ref()
             .context("hosted account resolution is not configured")?
             .resolve(did)
+    }
+
+    fn hosted_tenant(&self, did: &str) -> Result<Option<String>> {
+        if hyprstream_rpc::did_plc::is_did_plc(did) {
+            return Ok(None);
+        }
+        match &self.hosted {
+            Some(hosted) => hosted.hosted_tenant(did),
+            None => Ok(None),
+        }
     }
 }
 
@@ -673,6 +691,13 @@ pub trait IdentityConnectTimeResolver: Send + Sync {
     fn recognizes(&self, did: &str) -> bool;
 
     fn resolve(&self, did: &str) -> Result<ConnectTimeDiscovery>;
+
+    /// Return the deployment-authority tenant for a verified local hosted DID.
+    ///
+    /// Federation resolvers and test fakes default to no local binding.
+    fn hosted_tenant(&self, _did: &str) -> Result<Option<String>> {
+        Ok(None)
+    }
 }
 
 /// Exact HTTPS origins that may be resolved through the `did:web` intake arm.
@@ -788,6 +813,79 @@ impl IdentityRegistrationApi {
         Ok(RegisterHostedAccountResponse::from(result))
     }
 
+    /// Mint a hosted account from a cryptographically authenticated OAuth
+    /// authorize transaction.
+    ///
+    /// This is deliberately an internal call, not an HTTP registration route.
+    /// `dpop_jkt` comes from the verified PAR snapshot and `fingerprint` from
+    /// the verified vault proof. Both are used only as rate-limit identities;
+    /// the deployment authority still allocates the DID and tenant.
+    pub(super) fn mint_for_oauth_signup(
+        &self,
+        handle: &str,
+        dpop_jkt: &str,
+        fingerprint: &str,
+    ) -> Result<RegisterHostedAccountResponse, IdentityApiError> {
+        if handle.is_empty()
+            || handle == UNAUTHENTICATED_DID_SENTINEL
+            || dpop_jkt.is_empty()
+            || fingerprint.is_empty()
+        {
+            return Err(IdentityApiError::InvalidRequest);
+        }
+        if self
+            .rate_limiter
+            .check_and_increment(&format!("oauth-authorize-signup-key:{fingerprint}"))
+        {
+            return Err(IdentityApiError::RateLimited);
+        }
+
+        let mint_request =
+            HostedAccountRegistrationRequest::from_client_fields(handle.to_owned(), None)
+                .map_err(|_| IdentityApiError::InvalidRequest)?;
+        let caller = format!("oauth-signup:{fingerprint}");
+        let signer = CallerGenesisSigner {
+            provider: self.signer.as_ref(),
+            caller: &caller,
+            operator_manual: false,
+        };
+        let result = self.minter.mint(&mint_request, &signer).map_err(|error| {
+            if error.chain().any(|cause| {
+                cause
+                    .downcast_ref::<std::io::Error>()
+                    .is_some_and(|io| io.kind() == std::io::ErrorKind::AlreadyExists)
+            }) {
+                IdentityApiError::HandleUnavailable
+            } else {
+                IdentityApiError::Backend(error)
+            }
+        })?;
+        if result.did == UNAUTHENTICATED_DID_SENTINEL {
+            return Err(IdentityApiError::Backend(anyhow::anyhow!(
+                "hosted-account mint returned the reserved unauthenticated DID"
+            )));
+        }
+        Ok(result.into())
+    }
+
+    /// Charge the public/global and verified PAR-DPoP signup buckets before
+    /// performing even an Ed25519 proof verification. A single-use authorize
+    /// nonce limits replay; these bounded buckets limit fresh-PAR abuse.
+    pub(super) fn check_oauth_signup_rate(&self, dpop_jkt: &str) -> Result<(), IdentityApiError> {
+        if dpop_jkt.is_empty() {
+            return Err(IdentityApiError::InvalidRequest);
+        }
+        for bucket in [
+            COLD_SIGNUP_GLOBAL_RATE_LIMIT_BUCKET.to_owned(),
+            format!("oauth-authorize-signup-dpop:{dpop_jkt}"),
+        ] {
+            if self.rate_limiter.check_and_increment(&bucket) {
+                return Err(IdentityApiError::RateLimited);
+            }
+        }
+        Ok(())
+    }
+
     async fn intake(
         &self,
         caller: &AuthenticatedIdentityCaller,
@@ -825,6 +923,10 @@ impl IdentityRegistrationApi {
             .map_err(IdentityApiError::NotFound)
     }
 
+    pub(super) fn hosted_tenant(&self, did: &str) -> Result<Option<String>> {
+        self.identity_resolver.hosted_tenant(did)
+    }
+
     fn check_rate(&self, caller: &AuthenticatedIdentityCaller) -> Result<(), IdentityApiError> {
         if self.rate_limiter.check_and_increment(caller.subject()) {
             return Err(IdentityApiError::RateLimited);
@@ -847,13 +949,14 @@ impl HostedAccountGenesisSigner for CallerGenesisSigner<'_> {
 }
 
 #[derive(Debug)]
-enum IdentityApiError {
+pub(super) enum IdentityApiError {
     Unauthenticated,
     Forbidden,
     RateLimited,
     ResolveRateLimited,
     ResolvableHostDenied,
     InvalidRequest,
+    HandleUnavailable,
     NotFound(anyhow::Error),
     Backend(anyhow::Error),
 }
@@ -890,6 +993,11 @@ impl IntoResponse for IdentityApiError {
                 StatusCode::BAD_REQUEST,
                 "invalid_request",
                 "Registration or intake request is invalid",
+            ),
+            Self::HandleUnavailable => (
+                StatusCode::CONFLICT,
+                "handle_unavailable",
+                "Requested hosted-account handle is unavailable",
             ),
             Self::NotFound(_) => (
                 StatusCode::NOT_FOUND,

--- a/crates/hyprstream/src/services/oauth/oidc_callback.rs
+++ b/crates/hyprstream/src/services/oauth/oidc_callback.rs
@@ -549,6 +549,7 @@ async fn provision_federated_user(
         active: Some(true),
         external_id: external_claims["sub"].as_str().map(str::to_owned),
         atproto_did: None,
+        ..Default::default()
     };
     if let Err(e) = store.set_profile(subject, profile.into()).await {
         tracing::warn!(subject = %subject, error = %e, "Failed to set profile for federated user");

--- a/crates/hyprstream/src/services/oauth/state.rs
+++ b/crates/hyprstream/src/services/oauth/state.rs
@@ -291,7 +291,11 @@ mod tests {
             anyhow::bail!("not used")
         }
 
-        async fn set_profile(&self, _username: &str, _profile: crate::auth::UserProfilePatch) -> anyhow::Result<()> {
+        async fn set_profile(
+            &self,
+            _username: &str,
+            _profile: crate::auth::UserProfilePatch,
+        ) -> anyhow::Result<()> {
             anyhow::bail!("not used")
         }
 
@@ -528,7 +532,8 @@ mod tests {
                     UserProfile {
                         atproto_did: Some("did:plc:abcdefghijklmnqrstuvwx2p".to_owned()),
                         ..Default::default()
-                    }.into(),
+                    }
+                    .into(),
                 )
                 .await
                 .unwrap();
@@ -591,7 +596,9 @@ mod tests {
 
     #[tokio::test]
     async fn authorize_binding_sweep_tracks_live_nonces() {
-        let store = Arc::new(KeyReadErrorStore { profile: UserProfile::default() });
+        let store = Arc::new(KeyReadErrorStore {
+            profile: UserProfile::default(),
+        });
         let state = state_with_user_store(store);
         let binding = AuthorizeBinding {
             request: crate::services::oauth::authorize::AuthorizeParams {
@@ -609,8 +616,16 @@ mod tests {
             },
         };
         let now = Instant::now();
-        state.pending_nonces.write().await.insert("live".to_owned(), now + Duration::from_secs(60));
-        state.pending_nonces.write().await.insert("expired".to_owned(), now - Duration::from_secs(1));
+        state
+            .pending_nonces
+            .write()
+            .await
+            .insert("live".to_owned(), now + Duration::from_secs(60));
+        state
+            .pending_nonces
+            .write()
+            .await
+            .insert("expired".to_owned(), now - Duration::from_secs(1));
         let mut bindings = state.pending_authorize_bindings.write().await;
         bindings.insert("live".to_owned(), binding.clone());
         bindings.insert("expired".to_owned(), binding.clone());
@@ -1258,18 +1273,23 @@ impl OAuthState {
     /// store or record is a federated-only identity (`Ok(None)`); store
     /// corruption, authorization failure, and ambiguous bindings are errors.
     pub async fn hosted_account_tenant(&self, did: &str) -> Result<Option<String>, String> {
-        let Some(store) = &self.hosted_account_store else {
-            return Ok(None);
-        };
-        store
-            .resolve_tenant_for_hosted_did(
-                &hyprstream_rpc::Subject::new(
-                    hyprstream_pds_service::OAUTH_ACCOUNT_RESOLVER_SUBJECT,
-                ),
-                did,
-            )
-            .await
-            .map_err(|error| format!("hosted account tenant resolution failed: {error}"))
+        if let Some(store) = &self.hosted_account_store {
+            return store
+                .resolve_tenant_for_hosted_did(
+                    &hyprstream_rpc::Subject::new(
+                        hyprstream_pds_service::OAUTH_ACCOUNT_RESOLVER_SUBJECT,
+                    ),
+                    did,
+                )
+                .await
+                .map_err(|error| format!("hosted account tenant resolution failed: {error}"));
+        }
+        match &self.identity_registration_api {
+            Some(api) => api
+                .hosted_tenant(did)
+                .map_err(|error| format!("hosted account tenant resolution failed: {error:#}")),
+            None => Ok(None),
+        }
     }
 
     /// Host service DID accepted in ATProto service-auth `aud`.
@@ -1501,7 +1521,10 @@ impl OAuthState {
 
     /// Atomically claim a refresh token for one-time rotation. Only one caller
     /// across all OAuth replicas can receive a given entry.
-    pub async fn take_refresh_token(&self, token: &str) -> anyhow::Result<Option<RefreshTokenEntry>> {
+    pub async fn take_refresh_token(
+        &self,
+        token: &str,
+    ) -> anyhow::Result<Option<RefreshTokenEntry>> {
         let Some(ref store) = self.token_db else {
             return Ok(None);
         };
@@ -1530,12 +1553,7 @@ impl OAuthState {
     }
 
     /// Atomically consume an ATProto service-auth assertion identifier.
-    pub fn check_and_record_atproto_service_jti(
-        &self,
-        issuer: &str,
-        jti: &str,
-        exp: i64,
-    ) -> bool {
+    pub fn check_and_record_atproto_service_jti(&self, issuer: &str, jti: &str, exp: i64) -> bool {
         let remaining = exp - chrono::Utc::now().timestamp();
         if remaining <= 0 {
             return false;


### PR DESCRIPTION
Closes #37

## Summary

- adds cold hosted-account signup as `action=signup` on the existing PAR-bound `POST /oauth/authorize` interaction; no bespoke registration or authentication route is introduced
- verifies an aegis-vault Ed25519 proof over a domain-separated handle + fingerprint + authorize nonce + PKCE challenge, then invokes the merged #1345 authority mint for the permanent host-form `did:web:<label>.<account-zone>`
- atomically provisions the AS credential record, DID mapping, verified vault key, and reverse key index without overwriting an existing handle/key
- returns the ordinary authorization-code redirect and leaves first-session establishment to the existing token/service-auth/#1354 `/api/session/exchange` flow; signup never writes `hyprstream_session`
- resolves a newly minted local DID to its authority-owned tenant through the installed authority resolver when a separate PDS account-record reader is not attached

## Fail-closed / abuse boundaries

- signup requires the existing ATProto PAR profile and its verified ES256 DPoP thumbprint
- the authorize nonce and complete request snapshot are single-use and server-owned; changed browser echoes are rejected before mutation
- the browser cannot assert DID, tenant, PDS endpoint, transport metadata, custody mode, or external identity
- account-zone validation permits only #1124 host-form `did:web`; no `did:plc` or path-form branch exists
- handle/key conflicts fail closed; the #1345 authority reservation remains the final race-safe handle arbiter
- fixed-window global, PAR-DPoP, and verified-key rate buckets run before expensive/irreversible stages
- RocksDB uses an in-process conditional-insert lock plus one write batch; Valkey uses one Lua transaction and atomic key-owner checks

## External-IdP seam (design-in only)

- adds `AccountKeyCustody::{SelfCustody, Managed}`; demo signup always persists `SelfCustody`
- adds a persisted 0..N `ExternalIdentityBinding { issuer, subject }` collection with forward-list and reverse-lookup interfaces; demo records are empty
- no IdP discovery, callback, token verification, binding mutation endpoint, managed-key flow, or Google/GitHub behavior ships here

## Validation

- `cargo test -p hyprstream signup_ --lib`
- `cargo test -p hyprstream hosted_account_provisioning --lib`
- `cargo test -p hyprstream unregistered_key_proof --lib`
- `cargo test -p hyprstream oauth_handler_atproto_and_legacy_conformance --lib`
- `cargo check -p hyprstream --lib --features valkey`
- `cargo clippy -p hyprstream --lib --features valkey -- -D warnings`
- repository pre-commit full release Clippy hook

The exact frontline form/proof/handoff contract is recorded in `.fleet-coord/route-contracts.md`.