### PR TITLE
fix(build): require encrypted credential profile in deploy artifacts

### DIFF
--- a/.github/scripts/credential-pds-build-gate.sh
+++ b/.github/scripts/credential-pds-build-gate.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+# Prove that the former production release command fails closed when the
+# credential-pds feature is absent. At PR #1414's reviewed head (670715389),
+# this command exited zero after silently skipping the hyprstream binary.
+set -euo pipefail
+
+script_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+repo_root="${HYPRSTREAM_REPO_ROOT:-$(cd -- "${script_dir}/../.." && pwd)}"
+buildq="${HYPRSTREAM_BUILDQ:-}"
+buildq_slots="${HYPRSTREAM_BUILDQ_SLOTS:-2}"
+
+if [[ ! -f "${repo_root}/Cargo.toml" ]]; then
+  echo "credential-pds gate: repository root has no Cargo.toml: ${repo_root}" >&2
+  exit 2
+fi
+
+run_cargo() {
+  if [[ -n "${buildq}" ]]; then
+    "${buildq}" --slots "${buildq_slots}" -- cargo "$@"
+  else
+    cargo "$@"
+  fi
+}
+
+gate_log="$(mktemp "${TMPDIR:-/tmp}/credential-pds-build-gate.XXXXXX.log")"
+trap 'rm -f "${gate_log}"' EXIT
+
+set +e
+(
+  cd -- "${repo_root}"
+  run_cargo build --locked --release --no-default-features \
+    --features otel,gittorrent,xet
+) 2>&1 | tee "${gate_log}"
+build_status=${PIPESTATUS[0]}
+set -e
+
+if [[ "${build_status}" -eq 0 ]]; then
+  echo "credential-pds gate: feature-less release build unexpectedly succeeded" >&2
+  exit 1
+fi
+
+if ! grep -Fq 'every Hyprstream build requires the `credential-pds` feature' "${gate_log}"; then
+  echo "credential-pds gate: build failed without the provenance diagnostic" >&2
+  exit 1
+fi
+
+echo "credential-pds gate: expected feature-less build failure (status ${build_status})"

