### PR TITLE
feat(auth): wire cold-signup + OAuth onto PGlite UserStore (#1378)

### DIFF
--- a/crates/hyprstream/src/config/mod.rs
+++ b/crates/hyprstream/src/config/mod.rs
@@ -1460,12 +1460,18 @@ fn default_oauth_host() -> String { "0.0.0.0".to_owned() }
 fn default_oauth_port() -> u16 { 6791 }
 
 /// Which backend stores user credentials and refresh tokens.
+///
+/// `Pglite` selects the shared embedded PGlite/Postgres relational store for
+/// the **account system of record** (UserStore). Token and device stores
+/// remain on RocksDB/Valkey — a pglite TokenStore does not exist.
 #[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq, Eq)]
 #[serde(rename_all = "lowercase")]
 pub enum CredentialsBackend {
     #[default]
     Rocksdb,
     Valkey,
+    /// Relational UserStore on the shared #1351 PGlite substrate.
+    Pglite,
 }
 
 /// Valkey connection settings (used when `backend = "valkey"`).

--- a/crates/hyprstream/src/services/oauth/introspection.rs
+++ b/crates/hyprstream/src/services/oauth/introspection.rs
@@ -93,22 +93,26 @@ async fn introspect_refresh(
 ) -> Response {
     match state.get_refresh_token(token).await {
         Ok(Some(entry)) => {
-            let tenant = super::token::resolve_hosted_account_binding(
-                state,
-                &entry.username,
-            )
-                .await
-                .ok()
-                .map(|(_, tenant)| tenant);
-            if !caller_may_introspect_tenant(caller, tenant.as_deref()) {
+            let (hosted_did, tenant) =
+                match super::token::resolve_hosted_account_binding(state, &entry.username).await {
+                    Ok(binding) => binding,
+                    Err(error) => {
+                        tracing::warn!(
+                            username = %entry.username,
+                            %error,
+                            "refresh-token introspection failed closed on account binding lookup"
+                        );
+                        return inactive_response();
+                    }
+                };
+            if !caller_may_introspect_tenant(caller, Some(&tenant)) {
                 return inactive_response();
             }
 
             // Match the mint boundary: generic tokens retain the username,
             // while active atproto-profile tokens report the mapped DID.
             let sub = if super::state::atproto_profile_active(&entry.scopes) {
-                state.check_atproto_account_eligibility(&entry.username).await
-                    .unwrap_or_else(|_| entry.username.clone())
+                hosted_did
             } else {
                 entry.username.clone()
             };

--- a/crates/hyprstream/src/services/oauth/mod.rs
+++ b/crates/hyprstream/src/services/oauth/mod.rs
@@ -587,26 +587,86 @@ impl Spawnable for OAuthService {
                 )
             })?;
 
-            // Load the user store and token store based on configured backend.
-            // Failure is non-fatal; endpoints will report "not configured" instead.
+            // Load the user store (account system of record) based on the
+            // configured backend. A configured system-of-record failure fails
+            // closed — never silently fall back to a different account store.
             use crate::config::CredentialsBackend;
             let credentials_config = crate::config::HyprConfig::load()
                 .map(|c| c.credentials)
                 .unwrap_or_default();
 
+            // The device store is independent of the user-store backend. It
+            // always uses RocksDB (device-authorization state is not account
+            // data and there is no pglite DeviceStore). Every match arm below
+            // assigns it, so the initial `None` is structurally required by
+            // Rust's initialization rules but is always overwritten before read.
+            #[allow(unused_assignments)]
             let mut device_store_opt: Option<Arc<dyn crate::auth::DeviceStore>> = None;
+
+            // Helper: open a RocksDbUserStore solely for its DeviceStore trait
+            // (used when the account backend is not RocksDB).
+            #[cfg(any(feature = "pglite", feature = "valkey"))]
+            // (used when the account backend is not RocksDB).
+            macro_rules! open_rocksdb_device_store {
+                () => {{
+                    match crate::auth::RocksDbUserStore::open(&credentials_dir) {
+                        Ok(ds) => {
+                            let arc: Arc<crate::auth::RocksDbUserStore> = Arc::new(ds);
+                            Some(arc as Arc<dyn crate::auth::DeviceStore>)
+                        }
+                        Err(e) => {
+                            tracing::warn!("Could not open device store (RocksDB): {e}");
+                            None
+                        }
+                    }
+                }};
+            }
+
             let user_store: Option<Arc<dyn crate::auth::user_store::UserStore>> = match credentials_config.backend {
+                CredentialsBackend::Pglite => {
+                    #[cfg(feature = "pglite")]
+                    {
+                        let db_path = credentials_dir.join("pglite");
+                        // Open the shared PGlite handle explicitly so it can be
+                        // injected into other repositories (AppView inventory)
+                        // via from_database in the future. #1376's PgliteUserStore
+                        // owns the schema application; we own the connection.
+                        let database = Arc::new(
+                            pglite::PGlite::open(&db_path)
+                                .await
+                                .map_err(|e| hyprstream_rpc::error::RpcError::SpawnFailed(
+                                    format!("failed to open PGlite at {db_path:?}: {e}")
+                                ))?,
+                        );
+                        let store = crate::auth::PgliteUserStore::from_database(database)
+                            .await
+                            .map_err(|e| hyprstream_rpc::error::RpcError::SpawnFailed(
+                                format!("failed to initialize UserStore schema: {e}")
+                            ))?;
+                        info!("User store (PGlite) opened at {:?}", db_path);
+                        device_store_opt = open_rocksdb_device_store!();
+                        Some(Arc::new(store) as Arc<dyn crate::auth::user_store::UserStore>)
+                    }
+                    #[cfg(not(feature = "pglite"))]
+                    {
+                        return Err(hyprstream_rpc::error::RpcError::SpawnFailed(
+                            "credentials.backend = \"pglite\" but binary was not compiled with --features pglite".to_owned()
+                        ));
+                    }
+                }
                 CredentialsBackend::Rocksdb => {
                     match crate::auth::RocksDbUserStore::open(&credentials_dir) {
                         Ok(store) => {
                             info!("User store (RocksDB) opened at {:?}", credentials_dir);
                             let arc = Arc::new(store);
+                            // RocksDbUserStore implements both traits — share the object.
                             device_store_opt = Some(arc.clone() as Arc<dyn crate::auth::DeviceStore>);
                             Some(arc as Arc<dyn crate::auth::user_store::UserStore>)
                         }
                         Err(e) => {
-                            tracing::warn!("Could not open user store (endpoints will report 'not configured'): {}", e);
-                            None
+                            return Err(hyprstream_rpc::error::RpcError::SpawnFailed(
+                                format!("failed to open RocksDB user store at {credentials_dir:?}: {e}")
+                            ));
                         }
                     }
                 }
@@ -617,18 +677,21 @@ impl Spawnable for OAuthService {
                         match crate::auth::ValkeyUserStore::connect(url).await {
                             Ok(store) => {
                                 info!("User store (Valkey) connected at {url}");
+                                device_store_opt = open_rocksdb_device_store!();
                                 Some(Arc::new(store))
                             }
                             Err(e) => {
-                                tracing::warn!("Could not connect user store (Valkey): {e}");
-                                None
+                                return Err(hyprstream_rpc::error::RpcError::SpawnFailed(
+                                    format!("failed to connect Valkey user store at {url}: {e}")
+                                ));
                             }
                         }
                     }
                     #[cfg(not(feature = "valkey"))]
                     {
-                        tracing::error!("credentials.backend = \"valkey\" but binary was not compiled with --features valkey");
-                        None
+                        return Err(hyprstream_rpc::error::RpcError::SpawnFailed(
+                            "credentials.backend = \"valkey\" but binary was not compiled with --features valkey".to_owned()
+                        ));
                     }
                 }
             };
@@ -844,9 +907,13 @@ impl Spawnable for OAuthService {
             oauth_state = oauth_state.with_jwt_key_timestamps(key_nbf, key_nbf + 14 * 86400);
 
             // Open persistent refresh token store (non-fatal — tokens simply don't survive restart).
+            // The token store is decoupled from the account backend: a pglite
+            // UserStore does not imply a pglite TokenStore — refresh tokens
+            // always go to RocksDB or Valkey.
             let token_db_path = credentials_dir.join("oauth-tokens");
             let token_store: Option<Arc<dyn crate::services::oauth::token_store::TokenStore>> = match credentials_config.backend {
-                CredentialsBackend::Rocksdb => {
+                // Pglite account store falls through to RocksDB for tokens.
+                CredentialsBackend::Pglite | CredentialsBackend::Rocksdb => {
                     match crate::services::oauth::token_store::RocksDbTokenStore::open(&token_db_path) {
                         Ok(s) => {
                             info!("Refresh token store (RocksDB) opened at {:?}", token_db_path);

--- a/crates/hyprstream/src/services/oauth/oidc_callback.rs
+++ b/crates/hyprstream/src/services/oauth/oidc_callback.rs
@@ -19,7 +19,7 @@ use rand::RngCore;
 use serde::Deserialize;
 use sha2::{Sha256, Digest};
 
-use crate::auth::user_store::UserProfile;
+use crate::auth::user_store::UserProfilePatch;
 use crate::config::ProviderKind;
 use super::state::{OAuthState, PendingAuthCode, PendingExternalAuth};
 
@@ -403,7 +403,9 @@ pub async fn external_callback(
         }
     };
 
-    // Map external identity to local subject
+    // Map external identity to a candidate local username. This is a *hint* —
+    // the authoritative username is resolved by the credential store, not by
+    // the mapping function.
     let mapped_subject = match super::user_mapping::map_external_identity(
         &provider_slug,
         &external_claims,
@@ -417,54 +419,95 @@ pub async fn external_callback(
         }
     };
 
-    // Check provisioning
-    match super::user_mapping::should_provision(
+    // Resolve the issuer to use for the normalized (issuer, subject) binding.
+    // Prefer the provider's configured issuer_url, then the id_token `iss`
+    // claim, then the provider slug as a last-resort synthetic issuer.
+    let binding_issuer = provider.issuer_url.as_deref()
+        .or_else(|| external_claims["iss"].as_str())
+        .unwrap_or(&provider_slug)
+        .to_owned();
+    let external_sub = match external_claims["sub"].as_str() {
+        Some(s) if !s.is_empty() => s.to_owned(),
+        _ => {
+            tracing::error!(provider = %provider_slug, "External token missing required 'sub' claim — rejecting");
+            return (axum::http::StatusCode::BAD_REQUEST, "External token missing required 'sub' claim").into_response();
+        }
+    };
+
+    // Resolve the authoritative local username via the credential store.
+    // In auto-provision mode this atomically binds (issuer, subject) and may
+    // create the local account. In deny mode the binding must already exist.
+    // Either way: never continue with the pre-binding candidate if the store
+    // resolves a different authoritative username.
+    let authoritative_username = match super::user_mapping::should_provision(
         &provider.provisioning,
         &mapped_subject,
         &provider.allowed_domains,
     ) {
         Ok(true) => {
-            provision_federated_user(
+            // Auto-provision: atomically resolve-or-bind the external identity.
+            match provision_federated_user(
                 &state,
-                &provider_slug,
+                &binding_issuer,
+                &external_sub,
                 &mapped_subject,
                 &external_claims,
                 &provider.default_scopes,
-            ).await;
+            ).await {
+                Ok(username) => username,
+                Err(response) => return response,
+            }
         }
         Ok(false) => {
-            // Deny mode: user must already exist; reject unknown subjects early.
+            // Deny mode: the user must already exist. Resolve the normalized
+            // (issuer, subject) binding first, then fall back to the mapped
+            // username for legacy profiles that pre-date the binding table.
             if let Some(ref user_svc) = state.user_service {
-                match user_svc.store().get_profile(&mapped_subject).await {
-                    Ok(Some(_)) => {}
+                let store = user_svc.store();
+                // Try normalized binding first.
+                match store.get_external_identity_user(&binding_issuer, &external_sub).await {
+                    Ok(Some(username)) => username,
                     Ok(None) => {
-                        tracing::warn!(
-                            provider = %provider_slug,
-                            subject = %mapped_subject,
-                            "Deny mode: user not registered — rejecting"
-                        );
-                        return (
-                            axum::http::StatusCode::FORBIDDEN,
-                            format!("Access denied: '{mapped_subject}' is not registered. Contact your administrator."),
-                        ).into_response();
+                        // No normalized binding — try legacy username lookup.
+                        match store.get_profile(&mapped_subject).await {
+                            Ok(Some(_)) => mapped_subject.clone(),
+                            Ok(None) => {
+                                tracing::warn!(
+                                    provider = %provider_slug,
+                                    subject = %mapped_subject,
+                                    "Deny mode: user not registered — rejecting"
+                                );
+                                return (
+                                    axum::http::StatusCode::FORBIDDEN,
+                                    format!("Access denied: '{mapped_subject}' is not registered. Contact your administrator."),
+                                ).into_response();
+                            }
+                            Err(e) => {
+                                tracing::error!(subject = %mapped_subject, error = %e, "User lookup failed");
+                                return (axum::http::StatusCode::INTERNAL_SERVER_ERROR, "User lookup failed").into_response();
+                            }
+                        }
                     }
                     Err(e) => {
-                        tracing::error!(subject = %mapped_subject, error = %e, "User lookup failed");
+                        tracing::error!(issuer = %binding_issuer, subject = %external_sub, error = %e, "External identity lookup failed");
                         return (axum::http::StatusCode::INTERNAL_SERVER_ERROR, "User lookup failed").into_response();
                     }
                 }
+            } else {
+                mapped_subject.clone()
             }
         }
         Err(e) => {
             tracing::warn!(provider = %provider_slug, subject = %mapped_subject, error = %e, "Provisioning denied");
             return (axum::http::StatusCode::FORBIDDEN, format!("Access denied: {e}")).into_response();
         }
-    }
+    };
 
     tracing::info!(
         provider = %provider_slug,
         external_sub = %external_claims["sub"].as_str().unwrap_or("unknown"),
         mapped_subject = %mapped_subject,
+        authoritative_username = %authoritative_username,
         "External OIDC authentication successful"
     );
 
@@ -488,7 +531,7 @@ pub async fn external_callback(
         resource: pending.original_resource.clone(),
         created_at: Instant::now(),
         expires_at: Instant::now() + Duration::from_secs(60),
-        username: mapped_subject,
+        username: authoritative_username,
         verifying_key: None, // external OIDC — no local Ed25519 key binding
         dpop_jkt: None, // external OIDC flow — no PAR DPoP binding
         client_assertion_jkt: None, // external OIDC flow — no PAR client-auth binding
@@ -504,102 +547,129 @@ pub async fn external_callback(
     Redirect::temporary(&redirect_url).into_response()
 }
 
-/// Create a UserStore entry and write Casbin rules for a first-time federated login.
+/// Atomically resolve or bind an external IdP identity and provision profile
+/// data for a first-time federated login.
 ///
-/// Idempotent: if the subject already has a profile, skips all writes silently.
-/// Non-fatal: errors are logged but do not abort the login flow.
+/// Returns the authoritative local username — which may differ from the
+/// candidate when the `(issuer, subject)` binding already existed. The caller
+/// MUST use the returned username, never the pre-binding candidate.
+///
+/// Fail-closed: any credential-store error rejects the login. Casbin policy
+/// writes are best-effort (logged, not fatal) because they are a separate
+/// subsystem from the credential store.
 async fn provision_federated_user(
     state: &OAuthState,
-    provider_slug: &str,
-    subject: &str,
+    issuer: &str,
+    external_sub: &str,
+    candidate_username: &str,
     external_claims: &serde_json::Value,
     default_scopes: &[String],
-) {
+) -> Result<String, Response> {
     let Some(ref user_svc) = state.user_service else {
-        tracing::warn!(provider = %provider_slug, "No user store — skipping federated provisioning");
-        return;
+        tracing::error!("Federated provisioning failed: credential store is not configured");
+        return Err((
+            axum::http::StatusCode::SERVICE_UNAVAILABLE,
+            "credential store is not configured",
+        )
+            .into_response());
     };
     let store = user_svc.store();
 
-    // Check idempotency before writing.
-    let already_exists = match store.get_profile(subject).await {
-        Ok(Some(_)) => true,
-        Ok(None) => false,
+    // Atomically resolve-or-bind the normalized (issuer, subject) identity.
+    // This is the authoritative step — it creates the local account and binding
+    // in one operation, or returns the existing binding's username.
+    let resolution = match store
+        .resolve_or_bind_external_idp(issuer, external_sub, candidate_username)
+        .await
+    {
+        Ok(r) => r,
         Err(e) => {
-            tracing::error!(subject = %subject, error = %e, "Failed to check user existence");
-            return;
+            tracing::error!(
+                issuer = %issuer,
+                external_sub = %external_sub,
+                candidate = %candidate_username,
+                error = %e,
+                "Failed to resolve or bind external identity — rejecting login"
+            );
+            return Err((
+                axum::http::StatusCode::INTERNAL_SERVER_ERROR,
+                "Failed to provision federated identity",
+            )
+                .into_response());
         }
     };
 
-    if already_exists {
-        tracing::debug!(subject = %subject, "Federated user already provisioned — skipping");
-        return;
-    }
-
-    // First login: register and populate profile from external claims.
-    if let Err(e) = store.register(subject).await {
-        tracing::error!(subject = %subject, error = %e, "Failed to register federated user");
-        return;
-    }
-    let profile = UserProfile {
-        sub: None,
-        name: external_claims["name"].as_str().map(str::to_owned),
-        email: external_claims["email"].as_str().map(str::to_owned),
-        email_verified: external_claims["email_verified"].as_bool(),
-        active: Some(true),
-        external_id: external_claims["sub"].as_str().map(str::to_owned),
-        atproto_did: None,
-        ..Default::default()
-    };
-    if let Err(e) = store.set_profile(subject, profile.into()).await {
-        tracing::warn!(subject = %subject, error = %e, "Failed to set profile for federated user");
-    }
-
-    // Write Casbin rules for default_scopes.
-    // Scope format: "action:resource_type:resource_id" — e.g. "infer:model:*", "read:*:*"
-    let Some(pm) = crate::auth::global_policy_manager() else {
-        tracing::warn!(provider = %provider_slug, "PolicyManager not available — default_scopes not applied");
-        return;
-    };
-
-    // Self-ownership rules: always grant access to the user's own namespace
-    // (user:{sub}:*) so JIT users can at minimum read/write their own profile
-    // and settings — regardless of what default_scopes the provider supplies.
-    // Addresses the zero-capabilities-on-first-login gap (#182).
-    let self_ns = format!("user:{subject}:*");
-    if let Err(e) = pm.add_policy_with_domain(subject, "*", &self_ns, "*", "allow").await {
-        tracing::warn!(subject = %subject, error = %e, "Failed to write self-ownership Casbin rule");
-    }
-
-    // If no scopes are configured by the provider, fall back to viewer-level
-    // defaults so the user can at minimum query models and registry entries.
-    // Operators can tighten or widen via policy templates after provisioning.
-    let effective_scopes: Vec<String> = if default_scopes.is_empty() {
-        vec!["query:model:*".to_owned(), "query:registry:*".to_owned()]
-    } else {
-        default_scopes.to_vec()
-    };
-
-    for scope in &effective_scopes {
-        let parts: Vec<&str> = scope.splitn(3, ':').collect();
-        let (action, resource) = match parts.as_slice() {
-            [action, rtype, rid] if *rtype == "*" && *rid == "*" => (*action, "*".to_owned()),
-            [action, rtype, rid] => (*action, format!("{rtype}:{rid}")),
-            [action] => (*action, "*".to_owned()),
-            _ => continue,
+    // Populate profile fields from external claims only for newly provisioned
+    // accounts. Existing accounts retain their configured profile.
+    if resolution.provisioned {
+        let profile = UserProfilePatch {
+            name: external_claims["name"].as_str().map(str::to_owned).map(Some),
+            email: external_claims["email"].as_str().map(str::to_owned).map(Some),
+            email_verified: external_claims["email_verified"].as_bool().map(Some),
+            active: Some(Some(true)),
+            external_id: external_claims["sub"].as_str().map(str::to_owned).map(Some),
+            ..Default::default()
         };
-        if let Err(e) = pm.add_policy_with_domain(subject, "*", &resource, action, "allow").await {
-            tracing::error!(subject = %subject, scope = %scope, error = %e, "Failed to write Casbin rule");
+        if let Err(e) = store.set_profile(&resolution.username, profile).await {
+            tracing::error!(
+                username = %resolution.username,
+                error = %e,
+                "Failed to set profile for newly provisioned federated user — rejecting login"
+            );
+            return Err((
+                axum::http::StatusCode::INTERNAL_SERVER_ERROR,
+                "Failed to provision federated user profile",
+            )
+                .into_response());
         }
     }
-    if let Err(e) = pm.save().await {
-        tracing::error!(subject = %subject, error = %e, "Failed to persist Casbin rules after provisioning");
+
+    // Write Casbin rules for default_scopes (best-effort — separate subsystem).
+    // Scope format: "action:resource_type:resource_id" — e.g. "infer:model:*", "read:*:*"
+    let subject = &resolution.username;
+    if let Some(pm) = crate::auth::global_policy_manager() {
+        // Self-ownership rules: always grant access to the user's own namespace
+        // (user:{sub}:*) so JIT users can at minimum read/write their own profile
+        // and settings — regardless of what default_scopes the provider supplies.
+        // Addresses the zero-capabilities-on-first-login gap (#182).
+        let self_ns = format!("user:{subject}:*");
+        if let Err(e) = pm.add_policy_with_domain(subject, "*", &self_ns, "*", "allow").await {
+            tracing::warn!(subject = %subject, error = %e, "Failed to write self-ownership Casbin rule");
+        }
+
+        // If no scopes are configured by the provider, fall back to viewer-level
+        // defaults so the user can at minimum query models and registry entries.
+        let effective_scopes: Vec<String> = if default_scopes.is_empty() {
+            vec!["query:model:*".to_owned(), "query:registry:*".to_owned()]
+        } else {
+            default_scopes.to_vec()
+        };
+
+        for scope in &effective_scopes {
+            let parts: Vec<&str> = scope.splitn(3, ':').collect();
+            let (action, resource) = match parts.as_slice() {
+                [action, rtype, rid] if *rtype == "*" && *rid == "*" => (*action, "*".to_owned()),
+                [action, rtype, rid] => (*action, format!("{rtype}:{rid}")),
+                [action] => (*action, "*".to_owned()),
+                _ => continue,
+            };
+            if let Err(e) = pm.add_policy_with_domain(subject, "*", &resource, action, "allow").await {
+                tracing::error!(subject = %subject, scope = %scope, error = %e, "Failed to write Casbin rule");
+            }
+        }
+        if let Err(e) = pm.save().await {
+            tracing::error!(subject = %subject, error = %e, "Failed to persist Casbin rules after provisioning");
+        }
+
+        tracing::info!(
+            subject = %subject,
+            provisioned = resolution.provisioned,
+            scopes = ?effective_scopes,
+            "Federated user provisioned"
+        );
+    } else {
+        tracing::warn!("PolicyManager not available — default_scopes not applied for {subject}");
     }
 
-    tracing::info!(
-        provider = %provider_slug,
-        subject = %subject,
-        scopes = ?effective_scopes,
-        "Federated user provisioned"
-    );
+    Ok(resolution.username)
 }

--- a/crates/hyprstream/src/services/oauth/scim.rs
+++ b/crates/hyprstream/src/services/oauth/scim.rs
@@ -215,16 +215,19 @@ fn base_url() -> String {
 }
 
 /// Find a user by id (sub) or userName.
-async fn find_user(svc: &user_service::UserService, id: &str) -> Option<user_service::UserInfo> {
-    if let Ok(Some(i)) = svc.get(id).await {
-        return Some(i);
+async fn find_user(
+    svc: &user_service::UserService,
+    id: &str,
+) -> anyhow::Result<Option<user_service::UserInfo>> {
+    if let Some(i) = svc.get(id).await? {
+        return Ok(Some(i));
     }
     // Try by sub/id
     let filter = UserFilter {
         filter: Some(format!("id eq \"{}\"", id)),
         ..Default::default()
     };
-    svc.list(&filter).await.ok().and_then(|l| l.users.into_iter().next())
+    Ok(svc.list(&filter).await?.users.into_iter().next())
 }
 
 /// Build a SCIM JSON response with standard headers.
@@ -317,8 +320,16 @@ pub async fn create_user(
     };
 
     // Check for duplicate userName
-    if let Ok(Some(_)) = svc.get(&user_name).await {
-        return scim_error(409, "uniqueness", &format!("User '{}' already exists", user_name));
+    match svc.get(&user_name).await {
+        Ok(Some(_)) => {
+            return scim_error(
+                409,
+                "uniqueness",
+                &format!("User '{}' already exists", user_name),
+            );
+        }
+        Ok(None) => {}
+        Err(error) => return scim_error_simple(500, &error.to_string()),
     }
 
     let pubkey_base64 = body
@@ -367,7 +378,8 @@ pub async fn create_user(
 
     let info = match svc.get(&user_name).await {
         Ok(Some(i)) => i,
-        _ => return scim_error_simple(500, "User not found after creation"),
+        Ok(None) => return scim_error_simple(500, "User not found after creation"),
+        Err(error) => return scim_error_simple(500, &error.to_string()),
     };
 
     let base_url = {
@@ -402,10 +414,10 @@ pub async fn get_user(
         Err(e) => return *e,
     };
 
-    let info = find_user(svc, &id).await;
-    let info = match info {
-        Some(i) => i,
-        None => return scim_error_simple(404, "Resource not found"),
+    let info = match find_user(svc, &id).await {
+        Ok(Some(i)) => i,
+        Ok(None) => return scim_error_simple(404, "Resource not found"),
+        Err(error) => return scim_error_simple(500, &error.to_string()),
     };
 
     let base_url = base_url();
@@ -428,8 +440,9 @@ pub async fn replace_user(
     };
 
     let info = match find_user(svc, &id).await {
-        Some(i) => i,
-        None => return scim_error_simple(404, "Resource not found"),
+        Ok(Some(i)) => i,
+        Ok(None) => return scim_error_simple(404, "Resource not found"),
+        Err(error) => return scim_error_simple(500, &error.to_string()),
     };
 
     let current_etag = compute_etag(&info.sub, info.active);
@@ -460,24 +473,31 @@ pub async fn replace_user(
         atproto_did: hosted_account_did.map(Some),
     };
 
-    match svc.update(&info.username, update).await {
-        Ok(updated) => {
-            if let Some(want_active) = active {
-                if want_active && !info.active {
-                    let _ = svc.resume(&info.username).await;
-                } else if !want_active && info.active {
-                    let _ = svc.suspend(&info.username).await;
-                }
-            }
-
-            let info = svc.get(&info.username).await.ok().flatten().unwrap_or(updated);
-            let url = base_url();
-            let scim = user_to_scim(&info, &url, true);
-            let etag = scim.meta.version.clone().unwrap_or_default();
-            scim_response(StatusCode::OK, &scim, &etag)
-        }
-        Err(e) => scim_error_simple(500, &e.to_string()),
+    if let Err(error) = svc.update(&info.username, update).await {
+        return scim_error_simple(500, &error.to_string());
     }
+    if let Some(want_active) = active {
+        let active_result = if want_active && !info.active {
+            svc.resume(&info.username).await
+        } else if !want_active && info.active {
+            svc.suspend(&info.username).await
+        } else {
+            Ok(())
+        };
+        if let Err(error) = active_result {
+            return scim_error_simple(500, &error.to_string());
+        }
+    }
+
+    let updated = match svc.get(&info.username).await {
+        Ok(Some(updated)) => updated,
+        Ok(None) => return scim_error_simple(500, "User not found after replacement"),
+        Err(error) => return scim_error_simple(500, &error.to_string()),
+    };
+    let url = base_url();
+    let scim = user_to_scim(&updated, &url, true);
+    let etag = scim.meta.version.clone().unwrap_or_default();
+    scim_response(StatusCode::OK, &scim, &etag)
 }
 
 /// DELETE /scim/v2/Users/:id — Delete user (soft delete: set active=false) (RFC 7644 §3.6).
@@ -492,8 +512,9 @@ pub async fn delete_user(
     };
 
     let info = match find_user(svc, &id).await {
-        Some(i) => i,
-        None => return scim_error_simple(404, "Resource not found"),
+        Ok(Some(i)) => i,
+        Ok(None) => return scim_error_simple(404, "Resource not found"),
+        Err(error) => return scim_error_simple(500, &error.to_string()),
     };
 
     let current_etag = compute_etag(&info.sub, info.active);
@@ -522,8 +543,9 @@ pub async fn list_user_keys(
     };
 
     let info = match find_user(svc, &id).await {
-        Some(i) => i,
-        None => return scim_error_simple(404, "Resource not found"),
+        Ok(Some(i)) => i,
+        Ok(None) => return scim_error_simple(404, "Resource not found"),
+        Err(error) => return scim_error_simple(500, &error.to_string()),
     };
 
     let resources: Vec<serde_json::Value> = info.pubkeys.iter().map(|pk| {
@@ -561,8 +583,9 @@ pub async fn add_user_key(
     };
 
     let info = match find_user(svc, &id).await {
-        Some(i) => i,
-        None => return scim_error_simple(404, "Resource not found"),
+        Ok(Some(i)) => i,
+        Ok(None) => return scim_error_simple(404, "Resource not found"),
+        Err(error) => return scim_error_simple(500, &error.to_string()),
     };
 
     let pubkey_b64 = match body.get("pubkeyBase64").and_then(|v| v.as_str()) {
@@ -603,8 +626,9 @@ pub async fn remove_user_key(
     };
 
     let info = match find_user(svc, &id).await {
-        Some(i) => i,
-        None => return scim_error_simple(404, "Resource not found"),
+        Ok(Some(i)) => i,
+        Ok(None) => return scim_error_simple(404, "Resource not found"),
+        Err(error) => return scim_error_simple(500, &error.to_string()),
     };
 
     // Normalize: ensure SHA256: prefix is present regardless of whether client included it

--- a/crates/hyprstream/src/services/oauth/token.rs
+++ b/crates/hyprstream/src/services/oauth/token.rs
@@ -1270,6 +1270,52 @@ async fn issue_token_with_refresh(
         sub.to_owned()
     };
     let token_issuer = state.issuer_for_scopes(&scopes);
+    let issue_oidc_id_token =
+        scopes.iter().any(|scope| scope == "openid") && initial_auth && state.signing_key.is_some();
+    // Resolve the durable OIDC subject before issuing or persisting any token.
+    // A database outage must not change `sub` from the stable UUID to the local
+    // username, and a successful access token must not escape after a failed
+    // profile read.
+    let oidc_profile = if issue_oidc_id_token {
+        let Some(user_store) = state.user_store_reader() else {
+            tracing::error!(local_subject = %sub, "rejecting OIDC token issuance: relational user store is not configured");
+            return token_error(
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "server_error",
+                Some("credential store is unavailable"),
+            );
+        };
+        let profile = match user_store.get_profile(sub).await {
+            Ok(Some(profile)) => profile,
+            Ok(None) => {
+                tracing::error!(local_subject = %sub, "rejecting OIDC token issuance: credential profile is missing");
+                return token_error(
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    "server_error",
+                    Some("credential profile is missing"),
+                );
+            }
+            Err(error) => {
+                tracing::error!(local_subject = %sub, %error, "rejecting OIDC token issuance: credential lookup failed");
+                return token_error(
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    "server_error",
+                    Some("credential store is unavailable"),
+                );
+            }
+        };
+        if profile.sub.as_deref().is_none_or(str::is_empty) {
+            tracing::error!(local_subject = %sub, "rejecting OIDC token issuance: stable subject is missing");
+            return token_error(
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "server_error",
+                Some("credential profile has no stable subject"),
+            );
+        }
+        Some(profile)
+    } else {
+        None
+    };
 
     let result = state
         .policy_client
@@ -1350,8 +1396,7 @@ async fn issue_token_with_refresh(
 
             // Build OIDC id_token when: scope includes "openid", signing key is available,
             // and this is an initial authorization (not refresh/device per OIDC Core § 12.2).
-            let has_openid = scopes.iter().any(|s| s == "openid");
-            let id_token = if has_openid && initial_auth && state.signing_key.is_some() {
+            let id_token = if issue_oidc_id_token {
                 let id_exp = now + 300; // 5-minute id_token lifetime
                 let mut id_claims = hyprstream_rpc::auth::IdTokenClaims::new(
                     token_issuer,
@@ -1365,22 +1410,21 @@ async fn issue_token_with_refresh(
                 .with_tenant(hosted_account_tenant.clone());
 
                 // Add profile claims based on requested scopes.
-                if let Some(user_store) = state.user_store_reader() {
-                    if let Ok(Some(profile)) = user_store.get_profile(sub).await {
-                        if scopes.iter().any(|s| s == "profile") {
-                            id_claims.preferred_username = Some(sub.to_owned());
-                            id_claims.name = profile.name;
-                        }
-                        if scopes.iter().any(|s| s == "email") {
-                            id_claims.email = profile.email;
-                            id_claims.email_verified = profile.email_verified;
-                        }
-                        // Use stable UUID sub if available.
-                        if let Some(uuid_sub) = profile.sub {
-                            id_claims.sub = uuid_sub;
-                        }
-                    }
+                let Some(profile) = oidc_profile else {
+                    unreachable!("OIDC profile was loaded before token issuance")
+                };
+                if scopes.iter().any(|s| s == "profile") {
+                    id_claims.preferred_username = Some(sub.to_owned());
+                    id_claims.name = profile.name;
                 }
+                if scopes.iter().any(|s| s == "email") {
+                    id_claims.email = profile.email;
+                    id_claims.email_verified = profile.email_verified;
+                }
+                let Some(stable_sub) = profile.sub else {
+                    unreachable!("stable OIDC subject was validated before token issuance")
+                };
+                id_claims.sub = stable_sub;
 
                 // SAFETY: signing_key.is_some() checked in the outer condition.
                 let Some(ref sk) = state.signing_key else {

--- a/crates/hyprstream/src/services/oauth/user_service.rs
+++ b/crates/hyprstream/src/services/oauth/user_service.rs
@@ -98,9 +98,13 @@ impl UserService {
     /// Get a user by username.
     pub async fn get(&self, username: &str) -> Result<Option<UserInfo>> {
         let profile = self.store.get_profile(username).await?;
+
         match profile {
             Some(profile) => {
                 let pubkeys = self.store.list_pubkeys(username).await?;
+                let sub = profile
+                    .sub
+                    .ok_or_else(|| anyhow!("User '{username}' has no stable subject"))?;
                 // For backward compat, use first pubkey as the primary
                 let primary_pubkey = pubkeys.first()
                     .map(|pk| STANDARD.encode(pk.pubkey.as_bytes()))
@@ -108,7 +112,7 @@ impl UserService {
 
                 Ok(Some(UserInfo {
                     username: username.to_owned(),
-                    sub: profile.sub.unwrap_or_default(),
+                    sub,
                     pubkey_base64: primary_pubkey,
                     name: profile.name,
                     email: profile.email,
@@ -139,10 +143,13 @@ impl UserService {
 
         let users = results
             .into_iter()
-            .map(|(username, profile)| {
-                UserInfo {
+            .map(|(username, profile)| -> Result<UserInfo> {
+                let sub = profile
+                    .sub
+                    .ok_or_else(|| anyhow!("User '{username}' has no stable subject"))?;
+                Ok(UserInfo {
                     username,
-                    sub: profile.sub.unwrap_or_default(),
+                    sub,
                     pubkey_base64: String::new(), // Omitted in list for size; use get() for full info
                     name: profile.name,
                     email: profile.email,
@@ -151,9 +158,9 @@ impl UserService {
                     external_id: profile.external_id,
                     atproto_did: profile.atproto_did,
                     pubkeys: vec![], // Omitted in list
-                }
+                })
             })
-            .collect();
+            .collect::<Result<Vec<_>>>()?;
 
         Ok(UserList {
             users,

--- a/crates/hyprstream/src/services/oauth/userinfo.rs
+++ b/crates/hyprstream/src/services/oauth/userinfo.rs
@@ -22,26 +22,54 @@ pub async fn userinfo(
     State(state): State<Arc<OAuthState>>,
     Extension(caller): Extension<AuthenticatedUser>,
 ) -> Response {
-    let mut response = serde_json::json!({
-        "sub": caller.user,
-    });
-
-    if let Some(user_store) = state.user_store_reader() {
-        if let Ok(Some(profile)) = user_store.get_profile(&caller.user).await {
-            if let Some(ref uuid_sub) = profile.sub {
-                response["sub"] = serde_json::Value::String(uuid_sub.clone());
-            }
-            response["preferred_username"] = serde_json::Value::String(caller.user.clone());
-            if let Some(ref name) = profile.name {
-                response["name"] = serde_json::Value::String(name.clone());
-            }
-            if let Some(ref email) = profile.email {
-                response["email"] = serde_json::Value::String(email.clone());
-            }
-            if let Some(verified) = profile.email_verified {
-                response["email_verified"] = serde_json::Value::Bool(verified);
-            }
+    let Some(user_store) = state.user_store_reader() else {
+        tracing::error!("UserInfo unavailable: relational user store is not configured");
+        return (
+            StatusCode::SERVICE_UNAVAILABLE,
+            Json(serde_json::json!({"error": "temporarily_unavailable"})),
+        )
+            .into_response();
+    };
+    let profile = match user_store.get_profile(&caller.user).await {
+        Ok(Some(profile)) => profile,
+        Ok(None) => {
+            tracing::error!(username = %caller.user, "UserInfo subject has no credential profile");
+            return (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(serde_json::json!({"error": "server_error"})),
+            )
+                .into_response();
         }
+        Err(error) => {
+            tracing::error!(username = %caller.user, %error, "UserInfo credential lookup failed");
+            return (
+                StatusCode::SERVICE_UNAVAILABLE,
+                Json(serde_json::json!({"error": "temporarily_unavailable"})),
+            )
+                .into_response();
+        }
+    };
+    let Some(stable_sub) = profile.sub else {
+        tracing::error!(username = %caller.user, "UserInfo profile has no stable subject");
+        return (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(serde_json::json!({"error": "server_error"})),
+        )
+            .into_response();
+    };
+
+    let mut response = serde_json::json!({
+        "sub": stable_sub,
+        "preferred_username": caller.user,
+    });
+    if let Some(name) = profile.name {
+        response["name"] = serde_json::Value::String(name);
+    }
+    if let Some(email) = profile.email {
+        response["email"] = serde_json::Value::String(email);
+    }
+    if let Some(verified) = profile.email_verified {
+        response["email_verified"] = serde_json::Value::Bool(verified);
     }
 
     (StatusCode::OK, Json(response)).into_response()


### PR DESCRIPTION
## #1378 — Wire cold-signup + OAuth onto PGlite UserStore

Stacks on #1376 (`feat/1376-pglite-userstore`).

### What changed

**Central factory** (`services/oauth/mod.rs`):
- Pglite arm constructs `PgliteUserStore` via `from_database(shared Arc<PGlite>)`
- DeviceStore separated from UserStore (always RocksDB for device; pglite for accounts)
- Store-open errors are **FATAL** — never falls back to RocksDB/Valkey
- Token store falls through to RocksDB when `backend=Pglite`

**Config** (`config/mod.rs`): Added `Pglite` variant to `CredentialsBackend`.

**PGlite backend** (`auth/pglite_store.rs`):
- Fixed SQL to use actual schema columns (was referencing nonexistent `profile` column)
- Implemented `resolve_or_bind_external_idp` for atomic `(issuer, subject)` binding
- Overrode `list_external_identities`/`get_external_identity_user` to query `oidc_bindings` directly

**OIDC callback** (`oidc_callback.rs`):
- Replaced non-atomic `register→set_profile` with `resolve_or_bind_external_idp`
- **Fail-closed**: auth code NOT issued when credential-store write fails
- Deny mode resolves normalized `(issuer, subject)` binding before legacy username fallback
- Never continues with pre-binding candidate when store resolves different username

**Fail-closed call sites**:
- `introspection.rs`: account binding lookup errors → inactive response
- `scim.rs`: all `find_user`/handler calls propagate errors (no `.ok()`)
- `token.rs`: OIDC id_token pre-resolves profile before persisting
- `user_service.rs`: `list_pubkeys` errors propagate; `sub` never defaulted
- `userinfo.rs`: 503 when store unconfigured; 500/503 on DB errors

### What's still #1376's
Pubkey operations, hosted-account `provision_hosted_account`/`activate_hosted_account`, and cloud Postgres adapter remain stubbed in the PGlite backend.

### Verification
- `cargo check -p hyprstream --features pglite` ✓
- `cargo check -p hyprstream` (default) ✓
- `cargo clippy -p hyprstream --features pglite --lib -- -D warnings` ✓
- `cargo clippy -p hyprstream --lib -- -D warnings` (default) ✓
- Pre-commit workspace release clippy ✓