### PR TITLE
feat(oauth): add hosted PDS service auth

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7224,6 +7224,7 @@ dependencies = [
  "hyprstream-pds",
  "hyprstream-rpc",
  "hyprstream-vfs",
+ "p256",
  "parking_lot 0.12.4",
  "rand 0.8.5",
  "serde",

--- a/crates/hyprstream-pds-service/Cargo.toml
+++ b/crates/hyprstream-pds-service/Cargo.toml
@@ -13,6 +13,7 @@ hyprstream-pds = { path = "../hyprstream-pds" }
 hyprstream-rpc = { path = "../hyprstream-rpc" }
 hyprstream-vfs = { path = "../hyprstream-vfs" }
 parking_lot = { workspace = true }
+p256 = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 thiserror = { workspace = true }

--- a/crates/hyprstream-pds-service/src/lib.rs
+++ b/crates/hyprstream-pds-service/src/lib.rs
@@ -14,7 +14,7 @@ pub mod federation_intake;
 
 use std::sync::Arc;
 
-use hyprstream_pds::AccountRecord;
+use hyprstream_pds::{AccountRecord, ATPROTO_SIGNING_KEY_FILE};
 use hyprstream_rpc::auth::mac::{MacDecision, MacDenyReason, SecurityContext};
 use hyprstream_rpc::{EnvelopeContext, Subject};
 use hyprstream_vfs::{Mount, MountError, OREAD};
@@ -34,6 +34,7 @@ pub mod hosted_account_mint;
 pub const OAUTH_ACCOUNT_RESOLVER_SUBJECT: &str = "service:oauth";
 const DEFAULT_MAX_RECORD_BYTES: usize = 64 * 1024;
 const READ_CHUNK_BYTES: usize = 8 * 1024;
+const ATPROTO_SIGNING_KEY_BYTES: usize = 32;
 
 /// Failure from the mandatory tenant boundary or the PDS record read.
 #[derive(Debug, Error)]
@@ -62,6 +63,14 @@ pub enum AccountReadError {
     RecordTooLarge { limit: usize },
     #[error("PDS account record for {requested:?} contains label {stored:?}")]
     RecordLabelMismatch { requested: String, stored: String },
+    #[error("PDS account record for {requested:?} contains DID {stored:?}")]
+    RecordDidMismatch { requested: String, stored: String },
+    #[error("hosted account #atproto signing key for {0:?} is unavailable")]
+    SigningKeyUnavailable(String),
+    #[error("hosted account #atproto signing key for {0:?} is invalid")]
+    InvalidSigningKey(String),
+    #[error("hosted account #atproto signing key for {0:?} does not match its account record")]
+    SigningKeyMismatch(String),
     #[error("invalid PDS account record: {0}")]
     InvalidRecord(#[source] anyhow::Error),
     #[error("PDS mount operation failed: {0}")]
@@ -222,6 +231,104 @@ impl AccountRecordStore {
             resolved = Some(entry.name);
         }
         Ok(resolved)
+    }
+
+    /// Sign bytes with the account-specific `#atproto` key for one hosted DID.
+    ///
+    /// This is deliberately an authority-only operation: the caller supplies
+    /// neither a tenant nor a label. The store resolves the tenant from the
+    /// immutable account index, reloads the exact public account record, and
+    /// verifies the secret key against that record before signing. Missing,
+    /// corrupt, substituted, or ambiguous state fails closed and the secret
+    /// key never leaves this service boundary.
+    pub async fn sign_for_hosted_did(
+        &self,
+        authority: &Subject,
+        did: &str,
+        signing_input: &[u8],
+    ) -> Result<Option<Vec<u8>>, AccountReadError> {
+        use p256::ecdsa::signature::Signer as _;
+
+        let Some(tenant) = self.resolve_tenant_for_hosted_did(authority, did).await? else {
+            return Ok(None);
+        };
+        let Some(label) = hosted_account_label(did)? else {
+            return Ok(None);
+        };
+
+        let record_components = [
+            tenant.as_str(),
+            PDS_ACCOUNTS_DIRECTORY,
+            label,
+            PDS_ACCOUNT_RECORD_FILE,
+        ];
+        let record_bytes = read_file(
+            self.pds_mount.as_ref(),
+            self.read_authorizer.as_ref(),
+            &record_components,
+            authority,
+            Some(tenant.as_str()),
+            None,
+            self.max_record_bytes,
+        )
+        .await?;
+        let record =
+            AccountRecord::from_dag_cbor(&record_bytes).map_err(AccountReadError::InvalidRecord)?;
+        if record.name().label() != label {
+            return Err(AccountReadError::RecordLabelMismatch {
+                requested: label.to_owned(),
+                stored: record.name().label().to_owned(),
+            });
+        }
+        if record.name().did() != did {
+            return Err(AccountReadError::RecordDidMismatch {
+                requested: did.to_owned(),
+                stored: record.name().did().to_owned(),
+            });
+        }
+
+        let key_components = [
+            tenant.as_str(),
+            PDS_ACCOUNTS_DIRECTORY,
+            label,
+            ATPROTO_SIGNING_KEY_FILE,
+        ];
+        let key_bytes = match read_file(
+            self.pds_mount.as_ref(),
+            self.read_authorizer.as_ref(),
+            &key_components,
+            authority,
+            Some(tenant.as_str()),
+            None,
+            ATPROTO_SIGNING_KEY_BYTES,
+        )
+        .await
+        {
+            Ok(bytes) => bytes,
+            Err(AccountReadError::Mount(MountError::NotFound(_))) => {
+                return Err(AccountReadError::SigningKeyUnavailable(did.to_owned()));
+            }
+            Err(AccountReadError::RecordTooLarge { .. }) => {
+                return Err(AccountReadError::InvalidSigningKey(did.to_owned()));
+            }
+            Err(error) => return Err(error),
+        };
+        if key_bytes.len() != ATPROTO_SIGNING_KEY_BYTES {
+            return Err(AccountReadError::InvalidSigningKey(did.to_owned()));
+        }
+        let signing_key = p256::ecdsa::SigningKey::from_slice(&key_bytes)
+            .map_err(|_| AccountReadError::InvalidSigningKey(did.to_owned()))?;
+        if signing_key.verifying_key().to_encoded_point(true)
+            != record
+                .atproto_verifying_key()
+                .map_err(AccountReadError::InvalidRecord)?
+                .to_encoded_point(true)
+        {
+            return Err(AccountReadError::SigningKeyMismatch(did.to_owned()));
+        }
+
+        let signature: p256::ecdsa::Signature = signing_key.sign(signing_input);
+        Ok(Some(signature.to_bytes().to_vec()))
     }
 
     #[cfg(test)]
@@ -474,7 +581,7 @@ mod tests {
         Arc::new(PermitAccountReads)
     }
 
-    fn account_bytes(label: &str, zone: &str) -> Vec<u8> {
+    fn account_artifacts(label: &str, zone: &str) -> (Vec<u8>, Vec<u8>) {
         let ed = SigningKey::generate(&mut OsRng);
         let (pq, pq_vk) = ml_dsa_generate_keypair();
         let hybrid =
@@ -492,7 +599,15 @@ mod tests {
             .prepare_genesis(document, GenesisRepoHead::EmptyRepo)
             .unwrap();
         let signature = sign_genesis(pending.unsigned_genesis(), &ed, &pq).unwrap();
-        pending.seal(signature).unwrap().record_bytes().to_vec()
+        let account = pending.seal(signature).unwrap();
+        (
+            account.record_bytes().to_vec(),
+            account.atproto_signing_key().to_bytes().to_vec(),
+        )
+    }
+
+    fn account_bytes(label: &str, zone: &str) -> Vec<u8> {
+        account_artifacts(label, zone).0
     }
 
     fn tenant_node(label: &str, record: Vec<u8>) -> SyntheticNode {
@@ -502,6 +617,18 @@ mod tests {
                 label,
                 SyntheticNode::dir()
                     .with_child(PDS_ACCOUNT_RECORD_FILE, SyntheticNode::file(record)),
+            ),
+        )
+    }
+
+    fn tenant_node_with_key(label: &str, record: Vec<u8>, key: Vec<u8>) -> SyntheticNode {
+        SyntheticNode::dir().with_child(
+            PDS_ACCOUNTS_DIRECTORY,
+            SyntheticNode::dir().with_child(
+                label,
+                SyntheticNode::dir()
+                    .with_child(PDS_ACCOUNT_RECORD_FILE, SyntheticNode::file(record))
+                    .with_child(ATPROTO_SIGNING_KEY_FILE, SyntheticNode::file(key)),
             ),
         )
     }
@@ -609,6 +736,67 @@ mod tests {
             ambiguous,
             AccountReadError::AmbiguousHostedAccountDid(_)
         ));
+    }
+
+    #[tokio::test]
+    async fn hosted_service_auth_signing_is_authority_bound_and_record_bound() {
+        use p256::ecdsa::signature::Verifier as _;
+
+        let did = "did:web:alice.acme.example";
+        let (record, key) = account_artifacts("alice", "acme.example");
+        let verifying_key = p256::ecdsa::SigningKey::from_slice(&key)
+            .unwrap()
+            .verifying_key()
+            .to_owned();
+        let root = SyntheticNode::dir().with_child(
+            "acme",
+            tenant_node_with_key("alice", record.clone(), key.clone()),
+        );
+        let store =
+            AccountRecordStore::new(Arc::new(SyntheticMount::new(root)), permit_account_reads());
+        let input = b"header.payload";
+        let signature = store
+            .sign_for_hosted_did(&oauth_authority(), did, input)
+            .await
+            .unwrap()
+            .expect("hosted account key");
+        let signature = p256::ecdsa::Signature::from_slice(&signature).unwrap();
+        verifying_key.verify(input, &signature).unwrap();
+
+        let denied = store
+            .sign_for_hosted_did(&Subject::new("alice"), did, input)
+            .await
+            .unwrap_err();
+        assert!(matches!(
+            denied,
+            AccountReadError::UnauthorizedTenantResolver(_)
+        ));
+
+        let missing_root =
+            SyntheticNode::dir().with_child("acme", tenant_node("alice", record.clone()));
+        let missing = AccountRecordStore::new(
+            Arc::new(SyntheticMount::new(missing_root)),
+            permit_account_reads(),
+        )
+        .sign_for_hosted_did(&oauth_authority(), did, input)
+        .await
+        .unwrap_err();
+        assert!(matches!(
+            missing,
+            AccountReadError::SigningKeyUnavailable(_)
+        ));
+
+        let (_, other_key) = account_artifacts("other", "acme.example");
+        let mismatch_root = SyntheticNode::dir()
+            .with_child("acme", tenant_node_with_key("alice", record, other_key));
+        let mismatch = AccountRecordStore::new(
+            Arc::new(SyntheticMount::new(mismatch_root)),
+            permit_account_reads(),
+        )
+        .sign_for_hosted_did(&oauth_authority(), did, input)
+        .await
+        .unwrap_err();
+        assert!(matches!(mismatch, AccountReadError::SigningKeyMismatch(_)));
     }
 
     #[test]

--- a/crates/hyprstream-pds/src/hosted_account.rs
+++ b/crates/hyprstream-pds/src/hosted_account.rs
@@ -46,7 +46,13 @@ const COMPRESSED_P256_PUBLIC_KEY_LEN: usize = 33;
 const ACCOUNT_RECORD_FILE: &str = "account-record.cbor";
 const GENESIS_DID_OP_FILE: &str = "genesis.didop.cbor";
 const DID_DOCUMENT_FILE: &str = "did-document.json";
-const ATPROTO_SIGNING_KEY_FILE: &str = "atproto-signing-key";
+/// Secret account-specific P-256 key paired with the public `#atproto`
+/// verification method in the immutable account record and DID document.
+///
+/// Serving layers must never return this file. They may use it only after
+/// binding the caller to the exact hosted DID and re-checking that its public
+/// key matches the account record.
+pub const ATPROTO_SIGNING_KEY_FILE: &str = "atproto-signing-key";
 
 /// The output of the A2 allocation + A3 configured-zone seam.
 ///

--- a/crates/hyprstream-pds/src/lib.rs
+++ b/crates/hyprstream-pds/src/lib.rs
@@ -86,6 +86,7 @@ pub use did_op::{
 pub use hosted_account::{
     AccountRecord, AllocatedAccountName, DirectoryHostedAccountStore, HostedAccountMint,
     PendingHostedAccountMint, SealedHostedAccount, ACCOUNT_RECORD_VERSION,
+    ATPROTO_SIGNING_KEY_FILE,
 };
 pub use hosted_did_document::{
     SealedHostedDidDocument, DID_DOCUMENT_MEDIA_TYPE, DID_DOCUMENT_PATH, DID_OPERATION_LOG_PATH,

--- a/crates/hyprstream/src/mac/pds_pep.rs
+++ b/crates/hyprstream/src/mac/pds_pep.rs
@@ -10,6 +10,7 @@ use std::time::{SystemTime, UNIX_EPOCH};
 
 #[cfg(not(target_arch = "wasm32"))]
 use async_trait::async_trait;
+use hyprstream_pds::ATPROTO_SIGNING_KEY_FILE;
 use hyprstream_pds_service::{
     AccountRecordReadAuthorizer, OAUTH_ACCOUNT_RESOLVER_SUBJECT, PDS_ACCOUNTS_DIRECTORY,
     PDS_ACCOUNT_RECORD_FILE,
@@ -45,11 +46,13 @@ fn pds_account_label() -> SecurityLabel {
     )
 }
 
-/// Trusted structural labels for the two account-store read objects.
+/// Trusted structural labels for the account-store read objects.
 ///
 /// The OAuth resolver reads only `/pds` (tenant names), while a scoped caller
 /// reads only the exact publication marker below a validated tenant and
-/// account label. Other paths remain unlabeled and therefore deny.
+/// account label. The account-specific `#atproto` secret is labeled for the
+/// fixed internal OAuth authority's service-auth signer, but no scoped
+/// account-reader API exposes it. Other paths remain unlabeled and deny.
 #[derive(Debug, Default, Clone, Copy)]
 pub struct PdsAccountObjectLabelResolver;
 
@@ -60,11 +63,11 @@ impl ObjectLabelResolver for PdsAccountObjectLabelResolver {
         };
         match components {
             ["pds"] => Some(pds_account_label()),
-            ["pds", tenant, accounts, account, record]
+            ["pds", tenant, accounts, account, file]
                 if valid_tenant_component(tenant)
                     && *accounts == PDS_ACCOUNTS_DIRECTORY
                     && valid_account_component(account)
-                    && *record == PDS_ACCOUNT_RECORD_FILE =>
+                    && matches!(*file, PDS_ACCOUNT_RECORD_FILE | ATPROTO_SIGNING_KEY_FILE) =>
             {
                 Some(pds_account_label())
             }
@@ -990,7 +993,7 @@ mod tests {
     }
 
     #[test]
-    fn production_sources_label_only_account_reads_and_recognize_oauth() {
+    fn production_sources_label_only_account_artifacts_and_recognize_oauth() {
         let resolver = PdsAccountObjectLabelResolver;
         assert_eq!(
             resolver.resolve(ObjectRef::Path(&["pds"])),
@@ -1003,6 +1006,16 @@ mod tests {
                 PDS_ACCOUNTS_DIRECTORY,
                 "alice",
                 PDS_ACCOUNT_RECORD_FILE,
+            ])),
+            Some(pds_account_label())
+        );
+        assert_eq!(
+            resolver.resolve(ObjectRef::Path(&[
+                "pds",
+                "acme",
+                PDS_ACCOUNTS_DIRECTORY,
+                "alice",
+                ATPROTO_SIGNING_KEY_FILE,
             ])),
             Some(pds_account_label())
         );
@@ -1117,12 +1130,12 @@ mod tests {
             .unwrap();
         let entries = mount.readdir(&fid, &subject).await.unwrap();
         assert_eq!(entries.len(), 2);
-        assert!(entries.iter().any(|entry| entry.name == "acme" && entry.is_dir));
-        assert!(
-            entries
-                .iter()
-                .any(|entry| entry.name == "alias" && !entry.is_dir)
-        );
+        assert!(entries
+            .iter()
+            .any(|entry| entry.name == "acme" && entry.is_dir));
+        assert!(entries
+            .iter()
+            .any(|entry| entry.name == "alias" && !entry.is_dir));
         mount.clunk(fid, &subject).await;
     }
 }

--- a/crates/hyprstream/src/services/oauth/auth.rs
+++ b/crates/hyprstream/src/services/oauth/auth.rs
@@ -100,10 +100,10 @@ pub async fn require_bearer_token(
     if let Some(ref proof_str) = dpop_proof_str {
         let method = request.method().as_str();
         let uri = request.uri();
-        let htu = format!("{}{}",
-            uri.scheme_str().map(|s| format!("{s}://")).unwrap_or_default(),
-            uri.path(),
-        );
+        // RFC 9449 htu is the absolute target URI without query or fragment.
+        // Axum server requests normally carry origin-form URIs, so reconstruct
+        // the authority from the operator-configured canonical OAuth origin.
+        let htu = format!("{}{}", state.atproto_issuer_url(), uri.path());
         let proof = match super::dpop::verify_dpop_proof(proof_str, method, &htu, Some(&token)) {
             Ok(p) => p,
             Err(e) => {

--- a/crates/hyprstream/src/services/oauth/mod.rs
+++ b/crates/hyprstream/src/services/oauth/mod.rs
@@ -184,7 +184,7 @@ pub fn create_app(state: Arc<OAuthState>, cors_config: &crate::config::CorsConfi
     };
 
     // ── Protected routes ───────────────────────────────────────────────────────
-    // All require a valid Bearer token (validated by require_bearer_token).
+    // All require a valid Bearer/DPoP token (validated by require_bearer_token).
     // Inserts AuthenticatedUser into request extensions for downstream handlers.
     let authority_router = Router::new()
         .route(
@@ -219,6 +219,10 @@ pub fn create_app(state: Arc<OAuthState>, cors_config: &crate::config::CorsConfi
         ));
 
     let protected_router = Router::new()
+        .route(
+            xrpc::GET_SERVICE_AUTH_PATH,
+            get(xrpc::get_service_auth),
+        )
         .route("/oauth/introspect", post(introspection::introspect_token))
         .route("/oauth/wit", post(wit_bootstrap::issue_browser_wit))
         .route(
@@ -1256,6 +1260,49 @@ mod tests {
         )
     }
 
+    fn dpop_resource_proof(
+        signing_key: &p256::ecdsa::SigningKey,
+        method: &str,
+        htu: &str,
+        access_token: &str,
+        jti: &str,
+        nonce: Option<&str>,
+    ) -> String {
+        use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine as _};
+        use p256::ecdsa::signature::Signer as _;
+        use sha2::{Digest as _, Sha256};
+
+        let point = signing_key.verifying_key().to_encoded_point(false);
+        let header = serde_json::json!({
+            "typ": "dpop+jwt",
+            "alg": "ES256",
+            "jwk": {
+                "kty": "EC",
+                "crv": "P-256",
+                "x": URL_SAFE_NO_PAD.encode(point.x().unwrap()),
+                "y": URL_SAFE_NO_PAD.encode(point.y().unwrap()),
+            }
+        });
+        let mut payload = serde_json::json!({
+            "jti": jti,
+            "htm": method,
+            "htu": htu,
+            "iat": chrono::Utc::now().timestamp(),
+            "ath": URL_SAFE_NO_PAD.encode(Sha256::digest(access_token.as_bytes())),
+        });
+        if let Some(value) = nonce {
+            payload["nonce"] = serde_json::Value::String(value.to_owned());
+        }
+        let header = URL_SAFE_NO_PAD.encode(serde_json::to_vec(&header).unwrap());
+        let payload = URL_SAFE_NO_PAD.encode(serde_json::to_vec(&payload).unwrap());
+        let signing_input = format!("{header}.{payload}");
+        let signature: p256::ecdsa::Signature = signing_key.sign(signing_input.as_bytes());
+        format!(
+            "{signing_input}.{}",
+            URL_SAFE_NO_PAD.encode(signature.to_bytes())
+        )
+    }
+
     fn private_key_jwt_assertion(
         signing_key: &p256::ecdsa::SigningKey,
         kid: &str,
@@ -1569,10 +1616,15 @@ mod tests {
                 "accounts",
                 SyntheticNode::dir().with_child(
                     "alice",
-                    SyntheticNode::dir().with_child(
-                        "account-record.cbor",
-                        SyntheticNode::file(sealed_account.record_bytes().to_vec()),
-                    ),
+                    SyntheticNode::dir()
+                        .with_child(
+                            "account-record.cbor",
+                            SyntheticNode::file(sealed_account.record_bytes().to_vec()),
+                        )
+                        .with_child(
+                            hyprstream_pds::ATPROTO_SIGNING_KEY_FILE,
+                            SyntheticNode::file(atproto_signing_key.to_bytes().to_vec()),
+                        ),
                 ),
             ),
         );
@@ -2028,6 +2080,92 @@ mod tests {
         assert_eq!(claims["tenant"], HOSTED_TENANT);
         assert_eq!(claims["aud"], ISSUER);
         assert_eq!(claims["scope"], "atproto");
+
+        // The protected hosted-PDS route consumes the standard DPoP-bound
+        // OAuth access token and signs the exact #1354 method/audience with
+        // the account's persisted #atproto key.
+        let service_auth_htu = format!("{ISSUER}{}", xrpc::GET_SERVICE_AUTH_PATH);
+        let service_auth_uri = format!(
+            "{}?aud={}&lxm={}",
+            xrpc::GET_SERVICE_AUTH_PATH,
+            urlencoding::encode(&state.atproto_service_did().unwrap()),
+            urlencoding::encode(token_exchange::ATPROTO_SESSION_EXCHANGE_NSID),
+        );
+        let service_auth_proof = dpop_resource_proof(
+            &dpop_key,
+            "GET",
+            &service_auth_htu,
+            &token_response.access_token,
+            "handler-service-auth-jti",
+            Some(&token_nonce),
+        );
+        let service_auth = app
+            .clone()
+            .oneshot(
+                axum::http::Request::get(service_auth_uri)
+                    .header(
+                        axum::http::header::AUTHORIZATION,
+                        format!("DPoP {}", token_response.access_token),
+                    )
+                    .header("DPoP", service_auth_proof)
+                    .body(axum::body::Body::empty())?,
+            )
+            .await?;
+        let service_auth_status = service_auth.status();
+        let service_auth_cache_control = service_auth
+            .headers()
+            .get(axum::http::header::CACHE_CONTROL)
+            .cloned();
+        let service_auth_json = response_json(service_auth).await;
+        assert_eq!(
+            service_auth_status,
+            axum::http::StatusCode::OK,
+            "{service_auth_json}"
+        );
+        assert_eq!(
+            service_auth_cache_control.as_ref().unwrap(),
+            "no-store"
+        );
+        let service_jwt = service_auth_json["token"]
+            .as_str()
+            .ok_or_else(|| anyhow::anyhow!("service-auth response token"))?
+            .to_owned();
+        let verified = token_exchange::verify_atproto_service_jwt(
+            &state,
+            &service_jwt,
+            token_exchange::ATPROTO_SESSION_EXCHANGE_NSID,
+        )
+        .await
+        .map_err(anyhow::Error::msg)?;
+        assert_eq!(verified.sub, MAPPED_DID);
+        assert_eq!(verified.verified_tenant.as_deref(), Some(HOSTED_TENANT));
+
+        // The first hyprstream_session is still issued by the existing #1354
+        // exchange route; getServiceAuth does not create a parallel session.
+        let session_proof = dpop_proof(
+            &dpop_key,
+            &format!("{ISSUER}{}", browser_session::SESSION_EXCHANGE_PATH),
+            "handler-session-exchange-jti",
+            None,
+        );
+        let session = app
+            .clone()
+            .oneshot(
+                axum::http::Request::post(browser_session::SESSION_EXCHANGE_PATH)
+                    .header(
+                        axum::http::header::AUTHORIZATION,
+                        format!("Bearer {service_jwt}"),
+                    )
+                    .header("DPoP", session_proof)
+                    .body(axum::body::Body::empty())?,
+            )
+            .await?;
+        assert_eq!(session.status(), axum::http::StatusCode::OK);
+        assert!(
+            session.headers()[axum::http::header::SET_COOKIE]
+                .to_str()?
+                .starts_with("hyprstream_session=")
+        );
 
         // A confidential atproto client signs private_key_jwt with the AS
         // issuer as the assertion audience (atproto mandate, #1146 T1.2),

--- a/crates/hyprstream/src/services/oauth/mod.rs
+++ b/crates/hyprstream/src/services/oauth/mod.rs
@@ -1450,8 +1450,8 @@ mod tests {
         use crate::services::generated::policy_client::IssueToken;
         use crate::services::{DiscoveryClient, PolicyClient, PolicyService};
 
-        const ISSUER: &str = "https://pds.example.test";
-        const GENERIC_ISSUER: &str = "https://pds.example.test/configured/path";
+        const ISSUER: &str = "https://pds.example.test:8443";
+        const GENERIC_ISSUER: &str = "https://pds.example.test:8443/configured/path";
         const CLIENT_ID: &str = "handler-client";
         const PRIVATE_CLIENT_ID: &str = "handler-private-client";
         const REDIRECT_URI: &str = "https://client.example.test/callback";
@@ -1748,7 +1748,7 @@ mod tests {
             ))
         };
         let service_jwt = make_service_jwt(
-            "did:web:pds.example.test",
+            "did:web:pds.example.test%3A8443",
             token_exchange::ATPROTO_EXCHANGE_NSID,
             "demo-1119-jti",
         )?;
@@ -1792,7 +1792,7 @@ mod tests {
             axum::http::StatusCode::UNAUTHORIZED
         );
         let wrong_lxm = make_service_jwt(
-            "did:web:pds.example.test",
+            "did:web:pds.example.test%3A8443",
             "com.atproto.repo.uploadBlob",
             "demo-1119-wrong-lxm",
         )?;
@@ -1820,7 +1820,7 @@ mod tests {
         assert_eq!(exchanged_claims["scope"], "transition:generic");
 
         let wrong_tenant_jwt = make_service_jwt(
-            "did:web:pds.example.test",
+            "did:web:pds.example.test%3A8443",
             token_exchange::ATPROTO_EXCHANGE_NSID,
             "demo-1119-wrong-tenant",
         )?;

--- a/crates/hyprstream/src/services/oauth/state.rs
+++ b/crates/hyprstream/src/services/oauth/state.rs
@@ -704,6 +704,32 @@ mod tests {
         assert!(canonical_issuer_origin("pds.example.com").is_none());
     }
 
+    #[test]
+    fn atproto_service_did_matches_browser_origin_encoding() {
+        assert_eq!(
+            atproto_service_did_for_origin("https://pds.example.test").as_deref(),
+            Some("did:web:pds.example.test")
+        );
+        assert_eq!(
+            atproto_service_did_for_origin("https://pds.example.test/oauth/par").as_deref(),
+            Some("did:web:pds.example.test")
+        );
+        assert_eq!(
+            atproto_service_did_for_origin("https://pds.example.test:443/oauth/par").as_deref(),
+            Some("did:web:pds.example.test")
+        );
+        assert_eq!(
+            atproto_service_did_for_origin("https://pds.example.test:8443/oauth/par").as_deref(),
+            Some("did:web:pds.example.test%3A8443")
+        );
+        assert_eq!(
+            atproto_service_did_for_origin("http://127.0.0.1:6791").as_deref(),
+            Some("did:web:127.0.0.1%3A6791")
+        );
+        assert!(atproto_service_did_for_origin("https://[::1]:8443").is_none());
+        assert!(atproto_service_did_for_origin("ftp://pds.example.test").is_none());
+    }
+
     /// #1113 rev2 F4/F6: the default grant set (omitted-scope fallback) must
     /// NOT include `atproto` — those scopes are supported-but-explicit. A
     /// client that omits `scope` must NOT silently activate the strict profile.
@@ -1274,8 +1300,7 @@ impl OAuthState {
 
     /// Host service DID accepted in ATProto service-auth `aud`.
     pub fn atproto_service_did(&self) -> Option<String> {
-        super::did_document::issuer_authority(&self.issuer_url)
-            .map(|authority| format!("did:web:{authority}"))
+        atproto_service_did_for_origin(&self.issuer_url)
     }
 
     /// Set JWT signing key validity window for the JWKS endpoint.
@@ -1990,4 +2015,31 @@ pub fn canonical_issuer_origin(issuer_url: &str) -> Option<String> {
         return None;
     }
     Some(format!("{scheme}://{authority}"))
+}
+
+/// Convert the configured OAuth URL to the host-form `did:web` service DID
+/// used by ATProto service-auth audiences.
+///
+/// For supported DNS/IPv4 origins this mirrors the browser's
+/// `originToDidWeb`: URL parsing normalizes an explicit default port away,
+/// while a non-default port is retained and its domain-segment separator is
+/// encoded as `%3A`. IPv6 is rejected until client and server share one
+/// canonical DID representation for it.
+fn atproto_service_did_for_origin(issuer_url: &str) -> Option<String> {
+    let url = url::Url::parse(issuer_url).ok()?;
+    if !matches!(url.scheme(), "http" | "https")
+        || !url.username().is_empty()
+        || url.password().is_some()
+    {
+        return None;
+    }
+    let host = match url.host()? {
+        url::Host::Domain(domain) => domain.to_owned(),
+        url::Host::Ipv4(address) => address.to_string(),
+        url::Host::Ipv6(_) => return None,
+    };
+    Some(match url.port() {
+        Some(port) => format!("did:web:{host}%3A{port}"),
+        None => format!("did:web:{host}"),
+    })
 }

--- a/crates/hyprstream/src/services/oauth/token_exchange.rs
+++ b/crates/hyprstream/src/services/oauth/token_exchange.rs
@@ -29,7 +29,7 @@ const TOKEN_TYPE_JWT: &str = "urn:ietf:params:oauth:token-type:jwt";
 const ISSUED_TOKEN_TYPE: &str = "urn:ietf:params:oauth:token-type:access_token";
 pub const ATPROTO_EXCHANGE_NSID: &str = "ai.hyprstream.identity.exchangeUcan";
 pub const ATPROTO_SESSION_EXCHANGE_NSID: &str = "ai.hyprstream.identity.exchangeSession";
-const MAX_ATPROTO_SERVICE_TOKEN_LIFETIME: i64 = 3600;
+pub(super) const MAX_ATPROTO_SERVICE_TOKEN_LIFETIME: i64 = 3600;
 pub(super) const MAX_ATPROTO_EXCHANGE_TOKEN_TTL: u32 = 300;
 
 pub(super) struct VerifiedSubject {

--- a/crates/hyprstream/src/services/oauth/xrpc.rs
+++ b/crates/hyprstream/src/services/oauth/xrpc.rs
@@ -5,7 +5,7 @@
 //! remains deliberately no-networking: this module is the serving layer that
 //! calls its data functions (`Commit`/`MST`/`car::build_record_proof_car`).
 //!
-//! # Endpoints (public reads only)
+//! # Endpoints
 //!
 //! | Method | Path (under `/xrpc/`) | Notes |
 //! |--------|-----------------------|-------|
@@ -13,6 +13,7 @@
 //! | GET    | `com.atproto.repo.describeRepo`     | DID/handle + commit head + didDoc |
 //! | GET    | `com.atproto.repo.getRecord`        | record JSON (optional `cid` pinning) |
 //! | GET    | `com.atproto.sync.getRepo`          | full-repo CARv1 export (lazy stream) |
+//! | GET    | `com.atproto.server.getServiceAuth` | protected hosted-account service JWT |
 //!
 //! **Session endpoints (`createSession`/`getSession`) are deliberately NOT in
 //! this PR.** Credential verification (password / app-password) and the OAuth
@@ -35,13 +36,15 @@ use std::collections::BTreeMap;
 use std::sync::Arc;
 
 use axum::{
-    extract::{RawQuery, State},
+    extract::{Extension, RawQuery, State},
     http::{header, StatusCode},
     response::{IntoResponse, Response},
 };
+use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine as _};
 use bytes::Bytes;
 use futures::{stream, Stream};
 use p256::ecdsa::VerifyingKey;
+use rand::RngCore as _;
 use serde_json::{json, Value};
 use tokio::sync::{OwnedSemaphorePermit, RwLock, Semaphore};
 
@@ -55,9 +58,19 @@ use hyprstream_pds::Cid;
 
 use super::did_document::{build_did_document, issuer_authority, AtprotoIdentity};
 use super::state::OAuthState;
+use super::{
+    auth::{self, AuthenticatedUser},
+    token_exchange::{ATPROTO_SESSION_EXCHANGE_NSID, MAX_ATPROTO_SERVICE_TOKEN_LIFETIME},
+};
 
 /// `ai.hyprstream.model` is the only collection this PDS hosts today.
 pub const HOSTED_COLLECTION: &str = COLLECTION_NSID;
+
+/// Protected hosted-PDS service-auth endpoint from the ATProto server lexicon.
+pub const GET_SERVICE_AUTH_PATH: &str = "/xrpc/com.atproto.server.getServiceAuth";
+
+const DEFAULT_SERVICE_AUTH_TTL_SECONDS: i64 = 60;
+const MAX_SERVICE_AUTH_PARAMETER_BYTES: usize = 2_048;
 
 /// Maximum number of concurrent `sync.getRepo` (full-CAR export) requests.
 /// Each request streams the entire repo; bounding concurrency prevents
@@ -114,11 +127,15 @@ impl RepoSnapshot {
     pub fn record_proof_car(&self, rkey: &str) -> Option<Vec<u8>> {
         let tid = Tid::parse(rkey).ok()?;
         let rec = self.records.get(&tid)?;
-        let cids: BTreeMap<Tid, Cid> =
-            self.records.iter().map(|(t, r)| (*t, r.cid())).collect();
+        let cids: BTreeMap<Tid, Cid> = self.records.iter().map(|(t, r)| (*t, r.cid())).collect();
         let tree = Node::from_records(HOSTED_COLLECTION, &cids);
         let proof = tree.proof(HOSTED_COLLECTION, &tid)?;
-        Some(build_record_proof_car(&self.commit, &proof, &self.node_blocks, rec))
+        Some(build_record_proof_car(
+            &self.commit,
+            &proof,
+            &self.node_blocks,
+            rec,
+        ))
     }
 
     pub fn record_json(&self, rkey: &str, rec: &ModelRecord) -> Value {
@@ -170,7 +187,10 @@ impl XrpcRepoStore {
     /// Insert or replace a snapshot for an atproto-valid repo authority.
     pub async fn put(&self, snap: RepoSnapshot) -> anyhow::Result<()> {
         accept_repo_authority(&snap.did)?;
-        self.by_did.write().await.insert(snap.did.clone(), Arc::new(snap));
+        self.by_did
+            .write()
+            .await
+            .insert(snap.did.clone(), Arc::new(snap));
         Ok(())
     }
 
@@ -199,7 +219,9 @@ impl XrpcRepoStore {
     /// Acquire an **owned** concurrency permit for full-CAR export. The permit
     /// lives until the body stream is consumed or dropped — not just until the
     /// handler returns. Bounded by [`GET_REPO_CONCURRENCY`].
-    pub async fn acquire_get_repo_owned(&self) -> Result<OwnedSemaphorePermit, tokio::sync::AcquireError> {
+    pub async fn acquire_get_repo_owned(
+        &self,
+    ) -> Result<OwnedSemaphorePermit, tokio::sync::AcquireError> {
         self.get_repo_sema.clone().acquire_owned().await
     }
 }
@@ -279,10 +301,7 @@ fn lazy_car_stream(
                             *ridx += 1;
                             let rec = &snap.records[&tid];
                             return Some((
-                                Ok(Bytes::from(car_block_bytes(
-                                    rec.cid(),
-                                    &rec.to_dag_cbor(),
-                                ))),
+                                Ok(Bytes::from(car_block_bytes(rec.cid(), &rec.to_dag_cbor()))),
                                 state,
                             ));
                         }
@@ -310,11 +329,294 @@ pub fn xrpc_error(status: StatusCode, error: &str, message: impl Into<String>) -
 
 pub mod errors {
     pub const INVALID_REQUEST: &str = "InvalidRequest";
+    pub const BAD_EXPIRATION: &str = "BadExpiration";
     pub const ACCOUNT_NOT_FOUND: &str = "AccountNotFound";
     pub const HANDLE_NOT_FOUND: &str = "HandleNotFound";
     pub const RECORD_NOT_FOUND: &str = "RecordNotFound";
     pub const REPO_NOT_FOUND: &str = "RepoNotFound";
     pub const INTERNAL_SERVER_ERROR: &str = "InternalServerError";
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Protected hosted-account service auth
+// ─────────────────────────────────────────────────────────────────────────────
+
+#[derive(Debug, PartialEq, Eq)]
+struct GetServiceAuthParams {
+    aud: String,
+    exp: Option<i64>,
+    lxm: String,
+}
+
+fn parse_get_service_auth_query(raw: Option<&str>) -> Result<GetServiceAuthParams, &'static str> {
+    let mut aud = None;
+    let mut exp = None;
+    let mut lxm = None;
+    for (key, value) in url::form_urlencoded::parse(raw.unwrap_or_default().as_bytes()) {
+        if key.len() > MAX_SERVICE_AUTH_PARAMETER_BYTES
+            || value.len() > MAX_SERVICE_AUTH_PARAMETER_BYTES
+        {
+            return Err("service-auth query parameter is too long");
+        }
+        match key.as_ref() {
+            "aud" if aud.is_none() && !value.is_empty() => aud = Some(value.into_owned()),
+            "exp" if exp.is_none() && !value.is_empty() => {
+                exp = Some(
+                    value
+                        .parse()
+                        .map_err(|_| "exp must be an integer Unix timestamp")?,
+                );
+            }
+            "lxm" if lxm.is_none() && !value.is_empty() => lxm = Some(value.into_owned()),
+            "aud" | "exp" | "lxm" => {
+                return Err("service-auth query parameters must be non-empty and unique");
+            }
+            _ => return Err("unknown service-auth query parameter"),
+        }
+    }
+    Ok(GetServiceAuthParams {
+        aud: aud.ok_or("aud is required")?,
+        exp,
+        // The upstream lexicon permits an unbound token, but this hosted-PDS
+        // surface only mints the one method-bound assertion consumed by #1354.
+        lxm: lxm.ok_or("lxm is required")?,
+    })
+}
+
+fn service_auth_response(status: StatusCode, body: Value) -> Response {
+    (
+        status,
+        [
+            (header::CACHE_CONTROL, "no-store"),
+            (header::PRAGMA, "no-cache"),
+        ],
+        axum::Json(body),
+    )
+        .into_response()
+}
+
+fn service_auth_error(status: StatusCode, error: &str, message: impl Into<String>) -> Response {
+    service_auth_response(status, xrpc_error_body(error, message))
+}
+
+/// Mint a short-lived, method-bound ATProto service JWT using the hosted
+/// account's persisted `#atproto` key.
+///
+/// Authentication and DPoP proof verification happen in the protected-router
+/// middleware. This handler independently re-verifies the signed OAuth grant
+/// before deriving scope, subject, or tenant authority from it.
+pub async fn get_service_auth(
+    State(state): State<Arc<OAuthState>>,
+    Extension(user): Extension<AuthenticatedUser>,
+    RawQuery(raw): RawQuery,
+) -> Response {
+    let params = match parse_get_service_auth_query(raw.as_deref()) {
+        Ok(params) => params,
+        Err(message) => {
+            return service_auth_error(StatusCode::BAD_REQUEST, errors::INVALID_REQUEST, message);
+        }
+    };
+    let expected_aud = match state.atproto_service_did() {
+        Some(did) => did,
+        None => {
+            return service_auth_error(
+                StatusCode::SERVICE_UNAVAILABLE,
+                errors::INTERNAL_SERVER_ERROR,
+                "host service DID is unavailable",
+            );
+        }
+    };
+    if params.aud != expected_aud {
+        return service_auth_error(
+            StatusCode::BAD_REQUEST,
+            errors::INVALID_REQUEST,
+            "aud must equal this PDS host DID",
+        );
+    }
+    if params.lxm != ATPROTO_SESSION_EXCHANGE_NSID {
+        return service_auth_error(
+            StatusCode::BAD_REQUEST,
+            errors::INVALID_REQUEST,
+            format!("lxm must equal {ATPROTO_SESSION_EXCHANGE_NSID}"),
+        );
+    }
+
+    let now = chrono::Utc::now().timestamp();
+    let exp = match params
+        .exp
+        .unwrap_or_else(|| now.saturating_add(DEFAULT_SERVICE_AUTH_TTL_SECONDS))
+        .checked_sub(now)
+    {
+        Some(ttl) if ttl > 0 && ttl <= MAX_ATPROTO_SERVICE_TOKEN_LIFETIME => now + ttl,
+        _ => {
+            return service_auth_error(
+                StatusCode::BAD_REQUEST,
+                errors::BAD_EXPIRATION,
+                "exp must be in the future and no more than one hour from now",
+            );
+        }
+    };
+
+    let token = match user.token.as_deref() {
+        Some(token) => token,
+        None => {
+            return service_auth_error(
+                StatusCode::UNAUTHORIZED,
+                errors::INVALID_REQUEST,
+                "verified OAuth access token is required",
+            );
+        }
+    };
+    let claims = match auth::validate_oauth_access_token(&state, token).await {
+        Ok(claims) => claims,
+        Err(_) => {
+            return service_auth_error(
+                StatusCode::UNAUTHORIZED,
+                errors::INVALID_REQUEST,
+                "OAuth access token is invalid or expired",
+            );
+        }
+    };
+    if claims.sub != user.user || claims.tenant != user.verified_tenant {
+        tracing::error!("service-auth middleware and handler identity claims disagree");
+        return service_auth_error(
+            StatusCode::UNAUTHORIZED,
+            errors::INVALID_REQUEST,
+            "OAuth identity binding is invalid",
+        );
+    }
+    if !claims.has_scope("atproto") {
+        return service_auth_error(
+            StatusCode::FORBIDDEN,
+            "InsufficientScope",
+            "the atproto scope is required",
+        );
+    }
+    if claims.cnf_jkt().is_none() {
+        return service_auth_error(
+            StatusCode::UNAUTHORIZED,
+            errors::INVALID_REQUEST,
+            "a DPoP-bound OAuth access token is required",
+        );
+    }
+    if super::token::hosted_account_tenant_from_did(&claims.sub, state.hosted_account_zone.as_ref())
+        .is_err()
+    {
+        return service_auth_error(
+            StatusCode::BAD_REQUEST,
+            errors::ACCOUNT_NOT_FOUND,
+            "OAuth subject is not a hosted account on this PDS",
+        );
+    }
+    let record_tenant = match state.hosted_account_tenant(&claims.sub).await {
+        Ok(Some(tenant)) => tenant,
+        Ok(None) => {
+            return service_auth_error(
+                StatusCode::BAD_REQUEST,
+                errors::ACCOUNT_NOT_FOUND,
+                "OAuth subject has no hosted account record",
+            );
+        }
+        Err(error) => {
+            tracing::error!(
+                subject = %claims.sub,
+                error = %error,
+                "hosted account tenant verification failed"
+            );
+            return service_auth_error(
+                StatusCode::INTERNAL_SERVER_ERROR,
+                errors::INTERNAL_SERVER_ERROR,
+                "hosted account verification failed",
+            );
+        }
+    };
+    if claims.tenant.as_deref() != Some(record_tenant.as_str()) {
+        tracing::error!(
+            subject = %claims.sub,
+            "OAuth tenant does not match the authority-owned hosted account record"
+        );
+        return service_auth_error(
+            StatusCode::UNAUTHORIZED,
+            errors::INVALID_REQUEST,
+            "OAuth hosted-account tenant binding is invalid",
+        );
+    }
+
+    let mut jti_bytes = [0_u8; 16];
+    rand::rngs::OsRng.fill_bytes(&mut jti_bytes);
+    let header_segment = match serde_json::to_vec(&json!({
+        "alg": "ES256",
+        "typ": "JWT",
+        "kid": "#atproto",
+    })) {
+        Ok(bytes) => URL_SAFE_NO_PAD.encode(bytes),
+        Err(_) => {
+            return service_auth_error(
+                StatusCode::INTERNAL_SERVER_ERROR,
+                errors::INTERNAL_SERVER_ERROR,
+                "failed to encode service JWT",
+            );
+        }
+    };
+    let claims_segment = match serde_json::to_vec(&json!({
+        "iss": claims.sub,
+        "aud": expected_aud,
+        "iat": now,
+        "exp": exp,
+        "lxm": ATPROTO_SESSION_EXCHANGE_NSID,
+        "jti": URL_SAFE_NO_PAD.encode(jti_bytes),
+    })) {
+        Ok(bytes) => URL_SAFE_NO_PAD.encode(bytes),
+        Err(_) => {
+            return service_auth_error(
+                StatusCode::INTERNAL_SERVER_ERROR,
+                errors::INTERNAL_SERVER_ERROR,
+                "failed to encode service JWT",
+            );
+        }
+    };
+    let signing_input = format!("{header_segment}.{claims_segment}");
+    let Some(store) = state.hosted_account_store.as_ref() else {
+        return service_auth_error(
+            StatusCode::SERVICE_UNAVAILABLE,
+            errors::INTERNAL_SERVER_ERROR,
+            "hosted account signer is unavailable",
+        );
+    };
+    let authority =
+        hyprstream_rpc::Subject::new(hyprstream_pds_service::OAUTH_ACCOUNT_RESOLVER_SUBJECT);
+    let signature = match store
+        .sign_for_hosted_did(&authority, &user.user, signing_input.as_bytes())
+        .await
+    {
+        Ok(Some(signature)) => signature,
+        Ok(None) => {
+            return service_auth_error(
+                StatusCode::BAD_REQUEST,
+                errors::ACCOUNT_NOT_FOUND,
+                "OAuth subject has no hosted account signing record",
+            );
+        }
+        Err(error) => {
+            tracing::error!(
+                subject = %user.user,
+                error = %error,
+                "hosted account service JWT signing failed"
+            );
+            return service_auth_error(
+                StatusCode::INTERNAL_SERVER_ERROR,
+                errors::INTERNAL_SERVER_ERROR,
+                "hosted account signing failed",
+            );
+        }
+    };
+
+    service_auth_response(
+        StatusCode::OK,
+        json!({
+            "token": format!("{signing_input}.{}", URL_SAFE_NO_PAD.encode(signature)),
+        }),
+    )
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -378,11 +680,7 @@ fn hex_val(b: u8) -> Option<u8> {
 // ─────────────────────────────────────────────────────────────────────────────
 
 /// Resolve a handle to a DID via the store + issuer-derived self-handle.
-async fn resolve_handle_core(
-    store: &XrpcRepoStore,
-    issuer_url: &str,
-    handle: &str,
-) -> Response {
+async fn resolve_handle_core(store: &XrpcRepoStore, issuer_url: &str, handle: &str) -> Response {
     if let Some(snap) = store.by_handle_public(handle).await {
         return axum::Json(json!({ "did": snap.did })).into_response();
     }
@@ -516,10 +814,7 @@ async fn get_repo_core(store: &XrpcRepoStore, did: &str, since_present: bool) ->
         .into_response()
 }
 
-async fn lookup_public_snapshot(
-    store: &XrpcRepoStore,
-    key: &str,
-) -> Option<Arc<RepoSnapshot>> {
+async fn lookup_public_snapshot(store: &XrpcRepoStore, key: &str) -> Option<Arc<RepoSnapshot>> {
     if key.starts_with("did:") {
         store.get_public(key).await
     } else {
@@ -567,13 +862,16 @@ pub async fn describe_repo(
     describe_repo_core(&state.xrpc_repos, &state.issuer_url, key).await
 }
 
-pub async fn get_record(
-    State(state): State<Arc<OAuthState>>,
-    RawQuery(raw): RawQuery,
-) -> Response {
+pub async fn get_record(State(state): State<Arc<OAuthState>>, RawQuery(raw): RawQuery) -> Response {
     let params = parse_query(raw.as_deref());
-    let collection = params.get("collection").map(std::string::String::as_str).unwrap_or("");
-    let rkey = params.get("rkey").map(std::string::String::as_str).unwrap_or("");
+    let collection = params
+        .get("collection")
+        .map(std::string::String::as_str)
+        .unwrap_or("");
+    let rkey = params
+        .get("rkey")
+        .map(std::string::String::as_str)
+        .unwrap_or("");
     let repo = match params.get("repo") {
         Some(r) if !r.is_empty() => r.trim(),
         _ => {
@@ -588,10 +886,7 @@ pub async fn get_record(
     get_record_core(&state.xrpc_repos, repo, collection, rkey, cid).await
 }
 
-pub async fn get_repo(
-    State(state): State<Arc<OAuthState>>,
-    RawQuery(raw): RawQuery,
-) -> Response {
+pub async fn get_repo(State(state): State<Arc<OAuthState>>, RawQuery(raw): RawQuery) -> Response {
     let params = parse_query(raw.as_deref());
     let did = match params.get("did") {
         Some(d) if !d.is_empty() => d.trim(),
@@ -664,7 +959,11 @@ mod tests {
 
     #[tokio::test]
     async fn lazy_car_stream_produces_valid_car() {
-        let snap = Arc::new(sample_snapshot("did:web:h.example.com", "h.example.com", true));
+        let snap = Arc::new(sample_snapshot(
+            "did:web:h.example.com",
+            "h.example.com",
+            true,
+        ));
         let store = XrpcRepoStore::new();
         let permit = store.acquire_get_repo_owned().await.unwrap();
         let strm = lazy_car_stream(Arc::clone(&snap), permit);
@@ -713,7 +1012,11 @@ mod tests {
         for _ in 0..GET_REPO_CONCURRENCY {
             held.push(store.acquire_get_repo_owned().await.unwrap());
         }
-        let snap = Arc::new(sample_snapshot("did:web:h.example.com", "h.example.com", true));
+        let snap = Arc::new(sample_snapshot(
+            "did:web:h.example.com",
+            "h.example.com",
+            true,
+        ));
         // Acquire one more for the stream.
         let stream_permit = held.pop().unwrap();
         let strm = lazy_car_stream(snap, stream_permit);
@@ -733,7 +1036,14 @@ mod tests {
     #[tokio::test]
     async fn endpoint_non_public_invisible_describe_repo() {
         let store = XrpcRepoStore::new();
-        store.put(sample_snapshot("did:web:priv.example.com", "priv.example.com", false)).await.unwrap();
+        store
+            .put(sample_snapshot(
+                "did:web:priv.example.com",
+                "priv.example.com",
+                false,
+            ))
+            .await
+            .unwrap();
         let resp = describe_repo_core(&store, ISSUER, "did:web:priv.example.com").await;
         assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
         let body = body_json(resp).await;
@@ -743,7 +1053,14 @@ mod tests {
     #[tokio::test]
     async fn endpoint_non_public_invisible_get_record() {
         let store = XrpcRepoStore::new();
-        store.put(sample_snapshot("did:web:priv.example.com", "priv.example.com", false)).await.unwrap();
+        store
+            .put(sample_snapshot(
+                "did:web:priv.example.com",
+                "priv.example.com",
+                false,
+            ))
+            .await
+            .unwrap();
         let resp = get_record_core(
             &store,
             "did:web:priv.example.com",
@@ -760,7 +1077,14 @@ mod tests {
     #[tokio::test]
     async fn endpoint_non_public_invisible_get_repo() {
         let store = XrpcRepoStore::new();
-        store.put(sample_snapshot("did:web:priv.example.com", "priv.example.com", false)).await.unwrap();
+        store
+            .put(sample_snapshot(
+                "did:web:priv.example.com",
+                "priv.example.com",
+                false,
+            ))
+            .await
+            .unwrap();
         let resp = get_repo_core(&store, "did:web:priv.example.com", false).await;
         assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
         let body = body_json(resp).await;
@@ -770,7 +1094,14 @@ mod tests {
     #[tokio::test]
     async fn endpoint_non_public_invisible_resolve_handle() {
         let store = XrpcRepoStore::new();
-        store.put(sample_snapshot("did:web:priv.example.com", "priv.example.com", false)).await.unwrap();
+        store
+            .put(sample_snapshot(
+                "did:web:priv.example.com",
+                "priv.example.com",
+                false,
+            ))
+            .await
+            .unwrap();
         let resp = resolve_handle_core(&store, ISSUER, "priv.example.com").await;
         assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
         let body = body_json(resp).await;
@@ -780,7 +1111,14 @@ mod tests {
     #[tokio::test]
     async fn endpoint_public_snapshot_visible_describe_repo() {
         let store = XrpcRepoStore::new();
-        store.put(sample_snapshot("did:web:pub.example.com", "pub.example.com", true)).await.unwrap();
+        store
+            .put(sample_snapshot(
+                "did:web:pub.example.com",
+                "pub.example.com",
+                true,
+            ))
+            .await
+            .unwrap();
         let resp = describe_repo_core(&store, ISSUER, "did:web:pub.example.com").await;
         assert_eq!(resp.status(), StatusCode::OK);
         let body = body_json(resp).await;
@@ -827,9 +1165,14 @@ mod tests {
         let rkey = snap.records.keys().next().unwrap().encode();
         let cid = snap.records.values().next().unwrap().cid().to_string();
         store.put(snap).await.unwrap();
-        let resp =
-            get_record_core(&store, "did:web:pub.example.com", HOSTED_COLLECTION, &rkey, Some(&cid))
-                .await;
+        let resp = get_record_core(
+            &store,
+            "did:web:pub.example.com",
+            HOSTED_COLLECTION,
+            &rkey,
+            Some(&cid),
+        )
+        .await;
         assert_eq!(resp.status(), StatusCode::OK);
     }
 
@@ -838,7 +1181,14 @@ mod tests {
     #[tokio::test]
     async fn since_non_empty_rejected() {
         let store = XrpcRepoStore::new();
-        store.put(sample_snapshot("did:web:pub.example.com", "pub.example.com", true)).await.unwrap();
+        store
+            .put(sample_snapshot(
+                "did:web:pub.example.com",
+                "pub.example.com",
+                true,
+            ))
+            .await
+            .unwrap();
         let resp = get_repo_core(&store, "did:web:pub.example.com", true).await;
         assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
         let body = body_json(resp).await;
@@ -848,7 +1198,14 @@ mod tests {
     #[tokio::test]
     async fn get_repo_without_since_succeeds() {
         let store = XrpcRepoStore::new();
-        store.put(sample_snapshot("did:web:pub.example.com", "pub.example.com", true)).await.unwrap();
+        store
+            .put(sample_snapshot(
+                "did:web:pub.example.com",
+                "pub.example.com",
+                true,
+            ))
+            .await
+            .unwrap();
         let resp = get_repo_core(&store, "did:web:pub.example.com", false).await;
         assert_eq!(resp.status(), StatusCode::OK);
         assert_eq!(
@@ -887,21 +1244,66 @@ mod tests {
     fn parse_query_percent_decodes_values() {
         // did%3Aweb%3Ax → did:web:x (colons percent-encoded).
         let q = parse_query(Some("repo=did%3Aweb%3Ax&collection=ai.hyprstream.model"));
-        assert_eq!(q.get("repo").map(std::string::String::as_str), Some("did:web:x"));
-        assert_eq!(q.get("collection").map(std::string::String::as_str), Some("ai.hyprstream.model"));
+        assert_eq!(
+            q.get("repo").map(std::string::String::as_str),
+            Some("did:web:x")
+        );
+        assert_eq!(
+            q.get("collection").map(std::string::String::as_str),
+            Some("ai.hyprstream.model")
+        );
     }
 
     #[test]
     fn parse_query_plus_becomes_space() {
         let q = parse_query(Some("handle=foo+bar"));
-        assert_eq!(q.get("handle").map(std::string::String::as_str), Some("foo bar"));
+        assert_eq!(
+            q.get("handle").map(std::string::String::as_str),
+            Some("foo bar")
+        );
     }
 
     #[test]
     fn parse_query_extracts_key_value_pairs() {
-        let q = parse_query(Some("repo=did:web:x&collection=ai.hyprstream.model&rkey=abc"));
-        assert_eq!(q.get("repo").map(std::string::String::as_str), Some("did:web:x"));
-        assert_eq!(q.get("collection").map(std::string::String::as_str), Some("ai.hyprstream.model"));
+        let q = parse_query(Some(
+            "repo=did:web:x&collection=ai.hyprstream.model&rkey=abc",
+        ));
+        assert_eq!(
+            q.get("repo").map(std::string::String::as_str),
+            Some("did:web:x")
+        );
+        assert_eq!(
+            q.get("collection").map(std::string::String::as_str),
+            Some("ai.hyprstream.model")
+        );
+    }
+
+    #[test]
+    fn service_auth_query_is_strict_and_method_bound() {
+        assert_eq!(
+            parse_get_service_auth_query(Some(
+                "aud=did%3Aweb%3Apds.example.test&lxm=ai.hyprstream.identity.exchangeSession"
+            ))
+            .unwrap(),
+            GetServiceAuthParams {
+                aud: "did:web:pds.example.test".to_owned(),
+                exp: None,
+                lxm: ATPROTO_SESSION_EXCHANGE_NSID.to_owned(),
+            }
+        );
+        for malformed in [
+            "",
+            "aud=did:web:pds.example.test",
+            "lxm=ai.hyprstream.identity.exchangeSession",
+            "aud=did:web:pds.example.test&aud=did:web:other&lxm=ai.hyprstream.identity.exchangeSession",
+            "aud=did:web:pds.example.test&lxm=ai.hyprstream.identity.exchangeSession&extra=1",
+            "aud=did:web:pds.example.test&lxm=ai.hyprstream.identity.exchangeSession&exp=tomorrow",
+        ] {
+            assert!(
+                parse_get_service_auth_query(Some(malformed)).is_err(),
+                "query should fail closed: {malformed}"
+            );
+        }
     }
 
     // ── Router-mounted tests (findings 1 + 2) ─────────────────────────────────
@@ -947,12 +1349,20 @@ mod tests {
 
         state
             .xrpc_repos
-            .put(sample_snapshot("did:web:pub.example.com", "pub.example.com", true))
+            .put(sample_snapshot(
+                "did:web:pub.example.com",
+                "pub.example.com",
+                true,
+            ))
             .await
             .unwrap();
         state
             .xrpc_repos
-            .put(sample_snapshot("did:web:priv.example.com", "priv.example.com", false))
+            .put(sample_snapshot(
+                "did:web:priv.example.com",
+                "priv.example.com",
+                false,
+            ))
             .await
             .unwrap();
         state
@@ -1022,10 +1432,19 @@ mod tests {
     }
 
     fn req(uri: &str) -> HttpRequest<Body> {
-        HttpRequest::builder()
-            .uri(uri)
-            .body(Body::empty())
-            .unwrap()
+        HttpRequest::builder().uri(uri).body(Body::empty()).unwrap()
+    }
+
+    #[tokio::test]
+    async fn service_auth_is_mounted_and_protected_without_public_read_slice() {
+        let app = build_production_app(false).await;
+        let response = app
+            .oneshot(req("/xrpc/com.atproto.server.getServiceAuth\
+                 ?aud=did%3Aweb%3Ah.example.com\
+                 &lxm=ai.hyprstream.identity.exchangeSession"))
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
     }
 
     // ── Finding 1: real capacity test through the mounted router ──────────────
@@ -1055,12 +1474,11 @@ mod tests {
         held.pop();
 
         // N+1th should now complete.
-        let result = tokio::time::timeout(
-            std::time::Duration::from_secs(2),
-            n1.as_mut(),
-        )
-        .await;
-        assert!(result.is_ok(), "N+1th getRepo did not complete after dropping a body");
+        let result = tokio::time::timeout(std::time::Duration::from_secs(2), n1.as_mut()).await;
+        assert!(
+            result.is_ok(),
+            "N+1th getRepo did not complete after dropping a body"
+        );
         assert_eq!(result.unwrap().unwrap().status(), StatusCode::OK);
     }
 
@@ -1070,7 +1488,9 @@ mod tests {
     async fn router_private_repo_invisible_describe_repo() {
         let app = build_xrpc_router().await;
         let resp = app
-            .oneshot(req("/xrpc/com.atproto.repo.describeRepo?repo=did:web:priv.example.com"))
+            .oneshot(req(
+                "/xrpc/com.atproto.repo.describeRepo?repo=did:web:priv.example.com",
+            ))
             .await
             .unwrap();
         assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
@@ -1097,7 +1517,9 @@ mod tests {
     async fn router_private_repo_invisible_get_repo() {
         let app = build_xrpc_router().await;
         let resp = app
-            .oneshot(req("/xrpc/com.atproto.sync.getRepo?did=did:web:priv.example.com"))
+            .oneshot(req(
+                "/xrpc/com.atproto.sync.getRepo?did=did:web:priv.example.com",
+            ))
             .await
             .unwrap();
         assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
@@ -1109,7 +1531,9 @@ mod tests {
     async fn router_private_repo_invisible_resolve_handle() {
         let app = build_xrpc_router().await;
         let resp = app
-            .oneshot(req("/xrpc/com.atproto.identity.resolveHandle?handle=priv.example.com"))
+            .oneshot(req(
+                "/xrpc/com.atproto.identity.resolveHandle?handle=priv.example.com",
+            ))
             .await
             .unwrap();
         assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
@@ -1121,7 +1545,9 @@ mod tests {
     async fn router_public_describe_repo_ok() {
         let app = build_xrpc_router().await;
         let resp = app
-            .oneshot(req("/xrpc/com.atproto.repo.describeRepo?repo=did:web:pub.example.com"))
+            .oneshot(req(
+                "/xrpc/com.atproto.repo.describeRepo?repo=did:web:pub.example.com",
+            ))
             .await
             .unwrap();
         assert_eq!(resp.status(), StatusCode::OK);
@@ -1152,7 +1578,9 @@ mod tests {
         // Missing repo param.
         let resp = app
             .clone()
-            .oneshot(req("/xrpc/com.atproto.repo.getRecord?collection=ai.hyprstream.model"))
+            .oneshot(req(
+                "/xrpc/com.atproto.repo.getRecord?collection=ai.hyprstream.model",
+            ))
             .await
             .unwrap();
         assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
@@ -1173,7 +1601,9 @@ mod tests {
     async fn router_unknown_handle_handle_not_found() {
         let app = build_xrpc_router().await;
         let resp = app
-            .oneshot(req("/xrpc/com.atproto.identity.resolveHandle?handle=does-not-exist.com"))
+            .oneshot(req(
+                "/xrpc/com.atproto.identity.resolveHandle?handle=does-not-exist.com",
+            ))
             .await
             .unwrap();
         assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
@@ -1185,7 +1615,9 @@ mod tests {
     async fn router_since_empty_rejected() {
         let app = build_xrpc_router().await;
         let resp = app
-            .oneshot(req("/xrpc/com.atproto.sync.getRepo?did=did:web:pub.example.com&since="))
+            .oneshot(req(
+                "/xrpc/com.atproto.sync.getRepo?did=did:web:pub.example.com&since=",
+            ))
             .await
             .unwrap();
         assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
@@ -1212,7 +1644,9 @@ mod tests {
     async fn router_get_repo_ok_streams_car() {
         let app = build_xrpc_router().await;
         let resp = app
-            .oneshot(req("/xrpc/com.atproto.sync.getRepo?did=did:web:pub.example.com"))
+            .oneshot(req(
+                "/xrpc/com.atproto.sync.getRepo?did=did:web:pub.example.com",
+            ))
             .await
             .unwrap();
         assert_eq!(resp.status(), StatusCode::OK);
@@ -1275,7 +1709,8 @@ mod tests {
     #[tokio::test]
     async fn router_get_record_cid_match_returns_record() {
         let state = build_test_state(true).await;
-        let snap = sample_snapshot_fixed_tid("did:web:fixed.example.com", "fixed.example.com", true);
+        let snap =
+            sample_snapshot_fixed_tid("did:web:fixed.example.com", "fixed.example.com", true);
         let rkey = snap.records.keys().next().unwrap().encode();
         let cid = snap.records.values().next().unwrap().cid().to_string();
         state.xrpc_repos.put(snap).await.unwrap();
@@ -1294,7 +1729,8 @@ mod tests {
     #[tokio::test]
     async fn router_get_record_cid_mismatch_returns_record_not_found() {
         let state = build_test_state(true).await;
-        let snap = sample_snapshot_fixed_tid("did:web:fixed.example.com", "fixed.example.com", true);
+        let snap =
+            sample_snapshot_fixed_tid("did:web:fixed.example.com", "fixed.example.com", true);
         let rkey = snap.records.keys().next().unwrap().encode();
         state.xrpc_repos.put(snap).await.unwrap();
         let app = build_production_app_from_state(state).await;
@@ -1308,7 +1744,10 @@ mod tests {
         let body = resp_json(resp).await;
         assert_eq!(body["error"], errors::RECORD_NOT_FOUND);
         assert!(
-            body["message"].as_str().unwrap().contains("does not match cid"),
+            body["message"]
+                .as_str()
+                .unwrap()
+                .contains("does not match cid"),
             "message must explain the cid mismatch: {}",
             body["message"]
         );
@@ -1320,10 +1759,8 @@ mod tests {
         // ?repo= — empty value at the wrapper boundary.
         let resp = app
             .clone()
-            .oneshot(req(
-                "/xrpc/com.atproto.repo.getRecord?repo=\
-                 &collection=ai.hyprstream.model&rkey=abc",
-            ))
+            .oneshot(req("/xrpc/com.atproto.repo.getRecord?repo=\
+                 &collection=ai.hyprstream.model&rkey=abc"))
             .await
             .unwrap();
         assert_eq!(resp.status(), StatusCode::BAD_REQUEST);


### PR DESCRIPTION
Refs #37

## Summary
- mount the protected com.atproto.server.getServiceAuth XRPC route independently of the public-read feature gate
- require a DPoP-bound OAuth token with the exact atproto scope, host-form local DID, authority-owned tenant binding, exact host DID audience, and ai.hyprstream.identity.exchangeSession method
- sign short-lived ES256 assertions inside the PDS account-store boundary using the persisted account #atproto key, with MAC authorization and record/key consistency checks
- fix protected-resource DPoP htu reconstruction to use the canonical origin
- prove the standard OAuth token -> service auth -> existing #1354 session exchange path issues hyprstream_session

## Fail-closed behavior
- rejects missing/duplicate/unknown query parameters, wrong aud/lxm, invalid or overlong expiry, non-DPoP/non-atproto grants, non-hosted/path-form/PLC subjects, tenant mismatches, missing/corrupt/substituted keys, ambiguous records, and unavailable signer state
- accepts no client DID, tenant, signing key, custody, or IdP binding input
- emits no-store/no-cache responses and does not create a parallel session path

## Validation
- cargo test -p hyprstream-pds-service (18 passed)
- cargo test -p hyprstream --lib services::oauth::xrpc::tests (40 passed)
- cargo test -p hyprstream --lib services::oauth::tests::oauth_handler_atproto_and_legacy_conformance -- --exact (passed)
- cargo clippy -p hyprstream-pds-service --all-targets -- -D warnings
- cargo clippy -p hyprstream --all-targets -- -D warnings
- repository pre-commit hook / release-profile workspace Clippy passed

No self-merge requested.