### PR TITLE
fix(discovery): resolve rootless deployment trust paths

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7013,6 +7013,7 @@ dependencies = [
  "hyprstream-rpc-derive",
  "hyprstream-service",
  "hyprstream-util",
+ "libc",
  "p256",
  "parking_lot 0.12.4",
  "proptest",

--- a/crates/hyprstream-discovery/Cargo.toml
+++ b/crates/hyprstream-discovery/Cargo.toml
@@ -66,6 +66,9 @@ p256 = { workspace = true }
 # checkpointed PDS store. No downstream callback/trait can supply authority.
 rocksdb = "0.23"
 
+[target.'cfg(unix)'.dependencies]
+libc = { workspace = true }
+
 [dev-dependencies]
 # #431 / #524 — build/verify real CAR proofs in getRecord + placement tests.
 p256 = { workspace = true }

--- a/crates/hyprstream-discovery/src/did_anchored.rs
+++ b/crates/hyprstream-discovery/src/did_anchored.rs
@@ -23,7 +23,7 @@ use serde_json::Value;
 
 use crate::at9p_alias::At9pAliasResolver;
 use crate::at9p_resolver::CapsuleSource;
-use crate::service::HybridDeploymentCa;
+use crate::service::{DeploymentAuthorityLog, HybridDeploymentCa};
 
 const MAX_CAPSULE_BYTES: usize = 4 * 1024 * 1024;
 const DEPLOYMENT_REACH_SERVICE: &str = "#ns";
@@ -107,6 +107,10 @@ pub(crate) struct DidAnchoredTrust {
     /// profile, enforced by `validate_registry_deployment_credential_profile`),
     /// so the byte channel needs no trust of its own.
     pub registry_credential: String,
+    /// Current root-anchored authority log fetched beside the credential.
+    /// Its verified head must match the independently provisioned local
+    /// checkpoint before the credential is accepted.
+    pub authority_log: DeploymentAuthorityLog,
     /// The document's `#mesh-kem` hybrid-KEM recipient public, when published.
     /// Required by the REMOTE-node bootstrap arm (QUIC forbids cleartext
     /// envelopes); the same-node arm never encrypts over the local fabric.
@@ -187,6 +191,44 @@ impl HttpWellKnownCapsuleSource {
             bytes.extend_from_slice(&chunk);
         }
         String::from_utf8(bytes).context("registry deployment credential is not UTF-8")
+    }
+
+    /// Fetch the current root-anchored authority log from beside the registry
+    /// credential. HTTPS transports untrusted bytes; the capsule-derived root
+    /// and independent local head checkpoint authenticate them later.
+    async fn fetch_authority_log(&self) -> Result<DeploymentAuthorityLog> {
+        let prefix = self
+            .document_url
+            .strip_suffix("did.json")
+            .ok_or_else(|| anyhow::anyhow!("derived did:web URL does not end in did.json"))?;
+        let url = format!("{prefix}deployment/deployment-authority.log.json");
+        let mut response = self
+            .http
+            .get(&url)
+            .send()
+            .await
+            .with_context(|| format!("failed to fetch deployment authority log from {url}"))?
+            .error_for_status()
+            .with_context(|| format!("deployment authority-log endpoint rejected {url}"))?;
+        if let Some(length) = response.content_length() {
+            anyhow::ensure!(
+                length <= MAX_CREDENTIAL_BYTES as u64,
+                "deployment authority log exceeds {MAX_CREDENTIAL_BYTES}-byte limit"
+            );
+        }
+        let mut bytes = Vec::new();
+        while let Some(chunk) = response
+            .chunk()
+            .await
+            .context("failed to read deployment authority-log body")?
+        {
+            anyhow::ensure!(
+                bytes.len().saturating_add(chunk.len()) <= MAX_CREDENTIAL_BYTES,
+                "deployment authority log exceeds {MAX_CREDENTIAL_BYTES}-byte limit"
+            );
+            bytes.extend_from_slice(&chunk);
+        }
+        serde_json::from_slice(&bytes).context("deployment authority log is malformed")
     }
 
     fn capsule_url(&self, did: &str) -> Result<String> {
@@ -334,6 +376,7 @@ pub(crate) async fn verify_did_anchored_document(
     document: &Value,
     capsule_source: Arc<dyn CapsuleSource>,
     registry_credential: String,
+    authority_log: DeploymentAuthorityLog,
 ) -> Result<DidAnchoredTrust> {
     anyhow::ensure!(
         document.get("id").and_then(Value::as_str) == Some(anchors.cluster_did_web.as_str()),
@@ -372,6 +415,7 @@ pub(crate) async fn verify_did_anchored_document(
         discovery_transport,
         authoritative_identity,
         registry_credential,
+        authority_log,
         mesh_kem_recipient: hyprstream_rpc::did_web::mesh_kem_recipient(document),
         ml_dsa_65_keys: hyprstream_rpc::did_web::verification_method_ml_dsa_65_keys(document),
     })
@@ -397,9 +441,18 @@ pub(crate) async fn resolve_did_anchored_trust(anchors: &DidAnchors) -> Result<D
         .fetch_registry_credential()
         .await
         .context("failed to fetch registry deployment credential")?;
-    let trust =
-        verify_did_anchored_document(anchors, &document, capsule_source, registry_credential)
-            .await?;
+    let authority_log = capsule_source
+        .fetch_authority_log()
+        .await
+        .context("failed to fetch deployment authority log")?;
+    let trust = verify_did_anchored_document(
+        anchors,
+        &document,
+        capsule_source,
+        registry_credential,
+        authority_log,
+    )
+    .await?;
     tracing::info!(
         at9p = %trust.authoritative_identity.at9p_did,
         did_web = %trust.authoritative_identity.classical_did,
@@ -412,7 +465,11 @@ pub(crate) async fn resolve_did_anchored_trust(anchors: &DidAnchors) -> Result<D
 #[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {
     use super::*;
-    use ed25519_dalek::SigningKey;
+    use base64::{
+        engine::general_purpose::{STANDARD, URL_SAFE_NO_PAD},
+        Engine as _,
+    };
+    use ed25519_dalek::{Signer as _, SigningKey};
     use hyprstream_crypto::pq::{ml_dsa_generate_keypair, ml_dsa_vk_bytes, MlDsaSigningKey};
     use hyprstream_pds::at9p::{
         CapsuleBody, HybridKeyPair, ServiceEndpoint, ServiceEntry, ServiceType, Transport,
@@ -420,7 +477,17 @@ mod tests {
     };
     use hyprstream_pds::at9p_sign::sign_capsule;
     use hyprstream_pds::dag_cbor::DagCbor;
+    use hyprstream_rpc::{
+        auth::ucan::{
+            Ability, Capability, CaveatValue, Caveats, Did as UcanDid, Resource, Ucan, UcanPayload,
+        },
+        crypto::{
+            cose_sign::{assemble_composite_nested, inner_tbs, outer_tbs, split_composite},
+            pq::{ml_dsa_sign, ml_dsa_sk_to_vk_bytes},
+        },
+    };
     use serde_json::json;
+    use std::collections::BTreeMap;
 
     struct FixedCapsuleSource(Vec<u8>);
 
@@ -459,6 +526,200 @@ mod tests {
         SigningKey::from_bytes(&[tag; 32])
             .verifying_key()
             .to_bytes()
+    }
+
+    fn unused_authority_log() -> DeploymentAuthorityLog {
+        DeploymentAuthorityLog {
+            schema: "unused-test-schema".to_owned(),
+            deployment_domain: "unused-test-domain".to_owned(),
+            did: "did:plc:unusedtestauthoritylog".to_owned(),
+            operations_b64: vec![],
+        }
+    }
+
+    fn sign_nested_for_test(
+        payload: &[u8],
+        aad: &[u8],
+        ed: &SigningKey,
+        pq: &MlDsaSigningKey,
+    ) -> Vec<u8> {
+        let ed_signature = ed.sign(&inner_tbs(
+            ed.verifying_key().to_bytes().to_vec(),
+            payload,
+            aad,
+            true,
+        ));
+        let pq_public =
+            hyprstream_rpc::crypto::pq::ml_dsa_vk_from_bytes(&ml_dsa_sk_to_vk_bytes(pq)).unwrap();
+        let pq_signature = ml_dsa_sign(
+            pq,
+            &outer_tbs(
+                ml_dsa_vk_bytes(&pq_public),
+                payload,
+                &ed_signature.to_bytes(),
+                aad,
+            ),
+        );
+        assemble_composite_nested(
+            (
+                ed.verifying_key().to_bytes().to_vec(),
+                ed_signature.to_bytes().to_vec(),
+            ),
+            Some((ml_dsa_vk_bytes(&pq_public), pq_signature)),
+        )
+        .unwrap()
+    }
+
+    fn authority_log_and_checkpoint(
+        root: &CapsuleSigner,
+        deployment_domain: &str,
+    ) -> (
+        DeploymentAuthorityLog,
+        crate::service::DeploymentAuthorityCheckpoint,
+    ) {
+        let mut genesis = crate::did_op::DidOp {
+            sequence: 0,
+            prev: None,
+            rotation_keys: vec![crate::did_op::HybridRotationKey::new(
+                root.ed.verifying_key().to_bytes(),
+                ml_dsa_sk_to_vk_bytes(&root.pq),
+            )
+            .unwrap()],
+            signature: crate::did_op::HybridDidOpSignature {
+                ed25519: vec![0; 64],
+                mldsa65: vec![0; 3_309],
+            },
+        };
+        let composite = sign_nested_for_test(
+            &genesis.signable_bytes(),
+            crate::did_op::DID_OP_SIGNATURE_CONTEXT,
+            &root.ed,
+            &root.pq,
+        );
+        let (ed25519, mldsa65) = split_composite(&composite).unwrap();
+        genesis.signature = crate::did_op::HybridDidOpSignature {
+            ed25519,
+            mldsa65: mldsa65.unwrap(),
+        };
+        let did = genesis.genesis_did().unwrap();
+        let verified = crate::did_op::verify_did_op_log(&did, &[genesis.clone()]).unwrap();
+        (
+            DeploymentAuthorityLog {
+                schema: "hyprstream.deployment-authority-log.v1".to_owned(),
+                deployment_domain: deployment_domain.to_owned(),
+                did: did.clone(),
+                operations_b64: vec![STANDARD.encode(genesis.to_dag_cbor())],
+            },
+            crate::service::DeploymentAuthorityCheckpoint {
+                schema: "hyprstream.deployment-authority-checkpoint.v1".to_owned(),
+                deployment_domain: deployment_domain.to_owned(),
+                did,
+                sequence: verified.sequence,
+                head_cid: verified.head_cid,
+            },
+        )
+    }
+
+    fn delegated_registry_credential(
+        root: &CapsuleSigner,
+        authority_log: &DeploymentAuthorityLog,
+        deployment_domain: &str,
+        registry: &SigningKey,
+    ) -> String {
+        let delegated_ed = SigningKey::from_bytes(&[0xA2; 32]);
+        let (delegated_pq, _) = ml_dsa_generate_keypair();
+        let mut delegated_public = delegated_ed.verifying_key().to_bytes().to_vec();
+        delegated_public.extend_from_slice(&ml_dsa_sk_to_vk_bytes(&delegated_pq));
+        let now = u64::try_from(chrono::Utc::now().timestamp()).unwrap();
+        let mut caveats = BTreeMap::new();
+        caveats.insert(
+            "audience".to_owned(),
+            CaveatValue::Text("urn:hyprstream:service:registry".to_owned()),
+        );
+        caveats.insert(
+            "deployment_domain".to_owned(),
+            CaveatValue::Text(deployment_domain.to_owned()),
+        );
+        caveats.insert(
+            "delegated_public_key_b64".to_owned(),
+            CaveatValue::Text(STANDARD.encode(&delegated_public)),
+        );
+        caveats.insert("max_ttl_seconds".to_owned(), CaveatValue::Int(3_600));
+        caveats.insert(
+            "profile".to_owned(),
+            CaveatValue::Text("hyprstream.registry-deployment.v1".to_owned()),
+        );
+        let payload = UcanPayload {
+            issuer: UcanDid::from_ed25519(&root.ed.verifying_key().to_bytes()),
+            audience: UcanDid::from_ed25519(&delegated_ed.verifying_key().to_bytes()),
+            capabilities: vec![Capability::with_caveats(
+                Resource::new(format!(
+                    "hyprstream://deployment/{deployment_domain}/service/registry"
+                )),
+                Ability::new("mint-registry-jwt"),
+                Caveats(caveats),
+            )],
+            not_before: Some(now),
+            expiration: Some(now + 3_600),
+            nonce: vec![0xA3; 16],
+        };
+        let ucan = Ucan {
+            signature: sign_nested_for_test(
+                &payload.signing_bytes().unwrap(),
+                hyprstream_rpc::auth::ucan::token::UCAN_AAD,
+                &root.ed,
+                &root.pq,
+            ),
+            payload,
+            proofs: vec![],
+        };
+        let artifact = crate::service::RegistryDelegationArtifact {
+            schema: "hyprstream.registry-delegation.v1".to_owned(),
+            deployment_domain: deployment_domain.to_owned(),
+            authority_log_did: authority_log.did.clone(),
+            delegated_public_key_b64: STANDARD.encode(&delegated_public),
+            ucan_b64: STANDARD.encode(ucan.to_cbor().unwrap()),
+        };
+        let exp = i64::try_from(now + 60).unwrap();
+        let now = i64::try_from(now).unwrap();
+        let kid = hyprstream_rpc::auth::composite_kid(
+            &hyprstream_rpc::crypto::pq::ml_dsa_vk_from_bytes(&ml_dsa_sk_to_vk_bytes(
+                &delegated_pq,
+            ))
+            .unwrap(),
+            &delegated_ed.verifying_key(),
+        );
+        let protected = URL_SAFE_NO_PAD.encode(
+            serde_json::to_vec(&json!({
+                "alg": "ML-DSA-65-Ed25519",
+                "typ": "wit+jwt",
+                "kid": kid,
+            }))
+            .unwrap(),
+        );
+        let claims = URL_SAFE_NO_PAD.encode(
+            serde_json::to_vec(&json!({
+                "iss": format!("urn:hyprstream:deployment:{deployment_domain}"),
+                "sub": "service:registry",
+                "aud": "urn:hyprstream:service:registry",
+                "exp": exp,
+                "nbf": now,
+                "iat": now,
+                "deployment_domain": deployment_domain,
+                "profile": "hyprstream.registry-deployment.v1",
+                "cnf": {"jwk": {
+                    "kty": "OKP",
+                    "crv": "Ed25519",
+                    "x": URL_SAFE_NO_PAD.encode(registry.verifying_key().as_bytes()),
+                }},
+                "delegation": URL_SAFE_NO_PAD.encode(serde_json::to_vec(&artifact).unwrap()),
+            }))
+            .unwrap(),
+        );
+        let signing_input = format!("{protected}.{claims}");
+        let mut signature = ml_dsa_sign(&delegated_pq, signing_input.as_bytes());
+        signature.extend_from_slice(&delegated_ed.sign(signing_input.as_bytes()).to_bytes());
+        format!("{signing_input}.{}", URL_SAFE_NO_PAD.encode(signature))
     }
 
     fn capsule_with_carrier(
@@ -578,6 +839,7 @@ mod tests {
             &document(web, Some(&configured_did)),
             Arc::new(FixedCapsuleSource(served_bytes)),
             "unused-test-credential".to_owned(),
+            unused_authority_log(),
         )
         .await
         .err()
@@ -600,6 +862,7 @@ mod tests {
             &document(web, Some(&at9p)),
             Arc::new(FixedCapsuleSource(bytes)),
             "unused-test-credential".to_owned(),
+            unused_authority_log(),
         )
         .await
         .err()
@@ -621,6 +884,7 @@ mod tests {
             &document(web, Some(&at9p)),
             Arc::new(FixedCapsuleSource(bytes)),
             "unused-test-credential".to_owned(),
+            unused_authority_log(),
         )
         .await
         .unwrap();
@@ -638,6 +902,48 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn delegated_registry_token_bootstraps_through_did_anchored_log_and_checkpoint() {
+        let web = "did:web:cluster.example";
+        let root = capsule_signer(0x51);
+        let mut endpoint =
+            ServiceEndpoint::new(Transport::Iroh, "iroh://delegated-bootstrap").unwrap();
+        endpoint.node_id = Some(multikey(&[0xC1; 32]));
+        let service = ServiceEntry::new("#ns", ServiceType::NinePExport, endpoint).unwrap();
+        let mut body = CapsuleBody::new(vec![root.pair.clone()], vec![service]).unwrap();
+        body.also_known_as = Some(vec![web.to_owned()]);
+        let capsule = sign_capsule(body, &root.ed, &root.pq).unwrap();
+        let capsule_bytes = capsule.to_dag_cbor().unwrap();
+        let at9p = format!("did:at9p:{}", capsule.cid512().unwrap());
+        let anchors = DidAnchors {
+            cluster_at9p_did: at9p.clone(),
+            cluster_did_web: web.to_owned(),
+            extra_root_cert_pem: None,
+        };
+        let root_pq =
+            hyprstream_rpc::crypto::pq::ml_dsa_vk_from_bytes(&ml_dsa_sk_to_vk_bytes(&root.pq))
+                .unwrap();
+        let deployment_domain =
+            hyprstream_rpc::auth::composite_kid(&root_pq, &root.ed.verifying_key());
+        let (authority_log, checkpoint) = authority_log_and_checkpoint(&root, &deployment_domain);
+        let registry = SigningKey::from_bytes(&[0x52; 32]);
+        let credential =
+            delegated_registry_credential(&root, &authority_log, &deployment_domain, &registry);
+
+        let trust = verify_did_anchored_document(
+            &anchors,
+            &document(web, Some(&at9p)),
+            Arc::new(FixedCapsuleSource(capsule_bytes)),
+            credential,
+            authority_log,
+        )
+        .await
+        .unwrap();
+        let verifier = crate::service::authenticate_resolved_did_trust(trust, checkpoint)
+            .expect("delegated DID-anchored deployment credential");
+        assert!(verifier.matches(&registry.verifying_key()));
+    }
+
+    #[tokio::test]
     async fn substituted_document_ca_and_reach_are_ignored() {
         let web = "did:web:cluster.example";
         let (bytes, at9p) = capsule(web, 4);
@@ -652,6 +958,7 @@ mod tests {
             &document_with_ca_and_reach(web, Some(&at9p), [0x07; 32], [0x45; 32]),
             Arc::new(FixedCapsuleSource(bytes.clone())),
             "unused-test-credential".to_owned(),
+            unused_authority_log(),
         )
         .await
         .unwrap();
@@ -660,6 +967,7 @@ mod tests {
             &document_with_ca_and_reach(web, Some(&at9p), [0x66; 32], [0xEE; 32]),
             Arc::new(FixedCapsuleSource(bytes)),
             "unused-test-credential".to_owned(),
+            unused_authority_log(),
         )
         .await
         .unwrap();
@@ -695,6 +1003,7 @@ mod tests {
             &document(web, Some(&at9p)),
             Arc::new(FixedCapsuleSource(classical_only)),
             "unused-test-credential".to_owned(),
+            unused_authority_log(),
         )
         .await
         .err()
@@ -719,6 +1028,7 @@ mod tests {
             &document(web, Some(&at9p)),
             Arc::new(FixedCapsuleSource(bytes)),
             "unused-test-credential".to_owned(),
+            unused_authority_log(),
         )
         .await
         .err()
@@ -760,6 +1070,7 @@ mod tests {
             &document,
             Arc::new(FixedCapsuleSource(bytes)),
             "unused-test-credential".to_owned(),
+            unused_authority_log(),
         )
         .await
         .unwrap();

--- a/crates/hyprstream-discovery/src/did_op.rs
+++ b/crates/hyprstream-discovery/src/did_op.rs
@@ -498,6 +498,18 @@ fn validate_rotation_keys(keys: &[HybridRotationKey]) -> Result<()> {
             !keys[..index].contains(key),
             "duplicate hybrid rotation key at index {index}"
         );
+        ensure!(
+            !keys[..index]
+                .iter()
+                .any(|existing| existing.ed25519_pub == key.ed25519_pub),
+            "rotation key at index {index} reuses an Ed25519 component"
+        );
+        ensure!(
+            !keys[..index]
+                .iter()
+                .any(|existing| existing.mldsa65_pub == key.mldsa65_pub),
+            "rotation key at index {index} reuses an ML-DSA-65 component"
+        );
     }
     Ok(())
 }
@@ -695,6 +707,29 @@ mod tests {
             DidOp::signed_rotation(&genesis, vec![attacker.public], &attacker.ed, &attacker.pq)
                 .unwrap_err();
         assert!(error.to_string().contains("not authorized"));
+    }
+
+    #[test]
+    fn authority_set_rejects_reused_hybrid_components() {
+        let first = keys(31);
+        let second = keys(32);
+        let repeated_ed =
+            HybridRotationKey::new(first.public.ed25519_pub, second.public.mldsa65_pub.clone())
+                .unwrap();
+        let error = DidOp::signed_genesis(
+            vec![first.public.clone(), repeated_ed],
+            &first.ed,
+            &first.pq,
+        )
+        .unwrap_err();
+        assert!(error.to_string().contains("reuses an Ed25519 component"));
+
+        let repeated_pq =
+            HybridRotationKey::new(second.public.ed25519_pub, first.public.mldsa65_pub.clone())
+                .unwrap();
+        let error = DidOp::signed_genesis(vec![first.public, repeated_pq], &first.ed, &first.pq)
+            .unwrap_err();
+        assert!(error.to_string().contains("reuses an ML-DSA-65 component"));
     }
 
     #[test]

--- a/crates/hyprstream-discovery/src/lib.rs
+++ b/crates/hyprstream-discovery/src/lib.rs
@@ -137,9 +137,10 @@ pub use service::{
     bootstrap_deployment_process, deployment_registry_verifier, resolve_and_authenticate_did_anchors,
     AuthorizationProvider, DiscoveryService, RecordCarData, RecordResolver, RegistryDeploymentVerifier,
     production_browser_currentness_verifier, production_browser_provisioning,
-    production_rpc_client, verify_deployment_artifacts,
+    production_rpc_client, verify_genesis_deployment_artifacts,
     verify_deployment_artifacts_with_authority_log, verify_deployment_public_ca,
-    DeploymentAuthorityLog, RegistryDelegationArtifact, VerifiedDeploymentArtifacts,
+    DeploymentAuthorityCheckpoint, DeploymentAuthorityLog, RegistryDelegationArtifact,
+    VerifiedDeploymentArtifacts,
 };
 
 // Re-export generated types that consumers need

--- a/crates/hyprstream-discovery/src/lib.rs
+++ b/crates/hyprstream-discovery/src/lib.rs
@@ -137,7 +137,9 @@ pub use service::{
     bootstrap_deployment_process, deployment_registry_verifier, resolve_and_authenticate_did_anchors,
     AuthorizationProvider, DiscoveryService, RecordCarData, RecordResolver, RegistryDeploymentVerifier,
     production_browser_currentness_verifier, production_browser_provisioning,
-    production_rpc_client,
+    production_rpc_client, verify_deployment_artifacts,
+    verify_deployment_artifacts_with_authority_log, verify_deployment_public_ca,
+    DeploymentAuthorityLog, RegistryDelegationArtifact, VerifiedDeploymentArtifacts,
 };
 
 // Re-export generated types that consumers need

--- a/crates/hyprstream-discovery/src/service.rs
+++ b/crates/hyprstream-discovery/src/service.rs
@@ -1508,6 +1508,8 @@ static PROCESS_REGISTRY_VERIFIER: std::sync::OnceLock<RegistryDeploymentVerifier
 
 const DEPLOYMENT_CA_ROOT_PATH: &str = "/etc/hyprstream/trust/deployment-ca.hybrid";
 const DEPLOYMENT_AUTHORITY_LOG_PATH: &str = "/etc/hyprstream/trust/deployment-authority.log.json";
+const DEPLOYMENT_AUTHORITY_CHECKPOINT_PATH: &str =
+    "/etc/hyprstream/trust/deployment-authority.head.json";
 const REGISTRY_DEPLOYMENT_CREDENTIAL_PATH: &str =
     "/run/hyprstream/credentials/registry-service.jwt";
 const REGISTRY_DEPLOYMENT_CREDENTIAL_PROFILE: &str = "hyprstream.registry-deployment.v1";
@@ -1519,6 +1521,7 @@ const ML_DSA_65_PUBLIC_KEY_BYTES: usize = 1_952;
 const DEPLOYMENT_CA_ROOT_BYTES: usize = ED25519_PUBLIC_KEY_BYTES + ML_DSA_65_PUBLIC_KEY_BYTES;
 const HYBRID_JWT_SIGNATURE_BYTES: usize = 3_309 + 64;
 const AUTHORITY_LOG_SCHEMA: &str = "hyprstream.deployment-authority-log.v1";
+const AUTHORITY_CHECKPOINT_SCHEMA: &str = "hyprstream.deployment-authority-checkpoint.v1";
 const REGISTRY_DELEGATION_SCHEMA: &str = "hyprstream.registry-delegation.v1";
 const MAX_AUTHORITY_LOG_OPERATIONS: usize = 128;
 const MAX_REGISTRY_DELEGATION_BYTES: usize = 256 * 1024;
@@ -1533,6 +1536,21 @@ pub struct DeploymentAuthorityLog {
     pub deployment_domain: String,
     pub did: String,
     pub operations_b64: Vec<String>,
+}
+
+/// Independently provisioned expected head of the deployment authority log.
+///
+/// This checkpoint is deliberately separate from the remotely supplied log:
+/// a signature-valid historical prefix cannot redefine the expected sequence
+/// or CID and thereby reactivate retired authority keys.
+#[derive(Clone, Debug, Eq, PartialEq, serde::Serialize, serde::Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct DeploymentAuthorityCheckpoint {
+    pub schema: String,
+    pub deployment_domain: String,
+    pub did: String,
+    pub sequence: u64,
+    pub head_cid: String,
 }
 
 /// Root/current-authority UCAN delegation embedded in delegated registry JWTs.
@@ -1672,8 +1690,21 @@ struct AuthenticatedRegistryDeploymentIdentity {
 
 struct TrustedRegistryDeploymentCredentials {
     ca_verifying_key: HybridDeploymentCa,
-    authority_log: Option<DeploymentAuthorityLog>,
+    authority_log: DeploymentAuthorityLog,
+    authority_checkpoint: DeploymentAuthorityCheckpoint,
     registry_credential: String,
+}
+
+enum DeploymentAuthorityState<'a> {
+    /// Explicit, one-time genesis verification before enrollment. Production
+    /// loaders never select this state from an absent file.
+    GenesisOnly,
+    /// Normal enrolled operation: both independently trusted checkpoint and
+    /// current root-anchored log are mandatory.
+    Enrolled {
+        authority_log: &'a DeploymentAuthorityLog,
+        authority_checkpoint: &'a DeploymentAuthorityCheckpoint,
+    },
 }
 
 /// JSON value decoded while preserving the security property that every object
@@ -1888,8 +1919,8 @@ fn validate_registry_credential_numeric_dates(
 fn validate_registry_deployment_credential_profile(
     token: &str,
     ca_verifying_key: &HybridDeploymentCa,
-    installed_authority_log: Option<&DeploymentAuthorityLog>,
-) -> Result<[u8; 32]> {
+    authority_state: DeploymentAuthorityState<'_>,
+) -> Result<([u8; 32], i64)> {
     anyhow::ensure!(
         !token.is_empty() && !token.bytes().any(|byte| byte.is_ascii_whitespace()),
         "registry credential must be compact with no whitespace"
@@ -2015,8 +2046,27 @@ fn validate_registry_deployment_credential_profile(
         .try_into()
         .map_err(|_| anyhow::anyhow!("credential cnf.jwk.x must decode to exactly 32 bytes"))?;
 
+    let enrolled = match authority_state {
+        DeploymentAuthorityState::GenesisOnly => None,
+        DeploymentAuthorityState::Enrolled {
+            authority_log,
+            authority_checkpoint,
+        } => Some((
+            authority_log,
+            validate_deployment_authority_log(
+                ca_verifying_key,
+                authority_log,
+                authority_checkpoint,
+            )?,
+        )),
+    };
     let delegated_ca;
     let signing_ca = if delegated {
+        let (installed_authority_log, active) = enrolled.as_ref().ok_or_else(|| {
+            anyhow::anyhow!(
+                "delegated credential is forbidden during one-time genesis verification"
+            )
+        })?;
         let encoded = exact_string_member(claims, "delegation", "credential claims")?;
         let bytes = decode_canonical_jwt_segment(
             encoded,
@@ -2025,18 +2075,15 @@ fn validate_registry_deployment_credential_profile(
         )?;
         let artifact: RegistryDelegationArtifact = serde_json::from_slice(&bytes)
             .map_err(|error| anyhow::anyhow!("credential delegation is malformed: {error}"))?;
-        let installed_authority_log = installed_authority_log.ok_or_else(|| {
-            anyhow::anyhow!("delegated credential requires the installed deployment authority log")
-        })?;
         delegated_ca = validate_registry_delegation_artifact(
             ca_verifying_key,
             &artifact,
             installed_authority_log,
+            active,
             u64::try_from(now).map_err(|_| anyhow::anyhow!("system clock precedes Unix epoch"))?,
         )?;
         &delegated_ca
-    } else if let Some(installed_authority_log) = installed_authority_log {
-        let active = validate_deployment_authority_log(ca_verifying_key, installed_authority_log)?;
+    } else if let Some((_installed_authority_log, active)) = enrolled.as_ref() {
         anyhow::ensure!(
             active.rotation_keys.iter().any(|key| {
                 key.ed25519_pub == ca_verifying_key.ed25519.to_bytes()
@@ -2070,7 +2117,7 @@ fn validate_registry_deployment_credential_profile(
         verified.sub == "service:registry" && verified.cnf_key_bytes() == Some(key),
         "verified credential differs from the exact deployment profile"
     );
-    Ok(key)
+    Ok((key, exp))
 }
 
 struct AuthoritySetUcanVerifier<'a> {
@@ -2113,6 +2160,7 @@ fn validate_registry_delegation_artifact(
     root: &HybridDeploymentCa,
     artifact: &RegistryDelegationArtifact,
     installed_authority_log: &DeploymentAuthorityLog,
+    active: &crate::did_op::VerifiedDidOpLog,
     now: u64,
 ) -> Result<HybridDeploymentCa> {
     use hyprstream_rpc::auth::ucan::{
@@ -2127,7 +2175,6 @@ fn validate_registry_delegation_artifact(
         artifact.deployment_domain == root.domain(),
         "registry delegation deployment domain does not match pinned root"
     );
-    let active = validate_deployment_authority_log(root, installed_authority_log)?;
     anyhow::ensure!(
         artifact.authority_log_did == installed_authority_log.did,
         "registry delegation names a different authority log"
@@ -2213,6 +2260,7 @@ fn validate_registry_delegation_artifact(
 fn validate_deployment_authority_log(
     root: &HybridDeploymentCa,
     log: &DeploymentAuthorityLog,
+    checkpoint: &DeploymentAuthorityCheckpoint,
 ) -> Result<crate::did_op::VerifiedDidOpLog> {
     anyhow::ensure!(
         log.schema == AUTHORITY_LOG_SCHEMA,
@@ -2238,6 +2286,21 @@ fn validate_deployment_authority_log(
         .collect::<Result<Vec<_>>>()?;
     let active = crate::did_op::verify_did_op_log(&log.did, &operations)
         .context("verifying deployment authority log")?;
+    anyhow::ensure!(
+        checkpoint.schema == AUTHORITY_CHECKPOINT_SCHEMA,
+        "unsupported deployment authority-checkpoint schema"
+    );
+    anyhow::ensure!(
+        checkpoint.deployment_domain == root.domain(),
+        "deployment authority checkpoint domain does not match pinned root"
+    );
+    anyhow::ensure!(
+        checkpoint.did == log.did
+            && checkpoint.did == active.did
+            && checkpoint.sequence == active.sequence
+            && checkpoint.head_cid == active.head_cid,
+        "deployment authority-log head does not match the independently trusted checkpoint"
+    );
     let genesis = operations
         .first()
         .ok_or_else(|| anyhow::anyhow!("deployment authority log is empty"))?;
@@ -2271,45 +2334,53 @@ fn validate_deployment_authority_log(
     Ok(active)
 }
 
-/// Result of verifying the two deployment artifacts consumed at production
-/// bootstrap. This exposes no authority material and cannot install or replace
-/// process trust.
+/// Result of verifying the enrolled deployment artifact set consumed at
+/// production bootstrap. This exposes no authority material and cannot install
+/// or replace process trust.
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct VerifiedDeploymentArtifacts {
     pub deployment_domain: String,
     pub registry_public_key: [u8; ED25519_PUBLIC_KEY_BYTES],
+    pub expires_at: i64,
 }
 
 /// Parse the exact production public-root pin and return its stable deployment
-/// domain. This is the mint-time half of [`verify_deployment_artifacts`].
+/// domain. This is the mint-time half of
+/// [`verify_deployment_artifacts_with_authority_log`].
 pub fn verify_deployment_public_ca(public_ca: &[u8]) -> Result<String> {
     HybridDeploymentCa::from_os_pin(public_ca).map(|ca| ca.domain())
 }
 
-/// Parse and verify deployment artifacts through the exact production
-/// `HybridDeploymentCa` and closed registry-credential profile.
+/// Explicitly verify a direct-root credential during one-time genesis before
+/// authority-log enrollment. Production startup never calls this function and
+/// never infers genesis mode from a missing file.
 ///
 /// Tooling uses this entry point for pre-installation self-checks. Keeping the
 /// parser and validator here prevents a mint tool from accidentally blessing a
 /// byte layout or JWT shape that production would reject.
-pub fn verify_deployment_artifacts(
+pub fn verify_genesis_deployment_artifacts(
     public_ca: &[u8],
     registry_credential: &str,
 ) -> Result<VerifiedDeploymentArtifacts> {
     let ca = HybridDeploymentCa::from_os_pin(public_ca)?;
-    let registry_public_key =
-        validate_registry_deployment_credential_profile(registry_credential, &ca, None)?;
+    let (registry_public_key, expires_at) = validate_registry_deployment_credential_profile(
+        registry_credential,
+        &ca,
+        DeploymentAuthorityState::GenesisOnly,
+    )?;
     Ok(VerifiedDeploymentArtifacts {
         deployment_domain: ca.domain(),
         registry_public_key,
+        expires_at,
     })
 }
 
-/// Verify a delegated deployment credential against the public root and the
-/// installed/current authority-log checkpoint.
+/// Verify any enrolled deployment credential against the public root, the
+/// installed/current authority log, and its independently trusted head.
 pub fn verify_deployment_artifacts_with_authority_log(
     public_ca: &[u8],
     authority_log_json: &[u8],
+    authority_checkpoint_json: &[u8],
     registry_credential: &str,
 ) -> Result<VerifiedDeploymentArtifacts> {
     anyhow::ensure!(
@@ -2321,14 +2392,26 @@ pub fn verify_deployment_artifacts_with_authority_log(
         .map_err(|error| {
             anyhow::anyhow!("installed deployment authority log is malformed: {error}")
         })?;
-    let registry_public_key = validate_registry_deployment_credential_profile(
+    anyhow::ensure!(
+        authority_checkpoint_json.len() <= MAX_DEPLOYMENT_CLOUD_SECRET_BYTES,
+        "installed deployment authority checkpoint is too large"
+    );
+    let authority_checkpoint: DeploymentAuthorityCheckpoint =
+        serde_json::from_slice(authority_checkpoint_json).map_err(|error| {
+            anyhow::anyhow!("installed deployment authority checkpoint is malformed: {error}")
+        })?;
+    let (registry_public_key, expires_at) = validate_registry_deployment_credential_profile(
         registry_credential,
         &ca,
-        Some(&authority_log),
+        DeploymentAuthorityState::Enrolled {
+            authority_log: &authority_log,
+            authority_checkpoint: &authority_checkpoint,
+        },
     )?;
     Ok(VerifiedDeploymentArtifacts {
         deployment_domain: ca.domain(),
         registry_public_key,
+        expires_at,
     })
 }
 
@@ -2384,35 +2467,49 @@ fn load_trusted_registry_deployment_credentials() -> Result<TrustedRegistryDeplo
         "deployment CA root",
     )?;
     let ca_verifying_key = HybridDeploymentCa::from_os_pin(&ca_bytes)?;
-    let authority_log_path = std::path::Path::new(DEPLOYMENT_AUTHORITY_LOG_PATH);
-    let authority_log =
-        if authority_log_path.exists() {
-            let bytes = read_os_owned_file(authority_log_path, "deployment authority log")?;
-            anyhow::ensure!(
-                bytes.len() <= MAX_DEPLOYMENT_CLOUD_SECRET_BYTES,
-                "deployment authority log exceeds the 64 KiB cloud-secret contract"
-            );
-            Some(serde_json::from_slice(&bytes).map_err(|error| {
-                anyhow::anyhow!("deployment authority log is malformed: {error}")
-            })?)
-        } else {
-            None
-        };
+    let authority_log_bytes = read_os_owned_file(
+        std::path::Path::new(DEPLOYMENT_AUTHORITY_LOG_PATH),
+        "deployment authority log",
+    )?;
+    anyhow::ensure!(
+        authority_log_bytes.len() <= MAX_DEPLOYMENT_CLOUD_SECRET_BYTES,
+        "deployment authority log exceeds the 64 KiB cloud-secret contract"
+    );
+    let authority_log = serde_json::from_slice(&authority_log_bytes)
+        .map_err(|error| anyhow::anyhow!("deployment authority log is malformed: {error}"))?;
+    let authority_checkpoint = load_deployment_authority_checkpoint()?;
     let registry_credential = load_registry_deployment_credential()?;
     Ok(TrustedRegistryDeploymentCredentials {
         ca_verifying_key,
         authority_log,
+        authority_checkpoint,
         registry_credential,
     })
+}
+
+fn load_deployment_authority_checkpoint() -> Result<DeploymentAuthorityCheckpoint> {
+    let bytes = read_os_owned_file(
+        std::path::Path::new(DEPLOYMENT_AUTHORITY_CHECKPOINT_PATH),
+        "deployment authority checkpoint",
+    )?;
+    anyhow::ensure!(
+        bytes.len() <= MAX_DEPLOYMENT_CLOUD_SECRET_BYTES,
+        "deployment authority checkpoint exceeds the 64 KiB cloud-secret contract"
+    );
+    serde_json::from_slice(&bytes)
+        .map_err(|error| anyhow::anyhow!("deployment authority checkpoint is malformed: {error}"))
 }
 
 fn authenticate_registry_deployment_credentials(
     credentials: TrustedRegistryDeploymentCredentials,
 ) -> Result<AuthenticatedRegistryDeploymentIdentity> {
-    let key_bytes = validate_registry_deployment_credential_profile(
+    let (key_bytes, _expires_at) = validate_registry_deployment_credential_profile(
         &credentials.registry_credential,
         &credentials.ca_verifying_key,
-        credentials.authority_log.as_ref(),
+        DeploymentAuthorityState::Enrolled {
+            authority_log: &credentials.authority_log,
+            authority_checkpoint: &credentials.authority_checkpoint,
+        },
     )
     .map_err(|error| anyhow::anyhow!("registry deployment credential rejected: {error}"))?;
     let verifying_key = VerifyingKey::from_bytes(&key_bytes)
@@ -2582,22 +2679,34 @@ async fn authenticate_did_anchored_bootstrap(
 )> {
     seal_process_bootstrap_authority()?;
     let trust = crate::did_anchored::resolve_did_anchored_trust(anchors).await?;
-    let witness =
-        authenticate_registry_deployment_credentials(TrustedRegistryDeploymentCredentials {
-            ca_verifying_key: trust.ca_verifying_key,
-            authority_log: None,
-            registry_credential: trust.registry_credential,
-        })?;
+    let authority_checkpoint = load_deployment_authority_checkpoint()?;
+    let discovery_transport = trust.discovery_transport.clone();
+    let mesh_kem_recipient = trust.mesh_kem_recipient.clone();
+    let ml_dsa_65_keys = trust.ml_dsa_65_keys.clone();
+    let verifier = authenticate_resolved_did_trust(trust, authority_checkpoint)?;
     let authority = ProcessBootstrapAuthority {
         store_path: hyprstream_service::deployment_data_dir()?.join("pds-store"),
-        acceptance_identity: ProcessAcceptanceIdentity::Deployment(witness.verifier),
+        acceptance_identity: ProcessAcceptanceIdentity::Deployment(verifier),
     };
     Ok((
         authority,
-        trust.discovery_transport,
-        trust.mesh_kem_recipient,
-        trust.ml_dsa_65_keys,
+        discovery_transport,
+        mesh_kem_recipient,
+        ml_dsa_65_keys,
     ))
+}
+
+pub(crate) fn authenticate_resolved_did_trust(
+    trust: crate::did_anchored::DidAnchoredTrust,
+    authority_checkpoint: DeploymentAuthorityCheckpoint,
+) -> Result<RegistryDeploymentVerifier> {
+    authenticate_registry_deployment_credentials(TrustedRegistryDeploymentCredentials {
+        ca_verifying_key: trust.ca_verifying_key,
+        authority_log: trust.authority_log,
+        authority_checkpoint,
+        registry_credential: trust.registry_credential,
+    })
+    .map(|witness| witness.verifier)
 }
 
 /// Resolve the configured DID anchors and authenticate the fetched registry
@@ -2614,13 +2723,10 @@ pub async fn resolve_and_authenticate_did_anchors(
     anchors: &crate::DidAnchors,
 ) -> Result<(RegistryDeploymentVerifier, TransportConfig)> {
     let trust = crate::did_anchored::resolve_did_anchored_trust(anchors).await?;
-    let witness =
-        authenticate_registry_deployment_credentials(TrustedRegistryDeploymentCredentials {
-            ca_verifying_key: trust.ca_verifying_key,
-            authority_log: None,
-            registry_credential: trust.registry_credential,
-        })?;
-    Ok((witness.verifier, trust.discovery_transport))
+    let authority_checkpoint = load_deployment_authority_checkpoint()?;
+    let discovery_transport = trust.discovery_transport.clone();
+    let verifier = authenticate_resolved_did_trust(trust, authority_checkpoint)?;
+    Ok((verifier, discovery_transport))
 }
 
 #[cfg(test)]
@@ -3243,10 +3349,18 @@ mod resolver_tests {
         ca: &TestDeploymentCa,
         credential: String,
     ) -> Result<AuthenticatedRegistryDeploymentIdentity> {
-        authenticate_registry_deployment_credentials(TrustedRegistryDeploymentCredentials {
-            ca_verifying_key: ca.verifying_keys.clone(),
-            authority_log: None,
-            registry_credential: credential,
+        let (key_bytes, _expires_at) = validate_registry_deployment_credential_profile(
+            &credential,
+            &ca.verifying_keys,
+            DeploymentAuthorityState::GenesisOnly,
+        )?;
+        let verifying_key = VerifyingKey::from_bytes(&key_bytes)
+            .map_err(|error| anyhow::anyhow!("registry credential key is malformed: {error}"))?;
+        Ok(AuthenticatedRegistryDeploymentIdentity {
+            verifier: RegistryDeploymentVerifier {
+                verifying_key,
+                _deployment_ca: Arc::new(ca.verifying_keys.clone()),
+            },
         })
     }
 
@@ -4438,12 +4552,8 @@ mod resolver_tests {
         let ca = test_deployment_ca(0x62);
         let registry = SigningKey::from_bytes(&[0x63; 32]);
         let witness =
-            authenticate_registry_deployment_credentials(TrustedRegistryDeploymentCredentials {
-                ca_verifying_key: ca.verifying_keys.clone(),
-                authority_log: None,
-                registry_credential: exact_registry_credential(&ca, &registry),
-            })
-            .expect("trusted pair");
+            authenticate_test_registry_credential(&ca, exact_registry_credential(&ca, &registry))
+                .expect("explicit genesis-only trusted pair");
         std::env::set_var("CREDENTIALS_DIRECTORY", "post-start-attacker-directory");
         std::env::set_var("XDG_CONFIG_HOME", "post-start-attacker-config");
         assert!(witness.verifier.matches(&registry.verifying_key()));

--- a/crates/hyprstream-discovery/src/service.rs
+++ b/crates/hyprstream-discovery/src/service.rs
@@ -1507,6 +1507,7 @@ static PROCESS_REGISTRY_VERIFIER: std::sync::OnceLock<RegistryDeploymentVerifier
     std::sync::OnceLock::new();
 
 const DEPLOYMENT_CA_ROOT_PATH: &str = "/etc/hyprstream/trust/deployment-ca.hybrid";
+const DEPLOYMENT_AUTHORITY_LOG_PATH: &str = "/etc/hyprstream/trust/deployment-authority.log.json";
 const REGISTRY_DEPLOYMENT_CREDENTIAL_PATH: &str =
     "/run/hyprstream/credentials/registry-service.jwt";
 const REGISTRY_DEPLOYMENT_CREDENTIAL_PROFILE: &str = "hyprstream.registry-deployment.v1";
@@ -1517,6 +1518,33 @@ const ED25519_PUBLIC_KEY_BYTES: usize = 32;
 const ML_DSA_65_PUBLIC_KEY_BYTES: usize = 1_952;
 const DEPLOYMENT_CA_ROOT_BYTES: usize = ED25519_PUBLIC_KEY_BYTES + ML_DSA_65_PUBLIC_KEY_BYTES;
 const HYBRID_JWT_SIGNATURE_BYTES: usize = 3_309 + 64;
+const AUTHORITY_LOG_SCHEMA: &str = "hyprstream.deployment-authority-log.v1";
+const REGISTRY_DELEGATION_SCHEMA: &str = "hyprstream.registry-delegation.v1";
+const MAX_AUTHORITY_LOG_OPERATIONS: usize = 128;
+const MAX_REGISTRY_DELEGATION_BYTES: usize = 256 * 1024;
+const MAX_DEPLOYMENT_CLOUD_SECRET_BYTES: usize = 64 * 1024;
+const REGISTRY_DELEGATION_ABILITY: &str = "mint-registry-jwt";
+
+/// Signed DidOp authority history embedded in a registry delegation.
+#[derive(Clone, Debug, Eq, PartialEq, serde::Serialize, serde::Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct DeploymentAuthorityLog {
+    pub schema: String,
+    pub deployment_domain: String,
+    pub did: String,
+    pub operations_b64: Vec<String>,
+}
+
+/// Root/current-authority UCAN delegation embedded in delegated registry JWTs.
+#[derive(Clone, Debug, Eq, PartialEq, serde::Serialize, serde::Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct RegistryDelegationArtifact {
+    pub schema: String,
+    pub deployment_domain: String,
+    pub authority_log_did: String,
+    pub delegated_public_key_b64: String,
+    pub ucan_b64: String,
+}
 
 /// Non-optional Ed25519 + ML-DSA-65 deployment trust root.
 ///
@@ -1644,6 +1672,7 @@ struct AuthenticatedRegistryDeploymentIdentity {
 
 struct TrustedRegistryDeploymentCredentials {
     ca_verifying_key: HybridDeploymentCa,
+    authority_log: Option<DeploymentAuthorityLog>,
     registry_credential: String,
 }
 
@@ -1859,7 +1888,16 @@ fn validate_registry_credential_numeric_dates(
 fn validate_registry_deployment_credential_profile(
     token: &str,
     ca_verifying_key: &HybridDeploymentCa,
+    installed_authority_log: Option<&DeploymentAuthorityLog>,
 ) -> Result<[u8; 32]> {
+    anyhow::ensure!(
+        !token.is_empty() && !token.bytes().any(|byte| byte.is_ascii_whitespace()),
+        "registry credential must be compact with no whitespace"
+    );
+    anyhow::ensure!(
+        token.len() <= MAX_DEPLOYMENT_CLOUD_SECRET_BYTES,
+        "registry credential exceeds the 64 KiB cloud-secret contract"
+    );
     let mut segments = token.split('.');
     let protected_segment = segments.next().unwrap_or_default();
     let claims_segment = segments.next().unwrap_or_default();
@@ -1885,25 +1923,46 @@ fn validate_registry_deployment_credential_profile(
         "protected header typ must be exactly wit+jwt"
     );
     let domain = deployment_domain(ca_verifying_key);
-    anyhow::ensure!(
-        exact_string_member(protected, "kid", "protected header")? == domain,
-        "protected header kid does not bind the pinned deployment CA"
-    );
 
-    let claims = parse_unique_jwt_json(claims_segment, "credential claims", 16_384)?;
+    let claims = parse_unique_jwt_json(
+        claims_segment,
+        "credential claims",
+        MAX_REGISTRY_DELEGATION_BYTES + 16_384,
+    )?;
+    let claims_object = claims
+        .as_object()
+        .ok_or_else(|| anyhow::anyhow!("credential claims must be a JSON object"))?;
+    let delegated = claims_object.contains_key("delegation");
+    let direct_members = [
+        "iss",
+        "sub",
+        "aud",
+        "exp",
+        "nbf",
+        "iat",
+        "deployment_domain",
+        "profile",
+        "cnf",
+    ];
+    let delegated_members = [
+        "iss",
+        "sub",
+        "aud",
+        "exp",
+        "nbf",
+        "iat",
+        "deployment_domain",
+        "profile",
+        "cnf",
+        "delegation",
+    ];
     let claims = exact_json_object(
         &claims,
-        &[
-            "iss",
-            "sub",
-            "aud",
-            "exp",
-            "nbf",
-            "iat",
-            "deployment_domain",
-            "profile",
-            "cnf",
-        ],
+        if delegated {
+            &delegated_members
+        } else {
+            &direct_members
+        },
         "credential claims",
     )?;
     anyhow::ensure!(
@@ -1956,14 +2015,53 @@ fn validate_registry_deployment_credential_profile(
         .try_into()
         .map_err(|_| anyhow::anyhow!("credential cnf.jwk.x must decode to exactly 32 bytes"))?;
 
+    let delegated_ca;
+    let signing_ca = if delegated {
+        let encoded = exact_string_member(claims, "delegation", "credential claims")?;
+        let bytes = decode_canonical_jwt_segment(
+            encoded,
+            "credential delegation",
+            MAX_REGISTRY_DELEGATION_BYTES,
+        )?;
+        let artifact: RegistryDelegationArtifact = serde_json::from_slice(&bytes)
+            .map_err(|error| anyhow::anyhow!("credential delegation is malformed: {error}"))?;
+        let installed_authority_log = installed_authority_log.ok_or_else(|| {
+            anyhow::anyhow!("delegated credential requires the installed deployment authority log")
+        })?;
+        delegated_ca = validate_registry_delegation_artifact(
+            ca_verifying_key,
+            &artifact,
+            installed_authority_log,
+            u64::try_from(now).map_err(|_| anyhow::anyhow!("system clock precedes Unix epoch"))?,
+        )?;
+        &delegated_ca
+    } else if let Some(installed_authority_log) = installed_authority_log {
+        let active = validate_deployment_authority_log(ca_verifying_key, installed_authority_log)?;
+        anyhow::ensure!(
+            active.rotation_keys.iter().any(|key| {
+                key.ed25519_pub == ca_verifying_key.ed25519.to_bytes()
+                    && key.mldsa65_pub
+                        == hyprstream_rpc::crypto::pq::ml_dsa_vk_bytes(&ca_verifying_key.ml_dsa_65)
+            }),
+            "direct root credential issuer is retired at the installed authority-log head"
+        );
+        ca_verifying_key
+    } else {
+        ca_verifying_key
+    };
+    anyhow::ensure!(
+        exact_string_member(protected, "kid", "protected header")? == signing_ca.domain(),
+        "protected header kid does not bind the authorized deployment signer"
+    );
+
     // Signature verification is deliberately last: no parsed material can mint
     // authority unless the exact closed profile is authenticated by the fixed CA.
     let dispatch = hyprstream_rpc::auth::jwt::parse_composite_dispatch(token, &["wit+jwt"])
         .map_err(|error| anyhow::anyhow!("credential composite dispatch rejected: {error}"))?;
     let verified = hyprstream_rpc::auth::jwt::decode_composite(
         token,
-        &ca_verifying_key.ml_dsa_65,
-        &ca_verifying_key.ed25519,
+        &signing_ca.ml_dsa_65,
+        &signing_ca.ed25519,
         Some(REGISTRY_DEPLOYMENT_CREDENTIAL_AUDIENCE),
         &dispatch,
     )
@@ -1973,6 +2071,265 @@ fn validate_registry_deployment_credential_profile(
         "verified credential differs from the exact deployment profile"
     );
     Ok(key)
+}
+
+struct AuthoritySetUcanVerifier<'a> {
+    keys: &'a [crate::did_op::HybridRotationKey],
+}
+
+impl hyprstream_rpc::auth::ucan::UcanVerifier for AuthoritySetUcanVerifier<'_> {
+    fn verify(
+        &self,
+        _issuer: &hyprstream_rpc::auth::ucan::Did,
+        ed_key: &[u8; ED25519_PUBLIC_KEY_BYTES],
+        payload: &[u8],
+        signature: &[u8],
+    ) -> std::result::Result<(), hyprstream_rpc::auth::ucan::UcanError> {
+        use hyprstream_rpc::auth::ucan::UcanError;
+        let authority = self
+            .keys
+            .iter()
+            .find(|key| &key.ed25519_pub == ed_key)
+            .ok_or_else(|| {
+                UcanError::BadSignature("UCAN issuer is not in the active authority set".to_owned())
+            })?;
+        let (ed, pq) = authority
+            .verifying_keys()
+            .map_err(|error| UcanError::BadSignature(error.to_string()))?;
+        hyprstream_rpc::crypto::cose_sign::verify_composite(
+            signature,
+            &ed,
+            Some(&pq),
+            payload,
+            hyprstream_rpc::auth::ucan::token::UCAN_AAD,
+            true,
+        )
+        .map(|_| ())
+        .map_err(|error| UcanError::BadSignature(error.to_string()))
+    }
+}
+
+fn validate_registry_delegation_artifact(
+    root: &HybridDeploymentCa,
+    artifact: &RegistryDelegationArtifact,
+    installed_authority_log: &DeploymentAuthorityLog,
+    now: u64,
+) -> Result<HybridDeploymentCa> {
+    use hyprstream_rpc::auth::ucan::{
+        validate as validate_ucan, Ability, Capability, CaveatValue, Caveats, Resource, Ucan,
+    };
+
+    anyhow::ensure!(
+        artifact.schema == REGISTRY_DELEGATION_SCHEMA,
+        "unsupported registry delegation schema"
+    );
+    anyhow::ensure!(
+        artifact.deployment_domain == root.domain(),
+        "registry delegation deployment domain does not match pinned root"
+    );
+    let active = validate_deployment_authority_log(root, installed_authority_log)?;
+    anyhow::ensure!(
+        artifact.authority_log_did == installed_authority_log.did,
+        "registry delegation names a different authority log"
+    );
+    let active_keys = &active.rotation_keys;
+
+    let delegated_public = base64::engine::general_purpose::STANDARD
+        .decode(&artifact.delegated_public_key_b64)
+        .context("decoding delegated registry-signer public key")?;
+    anyhow::ensure!(
+        delegated_public.len() == DEPLOYMENT_CA_ROOT_BYTES,
+        "delegated registry-signer public key has the wrong length"
+    );
+    let delegated = HybridDeploymentCa::from_public_key_bytes(
+        &delegated_public[..ED25519_PUBLIC_KEY_BYTES],
+        &delegated_public[ED25519_PUBLIC_KEY_BYTES..],
+    )?;
+
+    let ucan_bytes = base64::engine::general_purpose::STANDARD
+        .decode(&artifact.ucan_b64)
+        .context("decoding registry delegation UCAN")?;
+    anyhow::ensure!(
+        ucan_bytes.len() <= MAX_REGISTRY_DELEGATION_BYTES,
+        "registry delegation UCAN is too large"
+    );
+    let ucan = Ucan::from_cbor(&ucan_bytes).context("decoding registry delegation UCAN")?;
+    anyhow::ensure!(
+        ucan.proofs.is_empty(),
+        "registry delegation must be one authority-to-signer link"
+    );
+    validate_ucan(&ucan, &AuthoritySetUcanVerifier { keys: active_keys }, now)
+        .context("validating registry delegation UCAN")?;
+    anyhow::ensure!(
+        active_keys
+            .iter()
+            .any(|key| ucan.issuer().to_ed25519().ok() == Some(key.ed25519_pub)),
+        "registry delegation issuer is not an active authority"
+    );
+    anyhow::ensure!(
+        ucan.audience().to_ed25519()? == delegated.ed25519.to_bytes(),
+        "registry delegation audience does not match delegated signer"
+    );
+    let mut caveats = std::collections::BTreeMap::new();
+    caveats.insert(
+        "audience".to_owned(),
+        CaveatValue::Text(REGISTRY_DEPLOYMENT_CREDENTIAL_AUDIENCE.to_owned()),
+    );
+    caveats.insert(
+        "deployment_domain".to_owned(),
+        CaveatValue::Text(root.domain()),
+    );
+    caveats.insert(
+        "delegated_public_key_b64".to_owned(),
+        CaveatValue::Text(artifact.delegated_public_key_b64.clone()),
+    );
+    caveats.insert(
+        "max_ttl_seconds".to_owned(),
+        CaveatValue::Int(REGISTRY_DEPLOYMENT_CREDENTIAL_MAX_TTL_SECONDS),
+    );
+    caveats.insert(
+        "profile".to_owned(),
+        CaveatValue::Text(REGISTRY_DEPLOYMENT_CREDENTIAL_PROFILE.to_owned()),
+    );
+    let expected = Capability::with_caveats(
+        Resource::new(format!(
+            "hyprstream://deployment/{}/service/registry",
+            root.domain()
+        )),
+        Ability::new(REGISTRY_DELEGATION_ABILITY),
+        Caveats(caveats),
+    );
+    anyhow::ensure!(
+        ucan.capabilities() == [expected],
+        "registry delegation capability is not the exact registry-only scope"
+    );
+    anyhow::ensure!(
+        ucan.payload.expiration.is_some(),
+        "registry delegation must expire"
+    );
+    Ok(delegated)
+}
+
+fn validate_deployment_authority_log(
+    root: &HybridDeploymentCa,
+    log: &DeploymentAuthorityLog,
+) -> Result<crate::did_op::VerifiedDidOpLog> {
+    anyhow::ensure!(
+        log.schema == AUTHORITY_LOG_SCHEMA,
+        "unsupported deployment authority-log schema"
+    );
+    anyhow::ensure!(
+        log.deployment_domain == root.domain(),
+        "deployment authority-log domain does not match pinned root"
+    );
+    anyhow::ensure!(
+        !log.operations_b64.is_empty() && log.operations_b64.len() <= MAX_AUTHORITY_LOG_OPERATIONS,
+        "deployment authority-log operation count is invalid"
+    );
+    let operations = log
+        .operations_b64
+        .iter()
+        .map(|encoded| {
+            let bytes = base64::engine::general_purpose::STANDARD
+                .decode(encoded)
+                .context("decoding deployment authority operation")?;
+            crate::did_op::DidOp::from_dag_cbor(&bytes)
+        })
+        .collect::<Result<Vec<_>>>()?;
+    let active = crate::did_op::verify_did_op_log(&log.did, &operations)
+        .context("verifying deployment authority log")?;
+    let genesis = operations
+        .first()
+        .ok_or_else(|| anyhow::anyhow!("deployment authority log is empty"))?;
+    let genesis_composite = hyprstream_rpc::crypto::cose_sign::assemble_composite_nested(
+        (
+            root.ed25519.to_bytes().to_vec(),
+            genesis.signature.ed25519.clone(),
+        ),
+        Some((
+            hyprstream_rpc::crypto::pq::ml_dsa_vk_bytes(&root.ml_dsa_65),
+            genesis.signature.mldsa65.clone(),
+        )),
+    )
+    .context("assembling pinned-root authority genesis signature")?;
+    hyprstream_rpc::crypto::cose_sign::verify_composite(
+        &genesis_composite,
+        &root.ed25519,
+        Some(&root.ml_dsa_65),
+        &genesis.signable_bytes(),
+        crate::did_op::DID_OP_SIGNATURE_CONTEXT,
+        true,
+    )
+    .context("authority-log genesis was not signed by the pinned root")?;
+    anyhow::ensure!(
+        genesis.rotation_keys.iter().any(|key| {
+            key.ed25519_pub == root.ed25519.to_bytes()
+                && key.mldsa65_pub == hyprstream_rpc::crypto::pq::ml_dsa_vk_bytes(&root.ml_dsa_65)
+        }),
+        "deployment authority-log genesis is not anchored by the pinned public root"
+    );
+    Ok(active)
+}
+
+/// Result of verifying the two deployment artifacts consumed at production
+/// bootstrap. This exposes no authority material and cannot install or replace
+/// process trust.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct VerifiedDeploymentArtifacts {
+    pub deployment_domain: String,
+    pub registry_public_key: [u8; ED25519_PUBLIC_KEY_BYTES],
+}
+
+/// Parse the exact production public-root pin and return its stable deployment
+/// domain. This is the mint-time half of [`verify_deployment_artifacts`].
+pub fn verify_deployment_public_ca(public_ca: &[u8]) -> Result<String> {
+    HybridDeploymentCa::from_os_pin(public_ca).map(|ca| ca.domain())
+}
+
+/// Parse and verify deployment artifacts through the exact production
+/// `HybridDeploymentCa` and closed registry-credential profile.
+///
+/// Tooling uses this entry point for pre-installation self-checks. Keeping the
+/// parser and validator here prevents a mint tool from accidentally blessing a
+/// byte layout or JWT shape that production would reject.
+pub fn verify_deployment_artifacts(
+    public_ca: &[u8],
+    registry_credential: &str,
+) -> Result<VerifiedDeploymentArtifacts> {
+    let ca = HybridDeploymentCa::from_os_pin(public_ca)?;
+    let registry_public_key =
+        validate_registry_deployment_credential_profile(registry_credential, &ca, None)?;
+    Ok(VerifiedDeploymentArtifacts {
+        deployment_domain: ca.domain(),
+        registry_public_key,
+    })
+}
+
+/// Verify a delegated deployment credential against the public root and the
+/// installed/current authority-log checkpoint.
+pub fn verify_deployment_artifacts_with_authority_log(
+    public_ca: &[u8],
+    authority_log_json: &[u8],
+    registry_credential: &str,
+) -> Result<VerifiedDeploymentArtifacts> {
+    anyhow::ensure!(
+        authority_log_json.len() <= MAX_DEPLOYMENT_CLOUD_SECRET_BYTES,
+        "installed deployment authority log is too large"
+    );
+    let ca = HybridDeploymentCa::from_os_pin(public_ca)?;
+    let authority_log: DeploymentAuthorityLog = serde_json::from_slice(authority_log_json)
+        .map_err(|error| {
+            anyhow::anyhow!("installed deployment authority log is malformed: {error}")
+        })?;
+    let registry_public_key = validate_registry_deployment_credential_profile(
+        registry_credential,
+        &ca,
+        Some(&authority_log),
+    )?;
+    Ok(VerifiedDeploymentArtifacts {
+        deployment_domain: ca.domain(),
+        registry_public_key,
+    })
 }
 
 #[cfg(unix)]
@@ -2027,9 +2384,24 @@ fn load_trusted_registry_deployment_credentials() -> Result<TrustedRegistryDeplo
         "deployment CA root",
     )?;
     let ca_verifying_key = HybridDeploymentCa::from_os_pin(&ca_bytes)?;
+    let authority_log_path = std::path::Path::new(DEPLOYMENT_AUTHORITY_LOG_PATH);
+    let authority_log =
+        if authority_log_path.exists() {
+            let bytes = read_os_owned_file(authority_log_path, "deployment authority log")?;
+            anyhow::ensure!(
+                bytes.len() <= MAX_DEPLOYMENT_CLOUD_SECRET_BYTES,
+                "deployment authority log exceeds the 64 KiB cloud-secret contract"
+            );
+            Some(serde_json::from_slice(&bytes).map_err(|error| {
+                anyhow::anyhow!("deployment authority log is malformed: {error}")
+            })?)
+        } else {
+            None
+        };
     let registry_credential = load_registry_deployment_credential()?;
     Ok(TrustedRegistryDeploymentCredentials {
         ca_verifying_key,
+        authority_log,
         registry_credential,
     })
 }
@@ -2040,6 +2412,7 @@ fn authenticate_registry_deployment_credentials(
     let key_bytes = validate_registry_deployment_credential_profile(
         &credentials.registry_credential,
         &credentials.ca_verifying_key,
+        credentials.authority_log.as_ref(),
     )
     .map_err(|error| anyhow::anyhow!("registry deployment credential rejected: {error}"))?;
     let verifying_key = VerifyingKey::from_bytes(&key_bytes)
@@ -2212,6 +2585,7 @@ async fn authenticate_did_anchored_bootstrap(
     let witness =
         authenticate_registry_deployment_credentials(TrustedRegistryDeploymentCredentials {
             ca_verifying_key: trust.ca_verifying_key,
+            authority_log: None,
             registry_credential: trust.registry_credential,
         })?;
     let authority = ProcessBootstrapAuthority {
@@ -2243,6 +2617,7 @@ pub async fn resolve_and_authenticate_did_anchors(
     let witness =
         authenticate_registry_deployment_credentials(TrustedRegistryDeploymentCredentials {
             ca_verifying_key: trust.ca_verifying_key,
+            authority_log: None,
             registry_credential: trust.registry_credential,
         })?;
     Ok((witness.verifier, trust.discovery_transport))
@@ -2870,6 +3245,7 @@ mod resolver_tests {
     ) -> Result<AuthenticatedRegistryDeploymentIdentity> {
         authenticate_registry_deployment_credentials(TrustedRegistryDeploymentCredentials {
             ca_verifying_key: ca.verifying_keys.clone(),
+            authority_log: None,
             registry_credential: credential,
         })
     }
@@ -4064,6 +4440,7 @@ mod resolver_tests {
         let witness =
             authenticate_registry_deployment_credentials(TrustedRegistryDeploymentCredentials {
                 ca_verifying_key: ca.verifying_keys.clone(),
+                authority_log: None,
                 registry_credential: exact_registry_credential(&ca, &registry),
             })
             .expect("trusted pair");

--- a/crates/hyprstream-discovery/src/service.rs
+++ b/crates/hyprstream-discovery/src/service.rs
@@ -1512,6 +1512,12 @@ const DEPLOYMENT_AUTHORITY_CHECKPOINT_PATH: &str =
     "/etc/hyprstream/trust/deployment-authority.head.json";
 const REGISTRY_DEPLOYMENT_CREDENTIAL_PATH: &str =
     "/run/hyprstream/credentials/registry-service.jwt";
+const DEPLOYMENT_TRUST_DIR_ENV: &str = "HYPRSTREAM_DEPLOYMENT_TRUST_DIR";
+const SYSTEMD_CREDENTIALS_DIRECTORY_ENV: &str = "CREDENTIALS_DIRECTORY";
+const DEPLOYMENT_CA_ROOT_FILE: &str = "deployment-ca.hybrid";
+const DEPLOYMENT_AUTHORITY_LOG_FILE: &str = "deployment-authority.log.json";
+const DEPLOYMENT_AUTHORITY_CHECKPOINT_FILE: &str = "deployment-authority.head.json";
+const REGISTRY_DEPLOYMENT_CREDENTIAL_FILE: &str = "registry-service.jwt";
 const REGISTRY_DEPLOYMENT_CREDENTIAL_PROFILE: &str = "hyprstream.registry-deployment.v1";
 const REGISTRY_DEPLOYMENT_CREDENTIAL_AUDIENCE: &str = "urn:hyprstream:service:registry";
 const REGISTRY_DEPLOYMENT_CREDENTIAL_MAX_TTL_SECONDS: i64 = 3_600;
@@ -2415,70 +2421,207 @@ pub fn verify_deployment_artifacts_with_authority_log(
     })
 }
 
-#[cfg(unix)]
-fn read_os_owned_file(path: &std::path::Path, description: &str) -> Result<Vec<u8>> {
-    use std::os::unix::fs::MetadataExt as _;
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum TrustFileOwner {
+    Root,
+    EffectiveUser,
+}
 
-    anyhow::ensure!(path.is_absolute(), "{description} path must be absolute");
-    let metadata = std::fs::symlink_metadata(path)
-        .map_err(|error| anyhow::anyhow!("{description} is unavailable at {path:?}: {error}"))?;
+#[derive(Clone, Debug, Eq, PartialEq)]
+struct TrustedArtifactPath {
+    path: std::path::PathBuf,
+    owner: TrustFileOwner,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+struct DeploymentTrustPaths {
+    public_ca: TrustedArtifactPath,
+    authority_log: TrustedArtifactPath,
+    authority_checkpoint: TrustedArtifactPath,
+    registry_credential: TrustedArtifactPath,
+}
+
+fn explicit_absolute_directory(
+    env_name: &str,
+    value: std::ffi::OsString,
+) -> Result<std::path::PathBuf> {
+    use std::path::Component;
+
+    let path = std::path::PathBuf::from(value);
     anyhow::ensure!(
-        metadata.file_type().is_file(),
-        "{description} is not a regular file"
+        !path.as_os_str().is_empty(),
+        "{env_name} is present but empty"
     );
-    anyhow::ensure!(metadata.uid() == 0, "{description} is not owned by root");
+    anyhow::ensure!(path.is_absolute(), "{env_name} must be an absolute path");
     anyhow::ensure!(
-        metadata.mode() & 0o022 == 0,
-        "{description} is group/world writable"
+        path.components()
+            .all(|component| matches!(component, Component::RootDir | Component::Normal(_))),
+        "{env_name} must not contain '..' components"
     );
-    for parent in path.ancestors().skip(1) {
+    Ok(path)
+}
+
+fn resolve_deployment_trust_paths_from(
+    trust_directory: Option<std::ffi::OsString>,
+    credentials_directory: Option<std::ffi::OsString>,
+) -> Result<DeploymentTrustPaths> {
+    let (public_ca, authority_log, authority_checkpoint, trust_owner) = match trust_directory {
+        Some(value) => {
+            let directory = explicit_absolute_directory(DEPLOYMENT_TRUST_DIR_ENV, value)?;
+            (
+                directory.join(DEPLOYMENT_CA_ROOT_FILE),
+                directory.join(DEPLOYMENT_AUTHORITY_LOG_FILE),
+                directory.join(DEPLOYMENT_AUTHORITY_CHECKPOINT_FILE),
+                TrustFileOwner::EffectiveUser,
+            )
+        }
+        None => (
+            std::path::PathBuf::from(DEPLOYMENT_CA_ROOT_PATH),
+            std::path::PathBuf::from(DEPLOYMENT_AUTHORITY_LOG_PATH),
+            std::path::PathBuf::from(DEPLOYMENT_AUTHORITY_CHECKPOINT_PATH),
+            TrustFileOwner::Root,
+        ),
+    };
+    let (registry_credential, credential_owner) = match credentials_directory {
+        Some(value) => {
+            let directory = explicit_absolute_directory(SYSTEMD_CREDENTIALS_DIRECTORY_ENV, value)?;
+            (
+                directory.join(REGISTRY_DEPLOYMENT_CREDENTIAL_FILE),
+                TrustFileOwner::EffectiveUser,
+            )
+        }
+        None => (
+            std::path::PathBuf::from(REGISTRY_DEPLOYMENT_CREDENTIAL_PATH),
+            TrustFileOwner::Root,
+        ),
+    };
+    Ok(DeploymentTrustPaths {
+        public_ca: TrustedArtifactPath {
+            path: public_ca,
+            owner: trust_owner,
+        },
+        authority_log: TrustedArtifactPath {
+            path: authority_log,
+            owner: trust_owner,
+        },
+        authority_checkpoint: TrustedArtifactPath {
+            path: authority_checkpoint,
+            owner: trust_owner,
+        },
+        registry_credential: TrustedArtifactPath {
+            path: registry_credential,
+            owner: credential_owner,
+        },
+    })
+}
+
+fn resolve_deployment_trust_paths() -> Result<DeploymentTrustPaths> {
+    resolve_deployment_trust_paths_from(
+        std::env::var_os(DEPLOYMENT_TRUST_DIR_ENV),
+        std::env::var_os(SYSTEMD_CREDENTIALS_DIRECTORY_ENV),
+    )
+}
+
+#[cfg(unix)]
+fn read_trusted_artifact(artifact: &TrustedArtifactPath, description: &str) -> Result<Vec<u8>> {
+    use std::io::Read as _;
+    use std::os::unix::fs::{MetadataExt as _, OpenOptionsExt as _};
+
+    anyhow::ensure!(
+        artifact.path.is_absolute(),
+        "{description} path must be absolute"
+    );
+    let effective_uid = {
+        // SAFETY: geteuid has no preconditions and returns process-local state.
+        unsafe { libc::geteuid() }
+    };
+    let owner_is_allowed = |uid| match artifact.owner {
+        TrustFileOwner::Root => uid == 0,
+        TrustFileOwner::EffectiveUser => uid == 0 || uid == effective_uid,
+    };
+    for parent in artifact.path.ancestors().skip(1) {
         let parent_metadata = std::fs::symlink_metadata(parent).map_err(|error| {
             anyhow::anyhow!("{description} parent {parent:?} is unavailable: {error}")
         })?;
         anyhow::ensure!(
             parent_metadata.file_type().is_dir(),
-            "{description} parent {parent:?} is not a directory"
+            "{description} parent {parent:?} is not a real directory"
         );
         anyhow::ensure!(
-            parent_metadata.uid() == 0 && parent_metadata.mode() & 0o022 == 0,
-            "{description} parent {parent:?} is writable or not root-owned"
+            owner_is_allowed(parent_metadata.uid()),
+            "{description} parent {parent:?} has an untrusted owner"
+        );
+        anyhow::ensure!(
+            parent_metadata.mode() & 0o022 == 0,
+            "{description} parent {parent:?} is group/world writable"
         );
     }
-    std::fs::read(path)
-        .map_err(|error| anyhow::anyhow!("failed to read {description} at {path:?}: {error}"))
+    let mut file = std::fs::OpenOptions::new()
+        .read(true)
+        .custom_flags(libc::O_CLOEXEC | libc::O_NOFOLLOW)
+        .open(&artifact.path)
+        .map_err(|error| {
+            anyhow::anyhow!(
+                "{description} is unavailable at {:?}: {error}",
+                artifact.path
+            )
+        })?;
+    let metadata = file.metadata().map_err(|error| {
+        anyhow::anyhow!(
+            "failed to inspect {description} at {:?}: {error}",
+            artifact.path
+        )
+    })?;
+    anyhow::ensure!(
+        metadata.file_type().is_file(),
+        "{description} is not a regular file"
+    );
+    anyhow::ensure!(
+        owner_is_allowed(metadata.uid()),
+        "{description} has an untrusted owner"
+    );
+    anyhow::ensure!(
+        metadata.mode() & 0o022 == 0,
+        "{description} is group/world writable"
+    );
+    let mut bytes = Vec::new();
+    file.read_to_end(&mut bytes).map_err(|error| {
+        anyhow::anyhow!(
+            "failed to read {description} at {:?}: {error}",
+            artifact.path
+        )
+    })?;
+    Ok(bytes)
 }
 
 #[cfg(not(unix))]
-fn read_os_owned_file(_path: &std::path::Path, description: &str) -> Result<Vec<u8>> {
-    anyhow::bail!("{description} requires the OS-owned Unix deployment seam")
+fn read_trusted_artifact(_artifact: &TrustedArtifactPath, description: &str) -> Result<Vec<u8>> {
+    anyhow::bail!("{description} requires the trusted Unix deployment seam")
 }
 
-fn load_registry_deployment_credential() -> Result<String> {
-    String::from_utf8(read_os_owned_file(
-        std::path::Path::new(REGISTRY_DEPLOYMENT_CREDENTIAL_PATH),
+fn load_registry_deployment_credential(paths: &DeploymentTrustPaths) -> Result<String> {
+    String::from_utf8(read_trusted_artifact(
+        &paths.registry_credential,
         "registry deployment credential",
     )?)
     .map_err(|error| anyhow::anyhow!("registry deployment credential is not UTF-8: {error}"))
 }
 
-fn load_trusted_registry_deployment_credentials() -> Result<TrustedRegistryDeploymentCredentials> {
-    let ca_bytes = read_os_owned_file(
-        std::path::Path::new(DEPLOYMENT_CA_ROOT_PATH),
-        "deployment CA root",
-    )?;
+fn load_trusted_registry_deployment_credentials_from(
+    paths: &DeploymentTrustPaths,
+) -> Result<TrustedRegistryDeploymentCredentials> {
+    let ca_bytes = read_trusted_artifact(&paths.public_ca, "deployment CA root")?;
     let ca_verifying_key = HybridDeploymentCa::from_os_pin(&ca_bytes)?;
-    let authority_log_bytes = read_os_owned_file(
-        std::path::Path::new(DEPLOYMENT_AUTHORITY_LOG_PATH),
-        "deployment authority log",
-    )?;
+    let authority_log_bytes =
+        read_trusted_artifact(&paths.authority_log, "deployment authority log")?;
     anyhow::ensure!(
         authority_log_bytes.len() <= MAX_DEPLOYMENT_CLOUD_SECRET_BYTES,
         "deployment authority log exceeds the 64 KiB cloud-secret contract"
     );
     let authority_log = serde_json::from_slice(&authority_log_bytes)
         .map_err(|error| anyhow::anyhow!("deployment authority log is malformed: {error}"))?;
-    let authority_checkpoint = load_deployment_authority_checkpoint()?;
-    let registry_credential = load_registry_deployment_credential()?;
+    let authority_checkpoint = load_deployment_authority_checkpoint_from(paths)?;
+    let registry_credential = load_registry_deployment_credential(paths)?;
     Ok(TrustedRegistryDeploymentCredentials {
         ca_verifying_key,
         authority_log,
@@ -2487,9 +2630,16 @@ fn load_trusted_registry_deployment_credentials() -> Result<TrustedRegistryDeplo
     })
 }
 
-fn load_deployment_authority_checkpoint() -> Result<DeploymentAuthorityCheckpoint> {
-    let bytes = read_os_owned_file(
-        std::path::Path::new(DEPLOYMENT_AUTHORITY_CHECKPOINT_PATH),
+fn load_trusted_registry_deployment_credentials() -> Result<TrustedRegistryDeploymentCredentials> {
+    let paths = resolve_deployment_trust_paths()?;
+    load_trusted_registry_deployment_credentials_from(&paths)
+}
+
+fn load_deployment_authority_checkpoint_from(
+    paths: &DeploymentTrustPaths,
+) -> Result<DeploymentAuthorityCheckpoint> {
+    let bytes = read_trusted_artifact(
+        &paths.authority_checkpoint,
         "deployment authority checkpoint",
     )?;
     anyhow::ensure!(
@@ -2498,6 +2648,11 @@ fn load_deployment_authority_checkpoint() -> Result<DeploymentAuthorityCheckpoin
     );
     serde_json::from_slice(&bytes)
         .map_err(|error| anyhow::anyhow!("deployment authority checkpoint is malformed: {error}"))
+}
+
+fn load_deployment_authority_checkpoint() -> Result<DeploymentAuthorityCheckpoint> {
+    let paths = resolve_deployment_trust_paths()?;
+    load_deployment_authority_checkpoint_from(&paths)
 }
 
 fn authenticate_registry_deployment_credentials(
@@ -3862,15 +4017,19 @@ mod resolver_tests {
         assert!(!production.contains("pub fn bootstrap_authenticated_process("));
         assert!(production.contains("/etc/hyprstream/trust/deployment-ca.hybrid"));
         assert!(production.contains("/run/hyprstream/credentials/registry-service.jwt"));
+        assert!(production.contains("HYPRSTREAM_DEPLOYMENT_TRUST_DIR"));
+        assert!(production.contains("CREDENTIALS_DIRECTORY"));
         let loader = production
             .split("fn load_trusted_registry_deployment_credentials()")
             .nth(1)
-            .expect("fixed deployment loader")
+            .expect("deployment trust loader")
             .split("fn authenticate_registry_deployment_credentials(")
             .next()
             .expect("loader body");
-        assert!(!loader.contains("CREDENTIALS_DIRECTORY"));
+        assert!(loader.contains("resolve_deployment_trust_paths()"));
+        assert!(loader.contains("load_trusted_registry_deployment_credentials_from(&paths)"));
         assert!(!loader.contains("dirs::config_dir"));
+        assert!(!loader.contains("HYPRSTREAM__SECRETS__PATH"));
     }
 
     fn service() -> DiscoveryService {
@@ -4457,69 +4616,289 @@ mod resolver_tests {
     }
 
     #[test]
-    fn redirected_credential_directories_have_zero_registry_authority() {
-        const CHILD: &str = "HYPRSTREAM_TEST_FIXED_REGISTRY_CREDENTIAL_CHILD";
-        const ATTACKER_KEY: &str = "HYPRSTREAM_TEST_ATTACKER_REGISTRY_KEY";
-        if std::env::var_os(CHILD).is_some() {
-            let key_bytes: [u8; 32] =
-                hex::decode(std::env::var(ATTACKER_KEY).expect("attacker registry key"))
-                    .expect("attacker key hex")
-                    .try_into()
-                    .expect("attacker key length");
-            let attacker = VerifyingKey::from_bytes(&key_bytes).expect("attacker key");
-            match load_trusted_registry_deployment_credentials() {
-                Ok(credentials) => {
-                    let witness = authenticate_registry_deployment_credentials(credentials)
-                        .expect("fixed OS-owned credential pair must authenticate");
-                    assert!(
-                        !witness.verifier.matches(&attacker),
-                        "ambient credential pair selected production authority"
-                    );
-                }
-                Err(error) => assert!(
-                    error.to_string().contains(DEPLOYMENT_CA_ROOT_PATH)
-                        || error
-                            .to_string()
-                            .contains(REGISTRY_DEPLOYMENT_CREDENTIAL_PATH),
-                    "startup did not fail at the fixed OS-owned seam: {error}"
-                ),
-            }
-            return;
-        }
+    fn deployment_trust_path_resolution_is_explicit_and_split() {
+        let fixed = resolve_deployment_trust_paths_from(None, None).expect("fixed paths");
+        assert_eq!(
+            fixed.public_ca.path,
+            std::path::Path::new(DEPLOYMENT_CA_ROOT_PATH)
+        );
+        assert_eq!(
+            fixed.authority_log.path,
+            std::path::Path::new(DEPLOYMENT_AUTHORITY_LOG_PATH)
+        );
+        assert_eq!(
+            fixed.authority_checkpoint.path,
+            std::path::Path::new(DEPLOYMENT_AUTHORITY_CHECKPOINT_PATH)
+        );
+        assert_eq!(
+            fixed.registry_credential.path,
+            std::path::Path::new(REGISTRY_DEPLOYMENT_CREDENTIAL_PATH)
+        );
+        assert_eq!(fixed.public_ca.owner, TrustFileOwner::Root);
+        assert_eq!(fixed.registry_credential.owner, TrustFileOwner::Root);
 
-        let alternate = tempfile::tempdir().expect("alternate credential directory");
+        let trust_dir = std::path::Path::new("/run/user/1000/hyprstream/trust");
+        let credentials_dir =
+            std::path::Path::new("/run/user/1000/systemd/credentials/hyprstream.service");
+        let overridden = resolve_deployment_trust_paths_from(
+            Some(trust_dir.as_os_str().to_owned()),
+            Some(credentials_dir.as_os_str().to_owned()),
+        )
+        .expect("explicit user-service paths");
+        assert_eq!(
+            overridden.public_ca.path,
+            trust_dir.join(DEPLOYMENT_CA_ROOT_FILE)
+        );
+        assert_eq!(
+            overridden.authority_log.path,
+            trust_dir.join(DEPLOYMENT_AUTHORITY_LOG_FILE)
+        );
+        assert_eq!(
+            overridden.authority_checkpoint.path,
+            trust_dir.join(DEPLOYMENT_AUTHORITY_CHECKPOINT_FILE)
+        );
+        assert_eq!(
+            overridden.registry_credential.path,
+            credentials_dir.join(REGISTRY_DEPLOYMENT_CREDENTIAL_FILE)
+        );
+        assert_eq!(overridden.public_ca.owner, TrustFileOwner::EffectiveUser);
+        assert_eq!(
+            overridden.registry_credential.owner,
+            TrustFileOwner::EffectiveUser
+        );
+
+        let trust_only =
+            resolve_deployment_trust_paths_from(Some(trust_dir.as_os_str().to_owned()), None)
+                .expect("trust-only override");
+        assert_eq!(
+            trust_only.public_ca.path,
+            trust_dir.join(DEPLOYMENT_CA_ROOT_FILE)
+        );
+        assert_eq!(
+            trust_only.registry_credential.path,
+            std::path::Path::new(REGISTRY_DEPLOYMENT_CREDENTIAL_PATH)
+        );
+        assert_eq!(trust_only.registry_credential.owner, TrustFileOwner::Root);
+
+        let credentials_only =
+            resolve_deployment_trust_paths_from(None, Some(credentials_dir.as_os_str().to_owned()))
+                .expect("credentials-only override");
+        assert_eq!(
+            credentials_only.public_ca.path,
+            std::path::Path::new(DEPLOYMENT_CA_ROOT_PATH)
+        );
+        assert_eq!(
+            credentials_only.registry_credential.path,
+            credentials_dir.join(REGISTRY_DEPLOYMENT_CREDENTIAL_FILE)
+        );
+        assert_eq!(credentials_only.public_ca.owner, TrustFileOwner::Root);
+    }
+
+    #[test]
+    fn invalid_present_trust_path_never_falls_back() {
+        for (name, trust_dir, credentials_dir) in [
+            (
+                DEPLOYMENT_TRUST_DIR_ENV,
+                Some(std::ffi::OsString::new()),
+                None,
+            ),
+            (
+                DEPLOYMENT_TRUST_DIR_ENV,
+                Some(std::ffi::OsString::from("relative/trust")),
+                None,
+            ),
+            (
+                DEPLOYMENT_TRUST_DIR_ENV,
+                Some(std::ffi::OsString::from("/secure/../other")),
+                None,
+            ),
+            (
+                SYSTEMD_CREDENTIALS_DIRECTORY_ENV,
+                None,
+                Some(std::ffi::OsString::new()),
+            ),
+            (
+                SYSTEMD_CREDENTIALS_DIRECTORY_ENV,
+                None,
+                Some(std::ffi::OsString::from("relative/credentials")),
+            ),
+            (
+                SYSTEMD_CREDENTIALS_DIRECTORY_ENV,
+                None,
+                Some(std::ffi::OsString::from("/secure/../other")),
+            ),
+        ] {
+            let error = resolve_deployment_trust_paths_from(trust_dir, credentials_dir)
+                .expect_err("invalid present override fell back");
+            assert!(
+                error.to_string().contains(name),
+                "error did not identify {name}: {error}"
+            );
+        }
+    }
+
+    #[cfg(unix)]
+    fn user_service_trust_fixture() -> (
+        tempfile::TempDir,
+        DeploymentTrustPaths,
+        TestDeploymentCa,
+        SigningKey,
+    ) {
+        use base64::engine::general_purpose::STANDARD;
+
+        let fixture = tempfile::Builder::new()
+            .prefix(".trust-loader-test-")
+            .tempdir_in(env!("CARGO_MANIFEST_DIR"))
+            .expect("secure fixture directory");
+        let trust_dir = fixture.path().join("trust");
+        let credentials_dir = fixture.path().join("credentials");
+        std::fs::create_dir(&trust_dir).expect("trust directory");
+        std::fs::create_dir(&credentials_dir).expect("credentials directory");
+
         let ca = test_deployment_ca(0x71);
         let registry = SigningKey::from_bytes(&[0x72; 32]);
-        let jwt = exact_registry_credential(&ca, &registry);
-        let mut ca_pin = ca.verifying_keys.ed25519_bytes().to_vec();
-        ca_pin.extend_from_slice(&ca.verifying_keys.ml_dsa_65_bytes());
-        std::fs::write(alternate.path().join("ca-pubkey"), ca_pin).expect("alternate CA");
-        std::fs::write(alternate.path().join("registry-service-jwt"), jwt)
-            .expect("alternate registry JWT");
-        let user_config = alternate.path().join("user-config");
-        let user_credentials = user_config.join("hyprstream/credentials");
-        std::fs::create_dir_all(&user_credentials).expect("user credential fallback");
-        std::fs::copy(
-            alternate.path().join("ca-pubkey"),
-            user_credentials.join("ca-pubkey"),
+        let rotation_key = crate::did_op::HybridRotationKey::new(
+            ca.ed25519.verifying_key().to_bytes(),
+            hyprstream_crypto::pq::ml_dsa_sk_to_vk_bytes(&ca.ml_dsa_65),
         )
-        .expect("user CA copy");
-        std::fs::copy(
-            alternate.path().join("registry-service-jwt"),
-            user_credentials.join("registry-service-jwt"),
+        .expect("hybrid rotation key");
+        let genesis =
+            crate::did_op::DidOp::signed_genesis(vec![rotation_key], &ca.ed25519, &ca.ml_dsa_65)
+                .expect("signed authority genesis");
+        let did = genesis.genesis_did().expect("authority-log DID");
+        let active = crate::did_op::verify_did_op_log(&did, std::slice::from_ref(&genesis))
+            .expect("verified authority log");
+        let log = DeploymentAuthorityLog {
+            schema: AUTHORITY_LOG_SCHEMA.to_owned(),
+            deployment_domain: ca.verifying_keys.domain(),
+            did: did.clone(),
+            operations_b64: vec![STANDARD.encode(genesis.to_dag_cbor())],
+        };
+        let checkpoint = DeploymentAuthorityCheckpoint {
+            schema: AUTHORITY_CHECKPOINT_SCHEMA.to_owned(),
+            deployment_domain: ca.verifying_keys.domain(),
+            did,
+            sequence: active.sequence,
+            head_cid: active.head_cid,
+        };
+        let mut public_ca = ca.verifying_keys.ed25519_bytes().to_vec();
+        public_ca.extend_from_slice(&ca.verifying_keys.ml_dsa_65_bytes());
+        std::fs::write(trust_dir.join(DEPLOYMENT_CA_ROOT_FILE), public_ca).expect("deployment CA");
+        std::fs::write(
+            trust_dir.join(DEPLOYMENT_AUTHORITY_LOG_FILE),
+            serde_json::to_vec(&log).expect("authority-log JSON"),
         )
-        .expect("user JWT copy");
-        let status = std::process::Command::new(std::env::current_exe().expect("test executable"))
-            .arg("--exact")
-            .arg("service::resolver_tests::redirected_credential_directories_have_zero_registry_authority")
-            .arg("--nocapture")
-            .env(CHILD, "1")
-            .env("CREDENTIALS_DIRECTORY", alternate.path())
-            .env("XDG_CONFIG_HOME", &user_config)
-            .env(ATTACKER_KEY, hex::encode(registry.verifying_key().as_bytes()))
-            .status()
-            .expect("redirected credential subprocess");
-        assert!(status.success(), "redirected credential subprocess failed");
+        .expect("authority log");
+        std::fs::write(
+            trust_dir.join(DEPLOYMENT_AUTHORITY_CHECKPOINT_FILE),
+            serde_json::to_vec(&checkpoint).expect("checkpoint JSON"),
+        )
+        .expect("authority checkpoint");
+        std::fs::write(
+            credentials_dir.join(REGISTRY_DEPLOYMENT_CREDENTIAL_FILE),
+            exact_registry_credential(&ca, &registry),
+        )
+        .expect("registry credential");
+        let paths = resolve_deployment_trust_paths_from(
+            Some(trust_dir.into_os_string()),
+            Some(credentials_dir.into_os_string()),
+        )
+        .expect("fixture trust paths");
+        (fixture, paths, ca, registry)
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn user_service_paths_preserve_complete_enrolled_verification() {
+        let (_fixture, paths, ca, registry) = user_service_trust_fixture();
+        let credentials = load_trusted_registry_deployment_credentials_from(&paths)
+            .expect("load explicit user-service artifacts");
+        let witness = authenticate_registry_deployment_credentials(credentials)
+            .expect("authenticate complete enrolled artifact set");
+        assert!(witness.verifier.matches(&registry.verifying_key()));
+        assert!(witness.verifier.matches_deployment_root(&ca.verifying_keys));
+
+        let (protected, mut claims) = exact_registry_credential_values(&ca, &registry);
+        claims["aud"] = serde_json::Value::String("urn:hyprstream:service:other".to_owned());
+        std::fs::write(
+            &paths.registry_credential.path,
+            sign_registry_credential_json(&ca, &protected.to_string(), &claims.to_string()),
+        )
+        .expect("invalid-audience credential");
+        let credentials = load_trusted_registry_deployment_credentials_from(&paths)
+            .expect("path loader must not pre-authenticate");
+        assert!(
+            authenticate_registry_deployment_credentials(credentials).is_err(),
+            "explicit path bypassed the closed JWT audience/profile verifier"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn user_service_paths_reject_writable_files_and_symlinks() {
+        use std::os::unix::fs::{symlink, PermissionsExt as _};
+
+        let (_fixture, paths, _ca, _registry) = user_service_trust_fixture();
+        std::fs::set_permissions(
+            &paths.registry_credential.path,
+            std::fs::Permissions::from_mode(0o622),
+        )
+        .expect("make credential writable");
+        let error = load_trusted_registry_deployment_credentials_from(&paths)
+            .err()
+            .expect("group-writable credential was trusted");
+        assert!(error.to_string().contains("group/world writable"));
+
+        let real_credential = paths
+            .registry_credential
+            .path
+            .with_file_name("registry-service.real.jwt");
+        std::fs::rename(&paths.registry_credential.path, &real_credential)
+            .expect("retain real credential");
+        std::fs::set_permissions(&real_credential, std::fs::Permissions::from_mode(0o600))
+            .expect("secure real credential");
+        symlink(&real_credential, &paths.registry_credential.path).expect("credential symlink");
+        let error = load_trusted_registry_deployment_credentials_from(&paths)
+            .err()
+            .expect("symlinked credential was trusted");
+        assert!(
+            error
+                .to_string()
+                .contains("Too many levels of symbolic links")
+                || error
+                    .to_string()
+                    .contains("registry deployment credential is unavailable"),
+            "unexpected symlink rejection: {error}"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn user_service_paths_reject_writable_or_symlinked_ancestors() {
+        use std::os::unix::fs::{symlink, PermissionsExt as _};
+
+        let (fixture, paths, _ca, _registry) = user_service_trust_fixture();
+        std::fs::set_permissions(fixture.path(), std::fs::Permissions::from_mode(0o770))
+            .expect("make fixture parent writable");
+        let error = load_trusted_registry_deployment_credentials_from(&paths)
+            .err()
+            .expect("group-writable ancestor was trusted");
+        assert!(error.to_string().contains("parent"));
+        assert!(error.to_string().contains("group/world writable"));
+
+        std::fs::set_permissions(fixture.path(), std::fs::Permissions::from_mode(0o700))
+            .expect("restore fixture parent");
+        let trust_dir = fixture.path().join("trust");
+        let real_trust_dir = fixture.path().join("real-trust");
+        std::fs::rename(&trust_dir, &real_trust_dir).expect("retain real trust directory");
+        symlink(&real_trust_dir, &trust_dir).expect("trust-directory symlink");
+        let error = load_trusted_registry_deployment_credentials_from(&paths)
+            .err()
+            .expect("symlinked trust ancestor was trusted");
+        assert!(
+            error.to_string().contains("not a real directory"),
+            "unexpected ancestor-symlink rejection: {error}"
+        );
     }
 
     #[test]

--- a/crates/hyprstream/Cargo.toml
+++ b/crates/hyprstream/Cargo.toml
@@ -170,7 +170,7 @@ blake3.workspace = true                  # Fast cryptographic hashing for checks
 ciborium.workspace = true                # Canonical CBOR for tamper-evident audit records (#677 Fu6)
 tempfile.workspace = true                # Temporary files for model conversion
 base64.workspace = true                  # JWT token encoding
-ed25519-dalek.workspace = true           # JWT Ed25519 signatures
+ed25519-dalek = { workspace = true, features = ["pkcs8"] } # JWT/PIV Ed25519 signatures
 ssh-key = { version = "0.6", features = ["ed25519", "encryption"] }  # OpenSSH Ed25519 key import (user create --ssh)
 p256.workspace = true                    # ES256 DPoP verification (atproto interop)
 k256.workspace = true                    # ES256K ATProto service-auth verification

--- a/crates/hyprstream/src/bin/main.rs
+++ b/crates/hyprstream/src/bin/main.rs
@@ -11,7 +11,8 @@ use tracing::info;
 
 // Core application imports
 use hyprstream_core::cli::commands::{
-    ExecutionMode, FlightArgs, ImageCommand, ServiceAction, TrainingAction, TuiAction, WorkerAction,
+    ExecutionMode, FlightArgs, ImageCommand, ServiceAction, TrainingAction, TrustCommand, TuiAction,
+    WorkerAction,
 };
 use hyprstream_core::cli::quick::{QuickCommand, RemoteQuickCommand, WorktreeQuickCommand};
 use hyprstream_core::cli::schema_cli;
@@ -135,6 +136,13 @@ fn build_cli() -> ClapCommand {
     app = app.subcommand(
         <ServiceAction as ClapSubcommand>::augment_subcommands(
             ClapCommand::new("service").about("Service management and lifecycle commands"),
+        ),
+    );
+
+    // Out-of-band deployment trust authority tooling.
+    app = app.subcommand(
+        <TrustCommand as ClapSubcommand>::augment_subcommands(
+            ClapCommand::new("trust").about("Mint and verify deployment trust artifacts"),
         ),
     );
 
@@ -1724,6 +1732,16 @@ fn main() -> Result<()> {
 
     // Parse CLI arguments using builder API
     let matches = build_cli().get_matches();
+
+    // Trust minting is intentionally independent of local service/config
+    // bootstrap. It must work on an offline operator machine and must never
+    // start a registry client or load instance credentials.
+    if let Some(("trust", sub_m)) = matches.subcommand() {
+        let command =
+            TrustCommand::from_arg_matches(sub_m).map_err(|error| anyhow::anyhow!("{error}"))?;
+        hyprstream_core::cli::trust::handle_trust_command(command)?;
+        return Ok(());
+    }
 
     // Extract global args
     let config_path = matches

--- a/crates/hyprstream/src/cli/commands/mod.rs
+++ b/crates/hyprstream/src/cli/commands/mod.rs
@@ -4,6 +4,7 @@ pub mod flight;
 pub mod git;
 pub mod policy;
 pub mod training;
+pub mod trust;
 pub mod user;
 pub mod worker;
 
@@ -11,6 +12,10 @@ pub use flight::FlightArgs;
 pub use git::{GitAction, GitCommand};
 pub use policy::{PolicyCommand, RoleCommand, TokenCommand};
 pub use training::{TrainingAction, TrainingCommand};
+pub use trust::{
+    DelegateRegistrySignerArgs, MintDeploymentCaArgs, MintRegistryJwtArgs, RotateAuthorityArgs,
+    TrustCommand, VerifyDeploymentArgs,
+};
 pub use user::{UserCommand, UserKeysCommand, UserKeysImportFormat};
 pub use worker::{ImageCommand, WorkerAction};
 

--- a/crates/hyprstream/src/cli/commands/trust.rs
+++ b/crates/hyprstream/src/cli/commands/trust.rs
@@ -29,6 +29,10 @@ pub struct MintDeploymentCaArgs {
     #[arg(long, default_value = "deployment-authority.log.json")]
     pub authority_log: PathBuf,
 
+    /// Independently provisioned expected authority-log head.
+    #[arg(long, default_value = "deployment-authority.head.json")]
+    pub authority_checkpoint: PathBuf,
+
     /// Native age or age-plugin recipient. Repeat to add recovery recipients.
     #[arg(long = "recipient", value_name = "AGE_RECIPIENT")]
     pub recipients: Vec<String>,
@@ -59,6 +63,10 @@ pub struct DelegateRegistrySignerArgs {
     /// Signed authority rotation log.
     #[arg(long, default_value = "deployment-authority.log.json")]
     pub authority_log: PathBuf,
+
+    /// Independently trusted expected authority-log head.
+    #[arg(long, default_value = "deployment-authority.head.json")]
+    pub authority_checkpoint: PathBuf,
 
     /// Age-encrypted root/current authority bundle.
     #[arg(long, default_value = "deployment-ca.age")]
@@ -140,13 +148,13 @@ pub struct MintRegistryJwtArgs {
     )]
     pub delegation: Option<PathBuf>,
 
-    /// Installed/current public authority log. Required for delegated credentials.
-    #[arg(
-        long,
-        value_name = "AUTHORITY_LOG.json",
-        required_unless_present = "root"
-    )]
-    pub authority_log: Option<PathBuf>,
+    /// Installed/current public authority log. Required for every credential.
+    #[arg(long, default_value = "deployment-authority.log.json")]
+    pub authority_log: PathBuf,
+
+    /// Independently trusted expected authority-log head.
+    #[arg(long, default_value = "deployment-authority.head.json")]
+    pub authority_checkpoint: PathBuf,
 
     /// Rare/bootstrap path: sign directly with the deployment authority.
     #[arg(long, conflicts_with = "via_delegated_signer")]
@@ -182,6 +190,10 @@ pub struct RotateAuthorityArgs {
     /// Current signed authority rotation log.
     #[arg(long, default_value = "deployment-authority.log.json")]
     pub authority_log: PathBuf,
+
+    /// Current independently trusted expected authority-log head.
+    #[arg(long, default_value = "deployment-authority.head.json")]
+    pub authority_checkpoint: PathBuf,
 
     /// Age-encrypted currently active authority used to sign the rotation.
     #[arg(long, default_value = "deployment-ca.age")]
@@ -223,6 +235,10 @@ pub struct RotateAuthorityArgs {
     #[arg(long, default_value = "deployment-authority.log.next.json")]
     pub authority_log_out: PathBuf,
 
+    /// Updated independently trusted authority-log head output.
+    #[arg(long, default_value = "deployment-authority.head.next.json")]
+    pub authority_checkpoint_out: PathBuf,
+
     /// Replace existing output files.
     #[arg(long)]
     pub force: bool,
@@ -238,9 +254,13 @@ pub struct VerifyDeploymentArgs {
     #[arg(long, default_value = "registry-service.jwt")]
     pub jwt: PathBuf,
 
-    /// Installed/current authority log (required for delegated credentials).
-    #[arg(long)]
-    pub authority_log: Option<PathBuf>,
+    /// Installed/current authority log (required for every credential).
+    #[arg(long, default_value = "deployment-authority.log.json")]
+    pub authority_log: PathBuf,
+
+    /// Independently trusted expected authority-log head.
+    #[arg(long, default_value = "deployment-authority.head.json")]
+    pub authority_checkpoint: PathBuf,
 
     /// Optional contract whose public artifacts must match the files.
     #[arg(long)]

--- a/crates/hyprstream/src/cli/commands/trust.rs
+++ b/crates/hyprstream/src/cli/commands/trust.rs
@@ -1,0 +1,248 @@
+use clap::{Args, Subcommand};
+use std::path::PathBuf;
+
+#[derive(Debug, Subcommand)]
+pub enum TrustCommand {
+    /// Generate an Ed25519 + ML-DSA-65 deployment authority.
+    MintDeploymentCa(MintDeploymentCaArgs),
+    /// Create a root-authorized, registry-only online signer.
+    DelegateRegistrySigner(DelegateRegistrySignerArgs),
+    /// Mint the one-hour registry deployment credential.
+    MintRegistryJwt(MintRegistryJwtArgs),
+    /// Verify deployment artifacts through the production verifier.
+    VerifyDeployment(VerifyDeploymentArgs),
+    /// Add or replace an authority key through the signed rotation log.
+    RotateAuthority(RotateAuthorityArgs),
+}
+
+#[derive(Debug, Args)]
+pub struct MintDeploymentCaArgs {
+    /// Raw 1984-byte public root output (32-byte Ed25519, then 1952-byte ML-DSA-65).
+    #[arg(long, default_value = "deployment-ca.hybrid")]
+    pub public_ca: PathBuf,
+
+    /// Age-encrypted authority bundle. This file must remain operator-held.
+    #[arg(long, default_value = "deployment-ca.age")]
+    pub authority_key: PathBuf,
+
+    /// Signed authority rotation log, anchored by the raw public root.
+    #[arg(long, default_value = "deployment-authority.log.json")]
+    pub authority_log: PathBuf,
+
+    /// Native age or age-plugin recipient. Repeat to add recovery recipients.
+    #[arg(long = "recipient", value_name = "AGE_RECIPIENT")]
+    pub recipients: Vec<String>,
+
+    /// age-plugin-yubikey recipient (age1yubikey1...). Repeatable.
+    #[arg(long = "yubikey", value_name = "AGE_YUBIKEY_RECIPIENT")]
+    pub yubikey_recipients: Vec<String>,
+
+    /// Cloud/PQ-HSM age-plugin recipient. Repeatable.
+    #[arg(long = "kms-plugin", value_name = "AGE_PLUGIN_RECIPIENT")]
+    pub kms_plugin_recipients: Vec<String>,
+
+    /// Place the Ed25519 leg in this YubiKey PIV slot (firmware 5.7.4+).
+    #[arg(long, value_name = "SLOT")]
+    pub piv_slot: Option<String>,
+
+    /// Replace existing output files.
+    #[arg(long)]
+    pub force: bool,
+}
+
+#[derive(Debug, Args)]
+pub struct DelegateRegistrySignerArgs {
+    /// Raw 1984-byte public deployment root.
+    #[arg(long, default_value = "deployment-ca.hybrid")]
+    pub public_ca: PathBuf,
+
+    /// Signed authority rotation log.
+    #[arg(long, default_value = "deployment-authority.log.json")]
+    pub authority_log: PathBuf,
+
+    /// Age-encrypted root/current authority bundle.
+    #[arg(long, default_value = "deployment-ca.age")]
+    pub authority_key: PathBuf,
+
+    /// Identity used to unlock the root/current authority. Repeatable.
+    #[arg(long = "identity", value_name = "AGE_IDENTITY_FILE")]
+    pub identities: Vec<PathBuf>,
+
+    /// YubiKey identity used to unlock the root/current authority. Repeatable.
+    #[arg(long = "yubikey-identity", value_name = "AGE_YUBIKEY_IDENTITY_FILE")]
+    pub yubikey_identities: Vec<PathBuf>,
+
+    /// Break-glass: use the age-wrapped recovery copy of a PIV Ed25519 key.
+    #[arg(long)]
+    pub software_recovery: bool,
+
+    /// Recipient for the separately encrypted online signer. Repeatable.
+    #[arg(long = "signer-recipient", value_name = "AGE_RECIPIENT")]
+    pub signer_recipients: Vec<String>,
+
+    /// Encrypted online signer output.
+    #[arg(long, default_value = "registry-delegated-signer.age")]
+    pub delegated_key: PathBuf,
+
+    /// Root-authorized delegation output.
+    #[arg(long, default_value = "registry-signer.delegation.json")]
+    pub delegation: PathBuf,
+
+    /// Delegation lifetime in seconds (default 30 days, maximum one year).
+    #[arg(
+        long,
+        default_value_t = 2_592_000,
+        value_parser = clap::value_parser!(u64).range(3600..=31_536_000)
+    )]
+    pub delegation_ttl_seconds: u64,
+
+    /// Replace existing output files.
+    #[arg(long)]
+    pub force: bool,
+}
+
+#[derive(Debug, Args)]
+pub struct MintRegistryJwtArgs {
+    /// Raw 1984-byte public deployment root.
+    #[arg(long, default_value = "deployment-ca.hybrid")]
+    pub public_ca: PathBuf,
+
+    /// Age-encrypted root authority bundle (used only with --root).
+    #[arg(long, default_value = "deployment-ca.age")]
+    pub authority_key: PathBuf,
+
+    /// Age identity file. Repeatable for native or plugin identities.
+    #[arg(long = "identity", value_name = "AGE_IDENTITY_FILE")]
+    pub identities: Vec<PathBuf>,
+
+    /// age-plugin-yubikey identity file. Repeatable; decryption requires the token.
+    #[arg(long = "yubikey-identity", value_name = "AGE_YUBIKEY_IDENTITY_FILE")]
+    pub yubikey_identities: Vec<PathBuf>,
+
+    /// Break-glass: use the age-wrapped recovery copy of a PIV Ed25519 key.
+    #[arg(long)]
+    pub software_recovery: bool,
+
+    /// Common path: decrypt this scoped online signer.
+    #[arg(
+        long,
+        value_name = "DELEGATED_KEY.age",
+        conflicts_with = "root",
+        required_unless_present = "root"
+    )]
+    pub via_delegated_signer: Option<PathBuf>,
+
+    /// Delegation authorizing --via-delegated-signer.
+    #[arg(
+        long,
+        value_name = "DELEGATION.json",
+        requires = "via_delegated_signer"
+    )]
+    pub delegation: Option<PathBuf>,
+
+    /// Installed/current public authority log. Required for delegated credentials.
+    #[arg(
+        long,
+        value_name = "AUTHORITY_LOG.json",
+        required_unless_present = "root"
+    )]
+    pub authority_log: Option<PathBuf>,
+
+    /// Rare/bootstrap path: sign directly with the deployment authority.
+    #[arg(long, conflicts_with = "via_delegated_signer")]
+    pub root: bool,
+
+    /// Raw 32-byte Ed25519 registry-service public key for the cnf claim.
+    #[arg(long, value_name = "PATH")]
+    pub registry_public_key: PathBuf,
+
+    /// Credential lifetime in seconds; the profile caps this at one hour.
+    #[arg(long, default_value_t = 3600, value_parser = clap::value_parser!(u32).range(1..=3600))]
+    pub ttl_seconds: u32,
+
+    /// Registry deployment credential output.
+    #[arg(long, default_value = "registry-service.jwt")]
+    pub jwt: PathBuf,
+
+    /// Out-of-band cloud-secret publisher manifest (never pass its values to Terraform).
+    #[arg(long, default_value = "deployment-trust.contract.json")]
+    pub contract: PathBuf,
+
+    /// Replace existing output files.
+    #[arg(long)]
+    pub force: bool,
+}
+
+#[derive(Debug, Args)]
+pub struct RotateAuthorityArgs {
+    /// Raw 1984-byte original public root (does not change during log rotation).
+    #[arg(long, default_value = "deployment-ca.hybrid")]
+    pub public_ca: PathBuf,
+
+    /// Current signed authority rotation log.
+    #[arg(long, default_value = "deployment-authority.log.json")]
+    pub authority_log: PathBuf,
+
+    /// Age-encrypted currently active authority used to sign the rotation.
+    #[arg(long, default_value = "deployment-ca.age")]
+    pub authority_key: PathBuf,
+
+    /// Identity used to unlock the current authority. Repeatable.
+    #[arg(long = "identity", value_name = "AGE_IDENTITY_FILE")]
+    pub identities: Vec<PathBuf>,
+
+    /// YubiKey identity used to unlock the current authority. Repeatable.
+    #[arg(long = "yubikey-identity", value_name = "AGE_YUBIKEY_IDENTITY_FILE")]
+    pub yubikey_identities: Vec<PathBuf>,
+
+    /// Break-glass: use the age-wrapped recovery copy of a PIV Ed25519 key.
+    #[arg(long)]
+    pub software_recovery: bool,
+
+    /// Recipient ring for the new authority. At least two distinct values.
+    #[arg(long = "recipient", value_name = "AGE_RECIPIENT")]
+    pub recipients: Vec<String>,
+
+    /// Keep existing active authority keys and add the new key.
+    #[arg(long, conflicts_with = "replace")]
+    pub add: bool,
+
+    /// Retire existing active authority keys after authorizing the new key.
+    #[arg(long, conflicts_with = "add")]
+    pub replace: bool,
+
+    /// Encrypted new authority key output.
+    #[arg(long, default_value = "deployment-authority-next.age")]
+    pub new_authority_key: PathBuf,
+
+    /// Raw 1984-byte new authority public pair (operator record, not the root pin).
+    #[arg(long, default_value = "deployment-authority-next.hybrid")]
+    pub new_public_key: PathBuf,
+
+    /// Updated signed rotation log output.
+    #[arg(long, default_value = "deployment-authority.log.next.json")]
+    pub authority_log_out: PathBuf,
+
+    /// Replace existing output files.
+    #[arg(long)]
+    pub force: bool,
+}
+
+#[derive(Debug, Args)]
+pub struct VerifyDeploymentArgs {
+    /// Raw 1984-byte public deployment root.
+    #[arg(long, default_value = "deployment-ca.hybrid")]
+    pub public_ca: PathBuf,
+
+    /// Registry deployment credential.
+    #[arg(long, default_value = "registry-service.jwt")]
+    pub jwt: PathBuf,
+
+    /// Installed/current authority log (required for delegated credentials).
+    #[arg(long)]
+    pub authority_log: Option<PathBuf>,
+
+    /// Optional contract whose public artifacts must match the files.
+    #[arg(long)]
+    pub contract: Option<PathBuf>,
+}

--- a/crates/hyprstream/src/cli/mod.rs
+++ b/crates/hyprstream/src/cli/mod.rs
@@ -24,6 +24,7 @@ pub mod shell_handlers;
 pub mod sign_challenge;
 pub mod systemd_setup;
 pub mod training_handlers;
+pub mod trust;
 pub mod tui_handlers;
 pub mod update_handlers;
 pub mod user_handlers;

--- a/crates/hyprstream/src/cli/trust.rs
+++ b/crates/hyprstream/src/cli/trust.rs
@@ -1,0 +1,1874 @@
+//! Deployment trust-authority minting.
+//!
+//! The root authority is an out-of-band, age-encrypted operator asset. Hourly
+//! registry credentials should be minted by a narrowly scoped delegated signer;
+//! direct root signing exists only for bootstrap and recovery.
+
+#![allow(clippy::print_stdout)]
+
+use crate::cli::commands::{
+    DelegateRegistrySignerArgs, MintDeploymentCaArgs, MintRegistryJwtArgs, RotateAuthorityArgs,
+    TrustCommand, VerifyDeploymentArgs,
+};
+use anyhow::{anyhow, bail, ensure, Context, Result};
+use base64::{
+    engine::general_purpose::{STANDARD, URL_SAFE_NO_PAD},
+    Engine as _,
+};
+use ed25519_dalek::{pkcs8::EncodePrivateKey as _, Signer as _, SigningKey, VerifyingKey};
+use hyprstream_discovery::did_op::{
+    verify_did_op_log, DidOp, HybridDidOpSignature, HybridRotationKey, DID_OP_SIGNATURE_CONTEXT,
+};
+use hyprstream_discovery::{
+    DeploymentAuthorityLog as AuthorityLogFile, RegistryDelegationArtifact as DelegationArtifact,
+};
+use hyprstream_rpc::{
+    auth::ucan::{
+        validate as validate_ucan, Ability, Capability, CaveatValue, Caveats, Did, Resource, Ucan,
+        UcanError, UcanPayload, UcanVerifier,
+    },
+    crypto::{
+        cose_sign::{assemble_composite_nested, inner_tbs, outer_tbs},
+        pq::{
+            ml_dsa_generate_keypair, ml_dsa_sign, ml_dsa_sk_from_seed, ml_dsa_sk_to_seed,
+            ml_dsa_sk_to_vk_bytes, ml_dsa_vk_bytes, ml_dsa_vk_from_bytes, MlDsaSigningKey,
+        },
+    },
+};
+use rand::RngCore as _;
+use serde::{Deserialize, Serialize};
+use sha2::{Digest as _, Sha256};
+use std::{
+    collections::{BTreeMap, BTreeSet},
+    fs::OpenOptions,
+    io::{Read as _, Write as _},
+    os::unix::fs::{OpenOptionsExt as _, PermissionsExt as _},
+    path::{Path, PathBuf},
+    process::{Command, Stdio},
+};
+use zeroize::Zeroize as _;
+
+const PUBLIC_CA_BYTES: usize = 32 + 1_952;
+const HYBRID_SIGNATURE_BYTES: usize = 3_309 + 64;
+const REGISTRY_AUDIENCE: &str = "urn:hyprstream:service:registry";
+const REGISTRY_PROFILE: &str = "hyprstream.registry-deployment.v1";
+const AUTHORITY_BUNDLE_SCHEMA: &str = "hyprstream.deployment-authority.v1";
+const AUTHORITY_LOG_SCHEMA: &str = "hyprstream.deployment-authority-log.v1";
+const DELEGATION_SCHEMA: &str = "hyprstream.registry-delegation.v1";
+const PUBLISHER_MANIFEST_SCHEMA: &str = "hyprstream.deployment-trust-publisher-manifest.v1";
+const DELEGATION_RESOURCE_PREFIX: &str = "hyprstream://deployment";
+const DELEGATION_ABILITY: &str = "mint-registry-jwt";
+const MAX_AUTHORITY_LOG_OPERATIONS: usize = 128;
+const MAX_DELEGATION_BYTES: usize = 256 * 1024;
+const MAX_CLOUD_SECRET_BYTES: usize = 64 * 1024;
+
+#[derive(Clone, Debug, Serialize, Deserialize, Eq, PartialEq)]
+#[serde(rename_all = "snake_case")]
+enum AuthorityPurpose {
+    Root,
+    RotatedAuthority,
+    RegistryDelegatedSigner,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+enum Ed25519Secret {
+    Software {
+        seed_b64: String,
+        public_b64: String,
+    },
+    YubikeyPiv {
+        slot: String,
+        public_b64: String,
+        recovery_seed_b64: String,
+    },
+}
+
+impl Drop for Ed25519Secret {
+    fn drop(&mut self) {
+        match self {
+            Self::Software { seed_b64, .. } => seed_b64.zeroize(),
+            Self::YubikeyPiv {
+                recovery_seed_b64, ..
+            } => recovery_seed_b64.zeroize(),
+        }
+    }
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct AuthorityBundle {
+    schema: String,
+    purpose: AuthorityPurpose,
+    deployment_domain: String,
+    public_key_sha256: String,
+    ed25519: Ed25519Secret,
+    ml_dsa_65_seed_b64: String,
+    recipient_count: usize,
+}
+
+impl Drop for AuthorityBundle {
+    fn drop(&mut self) {
+        self.ml_dsa_65_seed_b64.zeroize();
+    }
+}
+
+#[derive(Debug, Serialize)]
+struct CaMintOutput {
+    schema: &'static str,
+    deployment_domain: String,
+    authority_log_did: String,
+    public_ca_path: String,
+    public_ca_install_path: &'static str,
+    public_ca_bytes: usize,
+    public_ca_base64: String,
+    public_ca_sha256: String,
+    authority_key_path: String,
+    authority_key_export_allowed: bool,
+    recipient_count: usize,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct PublisherArtifact {
+    local_path: String,
+    install_path: String,
+    encoding: String,
+    base64: String,
+    sha256: String,
+    size_bytes: usize,
+    cloud_secret_store: bool,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct PublisherManifest {
+    schema: String,
+    deployment_domain: String,
+    profile: String,
+    audience: String,
+    expires_at: i64,
+    public_ca: PublisherArtifact,
+    authority_log: Option<PublisherArtifact>,
+    registry_jwt: PublisherArtifact,
+    private_authority_exported: bool,
+    terraform_state_may_contain_private_authority: bool,
+}
+
+enum LoadedEdSigner {
+    Software(SigningKey),
+    YubikeyPiv { slot: String, public: VerifyingKey },
+}
+
+impl LoadedEdSigner {
+    fn verifying_key(&self) -> VerifyingKey {
+        match self {
+            Self::Software(key) => key.verifying_key(),
+            Self::YubikeyPiv { public, .. } => *public,
+        }
+    }
+
+    fn sign(&self, message: &[u8]) -> Result<[u8; 64]> {
+        match self {
+            Self::Software(key) => Ok(key.sign(message).to_bytes()),
+            Self::YubikeyPiv { slot, public } => piv_sign(slot, public, message),
+        }
+    }
+}
+
+struct LoadedAuthority {
+    bundle: AuthorityBundle,
+    ed: LoadedEdSigner,
+    pq: MlDsaSigningKey,
+}
+
+impl LoadedAuthority {
+    fn public_bytes(&self) -> Vec<u8> {
+        public_pair_bytes(&self.ed.verifying_key(), &self.pq)
+    }
+}
+
+/// Dispatch one early-startup trust command.
+pub fn handle_trust_command(command: TrustCommand) -> Result<()> {
+    match command {
+        TrustCommand::MintDeploymentCa(args) => mint_deployment_ca(&args),
+        TrustCommand::DelegateRegistrySigner(args) => delegate_registry_signer(&args),
+        TrustCommand::MintRegistryJwt(args) => mint_registry_jwt(&args),
+        TrustCommand::VerifyDeployment(args) => verify_deployment(&args),
+        TrustCommand::RotateAuthority(args) => rotate_authority(&args),
+    }
+}
+
+fn mint_deployment_ca(args: &MintDeploymentCaArgs) -> Result<()> {
+    preflight_outputs(
+        [&args.public_ca, &args.authority_key, &args.authority_log],
+        args.force,
+    )?;
+    let recipients = root_recipient_ring(args)?;
+
+    let (ed_secret, ed_signer) = match args.piv_slot.as_deref() {
+        Some(slot) => {
+            let recovery_key = SigningKey::generate(&mut rand::rngs::OsRng);
+            let (slot, public) = piv_import_ed25519(slot, &recovery_key)?;
+            (
+                Ed25519Secret::YubikeyPiv {
+                    slot: slot.clone(),
+                    public_b64: STANDARD.encode(public.as_bytes()),
+                    recovery_seed_b64: STANDARD.encode(recovery_key.to_bytes()),
+                },
+                LoadedEdSigner::YubikeyPiv { slot, public },
+            )
+        }
+        None => {
+            let key = SigningKey::generate(&mut rand::rngs::OsRng);
+            (
+                Ed25519Secret::Software {
+                    seed_b64: STANDARD.encode(key.to_bytes()),
+                    public_b64: STANDARD.encode(key.verifying_key().as_bytes()),
+                },
+                LoadedEdSigner::Software(key),
+            )
+        }
+    };
+    let (pq, _) = ml_dsa_generate_keypair();
+    let public_ca = public_pair_bytes(&ed_signer.verifying_key(), &pq);
+    ensure!(
+        public_ca.len() == PUBLIC_CA_BYTES,
+        "internal public-root layout error"
+    );
+    let deployment_domain = hyprstream_discovery::verify_deployment_public_ca(&public_ca)
+        .context("production HybridDeploymentCa rejected generated public root")?;
+
+    let root_key = HybridRotationKey::new(
+        ed_signer.verifying_key().to_bytes(),
+        ml_dsa_sk_to_vk_bytes(&pq),
+    )?;
+    let genesis = sign_did_op(
+        DidOp {
+            sequence: 0,
+            prev: None,
+            rotation_keys: vec![root_key],
+            signature: placeholder_did_signature(),
+        },
+        &ed_signer,
+        &pq,
+    )?;
+    let authority_log = authority_log_from_ops(&deployment_domain, vec![genesis])?;
+    validate_authority_log(&public_ca, &authority_log)?;
+
+    let bundle = AuthorityBundle {
+        schema: AUTHORITY_BUNDLE_SCHEMA.to_owned(),
+        purpose: AuthorityPurpose::Root,
+        deployment_domain: deployment_domain.clone(),
+        public_key_sha256: sha256_hex(&public_ca),
+        ed25519: ed_secret,
+        ml_dsa_65_seed_b64: STANDARD.encode(ml_dsa_sk_to_seed(&pq)),
+        recipient_count: recipients.len(),
+    };
+    let mut plaintext = serde_json::to_vec(&bundle).context("encode authority bundle")?;
+    let encrypted = encrypt_age(&plaintext, &recipients)?;
+    plaintext.zeroize();
+
+    commit_outputs(vec![
+        PendingOutput::new(&args.public_ca, public_ca.clone(), 0o644),
+        PendingOutput::new(&args.authority_key, encrypted, 0o600),
+        PendingOutput::new(
+            &args.authority_log,
+            pretty_json_bytes(&authority_log)?,
+            0o644,
+        ),
+    ])?;
+
+    let output = CaMintOutput {
+        schema: "hyprstream.deployment-ca-mint-output.v1",
+        deployment_domain,
+        authority_log_did: authority_log.did,
+        public_ca_path: display_path(&args.public_ca),
+        public_ca_install_path: "/etc/hyprstream/trust/deployment-ca.hybrid",
+        public_ca_bytes: public_ca.len(),
+        public_ca_base64: STANDARD.encode(&public_ca),
+        public_ca_sha256: sha256_hex(&public_ca),
+        authority_key_path: display_path(&args.authority_key),
+        authority_key_export_allowed: false,
+        recipient_count: recipients.len(),
+    };
+    println!("{}", serde_json::to_string_pretty(&output)?);
+    Ok(())
+}
+
+fn delegate_registry_signer(args: &DelegateRegistrySignerArgs) -> Result<()> {
+    preflight_outputs([&args.delegated_key, &args.delegation], args.force)?;
+    ensure!(
+        !args.signer_recipients.is_empty(),
+        "at least one --signer-recipient is required for the rotatable online signer"
+    );
+    let signer_recipients = distinct_recipients(args.signer_recipients.clone())?;
+    let public_ca = read_limited(&args.public_ca, PUBLIC_CA_BYTES)?;
+    let log: AuthorityLogFile = read_json_limited(&args.authority_log, MAX_CLOUD_SECRET_BYTES)?;
+    let active = validate_authority_log(&public_ca, &log)?;
+
+    let identities = combined_identities(&args.identities, &args.yubikey_identities)?;
+    let authority = decrypt_authority(&args.authority_key, &identities, args.software_recovery)?;
+    ensure!(
+        authority.bundle.purpose != AuthorityPurpose::RegistryDelegatedSigner,
+        "a delegated signer cannot delegate another registry signer"
+    );
+    ensure_active_authority(&authority, &active)?;
+
+    let delegated_ed = SigningKey::generate(&mut rand::rngs::OsRng);
+    let (delegated_pq, _) = ml_dsa_generate_keypair();
+    let delegated_public = public_pair_bytes(&delegated_ed.verifying_key(), &delegated_pq);
+
+    let now = now_unix_u64()?;
+    let expiration = now
+        .checked_add(args.delegation_ttl_seconds)
+        .ok_or_else(|| anyhow!("delegation expiration overflow"))?;
+    let capability =
+        registry_mint_capability(&authority.bundle.deployment_domain, &delegated_public);
+    let payload = UcanPayload {
+        issuer: Did::from_ed25519(&authority.ed.verifying_key().to_bytes()),
+        audience: Did::from_ed25519(&delegated_ed.verifying_key().to_bytes()),
+        capabilities: vec![capability],
+        not_before: Some(now),
+        expiration: Some(expiration),
+        nonce: random_bytes(16),
+    };
+    let ucan = sign_ucan(payload, &authority.ed, &authority.pq)?;
+    validate_registry_delegation_ucan(
+        &ucan,
+        &authority.bundle.deployment_domain,
+        &delegated_public,
+        &active.rotation_keys,
+        now,
+    )?;
+
+    let delegated_bundle = AuthorityBundle {
+        schema: AUTHORITY_BUNDLE_SCHEMA.to_owned(),
+        purpose: AuthorityPurpose::RegistryDelegatedSigner,
+        deployment_domain: authority.bundle.deployment_domain.clone(),
+        public_key_sha256: sha256_hex(&delegated_public),
+        ed25519: Ed25519Secret::Software {
+            seed_b64: STANDARD.encode(delegated_ed.to_bytes()),
+            public_b64: STANDARD.encode(delegated_ed.verifying_key().as_bytes()),
+        },
+        ml_dsa_65_seed_b64: STANDARD.encode(ml_dsa_sk_to_seed(&delegated_pq)),
+        recipient_count: signer_recipients.len(),
+    };
+    let mut plaintext = serde_json::to_vec(&delegated_bundle)?;
+    let encrypted = encrypt_age(&plaintext, &signer_recipients)?;
+    plaintext.zeroize();
+
+    let artifact = DelegationArtifact {
+        schema: DELEGATION_SCHEMA.to_owned(),
+        deployment_domain: authority.bundle.deployment_domain.clone(),
+        authority_log_did: log.did.clone(),
+        delegated_public_key_b64: STANDARD.encode(&delegated_public),
+        ucan_b64: STANDARD.encode(ucan.to_cbor()?),
+    };
+    validate_delegation_artifact(&public_ca, &log, &artifact, now)?;
+    commit_outputs(vec![
+        PendingOutput::new(&args.delegated_key, encrypted, 0o600),
+        PendingOutput::new(&args.delegation, pretty_json_bytes(&artifact)?, 0o644),
+    ])?;
+    println!(
+        "{}",
+        serde_json::to_string_pretty(&serde_json::json!({
+            "schema": "hyprstream.registry-delegation-output.v1",
+            "deployment_domain": artifact.deployment_domain,
+            "delegated_key_path": display_path(&args.delegated_key),
+            "delegation_path": display_path(&args.delegation),
+            "delegation_expires_at": expiration,
+            "scope": {
+                "sub": "service:registry",
+                "aud": REGISTRY_AUDIENCE,
+                "profile": REGISTRY_PROFILE,
+                "max_ttl_seconds": 3600
+            }
+        }))?
+    );
+    Ok(())
+}
+
+fn mint_registry_jwt(args: &MintRegistryJwtArgs) -> Result<()> {
+    preflight_outputs([&args.jwt, &args.contract], args.force)?;
+    let public_ca = read_limited(&args.public_ca, PUBLIC_CA_BYTES)?;
+    let root_domain = hyprstream_discovery::verify_deployment_public_ca(&public_ca)?;
+    let registry_key: [u8; 32] = read_limited(&args.registry_public_key, 32)?
+        .try_into()
+        .map_err(|_| anyhow!("registry public key must be exactly 32 bytes"))?;
+    VerifyingKey::from_bytes(&registry_key).context("invalid registry Ed25519 public key")?;
+    let identities = combined_identities(&args.identities, &args.yubikey_identities)?;
+
+    let (signer, delegation_b64, authority_log) = if args.root {
+        let authority =
+            decrypt_authority(&args.authority_key, &identities, args.software_recovery)?;
+        ensure!(
+            authority.bundle.purpose == AuthorityPurpose::Root,
+            "--root accepts only the original root authority bundle"
+        );
+        ensure!(
+            authority.public_bytes() == public_ca,
+            "root authority does not match the pinned public CA"
+        );
+        let authority_log = args
+            .authority_log
+            .as_ref()
+            .map(|path| read_json_limited::<AuthorityLogFile>(path, MAX_CLOUD_SECRET_BYTES))
+            .transpose()?;
+        if let Some(log) = authority_log.as_ref() {
+            let active = validate_authority_log(&public_ca, log)?;
+            ensure_active_authority(&authority, &active)?;
+        }
+        (authority, None, authority_log)
+    } else {
+        let delegated_path = args
+            .via_delegated_signer
+            .as_ref()
+            .ok_or_else(|| anyhow!("--via-delegated-signer is required"))?;
+        let artifact_path = args
+            .delegation
+            .as_ref()
+            .ok_or_else(|| anyhow!("--delegation is required"))?;
+        let artifact: DelegationArtifact = read_json_limited(artifact_path, MAX_DELEGATION_BYTES)?;
+        let authority_log_path = args
+            .authority_log
+            .as_ref()
+            .ok_or_else(|| anyhow!("--authority-log is required with delegated signing"))?;
+        let installed_log: AuthorityLogFile =
+            read_json_limited(authority_log_path, MAX_CLOUD_SECRET_BYTES)?;
+        validate_authority_log(&public_ca, &installed_log)?;
+        validate_delegation_artifact(&public_ca, &installed_log, &artifact, now_unix_u64()?)?;
+        let delegated = decrypt_authority(delegated_path, &identities, args.software_recovery)?;
+        ensure!(
+            delegated.bundle.purpose == AuthorityPurpose::RegistryDelegatedSigner,
+            "selected key is not a registry delegated signer"
+        );
+        let declared = STANDARD
+            .decode(&artifact.delegated_public_key_b64)
+            .context("decode delegated public key")?;
+        ensure!(
+            delegated.public_bytes() == declared,
+            "delegated private key does not match the root-authorized delegation"
+        );
+        let artifact_json = serde_json::to_vec(&artifact)?;
+        (
+            delegated,
+            Some(URL_SAFE_NO_PAD.encode(artifact_json)),
+            Some(installed_log),
+        )
+    };
+    ensure!(
+        signer.bundle.deployment_domain == root_domain,
+        "signer is bound to a different deployment domain"
+    );
+
+    let now = chrono::Utc::now().timestamp();
+    let exp = now
+        .checked_add(i64::from(args.ttl_seconds))
+        .ok_or_else(|| anyhow!("credential expiration overflow"))?;
+    let token = encode_registry_jwt(&signer, &registry_key, now, exp, delegation_b64.as_deref())?;
+    ensure!(
+        token.len() <= MAX_CLOUD_SECRET_BYTES,
+        "registry JWT exceeds the 64 KiB cloud-secret contract"
+    );
+    let verified = match authority_log.as_ref() {
+        Some(log) => hyprstream_discovery::verify_deployment_artifacts_with_authority_log(
+            &public_ca,
+            &serde_json::to_vec(log)?,
+            &token,
+        ),
+        None => hyprstream_discovery::verify_deployment_artifacts(&public_ca, &token),
+    }
+    .context("production deployment verifier rejected minted credential")?;
+    ensure!(
+        verified.registry_public_key == registry_key && verified.deployment_domain == root_domain,
+        "production verification result does not match minted inputs"
+    );
+
+    let jwt_bytes = token.as_bytes();
+    let contract = PublisherManifest {
+        schema: PUBLISHER_MANIFEST_SCHEMA.to_owned(),
+        deployment_domain: root_domain,
+        profile: REGISTRY_PROFILE.to_owned(),
+        audience: REGISTRY_AUDIENCE.to_owned(),
+        expires_at: exp,
+        public_ca: PublisherArtifact {
+            local_path: display_path(&args.public_ca),
+            install_path: "/etc/hyprstream/trust/deployment-ca.hybrid".to_owned(),
+            encoding: "raw".to_owned(),
+            base64: STANDARD.encode(&public_ca),
+            sha256: sha256_hex(&public_ca),
+            size_bytes: public_ca.len(),
+            cloud_secret_store: true,
+        },
+        authority_log: authority_log
+            .as_ref()
+            .map(|log| {
+                let path = args
+                    .authority_log
+                    .as_ref()
+                    .ok_or_else(|| anyhow!("authority log path disappeared"))?;
+                let bytes = read_limited(path, MAX_CLOUD_SECRET_BYTES)?;
+                let persisted: AuthorityLogFile = serde_json::from_slice(&bytes)?;
+                ensure!(
+                    &persisted == log,
+                    "authority log changed while building publisher manifest"
+                );
+                Ok::<PublisherArtifact, anyhow::Error>(PublisherArtifact {
+                    local_path: display_path(path),
+                    install_path: "/etc/hyprstream/trust/deployment-authority.log.json".to_owned(),
+                    encoding: "json".to_owned(),
+                    base64: STANDARD.encode(&bytes),
+                    sha256: sha256_hex(&bytes),
+                    size_bytes: bytes.len(),
+                    cloud_secret_store: true,
+                })
+            })
+            .transpose()?,
+        registry_jwt: PublisherArtifact {
+            local_path: display_path(&args.jwt),
+            install_path: "/run/hyprstream/credentials/registry-service.jwt".to_owned(),
+            encoding: "utf8".to_owned(),
+            base64: STANDARD.encode(jwt_bytes),
+            sha256: sha256_hex(jwt_bytes),
+            size_bytes: jwt_bytes.len(),
+            cloud_secret_store: true,
+        },
+        private_authority_exported: false,
+        terraform_state_may_contain_private_authority: false,
+    };
+    commit_outputs(vec![
+        PendingOutput::new(&args.jwt, token.into_bytes(), 0o600),
+        PendingOutput::new(&args.contract, pretty_json_bytes(&contract)?, 0o600),
+    ])?;
+    println!("{}", serde_json::to_string_pretty(&contract)?);
+    Ok(())
+}
+
+fn verify_deployment(args: &VerifyDeploymentArgs) -> Result<()> {
+    let public_ca = read_limited(&args.public_ca, PUBLIC_CA_BYTES)?;
+    let token = String::from_utf8(read_limited(&args.jwt, MAX_CLOUD_SECRET_BYTES)?)
+        .context("registry JWT is not UTF-8")?;
+    ensure!(
+        !token.is_empty() && !token.bytes().any(|byte| byte.is_ascii_whitespace()),
+        "registry JWT must be compact with no surrounding or embedded whitespace"
+    );
+    let contract = args
+        .contract
+        .as_ref()
+        .map(|path| read_json_limited::<PublisherManifest>(path, 1024 * 1024))
+        .transpose()?;
+    let authority_log = match (&args.authority_log, contract.as_ref()) {
+        (Some(path), _) => Some(read_limited(path, MAX_CLOUD_SECRET_BYTES)?),
+        (None, Some(contract)) => contract
+            .authority_log
+            .as_ref()
+            .map(|artifact| STANDARD.decode(&artifact.base64))
+            .transpose()?,
+        (None, None) => None,
+    };
+    let verified = match authority_log.as_deref() {
+        Some(log) => hyprstream_discovery::verify_deployment_artifacts_with_authority_log(
+            &public_ca, log, &token,
+        ),
+        None => hyprstream_discovery::verify_deployment_artifacts(&public_ca, &token),
+    }?;
+    if let Some(contract) = contract {
+        ensure!(
+            contract.schema == PUBLISHER_MANIFEST_SCHEMA,
+            "unsupported contract schema"
+        );
+        ensure!(
+            STANDARD.decode(&contract.public_ca.base64)? == public_ca,
+            "contract public CA does not match file"
+        );
+        ensure!(
+            STANDARD.decode(&contract.registry_jwt.base64)? == token.as_bytes(),
+            "contract JWT does not match file"
+        );
+        if let Some(artifact) = contract.authority_log.as_ref() {
+            let log = authority_log
+                .as_ref()
+                .ok_or_else(|| anyhow!("contract authority log was not verified"))?;
+            ensure!(
+                STANDARD.decode(&artifact.base64)? == *log,
+                "contract authority log does not match verified bytes"
+            );
+        }
+        ensure!(
+            !contract.private_authority_exported
+                && !contract.terraform_state_may_contain_private_authority,
+            "contract permits private authority export"
+        );
+    }
+    println!(
+        "{}",
+        serde_json::to_string_pretty(&serde_json::json!({
+            "valid": true,
+            "deployment_domain": verified.deployment_domain,
+            "registry_public_key_base64": STANDARD.encode(verified.registry_public_key),
+            "public_ca_bytes": public_ca.len(),
+            "profile": REGISTRY_PROFILE,
+            "audience": REGISTRY_AUDIENCE
+        }))?
+    );
+    Ok(())
+}
+
+fn rotate_authority(args: &RotateAuthorityArgs) -> Result<()> {
+    ensure!(
+        args.add ^ args.replace,
+        "select exactly one rotation mode: --add or --replace"
+    );
+    preflight_outputs(
+        [
+            &args.new_authority_key,
+            &args.new_public_key,
+            &args.authority_log_out,
+        ],
+        args.force,
+    )?;
+    let recipients = distinct_recipients(args.recipients.clone())?;
+    ensure!(
+        recipients.len() >= 2,
+        "authority rotation requires at least two distinct age recipients"
+    );
+    let public_ca = read_limited(&args.public_ca, PUBLIC_CA_BYTES)?;
+    let log: AuthorityLogFile = read_json_limited(&args.authority_log, MAX_CLOUD_SECRET_BYTES)?;
+    let active = validate_authority_log(&public_ca, &log)?;
+    let identities = combined_identities(&args.identities, &args.yubikey_identities)?;
+    let current = decrypt_authority(&args.authority_key, &identities, args.software_recovery)?;
+    ensure_active_authority(&current, &active)?;
+
+    let new_ed = SigningKey::generate(&mut rand::rngs::OsRng);
+    let (new_pq, _) = ml_dsa_generate_keypair();
+    let new_public = public_pair_bytes(&new_ed.verifying_key(), &new_pq);
+    let new_rotation_key = HybridRotationKey::new(
+        new_ed.verifying_key().to_bytes(),
+        ml_dsa_sk_to_vk_bytes(&new_pq),
+    )?;
+    let next_keys = if args.add {
+        let mut keys = active.rotation_keys.clone();
+        ensure!(
+            keys.len() < hyprstream_discovery::did_op::MAX_ROTATION_KEYS,
+            "authority set is already at its maximum size"
+        );
+        keys.push(new_rotation_key);
+        keys
+    } else {
+        vec![new_rotation_key]
+    };
+    let operations = decode_authority_operations(&log)?;
+    let previous = operations
+        .last()
+        .ok_or_else(|| anyhow!("authority log is empty"))?;
+    let next = sign_did_op(
+        DidOp {
+            sequence: previous
+                .sequence
+                .checked_add(1)
+                .ok_or_else(|| anyhow!("authority sequence overflow"))?,
+            prev: Some(previous.cid().encode()),
+            rotation_keys: next_keys,
+            signature: placeholder_did_signature(),
+        },
+        &current.ed,
+        &current.pq,
+    )?;
+    let mut operations = operations;
+    operations.push(next);
+    let next_log = authority_log_from_ops(&log.deployment_domain, operations)?;
+    validate_authority_log(&public_ca, &next_log)?;
+
+    let new_bundle = AuthorityBundle {
+        schema: AUTHORITY_BUNDLE_SCHEMA.to_owned(),
+        purpose: AuthorityPurpose::RotatedAuthority,
+        deployment_domain: log.deployment_domain.clone(),
+        public_key_sha256: sha256_hex(&new_public),
+        ed25519: Ed25519Secret::Software {
+            seed_b64: STANDARD.encode(new_ed.to_bytes()),
+            public_b64: STANDARD.encode(new_ed.verifying_key().as_bytes()),
+        },
+        ml_dsa_65_seed_b64: STANDARD.encode(ml_dsa_sk_to_seed(&new_pq)),
+        recipient_count: recipients.len(),
+    };
+    let mut plaintext = serde_json::to_vec(&new_bundle)?;
+    let encrypted = encrypt_age(&plaintext, &recipients)?;
+    plaintext.zeroize();
+
+    commit_outputs(vec![
+        PendingOutput::new(&args.new_public_key, new_public, 0o644),
+        PendingOutput::new(&args.new_authority_key, encrypted, 0o600),
+        PendingOutput::new(
+            &args.authority_log_out,
+            pretty_json_bytes(&next_log)?,
+            0o644,
+        ),
+    ])?;
+    println!(
+        "{}",
+        serde_json::to_string_pretty(&serde_json::json!({
+            "schema": "hyprstream.authority-rotation-output.v1",
+            "deployment_domain": next_log.deployment_domain,
+            "authority_log_did": next_log.did,
+            "sequence": next_log.operations_b64.len() - 1,
+            "mode": if args.add { "add" } else { "replace" },
+            "new_public_key_path": display_path(&args.new_public_key),
+            "new_authority_key_path": display_path(&args.new_authority_key),
+            "authority_log_path": display_path(&args.authority_log_out)
+        }))?
+    );
+    Ok(())
+}
+
+fn root_recipient_ring(args: &MintDeploymentCaArgs) -> Result<Vec<String>> {
+    for recipient in &args.yubikey_recipients {
+        ensure!(
+            recipient.starts_with("age1yubikey1"),
+            "--yubikey value is not an age-plugin-yubikey recipient"
+        );
+    }
+    let all = args
+        .recipients
+        .iter()
+        .chain(&args.yubikey_recipients)
+        .chain(&args.kms_plugin_recipients)
+        .cloned()
+        .collect();
+    let recipients = distinct_recipients(all)?;
+    ensure!(
+        recipients.len() >= 2,
+        "root authority requires at least two distinct age recipients \
+         (primary + backup/break-glass); a sole YubiKey is forbidden"
+    );
+    Ok(recipients)
+}
+
+fn distinct_recipients(recipients: Vec<String>) -> Result<Vec<String>> {
+    let mut unique = BTreeSet::new();
+    for recipient in recipients {
+        let recipient = recipient.trim();
+        ensure!(!recipient.is_empty(), "age recipient is empty");
+        ensure!(
+            recipient.is_ascii() && !recipient.contains(['\n', '\r', '\0']),
+            "age recipient contains invalid characters"
+        );
+        unique.insert(recipient.to_owned());
+    }
+    Ok(unique.into_iter().collect())
+}
+
+fn combined_identities(generic: &[PathBuf], yubikey: &[PathBuf]) -> Result<Vec<PathBuf>> {
+    let identities: Vec<_> = generic.iter().chain(yubikey).cloned().collect();
+    ensure!(
+        !identities.is_empty(),
+        "at least one --identity or --yubikey-identity is required"
+    );
+    for identity in &identities {
+        ensure!(
+            identity.is_file(),
+            "age identity file does not exist: {}",
+            identity.display()
+        );
+    }
+    Ok(identities)
+}
+
+fn encrypt_age(plaintext: &[u8], recipients: &[String]) -> Result<Vec<u8>> {
+    ensure!(!recipients.is_empty(), "no age recipients supplied");
+    let mut command = Command::new("age");
+    command
+        .arg("--encrypt")
+        .arg("--output")
+        .arg("-")
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::inherit());
+    for recipient in recipients {
+        command.arg("--recipient").arg(recipient);
+    }
+    command.arg("-");
+    let mut child = command.spawn().context("launch age encryption")?;
+    child
+        .stdin
+        .take()
+        .ok_or_else(|| anyhow!("age stdin unavailable"))?
+        .write_all(plaintext)
+        .context("write authority plaintext to age")?;
+    let output = child
+        .wait_with_output()
+        .context("wait for age encryption")?;
+    ensure!(output.status.success(), "age encryption failed");
+    ensure!(!output.stdout.is_empty(), "age produced empty ciphertext");
+    Ok(output.stdout)
+}
+
+fn decrypt_age(path: &Path, identities: &[PathBuf]) -> Result<Vec<u8>> {
+    let mut command = Command::new("age");
+    command
+        .arg("--decrypt")
+        .arg("--output")
+        .arg("-")
+        .stdin(Stdio::inherit())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::inherit());
+    for identity in identities {
+        command.arg("--identity").arg(identity);
+    }
+    command.arg(path);
+    let output = command.output().context("launch age decryption")?;
+    ensure!(output.status.success(), "age decryption failed");
+    ensure!(
+        output.stdout.len() <= 128 * 1024,
+        "decrypted authority bundle is too large"
+    );
+    Ok(output.stdout)
+}
+
+fn decrypt_authority(
+    path: &Path,
+    identities: &[PathBuf],
+    software_recovery: bool,
+) -> Result<LoadedAuthority> {
+    let mut plaintext = decrypt_age(path, identities)?;
+    let bundle: AuthorityBundle =
+        serde_json::from_slice(&plaintext).context("decode authority bundle")?;
+    plaintext.zeroize();
+    ensure!(
+        bundle.schema == AUTHORITY_BUNDLE_SCHEMA,
+        "unsupported authority bundle schema"
+    );
+    let mut pq_seed = decode_fixed_b64::<32>(&bundle.ml_dsa_65_seed_b64, "ML-DSA-65 seed")?;
+    let pq = ml_dsa_sk_from_seed(&pq_seed);
+    pq_seed.zeroize();
+    let ed = match &bundle.ed25519 {
+        Ed25519Secret::Software {
+            seed_b64,
+            public_b64,
+        } => {
+            ensure!(
+                !software_recovery,
+                "--software-recovery applies only to a PIV-backed authority"
+            );
+            let mut seed = decode_fixed_b64::<32>(seed_b64, "Ed25519 seed")?;
+            let key = SigningKey::from_bytes(&seed);
+            seed.zeroize();
+            ensure!(
+                STANDARD.decode(public_b64)? == key.verifying_key().as_bytes(),
+                "authority Ed25519 public key does not match seed"
+            );
+            LoadedEdSigner::Software(key)
+        }
+        Ed25519Secret::YubikeyPiv {
+            slot,
+            public_b64,
+            recovery_seed_b64,
+        } => {
+            validate_piv_slot(slot)?;
+            let public_bytes = decode_fixed_b64::<32>(public_b64, "PIV Ed25519 public key")?;
+            let public =
+                VerifyingKey::from_bytes(&public_bytes).context("invalid PIV public key")?;
+            if software_recovery {
+                let mut seed =
+                    decode_fixed_b64::<32>(recovery_seed_b64, "PIV recovery Ed25519 seed")?;
+                let key = SigningKey::from_bytes(&seed);
+                seed.zeroize();
+                ensure!(
+                    key.verifying_key() == public,
+                    "PIV recovery seed does not match the recorded public key"
+                );
+                LoadedEdSigner::Software(key)
+            } else {
+                LoadedEdSigner::YubikeyPiv {
+                    slot: slot.clone(),
+                    public,
+                }
+            }
+        }
+    };
+    let loaded = LoadedAuthority { bundle, ed, pq };
+    let public = loaded.public_bytes();
+    ensure!(
+        sha256_hex(&public) == loaded.bundle.public_key_sha256,
+        "authority public-key fingerprint mismatch"
+    );
+    Ok(loaded)
+}
+
+fn public_pair_bytes(ed: &VerifyingKey, pq: &MlDsaSigningKey) -> Vec<u8> {
+    let mut output = Vec::with_capacity(PUBLIC_CA_BYTES);
+    output.extend_from_slice(ed.as_bytes());
+    output.extend_from_slice(&ml_dsa_sk_to_vk_bytes(pq));
+    output
+}
+
+fn parse_public_pair(
+    bytes: &[u8],
+) -> Result<(VerifyingKey, hyprstream_rpc::crypto::pq::MlDsaVerifyingKey)> {
+    ensure!(
+        bytes.len() == PUBLIC_CA_BYTES,
+        "hybrid public key must be exactly {PUBLIC_CA_BYTES} bytes"
+    );
+    let ed_bytes: [u8; 32] = bytes[..32]
+        .try_into()
+        .map_err(|_| anyhow!("invalid Ed25519 public-key length"))?;
+    let ed = VerifyingKey::from_bytes(&ed_bytes).context("invalid Ed25519 public key")?;
+    let pq = ml_dsa_vk_from_bytes(&bytes[32..])?;
+    Ok((ed, pq))
+}
+
+fn encode_registry_jwt(
+    signer: &LoadedAuthority,
+    registry_key: &[u8; 32],
+    now: i64,
+    exp: i64,
+    delegation_b64: Option<&str>,
+) -> Result<String> {
+    let signer_ed = signer.ed.verifying_key();
+    let signer_pq = ml_dsa_vk_from_bytes(&ml_dsa_sk_to_vk_bytes(&signer.pq))?;
+    let kid = hyprstream_rpc::auth::composite_kid(&signer_pq, &signer_ed);
+    let protected = serde_json::json!({
+        "alg": "ML-DSA-65-Ed25519",
+        "typ": "wit+jwt",
+        "kid": kid
+    });
+    let mut claims = serde_json::Map::new();
+    claims.insert(
+        "iss".to_owned(),
+        serde_json::Value::String(format!(
+            "urn:hyprstream:deployment:{}",
+            signer.bundle.deployment_domain
+        )),
+    );
+    claims.insert(
+        "sub".to_owned(),
+        serde_json::Value::String("service:registry".to_owned()),
+    );
+    claims.insert(
+        "aud".to_owned(),
+        serde_json::Value::String(REGISTRY_AUDIENCE.to_owned()),
+    );
+    claims.insert("exp".to_owned(), serde_json::Value::Number(exp.into()));
+    claims.insert("nbf".to_owned(), serde_json::Value::Number(now.into()));
+    claims.insert("iat".to_owned(), serde_json::Value::Number(now.into()));
+    claims.insert(
+        "deployment_domain".to_owned(),
+        serde_json::Value::String(signer.bundle.deployment_domain.clone()),
+    );
+    claims.insert(
+        "profile".to_owned(),
+        serde_json::Value::String(REGISTRY_PROFILE.to_owned()),
+    );
+    claims.insert(
+        "cnf".to_owned(),
+        serde_json::json!({
+            "jwk": {
+                "kty": "OKP",
+                "crv": "Ed25519",
+                "x": URL_SAFE_NO_PAD.encode(registry_key)
+            }
+        }),
+    );
+    if let Some(delegation) = delegation_b64 {
+        claims.insert(
+            "delegation".to_owned(),
+            serde_json::Value::String(delegation.to_owned()),
+        );
+    }
+    let protected_b64 = URL_SAFE_NO_PAD.encode(serde_json::to_vec(&protected)?);
+    let claims_b64 = URL_SAFE_NO_PAD.encode(serde_json::to_vec(&claims)?);
+    let signing_input = format!("{protected_b64}.{claims_b64}");
+    let pq_signature = ml_dsa_sign(&signer.pq, signing_input.as_bytes());
+    let ed_signature = signer.ed.sign(signing_input.as_bytes())?;
+    let mut signature = Vec::with_capacity(HYBRID_SIGNATURE_BYTES);
+    signature.extend_from_slice(&pq_signature);
+    signature.extend_from_slice(&ed_signature);
+    ensure!(
+        signature.len() == HYBRID_SIGNATURE_BYTES,
+        "internal hybrid JWT signature length error"
+    );
+    Ok(format!(
+        "{signing_input}.{}",
+        URL_SAFE_NO_PAD.encode(signature)
+    ))
+}
+
+fn registry_mint_capability(deployment_domain: &str, delegated_public: &[u8]) -> Capability {
+    let mut caveats = BTreeMap::new();
+    caveats.insert(
+        "audience".to_owned(),
+        CaveatValue::Text(REGISTRY_AUDIENCE.to_owned()),
+    );
+    caveats.insert(
+        "deployment_domain".to_owned(),
+        CaveatValue::Text(deployment_domain.to_owned()),
+    );
+    caveats.insert(
+        "delegated_public_key_b64".to_owned(),
+        CaveatValue::Text(STANDARD.encode(delegated_public)),
+    );
+    caveats.insert("max_ttl_seconds".to_owned(), CaveatValue::Int(3_600));
+    caveats.insert(
+        "profile".to_owned(),
+        CaveatValue::Text(REGISTRY_PROFILE.to_owned()),
+    );
+    Capability::with_caveats(
+        Resource::new(format!(
+            "{DELEGATION_RESOURCE_PREFIX}/{deployment_domain}/service/registry"
+        )),
+        Ability::new(DELEGATION_ABILITY),
+        Caveats(caveats),
+    )
+}
+
+fn sign_ucan(payload: UcanPayload, ed: &LoadedEdSigner, pq: &MlDsaSigningKey) -> Result<Ucan> {
+    let payload_bytes = payload.signing_bytes()?;
+    let signature = sign_nested(
+        &payload_bytes,
+        hyprstream_rpc::auth::ucan::token::UCAN_AAD,
+        ed,
+        pq,
+    )?;
+    Ok(Ucan {
+        payload,
+        proofs: Vec::new(),
+        signature,
+    })
+}
+
+fn sign_nested(
+    payload: &[u8],
+    aad: &[u8],
+    ed: &LoadedEdSigner,
+    pq: &MlDsaSigningKey,
+) -> Result<Vec<u8>> {
+    let ed_public = ed.verifying_key();
+    let pq_public = ml_dsa_vk_from_bytes(&ml_dsa_sk_to_vk_bytes(pq))?;
+    let ed_tbs = inner_tbs(ed_public.to_bytes().to_vec(), payload, aad, true);
+    let ed_signature = ed.sign(&ed_tbs)?;
+    let pq_tbs = outer_tbs(ml_dsa_vk_bytes(&pq_public), payload, &ed_signature, aad);
+    let pq_signature = ml_dsa_sign(pq, &pq_tbs);
+    assemble_composite_nested(
+        (ed_public.to_bytes().to_vec(), ed_signature.to_vec()),
+        Some((ml_dsa_vk_bytes(&pq_public), pq_signature)),
+    )
+}
+
+fn sign_did_op(mut op: DidOp, ed: &LoadedEdSigner, pq: &MlDsaSigningKey) -> Result<DidOp> {
+    let composite = sign_nested(&op.signable_bytes(), DID_OP_SIGNATURE_CONTEXT, ed, pq)?;
+    let (ed_signature, pq_signature) =
+        hyprstream_rpc::crypto::cose_sign::split_composite(&composite)?;
+    op.signature = HybridDidOpSignature {
+        ed25519: ed_signature,
+        mldsa65: pq_signature.ok_or_else(|| anyhow!("missing ML-DSA signature"))?,
+    };
+    DidOp::from_dag_cbor(&op.to_dag_cbor()).context("self-verify signed DID operation")
+}
+
+fn placeholder_did_signature() -> HybridDidOpSignature {
+    HybridDidOpSignature {
+        ed25519: vec![0; 64],
+        mldsa65: vec![0; 3_309],
+    }
+}
+
+fn authority_log_from_ops(
+    deployment_domain: &str,
+    operations: Vec<DidOp>,
+) -> Result<AuthorityLogFile> {
+    ensure!(!operations.is_empty(), "authority log cannot be empty");
+    ensure!(
+        operations.len() <= MAX_AUTHORITY_LOG_OPERATIONS,
+        "authority log has too many operations"
+    );
+    let did = operations[0].genesis_did()?;
+    verify_did_op_log(&did, &operations)?;
+    let log = AuthorityLogFile {
+        schema: AUTHORITY_LOG_SCHEMA.to_owned(),
+        deployment_domain: deployment_domain.to_owned(),
+        did,
+        operations_b64: operations
+            .iter()
+            .map(|op| STANDARD.encode(op.to_dag_cbor()))
+            .collect(),
+    };
+    ensure!(
+        pretty_json_bytes(&log)?.len() <= MAX_CLOUD_SECRET_BYTES,
+        "authority log exceeds the 64 KiB cloud-secret contract"
+    );
+    Ok(log)
+}
+
+fn decode_authority_operations(log: &AuthorityLogFile) -> Result<Vec<DidOp>> {
+    ensure!(
+        log.schema == AUTHORITY_LOG_SCHEMA,
+        "unsupported authority-log schema"
+    );
+    ensure!(
+        !log.operations_b64.is_empty() && log.operations_b64.len() <= MAX_AUTHORITY_LOG_OPERATIONS,
+        "authority log operation count is invalid"
+    );
+    log.operations_b64
+        .iter()
+        .map(|encoded| {
+            let bytes = STANDARD
+                .decode(encoded)
+                .context("decode authority operation")?;
+            DidOp::from_dag_cbor(&bytes)
+        })
+        .collect()
+}
+
+fn validate_authority_log(
+    public_ca: &[u8],
+    log: &AuthorityLogFile,
+) -> Result<hyprstream_discovery::did_op::VerifiedDidOpLog> {
+    let root_domain = hyprstream_discovery::verify_deployment_public_ca(public_ca)?;
+    ensure!(
+        log.deployment_domain == root_domain,
+        "authority log deployment domain does not match pinned root"
+    );
+    let operations = decode_authority_operations(log)?;
+    let verified = verify_did_op_log(&log.did, &operations)?;
+    let (root_ed, root_pq) = parse_public_pair(public_ca)?;
+    let genesis = operations
+        .first()
+        .ok_or_else(|| anyhow!("authority log is empty"))?;
+    let genesis_composite = assemble_composite_nested(
+        (
+            root_ed.to_bytes().to_vec(),
+            genesis.signature.ed25519.clone(),
+        ),
+        Some((ml_dsa_vk_bytes(&root_pq), genesis.signature.mldsa65.clone())),
+    )?;
+    hyprstream_rpc::crypto::cose_sign::verify_composite(
+        &genesis_composite,
+        &root_ed,
+        Some(&root_pq),
+        &genesis.signable_bytes(),
+        DID_OP_SIGNATURE_CONTEXT,
+        true,
+    )
+    .context("authority-log genesis was not signed by the pinned root")?;
+    ensure!(
+        genesis.rotation_keys.iter().any(|key| {
+            key.ed25519_pub == root_ed.to_bytes() && key.mldsa65_pub == ml_dsa_vk_bytes(&root_pq)
+        }),
+        "authority log genesis is not anchored by the pinned public root"
+    );
+    Ok(verified)
+}
+
+fn ensure_active_authority(
+    authority: &LoadedAuthority,
+    active: &hyprstream_discovery::did_op::VerifiedDidOpLog,
+) -> Result<()> {
+    let public = authority.public_bytes();
+    ensure!(
+        active
+            .rotation_keys
+            .iter()
+            .any(|key| { public[..32] == key.ed25519_pub && public[32..] == key.mldsa65_pub }),
+        "authority key is not active at the rotation-log head"
+    );
+    Ok(())
+}
+
+struct AuthorityUcanVerifier<'a> {
+    keys: &'a [HybridRotationKey],
+}
+
+impl UcanVerifier for AuthorityUcanVerifier<'_> {
+    fn verify(
+        &self,
+        _issuer: &Did,
+        ed_key: &[u8; 32],
+        payload: &[u8],
+        signature: &[u8],
+    ) -> std::result::Result<(), UcanError> {
+        let key = self
+            .keys
+            .iter()
+            .find(|key| &key.ed25519_pub == ed_key)
+            .ok_or_else(|| {
+                UcanError::BadSignature("issuer is not an active authority".to_owned())
+            })?;
+        let ed = VerifyingKey::from_bytes(ed_key)
+            .map_err(|error| UcanError::BadSignature(error.to_string()))?;
+        let pq = ml_dsa_vk_from_bytes(&key.mldsa65_pub)
+            .map_err(|error| UcanError::BadSignature(error.to_string()))?;
+        hyprstream_rpc::crypto::cose_sign::verify_composite(
+            signature,
+            &ed,
+            Some(&pq),
+            payload,
+            hyprstream_rpc::auth::ucan::token::UCAN_AAD,
+            true,
+        )
+        .map(|_| ())
+        .map_err(|error| UcanError::BadSignature(error.to_string()))
+    }
+}
+
+fn validate_registry_delegation_ucan(
+    ucan: &Ucan,
+    deployment_domain: &str,
+    delegated_public: &[u8],
+    active_keys: &[HybridRotationKey],
+    now: u64,
+) -> Result<()> {
+    ensure!(
+        ucan.proofs.is_empty(),
+        "registry delegation must be one root-authorized link"
+    );
+    let verifier = AuthorityUcanVerifier { keys: active_keys };
+    validate_ucan(ucan, &verifier, now).context("validate registry UCAN delegation")?;
+    ensure!(
+        active_keys
+            .iter()
+            .any(|key| ucan.issuer().to_ed25519().ok() == Some(key.ed25519_pub)),
+        "delegation issuer is not active"
+    );
+    let delegated_ed: [u8; 32] = delegated_public
+        .get(..32)
+        .ok_or_else(|| anyhow!("delegated public key is truncated"))?
+        .try_into()
+        .map_err(|_| anyhow!("delegated Ed25519 key is malformed"))?;
+    ensure!(
+        ucan.audience().to_ed25519()? == delegated_ed,
+        "delegation audience does not match delegated signer"
+    );
+    ensure!(
+        ucan.capabilities()
+            == [registry_mint_capability(
+                deployment_domain,
+                delegated_public
+            )],
+        "delegation capability is not the exact registry-only scope"
+    );
+    ensure!(
+        ucan.payload.expiration.is_some(),
+        "registry delegation must expire"
+    );
+    Ok(())
+}
+
+fn validate_delegation_artifact(
+    public_ca: &[u8],
+    authority_log: &AuthorityLogFile,
+    artifact: &DelegationArtifact,
+    now: u64,
+) -> Result<()> {
+    ensure!(
+        artifact.schema == DELEGATION_SCHEMA,
+        "unsupported delegation schema"
+    );
+    let active = validate_authority_log(public_ca, authority_log)?;
+    ensure!(
+        artifact.deployment_domain == authority_log.deployment_domain,
+        "delegation domain does not match authority log"
+    );
+    ensure!(
+        artifact.authority_log_did == authority_log.did,
+        "delegation names a different authority log"
+    );
+    let delegated_public = STANDARD
+        .decode(&artifact.delegated_public_key_b64)
+        .context("decode delegated public key")?;
+    parse_public_pair(&delegated_public)?;
+    let ucan_bytes = STANDARD
+        .decode(&artifact.ucan_b64)
+        .context("decode delegation UCAN")?;
+    ensure!(
+        ucan_bytes.len() <= MAX_DELEGATION_BYTES,
+        "delegation UCAN is too large"
+    );
+    let ucan = Ucan::from_cbor(&ucan_bytes)?;
+    validate_registry_delegation_ucan(
+        &ucan,
+        &artifact.deployment_domain,
+        &delegated_public,
+        &active.rotation_keys,
+        now,
+    )
+}
+
+fn piv_import_ed25519(slot: &str, key: &SigningKey) -> Result<(String, VerifyingKey)> {
+    let slot = validate_piv_slot(slot)?;
+    let private_der = key
+        .to_pkcs8_der()
+        .context("encode Ed25519 key for PIV import")?;
+    let mut child = Command::new("ykman")
+        .args([
+            "piv",
+            "keys",
+            "import",
+            "--pin-policy",
+            "ALWAYS",
+            "--touch-policy",
+            "ALWAYS",
+        ])
+        .arg(&slot)
+        .arg("-")
+        .stdin(Stdio::piped())
+        .stdout(Stdio::inherit())
+        .stderr(Stdio::inherit())
+        .spawn()
+        .context("launch ykman PIV import (YubiKey 5.7.4+ is required)")?;
+    child
+        .stdin
+        .take()
+        .ok_or_else(|| anyhow!("ykman stdin unavailable"))?
+        .write_all(private_der.as_bytes())
+        .context("write Ed25519 PKCS#8 key to ykman")?;
+    let status = child.wait().context("wait for ykman PIV import")?;
+    ensure!(status.success(), "ykman PIV Ed25519 import failed");
+    let public = key.verifying_key();
+    piv_sign(
+        &slot,
+        &public,
+        b"hyprstream deployment authority PIV import self-check",
+    )
+    .context("PIV import self-check")?;
+    Ok((slot, public))
+}
+
+fn piv_sign(slot: &str, public: &VerifyingKey, message: &[u8]) -> Result<[u8; 64]> {
+    validate_piv_slot(slot)?;
+    let input = tempfile::NamedTempFile::new().context("create PIV signing input")?;
+    let output = tempfile::NamedTempFile::new().context("create PIV signing output")?;
+    std::fs::write(input.path(), message).context("write PIV signing input")?;
+    let status = Command::new("yubico-piv-tool")
+        .args(["-a", "verify-pin", "--sign", "-s"])
+        .arg(slot)
+        .args(["-A", "ED25519", "-i"])
+        .arg(input.path())
+        .arg("-o")
+        .arg(output.path())
+        .stdin(Stdio::inherit())
+        .stdout(Stdio::inherit())
+        .stderr(Stdio::inherit())
+        .status()
+        .context("launch yubico-piv-tool")?;
+    ensure!(status.success(), "YubiKey PIV signing failed");
+    let signature: [u8; 64] = std::fs::read(output.path())?
+        .try_into()
+        .map_err(|_| anyhow!("YubiKey returned a non-64-byte Ed25519 signature"))?;
+    public
+        .verify_strict(message, &ed25519_dalek::Signature::from_bytes(&signature))
+        .context("YubiKey signature self-check failed")?;
+    Ok(signature)
+}
+
+fn validate_piv_slot(slot: &str) -> Result<String> {
+    let slot = slot.trim().to_ascii_lowercase();
+    let allowed = matches!(
+        slot.as_str(),
+        "9a" | "9c"
+            | "9d"
+            | "9e"
+            | "82"
+            | "83"
+            | "84"
+            | "85"
+            | "86"
+            | "87"
+            | "88"
+            | "89"
+            | "8a"
+            | "8b"
+            | "8c"
+            | "8d"
+            | "8e"
+            | "8f"
+            | "90"
+            | "91"
+            | "92"
+            | "93"
+            | "94"
+            | "95"
+    );
+    ensure!(allowed, "unsupported or unsafe PIV slot {slot:?}");
+    Ok(slot)
+}
+
+fn preflight_outputs<'a>(paths: impl IntoIterator<Item = &'a PathBuf>, force: bool) -> Result<()> {
+    let mut seen = BTreeSet::new();
+    for path in paths {
+        ensure!(
+            seen.insert(path.clone()),
+            "duplicate output path {}",
+            path.display()
+        );
+        if path.exists() && !force {
+            bail!(
+                "refusing to replace existing output {} without --force",
+                path.display()
+            );
+        }
+        if let Ok(metadata) = std::fs::symlink_metadata(path) {
+            ensure!(
+                metadata.file_type().is_file() && !metadata.file_type().is_symlink(),
+                "refusing non-regular or symlink output target {}",
+                path.display()
+            );
+        }
+        let parent = path.parent().unwrap_or_else(|| Path::new("."));
+        ensure!(
+            parent.is_dir(),
+            "output parent does not exist: {}",
+            parent.display()
+        );
+    }
+    Ok(())
+}
+
+fn pretty_json_bytes(value: &impl Serialize) -> Result<Vec<u8>> {
+    let mut bytes = serde_json::to_vec_pretty(value)?;
+    bytes.push(b'\n');
+    Ok(bytes)
+}
+
+struct PendingOutput<'a> {
+    path: &'a Path,
+    bytes: Vec<u8>,
+    mode: u32,
+}
+
+impl<'a> PendingOutput<'a> {
+    fn new(path: &'a Path, bytes: Vec<u8>, mode: u32) -> Self {
+        Self { path, bytes, mode }
+    }
+}
+
+/// Stage every output before moving any destination, then roll back the whole
+/// set if a rename fails. Each rename is filesystem-atomic; the rollback closes
+/// the ordinary error path across the multi-file mint commands.
+fn commit_outputs(outputs: Vec<PendingOutput<'_>>) -> Result<()> {
+    let mut staged = Vec::with_capacity(outputs.len());
+    for output in &outputs {
+        let parent = output.path.parent().unwrap_or_else(|| Path::new("."));
+        let mut temp = tempfile::NamedTempFile::new_in(parent)
+            .with_context(|| format!("create staged output for {}", output.path.display()))?;
+        temp.as_file_mut()
+            .set_permissions(std::fs::Permissions::from_mode(output.mode))?;
+        temp.write_all(&output.bytes)?;
+        temp.as_file_mut().sync_all()?;
+        let (_file, path) = temp.keep().context("retain staged output")?;
+        staged.push(path);
+    }
+
+    let mut backups: Vec<Option<PathBuf>> = vec![None; outputs.len()];
+    for (index, output) in outputs.iter().enumerate() {
+        if output.path.exists() {
+            let parent = output.path.parent().unwrap_or_else(|| Path::new("."));
+            let placeholder = tempfile::Builder::new()
+                .prefix(".hyprstream-backup-")
+                .tempfile_in(parent)
+                .with_context(|| format!("stage backup for {}", output.path.display()))?;
+            let backup = placeholder.path().to_path_buf();
+            drop(placeholder);
+            if let Err(error) = std::fs::rename(output.path, &backup) {
+                restore_outputs(&outputs, &backups, 0);
+                cleanup_paths(&staged);
+                return Err(error)
+                    .with_context(|| format!("back up existing {}", output.path.display()));
+            }
+            backups[index] = Some(backup);
+        }
+    }
+
+    for (index, output) in outputs.iter().enumerate() {
+        if let Err(error) = std::fs::rename(&staged[index], output.path) {
+            restore_outputs(&outputs, &backups, index);
+            cleanup_paths(&staged[index..]);
+            return Err(error).with_context(|| format!("commit {}", output.path.display()));
+        }
+    }
+
+    for backup in backups.into_iter().flatten() {
+        let _ = std::fs::remove_file(backup);
+    }
+    sync_output_parents(&outputs);
+    Ok(())
+}
+
+fn restore_outputs(outputs: &[PendingOutput<'_>], backups: &[Option<PathBuf>], committed: usize) {
+    for output in outputs.iter().take(committed) {
+        let _ = std::fs::remove_file(output.path);
+    }
+    for (output, backup) in outputs.iter().zip(backups).rev() {
+        if let Some(backup) = backup {
+            let _ = std::fs::rename(backup, output.path);
+        }
+    }
+    sync_output_parents(outputs);
+}
+
+fn cleanup_paths(paths: &[PathBuf]) {
+    for path in paths {
+        let _ = std::fs::remove_file(path);
+    }
+}
+
+fn sync_output_parents(outputs: &[PendingOutput<'_>]) {
+    let parents: BTreeSet<_> = outputs
+        .iter()
+        .map(|output| {
+            output
+                .path
+                .parent()
+                .unwrap_or_else(|| Path::new("."))
+                .to_path_buf()
+        })
+        .collect();
+    for parent in parents {
+        if let Ok(directory) = std::fs::File::open(parent) {
+            let _ = directory.sync_all();
+        }
+    }
+}
+
+fn read_limited(path: &Path, max: usize) -> Result<Vec<u8>> {
+    let metadata = std::fs::metadata(path).with_context(|| format!("stat {}", path.display()))?;
+    ensure!(
+        metadata.is_file(),
+        "{} is not a regular file",
+        path.display()
+    );
+    ensure!(
+        metadata.len() <= u64::try_from(max).unwrap_or(u64::MAX),
+        "{} exceeds {max} bytes",
+        path.display()
+    );
+    let file = OpenOptions::new()
+        .read(true)
+        .custom_flags(libc::O_NOFOLLOW)
+        .open(path)
+        .with_context(|| format!("open {}", path.display()))?;
+    let mut bytes = Vec::with_capacity(metadata.len() as usize);
+    file.take(u64::try_from(max + 1).unwrap_or(u64::MAX))
+        .read_to_end(&mut bytes)?;
+    ensure!(bytes.len() <= max, "{} exceeds {max} bytes", path.display());
+    Ok(bytes)
+}
+
+fn read_json_limited<T: for<'de> Deserialize<'de>>(path: &Path, max: usize) -> Result<T> {
+    serde_json::from_slice(&read_limited(path, max)?)
+        .with_context(|| format!("decode JSON {}", path.display()))
+}
+
+fn decode_fixed_b64<const N: usize>(value: &str, description: &str) -> Result<[u8; N]> {
+    STANDARD
+        .decode(value)
+        .with_context(|| format!("decode {description}"))?
+        .try_into()
+        .map_err(|_| anyhow!("{description} must decode to exactly {N} bytes"))
+}
+
+fn sha256_hex(bytes: &[u8]) -> String {
+    Sha256::digest(bytes)
+        .iter()
+        .map(|byte| format!("{byte:02x}"))
+        .collect()
+}
+
+fn display_path(path: &Path) -> String {
+    path.canonicalize()
+        .unwrap_or_else(|_| path.to_path_buf())
+        .display()
+        .to_string()
+}
+
+fn random_bytes(len: usize) -> Vec<u8> {
+    let mut bytes = vec![0; len];
+    rand::rngs::OsRng.fill_bytes(&mut bytes);
+    bytes
+}
+
+fn now_unix_u64() -> Result<u64> {
+    chrono::Utc::now()
+        .timestamp()
+        .try_into()
+        .map_err(|_| anyhow!("system clock precedes Unix epoch"))
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+mod tests {
+    use super::*;
+
+    fn test_authority(
+        purpose: AuthorityPurpose,
+        deployment_domain: Option<String>,
+    ) -> LoadedAuthority {
+        let ed = SigningKey::generate(&mut rand::rngs::OsRng);
+        let (pq, _) = ml_dsa_generate_keypair();
+        let public = public_pair_bytes(&ed.verifying_key(), &pq);
+        let domain = deployment_domain
+            .unwrap_or_else(|| hyprstream_discovery::verify_deployment_public_ca(&public).unwrap());
+        LoadedAuthority {
+            bundle: AuthorityBundle {
+                schema: AUTHORITY_BUNDLE_SCHEMA.to_owned(),
+                purpose,
+                deployment_domain: domain,
+                public_key_sha256: sha256_hex(&public),
+                ed25519: Ed25519Secret::Software {
+                    seed_b64: STANDARD.encode(ed.to_bytes()),
+                    public_b64: STANDARD.encode(ed.verifying_key().as_bytes()),
+                },
+                ml_dsa_65_seed_b64: STANDARD.encode(ml_dsa_sk_to_seed(&pq)),
+                recipient_count: 2,
+            },
+            ed: LoadedEdSigner::Software(ed),
+            pq,
+        }
+    }
+
+    #[test]
+    fn recipient_ring_rejects_duplicates_and_singletons() {
+        let one = distinct_recipients(vec!["age1one".to_owned(), "age1one".to_owned()]).unwrap();
+        assert_eq!(one.len(), 1);
+        let args = MintDeploymentCaArgs {
+            public_ca: "ca".into(),
+            authority_key: "key".into(),
+            authority_log: "log".into(),
+            recipients: vec!["age1one".to_owned(), "age1one".to_owned()],
+            yubikey_recipients: vec![],
+            kms_plugin_recipients: vec![],
+            piv_slot: None,
+            force: false,
+        };
+        assert!(root_recipient_ring(&args).is_err());
+    }
+
+    #[test]
+    fn public_pair_layout_is_ed_then_ml_dsa() {
+        let ed = SigningKey::generate(&mut rand::rngs::OsRng);
+        let (pq, _) = ml_dsa_generate_keypair();
+        let bytes = public_pair_bytes(&ed.verifying_key(), &pq);
+        assert_eq!(bytes.len(), PUBLIC_CA_BYTES);
+        assert_eq!(&bytes[..32], ed.verifying_key().as_bytes());
+        assert_eq!(&bytes[32..], ml_dsa_sk_to_vk_bytes(&pq));
+        assert!(hyprstream_discovery::verify_deployment_public_ca(&bytes).is_ok());
+    }
+
+    #[test]
+    fn exact_registry_capability_cannot_widen() {
+        let (pq, _) = ml_dsa_generate_keypair();
+        let ed = SigningKey::generate(&mut rand::rngs::OsRng);
+        let public = public_pair_bytes(&ed.verifying_key(), &pq);
+        let capability = registry_mint_capability("domain", &public);
+        assert_eq!(capability.ability.as_str(), DELEGATION_ABILITY);
+        assert!(!capability.resource.as_str().contains('*'));
+        assert_eq!(
+            capability.caveats.0["max_ttl_seconds"],
+            CaveatValue::Int(3600)
+        );
+    }
+
+    #[test]
+    fn publisher_manifest_has_no_authority_key_field() {
+        let value = serde_json::to_value(PublisherManifest {
+            schema: PUBLISHER_MANIFEST_SCHEMA.to_owned(),
+            deployment_domain: "d".to_owned(),
+            profile: REGISTRY_PROFILE.to_owned(),
+            audience: REGISTRY_AUDIENCE.to_owned(),
+            expires_at: 1,
+            public_ca: PublisherArtifact {
+                local_path: "ca".to_owned(),
+                install_path: "ca".to_owned(),
+                encoding: "raw".to_owned(),
+                base64: "x".to_owned(),
+                sha256: "x".to_owned(),
+                size_bytes: 1,
+                cloud_secret_store: true,
+            },
+            authority_log: None,
+            registry_jwt: PublisherArtifact {
+                local_path: "jwt".to_owned(),
+                install_path: "jwt".to_owned(),
+                encoding: "utf8".to_owned(),
+                base64: "x".to_owned(),
+                sha256: "x".to_owned(),
+                size_bytes: 1,
+                cloud_secret_store: true,
+            },
+            private_authority_exported: false,
+            terraform_state_may_contain_private_authority: false,
+        })
+        .unwrap();
+        let object = value.as_object().unwrap();
+        assert!(!object.contains_key("authority_key"));
+        assert_eq!(object["private_authority_exported"], false);
+    }
+
+    #[test]
+    fn delegated_credential_follows_add_then_fails_after_replace() {
+        let root = test_authority(AuthorityPurpose::Root, None);
+        let public_ca = root.public_bytes();
+        let root_rotation_key = HybridRotationKey::new(
+            root.ed.verifying_key().to_bytes(),
+            ml_dsa_sk_to_vk_bytes(&root.pq),
+        )
+        .unwrap();
+        let genesis = sign_did_op(
+            DidOp {
+                sequence: 0,
+                prev: None,
+                rotation_keys: vec![root_rotation_key.clone()],
+                signature: placeholder_did_signature(),
+            },
+            &root.ed,
+            &root.pq,
+        )
+        .unwrap();
+        let genesis_log =
+            authority_log_from_ops(&root.bundle.deployment_domain, vec![genesis.clone()]).unwrap();
+
+        let delegated = test_authority(
+            AuthorityPurpose::RegistryDelegatedSigner,
+            Some(root.bundle.deployment_domain.clone()),
+        );
+        let delegated_public = delegated.public_bytes();
+        let now = now_unix_u64().unwrap();
+        let ucan = sign_ucan(
+            UcanPayload {
+                issuer: Did::from_ed25519(&root.ed.verifying_key().to_bytes()),
+                audience: Did::from_ed25519(&delegated.ed.verifying_key().to_bytes()),
+                capabilities: vec![registry_mint_capability(
+                    &root.bundle.deployment_domain,
+                    &delegated_public,
+                )],
+                not_before: Some(now),
+                expiration: Some(now + 3_600),
+                nonce: random_bytes(16),
+            },
+            &root.ed,
+            &root.pq,
+        )
+        .unwrap();
+        let artifact = DelegationArtifact {
+            schema: DELEGATION_SCHEMA.to_owned(),
+            deployment_domain: root.bundle.deployment_domain.clone(),
+            authority_log_did: genesis_log.did.clone(),
+            delegated_public_key_b64: STANDARD.encode(&delegated_public),
+            ucan_b64: STANDARD.encode(ucan.to_cbor().unwrap()),
+        };
+        let registry = SigningKey::generate(&mut rand::rngs::OsRng);
+        let direct_token = encode_registry_jwt(
+            &root,
+            registry.verifying_key().as_bytes(),
+            i64::try_from(now).unwrap(),
+            i64::try_from(now + 60).unwrap(),
+            None,
+        )
+        .unwrap();
+        let token = encode_registry_jwt(
+            &delegated,
+            registry.verifying_key().as_bytes(),
+            i64::try_from(now).unwrap(),
+            i64::try_from(now + 60).unwrap(),
+            Some(&URL_SAFE_NO_PAD.encode(serde_json::to_vec(&artifact).unwrap())),
+        )
+        .unwrap();
+        hyprstream_discovery::verify_deployment_artifacts_with_authority_log(
+            &public_ca,
+            &serde_json::to_vec(&genesis_log).unwrap(),
+            &direct_token,
+        )
+        .unwrap();
+        hyprstream_discovery::verify_deployment_artifacts_with_authority_log(
+            &public_ca,
+            &serde_json::to_vec(&genesis_log).unwrap(),
+            &token,
+        )
+        .unwrap();
+
+        let added = test_authority(
+            AuthorityPurpose::RotatedAuthority,
+            Some(root.bundle.deployment_domain.clone()),
+        );
+        let added_rotation_key = HybridRotationKey::new(
+            added.ed.verifying_key().to_bytes(),
+            ml_dsa_sk_to_vk_bytes(&added.pq),
+        )
+        .unwrap();
+        let add = sign_did_op(
+            DidOp {
+                sequence: 1,
+                prev: Some(genesis.cid().encode()),
+                rotation_keys: vec![root_rotation_key, added_rotation_key.clone()],
+                signature: placeholder_did_signature(),
+            },
+            &root.ed,
+            &root.pq,
+        )
+        .unwrap();
+        let add_log = authority_log_from_ops(
+            &root.bundle.deployment_domain,
+            vec![genesis.clone(), add.clone()],
+        )
+        .unwrap();
+        hyprstream_discovery::verify_deployment_artifacts_with_authority_log(
+            &public_ca,
+            &serde_json::to_vec(&add_log).unwrap(),
+            &token,
+        )
+        .unwrap();
+
+        let replace = sign_did_op(
+            DidOp {
+                sequence: 2,
+                prev: Some(add.cid().encode()),
+                rotation_keys: vec![added_rotation_key],
+                signature: placeholder_did_signature(),
+            },
+            &root.ed,
+            &root.pq,
+        )
+        .unwrap();
+        let replace_log =
+            authority_log_from_ops(&root.bundle.deployment_domain, vec![genesis, add, replace])
+                .unwrap();
+        assert!(
+            hyprstream_discovery::verify_deployment_artifacts_with_authority_log(
+                &public_ca,
+                &serde_json::to_vec(&replace_log).unwrap(),
+                &token,
+            )
+            .is_err()
+        );
+        assert!(
+            hyprstream_discovery::verify_deployment_artifacts_with_authority_log(
+                &public_ca,
+                &serde_json::to_vec(&replace_log).unwrap(),
+                &direct_token,
+            )
+            .is_err()
+        );
+    }
+
+    #[test]
+    fn compact_registry_jwt_rejects_any_whitespace() {
+        let root = test_authority(AuthorityPurpose::Root, None);
+        let registry = SigningKey::generate(&mut rand::rngs::OsRng);
+        let now = chrono::Utc::now().timestamp();
+        let token = encode_registry_jwt(
+            &root,
+            registry.verifying_key().as_bytes(),
+            now,
+            now + 60,
+            None,
+        )
+        .unwrap();
+        assert!(
+            hyprstream_discovery::verify_deployment_artifacts(&root.public_bytes(), &token).is_ok()
+        );
+        assert!(hyprstream_discovery::verify_deployment_artifacts(
+            &root.public_bytes(),
+            &format!("{token}\n")
+        )
+        .is_err());
+    }
+}

--- a/crates/hyprstream/src/cli/trust.rs
+++ b/crates/hyprstream/src/cli/trust.rs
@@ -20,6 +20,7 @@ use hyprstream_discovery::did_op::{
     verify_did_op_log, DidOp, HybridDidOpSignature, HybridRotationKey, DID_OP_SIGNATURE_CONTEXT,
 };
 use hyprstream_discovery::{
+    DeploymentAuthorityCheckpoint as AuthorityCheckpointFile,
     DeploymentAuthorityLog as AuthorityLogFile, RegistryDelegationArtifact as DelegationArtifact,
 };
 use hyprstream_rpc::{
@@ -46,7 +47,7 @@ use std::{
     path::{Path, PathBuf},
     process::{Command, Stdio},
 };
-use zeroize::Zeroize as _;
+use zeroize::{Zeroize as _, Zeroizing};
 
 const PUBLIC_CA_BYTES: usize = 32 + 1_952;
 const HYBRID_SIGNATURE_BYTES: usize = 3_309 + 64;
@@ -54,6 +55,7 @@ const REGISTRY_AUDIENCE: &str = "urn:hyprstream:service:registry";
 const REGISTRY_PROFILE: &str = "hyprstream.registry-deployment.v1";
 const AUTHORITY_BUNDLE_SCHEMA: &str = "hyprstream.deployment-authority.v1";
 const AUTHORITY_LOG_SCHEMA: &str = "hyprstream.deployment-authority-log.v1";
+const AUTHORITY_CHECKPOINT_SCHEMA: &str = "hyprstream.deployment-authority-checkpoint.v1";
 const DELEGATION_SCHEMA: &str = "hyprstream.registry-delegation.v1";
 const PUBLISHER_MANIFEST_SCHEMA: &str = "hyprstream.deployment-trust-publisher-manifest.v1";
 const DELEGATION_RESOURCE_PREFIX: &str = "hyprstream://deployment";
@@ -61,6 +63,11 @@ const DELEGATION_ABILITY: &str = "mint-registry-jwt";
 const MAX_AUTHORITY_LOG_OPERATIONS: usize = 128;
 const MAX_DELEGATION_BYTES: usize = 256 * 1024;
 const MAX_CLOUD_SECRET_BYTES: usize = 64 * 1024;
+const PUBLIC_CA_INSTALL_PATH: &str = "/etc/hyprstream/trust/deployment-ca.hybrid";
+const AUTHORITY_LOG_INSTALL_PATH: &str = "/etc/hyprstream/trust/deployment-authority.log.json";
+const AUTHORITY_CHECKPOINT_INSTALL_PATH: &str =
+    "/etc/hyprstream/trust/deployment-authority.head.json";
+const REGISTRY_JWT_INSTALL_PATH: &str = "/run/hyprstream/credentials/registry-service.jwt";
 
 #[derive(Clone, Debug, Serialize, Deserialize, Eq, PartialEq)]
 #[serde(rename_all = "snake_case")]
@@ -118,6 +125,12 @@ struct CaMintOutput {
     schema: &'static str,
     deployment_domain: String,
     authority_log_did: String,
+    authority_log_sequence: u64,
+    authority_log_head_cid: String,
+    authority_log_path: String,
+    authority_log_install_path: &'static str,
+    authority_checkpoint_path: String,
+    authority_checkpoint_install_path: &'static str,
     public_ca_path: String,
     public_ca_install_path: &'static str,
     public_ca_bytes: usize,
@@ -149,7 +162,8 @@ struct PublisherManifest {
     audience: String,
     expires_at: i64,
     public_ca: PublisherArtifact,
-    authority_log: Option<PublisherArtifact>,
+    authority_log: PublisherArtifact,
+    authority_checkpoint: PublisherArtifact,
     registry_jwt: PublisherArtifact,
     private_authority_exported: bool,
     terraform_state_may_contain_private_authority: bool,
@@ -201,7 +215,12 @@ pub fn handle_trust_command(command: TrustCommand) -> Result<()> {
 
 fn mint_deployment_ca(args: &MintDeploymentCaArgs) -> Result<()> {
     preflight_outputs(
-        [&args.public_ca, &args.authority_key, &args.authority_log],
+        [
+            &args.public_ca,
+            &args.authority_key,
+            &args.authority_log,
+            &args.authority_checkpoint,
+        ],
         args.force,
     )?;
     let recipients = root_recipient_ring(args)?;
@@ -214,7 +233,7 @@ fn mint_deployment_ca(args: &MintDeploymentCaArgs) -> Result<()> {
                 Ed25519Secret::YubikeyPiv {
                     slot: slot.clone(),
                     public_b64: STANDARD.encode(public.as_bytes()),
-                    recovery_seed_b64: STANDARD.encode(recovery_key.to_bytes()),
+                    recovery_seed_b64: encode_secret_b64(recovery_key.to_bytes()),
                 },
                 LoadedEdSigner::YubikeyPiv { slot, public },
             )
@@ -223,7 +242,7 @@ fn mint_deployment_ca(args: &MintDeploymentCaArgs) -> Result<()> {
             let key = SigningKey::generate(&mut rand::rngs::OsRng);
             (
                 Ed25519Secret::Software {
-                    seed_b64: STANDARD.encode(key.to_bytes()),
+                    seed_b64: encode_secret_b64(key.to_bytes()),
                     public_b64: STANDARD.encode(key.verifying_key().as_bytes()),
                 },
                 LoadedEdSigner::Software(key),
@@ -254,7 +273,9 @@ fn mint_deployment_ca(args: &MintDeploymentCaArgs) -> Result<()> {
         &pq,
     )?;
     let authority_log = authority_log_from_ops(&deployment_domain, vec![genesis])?;
-    validate_authority_log(&public_ca, &authority_log)?;
+    let verified_log = validate_authority_log_root(&public_ca, &authority_log)?;
+    let checkpoint = authority_checkpoint(&deployment_domain, &verified_log);
+    validate_authority_log(&public_ca, &authority_log, &checkpoint)?;
 
     let bundle = AuthorityBundle {
         schema: AUTHORITY_BUNDLE_SCHEMA.to_owned(),
@@ -262,12 +283,11 @@ fn mint_deployment_ca(args: &MintDeploymentCaArgs) -> Result<()> {
         deployment_domain: deployment_domain.clone(),
         public_key_sha256: sha256_hex(&public_ca),
         ed25519: ed_secret,
-        ml_dsa_65_seed_b64: STANDARD.encode(ml_dsa_sk_to_seed(&pq)),
+        ml_dsa_65_seed_b64: encode_secret_b64(ml_dsa_sk_to_seed(&pq)),
         recipient_count: recipients.len(),
     };
-    let mut plaintext = serde_json::to_vec(&bundle).context("encode authority bundle")?;
+    let plaintext = serialize_secret_json(&bundle).context("encode authority bundle")?;
     let encrypted = encrypt_age(&plaintext, &recipients)?;
-    plaintext.zeroize();
 
     commit_outputs(vec![
         PendingOutput::new(&args.public_ca, public_ca.clone(), 0o644),
@@ -277,14 +297,25 @@ fn mint_deployment_ca(args: &MintDeploymentCaArgs) -> Result<()> {
             pretty_json_bytes(&authority_log)?,
             0o644,
         ),
+        PendingOutput::new(
+            &args.authority_checkpoint,
+            pretty_json_bytes(&checkpoint)?,
+            0o644,
+        ),
     ])?;
 
     let output = CaMintOutput {
         schema: "hyprstream.deployment-ca-mint-output.v1",
         deployment_domain,
         authority_log_did: authority_log.did,
+        authority_log_sequence: checkpoint.sequence,
+        authority_log_head_cid: checkpoint.head_cid,
+        authority_log_path: display_path(&args.authority_log),
+        authority_log_install_path: AUTHORITY_LOG_INSTALL_PATH,
+        authority_checkpoint_path: display_path(&args.authority_checkpoint),
+        authority_checkpoint_install_path: AUTHORITY_CHECKPOINT_INSTALL_PATH,
         public_ca_path: display_path(&args.public_ca),
-        public_ca_install_path: "/etc/hyprstream/trust/deployment-ca.hybrid",
+        public_ca_install_path: PUBLIC_CA_INSTALL_PATH,
         public_ca_bytes: public_ca.len(),
         public_ca_base64: STANDARD.encode(&public_ca),
         public_ca_sha256: sha256_hex(&public_ca),
@@ -305,7 +336,9 @@ fn delegate_registry_signer(args: &DelegateRegistrySignerArgs) -> Result<()> {
     let signer_recipients = distinct_recipients(args.signer_recipients.clone())?;
     let public_ca = read_limited(&args.public_ca, PUBLIC_CA_BYTES)?;
     let log: AuthorityLogFile = read_json_limited(&args.authority_log, MAX_CLOUD_SECRET_BYTES)?;
-    let active = validate_authority_log(&public_ca, &log)?;
+    let checkpoint: AuthorityCheckpointFile =
+        read_json_limited(&args.authority_checkpoint, MAX_CLOUD_SECRET_BYTES)?;
+    let active = validate_authority_log(&public_ca, &log, &checkpoint)?;
 
     let identities = combined_identities(&args.identities, &args.yubikey_identities)?;
     let authority = decrypt_authority(&args.authority_key, &identities, args.software_recovery)?;
@@ -348,15 +381,14 @@ fn delegate_registry_signer(args: &DelegateRegistrySignerArgs) -> Result<()> {
         deployment_domain: authority.bundle.deployment_domain.clone(),
         public_key_sha256: sha256_hex(&delegated_public),
         ed25519: Ed25519Secret::Software {
-            seed_b64: STANDARD.encode(delegated_ed.to_bytes()),
+            seed_b64: encode_secret_b64(delegated_ed.to_bytes()),
             public_b64: STANDARD.encode(delegated_ed.verifying_key().as_bytes()),
         },
-        ml_dsa_65_seed_b64: STANDARD.encode(ml_dsa_sk_to_seed(&delegated_pq)),
+        ml_dsa_65_seed_b64: encode_secret_b64(ml_dsa_sk_to_seed(&delegated_pq)),
         recipient_count: signer_recipients.len(),
     };
-    let mut plaintext = serde_json::to_vec(&delegated_bundle)?;
+    let plaintext = serialize_secret_json(&delegated_bundle)?;
     let encrypted = encrypt_age(&plaintext, &signer_recipients)?;
-    plaintext.zeroize();
 
     let artifact = DelegationArtifact {
         schema: DELEGATION_SCHEMA.to_owned(),
@@ -365,7 +397,7 @@ fn delegate_registry_signer(args: &DelegateRegistrySignerArgs) -> Result<()> {
         delegated_public_key_b64: STANDARD.encode(&delegated_public),
         ucan_b64: STANDARD.encode(ucan.to_cbor()?),
     };
-    validate_delegation_artifact(&public_ca, &log, &artifact, now)?;
+    validate_delegation_artifact(&public_ca, &log, &checkpoint, &artifact, now)?;
     commit_outputs(vec![
         PendingOutput::new(&args.delegated_key, encrypted, 0o600),
         PendingOutput::new(&args.delegation, pretty_json_bytes(&artifact)?, 0o644),
@@ -398,8 +430,17 @@ fn mint_registry_jwt(args: &MintRegistryJwtArgs) -> Result<()> {
         .map_err(|_| anyhow!("registry public key must be exactly 32 bytes"))?;
     VerifyingKey::from_bytes(&registry_key).context("invalid registry Ed25519 public key")?;
     let identities = combined_identities(&args.identities, &args.yubikey_identities)?;
+    let authority_log_bytes = read_limited(&args.authority_log, MAX_CLOUD_SECRET_BYTES)?;
+    let installed_log: AuthorityLogFile =
+        serde_json::from_slice(&authority_log_bytes).context("decode installed authority log")?;
+    let authority_checkpoint_bytes =
+        read_limited(&args.authority_checkpoint, MAX_CLOUD_SECRET_BYTES)?;
+    let installed_checkpoint: AuthorityCheckpointFile =
+        serde_json::from_slice(&authority_checkpoint_bytes)
+            .context("decode installed authority checkpoint")?;
+    let active = validate_authority_log(&public_ca, &installed_log, &installed_checkpoint)?;
 
-    let (signer, delegation_b64, authority_log) = if args.root {
+    let (signer, delegation_b64) = if args.root {
         let authority =
             decrypt_authority(&args.authority_key, &identities, args.software_recovery)?;
         ensure!(
@@ -410,16 +451,8 @@ fn mint_registry_jwt(args: &MintRegistryJwtArgs) -> Result<()> {
             authority.public_bytes() == public_ca,
             "root authority does not match the pinned public CA"
         );
-        let authority_log = args
-            .authority_log
-            .as_ref()
-            .map(|path| read_json_limited::<AuthorityLogFile>(path, MAX_CLOUD_SECRET_BYTES))
-            .transpose()?;
-        if let Some(log) = authority_log.as_ref() {
-            let active = validate_authority_log(&public_ca, log)?;
-            ensure_active_authority(&authority, &active)?;
-        }
-        (authority, None, authority_log)
+        ensure_active_authority(&authority, &active)?;
+        (authority, None)
     } else {
         let delegated_path = args
             .via_delegated_signer
@@ -430,14 +463,13 @@ fn mint_registry_jwt(args: &MintRegistryJwtArgs) -> Result<()> {
             .as_ref()
             .ok_or_else(|| anyhow!("--delegation is required"))?;
         let artifact: DelegationArtifact = read_json_limited(artifact_path, MAX_DELEGATION_BYTES)?;
-        let authority_log_path = args
-            .authority_log
-            .as_ref()
-            .ok_or_else(|| anyhow!("--authority-log is required with delegated signing"))?;
-        let installed_log: AuthorityLogFile =
-            read_json_limited(authority_log_path, MAX_CLOUD_SECRET_BYTES)?;
-        validate_authority_log(&public_ca, &installed_log)?;
-        validate_delegation_artifact(&public_ca, &installed_log, &artifact, now_unix_u64()?)?;
+        validate_delegation_artifact(
+            &public_ca,
+            &installed_log,
+            &installed_checkpoint,
+            &artifact,
+            now_unix_u64()?,
+        )?;
         let delegated = decrypt_authority(delegated_path, &identities, args.software_recovery)?;
         ensure!(
             delegated.bundle.purpose == AuthorityPurpose::RegistryDelegatedSigner,
@@ -451,11 +483,7 @@ fn mint_registry_jwt(args: &MintRegistryJwtArgs) -> Result<()> {
             "delegated private key does not match the root-authorized delegation"
         );
         let artifact_json = serde_json::to_vec(&artifact)?;
-        (
-            delegated,
-            Some(URL_SAFE_NO_PAD.encode(artifact_json)),
-            Some(installed_log),
-        )
+        (delegated, Some(URL_SAFE_NO_PAD.encode(artifact_json)))
     };
     ensure!(
         signer.bundle.deployment_domain == root_domain,
@@ -471,14 +499,12 @@ fn mint_registry_jwt(args: &MintRegistryJwtArgs) -> Result<()> {
         token.len() <= MAX_CLOUD_SECRET_BYTES,
         "registry JWT exceeds the 64 KiB cloud-secret contract"
     );
-    let verified = match authority_log.as_ref() {
-        Some(log) => hyprstream_discovery::verify_deployment_artifacts_with_authority_log(
-            &public_ca,
-            &serde_json::to_vec(log)?,
-            &token,
-        ),
-        None => hyprstream_discovery::verify_deployment_artifacts(&public_ca, &token),
-    }
+    let verified = hyprstream_discovery::verify_deployment_artifacts_with_authority_log(
+        &public_ca,
+        &authority_log_bytes,
+        &authority_checkpoint_bytes,
+        &token,
+    )
     .context("production deployment verifier rejected minted credential")?;
     ensure!(
         verified.registry_public_key == registry_key && verified.deployment_domain == root_domain,
@@ -494,40 +520,34 @@ fn mint_registry_jwt(args: &MintRegistryJwtArgs) -> Result<()> {
         expires_at: exp,
         public_ca: PublisherArtifact {
             local_path: display_path(&args.public_ca),
-            install_path: "/etc/hyprstream/trust/deployment-ca.hybrid".to_owned(),
+            install_path: PUBLIC_CA_INSTALL_PATH.to_owned(),
             encoding: "raw".to_owned(),
             base64: STANDARD.encode(&public_ca),
             sha256: sha256_hex(&public_ca),
             size_bytes: public_ca.len(),
             cloud_secret_store: true,
         },
-        authority_log: authority_log
-            .as_ref()
-            .map(|log| {
-                let path = args
-                    .authority_log
-                    .as_ref()
-                    .ok_or_else(|| anyhow!("authority log path disappeared"))?;
-                let bytes = read_limited(path, MAX_CLOUD_SECRET_BYTES)?;
-                let persisted: AuthorityLogFile = serde_json::from_slice(&bytes)?;
-                ensure!(
-                    &persisted == log,
-                    "authority log changed while building publisher manifest"
-                );
-                Ok::<PublisherArtifact, anyhow::Error>(PublisherArtifact {
-                    local_path: display_path(path),
-                    install_path: "/etc/hyprstream/trust/deployment-authority.log.json".to_owned(),
-                    encoding: "json".to_owned(),
-                    base64: STANDARD.encode(&bytes),
-                    sha256: sha256_hex(&bytes),
-                    size_bytes: bytes.len(),
-                    cloud_secret_store: true,
-                })
-            })
-            .transpose()?,
+        authority_log: PublisherArtifact {
+            local_path: display_path(&args.authority_log),
+            install_path: AUTHORITY_LOG_INSTALL_PATH.to_owned(),
+            encoding: "json".to_owned(),
+            base64: STANDARD.encode(&authority_log_bytes),
+            sha256: sha256_hex(&authority_log_bytes),
+            size_bytes: authority_log_bytes.len(),
+            cloud_secret_store: true,
+        },
+        authority_checkpoint: PublisherArtifact {
+            local_path: display_path(&args.authority_checkpoint),
+            install_path: AUTHORITY_CHECKPOINT_INSTALL_PATH.to_owned(),
+            encoding: "json".to_owned(),
+            base64: STANDARD.encode(&authority_checkpoint_bytes),
+            sha256: sha256_hex(&authority_checkpoint_bytes),
+            size_bytes: authority_checkpoint_bytes.len(),
+            cloud_secret_store: true,
+        },
         registry_jwt: PublisherArtifact {
             local_path: display_path(&args.jwt),
-            install_path: "/run/hyprstream/credentials/registry-service.jwt".to_owned(),
+            install_path: REGISTRY_JWT_INSTALL_PATH.to_owned(),
             encoding: "utf8".to_owned(),
             base64: STANDARD.encode(jwt_bytes),
             sha256: sha256_hex(jwt_bytes),
@@ -547,8 +567,8 @@ fn mint_registry_jwt(args: &MintRegistryJwtArgs) -> Result<()> {
 
 fn verify_deployment(args: &VerifyDeploymentArgs) -> Result<()> {
     let public_ca = read_limited(&args.public_ca, PUBLIC_CA_BYTES)?;
-    let token = String::from_utf8(read_limited(&args.jwt, MAX_CLOUD_SECRET_BYTES)?)
-        .context("registry JWT is not UTF-8")?;
+    let token_bytes = read_limited(&args.jwt, MAX_CLOUD_SECRET_BYTES)?;
+    let token = String::from_utf8(token_bytes.clone()).context("registry JWT is not UTF-8")?;
     ensure!(
         !token.is_empty() && !token.bytes().any(|byte| byte.is_ascii_whitespace()),
         "registry JWT must be compact with no surrounding or embedded whitespace"
@@ -558,43 +578,63 @@ fn verify_deployment(args: &VerifyDeploymentArgs) -> Result<()> {
         .as_ref()
         .map(|path| read_json_limited::<PublisherManifest>(path, 1024 * 1024))
         .transpose()?;
-    let authority_log = match (&args.authority_log, contract.as_ref()) {
-        (Some(path), _) => Some(read_limited(path, MAX_CLOUD_SECRET_BYTES)?),
-        (None, Some(contract)) => contract
-            .authority_log
-            .as_ref()
-            .map(|artifact| STANDARD.decode(&artifact.base64))
-            .transpose()?,
-        (None, None) => None,
-    };
-    let verified = match authority_log.as_deref() {
-        Some(log) => hyprstream_discovery::verify_deployment_artifacts_with_authority_log(
-            &public_ca, log, &token,
-        ),
-        None => hyprstream_discovery::verify_deployment_artifacts(&public_ca, &token),
-    }?;
+    let authority_log = read_limited(&args.authority_log, MAX_CLOUD_SECRET_BYTES)?;
+    let authority_checkpoint = read_limited(&args.authority_checkpoint, MAX_CLOUD_SECRET_BYTES)?;
+    let verified = hyprstream_discovery::verify_deployment_artifacts_with_authority_log(
+        &public_ca,
+        &authority_log,
+        &authority_checkpoint,
+        &token,
+    )?;
     if let Some(contract) = contract {
         ensure!(
             contract.schema == PUBLISHER_MANIFEST_SCHEMA,
             "unsupported contract schema"
         );
         ensure!(
-            STANDARD.decode(&contract.public_ca.base64)? == public_ca,
-            "contract public CA does not match file"
+            contract.deployment_domain == verified.deployment_domain,
+            "contract deployment domain does not match authenticated JWT/root"
         );
         ensure!(
-            STANDARD.decode(&contract.registry_jwt.base64)? == token.as_bytes(),
-            "contract JWT does not match file"
+            contract.profile == REGISTRY_PROFILE,
+            "contract profile does not match the fixed deployment profile"
         );
-        if let Some(artifact) = contract.authority_log.as_ref() {
-            let log = authority_log
-                .as_ref()
-                .ok_or_else(|| anyhow!("contract authority log was not verified"))?;
-            ensure!(
-                STANDARD.decode(&artifact.base64)? == *log,
-                "contract authority log does not match verified bytes"
-            );
-        }
+        ensure!(
+            contract.audience == REGISTRY_AUDIENCE,
+            "contract audience does not match the fixed registry audience"
+        );
+        ensure!(
+            contract.expires_at == verified.expires_at,
+            "contract expiry does not equal the authenticated JWT exp"
+        );
+        verify_publisher_artifact(
+            &contract.public_ca,
+            &public_ca,
+            &display_path(&args.public_ca),
+            PUBLIC_CA_INSTALL_PATH,
+            "raw",
+        )?;
+        verify_publisher_artifact(
+            &contract.authority_log,
+            &authority_log,
+            &display_path(&args.authority_log),
+            AUTHORITY_LOG_INSTALL_PATH,
+            "json",
+        )?;
+        verify_publisher_artifact(
+            &contract.authority_checkpoint,
+            &authority_checkpoint,
+            &display_path(&args.authority_checkpoint),
+            AUTHORITY_CHECKPOINT_INSTALL_PATH,
+            "json",
+        )?;
+        verify_publisher_artifact(
+            &contract.registry_jwt,
+            &token_bytes,
+            &display_path(&args.jwt),
+            REGISTRY_JWT_INSTALL_PATH,
+            "utf8",
+        )?;
         ensure!(
             !contract.private_authority_exported
                 && !contract.terraform_state_may_contain_private_authority,
@@ -615,6 +655,51 @@ fn verify_deployment(args: &VerifyDeploymentArgs) -> Result<()> {
     Ok(())
 }
 
+fn verify_publisher_artifact(
+    artifact: &PublisherArtifact,
+    expected_bytes: &[u8],
+    expected_local_path: &str,
+    expected_install_path: &str,
+    expected_encoding: &str,
+) -> Result<()> {
+    ensure!(
+        artifact.local_path == expected_local_path,
+        "contract artifact local path does not match the verified input"
+    );
+    ensure!(
+        artifact.install_path == expected_install_path,
+        "contract artifact install path is not the fixed deployment path"
+    );
+    ensure!(
+        artifact.encoding == expected_encoding,
+        "contract artifact encoding is not the fixed deployment encoding"
+    );
+    ensure!(
+        artifact.cloud_secret_store,
+        "contract artifact unexpectedly forbids cloud secret-store publication"
+    );
+    let decoded = STANDARD
+        .decode(&artifact.base64)
+        .context("decode contract artifact base64")?;
+    ensure!(
+        STANDARD.encode(&decoded) == artifact.base64,
+        "contract artifact base64 is not canonical"
+    );
+    ensure!(
+        decoded == expected_bytes,
+        "contract artifact bytes do not match the verified input"
+    );
+    ensure!(
+        artifact.size_bytes == decoded.len(),
+        "contract artifact size does not match authenticated bytes"
+    );
+    ensure!(
+        artifact.sha256 == sha256_hex(&decoded),
+        "contract artifact SHA-256 does not match authenticated bytes"
+    );
+    Ok(())
+}
+
 fn rotate_authority(args: &RotateAuthorityArgs) -> Result<()> {
     ensure!(
         args.add ^ args.replace,
@@ -625,6 +710,7 @@ fn rotate_authority(args: &RotateAuthorityArgs) -> Result<()> {
             &args.new_authority_key,
             &args.new_public_key,
             &args.authority_log_out,
+            &args.authority_checkpoint_out,
         ],
         args.force,
     )?;
@@ -635,7 +721,9 @@ fn rotate_authority(args: &RotateAuthorityArgs) -> Result<()> {
     );
     let public_ca = read_limited(&args.public_ca, PUBLIC_CA_BYTES)?;
     let log: AuthorityLogFile = read_json_limited(&args.authority_log, MAX_CLOUD_SECRET_BYTES)?;
-    let active = validate_authority_log(&public_ca, &log)?;
+    let checkpoint: AuthorityCheckpointFile =
+        read_json_limited(&args.authority_checkpoint, MAX_CLOUD_SECRET_BYTES)?;
+    let active = validate_authority_log(&public_ca, &log, &checkpoint)?;
     let identities = combined_identities(&args.identities, &args.yubikey_identities)?;
     let current = decrypt_authority(&args.authority_key, &identities, args.software_recovery)?;
     ensure_active_authority(&current, &active)?;
@@ -678,7 +766,17 @@ fn rotate_authority(args: &RotateAuthorityArgs) -> Result<()> {
     let mut operations = operations;
     operations.push(next);
     let next_log = authority_log_from_ops(&log.deployment_domain, operations)?;
-    validate_authority_log(&public_ca, &next_log)?;
+    let next_verified = validate_authority_log_root(&public_ca, &next_log)?;
+    let expected_sequence = checkpoint
+        .sequence
+        .checked_add(1)
+        .ok_or_else(|| anyhow!("authority checkpoint sequence overflow"))?;
+    ensure!(
+        next_verified.did == checkpoint.did && next_verified.sequence == expected_sequence,
+        "authority rotation did not advance the trusted checkpoint exactly once"
+    );
+    let next_checkpoint = authority_checkpoint(&next_log.deployment_domain, &next_verified);
+    validate_authority_log(&public_ca, &next_log, &next_checkpoint)?;
 
     let new_bundle = AuthorityBundle {
         schema: AUTHORITY_BUNDLE_SCHEMA.to_owned(),
@@ -686,15 +784,14 @@ fn rotate_authority(args: &RotateAuthorityArgs) -> Result<()> {
         deployment_domain: log.deployment_domain.clone(),
         public_key_sha256: sha256_hex(&new_public),
         ed25519: Ed25519Secret::Software {
-            seed_b64: STANDARD.encode(new_ed.to_bytes()),
+            seed_b64: encode_secret_b64(new_ed.to_bytes()),
             public_b64: STANDARD.encode(new_ed.verifying_key().as_bytes()),
         },
-        ml_dsa_65_seed_b64: STANDARD.encode(ml_dsa_sk_to_seed(&new_pq)),
+        ml_dsa_65_seed_b64: encode_secret_b64(ml_dsa_sk_to_seed(&new_pq)),
         recipient_count: recipients.len(),
     };
-    let mut plaintext = serde_json::to_vec(&new_bundle)?;
+    let plaintext = serialize_secret_json(&new_bundle)?;
     let encrypted = encrypt_age(&plaintext, &recipients)?;
-    plaintext.zeroize();
 
     commit_outputs(vec![
         PendingOutput::new(&args.new_public_key, new_public, 0o644),
@@ -704,6 +801,11 @@ fn rotate_authority(args: &RotateAuthorityArgs) -> Result<()> {
             pretty_json_bytes(&next_log)?,
             0o644,
         ),
+        PendingOutput::new(
+            &args.authority_checkpoint_out,
+            pretty_json_bytes(&next_checkpoint)?,
+            0o644,
+        ),
     ])?;
     println!(
         "{}",
@@ -711,11 +813,13 @@ fn rotate_authority(args: &RotateAuthorityArgs) -> Result<()> {
             "schema": "hyprstream.authority-rotation-output.v1",
             "deployment_domain": next_log.deployment_domain,
             "authority_log_did": next_log.did,
-            "sequence": next_log.operations_b64.len() - 1,
+            "sequence": next_checkpoint.sequence,
+            "head_cid": next_checkpoint.head_cid,
             "mode": if args.add { "add" } else { "replace" },
             "new_public_key_path": display_path(&args.new_public_key),
             "new_authority_key_path": display_path(&args.new_authority_key),
-            "authority_log_path": display_path(&args.authority_log_out)
+            "authority_log_path": display_path(&args.authority_log_out),
+            "authority_checkpoint_path": display_path(&args.authority_checkpoint_out)
         }))?
     );
     Ok(())
@@ -803,7 +907,7 @@ fn encrypt_age(plaintext: &[u8], recipients: &[String]) -> Result<Vec<u8>> {
     Ok(output.stdout)
 }
 
-fn decrypt_age(path: &Path, identities: &[PathBuf]) -> Result<Vec<u8>> {
+fn decrypt_age(path: &Path, identities: &[PathBuf]) -> Result<Zeroizing<Vec<u8>>> {
     let mut command = Command::new("age");
     command
         .arg("--decrypt")
@@ -817,12 +921,14 @@ fn decrypt_age(path: &Path, identities: &[PathBuf]) -> Result<Vec<u8>> {
     }
     command.arg(path);
     let output = command.output().context("launch age decryption")?;
-    ensure!(output.status.success(), "age decryption failed");
+    let status = output.status;
+    let plaintext = Zeroizing::new(output.stdout);
+    ensure!(status.success(), "age decryption failed");
     ensure!(
-        output.stdout.len() <= 128 * 1024,
+        plaintext.len() <= 128 * 1024,
         "decrypted authority bundle is too large"
     );
-    Ok(output.stdout)
+    Ok(plaintext)
 }
 
 fn decrypt_authority(
@@ -830,17 +936,15 @@ fn decrypt_authority(
     identities: &[PathBuf],
     software_recovery: bool,
 ) -> Result<LoadedAuthority> {
-    let mut plaintext = decrypt_age(path, identities)?;
+    let plaintext = decrypt_age(path, identities)?;
     let bundle: AuthorityBundle =
         serde_json::from_slice(&plaintext).context("decode authority bundle")?;
-    plaintext.zeroize();
     ensure!(
         bundle.schema == AUTHORITY_BUNDLE_SCHEMA,
         "unsupported authority bundle schema"
     );
-    let mut pq_seed = decode_fixed_b64::<32>(&bundle.ml_dsa_65_seed_b64, "ML-DSA-65 seed")?;
+    let pq_seed = decode_fixed_b64::<32>(&bundle.ml_dsa_65_seed_b64, "ML-DSA-65 seed")?;
     let pq = ml_dsa_sk_from_seed(&pq_seed);
-    pq_seed.zeroize();
     let ed = match &bundle.ed25519 {
         Ed25519Secret::Software {
             seed_b64,
@@ -850,9 +954,8 @@ fn decrypt_authority(
                 !software_recovery,
                 "--software-recovery applies only to a PIV-backed authority"
             );
-            let mut seed = decode_fixed_b64::<32>(seed_b64, "Ed25519 seed")?;
+            let seed = decode_fixed_b64::<32>(seed_b64, "Ed25519 seed")?;
             let key = SigningKey::from_bytes(&seed);
-            seed.zeroize();
             ensure!(
                 STANDARD.decode(public_b64)? == key.verifying_key().as_bytes(),
                 "authority Ed25519 public key does not match seed"
@@ -869,10 +972,8 @@ fn decrypt_authority(
             let public =
                 VerifyingKey::from_bytes(&public_bytes).context("invalid PIV public key")?;
             if software_recovery {
-                let mut seed =
-                    decode_fixed_b64::<32>(recovery_seed_b64, "PIV recovery Ed25519 seed")?;
+                let seed = decode_fixed_b64::<32>(recovery_seed_b64, "PIV recovery Ed25519 seed")?;
                 let key = SigningKey::from_bytes(&seed);
-                seed.zeroize();
                 ensure!(
                     key.verifying_key() == public,
                     "PIV recovery seed does not match the recorded public key"
@@ -1119,7 +1220,7 @@ fn decode_authority_operations(log: &AuthorityLogFile) -> Result<Vec<DidOp>> {
         .collect()
 }
 
-fn validate_authority_log(
+fn validate_authority_log_root(
     public_ca: &[u8],
     log: &AuthorityLogFile,
 ) -> Result<hyprstream_discovery::did_op::VerifiedDidOpLog> {
@@ -1155,6 +1256,43 @@ fn validate_authority_log(
             key.ed25519_pub == root_ed.to_bytes() && key.mldsa65_pub == ml_dsa_vk_bytes(&root_pq)
         }),
         "authority log genesis is not anchored by the pinned public root"
+    );
+    Ok(verified)
+}
+
+fn authority_checkpoint(
+    deployment_domain: &str,
+    verified: &hyprstream_discovery::did_op::VerifiedDidOpLog,
+) -> AuthorityCheckpointFile {
+    AuthorityCheckpointFile {
+        schema: AUTHORITY_CHECKPOINT_SCHEMA.to_owned(),
+        deployment_domain: deployment_domain.to_owned(),
+        did: verified.did.clone(),
+        sequence: verified.sequence,
+        head_cid: verified.head_cid.clone(),
+    }
+}
+
+fn validate_authority_log(
+    public_ca: &[u8],
+    log: &AuthorityLogFile,
+    checkpoint: &AuthorityCheckpointFile,
+) -> Result<hyprstream_discovery::did_op::VerifiedDidOpLog> {
+    let verified = validate_authority_log_root(public_ca, log)?;
+    ensure!(
+        checkpoint.schema == AUTHORITY_CHECKPOINT_SCHEMA,
+        "unsupported authority-checkpoint schema"
+    );
+    ensure!(
+        checkpoint.deployment_domain == log.deployment_domain,
+        "authority checkpoint deployment domain does not match log"
+    );
+    ensure!(
+        checkpoint.did == log.did
+            && checkpoint.did == verified.did
+            && checkpoint.sequence == verified.sequence
+            && checkpoint.head_cid == verified.head_cid,
+        "authority-log head does not match the independently trusted checkpoint"
     );
     Ok(verified)
 }
@@ -1256,6 +1394,7 @@ fn validate_registry_delegation_ucan(
 fn validate_delegation_artifact(
     public_ca: &[u8],
     authority_log: &AuthorityLogFile,
+    authority_checkpoint: &AuthorityCheckpointFile,
     artifact: &DelegationArtifact,
     now: u64,
 ) -> Result<()> {
@@ -1263,7 +1402,7 @@ fn validate_delegation_artifact(
         artifact.schema == DELEGATION_SCHEMA,
         "unsupported delegation schema"
     );
-    let active = validate_authority_log(public_ca, authority_log)?;
+    let active = validate_authority_log(public_ca, authority_log, authority_checkpoint)?;
     ensure!(
         artifact.deployment_domain == authority_log.deployment_domain,
         "delegation domain does not match authority log"
@@ -1429,6 +1568,12 @@ fn pretty_json_bytes(value: &impl Serialize) -> Result<Vec<u8>> {
     Ok(bytes)
 }
 
+fn serialize_secret_json(value: &impl Serialize) -> Result<Zeroizing<Vec<u8>>> {
+    let mut plaintext = Zeroizing::new(Vec::new());
+    serde_json::to_writer(&mut *plaintext, value)?;
+    Ok(plaintext)
+}
+
 struct PendingOutput<'a> {
     path: &'a Path,
     bytes: Vec<u8>,
@@ -1469,49 +1614,125 @@ fn commit_outputs(outputs: Vec<PendingOutput<'_>>) -> Result<()> {
             let backup = placeholder.path().to_path_buf();
             drop(placeholder);
             if let Err(error) = std::fs::rename(output.path, &backup) {
-                restore_outputs(&outputs, &backups, 0);
-                cleanup_paths(&staged);
-                return Err(error)
-                    .with_context(|| format!("back up existing {}", output.path.display()));
+                return Err(transaction_failure(
+                    error.into(),
+                    format!("back up existing {}", output.path.display()),
+                    restore_outputs(&outputs, &backups, 0),
+                    cleanup_paths(&staged),
+                ));
             }
             backups[index] = Some(backup);
         }
     }
+    if let Err(error) = sync_output_parents(&outputs) {
+        return Err(transaction_failure(
+            error,
+            "durably record output backups".to_owned(),
+            restore_outputs(&outputs, &backups, 0),
+            cleanup_paths(&staged),
+        ));
+    }
 
     for (index, output) in outputs.iter().enumerate() {
         if let Err(error) = std::fs::rename(&staged[index], output.path) {
-            restore_outputs(&outputs, &backups, index);
-            cleanup_paths(&staged[index..]);
-            return Err(error).with_context(|| format!("commit {}", output.path.display()));
+            return Err(transaction_failure(
+                error.into(),
+                format!("commit {}", output.path.display()),
+                restore_outputs(&outputs, &backups, index),
+                cleanup_paths(&staged[index..]),
+            ));
         }
     }
-
-    for backup in backups.into_iter().flatten() {
-        let _ = std::fs::remove_file(backup);
+    if let Err(error) = sync_output_parents(&outputs) {
+        return Err(transaction_failure(
+            error,
+            "durably record committed outputs".to_owned(),
+            restore_outputs(&outputs, &backups, outputs.len()),
+            Ok(()),
+        ));
     }
-    sync_output_parents(&outputs);
+
+    let mut cleanup_errors = Vec::new();
+    for backup in backups.into_iter().flatten() {
+        if let Err(error) = std::fs::remove_file(&backup) {
+            cleanup_errors.push(format!("remove backup {}: {error}", backup.display()));
+        }
+    }
+    if let Err(error) = sync_output_parents(&outputs) {
+        cleanup_errors.push(format!("durably record backup deletion: {error:#}"));
+    }
+    ensure!(
+        cleanup_errors.is_empty(),
+        "outputs committed, but transaction cleanup was incomplete; preserved backup state where possible: {}",
+        cleanup_errors.join("; ")
+    );
     Ok(())
 }
 
-fn restore_outputs(outputs: &[PendingOutput<'_>], backups: &[Option<PathBuf>], committed: usize) {
+fn transaction_failure(
+    primary: anyhow::Error,
+    context: String,
+    rollback: Result<()>,
+    staged_cleanup: Result<()>,
+) -> anyhow::Error {
+    let mut message = format!("{context}: {primary:#}");
+    if let Err(error) = rollback {
+        message.push_str(&format!(
+            "; ROLLBACK INCOMPLETE (backup state preserved where possible): {error:#}"
+        ));
+    }
+    if let Err(error) = staged_cleanup {
+        message.push_str(&format!("; staged-output cleanup incomplete: {error:#}"));
+    }
+    anyhow!(message)
+}
+
+fn restore_outputs(
+    outputs: &[PendingOutput<'_>],
+    backups: &[Option<PathBuf>],
+    committed: usize,
+) -> Result<()> {
+    let mut errors = Vec::new();
     for output in outputs.iter().take(committed) {
-        let _ = std::fs::remove_file(output.path);
+        if let Err(error) = std::fs::remove_file(output.path) {
+            errors.push(format!(
+                "remove newly committed {}: {error}",
+                output.path.display()
+            ));
+        }
     }
     for (output, backup) in outputs.iter().zip(backups).rev() {
         if let Some(backup) = backup {
-            let _ = std::fs::rename(backup, output.path);
+            if let Err(error) = std::fs::rename(backup, output.path) {
+                errors.push(format!(
+                    "restore {} from {}: {error}",
+                    output.path.display(),
+                    backup.display()
+                ));
+            }
         }
     }
-    sync_output_parents(outputs);
-}
-
-fn cleanup_paths(paths: &[PathBuf]) {
-    for path in paths {
-        let _ = std::fs::remove_file(path);
+    if let Err(error) = sync_output_parents(outputs) {
+        errors.push(format!("durably record rollback: {error:#}"));
     }
+    ensure!(errors.is_empty(), "{}", errors.join("; "));
+    Ok(())
 }
 
-fn sync_output_parents(outputs: &[PendingOutput<'_>]) {
+fn cleanup_paths(paths: &[PathBuf]) -> Result<()> {
+    let mut errors = Vec::new();
+    for path in paths {
+        if path.exists() {
+            if let Err(error) = std::fs::remove_file(path) {
+                errors.push(format!("remove staged {}: {error}", path.display()));
+            }
+        }
+    }
+    ensure!(errors.is_empty(), "{}", errors.join("; "));
+    Ok(())
+}
+
+fn sync_output_parents(outputs: &[PendingOutput<'_>]) -> Result<()> {
     let parents: BTreeSet<_> = outputs
         .iter()
         .map(|output| {
@@ -1523,10 +1744,13 @@ fn sync_output_parents(outputs: &[PendingOutput<'_>]) {
         })
         .collect();
     for parent in parents {
-        if let Ok(directory) = std::fs::File::open(parent) {
-            let _ = directory.sync_all();
-        }
+        let directory = std::fs::File::open(&parent)
+            .with_context(|| format!("open output directory {}", parent.display()))?;
+        directory
+            .sync_all()
+            .with_context(|| format!("fsync output directory {}", parent.display()))?;
     }
+    Ok(())
 }
 
 fn read_limited(path: &Path, max: usize) -> Result<Vec<u8>> {
@@ -1558,12 +1782,22 @@ fn read_json_limited<T: for<'de> Deserialize<'de>>(path: &Path, max: usize) -> R
         .with_context(|| format!("decode JSON {}", path.display()))
 }
 
-fn decode_fixed_b64<const N: usize>(value: &str, description: &str) -> Result<[u8; N]> {
-    STANDARD
-        .decode(value)
-        .with_context(|| format!("decode {description}"))?
+fn decode_fixed_b64<const N: usize>(value: &str, description: &str) -> Result<Zeroizing<[u8; N]>> {
+    let decoded = Zeroizing::new(
+        STANDARD
+            .decode(value)
+            .with_context(|| format!("decode {description}"))?,
+    );
+    decoded
+        .as_slice()
         .try_into()
+        .map(Zeroizing::new)
         .map_err(|_| anyhow!("{description} must decode to exactly {N} bytes"))
+}
+
+fn encode_secret_b64<const N: usize>(secret: [u8; N]) -> String {
+    let secret = Zeroizing::new(secret);
+    STANDARD.encode(secret.as_ref())
 }
 
 fn sha256_hex(bytes: &[u8]) -> String {
@@ -1575,7 +1809,14 @@ fn sha256_hex(bytes: &[u8]) -> String {
 
 fn display_path(path: &Path) -> String {
     path.canonicalize()
-        .unwrap_or_else(|_| path.to_path_buf())
+        .unwrap_or_else(|_| {
+            path.parent()
+                .unwrap_or_else(|| Path::new("."))
+                .canonicalize()
+                .ok()
+                .and_then(|parent| path.file_name().map(|name| parent.join(name)))
+                .unwrap_or_else(|| path.to_path_buf())
+        })
         .display()
         .to_string()
 }
@@ -1614,15 +1855,35 @@ mod tests {
                 deployment_domain: domain,
                 public_key_sha256: sha256_hex(&public),
                 ed25519: Ed25519Secret::Software {
-                    seed_b64: STANDARD.encode(ed.to_bytes()),
+                    seed_b64: encode_secret_b64(ed.to_bytes()),
                     public_b64: STANDARD.encode(ed.verifying_key().as_bytes()),
                 },
-                ml_dsa_65_seed_b64: STANDARD.encode(ml_dsa_sk_to_seed(&pq)),
+                ml_dsa_65_seed_b64: encode_secret_b64(ml_dsa_sk_to_seed(&pq)),
                 recipient_count: 2,
             },
             ed: LoadedEdSigner::Software(ed),
             pq,
         }
+    }
+
+    fn checkpoint_for(log: &AuthorityLogFile) -> AuthorityCheckpointFile {
+        let operations = decode_authority_operations(log).unwrap();
+        let verified = verify_did_op_log(&log.did, &operations).unwrap();
+        authority_checkpoint(&log.deployment_domain, &verified)
+    }
+
+    fn verify_with_log(
+        public_ca: &[u8],
+        log: &AuthorityLogFile,
+        checkpoint: &AuthorityCheckpointFile,
+        token: &str,
+    ) -> Result<hyprstream_discovery::VerifiedDeploymentArtifacts> {
+        hyprstream_discovery::verify_deployment_artifacts_with_authority_log(
+            public_ca,
+            &serde_json::to_vec(log)?,
+            &serde_json::to_vec(checkpoint)?,
+            token,
+        )
     }
 
     #[test]
@@ -1633,6 +1894,7 @@ mod tests {
             public_ca: "ca".into(),
             authority_key: "key".into(),
             authority_log: "log".into(),
+            authority_checkpoint: "head".into(),
             recipients: vec!["age1one".to_owned(), "age1one".to_owned()],
             yubikey_recipients: vec![],
             kms_plugin_recipients: vec![],
@@ -1684,7 +1946,24 @@ mod tests {
                 size_bytes: 1,
                 cloud_secret_store: true,
             },
-            authority_log: None,
+            authority_log: PublisherArtifact {
+                local_path: "log".to_owned(),
+                install_path: AUTHORITY_LOG_INSTALL_PATH.to_owned(),
+                encoding: "json".to_owned(),
+                base64: "eA==".to_owned(),
+                sha256: sha256_hex(b"x"),
+                size_bytes: 1,
+                cloud_secret_store: true,
+            },
+            authority_checkpoint: PublisherArtifact {
+                local_path: "head".to_owned(),
+                install_path: AUTHORITY_CHECKPOINT_INSTALL_PATH.to_owned(),
+                encoding: "json".to_owned(),
+                base64: "eA==".to_owned(),
+                sha256: sha256_hex(b"x"),
+                size_bytes: 1,
+                cloud_secret_store: true,
+            },
             registry_jwt: PublisherArtifact {
                 local_path: "jwt".to_owned(),
                 install_path: "jwt".to_owned(),
@@ -1701,6 +1980,67 @@ mod tests {
         let object = value.as_object().unwrap();
         assert!(!object.contains_key("authority_key"));
         assert_eq!(object["private_authority_exported"], false);
+    }
+
+    #[test]
+    fn publisher_artifact_verification_covers_every_contract_field() {
+        let bytes = b"authenticated artifact bytes";
+        let valid = PublisherArtifact {
+            local_path: "/operator/artifact".to_owned(),
+            install_path: PUBLIC_CA_INSTALL_PATH.to_owned(),
+            encoding: "raw".to_owned(),
+            base64: STANDARD.encode(bytes),
+            sha256: sha256_hex(bytes),
+            size_bytes: bytes.len(),
+            cloud_secret_store: true,
+        };
+        verify_publisher_artifact(
+            &valid,
+            bytes,
+            "/operator/artifact",
+            PUBLIC_CA_INSTALL_PATH,
+            "raw",
+        )
+        .unwrap();
+
+        let mutations: [(&str, fn(&mut PublisherArtifact)); 7] = [
+            ("local_path", |artifact| {
+                artifact.local_path = "/attacker".to_owned();
+            }),
+            ("install_path", |artifact| {
+                artifact.install_path = "/tmp/attacker".to_owned();
+            }),
+            ("encoding", |artifact| {
+                artifact.encoding = "utf8".to_owned();
+            }),
+            ("base64", |artifact| {
+                artifact.base64 = STANDARD.encode(b"attacker");
+            }),
+            ("sha256", |artifact| {
+                artifact.sha256 = "00".repeat(32);
+            }),
+            ("size_bytes", |artifact| {
+                artifact.size_bytes += 1;
+            }),
+            ("cloud_secret_store", |artifact| {
+                artifact.cloud_secret_store = false;
+            }),
+        ];
+        for (field, mutate) in mutations {
+            let mut changed = valid.clone();
+            mutate(&mut changed);
+            assert!(
+                verify_publisher_artifact(
+                    &changed,
+                    bytes,
+                    "/operator/artifact",
+                    PUBLIC_CA_INSTALL_PATH,
+                    "raw",
+                )
+                .is_err(),
+                "modified contract field {field} was accepted"
+            );
+        }
     }
 
     #[test]
@@ -1725,6 +2065,7 @@ mod tests {
         .unwrap();
         let genesis_log =
             authority_log_from_ops(&root.bundle.deployment_domain, vec![genesis.clone()]).unwrap();
+        let genesis_checkpoint = checkpoint_for(&genesis_log);
 
         let delegated = test_authority(
             AuthorityPurpose::RegistryDelegatedSigner,
@@ -1772,18 +2113,8 @@ mod tests {
             Some(&URL_SAFE_NO_PAD.encode(serde_json::to_vec(&artifact).unwrap())),
         )
         .unwrap();
-        hyprstream_discovery::verify_deployment_artifacts_with_authority_log(
-            &public_ca,
-            &serde_json::to_vec(&genesis_log).unwrap(),
-            &direct_token,
-        )
-        .unwrap();
-        hyprstream_discovery::verify_deployment_artifacts_with_authority_log(
-            &public_ca,
-            &serde_json::to_vec(&genesis_log).unwrap(),
-            &token,
-        )
-        .unwrap();
+        verify_with_log(&public_ca, &genesis_log, &genesis_checkpoint, &direct_token).unwrap();
+        verify_with_log(&public_ca, &genesis_log, &genesis_checkpoint, &token).unwrap();
 
         let added = test_authority(
             AuthorityPurpose::RotatedAuthority,
@@ -1810,12 +2141,8 @@ mod tests {
             vec![genesis.clone(), add.clone()],
         )
         .unwrap();
-        hyprstream_discovery::verify_deployment_artifacts_with_authority_log(
-            &public_ca,
-            &serde_json::to_vec(&add_log).unwrap(),
-            &token,
-        )
-        .unwrap();
+        let add_checkpoint = checkpoint_for(&add_log);
+        verify_with_log(&public_ca, &add_log, &add_checkpoint, &token).unwrap();
 
         let replace = sign_did_op(
             DidOp {
@@ -1831,21 +2158,14 @@ mod tests {
         let replace_log =
             authority_log_from_ops(&root.bundle.deployment_domain, vec![genesis, add, replace])
                 .unwrap();
+        let replace_checkpoint = checkpoint_for(&replace_log);
         assert!(
-            hyprstream_discovery::verify_deployment_artifacts_with_authority_log(
-                &public_ca,
-                &serde_json::to_vec(&replace_log).unwrap(),
-                &token,
-            )
-            .is_err()
+            verify_with_log(&public_ca, &genesis_log, &replace_checkpoint, &token,).is_err(),
+            "historical authority-log prefix matched against a newer checkpoint"
         );
+        assert!(verify_with_log(&public_ca, &replace_log, &replace_checkpoint, &token,).is_err());
         assert!(
-            hyprstream_discovery::verify_deployment_artifacts_with_authority_log(
-                &public_ca,
-                &serde_json::to_vec(&replace_log).unwrap(),
-                &direct_token,
-            )
-            .is_err()
+            verify_with_log(&public_ca, &replace_log, &replace_checkpoint, &direct_token,).is_err()
         );
     }
 
@@ -1862,10 +2182,22 @@ mod tests {
             None,
         )
         .unwrap();
+        assert!(hyprstream_discovery::verify_genesis_deployment_artifacts(
+            &root.public_bytes(),
+            &token
+        )
+        .is_ok());
         assert!(
-            hyprstream_discovery::verify_deployment_artifacts(&root.public_bytes(), &token).is_ok()
+            hyprstream_discovery::verify_deployment_artifacts_with_authority_log(
+                &root.public_bytes(),
+                b"",
+                b"",
+                &token,
+            )
+            .is_err(),
+            "enrolled verification inferred direct-root genesis mode from omitted trust files"
         );
-        assert!(hyprstream_discovery::verify_deployment_artifacts(
+        assert!(hyprstream_discovery::verify_genesis_deployment_artifacts(
             &root.public_bytes(),
             &format!("{token}\n")
         )

--- a/crates/hyprstream/src/cli/trust.rs
+++ b/crates/hyprstream/src/cli/trust.rs
@@ -69,6 +69,13 @@ const AUTHORITY_CHECKPOINT_INSTALL_PATH: &str =
     "/etc/hyprstream/trust/deployment-authority.head.json";
 const REGISTRY_JWT_INSTALL_PATH: &str = "/run/hyprstream/credentials/registry-service.jwt";
 
+#[cfg(test)]
+static SECRET_BUNDLE_DROPS: [std::sync::atomic::AtomicUsize; 3] = [
+    std::sync::atomic::AtomicUsize::new(0),
+    std::sync::atomic::AtomicUsize::new(0),
+    std::sync::atomic::AtomicUsize::new(0),
+];
+
 #[derive(Clone, Debug, Serialize, Deserialize, Eq, PartialEq)]
 #[serde(rename_all = "snake_case")]
 enum AuthorityPurpose {
@@ -117,6 +124,13 @@ struct AuthorityBundle {
 impl Drop for AuthorityBundle {
     fn drop(&mut self) {
         self.ml_dsa_65_seed_b64.zeroize();
+        #[cfg(test)]
+        SECRET_BUNDLE_DROPS[match &self.purpose {
+            AuthorityPurpose::Root => 0,
+            AuthorityPurpose::RotatedAuthority => 1,
+            AuthorityPurpose::RegistryDelegatedSigner => 2,
+        }]
+        .fetch_add(1, std::sync::atomic::Ordering::SeqCst);
     }
 }
 
@@ -233,7 +247,7 @@ fn mint_deployment_ca(args: &MintDeploymentCaArgs) -> Result<()> {
                 Ed25519Secret::YubikeyPiv {
                     slot: slot.clone(),
                     public_b64: STANDARD.encode(public.as_bytes()),
-                    recovery_seed_b64: encode_secret_b64(recovery_key.to_bytes()),
+                    recovery_seed_b64: encode_ed25519_seed_b64(&recovery_key),
                 },
                 LoadedEdSigner::YubikeyPiv { slot, public },
             )
@@ -242,7 +256,7 @@ fn mint_deployment_ca(args: &MintDeploymentCaArgs) -> Result<()> {
             let key = SigningKey::generate(&mut rand::rngs::OsRng);
             (
                 Ed25519Secret::Software {
-                    seed_b64: encode_secret_b64(key.to_bytes()),
+                    seed_b64: encode_ed25519_seed_b64(&key),
                     public_b64: STANDARD.encode(key.verifying_key().as_bytes()),
                 },
                 LoadedEdSigner::Software(key),
@@ -283,7 +297,7 @@ fn mint_deployment_ca(args: &MintDeploymentCaArgs) -> Result<()> {
         deployment_domain: deployment_domain.clone(),
         public_key_sha256: sha256_hex(&public_ca),
         ed25519: ed_secret,
-        ml_dsa_65_seed_b64: encode_secret_b64(ml_dsa_sk_to_seed(&pq)),
+        ml_dsa_65_seed_b64: encode_ml_dsa_seed_b64(&pq),
         recipient_count: recipients.len(),
     };
     let plaintext = serialize_secret_json(&bundle).context("encode authority bundle")?;
@@ -381,10 +395,10 @@ fn delegate_registry_signer(args: &DelegateRegistrySignerArgs) -> Result<()> {
         deployment_domain: authority.bundle.deployment_domain.clone(),
         public_key_sha256: sha256_hex(&delegated_public),
         ed25519: Ed25519Secret::Software {
-            seed_b64: encode_secret_b64(delegated_ed.to_bytes()),
+            seed_b64: encode_ed25519_seed_b64(&delegated_ed),
             public_b64: STANDARD.encode(delegated_ed.verifying_key().as_bytes()),
         },
-        ml_dsa_65_seed_b64: encode_secret_b64(ml_dsa_sk_to_seed(&delegated_pq)),
+        ml_dsa_65_seed_b64: encode_ml_dsa_seed_b64(&delegated_pq),
         recipient_count: signer_recipients.len(),
     };
     let plaintext = serialize_secret_json(&delegated_bundle)?;
@@ -784,10 +798,10 @@ fn rotate_authority(args: &RotateAuthorityArgs) -> Result<()> {
         deployment_domain: log.deployment_domain.clone(),
         public_key_sha256: sha256_hex(&new_public),
         ed25519: Ed25519Secret::Software {
-            seed_b64: encode_secret_b64(new_ed.to_bytes()),
+            seed_b64: encode_ed25519_seed_b64(&new_ed),
             public_b64: STANDARD.encode(new_ed.verifying_key().as_bytes()),
         },
-        ml_dsa_65_seed_b64: encode_secret_b64(ml_dsa_sk_to_seed(&new_pq)),
+        ml_dsa_65_seed_b64: encode_ml_dsa_seed_b64(&new_pq),
         recipient_count: recipients.len(),
     };
     let plaintext = serialize_secret_json(&new_bundle)?;
@@ -1586,79 +1600,189 @@ impl<'a> PendingOutput<'a> {
     }
 }
 
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum CommitOperation {
+    StageCreate(usize),
+    StagePermissions(usize),
+    StageWrite(usize),
+    StageSync(usize),
+    StageKeep(usize),
+    BackupCreate(usize),
+    BackupPlaceholderRemove(usize),
+    BackupRename(usize),
+    BackupParentsSync,
+    CommitRename(usize),
+    CommitParentsSync,
+    BackupDelete(usize),
+    CleanupParentsSync,
+    RollbackRemove(usize),
+    RollbackRestore(usize),
+    RollbackParentsSync,
+    StageCleanup(usize),
+}
+
+#[derive(Default)]
+struct CommitFaultInjector {
+    #[cfg(test)]
+    faults: std::collections::VecDeque<CommitOperation>,
+}
+
+impl CommitFaultInjector {
+    fn check(&mut self, operation: CommitOperation) -> Result<()> {
+        #[cfg(test)]
+        if self.faults.front() == Some(&operation) {
+            self.faults.pop_front();
+            bail!("injected transaction fault at {operation:?}");
+        }
+        let _ = operation;
+        Ok(())
+    }
+
+    #[cfg(test)]
+    fn with_faults(faults: impl IntoIterator<Item = CommitOperation>) -> Self {
+        Self {
+            faults: faults.into_iter().collect(),
+        }
+    }
+}
+
 /// Stage every output before moving any destination, then roll back the whole
-/// set if a rename fails. Each rename is filesystem-atomic; the rollback closes
-/// the ordinary error path across the multi-file mint commands.
+/// set if any subsequent operation fails. Each rename is filesystem-atomic;
+/// every fallible step after the first retained staging path is routed through
+/// the same rollback/cleanup path.
 fn commit_outputs(outputs: Vec<PendingOutput<'_>>) -> Result<()> {
+    commit_outputs_with_faults(outputs, &mut CommitFaultInjector::default())
+}
+
+fn commit_outputs_with_faults(
+    outputs: Vec<PendingOutput<'_>>,
+    faults: &mut CommitFaultInjector,
+) -> Result<()> {
     let mut staged = Vec::with_capacity(outputs.len());
-    for output in &outputs {
+    for (index, output) in outputs.iter().enumerate() {
         let parent = output.path.parent().unwrap_or_else(|| Path::new("."));
-        let mut temp = tempfile::NamedTempFile::new_in(parent)
-            .with_context(|| format!("create staged output for {}", output.path.display()))?;
-        temp.as_file_mut()
-            .set_permissions(std::fs::Permissions::from_mode(output.mode))?;
-        temp.write_all(&output.bytes)?;
-        temp.as_file_mut().sync_all()?;
-        let (_file, path) = temp.keep().context("retain staged output")?;
-        staged.push(path);
+        let staged_result = (|| -> Result<PathBuf> {
+            faults.check(CommitOperation::StageCreate(index))?;
+            let mut temp = tempfile::NamedTempFile::new_in(parent)
+                .with_context(|| format!("create staged output for {}", output.path.display()))?;
+            faults.check(CommitOperation::StagePermissions(index))?;
+            temp.as_file_mut()
+                .set_permissions(std::fs::Permissions::from_mode(output.mode))?;
+            faults.check(CommitOperation::StageWrite(index))?;
+            temp.write_all(&output.bytes)?;
+            faults.check(CommitOperation::StageSync(index))?;
+            temp.as_file_mut().sync_all()?;
+            faults.check(CommitOperation::StageKeep(index))?;
+            let (_file, path) = temp.keep().context("retain staged output")?;
+            Ok(path)
+        })();
+        match staged_result {
+            Ok(path) => staged.push(path),
+            Err(error) => {
+                return Err(transaction_failure(
+                    error,
+                    format!("stage {}", output.path.display()),
+                    Ok(()),
+                    cleanup_paths(&staged, faults),
+                ));
+            }
+        }
     }
 
     let mut backups: Vec<Option<PathBuf>> = vec![None; outputs.len()];
     for (index, output) in outputs.iter().enumerate() {
         if output.path.exists() {
             let parent = output.path.parent().unwrap_or_else(|| Path::new("."));
-            let placeholder = tempfile::Builder::new()
-                .prefix(".hyprstream-backup-")
-                .tempfile_in(parent)
-                .with_context(|| format!("stage backup for {}", output.path.display()))?;
-            let backup = placeholder.path().to_path_buf();
-            drop(placeholder);
-            if let Err(error) = std::fs::rename(output.path, &backup) {
+            let backup = (|| -> Result<PathBuf> {
+                faults.check(CommitOperation::BackupCreate(index))?;
+                let placeholder = tempfile::Builder::new()
+                    .prefix(".hyprstream-backup-")
+                    .tempfile_in(parent)
+                    .with_context(|| format!("stage backup for {}", output.path.display()))?;
+                let backup = placeholder.path().to_path_buf();
+                faults.check(CommitOperation::BackupPlaceholderRemove(index))?;
+                placeholder.close().with_context(|| {
+                    format!("release backup placeholder for {}", output.path.display())
+                })?;
+                Ok(backup)
+            })();
+            let backup = match backup {
+                Ok(backup) => backup,
+                Err(error) => {
+                    return Err(transaction_failure(
+                        error,
+                        format!("reserve backup for {}", output.path.display()),
+                        restore_outputs(&outputs, &backups, 0, faults),
+                        cleanup_paths(&staged, faults),
+                    ));
+                }
+            };
+            let rename = faults
+                .check(CommitOperation::BackupRename(index))
+                .and_then(|()| {
+                    std::fs::rename(output.path, &backup)
+                        .with_context(|| format!("back up existing {}", output.path.display()))
+                });
+            if let Err(error) = rename {
                 return Err(transaction_failure(
-                    error.into(),
+                    error,
                     format!("back up existing {}", output.path.display()),
-                    restore_outputs(&outputs, &backups, 0),
-                    cleanup_paths(&staged),
+                    restore_outputs(&outputs, &backups, 0, faults),
+                    cleanup_paths(&staged, faults),
                 ));
             }
             backups[index] = Some(backup);
         }
     }
-    if let Err(error) = sync_output_parents(&outputs) {
+    if let Err(error) = sync_output_parents(&outputs, faults, CommitOperation::BackupParentsSync) {
         return Err(transaction_failure(
             error,
             "durably record output backups".to_owned(),
-            restore_outputs(&outputs, &backups, 0),
-            cleanup_paths(&staged),
+            restore_outputs(&outputs, &backups, 0, faults),
+            cleanup_paths(&staged, faults),
         ));
     }
 
     for (index, output) in outputs.iter().enumerate() {
-        if let Err(error) = std::fs::rename(&staged[index], output.path) {
+        let rename = faults
+            .check(CommitOperation::CommitRename(index))
+            .and_then(|()| {
+                std::fs::rename(&staged[index], output.path)
+                    .with_context(|| format!("commit {}", output.path.display()))
+            });
+        if let Err(error) = rename {
             return Err(transaction_failure(
-                error.into(),
+                error,
                 format!("commit {}", output.path.display()),
-                restore_outputs(&outputs, &backups, index),
-                cleanup_paths(&staged[index..]),
+                restore_outputs(&outputs, &backups, index, faults),
+                cleanup_paths(&staged[index..], faults),
             ));
         }
     }
-    if let Err(error) = sync_output_parents(&outputs) {
+    if let Err(error) = sync_output_parents(&outputs, faults, CommitOperation::CommitParentsSync) {
         return Err(transaction_failure(
             error,
             "durably record committed outputs".to_owned(),
-            restore_outputs(&outputs, &backups, outputs.len()),
+            restore_outputs(&outputs, &backups, outputs.len(), faults),
             Ok(()),
         ));
     }
 
     let mut cleanup_errors = Vec::new();
-    for backup in backups.into_iter().flatten() {
-        if let Err(error) = std::fs::remove_file(&backup) {
-            cleanup_errors.push(format!("remove backup {}: {error}", backup.display()));
+    for (index, backup) in backups.into_iter().enumerate() {
+        if let Some(backup) = backup {
+            let removal = faults
+                .check(CommitOperation::BackupDelete(index))
+                .and_then(|()| {
+                    std::fs::remove_file(&backup)
+                        .with_context(|| format!("remove backup {}", backup.display()))
+                });
+            if let Err(error) = removal {
+                cleanup_errors.push(format!("{error:#}"));
+            }
         }
     }
-    if let Err(error) = sync_output_parents(&outputs) {
+    if let Err(error) = sync_output_parents(&outputs, faults, CommitOperation::CleanupParentsSync) {
         cleanup_errors.push(format!("durably record backup deletion: {error:#}"));
     }
     ensure!(
@@ -1691,40 +1815,64 @@ fn restore_outputs(
     outputs: &[PendingOutput<'_>],
     backups: &[Option<PathBuf>],
     committed: usize,
+    faults: &mut CommitFaultInjector,
 ) -> Result<()> {
     let mut errors = Vec::new();
-    for output in outputs.iter().take(committed) {
-        if let Err(error) = std::fs::remove_file(output.path) {
+    for (index, output) in outputs.iter().take(committed).enumerate() {
+        let removal = faults
+            .check(CommitOperation::RollbackRemove(index))
+            .and_then(|()| {
+                std::fs::remove_file(output.path)
+                    .with_context(|| format!("remove newly committed {}", output.path.display()))
+            });
+        if let Err(error) = removal {
             errors.push(format!(
-                "remove newly committed {}: {error}",
-                output.path.display()
+                "remove newly committed {}: {error:#}",
+                output.path.display(),
             ));
         }
     }
-    for (output, backup) in outputs.iter().zip(backups).rev() {
+    for (index, (output, backup)) in outputs.iter().zip(backups).enumerate().rev() {
         if let Some(backup) = backup {
-            if let Err(error) = std::fs::rename(backup, output.path) {
+            let restore = faults
+                .check(CommitOperation::RollbackRestore(index))
+                .and_then(|()| {
+                    std::fs::rename(backup, output.path).with_context(|| {
+                        format!(
+                            "restore {} from {}",
+                            output.path.display(),
+                            backup.display()
+                        )
+                    })
+                });
+            if let Err(error) = restore {
                 errors.push(format!(
-                    "restore {} from {}: {error}",
+                    "restore {} from {}: {error:#}",
                     output.path.display(),
-                    backup.display()
+                    backup.display(),
                 ));
             }
         }
     }
-    if let Err(error) = sync_output_parents(outputs) {
+    if let Err(error) = sync_output_parents(outputs, faults, CommitOperation::RollbackParentsSync) {
         errors.push(format!("durably record rollback: {error:#}"));
     }
     ensure!(errors.is_empty(), "{}", errors.join("; "));
     Ok(())
 }
 
-fn cleanup_paths(paths: &[PathBuf]) -> Result<()> {
+fn cleanup_paths(paths: &[PathBuf], faults: &mut CommitFaultInjector) -> Result<()> {
     let mut errors = Vec::new();
-    for path in paths {
+    for (index, path) in paths.iter().enumerate() {
         if path.exists() {
-            if let Err(error) = std::fs::remove_file(path) {
-                errors.push(format!("remove staged {}: {error}", path.display()));
+            let removal = faults
+                .check(CommitOperation::StageCleanup(index))
+                .and_then(|()| {
+                    std::fs::remove_file(path)
+                        .with_context(|| format!("remove staged {}", path.display()))
+                });
+            if let Err(error) = removal {
+                errors.push(format!("remove staged {}: {error:#}", path.display()));
             }
         }
     }
@@ -1732,7 +1880,12 @@ fn cleanup_paths(paths: &[PathBuf]) -> Result<()> {
     Ok(())
 }
 
-fn sync_output_parents(outputs: &[PendingOutput<'_>]) -> Result<()> {
+fn sync_output_parents(
+    outputs: &[PendingOutput<'_>],
+    faults: &mut CommitFaultInjector,
+    operation: CommitOperation,
+) -> Result<()> {
+    faults.check(operation)?;
     let parents: BTreeSet<_> = outputs
         .iter()
         .map(|output| {
@@ -1788,16 +1941,25 @@ fn decode_fixed_b64<const N: usize>(value: &str, description: &str) -> Result<Ze
             .decode(value)
             .with_context(|| format!("decode {description}"))?,
     );
-    decoded
-        .as_slice()
-        .try_into()
-        .map(Zeroizing::new)
-        .map_err(|_| anyhow!("{description} must decode to exactly {N} bytes"))
+    ensure!(
+        decoded.len() == N,
+        "{description} must decode to exactly {N} bytes"
+    );
+    let mut fixed = Zeroizing::new([0; N]);
+    fixed.copy_from_slice(&decoded);
+    Ok(fixed)
 }
 
-fn encode_secret_b64<const N: usize>(secret: [u8; N]) -> String {
-    let secret = Zeroizing::new(secret);
+fn encode_secret_b64<const N: usize>(secret: Zeroizing<[u8; N]>) -> String {
     STANDARD.encode(secret.as_ref())
+}
+
+fn encode_ed25519_seed_b64(key: &SigningKey) -> String {
+    encode_secret_b64(Zeroizing::new(key.to_bytes()))
+}
+
+fn encode_ml_dsa_seed_b64(key: &MlDsaSigningKey) -> String {
+    encode_secret_b64(Zeroizing::new(ml_dsa_sk_to_seed(key)))
 }
 
 fn sha256_hex(bytes: &[u8]) -> String {
@@ -1855,10 +2017,10 @@ mod tests {
                 deployment_domain: domain,
                 public_key_sha256: sha256_hex(&public),
                 ed25519: Ed25519Secret::Software {
-                    seed_b64: encode_secret_b64(ed.to_bytes()),
+                    seed_b64: encode_ed25519_seed_b64(&ed),
                     public_b64: STANDARD.encode(ed.verifying_key().as_bytes()),
                 },
-                ml_dsa_65_seed_b64: encode_secret_b64(ml_dsa_sk_to_seed(&pq)),
+                ml_dsa_65_seed_b64: encode_ml_dsa_seed_b64(&pq),
                 recipient_count: 2,
             },
             ed: LoadedEdSigner::Software(ed),
@@ -1884,6 +2046,185 @@ mod tests {
             &serde_json::to_vec(checkpoint)?,
             token,
         )
+    }
+
+    fn transaction_fault_case(
+        faults: impl IntoIterator<Item = CommitOperation>,
+    ) -> (tempfile::TempDir, PathBuf, PathBuf, Result<()>) {
+        let directory = tempfile::tempdir().unwrap();
+        let first = directory.path().join("first");
+        let second = directory.path().join("second");
+        std::fs::write(&first, b"old-first").unwrap();
+        std::fs::write(&second, b"old-second").unwrap();
+        let result = commit_outputs_with_faults(
+            vec![
+                PendingOutput::new(&first, b"new-first".to_vec(), 0o600),
+                PendingOutput::new(&second, b"new-second".to_vec(), 0o600),
+            ],
+            &mut CommitFaultInjector::with_faults(faults),
+        );
+        (directory, first, second, result)
+    }
+
+    fn directory_entries(directory: &Path) -> Vec<String> {
+        let mut entries: Vec<_> = std::fs::read_dir(directory)
+            .unwrap()
+            .map(|entry| {
+                entry
+                    .unwrap()
+                    .file_name()
+                    .into_string()
+                    .expect("test path is UTF-8")
+            })
+            .collect();
+        entries.sort();
+        entries
+    }
+
+    #[test]
+    fn generated_secret_bundles_zeroize_on_error_for_every_authority_purpose() {
+        let purposes = [
+            (AuthorityPurpose::Root, 0),
+            (AuthorityPurpose::RotatedAuthority, 1),
+            (AuthorityPurpose::RegistryDelegatedSigner, 2),
+        ];
+        for (purpose, counter) in purposes {
+            let before = SECRET_BUNDLE_DROPS[counter].load(std::sync::atomic::Ordering::SeqCst);
+            let result = (|| -> Result<()> {
+                let _authority = test_authority(purpose, None);
+                bail!("injected error after guarded seed encoding");
+            })();
+            assert!(result.is_err());
+            assert!(
+                SECRET_BUNDLE_DROPS[counter].load(std::sync::atomic::Ordering::SeqCst) > before,
+                "secret bundle did not run its wiping drop on the error path"
+            );
+        }
+
+        let guarded = Zeroizing::new([0xA5; 32]);
+        assert_eq!(
+            STANDARD.decode(encode_secret_b64(guarded)).unwrap(),
+            vec![0xA5; 32]
+        );
+    }
+
+    #[test]
+    fn transaction_faults_before_durable_commit_restore_the_complete_old_set() {
+        let faults = [
+            CommitOperation::StageCreate(1),
+            CommitOperation::StagePermissions(1),
+            CommitOperation::StageWrite(1),
+            CommitOperation::StageSync(1),
+            CommitOperation::StageKeep(1),
+            CommitOperation::BackupCreate(1),
+            CommitOperation::BackupPlaceholderRemove(1),
+            CommitOperation::BackupRename(0),
+            CommitOperation::BackupRename(1),
+            CommitOperation::BackupParentsSync,
+            CommitOperation::CommitRename(0),
+            CommitOperation::CommitRename(1),
+            CommitOperation::CommitParentsSync,
+        ];
+        for fault in faults {
+            let (directory, first, second, result) = transaction_fault_case([fault]);
+            assert!(result.is_err(), "{fault:?} unexpectedly succeeded");
+            assert_eq!(
+                std::fs::read(&first).unwrap(),
+                b"old-first",
+                "{fault:?} did not restore the first output"
+            );
+            assert_eq!(
+                std::fs::read(&second).unwrap(),
+                b"old-second",
+                "{fault:?} did not restore the second output"
+            );
+            assert_eq!(
+                directory_entries(directory.path()),
+                vec!["first", "second"],
+                "{fault:?} left unreported transaction state"
+            );
+        }
+    }
+
+    #[test]
+    fn transaction_cleanup_faults_return_error_with_recovery_state() {
+        let (directory, first, second, result) =
+            transaction_fault_case([CommitOperation::BackupDelete(0)]);
+        let error = result.unwrap_err().to_string();
+        assert!(error.contains("transaction cleanup was incomplete"));
+        assert_eq!(std::fs::read(&first).unwrap(), b"new-first");
+        assert_eq!(std::fs::read(&second).unwrap(), b"new-second");
+        assert!(
+            directory_entries(directory.path())
+                .iter()
+                .any(|name| name.starts_with(".hyprstream-backup-")),
+            "failed backup deletion did not preserve the recovery file"
+        );
+
+        let (directory, first, second, result) =
+            transaction_fault_case([CommitOperation::CleanupParentsSync]);
+        assert!(result
+            .unwrap_err()
+            .to_string()
+            .contains("durably record backup deletion"));
+        assert_eq!(std::fs::read(&first).unwrap(), b"new-first");
+        assert_eq!(std::fs::read(&second).unwrap(), b"new-second");
+        assert_eq!(directory_entries(directory.path()), vec!["first", "second"]);
+    }
+
+    #[test]
+    fn transaction_reports_and_preserves_incomplete_rollback_or_staging_cleanup() {
+        let (directory, first, second, result) = transaction_fault_case([
+            CommitOperation::CommitRename(1),
+            CommitOperation::RollbackRemove(0),
+        ]);
+        assert!(result
+            .unwrap_err()
+            .to_string()
+            .contains("ROLLBACK INCOMPLETE"));
+        assert_eq!(std::fs::read(&first).unwrap(), b"old-first");
+        assert_eq!(std::fs::read(&second).unwrap(), b"old-second");
+        assert_eq!(directory_entries(directory.path()), vec!["first", "second"]);
+
+        let (directory, first, second, result) = transaction_fault_case([
+            CommitOperation::CommitRename(1),
+            CommitOperation::RollbackRestore(1),
+        ]);
+        assert!(result
+            .unwrap_err()
+            .to_string()
+            .contains("ROLLBACK INCOMPLETE"));
+        assert_eq!(std::fs::read(&first).unwrap(), b"old-first");
+        assert!(!second.exists());
+        assert!(
+            directory_entries(directory.path())
+                .iter()
+                .any(|name| name.starts_with(".hyprstream-backup-")),
+            "failed restoration did not preserve its backup"
+        );
+
+        let (_directory, first, second, result) = transaction_fault_case([
+            CommitOperation::CommitRename(1),
+            CommitOperation::RollbackParentsSync,
+        ]);
+        assert!(result
+            .unwrap_err()
+            .to_string()
+            .contains("ROLLBACK INCOMPLETE"));
+        assert_eq!(std::fs::read(&first).unwrap(), b"old-first");
+        assert_eq!(std::fs::read(&second).unwrap(), b"old-second");
+
+        let (directory, first, second, result) = transaction_fault_case([
+            CommitOperation::StageCreate(1),
+            CommitOperation::StageCleanup(0),
+        ]);
+        assert!(result
+            .unwrap_err()
+            .to_string()
+            .contains("staged-output cleanup incomplete"));
+        assert_eq!(std::fs::read(&first).unwrap(), b"old-first");
+        assert_eq!(std::fs::read(&second).unwrap(), b"old-second");
+        assert_eq!(directory_entries(directory.path()).len(), 3);
     }
 
     #[test]

--- a/crates/hyprstream/src/cli/trust.rs
+++ b/crates/hyprstream/src/cli/trust.rs
@@ -1553,23 +1553,31 @@ fn preflight_outputs<'a>(paths: impl IntoIterator<Item = &'a PathBuf>, force: bo
             "duplicate output path {}",
             path.display()
         );
-        if path.exists() && !force {
-            bail!(
-                "refusing to replace existing output {} without --force",
-                path.display()
-            );
-        }
-        if let Ok(metadata) = std::fs::symlink_metadata(path) {
-            ensure!(
-                metadata.file_type().is_file() && !metadata.file_type().is_symlink(),
-                "refusing non-regular or symlink output target {}",
-                path.display()
-            );
+        match std::fs::symlink_metadata(path) {
+            Ok(metadata) => {
+                ensure!(
+                    force,
+                    "refusing to replace existing output {} without --force",
+                    path.display()
+                );
+                ensure!(
+                    metadata.file_type().is_file() && !metadata.file_type().is_symlink(),
+                    "refusing non-regular or symlink output target {}",
+                    path.display()
+                );
+            }
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+            Err(error) => {
+                return Err(error)
+                    .with_context(|| format!("inspect output target {}", path.display()));
+            }
         }
         let parent = path.parent().unwrap_or_else(|| Path::new("."));
+        let parent_metadata = std::fs::metadata(parent)
+            .with_context(|| format!("inspect output parent {}", parent.display()))?;
         ensure!(
-            parent.is_dir(),
-            "output parent does not exist: {}",
+            parent_metadata.is_dir(),
+            "output parent is not a directory: {}",
             parent.display()
         );
     }
@@ -1607,7 +1615,9 @@ enum CommitOperation {
     StageWrite(usize),
     StageSync(usize),
     StageKeep(usize),
+    BackupMetadata(usize),
     BackupCreate(usize),
+    BackupPlaceholderKeep(usize),
     BackupPlaceholderRemove(usize),
     BackupRename(usize),
     BackupParentsSync,
@@ -1654,6 +1664,28 @@ fn commit_outputs(outputs: Vec<PendingOutput<'_>>) -> Result<()> {
     commit_outputs_with_faults(outputs, &mut CommitFaultInjector::default())
 }
 
+fn destination_exists_for_backup(
+    output: &PendingOutput<'_>,
+    index: usize,
+    faults: &mut CommitFaultInjector,
+) -> Result<bool> {
+    faults.check(CommitOperation::BackupMetadata(index))?;
+    match std::fs::symlink_metadata(output.path) {
+        Ok(metadata) => {
+            ensure!(
+                metadata.file_type().is_file() && !metadata.file_type().is_symlink(),
+                "refusing non-regular or symlink output target {}",
+                output.path.display()
+            );
+            Ok(true)
+        }
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(false),
+        Err(error) => {
+            Err(error).with_context(|| format!("inspect output target {}", output.path.display()))
+        }
+    }
+}
+
 fn commit_outputs_with_faults(
     outputs: Vec<PendingOutput<'_>>,
     faults: &mut CommitFaultInjector,
@@ -1691,7 +1723,18 @@ fn commit_outputs_with_faults(
 
     let mut backups: Vec<Option<PathBuf>> = vec![None; outputs.len()];
     for (index, output) in outputs.iter().enumerate() {
-        if output.path.exists() {
+        let destination_exists = match destination_exists_for_backup(output, index, faults) {
+            Ok(exists) => exists,
+            Err(error) => {
+                return Err(transaction_failure(
+                    error,
+                    format!("inspect existing {}", output.path.display()),
+                    restore_outputs(&outputs, &backups, 0, faults),
+                    cleanup_paths(&staged, faults),
+                ));
+            }
+        };
+        if destination_exists {
             let parent = output.path.parent().unwrap_or_else(|| Path::new("."));
             let backup = (|| -> Result<PathBuf> {
                 faults.check(CommitOperation::BackupCreate(index))?;
@@ -1699,11 +1742,23 @@ fn commit_outputs_with_faults(
                     .prefix(".hyprstream-backup-")
                     .tempfile_in(parent)
                     .with_context(|| format!("stage backup for {}", output.path.display()))?;
-                let backup = placeholder.path().to_path_buf();
-                faults.check(CommitOperation::BackupPlaceholderRemove(index))?;
-                placeholder.close().with_context(|| {
-                    format!("release backup placeholder for {}", output.path.display())
+                faults.check(CommitOperation::BackupPlaceholderKeep(index))?;
+                let (_file, backup) = placeholder.keep().with_context(|| {
+                    format!("retain backup placeholder for {}", output.path.display())
                 })?;
+                let removal = faults
+                    .check(CommitOperation::BackupPlaceholderRemove(index))
+                    .and_then(|()| {
+                        std::fs::remove_file(&backup).with_context(|| {
+                            format!("remove backup placeholder {}", backup.display())
+                        })
+                    });
+                if let Err(error) = removal {
+                    bail!(
+                        "backup placeholder removal failed; preserved empty recovery marker at {}: {error:#}",
+                        backup.display()
+                    );
+                }
                 Ok(backup)
             })();
             let backup = match backup {
@@ -1864,15 +1919,15 @@ fn restore_outputs(
 fn cleanup_paths(paths: &[PathBuf], faults: &mut CommitFaultInjector) -> Result<()> {
     let mut errors = Vec::new();
     for (index, path) in paths.iter().enumerate() {
-        if path.exists() {
-            let removal = faults
-                .check(CommitOperation::StageCleanup(index))
-                .and_then(|()| {
-                    std::fs::remove_file(path)
-                        .with_context(|| format!("remove staged {}", path.display()))
-                });
-            if let Err(error) = removal {
-                errors.push(format!("remove staged {}: {error:#}", path.display()));
+        if let Err(error) = faults.check(CommitOperation::StageCleanup(index)) {
+            errors.push(format!("remove staged {}: {error:#}", path.display()));
+            continue;
+        }
+        match std::fs::remove_file(path) {
+            Ok(()) => {}
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+            Err(error) => {
+                errors.push(format!("remove staged {}: {error}", path.display()));
             }
         }
     }
@@ -2116,8 +2171,9 @@ mod tests {
             CommitOperation::StageWrite(1),
             CommitOperation::StageSync(1),
             CommitOperation::StageKeep(1),
+            CommitOperation::BackupMetadata(1),
             CommitOperation::BackupCreate(1),
-            CommitOperation::BackupPlaceholderRemove(1),
+            CommitOperation::BackupPlaceholderKeep(1),
             CommitOperation::BackupRename(0),
             CommitOperation::BackupRename(1),
             CommitOperation::BackupParentsSync,
@@ -2225,6 +2281,21 @@ mod tests {
         assert_eq!(std::fs::read(&first).unwrap(), b"old-first");
         assert_eq!(std::fs::read(&second).unwrap(), b"old-second");
         assert_eq!(directory_entries(directory.path()).len(), 3);
+
+        let (directory, first, second, result) =
+            transaction_fault_case([CommitOperation::BackupPlaceholderRemove(1)]);
+        let error = result.unwrap_err().to_string();
+        assert!(error.contains("preserved empty recovery marker"));
+        assert_eq!(std::fs::read(&first).unwrap(), b"old-first");
+        assert_eq!(std::fs::read(&second).unwrap(), b"old-second");
+        let entries = directory_entries(directory.path());
+        assert_eq!(entries.len(), 3);
+        assert!(
+            entries
+                .iter()
+                .any(|name| name.starts_with(".hyprstream-backup-")),
+            "failed placeholder unlink did not preserve and expose its path"
+        );
     }
 
     #[test]

--- a/crates/hyprstream/src/config/mod.rs
+++ b/crates/hyprstream/src/config/mod.rs
@@ -1226,10 +1226,12 @@ pub struct OAuthConfig {
     /// When set, this OAuth instance terminates the deployment's did:web host:
     /// `/.well-known/did.json` serves `<dir>/did.json` (replacing the dynamic
     /// node document), `/.well-known/at9p/<cid>.cbor` serves the cluster at9p
-    /// capsule, and `/.well-known/deployment/registry-service.jwt` serves the
-    /// current CA-signed registry deployment credential. All are public,
-    /// integrity-anchored bytes re-read on every request so an external
-    /// credential-refresh agent needs no restart.
+    /// capsule, `/.well-known/deployment/deployment-authority.log.json` serves
+    /// the current root-anchored authority log, and
+    /// `/.well-known/deployment/registry-service.jwt` serves the current
+    /// registry credential. All are public, integrity-anchored bytes re-read
+    /// on every request so an external credential-refresh agent needs no
+    /// restart.
     #[serde(default)]
     pub deployment_well_known_dir: Option<PathBuf>,
 

--- a/crates/hyprstream/src/services/oauth/deployment_well_known.rs
+++ b/crates/hyprstream/src/services/oauth/deployment_well_known.rs
@@ -1,6 +1,6 @@
 //! Deployment static well-known endpoints (#1137 / #1136 serving half).
 //!
-//! The DID-anchored trust bootstrap (#1143) fetches three public,
+//! The DID-anchored trust bootstrap (#1143) fetches four public,
 //! integrity-anchored documents from the deployment's did:web host:
 //!
 //! - `/.well-known/did.json` — the deployment DID document (alsoKnownAs →
@@ -10,6 +10,9 @@
 //!   (self-certifying: BLAKE3-512 over its canonical bytes IS the DID);
 //! - `/.well-known/deployment/registry-service.jwt` — the current CA-signed
 //!   registry deployment credential (one-hour freshness profile).
+//! - `/.well-known/deployment/deployment-authority.log.json` — the current
+//!   root-anchored authority log. Its head must equal the node's separately
+//!   provisioned OS-owned anti-rollback checkpoint.
 //!
 //! None of these are secret: every one is verified by the fetcher (GATE
 //! canon → hash → sig for the capsule; mutual alsoKnownAs attestation for
@@ -26,6 +29,7 @@
 //! ```text
 //! <dir>/did.json
 //! <dir>/at9p/<cid>.cbor
+//! <dir>/deployment/deployment-authority.log.json
 //! <dir>/deployment/registry-service.jwt   (refreshed hourly by the CA holder)
 //! ```
 //!
@@ -65,6 +69,10 @@ where
         .route(
             "/.well-known/deployment/registry-service.jwt",
             get(serve_registry_credential),
+        )
+        .route(
+            "/.well-known/deployment/deployment-authority.log.json",
+            get(serve_authority_log),
         )
         .with_state(deployment_dir)
 }
@@ -122,6 +130,18 @@ async fn serve_registry_credential(State(deployment_dir): State<Option<PathBuf>>
     serve_file(
         &dir.join("deployment").join("registry-service.jwt"),
         "application/jwt",
+        MAX_CREDENTIAL_BYTES,
+    )
+    .await
+}
+
+async fn serve_authority_log(State(deployment_dir): State<Option<PathBuf>>) -> Response {
+    let Some(ref dir) = deployment_dir else {
+        return StatusCode::NOT_FOUND.into_response();
+    };
+    serve_file(
+        &dir.join("deployment").join("deployment-authority.log.json"),
+        "application/json",
         MAX_CREDENTIAL_BYTES,
     )
     .await

--- a/crates/hyprstream/src/services/oauth/mod.rs
+++ b/crates/hyprstream/src/services/oauth/mod.rs
@@ -264,8 +264,9 @@ pub fn create_app(state: Arc<OAuthState>, cors_config: &crate::config::CorsConfi
     if state.deployment_well_known_dir.is_some() {
         // #1137 serving half — deployment mode: this host terminates the
         // deployment's did:web. The static router owns `/.well-known/did.json`
-        // plus the at9p capsule and registry credential endpoints (each 404s
-        // when its file is absent — never a silent fall-through).
+        // plus the at9p capsule, authority log, and registry credential
+        // endpoints (each 404s when its file is absent — never a silent
+        // fall-through).
         did_router = did_router.merge(deployment_well_known::router(
             state.deployment_well_known_dir.clone(),
         ));

--- a/crates/hyprstream/src/services/oauth/state.rs
+++ b/crates/hyprstream/src/services/oauth/state.rs
@@ -1002,8 +1002,10 @@ pub struct OAuthState {
     /// Deployment static well-known directory (#1137 serving half). When set,
     /// this OAuth instance terminates the deployment's did:web host: it serves
     /// `<dir>/did.json` in place of the dynamic node document, plus
-    /// `<dir>/at9p/<cid>.cbor` and `<dir>/deployment/registry-service.jwt`.
-    /// All three are public, integrity-anchored bytes — see
+    /// `<dir>/at9p/<cid>.cbor`,
+    /// `<dir>/deployment/deployment-authority.log.json`, and
+    /// `<dir>/deployment/registry-service.jwt`. All four are public,
+    /// integrity-anchored bytes — see
     /// `deployment_well_known.rs`. Copied from
     /// `OAuthConfig::deployment_well_known_dir`.
     pub deployment_well_known_dir: Option<std::path::PathBuf>,

--- a/docs/deployment-registry-trust.md
+++ b/docs/deployment-registry-trust.md
@@ -1,9 +1,10 @@
 # Deployment registry trust provisioning
 
 Production Discovery/PDS authority is rooted before commands, factories, plugins,
-or generated clients run. The executable does not consult
-`CREDENTIALS_DIRECTORY`, XDG/user configuration, `HYPRSTREAM__SECRETS__PATH`, a
-public setter, or a caller-provided path for this authority.
+or generated clients run. The executable consults only the explicit deployment
+trust sources described below. It does not consult XDG/user configuration,
+`HYPRSTREAM__SECRETS__PATH`, a public setter, or an arbitrary caller-provided
+file path for this authority.
 
 The OS-owned deployment seam is deliberately small and fail-closed:
 
@@ -19,21 +20,49 @@ The OS-owned deployment seam is deliberately small and fail-closed:
   provisioned expected log head: schema, deployment domain, log DID, sequence,
   and head CID. The supplied log must match it exactly.
 
-All installed files must be regular, root-owned, and not group/world writable. Missing,
-malformed, symlinked, or incorrectly owned material makes production resolver
-startup fail closed. Missing log or checkpoint never selects a less restrictive
-verifier. Both JWT signature components are verified against the checkpointed
-active authority before its key is represented by an opaque verification-only
-capability. The raw keys and one-shot witness are not exposed through the
-public service or Discovery APIs.
+By default, all installed files and parent directories must be real,
+root-owned paths and not group/world writable. Missing, malformed, symlinked,
+or incorrectly owned material makes production resolver startup fail closed.
+Missing log or checkpoint never selects a less restrictive verifier. Both JWT
+signature components are verified against the checkpointed active authority
+before its key is represented by an opaque verification-only capability. The
+raw keys and one-shot witness are not exposed through the public service or
+Discovery APIs.
 
 The repository does not yet contain an operator enrollment protocol. Deployments
 using this OS-owned source must therefore provision the `/etc` pin through their
 OS image, configuration manager, measured-boot policy, or equivalent root-owned
 mechanism, and project the registry JWT into the fixed `/run` location before
-starting hyprstream. User-mode service-manager installations that cannot provide
-these fixed OS-owned files are intentionally not production-authoritative and
-fail closed; ambient credential-directory fallback is not supported.
+starting hyprstream.
+
+## Explicit user-service trust paths
+
+A rootless service may select a complete public trust directory with:
+
+```text
+HYPRSTREAM_DEPLOYMENT_TRUST_DIR=/absolute/path/to/trust
+```
+
+That directory must contain exactly the same named public artifacts:
+`deployment-ca.hybrid`, `deployment-authority.log.json`, and
+`deployment-authority.head.json`. The registry JWT is independently resolved
+from systemd's absolute `$CREDENTIALS_DIRECTORY` as
+`$CREDENTIALS_DIRECTORY/registry-service.jwt`. Either variable being present
+but empty, relative, or containing `..` components is a startup error; it
+never falls back to a fixed path. When a variable is absent, only its fixed
+root-owned path is used.
+
+Explicit user-service artifacts and every real ancestor must be owned by root
+or the daemon's effective user and must not be group/world writable. Symlinks
+are rejected and the final file is opened with `O_NOFOLLOW`. This mode trusts
+the service account to provision its own development trust inputs; it does not
+turn XDG or general secret directories into authority.
+
+Path selection changes no cryptographic rule. The CA is still exactly the
+mandatory 1,984-byte Ed25519 + ML-DSA-65 pair; the authority log must still
+match the independent checkpoint exactly; and the registry JWT still passes
+the closed profile, audience, shape, lifetime, currentness, delegation, and
+both-signature checks. Any incomplete or invalid selected set fails startup.
 
 The CA authenticates the registry credential. The registry key in that credential
 then certifies the purpose-derived audit key used by accepted-state envelopes and

--- a/docs/deployment-registry-trust.md
+++ b/docs/deployment-registry-trust.md
@@ -13,8 +13,11 @@ The OS-owned deployment seam is deliberately small and fail-closed:
 - `/run/hyprstream/credentials/registry-service.jwt` is the separately
   provisioned, short-lived `service:registry` credential. Its `cnf.jwk` names the
   registry key that certifies accepted `did:at9p:<cid512>` state.
+- `/etc/hyprstream/trust/deployment-authority.log.json` is the public,
+  root-anchored authority-set checkpoint required when the credential was
+  issued by a scoped delegated signer.
 
-Both files must be regular, root-owned, and not group/world writable. Missing,
+All installed files must be regular, root-owned, and not group/world writable. Missing,
 malformed, symlinked, or incorrectly owned material makes production resolver
 startup fail closed. Both JWT signature components are verified against the
 `/etc` pin before its key is represented by an opaque verification-only
@@ -175,6 +178,21 @@ optional JOSE/JWK metadata (`crit`, `use`, `key_ops`, or a JWK-local `alg` or
 token types, and a signature or key identifier that does not bind the pinned CA
 fail closed before a registry witness can be minted. The credential file is the
 compact JWT itself with no surrounding whitespace or trailing newline.
+
+The common operational form adds exactly one `delegation` claim to that closed
+claim set. It is canonical unpadded base64url JSON containing the scoped UCAN,
+the delegated 1,984-byte hybrid public key, and the stable authority-log DID.
+The separately installed current root-anchored DidOp log must have that DID,
+and the UCAN issuer must still be in its active any-of-N authority set. The
+UCAN is restricted to this deployment's registry-service mint ability, exact
+profile and audience, and the one-hour ceiling. Direct rare-root credentials
+retain the original claim set without `delegation`.
+
+This profile is deployment/registry scoped. It has no PDS or host identifier.
+The demo therefore projects one shared deployment CA and current credential to
+both PDS hosts; a per-PDS binding would require a new profile or separate roots.
+The exact mint, rotation, recovery, publisher, and Metal input contracts are in
+[`deployment-trust-contract.md`](deployment-trust-contract.md).
 
 Classical-only atproto peer keys remain supported only at the separately named
 peer/federation record-resolution surface. That P-256 interoperability path

--- a/docs/deployment-registry-trust.md
+++ b/docs/deployment-registry-trust.md
@@ -14,13 +14,16 @@ The OS-owned deployment seam is deliberately small and fail-closed:
   provisioned, short-lived `service:registry` credential. Its `cnf.jwk` names the
   registry key that certifies accepted `did:at9p:<cid512>` state.
 - `/etc/hyprstream/trust/deployment-authority.log.json` is the public,
-  root-anchored authority-set checkpoint required when the credential was
-  issued by a scoped delegated signer.
+  root-anchored authority-set history required for every enrolled credential.
+- `/etc/hyprstream/trust/deployment-authority.head.json` is the independently
+  provisioned expected log head: schema, deployment domain, log DID, sequence,
+  and head CID. The supplied log must match it exactly.
 
 All installed files must be regular, root-owned, and not group/world writable. Missing,
 malformed, symlinked, or incorrectly owned material makes production resolver
-startup fail closed. Both JWT signature components are verified against the
-`/etc` pin before its key is represented by an opaque verification-only
+startup fail closed. Missing log or checkpoint never selects a less restrictive
+verifier. Both JWT signature components are verified against the checkpointed
+active authority before its key is represented by an opaque verification-only
 capability. The raw keys and one-shot witness are not exposed through the
 public service or Discovery APIs.
 
@@ -80,15 +83,16 @@ not become trust decisions: identity remains pinned by the configured at9p
 hash and mutual alias rule, while application responses remain pinned to the
 separately authenticated Discovery service key.
 
-The registry deployment credential is fetched from beside the capsule —
-`/.well-known/deployment/registry-service.jwt` — and validated with the exact
-same profile as the OS-owned file (CA-bound `kid`/`iss`/`deployment_domain`,
-one-hour freshness). The credential is CA-signed and short-lived, so the
-channel is untrusted by design; the OS-owned JWT file is required only when
-the OS-owned source is selected. Enrollment (operator-approved device flow,
-unattended machine attestation) and final `SecretsProfile` integration remain
-separate work; no client-authentication authority is inferred from the two
-public anchors.
+The registry deployment credential and current root-anchored authority log are
+fetched from beside the capsule at
+`/.well-known/deployment/registry-service.jwt` and
+`/.well-known/deployment/deployment-authority.log.json`. The log is
+authenticated against the capsule-derived hybrid root and must match the
+separately provisioned OS-owned head checkpoint exactly; the credential is then
+validated against that active set with the same closed profile as the OS-owned
+path. The HTTPS channel is untrusted by design and cannot redefine currentness.
+The OS-owned JWT and log files are required only when the OS-owned source is
+selected, but the OS-owned checkpoint is required for both enrolled sources.
 
 ### Serving the deployment well-known documents
 
@@ -101,12 +105,14 @@ service, and it already owns `/.well-known/did.json`):
 deployment_well_known_dir = "/var/lib/hyprstream/deployment-well-known"
 ```
 
-The operator provisions three public, integrity-anchored documents, re-read
+The operator provisions four public, integrity-anchored documents, re-read
 on every request (so the hourly credential refresh needs no restart):
 
 ```text
 <dir>/did.json                              the deployment DID document
 <dir>/at9p/<cid512>.cbor                    the cluster at9p genesis capsule
+<dir>/deployment/deployment-authority.log.json
+                                            the current root-anchored authority log
 <dir>/deployment/registry-service.jwt       the current CA-signed credential
 ```
 
@@ -182,11 +188,13 @@ compact JWT itself with no surrounding whitespace or trailing newline.
 The common operational form adds exactly one `delegation` claim to that closed
 claim set. It is canonical unpadded base64url JSON containing the scoped UCAN,
 the delegated 1,984-byte hybrid public key, and the stable authority-log DID.
-The separately installed current root-anchored DidOp log must have that DID,
-and the UCAN issuer must still be in its active any-of-N authority set. The
-UCAN is restricted to this deployment's registry-service mint ability, exact
-profile and audience, and the one-hour ceiling. Direct rare-root credentials
-retain the original claim set without `delegation`.
+The separately installed or fetched root-anchored DidOp log must have that DID,
+its verified sequence and head CID must equal the independent checkpoint, and
+the UCAN issuer must still be in its active any-of-N authority set. The UCAN is
+restricted to this deployment's registry-service mint ability, exact profile
+and audience, and the one-hour ceiling. Direct rare-root credentials retain the
+original claim set without `delegation`, but they are subject to the same
+mandatory log/checkpoint test and fail after root retirement.
 
 This profile is deployment/registry scoped. It has no PDS or host identifier.
 The demo therefore projects one shared deployment CA and current credential to

--- a/docs/deployment-trust-contract.md
+++ b/docs/deployment-trust-contract.md
@@ -1,0 +1,185 @@
+# Deployment trust minting and Metal consumption contract
+
+This is the operator and Metal #38 contract for deployment registry trust. The
+scope is one Hyprstream deployment, not a PDS or host. For the demo, the same
+deployment CA, authority log, and current registry credential are projected to
+both PDS hosts. The v1 credential has no PDS/host claim; consumers must not
+invent one.
+
+## Fixed runtime artifacts
+
+Metal's root-owned projection service installs these files atomically after
+validating them through `hyprstream trust verify-deployment`:
+
+| Artifact | Fixed path | Required representation |
+| --- | --- | --- |
+| Deployment public CA | `/etc/hyprstream/trust/deployment-ca.hybrid` | Exactly 1,984 raw bytes: 32-byte Ed25519 public key followed by 1,952-byte ML-DSA-65 public key |
+| Authority rotation log | `/etc/hyprstream/trust/deployment-authority.log.json` | Root-anchored `hyprstream.deployment-authority-log.v1` JSON; public metadata, required by delegated credentials |
+| Registry credential | `/run/hyprstream/credentials/registry-service.jwt` | Compact hybrid JWT with no whitespace or newline, profile `hyprstream.registry-deployment.v1`, audience `urn:hyprstream:service:registry`, lifetime at most 3,600 seconds |
+
+Every file and parent directory is a regular root-owned OS path and must not be
+group/world writable. The first and third paths and representations are the
+stable executable contract. The public authority log is the design-in rotation
+checkpoint: the verifier accepts a UCAN delegation only when the installed
+root-anchored log has the DID named by the delegation and its issuer remains in
+the installed any-of-N active authority set. Replacing/removing an authority
+therefore revokes its delegations without changing the original 1,984-byte root
+pin.
+
+## Metal #38 input schema
+
+Metal/OpenTofu accepts this reference-only object. These field names and
+semantics are pinned:
+
+```hcl
+deployment_trust = {
+  public_ca = {
+    secret_arn = "exact cloud-secret ARN"
+    version_id = "immutable version"
+    sha256     = "lowercase SHA-256 of the raw 1,984 bytes"
+    size_bytes = 1984
+  }
+  authority_log = {
+    secret_arn = "exact cloud-secret ARN"
+    version_id = "immutable version authorized for this rollout"
+    sha256     = "lowercase SHA-256 of the exact JSON bytes"
+    schema     = "hyprstream.deployment-authority-log.v1"
+    max_bytes  = 65536
+  }
+  registry_credential = {
+    secret_arn             = "exact rotating cloud-secret ARN"
+    version_stage          = "AWSCURRENT"
+    profile                = "hyprstream.registry-deployment.v1"
+    audience               = "urn:hyprstream:service:registry"
+    max_ttl_seconds        = 3600
+    refresh_before_seconds = 300
+  }
+}
+```
+
+OpenTofu sees only these references and public integrity values. It must never
+read, render, output, log, or store the CA/JWT values in state, plans, tfvars,
+user data, or cloud-init. The exact secret ARNs and required KMS encryption
+context are the entire instance IAM read scope. The projection unit retrieves
+the referenced values at runtime, validates the CA length/layout, authority-log
+root and head, JWT profile/audience/freshness/signatures, then uses
+write-fsync-rename to replace the fixed files. A failed fetch or verification
+never replaces the last valid file, and startup fails when no current valid
+set exists.
+
+The mint and verifier cap both the rotating JWT and public authority log at
+65,536 bytes so either remains a valid cloud-secret value. The delegation names
+the stable authority-log DID instead of embedding its growing DidOp history, so
+hourly JWT size does not grow with rotations. A deployment that exhausts the
+log's 65,536-byte append budget must perform the documented new-CA
+reprovisioning flow; v1 does not claim a history-compaction protocol.
+
+The CA and authority-log versions are immutable inputs for a rollout. The JWT
+intentionally follows `AWSCURRENT` and is refreshed before expiry. An authority
+rotation is a deliberate Metal input update to the new immutable log version;
+it is not the hourly JWT refresh path.
+
+## Out-of-band mint and publish flow
+
+The root authority is never placed in AWS, Metal, Terraform/OpenTofu, an
+instance, or an online refresh job. Generate it on an operator machine with an
+any-one-decrypts age recipient ring:
+
+```console
+hyprstream trust mint-deployment-ca \
+  --public-ca deployment-ca.hybrid \
+  --authority-key deployment-ca.age \
+  --authority-log deployment-authority.log.json \
+  --yubikey age1yubikey1PRIMARY... \
+  --yubikey age1yubikey1BACKUP... \
+  --recipient age1BREAKGLASS...
+```
+
+At least two distinct root recipients are enforced; three (primary YubiKey,
+backup YubiKey, offline break-glass) are the operational baseline. Native age
+recipients and age-plugin recipients are interchangeable and any one can
+decrypt. `--piv-slot` optionally keeps the Ed25519 signing leg in a YubiKey PIV
+slot with always-touch policy. To prevent that device from becoming a sole
+holder, the same Ed25519 seed exists only as a recovery copy inside the
+multi-recipient age bundle; using it requires the explicit
+`--software-recovery` break-glass flag. YubiKey does not provide native
+ML-DSA-65: the PQ seed also remains inside that age-encrypted bundle. Age's
+standard native at-rest recipient is classical X25519; a future PQ-HSM plugin
+can use the same recipient interface.
+
+Touch the rare authority once at deployment setup to authorize a separate
+online hybrid signer:
+
+```console
+hyprstream trust delegate-registry-signer \
+  --public-ca deployment-ca.hybrid \
+  --authority-log deployment-authority.log.json \
+  --authority-key deployment-ca.age \
+  --yubikey-identity primary-yubikey-identity.txt \
+  --signer-recipient age1ONLINE_KMS_OR_SERVICE_IDENTITY... \
+  --delegated-key registry-delegated-signer.age \
+  --delegation registry-signer.delegation.json
+```
+
+The signed UCAN grants only
+`hyprstream://deployment/<deployment_domain>/service/registry` with ability
+`mint-registry-jwt`, exact profile/audience/domain/delegated-key caveats, and a
+3,600-second JWT ceiling. It cannot delegate further or mint any other token.
+The online job uses it hourly without the root:
+
+```console
+hyprstream trust mint-registry-jwt \
+  --public-ca deployment-ca.hybrid \
+  --authority-log deployment-authority.log.json \
+  --identity online-signer-identity.txt \
+  --via-delegated-signer registry-delegated-signer.age \
+  --delegation registry-signer.delegation.json \
+  --registry-public-key registry-service.ed25519.pub \
+  --ttl-seconds 3600 \
+  --jwt registry-service.jwt \
+  --contract deployment-trust.publisher-manifest.json
+```
+
+The common-path key is named by `--via-delegated-signer`; `--authority-key`
+is used only by the explicit rare/bootstrap `--root` alternative.
+
+The JSON `--contract` output is
+`hyprstream.deployment-trust-publisher-manifest.v1`: it contains local paths,
+base64 artifact values, and fingerprints for an out-of-band secret publisher.
+It contains no authority key. Because it contains the JWT and public artifacts,
+it is sensitive operational input and must never be passed to OpenTofu. The
+publisher writes the public CA and authority log to immutable cloud-secret
+versions, rotates only the JWT's `AWSCURRENT` version hourly, and returns the
+reference-only Metal object above through a separate control path.
+
+Verify the exact bytes before publishing:
+
+```console
+hyprstream trust verify-deployment \
+  --public-ca deployment-ca.hybrid \
+  --authority-log deployment-authority.log.json \
+  --jwt registry-service.jwt \
+  --contract deployment-trust.publisher-manifest.json
+```
+
+## Authority rotation, revocation, and loss recovery
+
+`hyprstream trust rotate-authority --add` signs a DidOp head that retains the
+old active keys and adds the new hybrid key. Publish and roll out the new
+authority log, create a new delegation with the new authority, then use
+`--replace` to publish a later head that retires the old set. During the add
+phase, delegations from retained authorities remain valid because they name the
+same log DID; after replacement, the same delegations fail because their issuer
+is no longer active.
+
+Loss of one age recipient is recovered by decrypting with another, then
+rotating the recipient ring and authority as appropriate. Full loss of every
+root recipient is not cryptographically recoverable: generate a new deployment
+CA, re-provision `/etc/hyprstream/trust/deployment-ca.hybrid` and the new
+authority log on every instance, issue a new delegation, and replace the
+registry credential.
+
+Threshold M-of-N signing is deliberately deferred. FROST-style Ed25519
+threshold schemes do not solve the ML-DSA-65 leg, whose threshold signing and
+hardware support remain research-grade. The authority-set/DidOp seam supports
+operational key rotation today without claiming PQ threshold security.

--- a/docs/deployment-trust-contract.md
+++ b/docs/deployment-trust-contract.md
@@ -2,9 +2,9 @@
 
 This is the operator and Metal #38 contract for deployment registry trust. The
 scope is one Hyprstream deployment, not a PDS or host. For the demo, the same
-deployment CA, authority log, and current registry credential are projected to
-both PDS hosts. The v1 credential has no PDS/host claim; consumers must not
-invent one.
+deployment CA, authority log, independently trusted log-head checkpoint, and
+current registry credential are projected to both PDS hosts. The v1 credential
+has no PDS/host claim; consumers must not invent one.
 
 ## Fixed runtime artifacts
 
@@ -14,17 +14,20 @@ validating them through `hyprstream trust verify-deployment`:
 | Artifact | Fixed path | Required representation |
 | --- | --- | --- |
 | Deployment public CA | `/etc/hyprstream/trust/deployment-ca.hybrid` | Exactly 1,984 raw bytes: 32-byte Ed25519 public key followed by 1,952-byte ML-DSA-65 public key |
-| Authority rotation log | `/etc/hyprstream/trust/deployment-authority.log.json` | Root-anchored `hyprstream.deployment-authority-log.v1` JSON; public metadata, required by delegated credentials |
+| Authority rotation log | `/etc/hyprstream/trust/deployment-authority.log.json` | Root-anchored `hyprstream.deployment-authority-log.v1` JSON; public metadata, required for every credential |
+| Authority head checkpoint | `/etc/hyprstream/trust/deployment-authority.head.json` | Independently provisioned `hyprstream.deployment-authority-checkpoint.v1` JSON containing the expected domain, log DID, sequence, and head CID |
 | Registry credential | `/run/hyprstream/credentials/registry-service.jwt` | Compact hybrid JWT with no whitespace or newline, profile `hyprstream.registry-deployment.v1`, audience `urn:hyprstream:service:registry`, lifetime at most 3,600 seconds |
 
 Every file and parent directory is a regular root-owned OS path and must not be
-group/world writable. The first and third paths and representations are the
-stable executable contract. The public authority log is the design-in rotation
-checkpoint: the verifier accepts a UCAN delegation only when the installed
-root-anchored log has the DID named by the delegation and its issuer remains in
-the installed any-of-N active authority set. Replacing/removing an authority
-therefore revokes its delegations without changing the original 1,984-byte root
-pin.
+group/world writable. The verifier requires the log and checkpoint for
+direct-root and delegated credentials alike. A supplied log is accepted only
+when its verified DID, sequence, and head CID exactly equal the independently
+provisioned checkpoint; a signature-valid historical prefix therefore cannot
+reactivate a retired authority. The UCAN issuer must also remain in the
+checkpointed any-of-N active authority set. Replacing/removing an authority
+revokes both its direct credentials and delegations without changing the
+original 1,984-byte root pin. Logless genesis validation is a separately named,
+one-time tooling mode and is never inferred from a missing production file.
 
 ## Metal #38 input schema
 
@@ -46,6 +49,13 @@ deployment_trust = {
     schema     = "hyprstream.deployment-authority-log.v1"
     max_bytes  = 65536
   }
+  authority_checkpoint = {
+    secret_arn = "exact cloud-secret ARN"
+    version_id = "same rollout as authority_log"
+    sha256     = "lowercase SHA-256 of the exact checkpoint JSON bytes"
+    schema     = "hyprstream.deployment-authority-checkpoint.v1"
+    max_bytes  = 65536
+  }
   registry_credential = {
     secret_arn             = "exact rotating cloud-secret ARN"
     version_stage          = "AWSCURRENT"
@@ -62,22 +72,25 @@ read, render, output, log, or store the CA/JWT values in state, plans, tfvars,
 user data, or cloud-init. The exact secret ARNs and required KMS encryption
 context are the entire instance IAM read scope. The projection unit retrieves
 the referenced values at runtime, validates the CA length/layout, authority-log
-root and head, JWT profile/audience/freshness/signatures, then uses
+root and exact independently trusted head, JWT
+profile/audience/freshness/signatures, then uses
 write-fsync-rename to replace the fixed files. A failed fetch or verification
 never replaces the last valid file, and startup fails when no current valid
 set exists.
 
-The mint and verifier cap both the rotating JWT and public authority log at
-65,536 bytes so either remains a valid cloud-secret value. The delegation names
+The mint and verifier cap the rotating JWT, public authority log, and checkpoint
+at 65,536 bytes so each remains a valid cloud-secret value. The delegation names
 the stable authority-log DID instead of embedding its growing DidOp history, so
 hourly JWT size does not grow with rotations. A deployment that exhausts the
 log's 65,536-byte append budget must perform the documented new-CA
 reprovisioning flow; v1 does not claim a history-compaction protocol.
 
-The CA and authority-log versions are immutable inputs for a rollout. The JWT
-intentionally follows `AWSCURRENT` and is refreshed before expiry. An authority
-rotation is a deliberate Metal input update to the new immutable log version;
-it is not the hourly JWT refresh path.
+The CA, authority-log, and authority-checkpoint versions are immutable inputs
+for a rollout. The log and checkpoint are minted and durably committed together,
+and Metal must project them as one rollout unit; a mixed pair fails closed. The
+JWT intentionally follows `AWSCURRENT` and is refreshed before expiry. An
+authority rotation is a deliberate Metal input update to the new immutable log
+and checkpoint versions; it is not the hourly JWT refresh path.
 
 ## Out-of-band mint and publish flow
 
@@ -90,6 +103,7 @@ hyprstream trust mint-deployment-ca \
   --public-ca deployment-ca.hybrid \
   --authority-key deployment-ca.age \
   --authority-log deployment-authority.log.json \
+  --authority-checkpoint deployment-authority.head.json \
   --yubikey age1yubikey1PRIMARY... \
   --yubikey age1yubikey1BACKUP... \
   --recipient age1BREAKGLASS...
@@ -114,6 +128,7 @@ online hybrid signer:
 hyprstream trust delegate-registry-signer \
   --public-ca deployment-ca.hybrid \
   --authority-log deployment-authority.log.json \
+  --authority-checkpoint deployment-authority.head.json \
   --authority-key deployment-ca.age \
   --yubikey-identity primary-yubikey-identity.txt \
   --signer-recipient age1ONLINE_KMS_OR_SERVICE_IDENTITY... \
@@ -131,6 +146,7 @@ The online job uses it hourly without the root:
 hyprstream trust mint-registry-jwt \
   --public-ca deployment-ca.hybrid \
   --authority-log deployment-authority.log.json \
+  --authority-checkpoint deployment-authority.head.json \
   --identity online-signer-identity.txt \
   --via-delegated-signer registry-delegated-signer.age \
   --delegation registry-signer.delegation.json \
@@ -148,9 +164,10 @@ The JSON `--contract` output is
 base64 artifact values, and fingerprints for an out-of-band secret publisher.
 It contains no authority key. Because it contains the JWT and public artifacts,
 it is sensitive operational input and must never be passed to OpenTofu. The
-publisher writes the public CA and authority log to immutable cloud-secret
-versions, rotates only the JWT's `AWSCURRENT` version hourly, and returns the
-reference-only Metal object above through a separate control path.
+publisher writes the public CA, authority log, and authority checkpoint to
+immutable cloud-secret versions, rotates only the JWT's `AWSCURRENT` version
+hourly, and returns the reference-only Metal object above through a separate
+control path.
 
 Verify the exact bytes before publishing:
 
@@ -158,6 +175,7 @@ Verify the exact bytes before publishing:
 hyprstream trust verify-deployment \
   --public-ca deployment-ca.hybrid \
   --authority-log deployment-authority.log.json \
+  --authority-checkpoint deployment-authority.head.json \
   --jwt registry-service.jwt \
   --contract deployment-trust.publisher-manifest.json
 ```
@@ -166,8 +184,9 @@ hyprstream trust verify-deployment \
 
 `hyprstream trust rotate-authority --add` signs a DidOp head that retains the
 old active keys and adds the new hybrid key. Publish and roll out the new
-authority log, create a new delegation with the new authority, then use
-`--replace` to publish a later head that retires the old set. During the add
+authority log and its same-transaction checkpoint, create a new delegation with
+the new authority, then use `--replace` to publish a later log/checkpoint pair
+that retires the old set. During the add
 phase, delegations from retained authorities remain valid because they name the
 same log DID; after replacement, the same delegations fail because their issuer
 is no longer active.
@@ -175,9 +194,9 @@ is no longer active.
 Loss of one age recipient is recovered by decrypting with another, then
 rotating the recipient ring and authority as appropriate. Full loss of every
 root recipient is not cryptographically recoverable: generate a new deployment
-CA, re-provision `/etc/hyprstream/trust/deployment-ca.hybrid` and the new
-authority log on every instance, issue a new delegation, and replace the
-registry credential.
+CA, re-provision `/etc/hyprstream/trust/deployment-ca.hybrid`, the new authority
+log, and its head checkpoint on every instance, issue a new delegation, and
+replace the registry credential.
 
 Threshold M-of-N signing is deliberately deferred. FROST-style Ed25519
 threshold schemes do not solve the ML-DSA-65 leg, whose threshold signing and

--- a/docs/deployment-trust-contract.md
+++ b/docs/deployment-trust-contract.md
@@ -18,8 +18,8 @@ validating them through `hyprstream trust verify-deployment`:
 | Authority head checkpoint | `/etc/hyprstream/trust/deployment-authority.head.json` | Independently provisioned `hyprstream.deployment-authority-checkpoint.v1` JSON containing the expected domain, log DID, sequence, and head CID |
 | Registry credential | `/run/hyprstream/credentials/registry-service.jwt` | Compact hybrid JWT with no whitespace or newline, profile `hyprstream.registry-deployment.v1`, audience `urn:hyprstream:service:registry`, lifetime at most 3,600 seconds |
 
-Every file and parent directory is a regular root-owned OS path and must not be
-group/world writable. The verifier requires the log and checkpoint for
+Every fixed-path file and parent directory is a regular root-owned OS path and
+must not be group/world writable. The verifier requires the log and checkpoint for
 direct-root and delegated credentials alike. A supplied log is accepted only
 when its verified DID, sequence, and head CID exactly equal the independently
 provisioned checkpoint; a signature-valid historical prefix therefore cannot
@@ -28,6 +28,27 @@ checkpointed any-of-N active authority set. Replacing/removing an authority
 revokes both its direct credentials and delegations without changing the
 original 1,984-byte root pin. Logless genesis validation is a separately named,
 one-time tooling mode and is never inferred from a missing production file.
+
+For rootless development and `systemd --user`, the daemon also supports the
+explicit loader contract below:
+
+```text
+HYPRSTREAM_DEPLOYMENT_TRUST_DIR=/absolute/trust/directory
+CREDENTIALS_DIRECTORY=/absolute/systemd/credentials/directory
+```
+
+The trust directory supplies `deployment-ca.hybrid`,
+`deployment-authority.log.json`, and `deployment-authority.head.json`.
+`CREDENTIALS_DIRECTORY` supplies `registry-service.jwt`. Each variable controls
+only its named side of the split; an absent variable falls back to the fixed
+path in the table, while an invalid present value fails startup without
+fallback. User-service paths require real, non-group/world-writable files and
+ancestors owned by root or the daemon's effective user, and symlinks are
+rejected.
+
+This is path and ownership resolution only. It does not add a genesis mode or
+relax the 1,984-byte hybrid CA, exact checkpoint/log binding, JWT profile,
+audience, freshness, claim-shape, delegation, or hybrid-signature checks.
 
 ## Metal #38 input schema
 


### PR DESCRIPTION
## Summary

- honor systemd `CREDENTIALS_DIRECTORY` for `registry-service.jwt`
- add `HYPRSTREAM_DEPLOYMENT_TRUST_DIR` for the deployment CA, authority log, and independent checkpoint
- preserve independent fixed-path fallback for each unset selector
- reject empty, relative, traversing, symlinked, writable, or wrongly owned selected paths
- retain the complete enrolled hybrid trust verifier without a downgrade or alternate validation mode

## Resolution contract

```text
HYPRSTREAM_DEPLOYMENT_TRUST_DIR=/absolute/path/to/trust
CREDENTIALS_DIRECTORY=/absolute/path/to/systemd/credentials
```

The trust directory supplies these fixed names:

- `deployment-ca.hybrid`
- `deployment-authority.log.json`
- `deployment-authority.head.json`

The systemd credentials directory supplies only:

- `registry-service.jwt`

An unset selector independently falls back to the existing root path. A
present invalid selector fails startup and never falls back.

Fixed-path artifacts remain root-owned. Explicit user-service artifacts and
every real ancestor must be owned by root or the daemon effective user and must
not be group/world writable. Symlinked ancestors are rejected, and final files
are opened with `O_NOFOLLOW`.

## Verification invariants

Path resolution still feeds the same enrolled production verifier. This change
does not relax or bypass:

- the exact 1,984-byte Ed25519 + ML-DSA-65 deployment CA
- root-anchored authority-log verification
- exact independent checkpoint sequence/head anti-rollback binding
- closed JWT profile, audience, subject, issuer, confirmation-key, claim-shape,
  lifetime, currentness, and compact-serialization checks
- delegated-authority validation
- both hybrid JWT signature components

No XDG, general secrets directory, missing-file genesis inference, public
authority setter, or post-bootstrap environment mutation gains authority.

## Validation

All Cargo commands ran through the shared-target Hyprstream build helper.

- focused trust-path and enrolled-crypto tests: 5 passed
- `cargo test -p hyprstream-discovery --lib --tests --no-fail-fast`: 116 passed
- `cargo build -p hyprstream --lib`: passed
- affected-crate all-target Clippy with `-D warnings`: passed
- workspace all-target Clippy with `-D warnings`: passed
- release pre-commit Clippy: passed
- cargo-deny bans/licenses: passed

Independent trust-loader review artifacts will be linked in the coordination
handoff. This is a stacked PR targeting #1371's
`feat/trust-mint-v2` branch so the reviewed trust-mint history remains isolated.
No self-approval or self-merge.