--- a/.github/scripts/graviton-build-test.sh
+++ b/.github/scripts/graviton-build-test.sh
@@ -47,6 +47,11 @@ run_phase() {
 # browser-facing rpc + vfs + rpc-std package set used by www.
 run_phase "browser WASM check" bash .github/scripts/browser-wasm-check.sh
 
+# Prove the production credential profile is causal: omitting it must fail the
+# build, never silently skip the deployable target.
+run_phase "credential-pds negative build gate" \
+  bash .github/scripts/credential-pds-build-gate.sh
+
 # Default features (parity with the former x86 gate); libtorch is the image's
 # aarch64 wheel at /opt/libtorch, so NO download-libtorch feature here.
 run_phase "native release build" cargo build --release

--- a/.github/workflows/graviton-build-validate.yml
+++ b/.github/workflows/graviton-build-validate.yml
@@ -92,7 +92,8 @@ jobs:
             -e LIBTORCH_BYPASS_VERSION_CHECK=1 \
             -e CARGO_TERM_COLOR=always \
             hyprstream-builder-arm64:ci \
-            cargo build --release --no-default-features --features otel,gittorrent,xet
+            cargo build -p hyprstream --bin hyprstream --locked --release \
+              --no-default-features --features otel,gittorrent,xet,credential-pds
 
   cuda130-arm64-spike:
     # The Dockerfile target and normal dispatch-only workflow live on this

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,15 +27,15 @@ HyprStream is the runtime for AI that gets smarter the more you use it: a Plan 9
 ```bash
 export LIBTORCH=/path/to/libtorch
 export LD_LIBRARY_PATH=$LIBTORCH/lib:$LD_LIBRARY_PATH
-cargo build --release                    # Standard (includes xet, gittorrent, systemd, otel, kata-vm)
+cargo build --release                    # Standard (includes encrypted credential/PDS, xet, gittorrent, systemd, otel, kata-vm)
 cargo build --features cuda --release    # CUDA marker (backend from tch-rs/libtorch)
 cargo build --features bnb --release     # bitsandbytes quantization
 cargo build --features overlayfs --release
-cargo build --no-default-features --features "gittorrent,xet,otel" --release  # No systemd/kata
+cargo build --no-default-features --features "gittorrent,xet,otel,credential-pds" --release  # No systemd/kata; encrypted credentials remain mandatory
 cargo test --workspace --release
 ```
 
-**Feature flags**: `default = [gittorrent, xet, systemd, otel, kata-vm]`, `cuda` (empty marker), `bnb`, `valkey` (Valkey/Redis user+token stores), `overlayfs`, `oci-image` (RAFS ImageFs), `kata-vm` (implies `oci-image`), `download-libtorch`, `experimental`, `pq-hybrid` (NO-OP alias — PQ primitives always compiled, Classical/Hybrid selected at runtime)
+**Feature flags**: `default = [gittorrent, xet, systemd, otel, kata-vm, nspawn, credential-pds]`, `credential-pds` (mandatory encrypted production UserStore profile; implies `pglite`), `cuda` (empty marker), `bnb`, `valkey` (Valkey/Redis user+token stores), `overlayfs`, `oci-image` (RAFS ImageFs), `kata-vm` (implies `oci-image`), `download-libtorch`, `experimental`, `pq-hybrid` (NO-OP alias — PQ primitives always compiled, Classical/Hybrid selected at runtime)
 **Backend**: CPU/CUDA/ROCm controlled by tch-rs dependency (fork: github.com/hyprstream/tch-rs branch: hip), NOT cargo features
 
 ## Working Tree & Worktrees (multi-agent safety)

--- a/Dockerfile
+++ b/Dockerfile
@@ -272,7 +272,8 @@ ENV LD_LIBRARY_PATH=/opt/libtorch/lib
 # Build the project with BuildKit cache mounts for Cargo registry and sccache
 # LIBTORCH is already set in the variant-specific builder stages
 # We do NOT use LIBTORCH_USE_PYTORCH since we're using manual downloads
-# Note: --no-default-features excludes systemd (not needed in containers)
+# Note: --no-default-features excludes systemd (not needed in containers).
+# credential-pds is mandatory for the production encrypted UserStore boundary.
 # Cache mounts:
 #   - /root/.cargo/registry: Cargo crate registry
 #   - /root/.cargo/git: Git dependencies
@@ -281,7 +282,7 @@ RUN --mount=type=cache,target=/root/.cargo/registry \
     --mount=type=cache,target=/root/.cargo/git \
     --mount=type=cache,target=/sccache \
     --mount=type=cache,target=/build/target,sharing=locked \
-    OPENSSL_NO_VENDOR=1 cargo build --locked --release --no-default-features --features otel,gittorrent,xet \
+    OPENSSL_NO_VENDOR=1 cargo build --locked --release --no-default-features --features otel,gittorrent,xet,credential-pds \
     && mkdir -p /out \
     && cp /build/target/release/hyprstream /out/hyprstream
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -282,7 +282,7 @@ RUN --mount=type=cache,target=/root/.cargo/registry \
     --mount=type=cache,target=/root/.cargo/git \
     --mount=type=cache,target=/sccache \
     --mount=type=cache,target=/build/target,sharing=locked \
-    OPENSSL_NO_VENDOR=1 cargo build --locked --release --no-default-features --features otel,gittorrent,xet,credential-pds \
+    OPENSSL_NO_VENDOR=1 cargo build -p hyprstream --bin hyprstream --locked --release --no-default-features --features otel,gittorrent,xet,credential-pds \
     && mkdir -p /out \
     && cp /build/target/release/hyprstream /out/hyprstream
 

--- a/crates/hyprstream/Cargo.toml
+++ b/crates/hyprstream/Cargo.toml
@@ -20,7 +20,6 @@ doctest = true
 [[bin]]
 name = "hyprstream"
 path = "src/bin/main.rs"
-required-features = ["credential-pds"]
 
 
 [dependencies]
@@ -223,8 +222,8 @@ opentelemetry-stdout = { workspace = true, optional = true }
 [features]
 # The credential/PDS service is the default production shape. Keep DuckDB-backed
 # metrics opt-in: DuckDB and PGlite export overlapping PostgreSQL C symbols and
-# cannot be linked into the same process. The `hyprstream` binary target's
-# `required-features` prevents producing a deployable binary without this profile.
+# cannot be linked into the same process. The crate-level build assertion prevents
+# any Hyprstream build from silently omitting this profile.
 default = ["gittorrent", "xet", "systemd", "otel", "kata-vm", "nspawn", "credential-pds"]
 cuda = []
 valkey = ["dep:fred"]  # Enable Valkey/Redis-backed user and token stores

--- a/crates/hyprstream/Cargo.toml
+++ b/crates/hyprstream/Cargo.toml
@@ -20,6 +20,7 @@ doctest = true
 [[bin]]
 name = "hyprstream"
 path = "src/bin/main.rs"
+required-features = ["credential-pds"]
 
 
 [dependencies]
@@ -222,8 +223,9 @@ opentelemetry-stdout = { workspace = true, optional = true }
 [features]
 # The credential/PDS service is the default production shape. Keep DuckDB-backed
 # metrics opt-in: DuckDB and PGlite export overlapping PostgreSQL C symbols and
-# cannot be linked into the same process.
-default = ["gittorrent", "xet", "systemd", "otel", "kata-vm", "nspawn"]
+# cannot be linked into the same process. The `hyprstream` binary target's
+# `required-features` prevents producing a deployable binary without this profile.
+default = ["gittorrent", "xet", "systemd", "otel", "kata-vm", "nspawn", "credential-pds"]
 cuda = []
 valkey = ["dep:fred"]  # Enable Valkey/Redis-backed user and token stores
 pglite = ["dep:pglite-rs"]  # Enable PGlite embedded relational UserStore (#1376)

--- a/crates/hyprstream/src/auth/production_user_store.rs
+++ b/crates/hyprstream/src/auth/production_user_store.rs
@@ -244,7 +244,9 @@ mod tests {
             assert!(
                 error
                     .to_string()
-                    .contains("credential-pds requires credentials.backend = \"pglite\""),
+                    .contains(
+                        "encrypted credential storage requires credentials.backend = \"pglite\"",
+                    ),
                 "unexpected admission error: {error:#}"
             );
         }

--- a/crates/hyprstream/src/config/mod.rs
+++ b/crates/hyprstream/src/config/mod.rs
@@ -1476,24 +1476,16 @@ pub enum CredentialsBackend {
 }
 
 fn default_credentials_backend() -> CredentialsBackend {
-    #[cfg(feature = "credential-pds")]
-    {
-        CredentialsBackend::Pglite
-    }
-    #[cfg(not(feature = "credential-pds"))]
-    {
-        CredentialsBackend::Rocksdb
-    }
+    CredentialsBackend::Pglite
 }
 
 impl CredentialsBackend {
-    /// The credential/PDS production profile must never select a backend that
-    /// can persist the protected UserStore columns as plaintext.
+    /// Production must never select a backend that can persist protected
+    /// UserStore columns as plaintext.
     pub fn ensure_allowed_for_build(self) -> anyhow::Result<()> {
-        #[cfg(feature = "credential-pds")]
         anyhow::ensure!(
             self == Self::Pglite,
-            "credential-pds requires credentials.backend = \"pglite\""
+            "encrypted credential storage requires credentials.backend = \"pglite\""
         );
         Ok(())
     }
@@ -3073,20 +3065,14 @@ mod tests {
     fn credentials_backend_default_matches_build_profile() {
         let config: CredentialsConfig =
             toml::from_str("").unwrap_or_else(|error| panic!("{error}"));
-        #[cfg(feature = "credential-pds")]
         assert_eq!(config.backend, CredentialsBackend::Pglite);
-        #[cfg(not(feature = "credential-pds"))]
-        assert_eq!(config.backend, CredentialsBackend::Rocksdb);
     }
 
     #[test]
     fn credential_pds_rejects_plaintext_capable_backends() {
-        #[cfg(feature = "credential-pds")]
-        {
-            assert!(CredentialsBackend::Pglite.ensure_allowed_for_build().is_ok());
-            assert!(CredentialsBackend::Rocksdb.ensure_allowed_for_build().is_err());
-            assert!(CredentialsBackend::Valkey.ensure_allowed_for_build().is_err());
-        }
+        assert!(CredentialsBackend::Pglite.ensure_allowed_for_build().is_ok());
+        assert!(CredentialsBackend::Rocksdb.ensure_allowed_for_build().is_err());
+        assert!(CredentialsBackend::Valkey.ensure_allowed_for_build().is_err());
     }
 
     #[test]

--- a/crates/hyprstream/src/lib.rs
+++ b/crates/hyprstream/src/lib.rs
@@ -7,6 +7,12 @@
 //! - Memory-mapped disk persistence
 //! - FlightSQL interface for embeddings and similarity search
 
+#[cfg(not(feature = "credential-pds"))]
+compile_error!(
+    "security invariant: every Hyprstream build requires the `credential-pds` \
+     feature so the production UserStore cannot fall back to plaintext storage"
+);
+
 #[cfg(all(feature = "metrics", feature = "pglite"))]
 compile_error!(
     "features `metrics` and `pglite` are mutually exclusive: DuckDB and PGlite \


### PR DESCRIPTION
Closes #1410.

## Summary

- keeps `credential-pds` in the default production feature set
- explicitly builds `-p hyprstream --bin hyprstream` with `credential-pds` in Docker and the Graviton no-default validation
- replaces the silently-skipped Cargo `required-features` target gate with an always-built crate-level assertion: any Hyprstream build without `credential-pds` exits nonzero
- makes credential backend defaults and admission unconditionally PGlite-only; the feature-less `Ok(())` guard path is gone
- adds a causal negative release-build gate to the required Graviton merge-gate script

## R1 causal proof

The new gate runs the former live command without `credential-pds`:

```text
cargo build --locked --release --no-default-features \
  --features otel,gittorrent,xet
```

At reviewed head `670715389`, Cargo exited 0 after silently skipping the binary, so the new gate test exited 1:

```text
Finished `release` profile [optimized] target(s) in 2m 25s
credential-pds gate: feature-less release build unexpectedly succeeded
CAUSAL BASELINE CONFIRMED: gate test status=1 at 670715389
```

At R1 head `0957dfa67`, the same underlying build exits 101 and the gate passes:

```text
error: security invariant: every Hyprstream build requires the `credential-pds` feature so the production UserStore cannot fall back to plaintext storage
error: could not compile `hyprstream` (lib) due to 1 previous error
credential-pds gate: expected feature-less build failure (status 101)
```

## Positive artifact proof

Executed through `buildq --slots 2`:

```text
cargo build -p hyprstream --bin hyprstream --locked --release \
  --no-default-features --features otel,gittorrent,xet,credential-pds
```

Result:

```text
Finished `release` profile [optimized] target(s) in 4m 24s
production artifact present: /home/birdetta/.cache/buildq/target-1/release/hyprstream
```

Additional validation: 13 credential-filtered tests passed; the focused production plaintext-backend rejection test passed; exact-profile package Clippy and workspace all-target release Clippy passed with `-D warnings`; foreground pre-commit and `git diff --check` passed.

The metrics-only executable remains a separate architecture concern: PGlite and DuckDB are intentionally link-incompatible, and a safe metrics executable requires a true split that exposes no account-store surfaces. This PR does not add an unsafe exception to the credential build invariant.
