### PR TITLE
fix(discovery): lazy local discovery transport for OS-owned first-boot bootstrap

### DIFF
--- a/crates/hyprstream-discovery/src/checkpointed_pds.rs
+++ b/crates/hyprstream-discovery/src/checkpointed_pds.rs
@@ -85,9 +85,24 @@ impl CheckpointedPdsAcceptedStateSource {
     }
 }
 
+/// Filename of the first-boot provisioning marker.
+///
+/// Written by [`initialize_deployment_store`] (and any other path that creates
+/// a fresh empty store) and removed by the registry service on its first
+/// successful accepted-state commit. Its presence alongside an empty store is
+/// the ONLY lifecycle evidence that distinguishes a genuine first boot (store
+/// freshly provisioned, no accepted state written yet) from a steady-state
+/// store that lost its data. The QUIC startup gate reads it via
+/// [`crate::classify_pds_store_for_quic`]-equivalent logic in the app crate.
+pub const FIRST_BOOT_MARKER: &str = "FIRST-BOOT-PENDING";
+
 /// Explicitly create the empty checkpoint store for a newly provisioned
 /// deployment. Resolver startup never calls this: a missing store there is
 /// treated as lost security history and fails closed.
+///
+/// Also writes the [`FIRST_BOOT_MARKER`] so the QUIC startup gate can recognize
+/// this as a genuine first boot (defer-eligible) rather than data loss. The
+/// registry removes the marker once it writes the first accepted state.
 pub(crate) fn initialize_deployment_store() -> Result<()> {
     let path = hyprstream_service::deployment_data_dir()?.join("pds-store");
     anyhow::ensure!(
@@ -100,6 +115,9 @@ pub(crate) fn initialize_deployment_store() -> Result<()> {
     drop(rocksdb::DB::open(&opts, &path).with_context(|| {
         format!("failed to initialize checkpointed PDS store at {path:?}")
     })?);
+    std::fs::write(path.join(FIRST_BOOT_MARKER), b"").with_context(|| {
+        format!("failed to write first-boot marker at {}", path.join(FIRST_BOOT_MARKER).display())
+    })?;
     Ok(())
 }
 

--- a/crates/hyprstream-discovery/src/checkpointed_pds.rs
+++ b/crates/hyprstream-discovery/src/checkpointed_pds.rs
@@ -85,24 +85,27 @@ impl CheckpointedPdsAcceptedStateSource {
     }
 }
 
-/// Filename of the first-boot provisioning marker.
+/// RocksDB key for the first-boot provisioning marker.
 ///
 /// Written by [`initialize_deployment_store`] (and any other path that creates
-/// a fresh empty store) and removed by the registry service on its first
-/// successful accepted-state commit. Its presence alongside an empty store is
-/// the ONLY lifecycle evidence that distinguishes a genuine first boot (store
-/// freshly provisioned, no accepted state written yet) from a steady-state
-/// store that lost its data. The QUIC startup gate reads it via
-/// [`crate::classify_pds_store_for_quic`]-equivalent logic in the app crate.
-pub const FIRST_BOOT_MARKER: &str = "FIRST-BOOT-PENDING";
+/// a fresh empty store) and deleted by the registry service **in the same
+/// synchronous `WriteBatch` as the first accepted-state commit** — so the
+/// lifecycle transition is atomic with provisioning completion, not a
+/// best-effort filesystem side-effect. Its presence alongside an empty store
+/// is the ONLY lifecycle evidence that distinguishes a genuine first boot
+/// (store freshly provisioned, no accepted state written yet) from a
+/// steady-state store that lost its data. The QUIC startup gate reads it via
+/// [`PdsRecordStore::first_boot_pending`] in the app crate.
+pub const FIRST_BOOT_KEY: &[u8] = b"first-boot-pending";
 
 /// Explicitly create the empty checkpoint store for a newly provisioned
 /// deployment. Resolver startup never calls this: a missing store there is
 /// treated as lost security history and fails closed.
 ///
-/// Also writes the [`FIRST_BOOT_MARKER`] so the QUIC startup gate can recognize
+/// Also writes the [`FIRST_BOOT_KEY`] so the QUIC startup gate can recognize
 /// this as a genuine first boot (defer-eligible) rather than data loss. The
-/// registry removes the marker once it writes the first accepted state.
+/// registry deletes the key (in the same RocksDB batch as the first
+/// accepted-state commit) once provisioning completes.
 pub(crate) fn initialize_deployment_store() -> Result<()> {
     let path = hyprstream_service::deployment_data_dir()?.join("pds-store");
     anyhow::ensure!(
@@ -112,12 +115,14 @@ pub(crate) fn initialize_deployment_store() -> Result<()> {
     );
     let mut opts = rocksdb::Options::default();
     opts.create_if_missing(true);
-    drop(rocksdb::DB::open(&opts, &path).with_context(|| {
-        format!("failed to initialize checkpointed PDS store at {path:?}")
-    })?);
-    std::fs::write(path.join(FIRST_BOOT_MARKER), b"").with_context(|| {
-        format!("failed to write first-boot marker at {}", path.join(FIRST_BOOT_MARKER).display())
-    })?;
+    let db = rocksdb::DB::open(&opts, &path)
+        .with_context(|| format!("failed to initialize checkpointed PDS store at {path:?}"))?;
+    // Write the first-boot marker as a durable RocksDB key (not a filesystem
+    // side-effect) so its deletion can be atomic with the first accepted-state
+    // commit. A failed put propagates — provisioning must not appear successful
+    // if the marker wasn't written.
+    db.put(FIRST_BOOT_KEY, b"")
+        .with_context(|| format!("failed to write first-boot marker in store at {path:?}"))?;
     Ok(())
 }
 

--- a/crates/hyprstream-discovery/src/lib.rs
+++ b/crates/hyprstream-discovery/src/lib.rs
@@ -63,12 +63,13 @@ pub fn initialize_deployment_checkpoint_store() -> anyhow::Result<()> {
     checkpointed_pds::initialize_deployment_store()
 }
 
-/// The first-boot provisioning marker filename, written by
-/// [`initialize_deployment_checkpoint_store`] and removed by the registry on
-/// its first accepted-state commit. Re-exported so the app crate's QUIC
-/// startup gate and registry writer can share the exact name.
+/// The first-boot provisioning marker RocksDB key, written by
+/// [`initialize_deployment_checkpoint_store`] and deleted by the registry in
+/// the same `WriteBatch` as its first accepted-state commit. Re-exported so
+/// the app crate's QUIC startup gate and registry writer can share the exact
+/// key.
 #[cfg(not(target_arch = "wasm32"))]
-pub use checkpointed_pds::FIRST_BOOT_MARKER;
+pub use checkpointed_pds::FIRST_BOOT_KEY;
 
 /// #893 (at9p D1) — `did:at9p` capsule resolver: turns a GATE-verified capsule
 /// into a dialable `TransportConfig::iroh` (sibling to

--- a/crates/hyprstream-discovery/src/lib.rs
+++ b/crates/hyprstream-discovery/src/lib.rs
@@ -63,6 +63,13 @@ pub fn initialize_deployment_checkpoint_store() -> anyhow::Result<()> {
     checkpointed_pds::initialize_deployment_store()
 }
 
+/// The first-boot provisioning marker filename, written by
+/// [`initialize_deployment_checkpoint_store`] and removed by the registry on
+/// its first accepted-state commit. Re-exported so the app crate's QUIC
+/// startup gate and registry writer can share the exact name.
+#[cfg(not(target_arch = "wasm32"))]
+pub use checkpointed_pds::FIRST_BOOT_MARKER;
+
 /// #893 (at9p D1) — `did:at9p` capsule resolver: turns a GATE-verified capsule
 /// into a dialable `TransportConfig::iroh` (sibling to
 /// `hyprstream_rpc::service_entry::decode_iroh`). Injectable at the

--- a/crates/hyprstream-discovery/src/service.rs
+++ b/crates/hyprstream-discovery/src/service.rs
@@ -7173,38 +7173,78 @@ mod eager_resolver_regression {
     #![allow(clippy::unwrap_used, clippy::expect_used, clippy::indexing_slicing)]
     use super::*;
 
-    /// The OS-owned-files bootstrap path must resolve a lazy default discovery
-    /// transport even when no discovery endpoint has been registered yet — the
-    /// first-boot posture. On `origin/main` the equivalent code path
-    /// (`DiscoveryClient::for_local_bootstrap` → `registered_endpoint`) returns
-    /// `None` and errors; this test asserts the lazy resolution succeeds.
+    /// Regression for the eager-resolver bootstrap ordering bug.
+    ///
+    /// The OS-owned-files bootstrap path in `bootstrap_deployment_process` must
+    /// resolve the discovery endpoint via the lazy default (`try_endpoint`),
+    /// not the eager `registered_endpoint` that `for_local_bootstrap` used
+    /// (which returns `None` at first boot and errors). This test proves the
+    /// behavioral difference using IPC mode — the same-node production fabric —
+    /// with no discovery endpoint registered.
+    ///
+    /// On `origin/main`, `bootstrap_deployment_process`'s OsOwnedFiles arm
+    /// called `DiscoveryClient::for_local_bootstrap`, which internally calls
+    /// `registered_endpoint("discovery")` → `None` → error. The fix replaced
+    /// that with `resolve_local_discovery_transport()` → `try_endpoint` →
+    /// default UDS path. This test directly exercises that mechanism.
     #[test]
-    fn local_discovery_transport_resolves_without_registered_endpoint() {
-        // Ensure the global EndpointRegistry exists (idempotent — no-op if
-        // another test already initialized it).
-        hyprstream_rpc::registry::init(
-            hyprstream_rpc::registry::EndpointMode::Inproc,
-            None,
-        );
+    fn try_endpoint_resolves_lazy_default_while_registered_endpoint_returns_none() {
+        use hyprstream_rpc::registry::{EndpointMode, SocketKind};
 
-        // First-boot posture: discovery has not registered an endpoint.
-        // (If another test in this binary registered discovery, the lazy
-        // resolution is trivially satisfied — the assertion below still holds.)
+        // Use IPC mode with a temp runtime dir — the production same-node
+        // fabric. Inproc mode makes `dial` error immediately (processor
+        // lookup), so it can't prove the lazy transport is usable.
+        let runtime_dir = std::env::temp_dir().join(format!(
+            "hs-eager-resolver-regression-{}",
+            std::process::id()
+        ));
+        std::fs::create_dir_all(&runtime_dir).unwrap();
+        hyprstream_rpc::registry::init(EndpointMode::Ipc, Some(runtime_dir.clone()));
 
-        // The fix's lazy helper must succeed regardless — it falls back to the
-        // default discovery socket via `try_endpoint`.
-        let transport = resolve_local_discovery_transport()
-            .expect("lazy discovery transport must resolve at first-boot");
+        let registry = hyprstream_rpc::registry::try_global()
+            .expect("EndpointRegistry must be initialized");
+
+        // First-boot posture: discovery has NOT registered an endpoint.
+        // registered_endpoint returns None — this is what for_local_bootstrap
+        // (the origin/main code path) uses, and why it failed.
+        let registered =
+            registry.registered_endpoint("discovery", SocketKind::Rep);
+        // Only assert None if no other test in this binary registered discovery.
+        // The key assertion is that try_endpoint succeeds regardless.
+        if registered.is_none() {
+            // This proves the old code path would have failed here.
+        }
+
+        // try_endpoint falls back to the default discovery socket — the lazy
+        // mechanism the fix relies on. This MUST succeed even with no
+        // registered endpoint.
+        let transport = registry
+            .try_endpoint("discovery", SocketKind::Rep)
+            .expect("try_endpoint must resolve a lazy default for discovery");
+
+        // The default must be a local UDS path (IPC mode), not an error.
         assert!(
             matches!(
                 transport.endpoint,
-                hyprstream_rpc::transport::EndpointType::Inproc { .. }
-                    | hyprstream_rpc::transport::EndpointType::Ipc { .. }
-                    | hyprstream_rpc::transport::EndpointType::SystemdFd { .. }
+                hyprstream_rpc::transport::EndpointType::Ipc { .. }
             ),
-            "expected a local (inproc/IPC/systemd) transport for same-node \
-             bootstrap, got {:?}",
+            "expected IPC default transport for same-node discovery, got {:?}",
             transport.endpoint,
         );
+
+        // The fix's helper uses this same mechanism.
+        let helper_transport = resolve_local_discovery_transport()
+            .expect("resolve_local_discovery_transport must succeed");
+        assert!(
+            matches!(
+                helper_transport.endpoint,
+                hyprstream_rpc::transport::EndpointType::Ipc { .. }
+            ),
+            "expected IPC transport from resolve_local_discovery_transport, got {:?}",
+            helper_transport.endpoint,
+        );
+
+        // Cleanup
+        let _ = std::fs::remove_dir_all(&runtime_dir);
     }
 }

--- a/crates/hyprstream-discovery/src/service.rs
+++ b/crates/hyprstream-discovery/src/service.rs
@@ -2725,6 +2725,27 @@ fn resolve_local_discovery_transport(
         .try_endpoint("discovery", hyprstream_rpc::registry::SocketKind::Rep)
 }
 
+/// Build the lazy local discovery client used by the OS-owned-files bootstrap
+/// arm of [`bootstrap_deployment_process`].
+///
+/// This is the resolver-install half of that arm, extracted so the production
+/// code path — `resolve_local_discovery_transport` → `dial` →
+/// `DiscoveryClient::new` — is the single source of truth AND directly
+/// testable without the deployment-credential chain (which is orthogonal to
+/// the endpoint-resolution regression). `dial` connects on first use, so
+/// Discovery may start *after* this install inside the same process. Trust is
+/// not weakened: the checkpoint was already verified by the caller, and
+/// `discovery_vk` authenticates every lazy response.
+fn install_local_discovery_client(
+    signing_key: SigningKey,
+    discovery_vk: VerifyingKey,
+) -> Result<crate::DiscoveryClient> {
+    let transport = resolve_local_discovery_transport()?;
+    let signer = hyprstream_rpc::signer::LocalSigner::new(signing_key);
+    let rpc = hyprstream_rpc::dial::dial(&transport, signer, Some(discovery_vk), None)?;
+    Ok(crate::DiscoveryClient::new(rpc))
+}
+
 /// Atomically consume the explicitly selected deployment witness and install
 /// the process Discovery resolver. Selection never falls back between the
 /// OS-owned and DID-anchored providers.
@@ -2751,17 +2772,15 @@ pub async fn bootstrap_deployment_process(
     let (authority, discovery_client) = match trust_source {
         crate::DeploymentTrustSource::OsOwnedFiles => {
             let authority = authenticate_deployment_bootstrap()?;
-            // Lazy local discovery client — see `resolve_local_discovery_transport`:
+            // Lazy local discovery client — see `install_local_discovery_client`:
             // the default discovery socket is resolved via `try_endpoint` (not
             // the eager `for_local_bootstrap`), and `dial` connects on first use,
             // so Discovery may start *after* this install inside the same
             // process. Trust is not weakened — the checkpoint was already
             // verified by `authenticate_deployment_bootstrap()`, and
             // `discovery_vk` authenticates every lazy response.
-            let transport = resolve_local_discovery_transport()?;
-            let signer = hyprstream_rpc::signer::LocalSigner::new(signing_key);
-            let rpc = hyprstream_rpc::dial::dial(&transport, signer, Some(discovery_vk), None)?;
-            (authority, crate::DiscoveryClient::new(rpc))
+            let discovery_client = install_local_discovery_client(signing_key, discovery_vk)?;
+            (authority, discovery_client)
         }
         crate::DeploymentTrustSource::DidAnchored(anchors) => {
             let (authority, discovery_transport, mesh_kem_recipient, ml_dsa_65_keys) =
@@ -7164,9 +7183,10 @@ mod query_candidates_tests {
 // `registered_endpoint("discovery")` to be `Some`. At first-boot (before any
 // service binds a socket) this is always `None`, so every `service start`
 // aborted with "local bootstrap requires an explicitly registered service
-// endpoint" — a startup-ordering inversion. The fix replaces that with
-// `resolve_local_discovery_transport()`, which uses `try_endpoint` (lazy
-// default fallback) so Discovery may start after the resolver install.
+// endpoint" — a startup-ordering inversion. The fix extracts the arm's
+// resolver-install sequence into [`install_local_discovery_client`], which
+// uses `resolve_local_discovery_transport` → `try_endpoint` (lazy default
+// fallback) → `dial` (connects on first use) → `DiscoveryClient::new`.
 
 #[cfg(test)]
 mod eager_resolver_regression {
@@ -7175,28 +7195,31 @@ mod eager_resolver_regression {
 
     /// Regression for the eager-resolver bootstrap ordering bug.
     ///
-    /// The OS-owned-files bootstrap path in `bootstrap_deployment_process` must
-    /// resolve the discovery endpoint via the lazy default (`try_endpoint`),
-    /// not the eager `registered_endpoint` that `for_local_bootstrap` used
-    /// (which returns `None` at first boot and errors). This test proves the
-    /// behavioral difference using IPC mode — the same-node production fabric —
-    /// with no discovery endpoint registered.
+    /// This test is causal to the production OS-owned bootstrap path: it calls
+    /// [`install_local_discovery_client`] — the exact function
+    /// [`bootstrap_deployment_process`]'s OsOwnedFiles arm calls after
+    /// authenticating the checkpoint — which performs the full
+    /// `resolve_local_discovery_transport` → `dial` → `DiscoveryClient::new`
+    /// sequence. On `origin/main` the equivalent code
+    /// (`DiscoveryClient::for_local_bootstrap` → `registered_endpoint`) returns
+    /// `None` at first boot and errors; this test proves the lazy path
+    /// installs successfully instead.
     ///
-    /// On `origin/main`, `bootstrap_deployment_process`'s OsOwnedFiles arm
-    /// called `DiscoveryClient::for_local_bootstrap`, which internally calls
-    /// `registered_endpoint("discovery")` → `None` → error. The fix replaced
-    /// that with `resolve_local_discovery_transport()` → `try_endpoint` →
-    /// default UDS path. This test directly exercises that mechanism.
+    /// Reverting the OsOwnedFiles arm to `for_local_bootstrap` makes
+    /// `install_local_discovery_client` error (it resolves via
+    /// `try_endpoint`, which succeeds where `registered_endpoint` fails), so
+    /// this test fails — unlike the prior non-causal test which only inspected
+    /// endpoint synthesis and was insensitive to the arm's actual mechanism.
     #[test]
-    fn try_endpoint_resolves_lazy_default_while_registered_endpoint_returns_none() {
+    fn os_owned_bootstrap_installs_lazy_resolver_with_no_registered_endpoint() {
         use hyprstream_rpc::registry::{EndpointMode, SocketKind};
 
-        // Use IPC mode with a temp runtime dir — the production same-node
-        // fabric. Inproc mode makes `dial` error immediately (processor
-        // lookup), so it can't prove the lazy transport is usable.
+        // IPC mode with a temp runtime dir — the production same-node fabric.
+        // Inproc mode makes `dial` error at the processor-lookup step, so it
+        // cannot prove the lazy transport installs.
         let runtime_dir = std::env::temp_dir().join(format!(
             "hs-eager-resolver-regression-{}",
-            std::process::id()
+            std::process::id(),
         ));
         std::fs::create_dir_all(&runtime_dir).unwrap();
         hyprstream_rpc::registry::init(EndpointMode::Ipc, Some(runtime_dir.clone()));
@@ -7204,45 +7227,49 @@ mod eager_resolver_regression {
         let registry = hyprstream_rpc::registry::try_global()
             .expect("EndpointRegistry must be initialized");
 
-        // First-boot posture: discovery has NOT registered an endpoint.
-        // registered_endpoint returns None — this is what for_local_bootstrap
-        // (the origin/main code path) uses, and why it failed.
-        let registered =
-            registry.registered_endpoint("discovery", SocketKind::Rep);
-        // Only assert None if no other test in this binary registered discovery.
-        // The key assertion is that try_endpoint succeeds regardless.
-        if registered.is_none() {
-            // This proves the old code path would have failed here.
-        }
+        // First-boot posture: discovery has NOT registered an endpoint. This is
+        // the exact condition that made the old eager `for_local_bootstrap`
+        // fail. Assert it positively — the old test had an empty
+        // `if registered.is_none() {}` body that tested nothing.
+        let registered = registry.registered_endpoint("discovery", SocketKind::Rep);
+        assert!(
+            registered.is_none(),
+            "test precondition: discovery must not be registered at first boot, \
+             got {:?}",
+            registered,
+        );
 
-        // try_endpoint falls back to the default discovery socket — the lazy
-        // mechanism the fix relies on. This MUST succeed even with no
-        // registered endpoint.
-        let transport = registry
-            .try_endpoint("discovery", SocketKind::Rep)
-            .expect("try_endpoint must resolve a lazy default for discovery");
+        // The production resolver-install path: dial + DiscoveryClient::new.
+        // This MUST succeed even with no registered endpoint — the lazy
+        // `try_endpoint` resolves a default UDS path, and `dial` connects on
+        // first use (not now). An error here reproduces the original bug.
+        let signing_key = SigningKey::generate(&mut rand::rngs::OsRng);
+        let discovery_vk = signing_key.verifying_key();
+        let client = install_local_discovery_client(signing_key, discovery_vk)
+            .expect(
+                "install_local_discovery_client must succeed at first boot with \
+                 no registered discovery endpoint — the lazy transport resolves \
+                 a default UDS path and dial connects on first use",
+            );
 
-        // The default must be a local UDS path (IPC mode), not an error.
+        // The client is constructed (resolver installed). A later use against
+        // the absent socket fails with a transport connect error — proving the
+        // installed transport points at the default UDS path, not nowhere.
+        // We verify this by confirming the resolved transport is an IPC variant.
+        let transport = resolve_local_discovery_transport()
+            .expect("resolve_local_discovery_transport must resolve the same lazy default");
         assert!(
             matches!(
                 transport.endpoint,
                 hyprstream_rpc::transport::EndpointType::Ipc { .. }
             ),
-            "expected IPC default transport for same-node discovery, got {:?}",
+            "expected IPC transport (default discovery UDS) for same-node \
+             first-boot fabric, got {:?}",
             transport.endpoint,
         );
 
-        // The fix's helper uses this same mechanism.
-        let helper_transport = resolve_local_discovery_transport()
-            .expect("resolve_local_discovery_transport must succeed");
-        assert!(
-            matches!(
-                helper_transport.endpoint,
-                hyprstream_rpc::transport::EndpointType::Ipc { .. }
-            ),
-            "expected IPC transport from resolve_local_discovery_transport, got {:?}",
-            helper_transport.endpoint,
-        );
+        // Touch the client so the compiler knows we proved construction.
+        let _ = &client;
 
         // Cleanup
         let _ = std::fs::remove_dir_all(&runtime_dir);

--- a/crates/hyprstream-discovery/src/service.rs
+++ b/crates/hyprstream-discovery/src/service.rs
@@ -2697,6 +2697,34 @@ enum ProcessBootstrapAuthorityState {
 static PROCESS_BOOTSTRAP_AUTHORITY: parking_lot::Mutex<ProcessBootstrapAuthorityState> =
     parking_lot::Mutex::new(ProcessBootstrapAuthorityState::Unsealed);
 
+/// Resolve the lazy local discovery transport for the OS-owned-files
+/// bootstrap path.
+///
+/// `try_endpoint` falls back to the default discovery socket when nothing is
+/// registered yet, and the transport returned by [`dial`](hyprstream_rpc::dial)
+/// connects on first use — so Discovery may start *after* the process resolver
+/// is installed (first-boot / standalone / `--ipc` containers sharing the IPC
+/// volume). This mirrors the same-node DID-anchored fabric in
+/// [`bootstrap_deployment_process`] and replaces the eager
+/// `DiscoveryClient::for_local_bootstrap`, which required
+/// `registered_endpoint("discovery")` to be `Some` — impossible at first-boot
+/// before any service binds, causing every `service start` to abort with
+/// "local bootstrap requires an explicitly registered service endpoint".
+///
+/// Trust is not weakened: the checkpoint was already verified by
+/// `authenticate_deployment_bootstrap`, and the caller still authenticates
+/// every lazy response with the pinned `discovery_vk`.
+fn resolve_local_discovery_transport(
+) -> anyhow::Result<hyprstream_rpc::transport::TransportConfig> {
+    hyprstream_rpc::registry::try_global()
+        .ok_or_else(|| {
+            anyhow::anyhow!(
+                "EndpointRegistry not initialized — local discovery fabric unavailable"
+            )
+        })?
+        .try_endpoint("discovery", hyprstream_rpc::registry::SocketKind::Rep)
+}
+
 /// Atomically consume the explicitly selected deployment witness and install
 /// the process Discovery resolver. Selection never falls back between the
 /// OS-owned and DID-anchored providers.
@@ -2723,9 +2751,17 @@ pub async fn bootstrap_deployment_process(
     let (authority, discovery_client) = match trust_source {
         crate::DeploymentTrustSource::OsOwnedFiles => {
             let authority = authenticate_deployment_bootstrap()?;
-            let client =
-                crate::DiscoveryClient::for_local_bootstrap(signing_key, discovery_vk, None)?;
-            (authority, client)
+            // Lazy local discovery client — see `resolve_local_discovery_transport`:
+            // the default discovery socket is resolved via `try_endpoint` (not
+            // the eager `for_local_bootstrap`), and `dial` connects on first use,
+            // so Discovery may start *after* this install inside the same
+            // process. Trust is not weakened — the checkpoint was already
+            // verified by `authenticate_deployment_bootstrap()`, and
+            // `discovery_vk` authenticates every lazy response.
+            let transport = resolve_local_discovery_transport()?;
+            let signer = hyprstream_rpc::signer::LocalSigner::new(signing_key);
+            let rpc = hyprstream_rpc::dial::dial(&transport, signer, Some(discovery_vk), None)?;
+            (authority, crate::DiscoveryClient::new(rpc))
         }
         crate::DeploymentTrustSource::DidAnchored(anchors) => {
             let (authority, discovery_transport, mesh_kem_recipient, ml_dsa_65_keys) =
@@ -7116,5 +7152,59 @@ mod query_candidates_tests {
             "second heartbeat must win"
         );
         assert_eq!(set.candidates[0].allocatable[0].quantity, "8");
+    }
+}
+
+// ============================================================================
+// Regression: eager-resolver bootstrap ordering (#fix-eager-resolver)
+// ============================================================================
+//
+// Before the fix, `bootstrap_deployment_process`'s OsOwnedFiles arm called
+// `DiscoveryClient::for_local_bootstrap`, which requires
+// `registered_endpoint("discovery")` to be `Some`. At first-boot (before any
+// service binds a socket) this is always `None`, so every `service start`
+// aborted with "local bootstrap requires an explicitly registered service
+// endpoint" — a startup-ordering inversion. The fix replaces that with
+// `resolve_local_discovery_transport()`, which uses `try_endpoint` (lazy
+// default fallback) so Discovery may start after the resolver install.
+
+#[cfg(test)]
+mod eager_resolver_regression {
+    #![allow(clippy::unwrap_used, clippy::expect_used, clippy::indexing_slicing)]
+    use super::*;
+
+    /// The OS-owned-files bootstrap path must resolve a lazy default discovery
+    /// transport even when no discovery endpoint has been registered yet — the
+    /// first-boot posture. On `origin/main` the equivalent code path
+    /// (`DiscoveryClient::for_local_bootstrap` → `registered_endpoint`) returns
+    /// `None` and errors; this test asserts the lazy resolution succeeds.
+    #[test]
+    fn local_discovery_transport_resolves_without_registered_endpoint() {
+        // Ensure the global EndpointRegistry exists (idempotent — no-op if
+        // another test already initialized it).
+        hyprstream_rpc::registry::init(
+            hyprstream_rpc::registry::EndpointMode::Inproc,
+            None,
+        );
+
+        // First-boot posture: discovery has not registered an endpoint.
+        // (If another test in this binary registered discovery, the lazy
+        // resolution is trivially satisfied — the assertion below still holds.)
+
+        // The fix's lazy helper must succeed regardless — it falls back to the
+        // default discovery socket via `try_endpoint`.
+        let transport = resolve_local_discovery_transport()
+            .expect("lazy discovery transport must resolve at first-boot");
+        assert!(
+            matches!(
+                transport.endpoint,
+                hyprstream_rpc::transport::EndpointType::Inproc { .. }
+                    | hyprstream_rpc::transport::EndpointType::Ipc { .. }
+                    | hyprstream_rpc::transport::EndpointType::SystemdFd { .. }
+            ),
+            "expected a local (inproc/IPC/systemd) transport for same-node \
+             bootstrap, got {:?}",
+            transport.endpoint,
+        );
     }
 }

--- a/crates/hyprstream-discovery/src/service.rs
+++ b/crates/hyprstream-discovery/src/service.rs
@@ -2774,7 +2774,7 @@ pub async fn bootstrap_deployment_process(
             let authority = authenticate_deployment_bootstrap()?;
             // Lazy local discovery client — see `install_local_discovery_client`:
             // the default discovery socket is resolved via `try_endpoint` (not
-            // the eager `for_local_bootstrap`), and `dial` connects on first use,
+            // the eager registered_endpoint path), and `dial` connects on first use,
             // so Discovery may start *after* this install inside the same
             // process. Trust is not weakened — the checkpoint was already
             // verified by `authenticate_deployment_bootstrap()`, and
@@ -7193,25 +7193,16 @@ mod eager_resolver_regression {
     #![allow(clippy::unwrap_used, clippy::expect_used, clippy::indexing_slicing)]
     use super::*;
 
-    /// Regression for the eager-resolver bootstrap ordering bug.
+    /// Behavioral test: proves [`install_local_discovery_client`] succeeds at
+    /// first boot with no registered endpoint — the lazy `try_endpoint`
+    /// resolves a default UDS path and `dial` connects on first use (not now).
     ///
-    /// This test is causal to the production OS-owned bootstrap path: it calls
-    /// [`install_local_discovery_client`] — the exact function
-    /// [`bootstrap_deployment_process`]'s OsOwnedFiles arm calls after
-    /// authenticating the checkpoint — which performs the full
-    /// `resolve_local_discovery_transport` → `dial` → `DiscoveryClient::new`
-    /// sequence. On `origin/main` the equivalent code
-    /// (`DiscoveryClient::for_local_bootstrap` → `registered_endpoint`) returns
-    /// `None` at first boot and errors; this test proves the lazy path
-    /// installs successfully instead.
-    ///
-    /// Reverting the OsOwnedFiles arm to `for_local_bootstrap` makes
-    /// `install_local_discovery_client` error (it resolves via
-    /// `try_endpoint`, which succeeds where `registered_endpoint` fails), so
-    /// this test fails — unlike the prior non-causal test which only inspected
-    /// endpoint synthesis and was insensitive to the arm's actual mechanism.
+    /// This test exercises the extracted helper's mechanism (resolve → dial →
+    /// DiscoveryClient::new) and asserts `registered_endpoint` is `None`. It
+    /// does NOT by itself detect reversion of the OsOwnedFiles arm to
+    /// `for_local_bootstrap` — that is the job of the structural test below.
     #[test]
-    fn os_owned_bootstrap_installs_lazy_resolver_with_no_registered_endpoint() {
+    fn install_local_discovery_client_succeeds_with_no_registered_endpoint() {
         use hyprstream_rpc::registry::{EndpointMode, SocketKind};
 
         // IPC mode with a temp runtime dir — the production same-node fabric.
@@ -7227,10 +7218,7 @@ mod eager_resolver_regression {
         let registry = hyprstream_rpc::registry::try_global()
             .expect("EndpointRegistry must be initialized");
 
-        // First-boot posture: discovery has NOT registered an endpoint. This is
-        // the exact condition that made the old eager `for_local_bootstrap`
-        // fail. Assert it positively — the old test had an empty
-        // `if registered.is_none() {}` body that tested nothing.
+        // First-boot posture: discovery has NOT registered an endpoint.
         let registered = registry.registered_endpoint("discovery", SocketKind::Rep);
         assert!(
             registered.is_none(),
@@ -7239,39 +7227,68 @@ mod eager_resolver_regression {
             registered,
         );
 
-        // The production resolver-install path: dial + DiscoveryClient::new.
-        // This MUST succeed even with no registered endpoint — the lazy
-        // `try_endpoint` resolves a default UDS path, and `dial` connects on
-        // first use (not now). An error here reproduces the original bug.
+        // The resolver-install path: dial + DiscoveryClient::new.
         let signing_key = SigningKey::generate(&mut rand::rngs::OsRng);
         let discovery_vk = signing_key.verifying_key();
-        let client = install_local_discovery_client(signing_key, discovery_vk)
+        let _client = install_local_discovery_client(signing_key, discovery_vk)
             .expect(
                 "install_local_discovery_client must succeed at first boot with \
-                 no registered discovery endpoint — the lazy transport resolves \
-                 a default UDS path and dial connects on first use",
+                 no registered discovery endpoint",
             );
 
-        // The client is constructed (resolver installed). A later use against
-        // the absent socket fails with a transport connect error — proving the
-        // installed transport points at the default UDS path, not nowhere.
-        // We verify this by confirming the resolved transport is an IPC variant.
+        // Confirm the resolved transport is the default UDS path (IPC variant).
         let transport = resolve_local_discovery_transport()
-            .expect("resolve_local_discovery_transport must resolve the same lazy default");
+            .expect("resolve_local_discovery_transport must resolve the lazy default");
         assert!(
             matches!(
                 transport.endpoint,
                 hyprstream_rpc::transport::EndpointType::Ipc { .. }
             ),
-            "expected IPC transport (default discovery UDS) for same-node \
-             first-boot fabric, got {:?}",
+            "expected IPC transport (default discovery UDS), got {:?}",
             transport.endpoint,
         );
 
-        // Touch the client so the compiler knows we proved construction.
-        let _ = &client;
-
         // Cleanup
         let _ = std::fs::remove_dir_all(&runtime_dir);
+    }
+
+    /// Structural guard: the OsOwnedFiles arm of
+    /// [`bootstrap_deployment_process`] must call
+    /// [`install_local_discovery_client`] (the lazy resolver), not
+    /// `DiscoveryClient::for_local_bootstrap` (the eager resolver that fails at
+    /// first boot). This test inspects the production source of the arm — if
+    /// someone reverts the arm to `for_local_bootstrap`, this test fails.
+    ///
+    /// Together with the behavioral test above (which proves the helper
+    /// succeeds with no registered endpoint), this guards the production
+    /// install boundary: the arm calls the proven-correct helper, and the
+    /// helper works.
+    #[test]
+    fn os_owned_arm_uses_lazy_resolver_not_for_local_bootstrap() {
+        let source = include_str!("service.rs");
+        // Production code only — exclude this regression test module.
+        let production = source
+            .split("// ============================================================================\n// Regression: eager-resolver")
+            .next()
+            .expect("production source before regression test module");
+
+        // Find the OsOwnedFiles arm of bootstrap_deployment_process.
+        let arm = production
+            .find("DeploymentTrustSource::OsOwnedFiles =>")
+            .expect("OsOwnedFiles arm must exist in bootstrap_deployment_process");
+        let arm_block = &production[arm..arm + 800];
+
+        assert!(
+            arm_block.contains("install_local_discovery_client"),
+            "OsOwnedFiles arm must call install_local_discovery_client (lazy resolver), \
+             got:\n{}",
+            arm_block,
+        );
+        assert!(
+            !arm_block.contains("for_local_bootstrap"),
+            "OsOwnedFiles arm must NOT call for_local_bootstrap (eager resolver), \
+             got:\n{}",
+            arm_block,
+        );
     }
 }

--- a/crates/hyprstream/src/bin/main.rs
+++ b/crates/hyprstream/src/bin/main.rs
@@ -2353,36 +2353,56 @@ fn main() -> Result<()> {
                                 }
 
                                 if quic_cfg.enabled {
-                                    // First-boot deferral: the checkpointed PDS store
-                                    // is empty until the discovery/registry announcement
-                                    // pipeline processes service registrations — which
-                                    // happens AFTER services bind. Rather than hard-fail
-                                    // at `with_checkpointed_native_announcements`
-                                    // (which requires pre-existing accepted states),
-                                    // defer QUIC startup: services bind via inproc/IPC
-                                    // and serve HTTP routes; QUIC activates once the
-                                    // announcement pipeline writes accepted states
-                                    // (typically on the next boot or after a runtime
-                                    // discovery cycle). This does NOT weaken the
-                                    // checkpoint gate — QUIC simply waits for the
-                                    // states it requires.
-                                    let has_states = hyprstream_core::services::factories::pds_store_has_accepted_states(&ctx)
-                                        .unwrap_or_else(|e| {
-                                            tracing::warn!("failed to read PDS accepted states; treating as first boot: {e}");
-                                            false
-                                        });
-                                    if has_states {
-                                        ctx = hyprstream_core::services::factories::with_checkpointed_native_announcements(
-                                            ctx,
-                                            &service_names,
-                                        )?;
-                                    } else {
-                                        tracing::info!(
-                                            "QUIC deferred: PDS store has no accepted states (first boot). \
-                                             Services will bind via inproc/IPC; QUIC activates after the \
-                                             discovery pipeline writes accepted states."
-                                        );
-                                        quic_cfg.enabled = false;
+                                    // The checkpoint gate: QUIC announcements require
+                                    // checkpoint-verified accepted states. Classify the
+                                    // store explicitly — only a genuine first-boot
+                                    // state may defer QUIC; every read/verify error or
+                                    // data-loss ambiguity fails closed here.
+                                    use hyprstream_core::services::factories::{
+                                        classify_pds_store_for_quic, PdsBootState,
+                                    };
+                                    match classify_pds_store_for_quic(&ctx) {
+                                        Ok(PdsBootState::Populated) => {
+                                            ctx = hyprstream_core::services::factories::with_checkpointed_native_announcements(
+                                                ctx,
+                                                &service_names,
+                                            )?;
+                                        }
+                                        Ok(PdsBootState::FirstBoot) => {
+                                            // An explicit --quic-bind that cannot be
+                                            // honored (no accepted states exist yet) is
+                                            // an error, never a silent disable.
+                                            if quic_bind.is_some() {
+                                                anyhow::bail!(
+                                                    "QUIC requested via --quic-bind but the PDS \
+                                                     accepted-state store is at first boot (no \
+                                                     accepted states written yet). Complete \
+                                                     discovery/registry provisioning, then restart \
+                                                     to activate QUIC."
+                                                );
+                                            }
+                                            // Genuine first boot, no explicit network
+                                            // request: defer QUIC for this run. Services
+                                            // bind via inproc/IPC and serve HTTP. QUIC is
+                                            // NOT re-enabled at runtime — a restart after
+                                            // provisioning is required.
+                                            tracing::warn!(
+                                                "QUIC disabled for this run: the PDS \
+                                                 accepted-state store is at first boot (no \
+                                                 accepted states written yet). Services will \
+                                                 bind via inproc/IPC and serve HTTP. Restart \
+                                                 after the discovery/registry pipeline writes \
+                                                 accepted states to activate QUIC. No runtime \
+                                                 auto-activation is implemented."
+                                            );
+                                            quic_cfg.enabled = false;
+                                        }
+                                        Err(e) => {
+                                            return Err(e).context(
+                                                "PDS accepted-state store read failed; \
+                                                 refusing to start QUIC (fail-closed)"
+                                            );
+                                        }
                                     }
                                 }
 

--- a/crates/hyprstream/src/bin/main.rs
+++ b/crates/hyprstream/src/bin/main.rs
@@ -1579,6 +1579,33 @@ async fn install_process_production_resolver(
     Ok(is_os_owned_bootstrap)
 }
 
+/// The only startup policy that consumes PDS lifecycle classification.
+///
+/// `is_os_owned_bootstrap` is derived from the authenticated deployment trust
+/// source before bootstrap consumes it. Keeping the classifier inside this
+/// gate is intentional: DID-anchored deployments must take the ordinary
+/// checkpointed path without reading lifecycle state or mutating QUIC.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum QuicCheckpointPolicy {
+    CheckpointedAnnouncements,
+    DeferForFirstBoot,
+}
+
+fn quic_checkpoint_policy(
+    is_os_owned_bootstrap: bool,
+    classify: impl FnOnce() -> Result<hyprstream_core::services::factories::PdsBootState>,
+) -> Result<QuicCheckpointPolicy> {
+    if !is_os_owned_bootstrap {
+        return Ok(QuicCheckpointPolicy::CheckpointedAnnouncements);
+    }
+
+    use hyprstream_core::services::factories::PdsBootState;
+    match classify()? {
+        PdsBootState::Populated => Ok(QuicCheckpointPolicy::CheckpointedAnnouncements),
+        PdsBootState::FirstBoot => Ok(QuicCheckpointPolicy::DeferForFirstBoot),
+    }
+}
+
 /// Install the process-global envelope verify configuration (#152, #160).
 ///
 /// MUST be called once at startup on **every** process entrypoint that serves
@@ -2369,27 +2396,26 @@ fn main() -> Result<()> {
                                     // The checkpoint gate: QUIC announcements require
                                     // checkpoint-verified accepted states.
                                     //
-                                    // First-boot deferral (classify + defer) is scoped
-                                    // to the OS-owned bootstrap source ONLY. Every
-                                    // other authenticated trust source (DID-anchored,
-                                    // restarts, etc.) takes the normal checkpointed
-                                    // path with no classification, no deferral, and no
-                                    // quic_cfg mutation. This is the retained selection
-                                    // from install_process_production_resolver — the
-                                    // authenticated trust-source choice carried to this
-                                    // boundary.
-                                    if is_os_owned_bootstrap {
-                                        use hyprstream_core::services::factories::{
-                                            classify_pds_store_for_quic, PdsBootState,
-                                        };
-                                        match classify_pds_store_for_quic(&ctx) {
-                                            Ok(PdsBootState::Populated) => {
+                                    // First-boot deferral is scoped to the OS-owned
+                                    // bootstrap source ONLY. An OS-owned deployment
+                                    // remains that source on restart, so it classifies
+                                    // then takes the ordinary checkpointed path when
+                                    // populated. DID-anchored deployments never read
+                                    // lifecycle state or mutate QUIC here.
+                                    match quic_checkpoint_policy(is_os_owned_bootstrap, || {
+                                        hyprstream_core::services::factories::classify_pds_store_for_quic(&ctx)
+                                    })
+                                    .context(
+                                        "PDS accepted-state store read failed; \
+                                         refusing to start QUIC (fail-closed)",
+                                    )? {
+                                        QuicCheckpointPolicy::CheckpointedAnnouncements => {
                                                 ctx = hyprstream_core::services::factories::with_checkpointed_native_announcements(
                                                     ctx,
                                                     &service_names,
                                                 )?;
-                                            }
-                                            Ok(PdsBootState::FirstBoot) => {
+                                        }
+                                        QuicCheckpointPolicy::DeferForFirstBoot => {
                                                 // An explicit --quic-bind that cannot be
                                                 // honored (no accepted states exist yet) is
                                                 // an error, never a silent disable.
@@ -2417,23 +2443,7 @@ fn main() -> Result<()> {
                                                      auto-activation is implemented."
                                                 );
                                                 quic_cfg.enabled = false;
-                                            }
-                                            Err(e) => {
-                                                return Err(e).context(
-                                                    "PDS accepted-state store read failed; \
-                                                     refusing to start QUIC (fail-closed)"
-                                                );
-                                            }
                                         }
-                                    } else {
-                                        // Non-OS-owned source (DID-anchored, etc.):
-                                        // always checkpoint — accepted states are
-                                        // required, never deferred. Missing states fail
-                                        // loudly here, exactly as before this PR.
-                                        ctx = hyprstream_core::services::factories::with_checkpointed_native_announcements(
-                                            ctx,
-                                            &service_names,
-                                        )?;
                                     }
                                 }
 
@@ -3138,52 +3148,40 @@ mod resolver_startup_controls {
         }
     }
 
-    /// The first-boot QUIC deferral (classify + defer) must be scoped to the
-    /// OS-owned bootstrap source ONLY. This structural test guards the property
-    /// that has silently regressed three times: if someone removes the
-    /// `is_os_owned_bootstrap` gate, the `classify_pds_store_for_quic` call
-    /// would fire on every QUIC-enabled start again.
+    /// Lifecycle classification is consumed only for the authenticated
+    /// OS-owned source. This is behavioral rather than positional: moving the
+    /// classifier outside `quic_checkpoint_policy`'s source gate makes the
+    /// DID-anchored case below invoke its deliberately failing classifier.
     #[test]
     fn first_boot_quic_deferral_is_scoped_to_os_owned_bootstrap() {
-        let source = include_str!("main.rs");
-        let production = source
-            .split("mod resolver_startup_controls {")
-            .next()
-            .expect("production binary source");
+        use std::cell::Cell;
 
-        // The retained trust-source selection must exist as an if-gate.
-        let gate_pos = production
-            .find("if is_os_owned_bootstrap {")
-            .expect("is_os_owned_bootstrap if-gate must exist");
+        use hyprstream_core::services::factories::PdsBootState;
 
-        // The classification must appear AFTER the gate (inside the gated
-        // branch), proving it's scoped to the OS-owned bootstrap source.
-        let classify_offset = production[gate_pos..]
-            .find("classify_pds_store_for_quic")
-            .expect("classify_pds_store_for_quic must exist inside the gated branch");
-
-        // The QUIC-disable mutation must appear AFTER the classification
-        // (inside the FirstBoot arm of the match), still within the gated branch.
-        let classify_end = gate_pos + classify_offset;
-        let defer_offset = production[classify_end..]
-            .find("quic_cfg.enabled = false")
-            .expect("quic_cfg.enabled = false must be after classify, inside the gated branch");
-
-        // After the defer, the non-bootstrap else branch must checkpoint
-        // directly — no classification, no deferral.
-        let defer_end = classify_end + defer_offset;
-        let else_offset = production[defer_end..]
-            .find("} else {")
-            .expect("non-bootstrap else branch must exist after the defer");
-        let else_start = defer_end + else_offset;
-        let else_region = &production[else_start..else_start + 800];
-        assert!(
-            else_region.contains("with_checkpointed_native_announcements"),
-            "non-bootstrap branch must call with_checkpointed_native_announcements directly"
+        let os_owned_calls = Cell::new(0);
+        assert_eq!(
+            super::quic_checkpoint_policy(true, || {
+                os_owned_calls.set(os_owned_calls.get() + 1);
+                Ok(PdsBootState::FirstBoot)
+            })
+            .expect("OS-owned classification succeeds"),
+            super::QuicCheckpointPolicy::DeferForFirstBoot,
         );
-        assert!(
-            !else_region.contains("classify_pds_store_for_quic"),
-            "non-bootstrap branch must NOT classify the store"
+        assert_eq!(os_owned_calls.get(), 1, "OS-owned input classifies once");
+
+        let did_anchored_calls = Cell::new(0);
+        assert_eq!(
+            super::quic_checkpoint_policy(false, || {
+                did_anchored_calls.set(did_anchored_calls.get() + 1);
+                anyhow::bail!("DID-anchored startup must never classify lifecycle state")
+            })
+            .expect("DID-anchored startup bypasses the classifier"),
+            super::QuicCheckpointPolicy::CheckpointedAnnouncements,
+        );
+        assert_eq!(
+            did_anchored_calls.get(),
+            0,
+            "DID-anchored input must not invoke the classifier"
         );
     }
 

--- a/crates/hyprstream/src/bin/main.rs
+++ b/crates/hyprstream/src/bin/main.rs
@@ -1523,10 +1523,14 @@ fn resolve_service_vk(service_name: &str) -> Option<VerifyingKey> {
     trust.resolve_one(service_name)
 }
 
+/// Install the process production resolver and return whether the
+/// authenticated trust source was the OS-owned bootstrap (`true`) or a
+/// DID-anchored source (`false`). The caller retains this selection so the
+/// QUIC startup gate can scope first-boot deferral to the OS-owned path only.
 async fn install_process_production_resolver(
     signing_key: &SigningKey,
     config: &HyprConfig,
-) -> Result<()> {
+) -> Result<bool> {
     // The bootstrap pins the discovery service key from the process trust
     // store; in CLI/service-start mode nothing has seeded it yet. Seed from
     // the node's own bootstrap-pubkeys (the same source resolve_service_vk
@@ -1556,6 +1560,13 @@ async fn install_process_production_resolver(
         }
         _ => trust_source,
     };
+    // Retain the authenticated selection before it is consumed by the
+    // bootstrap. The QUIC startup gate uses this to scope first-boot
+    // deferral to the OS-owned path only.
+    let is_os_owned_bootstrap = matches!(
+        trust_source,
+        hyprstream_discovery::DeploymentTrustSource::OsOwnedFiles
+    );
     hyprstream_discovery::bootstrap_deployment_process(
         signing_key.clone(),
         trust_source,
@@ -1564,7 +1575,8 @@ async fn install_process_production_resolver(
     .await?;
     hyprstream_rpc::envelope::install_browser_currentness_verifier(
         hyprstream_discovery::production_browser_currentness_verifier()?,
-    )
+    )?;
+    Ok(is_os_owned_bootstrap)
 }
 
 /// Install the process-global envelope verify configuration (#152, #160).
@@ -2006,24 +2018,25 @@ fn main() -> Result<()> {
         .context("Failed to create registry runtime")?;
 
     // Start services and create keypair
-    let (registry_client, signing_key, verifying_key): (
+    let (registry_client, signing_key, verifying_key, is_os_owned_bootstrap): (
         RegistryClient,
         SigningKey,
         VerifyingKey,
+        bool,
     ) = _registry_runtime
         .block_on(async {
             let keys_dir = config.models_dir().join(".registry").join("keys");
             let signing_key = load_or_generate_signing_key(&keys_dir).await?;
             let verifying_key = signing_key.verifying_key();
 
-            install_process_production_resolver(&signing_key, &config).await
+            let is_os_owned_bootstrap = install_process_production_resolver(&signing_key, &config).await
                 .context("Failed to install checkpoint-backed production resolver")?;
             let client = hyprstream_core::services::RegistryClient::from_resolver(
                 signing_key.clone(),
                 None,
             )?;
 
-            Ok::<_, anyhow::Error>((client, signing_key, verifying_key))
+            Ok::<_, anyhow::Error>((client, signing_key, verifying_key, is_os_owned_bootstrap))
         })
         .context("Failed to connect to services")?;
 
@@ -2354,55 +2367,73 @@ fn main() -> Result<()> {
 
                                 if quic_cfg.enabled {
                                     // The checkpoint gate: QUIC announcements require
-                                    // checkpoint-verified accepted states. Classify the
-                                    // store explicitly — only a genuine first-boot
-                                    // state may defer QUIC; every read/verify error or
-                                    // data-loss ambiguity fails closed here.
-                                    use hyprstream_core::services::factories::{
-                                        classify_pds_store_for_quic, PdsBootState,
-                                    };
-                                    match classify_pds_store_for_quic(&ctx) {
-                                        Ok(PdsBootState::Populated) => {
-                                            ctx = hyprstream_core::services::factories::with_checkpointed_native_announcements(
-                                                ctx,
-                                                &service_names,
-                                            )?;
-                                        }
-                                        Ok(PdsBootState::FirstBoot) => {
-                                            // An explicit --quic-bind that cannot be
-                                            // honored (no accepted states exist yet) is
-                                            // an error, never a silent disable.
-                                            if quic_bind.is_some() {
-                                                anyhow::bail!(
-                                                    "QUIC requested via --quic-bind but the PDS \
+                                    // checkpoint-verified accepted states.
+                                    //
+                                    // First-boot deferral (classify + defer) is scoped
+                                    // to the OS-owned bootstrap source ONLY. Every
+                                    // other authenticated trust source (DID-anchored,
+                                    // restarts, etc.) takes the normal checkpointed
+                                    // path with no classification, no deferral, and no
+                                    // quic_cfg mutation. This is the retained selection
+                                    // from install_process_production_resolver — the
+                                    // authenticated trust-source choice carried to this
+                                    // boundary.
+                                    if is_os_owned_bootstrap {
+                                        use hyprstream_core::services::factories::{
+                                            classify_pds_store_for_quic, PdsBootState,
+                                        };
+                                        match classify_pds_store_for_quic(&ctx) {
+                                            Ok(PdsBootState::Populated) => {
+                                                ctx = hyprstream_core::services::factories::with_checkpointed_native_announcements(
+                                                    ctx,
+                                                    &service_names,
+                                                )?;
+                                            }
+                                            Ok(PdsBootState::FirstBoot) => {
+                                                // An explicit --quic-bind that cannot be
+                                                // honored (no accepted states exist yet) is
+                                                // an error, never a silent disable.
+                                                if quic_bind.is_some() {
+                                                    anyhow::bail!(
+                                                        "QUIC requested via --quic-bind but the PDS \
+                                                         accepted-state store is at first boot (no \
+                                                         accepted states written yet). Complete \
+                                                         discovery/registry provisioning, then restart \
+                                                         to activate QUIC."
+                                                    );
+                                                }
+                                                // Genuine first boot, no explicit network
+                                                // request: defer QUIC for this run. Services
+                                                // bind via inproc/IPC and serve HTTP. QUIC is
+                                                // NOT re-enabled at runtime — a restart after
+                                                // provisioning is required.
+                                                tracing::warn!(
+                                                    "QUIC disabled for this run: the PDS \
                                                      accepted-state store is at first boot (no \
-                                                     accepted states written yet). Complete \
-                                                     discovery/registry provisioning, then restart \
-                                                     to activate QUIC."
+                                                     accepted states written yet). Services will \
+                                                     bind via inproc/IPC and serve HTTP. Restart \
+                                                     after the discovery/registry pipeline writes \
+                                                     accepted states to activate QUIC. No runtime \
+                                                     auto-activation is implemented."
+                                                );
+                                                quic_cfg.enabled = false;
+                                            }
+                                            Err(e) => {
+                                                return Err(e).context(
+                                                    "PDS accepted-state store read failed; \
+                                                     refusing to start QUIC (fail-closed)"
                                                 );
                                             }
-                                            // Genuine first boot, no explicit network
-                                            // request: defer QUIC for this run. Services
-                                            // bind via inproc/IPC and serve HTTP. QUIC is
-                                            // NOT re-enabled at runtime — a restart after
-                                            // provisioning is required.
-                                            tracing::warn!(
-                                                "QUIC disabled for this run: the PDS \
-                                                 accepted-state store is at first boot (no \
-                                                 accepted states written yet). Services will \
-                                                 bind via inproc/IPC and serve HTTP. Restart \
-                                                 after the discovery/registry pipeline writes \
-                                                 accepted states to activate QUIC. No runtime \
-                                                 auto-activation is implemented."
-                                            );
-                                            quic_cfg.enabled = false;
                                         }
-                                        Err(e) => {
-                                            return Err(e).context(
-                                                "PDS accepted-state store read failed; \
-                                                 refusing to start QUIC (fail-closed)"
-                                            );
-                                        }
+                                    } else {
+                                        // Non-OS-owned source (DID-anchored, etc.):
+                                        // always checkpoint — accepted states are
+                                        // required, never deferred. Missing states fail
+                                        // loudly here, exactly as before this PR.
+                                        ctx = hyprstream_core::services::factories::with_checkpointed_native_announcements(
+                                            ctx,
+                                            &service_names,
+                                        )?;
                                     }
                                 }
 
@@ -3105,6 +3136,55 @@ mod resolver_startup_controls {
         ] {
             assert!(production.contains(entry), "missing {entry}");
         }
+    }
+
+    /// The first-boot QUIC deferral (classify + defer) must be scoped to the
+    /// OS-owned bootstrap source ONLY. This structural test guards the property
+    /// that has silently regressed three times: if someone removes the
+    /// `is_os_owned_bootstrap` gate, the `classify_pds_store_for_quic` call
+    /// would fire on every QUIC-enabled start again.
+    #[test]
+    fn first_boot_quic_deferral_is_scoped_to_os_owned_bootstrap() {
+        let source = include_str!("main.rs");
+        let production = source
+            .split("mod resolver_startup_controls {")
+            .next()
+            .expect("production binary source");
+
+        // The retained trust-source selection must exist as an if-gate.
+        let gate_pos = production
+            .find("if is_os_owned_bootstrap {")
+            .expect("is_os_owned_bootstrap if-gate must exist");
+
+        // The classification must appear AFTER the gate (inside the gated
+        // branch), proving it's scoped to the OS-owned bootstrap source.
+        let classify_offset = production[gate_pos..]
+            .find("classify_pds_store_for_quic")
+            .expect("classify_pds_store_for_quic must exist inside the gated branch");
+
+        // The QUIC-disable mutation must appear AFTER the classification
+        // (inside the FirstBoot arm of the match), still within the gated branch.
+        let classify_end = gate_pos + classify_offset;
+        let defer_offset = production[classify_end..]
+            .find("quic_cfg.enabled = false")
+            .expect("quic_cfg.enabled = false must be after classify, inside the gated branch");
+
+        // After the defer, the non-bootstrap else branch must checkpoint
+        // directly — no classification, no deferral.
+        let defer_end = classify_end + defer_offset;
+        let else_offset = production[defer_end..]
+            .find("} else {")
+            .expect("non-bootstrap else branch must exist after the defer");
+        let else_start = defer_end + else_offset;
+        let else_region = &production[else_start..else_start + 800];
+        assert!(
+            else_region.contains("with_checkpointed_native_announcements"),
+            "non-bootstrap branch must call with_checkpointed_native_announcements directly"
+        );
+        assert!(
+            !else_region.contains("classify_pds_store_for_quic"),
+            "non-bootstrap branch must NOT classify the store"
+        );
     }
 
     #[test]

--- a/crates/hyprstream/src/bin/main.rs
+++ b/crates/hyprstream/src/bin/main.rs
@@ -2183,7 +2183,7 @@ fn main() -> Result<()> {
                                 .with_federation_key_source(fed_src);
 
                                 // Wire QUIC shared config from --quic-bind or [quic] config
-                                let quic_cfg = if let Some(ref bind_addr) = quic_bind {
+                                let mut quic_cfg = if let Some(ref bind_addr) = quic_bind {
                                     let mut qc = hyprstream_core::config::QuicConfig::default();
                                     qc.enabled = true;
                                     qc.bind_addr = bind_addr.clone();
@@ -2353,10 +2353,37 @@ fn main() -> Result<()> {
                                 }
 
                                 if quic_cfg.enabled {
-                                    ctx = hyprstream_core::services::factories::with_checkpointed_native_announcements(
-                                        ctx,
-                                        &service_names,
-                                    )?;
+                                    // First-boot deferral: the checkpointed PDS store
+                                    // is empty until the discovery/registry announcement
+                                    // pipeline processes service registrations — which
+                                    // happens AFTER services bind. Rather than hard-fail
+                                    // at `with_checkpointed_native_announcements`
+                                    // (which requires pre-existing accepted states),
+                                    // defer QUIC startup: services bind via inproc/IPC
+                                    // and serve HTTP routes; QUIC activates once the
+                                    // announcement pipeline writes accepted states
+                                    // (typically on the next boot or after a runtime
+                                    // discovery cycle). This does NOT weaken the
+                                    // checkpoint gate — QUIC simply waits for the
+                                    // states it requires.
+                                    let has_states = hyprstream_core::services::factories::pds_store_has_accepted_states(&ctx)
+                                        .unwrap_or_else(|e| {
+                                            tracing::warn!("failed to read PDS accepted states; treating as first boot: {e}");
+                                            false
+                                        });
+                                    if has_states {
+                                        ctx = hyprstream_core::services::factories::with_checkpointed_native_announcements(
+                                            ctx,
+                                            &service_names,
+                                        )?;
+                                    } else {
+                                        tracing::info!(
+                                            "QUIC deferred: PDS store has no accepted states (first boot). \
+                                             Services will bind via inproc/IPC; QUIC activates after the \
+                                             discovery pipeline writes accepted states."
+                                        );
+                                        quic_cfg.enabled = false;
+                                    }
                                 }
 
                                 // Wire QUIC shared config (must be after key generation so jwt_verifying_key is set)

--- a/crates/hyprstream/src/services/discovery.rs
+++ b/crates/hyprstream/src/services/discovery.rs
@@ -392,6 +392,36 @@ impl PdsRecordStore {
         }
     }
 
+    /// Check whether the first-boot provisioning marker (`FIRST_BOOT_KEY`) is
+    /// present in the store. The marker is written by `init-deployment-store`
+    /// and deleted atomically with the first accepted-state commit. Its
+    /// presence alongside an empty store is the ONLY lifecycle evidence that
+    /// distinguishes genuine first boot from data loss.
+    pub fn first_boot_pending(&self) -> AnyResult<bool> {
+        let check = |db: &rocksdb::DB| -> AnyResult<bool> {
+            Ok(db.get(hyprstream_discovery::FIRST_BOOT_KEY)?.is_some())
+        };
+        match &self.backing {
+            RecordBacking::ReadWrite(db) => check(db),
+            RecordBacking::ReadOnly(path) => {
+                let db = rocksdb::DB::open_for_read_only(&readonly_opts(), path, false)?;
+                check(&db)
+            }
+        }
+    }
+
+    /// Write the first-boot provisioning marker. Only valid on a read-write
+    /// store that has just been freshly created. Propagates the write error so
+    /// initialization cannot appear successful without the marker.
+    pub fn mark_first_boot(&self) -> AnyResult<()> {
+        let RecordBacking::ReadWrite(db) = &self.backing else {
+            bail!("first-boot marker write attempted on a read-only PDS store");
+        };
+        db.put(hyprstream_discovery::FIRST_BOOT_KEY, b"")
+            .context("failed to write first-boot provisioning marker")?;
+        Ok(())
+    }
+
     fn conditional_advance_at9p_state(
         &self,
         expected: Option<Watermark>,
@@ -416,25 +446,15 @@ impl PdsRecordStore {
         let mut batch = rocksdb::WriteBatch::default();
         batch.put(at9p_state_key(&state.subject_cid512), encoded);
         batch.put(at9p_checkpoint_key(&state.subject_cid512), checkpoint);
+        // Clear the first-boot provisioning marker in the SAME synchronous
+        // batch as the accepted-state commit — so the lifecycle transition is
+        // atomic with provisioning completion. A crash between commit and
+        // marker removal is impossible: they are one RocksDB write.
+        batch.delete(hyprstream_discovery::FIRST_BOOT_KEY);
         let mut options = rocksdb::WriteOptions::default();
         options.set_sync(true);
         db.write_opt(batch, &options)
             .context("synchronous accepted did:at9p state+checkpoint commit failed")?;
-        // The store is no longer at first boot: clear the provisioning marker
-        // (written by `init-deployment-store`) so a later read of an empty
-        // store — which can now only mean data loss — fails closed instead of
-        // being mistaken for first boot. Best-effort: a missing marker on a
-        // steady-state commit is the normal case.
-        let marker = db.path().join(hyprstream_discovery::FIRST_BOOT_MARKER);
-        if marker.exists() {
-            if let Err(e) = std::fs::remove_file(&marker) {
-                tracing::warn!(
-                    "failed to remove first-boot marker {}: {e}; \
-                     the store is populated but the marker lingers",
-                    marker.display()
-                );
-            }
-        }
         Ok(ConditionalAdvance::Committed)
     }
 

--- a/crates/hyprstream/src/services/discovery.rs
+++ b/crates/hyprstream/src/services/discovery.rs
@@ -420,6 +420,21 @@ impl PdsRecordStore {
         options.set_sync(true);
         db.write_opt(batch, &options)
             .context("synchronous accepted did:at9p state+checkpoint commit failed")?;
+        // The store is no longer at first boot: clear the provisioning marker
+        // (written by `init-deployment-store`) so a later read of an empty
+        // store — which can now only mean data loss — fails closed instead of
+        // being mistaken for first boot. Best-effort: a missing marker on a
+        // steady-state commit is the normal case.
+        let marker = db.path().join(hyprstream_discovery::FIRST_BOOT_MARKER);
+        if marker.exists() {
+            if let Err(e) = std::fs::remove_file(&marker) {
+                tracing::warn!(
+                    "failed to remove first-boot marker {}: {e}; \
+                     the store is populated but the marker lingers",
+                    marker.display()
+                );
+            }
+        }
         Ok(ConditionalAdvance::Committed)
     }
 

--- a/crates/hyprstream/src/services/factories.rs
+++ b/crates/hyprstream/src/services/factories.rs
@@ -114,8 +114,6 @@ pub enum PdsBootState {
 /// its data, and which collapsed every read/decode/signature/consistency
 /// error into "first boot". The classification is:
 ///
-/// - Store directory absent → [`PdsBootState::FirstBoot`] (no write has ever
-///   occurred — the registry has never run).
 /// - Store directory present, marker present, store empty →
 ///   [`PdsBootState::FirstBoot`] (provisioned via `init-deployment-store`;
 ///   the registry has not yet written an accepted state).

--- a/crates/hyprstream/src/services/factories.rs
+++ b/crates/hyprstream/src/services/factories.rs
@@ -100,10 +100,10 @@ pub enum PdsBootState {
     /// [`with_checkpointed_native_announcements`] to populate announcements.
     Populated,
     /// Genuine first boot: the store has never held an accepted state (the
-    /// [`hyprstream_discovery::FIRST_BOOT_MARKER`] is present alongside an empty
-    /// store, or the store directory does not yet exist). QUIC may be deferred
-    /// for this run; a restart is required after the registry writes its first
-    /// accepted state. No runtime auto-activation is implemented.
+    /// durable first-boot RocksDB key is present alongside an empty store).
+    /// QUIC may be deferred for this run; a restart is required after the
+    /// registry writes its first accepted state. No runtime auto-activation
+    /// is implemented.
     FirstBoot,
 }
 
@@ -123,6 +123,8 @@ pub enum PdsBootState {
 ///   [`PdsBootState::Populated`].
 /// - Store directory present, empty, **no** marker → `Err` (possible data
 ///   loss or corruption; a loud steady-state failure — never defer).
+/// - Store directory **absent** → `Err` (missing security history; run
+///   `init-deployment-store` to provision, or restore from backup).
 /// - Any read/decode/signature/consistency failure → `Err` (propagated;
 ///   fail-closed at the checkpoint boundary).
 ///
@@ -132,9 +134,16 @@ pub enum PdsBootState {
 pub fn classify_pds_store_for_quic(ctx: &ServiceContext) -> anyhow::Result<PdsBootState> {
     let store_dir = pds_store_dir(ctx)?;
     if !store_dir.exists() {
-        // Nothing has ever created the store — the registry has never written.
-        // This is a genuine first boot (or pre-provisioning).
-        return Ok(PdsBootState::FirstBoot);
+        // A missing store is indistinguishable from deletion of security
+        // history — the checkpoint source's documented rule. First boot is an
+        // explicit provisioning step (init-deployment-store), not an absent
+        // directory. Fail closed; do not defer.
+        anyhow::bail!(
+            "PDS accepted-state store at {} does not exist. Run \
+             `init-deployment-store` to provision a fresh deployment, or \
+             restore from backup. Refusing to defer QUIC startup.",
+            store_dir.display()
+        );
     }
     let acceptance_identity = hyprstream_discovery::deployment_registry_verifier()?;
     let store = crate::services::discovery::PdsRecordStore::open_readonly(&store_dir)?
@@ -147,9 +156,10 @@ pub fn classify_pds_store_for_quic(ctx: &ServiceContext) -> anyhow::Result<PdsBo
         return Ok(PdsBootState::Populated);
     }
     // The store exists and opens cleanly but holds no accepted states. Only
-    // the provisioning marker distinguishes genuine first boot from data loss.
-    let marker = store_dir.join(hyprstream_discovery::FIRST_BOOT_MARKER);
-    if marker.exists() {
+    // the durable first-boot marker (a RocksDB key deleted atomically with
+    // the first accepted-state commit) distinguishes genuine first boot from
+    // data loss.
+    if store.first_boot_pending()? {
         return Ok(PdsBootState::FirstBoot);
     }
     anyhow::bail!(
@@ -2166,9 +2176,9 @@ fn create_tui_service(ctx: &ServiceContext) -> anyhow::Result<Box<dyn Spawnable>
 /// has ever been registered — bootstrap by briefly opening read-write (which
 /// creates the DB files) and releasing the handle, then retry read-only.
 ///
-/// When this path creates a fresh empty store it also writes the
-/// [`hyprstream_discovery::FIRST_BOOT_MARKER`], so the QUIC startup gate
-/// recognizes it as a genuine first boot rather than data loss.
+/// When this path creates a fresh empty store it also writes the durable
+/// first-boot RocksDB key, so the QUIC startup gate recognizes it as a
+/// genuine first boot rather than data loss.
 ///
 /// Known limitation: if the registry and discovery services start
 /// concurrently on a brand-new install, both may race to bootstrap the same
@@ -2184,18 +2194,17 @@ fn open_pds_store_readonly(
             // read-only. If bootstrap itself fails (e.g. the writer holds the
             // lock, or the path is corrupt), surface BOTH errors so the real
             // cause is visible rather than masked by the retry (#910a, fable M3).
-            drop(
-                crate::services::discovery::PdsRecordStore::open(dir).with_context(|| {
+            let store = crate::services::discovery::PdsRecordStore::open(dir)
+                .with_context(|| {
                     format!("read-only open failed ({orig}); bootstrap open also failed")
-                })?,
-            );
+                })?;
             // This bootstrap created a fresh empty store — record first-boot
-            // lifecycle evidence so the QUIC gate doesn't mistake it for data
-            // loss on the next classification.
-            let marker = dir.join(hyprstream_discovery::FIRST_BOOT_MARKER);
-            if !marker.exists() {
-                let _ = std::fs::write(&marker, b"");
-            }
+            // lifecycle evidence as a durable RocksDB key so the QUIC gate
+            // doesn't mistake it for data loss on the next classification.
+            // Propagate the error: a failed marker write must not appear
+            // successful.
+            store.mark_first_boot()?;
+            drop(store);
             crate::services::discovery::PdsRecordStore::open_readonly(dir)
         }
     }

--- a/crates/hyprstream/src/services/factories.rs
+++ b/crates/hyprstream/src/services/factories.rs
@@ -92,6 +92,27 @@ pub(crate) fn pds_store_dir(ctx: &ServiceContext) -> anyhow::Result<std::path::P
     Ok(ctx.deployment_data_dir()?.join("pds-store"))
 }
 
+/// Check whether the checkpointed PDS store contains any accepted states.
+///
+/// At first boot (after `pds init-deployment-store` but before the discovery
+/// pipeline has processed any announcements) the store is empty. In that state
+/// `with_checkpointed_native_announcements` cannot construct checkpoint-verified
+/// QUIC announcements — the accepted states are written by the registry/
+/// discovery announcement pipeline, which runs AFTER services bind. Returning
+/// `false` here lets the caller defer QUIC startup (services bind via inproc/
+/// IPC and serve HTTP routes) without weakening the checkpoint gate: QUIC
+/// activates once the announcement pipeline populates accepted states.
+pub fn pds_store_has_accepted_states(ctx: &ServiceContext) -> anyhow::Result<bool> {
+    let store_dir = pds_store_dir(ctx)?;
+    if !store_dir.exists() {
+        return Ok(false);
+    }
+    let acceptance_identity = hyprstream_discovery::deployment_registry_verifier()?;
+    let store = crate::services::discovery::PdsRecordStore::open_readonly(&store_dir)?
+        .with_at9p_deployment_verifier(acceptance_identity);
+    Ok(!store.accepted_at9p_states()?.is_empty())
+}
+
 /// Populate every ordinary network service announcement from a fresh
 /// checkpoint-verifying PDS read. Missing or ambiguous state fails startup
 /// before any QUIC service can bind and advertise an incomplete bundle.

--- a/crates/hyprstream/src/services/factories.rs
+++ b/crates/hyprstream/src/services/factories.rs
@@ -92,25 +92,72 @@ pub(crate) fn pds_store_dir(ctx: &ServiceContext) -> anyhow::Result<std::path::P
     Ok(ctx.deployment_data_dir()?.join("pds-store"))
 }
 
-/// Check whether the checkpointed PDS store contains any accepted states.
+/// The lifecycle state of the checkpointed PDS store, as seen by the QUIC
+/// startup gate.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PdsBootState {
+    /// ≥1 checkpoint-verified accepted state is present. The caller MUST run
+    /// [`with_checkpointed_native_announcements`] to populate announcements.
+    Populated,
+    /// Genuine first boot: the store has never held an accepted state (the
+    /// [`hyprstream_discovery::FIRST_BOOT_MARKER`] is present alongside an empty
+    /// store, or the store directory does not yet exist). QUIC may be deferred
+    /// for this run; a restart is required after the registry writes its first
+    /// accepted state. No runtime auto-activation is implemented.
+    FirstBoot,
+}
+
+/// Classify the checkpointed PDS store for the QUIC startup gate.
 ///
-/// At first boot (after `pds init-deployment-store` but before the discovery
-/// pipeline has processed any announcements) the store is empty. In that state
-/// `with_checkpointed_native_announcements` cannot construct checkpoint-verified
-/// QUIC announcements — the accepted states are written by the registry/
-/// discovery announcement pipeline, which runs AFTER services bind. Returning
-/// `false` here lets the caller defer QUIC startup (services bind via inproc/
-/// IPC and serve HTTP routes) without weakening the checkpoint gate: QUIC
-/// activates once the announcement pipeline populates accepted states.
-pub fn pds_store_has_accepted_states(ctx: &ServiceContext) -> anyhow::Result<bool> {
+/// This replaces the prior emptiness check, which could not distinguish a
+/// freshly provisioned first-boot store from a steady-state store that lost
+/// its data, and which collapsed every read/decode/signature/consistency
+/// error into "first boot". The classification is:
+///
+/// - Store directory absent → [`PdsBootState::FirstBoot`] (no write has ever
+///   occurred — the registry has never run).
+/// - Store directory present, marker present, store empty →
+///   [`PdsBootState::FirstBoot`] (provisioned via `init-deployment-store`;
+///   the registry has not yet written an accepted state).
+/// - Store directory present, ≥1 verified accepted state →
+///   [`PdsBootState::Populated`].
+/// - Store directory present, empty, **no** marker → `Err` (possible data
+///   loss or corruption; a loud steady-state failure — never defer).
+/// - Any read/decode/signature/consistency failure → `Err` (propagated;
+///   fail-closed at the checkpoint boundary).
+///
+/// Only [`PdsBootState::FirstBoot`] may enter a QUIC deferral path; every
+/// other outcome either proceeds with checkpointed announcements or fails
+/// startup.
+pub fn classify_pds_store_for_quic(ctx: &ServiceContext) -> anyhow::Result<PdsBootState> {
     let store_dir = pds_store_dir(ctx)?;
     if !store_dir.exists() {
-        return Ok(false);
+        // Nothing has ever created the store — the registry has never written.
+        // This is a genuine first boot (or pre-provisioning).
+        return Ok(PdsBootState::FirstBoot);
     }
     let acceptance_identity = hyprstream_discovery::deployment_registry_verifier()?;
     let store = crate::services::discovery::PdsRecordStore::open_readonly(&store_dir)?
         .with_at9p_deployment_verifier(acceptance_identity);
-    Ok(!store.accepted_at9p_states()?.is_empty())
+    // Propagates decode, signature-verification, and consistency failures
+    // (half-checkpoint mismatches, watermark/digest mismatches) as Err —
+    // these are NEVER evidence of first boot.
+    let states = store.accepted_at9p_states()?;
+    if !states.is_empty() {
+        return Ok(PdsBootState::Populated);
+    }
+    // The store exists and opens cleanly but holds no accepted states. Only
+    // the provisioning marker distinguishes genuine first boot from data loss.
+    let marker = store_dir.join(hyprstream_discovery::FIRST_BOOT_MARKER);
+    if marker.exists() {
+        return Ok(PdsBootState::FirstBoot);
+    }
+    anyhow::bail!(
+        "PDS accepted-state store at {} exists but contains no verified accepted \
+         states and no first-boot provisioning marker. This indicates data loss \
+         or corruption, not first boot; refusing to defer QUIC startup.",
+        store_dir.display()
+    )
 }
 
 /// Populate every ordinary network service announcement from a fresh
@@ -2119,6 +2166,10 @@ fn create_tui_service(ctx: &ServiceContext) -> anyhow::Result<Box<dyn Spawnable>
 /// has ever been registered — bootstrap by briefly opening read-write (which
 /// creates the DB files) and releasing the handle, then retry read-only.
 ///
+/// When this path creates a fresh empty store it also writes the
+/// [`hyprstream_discovery::FIRST_BOOT_MARKER`], so the QUIC startup gate
+/// recognizes it as a genuine first boot rather than data loss.
+///
 /// Known limitation: if the registry and discovery services start
 /// concurrently on a brand-new install, both may race to bootstrap the same
 /// directory; one loses the RocksDB lock and its factory call fails, which
@@ -2138,6 +2189,13 @@ fn open_pds_store_readonly(
                     format!("read-only open failed ({orig}); bootstrap open also failed")
                 })?,
             );
+            // This bootstrap created a fresh empty store — record first-boot
+            // lifecycle evidence so the QUIC gate doesn't mistake it for data
+            // loss on the next classification.
+            let marker = dir.join(hyprstream_discovery::FIRST_BOOT_MARKER);
+            if !marker.exists() {
+                let _ = std::fs::write(&marker, b"");
+            }
             crate::services::discovery::PdsRecordStore::open_readonly(dir)
         }
     }


### PR DESCRIPTION
## The defect

The `OsOwnedFiles` deployment bootstrap used an eager local discovery resolver that requires a registered discovery endpoint before any service has bound one. At a genuine, explicitly provisioned first boot, the checkpointed PDS store is empty and QUIC announcements cannot yet be populated.

## The fix (R5)

- The `OsOwnedFiles` arm uses `install_local_discovery_client` (lazy `try_endpoint` + first-use `dial`) instead of the eager `for_local_bootstrap` constructor.
- `quic_checkpoint_policy` receives the authenticated OS-owned selection and owns invocation of the PDS lifecycle classifier. OS-owned input may classify and map `FirstBoot` to the existing QUIC-deferral policy; DID-anchored input returns the ordinary checkpointed-announcements policy without invoking the classifier or mutating QUIC.
- The causal policy test injects a classifier. It proves the OS-owned first-boot mapping, proves the DID-anchored classifier is never invoked, and fails under a controlled mutation that makes classification unconditional.
- The durable RocksDB first-boot marker remains deleted atomically with the first accepted-state commit. An absent store directory remains fail-closed (`Err`).

## Corrected audit invariant

An OS-owned deployment remains `DeploymentTrustSource::OsOwnedFiles` on restart, so it does classify. When populated, that restart follows the normal checkpointed-announcements path. The narrower invariant is that only the OS-owned QUIC gate consumes lifecycle classification; DID-anchored startup does not classify or defer.

`FIRST_BOOT_KEY` is necessarily used at multiple lifecycle transition sites: explicit marker creation, fallback creation, read/classification, and atomic deletion with the first accepted state. It is incorrect to claim marker operations occur in exactly one source site.

## Trust invariant — held

`authenticate_deployment_bootstrap()` still verifies the deployment checkpoint before resolver installation. Lazy discovery responses remain authenticated by `discovery_vk`; the checkpoint gate is not weakened.