### PR TITLE
fix(oauth): fail closed replay JTI barriers

### DIFF
--- a/crates/hyprstream-rpc/src/auth/claims.rs
+++ b/crates/hyprstream-rpc/src/auth/claims.rs
@@ -682,6 +682,15 @@ mod tests {
     }
 
     #[test]
+    fn expiry_check_handles_i64_max_without_wrapping() {
+        let claims = Claims::new("alice".to_owned(), 0, i64::MAX);
+        assert!(
+            !claims.is_expired(),
+            "an i64::MAX expiry must not wrap into an expired timestamp"
+        );
+    }
+
+    #[test]
     fn test_claims_with_issuer() {
         let claims = Claims::new("alice".to_owned(), 1000, 2000)
             .with_issuer("https://a.example.com".to_owned());

--- a/crates/hyprstream-rpc/src/auth/claims.rs
+++ b/crates/hyprstream-rpc/src/auth/claims.rs
@@ -501,7 +501,7 @@ impl Claims {
 
     /// Check if token is expired (with 5-second leeway for clock skew).
     pub fn is_expired(&self) -> bool {
-        chrono::Utc::now().timestamp() > self.exp + 5
+        chrono::Utc::now().timestamp() > self.exp.saturating_add(5)
     }
 
     /// True if this token was issued by a local node.

--- a/crates/hyprstream-util/src/lib.rs
+++ b/crates/hyprstream-util/src/lib.rs
@@ -10,4 +10,4 @@
 
 pub mod ttl_cache;
 
-pub use ttl_cache::TtlCache;
+pub use ttl_cache::{InsertIfAbsentNoEvictResult, TtlCache};

--- a/crates/hyprstream-util/src/ttl_cache.rs
+++ b/crates/hyprstream-util/src/ttl_cache.rs
@@ -39,6 +39,21 @@ use std::time::{Duration, Instant};
 
 use parking_lot::Mutex;
 
+/// Result of attempting to insert a key into a non-evicting replay barrier.
+///
+/// Callers must distinguish a duplicate (a replay was blocked) from a full
+/// barrier (new traffic was refused to preserve previously recorded security
+/// state).
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+pub enum InsertIfAbsentNoEvictResult {
+    /// The previously unseen key was recorded.
+    Inserted,
+    /// The key was already present and still live.
+    Duplicate,
+    /// The barrier had no capacity for a new key.
+    Full,
+}
+
 /// A cached value with its expiry instant and version tag.
 #[derive(Debug, Clone)]
 struct Entry<V> {
@@ -189,11 +204,16 @@ where
     /// Atomically insert `key` only if it is absent and capacity is available.
     ///
     /// Unlike [`Self::insert_if_absent`], this variant never evicts a live
-    /// entry to make room. It returns `false` for either a duplicate key or a
-    /// full cache. This fail-closed behavior is intended for replay caches
+    /// entry to make room. This fail-closed behavior is intended for replay caches
     /// whose live entries are security state: evicting one early would allow
-    /// the corresponding assertion to be accepted again.
-    pub fn insert_if_absent_no_evict(&self, key: K, value: V, ttl: Duration) -> bool {
+    /// the corresponding assertion to be accepted again. The result separates
+    /// a blocked replay from exhaustion, so operators can alert on the latter.
+    pub fn insert_if_absent_no_evict(
+        &self,
+        key: K,
+        value: V,
+        ttl: Duration,
+    ) -> InsertIfAbsentNoEvictResult {
         let now = Instant::now();
         let expires_at = now + ttl;
         let version = self.next_version.fetch_add(1, Ordering::Relaxed);
@@ -201,8 +221,11 @@ where
         let mut inner = self.inner.lock();
         Self::reap(&mut inner, now, self.reap_budget);
 
-        if inner.entries.contains_key(&key) || inner.entries.len() >= self.max_entries {
-            return false;
+        if inner.entries.contains_key(&key) {
+            return InsertIfAbsentNoEvictResult::Duplicate;
+        }
+        if inner.entries.len() >= self.max_entries {
+            return InsertIfAbsentNoEvictResult::Full;
         }
         inner.entries.insert(
             key.clone(),
@@ -217,7 +240,7 @@ where
             key,
             version,
         }));
-        true
+        InsertIfAbsentNoEvictResult::Inserted
     }
 
     /// Look up `key`, returning a clone of the value if present and not
@@ -417,10 +440,25 @@ mod tests {
     #[test]
     fn insert_if_absent_no_evict_fails_closed_at_capacity() {
         let cache: TtlCache<String, ()> = TtlCache::new(2, 16);
-        assert!(cache.insert_if_absent_no_evict("jti-1".to_owned(), (), Duration::from_secs(60)));
-        assert!(cache.insert_if_absent_no_evict("jti-2".to_owned(), (), Duration::from_secs(60)));
+        assert_eq!(
+            cache.insert_if_absent_no_evict("jti-1".to_owned(), (), Duration::from_secs(60)),
+            InsertIfAbsentNoEvictResult::Inserted
+        );
+        assert_eq!(
+            cache.insert_if_absent_no_evict("jti-2".to_owned(), (), Duration::from_secs(60)),
+            InsertIfAbsentNoEvictResult::Inserted
+        );
 
-        assert!(!cache.insert_if_absent_no_evict("jti-3".to_owned(), (), Duration::from_secs(60)));
+        assert_eq!(
+            cache.insert_if_absent_no_evict("jti-1".to_owned(), (), Duration::from_secs(60)),
+            InsertIfAbsentNoEvictResult::Duplicate,
+            "a replay and capacity exhaustion must be distinguishable"
+        );
+        assert_eq!(
+            cache.insert_if_absent_no_evict("jti-3".to_owned(), (), Duration::from_secs(60)),
+            InsertIfAbsentNoEvictResult::Full,
+            "a full barrier must not evict the earlier jti"
+        );
         assert_eq!(cache.len(), 2);
         assert_eq!(cache.get("jti-1"), Some(()));
         assert_eq!(cache.get("jti-2"), Some(()));

--- a/crates/hyprstream/src/server/middleware.rs
+++ b/crates/hyprstream/src/server/middleware.rs
@@ -194,8 +194,8 @@ pub async fn auth_middleware(
                     result,
                 ) {
                     warn!("DPoP replay barrier is full; refusing fresh proof");
-                } else {
-                    debug!("DPoP proof jti already used: {}", proof.jti);
+                } else if result == InsertIfAbsentNoEvictResult::Duplicate {
+                    debug!("DPoP proof replayed");
                 }
                 return unauthorized_response("Authentication failed", &www_authenticate);
             }

--- a/crates/hyprstream/src/server/middleware.rs
+++ b/crates/hyprstream/src/server/middleware.rs
@@ -178,7 +178,15 @@ pub async fn auth_middleware(
         // iat ±60s window). Atomic check-and-record on the shared TtlCache.
         {
             let now = chrono::Utc::now().timestamp();
-            let ttl_secs = ((proof.iat + 120) - now).max(0) as u64;
+            let Some(ttl_secs) = proof
+                .iat
+                .checked_add(120)
+                .and_then(|deadline| deadline.checked_sub(now))
+                .filter(|remaining| *remaining > 0 && *remaining <= 180)
+                .and_then(|remaining| u64::try_from(remaining).ok())
+            else {
+                return unauthorized_response("Authentication failed", &www_authenticate);
+            };
             let result = state.dpop_jti_seen.insert_if_absent_no_evict(
                 crate::services::oauth::replay_key::dpop_jti(&proof.jti),
                 (),

--- a/crates/hyprstream/src/server/middleware.rs
+++ b/crates/hyprstream/src/server/middleware.rs
@@ -9,6 +9,7 @@ use axum::{
     response::{IntoResponse, Response},
 };
 use hyprstream_rpc::auth::JtiBlocklist as _;
+use hyprstream_util::InsertIfAbsentNoEvictResult;
 use std::sync::Arc;
 use std::time::Duration;
 use std::time::Instant;
@@ -178,12 +179,21 @@ pub async fn auth_middleware(
         {
             let now = chrono::Utc::now().timestamp();
             let ttl_secs = ((proof.iat + 120) - now).max(0) as u64;
-            if !state.dpop_jti_seen.insert_if_absent(
+            let result = state.dpop_jti_seen.insert_if_absent_no_evict(
                 proof.jti.clone(),
                 (),
                 Duration::from_secs(ttl_secs),
-            ) {
-                debug!("DPoP proof jti already used: {}", proof.jti);
+            );
+            if result != InsertIfAbsentNoEvictResult::Inserted {
+                crate::services::oauth::replay_metrics::record_rejection(
+                    crate::services::oauth::replay_metrics::DPOP,
+                    result,
+                );
+                if result == InsertIfAbsentNoEvictResult::Full {
+                    warn!("DPoP replay barrier is full; refusing fresh proof");
+                } else {
+                    debug!("DPoP proof jti already used: {}", proof.jti);
+                }
                 return unauthorized_response("Authentication failed", &www_authenticate);
             }
         }

--- a/crates/hyprstream/src/server/middleware.rs
+++ b/crates/hyprstream/src/server/middleware.rs
@@ -1,7 +1,7 @@
 //! Middleware for authentication, logging, and request processing
 
 use crate::auth::jwt;
-use crate::server::state::{ResourceAuthState, ServerState};
+use crate::server::state::ResourceAuthState;
 use axum::{
     extract::{Request, State},
     http::{header, HeaderValue, StatusCode},
@@ -582,13 +582,6 @@ pub(crate) async fn verify_resource_token_claims(
     claims.strip_federated_clearance(local_issuers);
     claims.strip_federated_tenant(local_issuers);
     Ok(claims)
-}
-
-pub(crate) async fn verify_token_claims(
-    state: &ServerState,
-    token: &str,
-) -> Result<jwt::Claims, &'static str> {
-    verify_resource_token_claims(&state.resource_auth_state(), token).await
 }
 
 /// Build WWW-Authenticate header value with resource_metadata URL (RFC 9728).

--- a/crates/hyprstream/src/server/middleware.rs
+++ b/crates/hyprstream/src/server/middleware.rs
@@ -180,7 +180,7 @@ pub async fn auth_middleware(
             let now = chrono::Utc::now().timestamp();
             let ttl_secs = ((proof.iat + 120) - now).max(0) as u64;
             let result = state.dpop_jti_seen.insert_if_absent_no_evict(
-                proof.jti.clone(),
+                crate::services::oauth::replay_key::dpop_jti(&proof.jti),
                 (),
                 Duration::from_secs(ttl_secs),
             );
@@ -189,7 +189,10 @@ pub async fn auth_middleware(
                     crate::services::oauth::replay_metrics::DPOP,
                     result,
                 );
-                if result == InsertIfAbsentNoEvictResult::Full {
+                if crate::services::oauth::replay_metrics::should_warn_full(
+                    crate::services::oauth::replay_metrics::DPOP,
+                    result,
+                ) {
                     warn!("DPoP replay barrier is full; refusing fresh proof");
                 } else {
                     debug!("DPoP proof jti already used: {}", proof.jti);

--- a/crates/hyprstream/src/server/routes/ninep.rs
+++ b/crates/hyprstream/src/server/routes/ninep.rs
@@ -24,7 +24,7 @@
 //!
 //! The mount ticket rides the URL query (`?ticket=<at+jwt>`) because a browser
 //! `WebSocket` cannot set request headers. It is validated at the WS upgrade
-//! via [`crate::server::middleware::verify_token_claims`] — the exact same
+//! via [`crate::server::middleware::verify_resource_token_claims`] — the exact same
 //! chain `auth_middleware` uses (issuer routing, Ed25519/ML-DSA signature +
 //! audience validation, JTI revocation). The validated `sub` becomes the
 //! session [`Subject`], threaded onto every 9P op by [`MountBackend`] (the
@@ -72,7 +72,7 @@ use serde::{Deserialize, Serialize};
 use tokio::io::{split, AsyncReadExt, AsyncWriteExt};
 use tracing::{debug, info, warn};
 
-use crate::server::state::ServerState;
+use crate::server::state::{ResourceAuthState, ServerState};
 
 const PLANE_WS: &str = "ws";
 const PLANE_WEBTRANSPORT: &str = "webtransport";
@@ -310,10 +310,10 @@ pub async fn ninep_ws(
 }
 
 /// Validate a mount ticket to a session [`Subject`], reusing the server auth
-/// chain ([`verify_token_claims`](crate::server::middleware::verify_token_claims)).
+/// chain ([`verify_resource_token_claims`](crate::server::middleware::verify_resource_token_claims)).
 ///
 /// Real controls enforced here: Ed25519/ML-DSA signature, audience binding to
-/// this resource, expiry, and JTI revocation (all inside `verify_token_claims`),
+/// this resource, expiry, and JTI revocation (all inside `verify_resource_token_claims`),
 /// plus subject-name validation. The `sub` becomes the session Subject.
 ///
 /// NOTE (flagged design fork — see PR body): one-shot replay prevention and
@@ -326,22 +326,23 @@ async fn validate_ticket(
     plane: &str,
     namespace_path: &str,
 ) -> Result<VerifiedAttach, &'static str> {
-    verify_mount_ticket(state, ticket, plane, namespace_path).await
+    let resource_state = state.resource_auth_state();
+    verify_mount_ticket(&resource_state, ticket, plane, namespace_path).await
 }
 
 /// Transport-agnostic core of mount-ticket validation, shared by H1a's
 /// URL-query path ([`validate_ticket`]) and H1b's `Tattach.uname` path
 /// ([`TicketAttachAuthorizer`]). Both present the same mount-ticket JWT;
 /// only *where* it rides differs (WS query vs 9P attach), so the verification —
-/// signature, expiry, revocation (in `verify_token_claims`), explicit
+/// signature, expiry, revocation (in `verify_resource_token_claims`), explicit
 /// mount-capability marker, then subject-name validation — is identical.
 async fn verify_mount_ticket(
-    state: &ServerState,
+    state: &ResourceAuthState,
     ticket: &str,
     plane: &str,
     namespace_path: &str,
 ) -> Result<VerifiedAttach, &'static str> {
-    let claims = crate::server::middleware::verify_token_claims(state, ticket).await?;
+    let claims = crate::server::middleware::verify_resource_token_claims(state, ticket).await?;
     // Mount tickets are local, MAC-bound credentials. Federation can attest an
     // identity for ordinary resource access, but cannot consume this shared
     // replay barrier or choose a local tenant/clearance.
@@ -665,7 +666,8 @@ impl AttachAuthorizer for TicketAttachAuthorizer {
         // NO fallback to a default export after an explicit selector
         // (#877/#1071 fail-closed contract).
         let requested_ns = aname_to_namespace_path(aname)?;
-        match verify_mount_ticket(&self.state, uname, PLANE_WEBTRANSPORT, &requested_ns).await {
+        let resource_state = self.state.resource_auth_state();
+        match verify_mount_ticket(&resource_state, uname, PLANE_WEBTRANSPORT, &requested_ns).await {
             Ok(verified) => Ok(verified),
             Err(reason) => {
                 warn!(reason, aname = %aname, "9P WT attach rejected: invalid mount ticket or export");
@@ -776,8 +778,135 @@ pub fn register_ninep_wt_handler(state: ServerState) {
 mod tests {
     use super::*;
     use axum::{routing::get, Router};
+    use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine as _};
+    use ed25519_dalek::Signer as _;
     use hyprstream_9p::msg::{self, Response as P9Response};
     use tokio_tungstenite::tungstenite::Message as WsMessage;
+
+    fn mount_claims(now: i64) -> hyprstream_rpc::auth::Claims {
+        hyprstream_rpc::auth::Claims::new("alice".to_owned(), now, now + 60)
+            .with_issuer("https://issuer.test".to_owned())
+            .with_audience(Some("https://resource.test".to_owned()))
+            .with_cap(crate::services::oauth::mount_ticket::ticket_capability("ws", "/"))
+            .with_tenant("tenant.test".to_owned())
+            .with_clearance(hyprstream_rpc::auth::mac::SecurityLabel::new(
+                hyprstream_rpc::auth::mac::Level::Secret,
+                hyprstream_rpc::auth::mac::Assurance::Classical,
+                hyprstream_rpc::auth::mac::CompartmentSet::EMPTY,
+            ))
+            .with_jti()
+    }
+
+    fn mount_ticket_state(
+    ) -> (
+        ResourceAuthState,
+        ed25519_dalek::SigningKey,
+        hyprstream_rpc::crypto::pq::MlDsaSigningKey,
+    ) {
+        let ed25519 = ed25519_dalek::SigningKey::from_bytes(&[0x5a; 32]);
+        let (ml_dsa, ml_dsa_verifying) = hyprstream_rpc::crypto::pq::ml_dsa_generate_keypair();
+        let composite_keys = Arc::new(hyprstream_rpc::auth::CompositeKeySet::default());
+        let pair = hyprstream_rpc::auth::CompositeKeyPair::verifying(
+            crate::auth::jwt::composite_kid(&ml_dsa_verifying, &ed25519.verifying_key()),
+            ml_dsa_verifying,
+            ed25519.verifying_key(),
+            hyprstream_rpc::auth::CompositePairRole::OAuth,
+            hyprstream_rpc::auth::CompositePairState::Active,
+            0,
+            i64::MAX,
+        );
+        composite_keys
+            .publish(1, "ninep-test".to_owned(), vec![pair])
+            .expect("test composite pair must publish");
+
+        let trusted = std::collections::HashMap::new();
+        let mut state = ResourceAuthState::new(
+            ed25519.verifying_key(),
+            "https://resource.test".to_owned(),
+            "https://issuer.test".to_owned(),
+            Arc::new(crate::auth::FederationKeyResolver::new(&trusted)),
+            Arc::new(hyprstream_rpc::auth::InMemoryJtiBlocklist::new()),
+        );
+        state.composite_key_set = composite_keys;
+        state.dpop_jti_seen = Arc::new(hyprstream_util::TtlCache::new(8, 16));
+        (state, ed25519, ml_dsa)
+    }
+
+    /// Test-only composite encoder that intentionally preserves an absent JTI.
+    /// Production encoders correctly add one, but this consumer must reject a
+    /// signed legacy/malformed ticket before it touches replay state.
+    fn encode_mount_ticket(
+        claims: &hyprstream_rpc::auth::Claims,
+        ml_dsa: &hyprstream_rpc::crypto::pq::MlDsaSigningKey,
+        ed25519: &ed25519_dalek::SigningKey,
+    ) -> String {
+        let ml_dsa_verifying = ml_dsa::Keypair::verifying_key(ml_dsa);
+        let kid = crate::auth::jwt::composite_kid(&ml_dsa_verifying, &ed25519.verifying_key());
+        let header = serde_json::json!({
+            "alg": "ML-DSA-65-Ed25519",
+            "typ": "at+jwt",
+            "kid": kid,
+        });
+        let signing_input = format!(
+            "{}.{}",
+            URL_SAFE_NO_PAD.encode(serde_json::to_vec(&header).expect("test header serializes")),
+            URL_SAFE_NO_PAD.encode(serde_json::to_vec(claims).expect("test claims serialize")),
+        );
+        let mut signature = hyprstream_rpc::crypto::pq::ml_dsa_sign(ml_dsa, signing_input.as_bytes());
+        signature.extend_from_slice(&ed25519.sign(signing_input.as_bytes()).to_bytes());
+        format!("{signing_input}.{}", URL_SAFE_NO_PAD.encode(signature))
+    }
+
+    #[tokio::test]
+    async fn mount_ticket_consumer_admits_once_without_pre_admission_consumption() {
+        let (state, ed25519, ml_dsa) = mount_ticket_state();
+        let now = chrono::Utc::now().timestamp();
+        let local_claims = mount_claims(now);
+        let local = encode_mount_ticket(&local_claims, &ml_dsa, &ed25519);
+        let first = verify_mount_ticket(&state, &local, "ws", "/").await;
+        assert!(first.is_ok(), "local ticket rejected: {first:?}");
+        assert!(verify_mount_ticket(&state, &local, "ws", "/").await.is_err());
+        let occupied = state.dpop_jti_seen.len();
+        assert_eq!(occupied, 1);
+
+        let mut federated = mount_claims(now);
+        federated.iss = "https://federation.test".to_owned();
+        let mut missing_tenant = mount_claims(now);
+        missing_tenant.tenant = None;
+        let mut missing_clearance = mount_claims(now);
+        missing_clearance.clearance = None;
+        let mut missing_jti = mount_claims(now);
+        missing_jti.jti = None;
+        let mut future_iat = mount_claims(now);
+        future_iat.iat = now + 1;
+        future_iat.exp = now + 61;
+        let mut extreme_i64 = mount_claims(now);
+        extreme_i64.iat = i64::MIN;
+        extreme_i64.exp = i64::MAX;
+        let mut overlong = mount_claims(now);
+        overlong.exp = now + crate::services::oauth::mount_ticket::MOUNT_TICKET_TTL + 1;
+
+        for (case, claims) in [
+            ("federated issuer", federated),
+            ("missing tenant", missing_tenant),
+            ("missing clearance", missing_clearance),
+            ("missing JTI", missing_jti),
+            ("future iat", future_iat),
+            ("extreme i64", extreme_i64),
+            ("overlong lifetime", overlong),
+        ] {
+            let token = encode_mount_ticket(&claims, &ml_dsa, &ed25519);
+            assert!(
+                verify_mount_ticket(&state, &token, "ws", "/").await.is_err(),
+                "{case} ticket was accepted"
+            );
+            assert_eq!(
+                state.dpop_jti_seen.len(),
+                occupied,
+                "{case} ticket consumed replay capacity"
+            );
+        }
+    }
 
     struct TransportTestDecider;
 

--- a/crates/hyprstream/src/server/routes/ninep.rs
+++ b/crates/hyprstream/src/server/routes/ninep.rs
@@ -363,7 +363,7 @@ async fn verify_mount_ticket(
     let now = chrono::Utc::now().timestamp();
     let ttl = (claims.exp - now).max(0) as u64;
     let result = state.dpop_jti_seen.insert_if_absent_no_evict(
-        format!("mount-ticket:{jti}"),
+        crate::services::oauth::replay_key::mount_ticket_jti(jti),
         (),
         Duration::from_secs(ttl),
     );
@@ -372,7 +372,10 @@ async fn verify_mount_ticket(
             crate::services::oauth::replay_metrics::DPOP,
             result,
         );
-        if result == hyprstream_util::InsertIfAbsentNoEvictResult::Full {
+        if crate::services::oauth::replay_metrics::should_warn_full(
+            crate::services::oauth::replay_metrics::DPOP,
+            result,
+        ) {
             warn!("DPoP replay barrier is full; refusing fresh mount ticket");
         }
         return Err("mount ticket already used");

--- a/crates/hyprstream/src/server/routes/ninep.rs
+++ b/crates/hyprstream/src/server/routes/ninep.rs
@@ -342,6 +342,12 @@ async fn verify_mount_ticket(
     namespace_path: &str,
 ) -> Result<VerifiedAttach, &'static str> {
     let claims = crate::server::middleware::verify_token_claims(state, ticket).await?;
+    // Mount tickets are local, MAC-bound credentials. Federation can attest an
+    // identity for ordinary resource access, but cannot consume this shared
+    // replay barrier or choose a local tenant/clearance.
+    if claims.iss != state.oauth_issuer_url {
+        return Err("mount ticket issuer is not local");
+    }
     if !crate::services::oauth::mount_ticket::is_mount_ticket_for(&claims, plane, namespace_path) {
         return Err("token is not valid for this 9P plane/path");
     }
@@ -357,11 +363,36 @@ async fn verify_mount_ticket(
         Some(n) if !n.is_empty() => {}
         _ => return Err("empty subject"),
     }
+    // Validate all authority and time admission before consuming one-use
+    // replay state. The bounded duration also makes subsequent Instant
+    // arithmetic safe from attacker-controlled overflow.
+    claims
+        .tenant
+        .as_deref()
+        .filter(|tenant| !tenant.is_empty() && *tenant != "*")
+        .ok_or("mount ticket missing authority-bound tenant")?;
+    claims
+        .security_context(VerifiedKeyMaterial::Classical)
+        .ok_or("mount ticket missing verified Claims clearance")?;
     let Some(jti) = claims.jti.as_ref() else {
         return Err("mount ticket missing jti");
     };
     let now = chrono::Utc::now().timestamp();
-    let ttl = (claims.exp - now).max(0) as u64;
+    let max_lifetime = crate::services::oauth::mount_ticket::MOUNT_TICKET_TTL;
+    let lifetime = claims
+        .exp
+        .checked_sub(claims.iat)
+        .filter(|lifetime| *lifetime > 0 && *lifetime <= max_lifetime)
+        .ok_or("mount ticket lifetime is invalid")?;
+    let remaining = claims
+        .exp
+        .checked_sub(now)
+        .filter(|remaining| *remaining > 0 && *remaining <= max_lifetime)
+        .ok_or("mount ticket expired")?;
+    if claims.iat > now || lifetime > max_lifetime {
+        return Err("mount ticket issued in the future");
+    }
+    let ttl = u64::try_from(remaining).map_err(|_| "mount ticket lifetime is invalid")?;
     let result = state.dpop_jti_seen.insert_if_absent_no_evict(
         crate::services::oauth::replay_key::mount_ticket_jti(jti),
         (),

--- a/crates/hyprstream/src/server/routes/ninep.rs
+++ b/crates/hyprstream/src/server/routes/ninep.rs
@@ -316,9 +316,8 @@ pub async fn ninep_ws(
 /// this resource, expiry, and JTI revocation (all inside `verify_resource_token_claims`),
 /// plus subject-name validation. The `sub` becomes the session Subject.
 ///
-/// NOTE (flagged design fork — see PR body): one-shot replay prevention and
-/// explicit browser-`Origin` binding beyond the JWT `aud` are NOT yet enforced;
-/// the current controls are signature + short expiry + audience + revocation.
+/// One-shot replay prevention is enforced for mount tickets. Explicit browser
+/// `Origin` binding beyond the JWT `aud` remains a separate design concern.
 async fn validate_ticket(
     state: &ServerState,
     ticket: &str,
@@ -802,8 +801,10 @@ mod tests {
         ResourceAuthState,
         ed25519_dalek::SigningKey,
         hyprstream_rpc::crypto::pq::MlDsaSigningKey,
+        ed25519_dalek::SigningKey,
     ) {
         let ed25519 = ed25519_dalek::SigningKey::from_bytes(&[0x5a; 32]);
+        let federation_ed25519 = ed25519_dalek::SigningKey::from_bytes(&[0x5b; 32]);
         let (ml_dsa, ml_dsa_verifying) = hyprstream_rpc::crypto::pq::ml_dsa_generate_keypair();
         let composite_keys = Arc::new(hyprstream_rpc::auth::CompositeKeySet::default());
         let pair = hyprstream_rpc::auth::CompositeKeyPair::verifying(
@@ -819,17 +820,44 @@ mod tests {
             .publish(1, "ninep-test".to_owned(), vec![pair])
             .expect("test composite pair must publish");
 
-        let trusted = std::collections::HashMap::new();
+        let federation_issuer = "https://federation.test";
+        let federation_kid = hyprstream_rpc::auth::jwt::kid_for_key(&federation_ed25519);
+        let federation_jwks = serde_json::json!({
+            "keys": [{
+                "kty": "OKP",
+                "crv": "Ed25519",
+                "x": URL_SAFE_NO_PAD.encode(federation_ed25519.verifying_key().as_bytes()),
+                "use": "sig",
+                "alg": "EdDSA",
+                "kid": federation_kid,
+            }]
+        });
+        let mut trusted = std::collections::HashMap::new();
+        trusted.insert(
+            federation_issuer.to_owned(),
+            crate::config::TrustedIssuerConfig {
+                jwks_uri: Some(format!("{federation_issuer}/jwks")),
+                jwks_cache_ttl_secs: 300,
+                allow_http: false,
+            },
+        );
+        let federation_fetcher = Arc::new(move |_url: &str| -> std::pin::Pin<Box<dyn std::future::Future<Output = anyhow::Result<serde_json::Value>> + Send>> {
+            let federation_jwks = federation_jwks.clone();
+            Box::pin(async move { Ok(federation_jwks) })
+        });
         let mut state = ResourceAuthState::new(
             ed25519.verifying_key(),
             "https://resource.test".to_owned(),
             "https://issuer.test".to_owned(),
-            Arc::new(crate::auth::FederationKeyResolver::new(&trusted)),
+            Arc::new(
+                crate::auth::FederationKeyResolver::new(&trusted)
+                    .with_jwks_fetcher(federation_fetcher),
+            ),
             Arc::new(hyprstream_rpc::auth::InMemoryJtiBlocklist::new()),
         );
         state.composite_key_set = composite_keys;
         state.dpop_jti_seen = Arc::new(hyprstream_util::TtlCache::new(8, 16));
-        (state, ed25519, ml_dsa)
+        (state, ed25519, ml_dsa, federation_ed25519)
     }
 
     /// Test-only composite encoder that intentionally preserves an absent JTI.
@@ -859,7 +887,7 @@ mod tests {
 
     #[tokio::test]
     async fn mount_ticket_consumer_admits_once_without_pre_admission_consumption() {
-        let (state, ed25519, ml_dsa) = mount_ticket_state();
+        let (state, ed25519, ml_dsa, federation_ed25519) = mount_ticket_state();
         let now = chrono::Utc::now().timestamp();
         let local_claims = mount_claims(now);
         let local = encode_mount_ticket(&local_claims, &ml_dsa, &ed25519);
@@ -871,6 +899,18 @@ mod tests {
 
         let mut federated = mount_claims(now);
         federated.iss = "https://federation.test".to_owned();
+        let federated = crate::auth::jwt::encode(&federated, &federation_ed25519);
+        assert_eq!(
+            verify_mount_ticket(&state, &federated, "ws", "/").await,
+            Err("mount ticket issuer is not local"),
+            "a trusted federated ticket must reach the mount-only issuer guard"
+        );
+        assert_eq!(
+            state.dpop_jti_seen.len(),
+            occupied,
+            "a federated mount ticket consumed replay capacity"
+        );
+
         let mut missing_tenant = mount_claims(now);
         missing_tenant.tenant = None;
         let mut missing_clearance = mount_claims(now);
@@ -878,8 +918,8 @@ mod tests {
         let mut missing_jti = mount_claims(now);
         missing_jti.jti = None;
         let mut future_iat = mount_claims(now);
-        future_iat.iat = now + 1;
-        future_iat.exp = now + 61;
+        future_iat.iat = now + 120;
+        future_iat.exp = now + 180;
         let mut extreme_i64 = mount_claims(now);
         extreme_i64.iat = i64::MIN;
         extreme_i64.exp = i64::MAX;
@@ -887,7 +927,6 @@ mod tests {
         overlong.exp = now + crate::services::oauth::mount_ticket::MOUNT_TICKET_TTL + 1;
 
         for (case, claims) in [
-            ("federated issuer", federated),
             ("missing tenant", missing_tenant),
             ("missing clearance", missing_clearance),
             ("missing JTI", missing_jti),

--- a/crates/hyprstream/src/server/routes/ninep.rs
+++ b/crates/hyprstream/src/server/routes/ninep.rs
@@ -362,11 +362,19 @@ async fn verify_mount_ticket(
     };
     let now = chrono::Utc::now().timestamp();
     let ttl = (claims.exp - now).max(0) as u64;
-    if !state.dpop_jti_seen.insert_if_absent(
+    let result = state.dpop_jti_seen.insert_if_absent_no_evict(
         format!("mount-ticket:{jti}"),
         (),
         Duration::from_secs(ttl),
-    ) {
+    );
+    if result != hyprstream_util::InsertIfAbsentNoEvictResult::Inserted {
+        crate::services::oauth::replay_metrics::record_rejection(
+            crate::services::oauth::replay_metrics::DPOP,
+            result,
+        );
+        if result == hyprstream_util::InsertIfAbsentNoEvictResult::Full {
+            warn!("DPoP replay barrier is full; refusing fresh mount ticket");
+        }
         return Err("mount ticket already used");
     }
     verified_attach_from_claims(claims, subject)

--- a/crates/hyprstream/src/server/routes/ninep.rs
+++ b/crates/hyprstream/src/server/routes/ninep.rs
@@ -439,16 +439,22 @@ fn verified_attach_from_claims(
     let security_context = claims
         .security_context(VerifiedKeyMaterial::Classical)
         .ok_or("mount ticket missing verified Claims clearance")?;
-    let valid_for = (claims.exp - chrono::Utc::now().timestamp()).max(0) as u64;
-    if valid_for == 0 {
-        return Err("mount ticket expired");
-    }
+    let valid_for = claims
+        .exp
+        .checked_sub(chrono::Utc::now().timestamp())
+        .filter(|remaining| {
+            *remaining > 0 && *remaining <= crate::services::oauth::mount_ticket::MOUNT_TICKET_TTL
+        })
+        .and_then(|remaining| u64::try_from(remaining).ok())
+        .ok_or("mount ticket expired")?;
     let identity =
         VerifiedAttachIdentity::from_verified_credential(claims.sub.clone(), tenant.to_owned());
     let scope = VerifiedTokenScope::from_verified_token(
         *security_context.clearance(),
         Arc::from(NINEP_ALL_ACTIONS),
-        Instant::now() + Duration::from_secs(valid_for),
+        Instant::now()
+            .checked_add(Duration::from_secs(valid_for))
+            .ok_or("mount ticket expiry is invalid")?,
     );
     let session = SessionContext::from_verified_token(identity.clone(), security_context, scope);
     let verified = VerifiedAttach::try_new(identity, subject, session)

--- a/crates/hyprstream/src/server/state.rs
+++ b/crates/hyprstream/src/server/state.rs
@@ -8,6 +8,11 @@ use std::collections::HashMap;
 use std::sync::Arc;
 use tokio::sync::RwLock;
 
+/// 1,000 sustained proofs or mount tickets/s for the longest (five-minute)
+/// replay window, plus 20% headroom. Ordinary DPoP proofs expire after 120s.
+const DPOP_JTI_MAX_ENTRIES: usize = 360_000;
+const DPOP_JTI_REAP_BUDGET: usize = 64;
+
 // Re-export config types so other server modules can access them via server::state
 pub use crate::config::{CorsConfig, SamplingParamDefaults, ServerConfig};
 
@@ -72,7 +77,7 @@ pub struct ServerState {
 
     /// Per-request DPoP JTI dedup cache (RFC 9449 §11.1 replay prevention).
     /// Backed by the shared `TtlCache` with atomic check-and-record
-    /// (`insert_if_absent`); TTL = iat + 120s; self-evicting.
+    /// (`insert_if_absent_no_evict`); TTL = iat + 120s; fail-closed at capacity.
     pub dpop_jti_seen: Arc<TtlCache<String, ()>>,
 
     /// Per-subject request rate limiter (fixed window, 300 req/60s default).
@@ -127,7 +132,7 @@ impl ResourceAuthState {
             oauth_issuer_url,
             federation_resolver,
             jti_blocklist,
-            dpop_jti_seen: Arc::new(TtlCache::new(10_000, 64)),
+            dpop_jti_seen: Arc::new(TtlCache::new(DPOP_JTI_MAX_ENTRIES, DPOP_JTI_REAP_BUDGET)),
             rate_limiter: Arc::new(crate::server::middleware::RateLimiter::new(300, 60)),
         }
     }
@@ -249,7 +254,7 @@ impl ServerState {
             oauth_issuer_url,
             federation_resolver,
             jti_blocklist,
-            dpop_jti_seen: Arc::new(TtlCache::new(10_000, 64)),
+            dpop_jti_seen: Arc::new(TtlCache::new(DPOP_JTI_MAX_ENTRIES, DPOP_JTI_REAP_BUDGET)),
             rate_limiter: Arc::new(crate::server::middleware::RateLimiter::new(300, 60)),
             browser_provisioning_rate_limiter: Arc::new(
                 crate::server::middleware::RateLimiter::new(60, 60),

--- a/crates/hyprstream/src/server/state.rs
+++ b/crates/hyprstream/src/server/state.rs
@@ -2,6 +2,7 @@
 
 use crate::services::generated::model_client::{LoadModelRequest, ModelClient};
 use crate::services::{PolicyClient, RegistryClient};
+use crate::services::oauth::replay_key::ReplayKey;
 use ed25519_dalek::{SigningKey, VerifyingKey};
 use hyprstream_util::TtlCache;
 use std::collections::HashMap;
@@ -10,6 +11,8 @@ use tokio::sync::RwLock;
 
 /// 1,000 sustained proofs or mount tickets/s for the longest (five-minute)
 /// replay window, plus 20% headroom. Ordinary DPoP proofs expire after 120s.
+/// Fixed BLAKE3-256 digest keys at 128 bytes/live entry plan this at about
+/// 43.9 MiB before allocator slack.
 const DPOP_JTI_MAX_ENTRIES: usize = 360_000;
 const DPOP_JTI_REAP_BUDGET: usize = 64;
 
@@ -78,7 +81,7 @@ pub struct ServerState {
     /// Per-request DPoP JTI dedup cache (RFC 9449 §11.1 replay prevention).
     /// Backed by the shared `TtlCache` with atomic check-and-record
     /// (`insert_if_absent_no_evict`); TTL = iat + 120s; fail-closed at capacity.
-    pub dpop_jti_seen: Arc<TtlCache<String, ()>>,
+    pub dpop_jti_seen: Arc<TtlCache<ReplayKey, ()>>,
 
     /// Per-subject request rate limiter (fixed window, 300 req/60s default).
     pub rate_limiter: Arc<crate::server::middleware::RateLimiter>,
@@ -111,7 +114,7 @@ pub struct ResourceAuthState {
     pub oauth_issuer_url: String,
     pub federation_resolver: Arc<crate::auth::FederationKeyResolver>,
     pub jti_blocklist: Arc<hyprstream_rpc::auth::InMemoryJtiBlocklist>,
-    pub dpop_jti_seen: Arc<TtlCache<String, ()>>,
+    pub dpop_jti_seen: Arc<TtlCache<ReplayKey, ()>>,
     pub rate_limiter: Arc<crate::server::middleware::RateLimiter>,
 }
 

--- a/crates/hyprstream/src/services/factories.rs
+++ b/crates/hyprstream/src/services/factories.rs
@@ -1916,7 +1916,19 @@ fn create_mcp_service(ctx: &ServiceContext) -> anyhow::Result<Box<dyn Spawnable>
                                 // Replay prevention: atomic check-and-record on the shared TtlCache.
                                 {
                                     let now = chrono::Utc::now().timestamp();
-                                    let ttl_secs = ((proof.iat + 120) - now).max(0) as u64;
+                                    let Some(ttl_secs) = proof
+                                        .iat
+                                        .checked_add(120)
+                                        .and_then(|deadline| deadline.checked_sub(now))
+                                        .filter(|remaining| *remaining > 0 && *remaining <= 180)
+                                        .and_then(|remaining| u64::try_from(remaining).ok())
+                                    else {
+                                        let mut res = (StatusCode::UNAUTHORIZED, "Authentication failed").into_response();
+                                        if let Ok(val) = header::HeaderValue::from_str(&www_authenticate) {
+                                            res.headers_mut().insert(header::WWW_AUTHENTICATE, val);
+                                        }
+                                        return res;
+                                    };
                                     let result = dpop_jti_seen.insert_if_absent_no_evict(
                                         crate::services::oauth::replay_key::dpop_jti(&proof.jti),
                                         (),

--- a/crates/hyprstream/src/services/factories.rs
+++ b/crates/hyprstream/src/services/factories.rs
@@ -1726,8 +1726,10 @@ fn create_mcp_service(ctx: &ServiceContext) -> anyhow::Result<Box<dyn Spawnable>
                     // Capture shared JTI blocklist for revocation checks (RFC 7009)
                     let mcp_jti_blocklist = SHARED_JTI_BLOCKLIST.get().map(Arc::clone);
                     // DPoP JTI replay cache (separate from OAI server's, RFC 9449).
+                    // 1,000 sustained DPoP proofs/s for the 120s replay window,
+                    // plus 20% headroom. This barrier never evicts live JTIs.
                     let mcp_dpop_jti_seen: std::sync::Arc<hyprstream_util::TtlCache<String, ()>> =
-                        std::sync::Arc::new(hyprstream_util::TtlCache::new(10_000, 64));
+                        std::sync::Arc::new(hyprstream_util::TtlCache::new(144_000, 64));
                     move |mut req: axum::extract::Request, next: axum::middleware::Next| {
                         let www_authenticate = www_authenticate.clone();
                         let mcp_resource_url = mcp_resource_url.clone();
@@ -1909,12 +1911,21 @@ fn create_mcp_service(ctx: &ServiceContext) -> anyhow::Result<Box<dyn Spawnable>
                                 {
                                     let now = chrono::Utc::now().timestamp();
                                     let ttl_secs = ((proof.iat + 120) - now).max(0) as u64;
-                                    if !dpop_jti_seen.insert_if_absent(
+                                    let result = dpop_jti_seen.insert_if_absent_no_evict(
                                         proof.jti.clone(),
                                         (),
                                         std::time::Duration::from_secs(ttl_secs),
-                                    ) {
-                                        tracing::debug!(%method, %uri, jti = %proof.jti, "MCP: DPoP jti replayed");
+                                    );
+                                    if result != hyprstream_util::InsertIfAbsentNoEvictResult::Inserted {
+                                        crate::services::oauth::replay_metrics::record_rejection(
+                                            crate::services::oauth::replay_metrics::DPOP,
+                                            result,
+                                        );
+                                        if result == hyprstream_util::InsertIfAbsentNoEvictResult::Full {
+                                            tracing::warn!(%method, %uri, "MCP: DPoP replay barrier is full; refusing fresh proof");
+                                        } else {
+                                            tracing::debug!(%method, %uri, jti = %proof.jti, "MCP: DPoP jti replayed");
+                                        }
                                         let mut res = (StatusCode::UNAUTHORIZED, "Authentication failed").into_response();
                                         if let Ok(val) = header::HeaderValue::from_str(&www_authenticate) {
                                             res.headers_mut().insert(header::WWW_AUTHENTICATE, val);

--- a/crates/hyprstream/src/services/factories.rs
+++ b/crates/hyprstream/src/services/factories.rs
@@ -1726,15 +1726,16 @@ fn create_mcp_service(ctx: &ServiceContext) -> anyhow::Result<Box<dyn Spawnable>
                     // Capture shared JTI blocklist for revocation checks (RFC 7009)
                     let mcp_jti_blocklist = SHARED_JTI_BLOCKLIST.get().map(Arc::clone);
                     // DPoP JTI replay cache (separate from OAI server's, RFC 9449).
-                    // 1,000 sustained DPoP proofs/s for the 120s replay window,
-                    // plus 20% headroom. Fixed BLAKE3-256 digest keys plan at
-                    // about 17.6 MiB before allocator slack; this barrier
+                    // 1,000 sustained DPoP proofs/s for the admitted 180s
+                    // maximum residency (60s future iat skew + 120s), plus
+                    // 20% headroom. Fixed digest keys plan 216,000 entries at
+                    // about 26.4 MiB before allocator slack; this barrier
                     // never evicts live JTIs.
                     let mcp_dpop_jti_seen: std::sync::Arc<hyprstream_util::TtlCache<
                         crate::services::oauth::replay_key::ReplayKey,
                         (),
                     >> =
-                        std::sync::Arc::new(hyprstream_util::TtlCache::new(144_000, 64));
+                        std::sync::Arc::new(hyprstream_util::TtlCache::new(216_000, 64));
                     move |mut req: axum::extract::Request, next: axum::middleware::Next| {
                         let www_authenticate = www_authenticate.clone();
                         let mcp_resource_url = mcp_resource_url.clone();
@@ -1931,8 +1932,10 @@ fn create_mcp_service(ctx: &ServiceContext) -> anyhow::Result<Box<dyn Spawnable>
                                             result,
                                         ) {
                                             tracing::warn!(%method, %uri, "MCP: DPoP replay barrier is full; refusing fresh proof");
-                                        } else {
-                                            tracing::debug!(%method, %uri, jti = %proof.jti, "MCP: DPoP jti replayed");
+                                        } else if result
+                                            == hyprstream_util::InsertIfAbsentNoEvictResult::Duplicate
+                                        {
+                                            tracing::debug!(%method, %uri, "MCP: DPoP proof replayed");
                                         }
                                         let mut res = (StatusCode::UNAUTHORIZED, "Authentication failed").into_response();
                                         if let Ok(val) = header::HeaderValue::from_str(&www_authenticate) {

--- a/crates/hyprstream/src/services/factories.rs
+++ b/crates/hyprstream/src/services/factories.rs
@@ -1727,8 +1727,13 @@ fn create_mcp_service(ctx: &ServiceContext) -> anyhow::Result<Box<dyn Spawnable>
                     let mcp_jti_blocklist = SHARED_JTI_BLOCKLIST.get().map(Arc::clone);
                     // DPoP JTI replay cache (separate from OAI server's, RFC 9449).
                     // 1,000 sustained DPoP proofs/s for the 120s replay window,
-                    // plus 20% headroom. This barrier never evicts live JTIs.
-                    let mcp_dpop_jti_seen: std::sync::Arc<hyprstream_util::TtlCache<String, ()>> =
+                    // plus 20% headroom. Fixed BLAKE3-256 digest keys plan at
+                    // about 17.6 MiB before allocator slack; this barrier
+                    // never evicts live JTIs.
+                    let mcp_dpop_jti_seen: std::sync::Arc<hyprstream_util::TtlCache<
+                        crate::services::oauth::replay_key::ReplayKey,
+                        (),
+                    >> =
                         std::sync::Arc::new(hyprstream_util::TtlCache::new(144_000, 64));
                     move |mut req: axum::extract::Request, next: axum::middleware::Next| {
                         let www_authenticate = www_authenticate.clone();
@@ -1912,7 +1917,7 @@ fn create_mcp_service(ctx: &ServiceContext) -> anyhow::Result<Box<dyn Spawnable>
                                     let now = chrono::Utc::now().timestamp();
                                     let ttl_secs = ((proof.iat + 120) - now).max(0) as u64;
                                     let result = dpop_jti_seen.insert_if_absent_no_evict(
-                                        proof.jti.clone(),
+                                        crate::services::oauth::replay_key::dpop_jti(&proof.jti),
                                         (),
                                         std::time::Duration::from_secs(ttl_secs),
                                     );
@@ -1921,7 +1926,10 @@ fn create_mcp_service(ctx: &ServiceContext) -> anyhow::Result<Box<dyn Spawnable>
                                             crate::services::oauth::replay_metrics::DPOP,
                                             result,
                                         );
-                                        if result == hyprstream_util::InsertIfAbsentNoEvictResult::Full {
+                                        if crate::services::oauth::replay_metrics::should_warn_full(
+                                            crate::services::oauth::replay_metrics::DPOP,
+                                            result,
+                                        ) {
                                             tracing::warn!(%method, %uri, "MCP: DPoP replay barrier is full; refusing fresh proof");
                                         } else {
                                             tracing::debug!(%method, %uri, jti = %proof.jti, "MCP: DPoP jti replayed");

--- a/crates/hyprstream/src/services/oauth/client_auth.rs
+++ b/crates/hyprstream/src/services/oauth/client_auth.rs
@@ -633,6 +633,16 @@ mod tests {
     }
 
     #[test]
+    fn accepts_maximum_admitted_future_skew_and_lifetime() {
+        let mut claims = valid_claims();
+        let now = chrono::Utc::now().timestamp();
+        let iat = now + 60;
+        claims["iat"] = serde_json::json!(iat);
+        claims["exp"] = serde_json::json!(iat + MAX_CLIENT_ASSERTION_LIFETIME_SECS);
+        assert!(check_claims(&claims, "https://app.test/c", &issuer_audiences()).is_ok());
+    }
+
+    #[test]
     fn rejects_missing_jti() {
         let (sk, jwk) = ed25519_keypair_and_jwk();
         let mut claims = valid_claims();

--- a/crates/hyprstream/src/services/oauth/client_auth.rs
+++ b/crates/hyprstream/src/services/oauth/client_auth.rs
@@ -84,6 +84,10 @@ impl std::error::Error for ClientAuthError {}
 pub const JWT_BEARER_ASSERTION_TYPE: &str =
     "urn:ietf:params:oauth:client-assertion-type:jwt-bearer";
 
+/// Bounds replay-barrier residency for client assertions and follows the
+/// short-lived private_key_jwt profile expected by OAuth clients.
+const MAX_CLIENT_ASSERTION_LIFETIME_SECS: i64 = 300;
+
 /// A successfully verified client assertion.
 #[derive(Debug, Clone)]
 pub struct VerifiedAssertion {
@@ -456,6 +460,11 @@ fn check_claims(
             "exp {exp} is not in the future (now={now})"
         )));
     }
+    if exp - iat > MAX_CLIENT_ASSERTION_LIFETIME_SECS {
+        return Err(ClientAuthError::InvalidClaim(format!(
+            "assertion lifetime exceeds {MAX_CLIENT_ASSERTION_LIFETIME_SECS}s"
+        )));
+    }
 
     // aud may be a string or an array of strings (RFC 7519 §4.1.3). It
     // must include one of the accepted audiences — on all profile paths
@@ -685,6 +694,16 @@ mod tests {
             &issuer_audiences(),
         );
         assert!(got.is_err(), "expired assertion should not verify: {got:?}");
+    }
+
+    #[test]
+    fn rejects_client_assertion_lifetime_over_replay_barrier_window() {
+        let mut claims = valid_claims();
+        let now = chrono::Utc::now().timestamp();
+        claims["iat"] = serde_json::json!(now);
+        claims["exp"] = serde_json::json!(now + MAX_CLIENT_ASSERTION_LIFETIME_SECS + 1);
+        let got = check_claims(&claims, "https://app.test/c", &issuer_audiences());
+        assert!(matches!(got, Err(ClientAuthError::InvalidClaim(message)) if message.contains("lifetime")));
     }
 
     #[test]

--- a/crates/hyprstream/src/services/oauth/client_auth.rs
+++ b/crates/hyprstream/src/services/oauth/client_auth.rs
@@ -437,7 +437,7 @@ fn check_claims(
     // audit anchor. Reject assertions dated beyond a 60s clock skew.
     let iat = claims.get("iat").and_then(Value::as_i64)
         .ok_or_else(|| ClientAuthError::InvalidClaim("missing iat".to_owned()))?;
-    if iat > now + 60 {
+    if iat > now.saturating_add(60) {
         return Err(ClientAuthError::InvalidClaim(format!(
             "iat {iat} is in the future (now={now})"
         )));
@@ -460,11 +460,10 @@ fn check_claims(
             "exp {exp} is not in the future (now={now})"
         )));
     }
-    if exp - iat > MAX_CLIENT_ASSERTION_LIFETIME_SECS {
-        return Err(ClientAuthError::InvalidClaim(format!(
-            "assertion lifetime exceeds {MAX_CLIENT_ASSERTION_LIFETIME_SECS}s"
-        )));
-    }
+    let _lifetime = exp
+        .checked_sub(iat)
+        .filter(|lifetime| *lifetime > 0 && *lifetime <= MAX_CLIENT_ASSERTION_LIFETIME_SECS)
+        .ok_or_else(|| ClientAuthError::InvalidClaim("assertion lifetime is invalid".to_owned()))?;
 
     // aud may be a string or an array of strings (RFC 7519 §4.1.3). It
     // must include one of the accepted audiences — on all profile paths
@@ -630,6 +629,15 @@ mod tests {
             matches!(&got, Err(ClientAuthError::InvalidClaim(c)) if c.contains("iat")),
             "future iat must be rejected: {got:?}"
         );
+    }
+
+    #[test]
+    fn rejects_extreme_timestamp_interval_without_overflow() {
+        let mut claims = valid_claims();
+        claims["iat"] = serde_json::json!(i64::MIN);
+        claims["exp"] = serde_json::json!(i64::MAX);
+        let got = check_claims(&claims, "https://app.test/c", &issuer_audiences());
+        assert!(matches!(got, Err(ClientAuthError::InvalidClaim(_))));
     }
 
     #[test]

--- a/crates/hyprstream/src/services/oauth/dpop.rs
+++ b/crates/hyprstream/src/services/oauth/dpop.rs
@@ -235,7 +235,7 @@ pub fn verify_dpop_proof(
 
     // Validate iat within ±60s.
     let now = chrono::Utc::now().timestamp();
-    if (iat - now).abs() > 60 {
+    if iat.abs_diff(now) > 60 {
         return Err(DpopError::IatOutOfWindow { iat, now });
     }
 

--- a/crates/hyprstream/src/services/oauth/dpop.rs
+++ b/crates/hyprstream/src/services/oauth/dpop.rs
@@ -429,6 +429,32 @@ mod dpop_stripping_tests {
     use super::*;
     use ed25519_dalek::Signer as _;
 
+    fn signed_ed25519_proof(iat: i64) -> String {
+        let signing_key = ed25519_dalek::SigningKey::from_bytes(&[0x33; 32]);
+        let header = serde_json::json!({
+            "typ": "dpop+jwt",
+            "alg": "EdDSA",
+            "jwk": {
+                "kty": "OKP",
+                "crv": "Ed25519",
+                "x": URL_SAFE_NO_PAD.encode(signing_key.verifying_key().to_bytes()),
+            },
+        });
+        let payload = serde_json::json!({
+            "jti": "extreme-iat",
+            "htm": "POST",
+            "htu": "https://example.test/oauth/token",
+            "iat": iat,
+        });
+        let signing_input = format!(
+            "{}.{}",
+            URL_SAFE_NO_PAD.encode(header.to_string()),
+            URL_SAFE_NO_PAD.encode(payload.to_string()),
+        );
+        let signature = signing_key.sign(signing_input.as_bytes());
+        format!("{signing_input}.{}", URL_SAFE_NO_PAD.encode(signature.to_bytes()))
+    }
+
     #[test]
     fn dpop_composite_stripped_signature_rejected() {
         let (ml_sk, ml_vk) = hyprstream_rpc::crypto::pq::ml_dsa_generate_keypair();
@@ -471,5 +497,14 @@ mod dpop_stripping_tests {
         let err = verify_dpop_proof(&stripped, "POST", "https://example.test/oauth/token", None).err();
         assert!(matches!(err, Some(DpopError::SignatureInvalid)),
             "expected SignatureInvalid, got {err:?}");
+    }
+
+    #[test]
+    fn dpop_extreme_iat_is_rejected_without_signed_overflow() {
+        let proof = signed_ed25519_proof(i64::MIN);
+        assert!(matches!(
+            verify_dpop_proof(&proof, "POST", "https://example.test/oauth/token", None),
+            Err(DpopError::IatOutOfWindow { iat: i64::MIN, .. })
+        ));
     }
 }

--- a/crates/hyprstream/src/services/oauth/mod.rs
+++ b/crates/hyprstream/src/services/oauth/mod.rs
@@ -50,6 +50,7 @@ pub mod oidc_callback;
 pub mod oidc_discovery;
 pub mod par;
 pub mod registration;
+pub mod replay_metrics;
 pub mod revocation;
 pub mod rpc_handler;
 pub mod scim;

--- a/crates/hyprstream/src/services/oauth/mod.rs
+++ b/crates/hyprstream/src/services/oauth/mod.rs
@@ -1706,13 +1706,18 @@ mod tests {
                 "alg": "ES256", "typ": "JWT", "kid": "#atproto"
             }))?,
         );
-        let make_service_jwt = |audience: &str, lxm: &str, jti: &str| -> anyhow::Result<String> {
+        let make_service_jwt_with_times = |audience: &str,
+                                           lxm: &str,
+                                           jti: &str,
+                                           iat: i64,
+                                           exp: i64|
+         -> anyhow::Result<String> {
             let payload = URL_SAFE_NO_PAD.encode(
                 serde_json::to_vec(&serde_json::json!({
                     "iss": MAPPED_DID,
                     "aud": audience,
-                    "iat": now,
-                    "exp": now + 60,
+                    "iat": iat,
+                    "exp": exp,
                     "lxm": lxm,
                     "jti": jti
                 }))?,
@@ -1724,6 +1729,9 @@ mod tests {
                 "{signing_input}.{}",
                 URL_SAFE_NO_PAD.encode(signature.to_bytes())
             ))
+        };
+        let make_service_jwt = |audience: &str, lxm: &str, jti: &str| {
+            make_service_jwt_with_times(audience, lxm, jti, now, now + 60)
         };
         let service_jwt = make_service_jwt(
             "did:web:pds.example.test%3A8443",
@@ -1779,6 +1787,24 @@ mod tests {
             .oneshot(exchange_request(&wrong_lxm, HOSTED_TENANT))
             .await?;
         assert_eq!(rejected_lxm.status(), axum::http::StatusCode::UNAUTHORIZED);
+
+        // The verifier must reject an unrepresentable signed interval before
+        // DID resolution, replay admission, or a token exchange can occur.
+        let extreme_interval = make_service_jwt_with_times(
+            "did:web:pds.example.test%3A8443",
+            token_exchange::ATPROTO_EXCHANGE_NSID,
+            "demo-1119-extreme-interval",
+            i64::MIN,
+            i64::MAX,
+        )?;
+        let rejected_extreme_interval = app
+            .clone()
+            .oneshot(exchange_request(&extreme_interval, HOSTED_TENANT))
+            .await?;
+        assert_eq!(
+            rejected_extreme_interval.status(),
+            axum::http::StatusCode::UNAUTHORIZED
+        );
 
         // #1314: the authority-owned account record supplies the binding. A
         // matching request succeeds and the minted credential carries exactly

--- a/crates/hyprstream/src/services/oauth/mod.rs
+++ b/crates/hyprstream/src/services/oauth/mod.rs
@@ -50,6 +50,7 @@ pub mod oidc_callback;
 pub mod oidc_discovery;
 pub mod par;
 pub mod registration;
+pub mod replay_key;
 pub mod replay_metrics;
 pub mod revocation;
 pub mod rpc_handler;

--- a/crates/hyprstream/src/services/oauth/mount_ticket.rs
+++ b/crates/hyprstream/src/services/oauth/mount_ticket.rs
@@ -152,6 +152,7 @@ pub async fn issue_mount_ticket(
         );
     };
     let mut claims = hyprstream_rpc::auth::Claims::new(user.user.clone(), now, exp)
+        .with_jti()
         .with_issuer(state.issuer_url.clone())
         .with_audience(Some(audience.clone()))
         .with_cap(capability.clone())
@@ -286,6 +287,7 @@ mod freeze_tests {
             None,
         )
         .unwrap();
+        assert!(claims.jti.is_some(), "issued mount tickets must be one-use");
         assert_eq!(claims.tenant.as_deref(), Some("tenant-a.example"));
         assert_eq!(claims.clearance, source.clearance);
     }

--- a/crates/hyprstream/src/services/oauth/replay_key.rs
+++ b/crates/hyprstream/src/services/oauth/replay_key.rs
@@ -23,32 +23,36 @@ pub type ReplayKey = [u8; 32];
 /// of its entry cap, rather than an exact multiple of this number.
 pub const REPLAY_BARRIER_ENTRY_BYTES: usize = 128;
 
-fn digest(parts: &[&[u8]]) -> ReplayKey {
+fn digest(domain: &[u8], components: &[&[u8]]) -> ReplayKey {
     let mut hasher = blake3::Hasher::new();
-    for part in parts {
-        hasher.update(part);
+    hasher.update(b"hyprstream:replay-key:v1\0");
+    hasher.update(&(domain.len() as u64).to_be_bytes());
+    hasher.update(domain);
+    for component in components {
+        hasher.update(&(component.len() as u64).to_be_bytes());
+        hasher.update(component);
     }
     *hasher.finalize().as_bytes()
 }
 
-/// Digest the exact raw key previously used for a DPoP proof JTI.
+/// Digest a DPoP proof JTI in its own replay domain.
 pub fn dpop_jti(jti: &str) -> ReplayKey {
-    digest(&[jti.as_bytes()])
+    digest(b"dpop", &[jti.as_bytes()])
 }
 
-/// Digest the exact raw key previously used for a one-use mount ticket.
+/// Digest a one-use mount ticket JTI in its own replay domain.
 pub fn mount_ticket_jti(jti: &str) -> ReplayKey {
-    digest(&[b"mount-ticket:", jti.as_bytes()])
+    digest(b"mount-ticket", &[jti.as_bytes()])
 }
 
-/// Digest the exact `{client_id}\x1f{jti}` client-assertion key.
+/// Digest a length-framed client-ID/JTI tuple in the client-assertion domain.
 pub fn client_assertion_jti(client_id: &str, jti: &str) -> ReplayKey {
-    digest(&[client_id.as_bytes(), b"\x1f", jti.as_bytes()])
+    digest(b"client-assertion", &[client_id.as_bytes(), jti.as_bytes()])
 }
 
-/// Digest the exact `{issuer}\x1f{jti}` ATProto service-assertion key.
+/// Digest a length-framed issuer/JTI tuple in the ATProto assertion domain.
 pub fn atproto_service_assertion_jti(issuer: &str, jti: &str) -> ReplayKey {
-    digest(&[issuer.as_bytes(), b"\x1f", jti.as_bytes()])
+    digest(b"atproto-service-assertion", &[issuer.as_bytes(), jti.as_bytes()])
 }
 
 #[cfg(test)]
@@ -56,21 +60,18 @@ mod tests {
     use super::*;
 
     #[test]
-    fn hashes_the_previous_raw_key_encoding() {
+    fn keys_are_fixed_size_domain_separated_and_tuple_framed() {
         assert_eq!(std::mem::size_of::<ReplayKey>(), 32);
         assert_eq!(REPLAY_BARRIER_ENTRY_BYTES, 128);
-        assert_eq!(dpop_jti("jti"), *blake3::hash(b"jti").as_bytes());
-        assert_eq!(
-            mount_ticket_jti("jti"),
-            *blake3::hash(b"mount-ticket:jti").as_bytes()
+        assert_ne!(dpop_jti("mount-ticket:x"), mount_ticket_jti("x"));
+        assert_ne!(dpop_jti("same"), mount_ticket_jti("same"));
+        assert_ne!(
+            client_assertion_jti("a", "b\x1fc"),
+            client_assertion_jti("a\x1fb", "c")
         );
-        assert_eq!(
-            client_assertion_jti("client", "jti"),
-            *blake3::hash(b"client\x1fjti").as_bytes()
-        );
-        assert_eq!(
-            atproto_service_assertion_jti("did:plc:issuer", "jti"),
-            *blake3::hash(b"did:plc:issuer\x1fjti").as_bytes()
+        assert_ne!(
+            atproto_service_assertion_jti("a", "b\x1fc"),
+            atproto_service_assertion_jti("a\x1fb", "c")
         );
     }
 }

--- a/crates/hyprstream/src/services/oauth/replay_key.rs
+++ b/crates/hyprstream/src/services/oauth/replay_key.rs
@@ -1,0 +1,76 @@
+//! Fixed-size keys for OAuth replay barriers.
+//!
+//! A replay barrier keeps one map entry and one heap node for each live key.
+//! On the supported 64-bit targets, a `[u8; 32]` key plus `Entry<()>` is 56
+//! bytes and a heap node is 56 bytes. `HashMap` needs at most eight buckets
+//! for seven live entries, so the map contributes at most 64 bytes per live
+//! key before allocation growth; together that is 120 bytes. Capacity planning
+//! rounds this to 128 bytes per live key before allocator slack. Unlike a
+//! `String`, every retained part of this key is fixed-size.
+//!
+//! Replay identifiers are controlled by remote callers. Keeping their raw
+//! strings in a bounded entry-count cache would still leave retained memory
+//! unbounded, and `TtlCache` stores each key in both its map and expiry heap.
+//! A BLAKE3-256 digest makes retained key storage exactly 32 bytes per copy.
+
+/// BLAKE3-256 replay-barrier key.
+pub type ReplayKey = [u8; 32];
+
+/// Conservative per-live-entry planning size for a no-refresh replay barrier.
+///
+/// See this module's documentation for the 64-bit layout derivation. The
+/// cache's geometric allocations make its exact resident size a fixed function
+/// of its entry cap, rather than an exact multiple of this number.
+pub const REPLAY_BARRIER_ENTRY_BYTES: usize = 128;
+
+fn digest(parts: &[&[u8]]) -> ReplayKey {
+    let mut hasher = blake3::Hasher::new();
+    for part in parts {
+        hasher.update(part);
+    }
+    *hasher.finalize().as_bytes()
+}
+
+/// Digest the exact raw key previously used for a DPoP proof JTI.
+pub fn dpop_jti(jti: &str) -> ReplayKey {
+    digest(&[jti.as_bytes()])
+}
+
+/// Digest the exact raw key previously used for a one-use mount ticket.
+pub fn mount_ticket_jti(jti: &str) -> ReplayKey {
+    digest(&[b"mount-ticket:", jti.as_bytes()])
+}
+
+/// Digest the exact `{client_id}\x1f{jti}` client-assertion key.
+pub fn client_assertion_jti(client_id: &str, jti: &str) -> ReplayKey {
+    digest(&[client_id.as_bytes(), b"\x1f", jti.as_bytes()])
+}
+
+/// Digest the exact `{issuer}\x1f{jti}` ATProto service-assertion key.
+pub fn atproto_service_assertion_jti(issuer: &str, jti: &str) -> ReplayKey {
+    digest(&[issuer.as_bytes(), b"\x1f", jti.as_bytes()])
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn hashes_the_previous_raw_key_encoding() {
+        assert_eq!(std::mem::size_of::<ReplayKey>(), 32);
+        assert_eq!(REPLAY_BARRIER_ENTRY_BYTES, 128);
+        assert_eq!(dpop_jti("jti"), *blake3::hash(b"jti").as_bytes());
+        assert_eq!(
+            mount_ticket_jti("jti"),
+            *blake3::hash(b"mount-ticket:jti").as_bytes()
+        );
+        assert_eq!(
+            client_assertion_jti("client", "jti"),
+            *blake3::hash(b"client\x1fjti").as_bytes()
+        );
+        assert_eq!(
+            atproto_service_assertion_jti("did:plc:issuer", "jti"),
+            *blake3::hash(b"did:plc:issuer\x1fjti").as_bytes()
+        );
+    }
+}

--- a/crates/hyprstream/src/services/oauth/replay_metrics.rs
+++ b/crates/hyprstream/src/services/oauth/replay_metrics.rs
@@ -1,10 +1,18 @@
 //! OpenTelemetry signals for fail-closed OAuth replay barriers.
 
 use hyprstream_util::InsertIfAbsentNoEvictResult;
+use once_cell::sync::Lazy;
+use parking_lot::Mutex;
+use std::collections::HashMap;
+use std::time::{Duration, Instant};
 
 pub const DPOP: &str = "dpop";
 pub const CLIENT_ASSERTION: &str = "client_assertion";
 pub const ATPROTO_SERVICE_ASSERTION: &str = "atproto_service_assertion";
+
+const FULL_WARNING_INTERVAL: Duration = Duration::from_secs(60);
+static LAST_FULL_WARNING: Lazy<Mutex<HashMap<&'static str, Instant>>> =
+    Lazy::new(|| Mutex::new(HashMap::new()));
 
 #[cfg(all(feature = "otel", not(target_arch = "wasm32")))]
 mod metered {
@@ -68,4 +76,42 @@ mod metered {
 /// the fail-closed barrier is saturated.
 pub fn record_rejection(barrier: &'static str, result: InsertIfAbsentNoEvictResult) {
     metered::record(barrier, result);
+}
+
+/// Return `true` at most once per barrier per minute for a full-barrier
+/// rejection. Metrics still record every rejection; this only prevents an
+/// attacker from turning saturation into unbounded warning-log volume.
+pub fn should_warn_full(barrier: &'static str, result: InsertIfAbsentNoEvictResult) -> bool {
+    if result != InsertIfAbsentNoEvictResult::Full {
+        return false;
+    }
+    let now = Instant::now();
+    let mut last_warning = LAST_FULL_WARNING.lock();
+    match last_warning.get_mut(barrier) {
+        Some(last) if now.duration_since(*last) < FULL_WARNING_INTERVAL => false,
+        Some(last) => {
+            *last = now;
+            true
+        }
+        None => {
+            last_warning.insert(barrier, now);
+            true
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn full_warnings_are_rate_limited_per_barrier() {
+        let barrier = "replay_metrics_rate_limit_test";
+        assert!(should_warn_full(barrier, InsertIfAbsentNoEvictResult::Full));
+        assert!(!should_warn_full(barrier, InsertIfAbsentNoEvictResult::Full));
+        assert!(!should_warn_full(
+            barrier,
+            InsertIfAbsentNoEvictResult::Duplicate
+        ));
+    }
 }

--- a/crates/hyprstream/src/services/oauth/replay_metrics.rs
+++ b/crates/hyprstream/src/services/oauth/replay_metrics.rs
@@ -1,0 +1,71 @@
+//! OpenTelemetry signals for fail-closed OAuth replay barriers.
+
+use hyprstream_util::InsertIfAbsentNoEvictResult;
+
+pub const DPOP: &str = "dpop";
+pub const CLIENT_ASSERTION: &str = "client_assertion";
+pub const ATPROTO_SERVICE_ASSERTION: &str = "atproto_service_assertion";
+
+#[cfg(all(feature = "otel", not(target_arch = "wasm32")))]
+mod metered {
+    use once_cell::sync::Lazy;
+    use opentelemetry::KeyValue;
+
+    use super::*;
+
+    const METER_NAME: &str = "hyprstream.oauth";
+    const METRIC_REJECTIONS: &str = "oauth_replay_barrier_rejections_total";
+
+    struct ReplayBarrierMeter {
+        rejections: opentelemetry::metrics::Counter<u64>,
+    }
+
+    impl ReplayBarrierMeter {
+        fn global() -> Self {
+            let meter = opentelemetry::global::meter(METER_NAME);
+            Self {
+                rejections: meter
+                    .u64_counter(METRIC_REJECTIONS)
+                    .with_description(
+                        "OAuth replay barrier rejections, by barrier and rejection reason",
+                    )
+                    .build(),
+            }
+        }
+
+        fn record(&self, barrier: &'static str, result: InsertIfAbsentNoEvictResult) {
+            let reason = match result {
+                InsertIfAbsentNoEvictResult::Duplicate => "duplicate",
+                InsertIfAbsentNoEvictResult::Full => "full",
+                InsertIfAbsentNoEvictResult::Inserted => return,
+            };
+            self.rejections.add(
+                1,
+                &[
+                    KeyValue::new("barrier", barrier),
+                    KeyValue::new("reason", reason),
+                ],
+            );
+        }
+    }
+
+    static METER: Lazy<ReplayBarrierMeter> = Lazy::new(ReplayBarrierMeter::global);
+
+    pub(super) fn record(barrier: &'static str, result: InsertIfAbsentNoEvictResult) {
+        METER.record(barrier, result);
+    }
+}
+
+#[cfg(not(all(feature = "otel", not(target_arch = "wasm32"))))]
+mod metered {
+    use super::*;
+
+    pub(super) fn record(_barrier: &'static str, _result: InsertIfAbsentNoEvictResult) {}
+}
+
+/// Record every failed replay-barrier insertion. The `reason` attribute makes
+/// a blocked replay distinguishable from legitimate traffic refused because
+/// the fail-closed barrier is saturated.
+pub fn record_rejection(barrier: &'static str, result: InsertIfAbsentNoEvictResult) {
+    metered::record(barrier, result);
+}

--- a/crates/hyprstream/src/services/oauth/state.rs
+++ b/crates/hyprstream/src/services/oauth/state.rs
@@ -335,6 +335,21 @@ mod tests {
         );
     }
 
+    #[test]
+    fn replay_caps_cover_maximum_admitted_future_skew() {
+        assert_eq!(OAuthState::DPOP_JTI_MAX_ENTRIES, 216_000);
+        assert_eq!(OAuthState::ASSERTION_JTI_MAX_ENTRIES, 43_200);
+
+        let state = state_for_replay_barrier_tests();
+        let now = chrono::Utc::now().timestamp();
+        assert!(state.check_and_record_dpop_jti("dpop-future-skew", now + 60));
+        assert!(state.check_and_record_assertion_jti(
+            "client",
+            "assertion-future-skew",
+            now + 360
+        ));
+    }
+
     struct KeyReadErrorStore {
         profile: UserProfile,
     }
@@ -1229,17 +1244,16 @@ fn mesh_kem_public_for_policy(
 }
 
 impl OAuthState {
-    /// DPoP JTI replay barrier: 1,000 proofs/s sustained for 120s plus 20%
-    /// headroom. Keys are fixed BLAKE3-256 digests; 128 bytes/live entry
-    /// before allocator slack plans this at about 17.6 MiB.
-    const DPOP_JTI_MAX_ENTRIES: usize = 144_000;
+    /// DPoP admits iat up to 60 seconds in the future and retains through
+    /// iat + 120 seconds: 180 seconds at 1,000 proofs/s plus 20% headroom.
+    /// Fixed BLAKE3-256 digest keys plan 216,000 entries at about 26.4 MiB.
+    const DPOP_JTI_MAX_ENTRIES: usize = 216_000;
     /// Inline reap budget per access (heap pops). Bounds tail latency.
     const DPOP_JTI_REAP_BUDGET: usize = 64;
-    /// Client-assertion replay barrier: 100 assertions/s for the five-minute
-    /// maximum assertion lifetime plus 20% headroom. Fixed 32-byte digest keys
-    /// at 128 bytes/live entry plan 36,000 entries at about 4.4 MiB before
-    /// allocator slack.
-    const ASSERTION_JTI_MAX_ENTRIES: usize = 36_000;
+    /// Client assertions admit iat up to 60 seconds future and live for at
+    /// most 300 seconds from iat: 360 seconds at 100/s plus 20% headroom.
+    /// Fixed digest keys plan 43,200 entries at about 5.3 MiB.
+    const ASSERTION_JTI_MAX_ENTRIES: usize = 43_200;
     /// Inline reap budget per access (heap pops). Bounds tail latency.
     const ASSERTION_JTI_REAP_BUDGET: usize = 64;
 

--- a/crates/hyprstream/src/services/oauth/state.rs
+++ b/crates/hyprstream/src/services/oauth/state.rs
@@ -20,6 +20,24 @@ use hyprstream_util::{InsertIfAbsentNoEvictResult, TtlCache};
 
 use super::replay_key::ReplayKey;
 
+/// Result of attempting to admit a DPoP proof to its replay barrier.
+///
+/// The token endpoint needs this distinction so a saturated barrier remains
+/// separately metered and rate-limited instead of being logged as a replay.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum DpopJtiAdmission {
+    Inserted,
+    Duplicate,
+    Full,
+    InvalidLifetime,
+}
+
+impl DpopJtiAdmission {
+    pub(crate) fn is_inserted(self) -> bool {
+        self == Self::Inserted
+    }
+}
+
 /// Read-only resolver used by the ATProto service-auth exchange perimeter.
 #[async_trait::async_trait]
 pub trait AtprotoDidDocumentResolver: Send + Sync {
@@ -310,14 +328,22 @@ mod tests {
         state.dpop_jti_seen = TtlCache::new(2, 16);
         let now = chrono::Utc::now().timestamp();
 
-        assert!(state.check_and_record_dpop_jti("dpop-first", now));
-        assert!(state.check_and_record_dpop_jti("dpop-second", now));
-        assert!(
-            !state.check_and_record_dpop_jti("dpop-fresh-when-full", now),
+        assert_eq!(
+            state.check_and_record_dpop_jti_admission("dpop-first", now),
+            DpopJtiAdmission::Inserted
+        );
+        assert_eq!(
+            state.check_and_record_dpop_jti_admission("dpop-second", now),
+            DpopJtiAdmission::Inserted
+        );
+        assert_eq!(
+            state.check_and_record_dpop_jti_admission("dpop-fresh-when-full", now),
+            DpopJtiAdmission::Full,
             "a fresh DPoP JTI must be refused once the barrier is full"
         );
-        assert!(
-            !state.check_and_record_dpop_jti("dpop-first", now),
+        assert_eq!(
+            state.check_and_record_dpop_jti_admission("dpop-first", now),
+            DpopJtiAdmission::Duplicate,
             "a full barrier must not evict an earlier DPoP JTI"
         );
 
@@ -1683,6 +1709,17 @@ impl OAuthState {
     /// Returns `false` when the JTI is a replay or the fail-closed barrier is full.
     /// Expired entries are pruned opportunistically on each call.
     pub fn check_and_record_dpop_jti(&self, jti: &str, iat: i64) -> bool {
+        self.check_and_record_dpop_jti_admission(jti, iat)
+            .is_inserted()
+    }
+
+    /// Check a DPoP JTI while retaining the fail-closed admission outcome for
+    /// callers that must distinguish an actual replay from a full barrier.
+    pub(crate) fn check_and_record_dpop_jti_admission(
+        &self,
+        jti: &str,
+        iat: i64,
+    ) -> DpopJtiAdmission {
         let now = chrono::Utc::now().timestamp();
         // Window ends at iat + 120s (±60s skew + 60s buffer); TTL = remainder.
         let Some(ttl_secs) = iat
@@ -1691,7 +1728,7 @@ impl OAuthState {
             .filter(|remaining| *remaining > 0 && *remaining <= 180)
             .and_then(|remaining| u64::try_from(remaining).ok())
         else {
-            return false;
+            return DpopJtiAdmission::InvalidLifetime;
         };
         let result = self.dpop_jti_seen.insert_if_absent_no_evict(
             super::replay_key::dpop_jti(jti),
@@ -1704,7 +1741,11 @@ impl OAuthState {
                 tracing::warn!("DPoP replay barrier is full; refusing fresh proof");
             }
         }
-        result == InsertIfAbsentNoEvictResult::Inserted
+        match result {
+            InsertIfAbsentNoEvictResult::Inserted => DpopJtiAdmission::Inserted,
+            InsertIfAbsentNoEvictResult::Duplicate => DpopJtiAdmission::Duplicate,
+            InsertIfAbsentNoEvictResult::Full => DpopJtiAdmission::Full,
+        }
     }
 
     /// Atomically consume an ATProto service-auth assertion identifier.

--- a/crates/hyprstream/src/services/oauth/state.rs
+++ b/crates/hyprstream/src/services/oauth/state.rs
@@ -16,7 +16,7 @@ use super::user_service::UserService;
 use crate::auth::user_store::UserStore;
 use crate::config::OAuthConfig;
 use crate::services::{DiscoveryClient, PolicyClient};
-use hyprstream_util::TtlCache;
+use hyprstream_util::{InsertIfAbsentNoEvictResult, TtlCache};
 
 /// Read-only resolver used by the ATProto service-auth exchange perimeter.
 #[async_trait::async_trait]
@@ -1169,14 +1169,14 @@ fn mesh_kem_public_for_policy(
 }
 
 impl OAuthState {
-    /// DPoP jti replay-dedup cache: capacity bound (memory ceiling for the
-    /// `TtlCache<String, ()>`). 120s TTL per entry.
-    const DPOP_JTI_MAX_ENTRIES: usize = 10_000;
+    /// DPoP JTI replay barrier: 1,000 proofs/s sustained for 120s plus 20%
+    /// headroom. This is deliberately fail-closed: it must hold every live JTI.
+    const DPOP_JTI_MAX_ENTRIES: usize = 144_000;
     /// Inline reap budget per access (heap pops). Bounds tail latency.
     const DPOP_JTI_REAP_BUDGET: usize = 64;
-    /// Client-assertion jti replay-dedup cache: same bounds as the DPoP
-    /// registry; per-entry TTL is the assertion's remaining lifetime.
-    const ASSERTION_JTI_MAX_ENTRIES: usize = 10_000;
+    /// Client-assertion replay barrier: 100 assertions/s for the five-minute
+    /// maximum assertion lifetime plus 20% headroom.
+    const ASSERTION_JTI_MAX_ENTRIES: usize = 36_000;
     /// Inline reap budget per access (heap pops). Bounds tail latency.
     const ASSERTION_JTI_REAP_BUDGET: usize = 64;
 
@@ -1236,7 +1236,9 @@ impl OAuthState {
                 Self::ASSERTION_JTI_REAP_BUDGET,
             ),
             atproto_service_jti_seen: TtlCache::new(
-                Self::ASSERTION_JTI_MAX_ENTRIES,
+                // ATProto service assertions can live for one hour. Reserve
+                // 100 assertions/s plus 20% headroom for that full window.
+                432_000,
                 Self::ASSERTION_JTI_REAP_BUDGET,
             ),
             atproto_did_resolver: atproto_did_resolver(config),
@@ -1570,14 +1572,24 @@ impl OAuthState {
     /// Check a DPoP JTI for replay and record it if new.
     ///
     /// Returns `true` when the JTI is fresh (caller should proceed).
-    /// Returns `false` when the JTI has been seen within its validity window (replay).
+    /// Returns `false` when the JTI is a replay or the fail-closed barrier is full.
     /// Expired entries are pruned opportunistically on each call.
     pub fn check_and_record_dpop_jti(&self, jti: &str, iat: i64) -> bool {
         let now = chrono::Utc::now().timestamp();
         // Window ends at iat + 120s (±60s skew + 60s buffer); TTL = remainder.
         let ttl_secs = ((iat + 120) - now).max(0) as u64;
-        self.dpop_jti_seen
-            .insert_if_absent(jti.to_owned(), (), Duration::from_secs(ttl_secs))
+        let result = self.dpop_jti_seen.insert_if_absent_no_evict(
+            jti.to_owned(),
+            (),
+            Duration::from_secs(ttl_secs),
+        );
+        if result != InsertIfAbsentNoEvictResult::Inserted {
+            super::replay_metrics::record_rejection(super::replay_metrics::DPOP, result);
+            if result == InsertIfAbsentNoEvictResult::Full {
+                tracing::warn!("DPoP replay barrier is full; refusing fresh proof");
+            }
+        }
+        result == InsertIfAbsentNoEvictResult::Inserted
     }
 
     /// Atomically consume an ATProto service-auth assertion identifier.
@@ -1587,11 +1599,23 @@ impl OAuthState {
             return false;
         }
         let ttl_secs = remaining as u64;
-        self.atproto_service_jti_seen.insert_if_absent_no_evict(
+        let result = self.atproto_service_jti_seen.insert_if_absent_no_evict(
             format!("{issuer}\u{1f}{jti}"),
             (),
             Duration::from_secs(ttl_secs),
-        )
+        );
+        if result != InsertIfAbsentNoEvictResult::Inserted {
+            super::replay_metrics::record_rejection(
+                super::replay_metrics::ATPROTO_SERVICE_ASSERTION,
+                result,
+            );
+            if result == InsertIfAbsentNoEvictResult::Full {
+                tracing::warn!(
+                    "ATProto service-assertion replay barrier is full; refusing fresh assertion"
+                );
+            }
+        }
+        result == InsertIfAbsentNoEvictResult::Inserted
     }
 
     /// Check a client-assertion JTI for replay and record it if new
@@ -1604,15 +1628,25 @@ impl OAuthState {
     /// rejected as expired anyway.
     ///
     /// Returns `true` when the JTI is fresh (caller should proceed);
-    /// `false` when it was seen within its validity window (replay).
+    /// `false` when it is a replay or the fail-closed barrier is full.
     pub fn check_and_record_assertion_jti(&self, client_id: &str, jti: &str, exp: i64) -> bool {
         let now = chrono::Utc::now().timestamp();
         let ttl_secs = (exp - now).max(0) as u64;
-        self.assertion_jti_seen.insert_if_absent(
+        let result = self.assertion_jti_seen.insert_if_absent_no_evict(
             format!("{client_id}\u{1f}{jti}"),
             (),
             Duration::from_secs(ttl_secs),
-        )
+        );
+        if result != InsertIfAbsentNoEvictResult::Inserted {
+            super::replay_metrics::record_rejection(
+                super::replay_metrics::CLIENT_ASSERTION,
+                result,
+            );
+            if result == InsertIfAbsentNoEvictResult::Full {
+                tracing::warn!("client-assertion replay barrier is full; refusing fresh assertion");
+            }
+        }
+        result == InsertIfAbsentNoEvictResult::Inserted
     }
 
     /// Issue a fresh server-side DPoP nonce (RFC 9449 §8).

--- a/crates/hyprstream/src/services/oauth/state.rs
+++ b/crates/hyprstream/src/services/oauth/state.rs
@@ -350,6 +350,28 @@ mod tests {
         ));
     }
 
+    #[test]
+    fn extreme_replay_expirations_are_rejected_without_consuming_capacity() {
+        let mut state = state_for_replay_barrier_tests();
+        state.assertion_jti_seen = TtlCache::new(1, 16);
+        assert!(!state.check_and_record_assertion_jti("client", "min", i64::MIN));
+        assert!(!state.check_and_record_assertion_jti("client", "max", i64::MAX));
+        assert!(state.check_and_record_assertion_jti(
+            "client",
+            "ordinary",
+            chrono::Utc::now().timestamp() + 60
+        ));
+
+        state.atproto_service_jti_seen = TtlCache::new(1, 16);
+        assert!(!state.check_and_record_atproto_service_jti("did:plc:test", "min", i64::MIN));
+        assert!(!state.check_and_record_atproto_service_jti("did:plc:test", "max", i64::MAX));
+        assert!(state.check_and_record_atproto_service_jti(
+            "did:plc:test",
+            "ordinary",
+            chrono::Utc::now().timestamp() + 60
+        ));
+    }
+
     struct KeyReadErrorStore {
         profile: UserProfile,
     }
@@ -1244,6 +1266,8 @@ fn mesh_kem_public_for_policy(
 }
 
 impl OAuthState {
+    const MAX_CLIENT_ASSERTION_REPLAY_SECS: i64 = 360;
+    const MAX_ATPROTO_SERVICE_ASSERTION_REPLAY_SECS: i64 = 3_600;
     /// DPoP admits iat up to 60 seconds in the future and retains through
     /// iat + 120 seconds: 180 seconds at 1,000 proofs/s plus 20% headroom.
     /// Fixed BLAKE3-256 digest keys plan 216,000 entries at about 26.4 MiB.
@@ -1661,7 +1685,14 @@ impl OAuthState {
     pub fn check_and_record_dpop_jti(&self, jti: &str, iat: i64) -> bool {
         let now = chrono::Utc::now().timestamp();
         // Window ends at iat + 120s (±60s skew + 60s buffer); TTL = remainder.
-        let ttl_secs = ((iat + 120) - now).max(0) as u64;
+        let Some(ttl_secs) = iat
+            .checked_add(120)
+            .and_then(|deadline| deadline.checked_sub(now))
+            .filter(|remaining| *remaining > 0 && *remaining <= 180)
+            .and_then(|remaining| u64::try_from(remaining).ok())
+        else {
+            return false;
+        };
         let result = self.dpop_jti_seen.insert_if_absent_no_evict(
             super::replay_key::dpop_jti(jti),
             (),
@@ -1678,11 +1709,15 @@ impl OAuthState {
 
     /// Atomically consume an ATProto service-auth assertion identifier.
     pub fn check_and_record_atproto_service_jti(&self, issuer: &str, jti: &str, exp: i64) -> bool {
-        let remaining = exp - chrono::Utc::now().timestamp();
-        if remaining <= 0 {
+        let Some(ttl_secs) = exp
+            .checked_sub(chrono::Utc::now().timestamp())
+            .filter(|remaining| {
+                *remaining > 0 && *remaining <= Self::MAX_ATPROTO_SERVICE_ASSERTION_REPLAY_SECS
+            })
+            .and_then(|remaining| u64::try_from(remaining).ok())
+        else {
             return false;
-        }
-        let ttl_secs = remaining as u64;
+        };
         let result = self.atproto_service_jti_seen.insert_if_absent_no_evict(
             super::replay_key::atproto_service_assertion_jti(issuer, jti),
             (),
@@ -1718,7 +1753,15 @@ impl OAuthState {
     /// `false` when it is a replay or the fail-closed barrier is full.
     pub fn check_and_record_assertion_jti(&self, client_id: &str, jti: &str, exp: i64) -> bool {
         let now = chrono::Utc::now().timestamp();
-        let ttl_secs = (exp - now).max(0) as u64;
+        let Some(ttl_secs) = exp
+            .checked_sub(now)
+            .filter(|remaining| {
+                *remaining > 0 && *remaining <= Self::MAX_CLIENT_ASSERTION_REPLAY_SECS
+            })
+            .and_then(|remaining| u64::try_from(remaining).ok())
+        else {
+            return false;
+        };
         let result = self.assertion_jti_seen.insert_if_absent_no_evict(
             super::replay_key::client_assertion_jti(client_id, jti),
             (),

--- a/crates/hyprstream/src/services/oauth/state.rs
+++ b/crates/hyprstream/src/services/oauth/state.rs
@@ -18,6 +18,8 @@ use crate::config::OAuthConfig;
 use crate::services::{DiscoveryClient, PolicyClient};
 use hyprstream_util::{InsertIfAbsentNoEvictResult, TtlCache};
 
+use super::replay_key::ReplayKey;
+
 /// Read-only resolver used by the ATProto service-auth exchange perimeter.
 #[async_trait::async_trait]
 pub trait AtprotoDidDocumentResolver: Send + Sync {
@@ -275,6 +277,62 @@ mod tests {
             signing_key.verifying_key().to_bytes(),
         )
         .with_user_store(crate::auth::ProductionUserStore::for_test(store))
+    }
+
+    fn state_for_replay_barrier_tests() -> OAuthState {
+        use hyprstream_rpc::rpc_client::RpcClientImpl;
+        use hyprstream_rpc::signer::LocalSigner;
+        use hyprstream_rpc::transport::lazy_uds::LazyUdsTransport;
+
+        let signing_key = ed25519_dalek::SigningKey::from_bytes(&[0x43; 32]);
+        let remote_key = ed25519_dalek::SigningKey::from_bytes(&[0x44; 32]).verifying_key();
+        let make_client = || {
+            Arc::new(
+                RpcClientImpl::new(
+                    LocalSigner::new(signing_key.clone()),
+                    LazyUdsTransport::new("/dev/null/replay-barrier-test.sock".into()),
+                    Some(remote_key),
+                )
+                .with_response_verify_policy(CryptoPolicy::Classical),
+            )
+        };
+        OAuthState::new(
+            &OAuthConfig::default(),
+            PolicyClient::new(make_client()),
+            DiscoveryClient::new(make_client()),
+            signing_key.verifying_key().to_bytes(),
+        )
+    }
+
+    #[test]
+    fn replay_callers_keep_seen_jtis_after_a_full_barrier() {
+        let mut state = state_for_replay_barrier_tests();
+        state.dpop_jti_seen = TtlCache::new(2, 16);
+        let now = chrono::Utc::now().timestamp();
+
+        assert!(state.check_and_record_dpop_jti("dpop-first", now));
+        assert!(state.check_and_record_dpop_jti("dpop-second", now));
+        assert!(
+            !state.check_and_record_dpop_jti("dpop-fresh-when-full", now),
+            "a fresh DPoP JTI must be refused once the barrier is full"
+        );
+        assert!(
+            !state.check_and_record_dpop_jti("dpop-first", now),
+            "a full barrier must not evict an earlier DPoP JTI"
+        );
+
+        state.assertion_jti_seen = TtlCache::new(2, 16);
+        let exp = now + 60;
+        assert!(state.check_and_record_assertion_jti("client", "assertion-first", exp));
+        assert!(state.check_and_record_assertion_jti("client", "assertion-second", exp));
+        assert!(
+            !state.check_and_record_assertion_jti("client", "assertion-fresh-when-full", exp),
+            "a fresh client assertion JTI must be refused once the barrier is full"
+        );
+        assert!(
+            !state.check_and_record_assertion_jti("client", "assertion-first", exp),
+            "a full barrier must not evict an earlier client assertion JTI"
+        );
     }
 
     struct KeyReadErrorStore {
@@ -1058,16 +1116,18 @@ pub struct OAuthState {
     pub rsa_kid: Option<String>,
     /// Seen DPoP JTIs for replay prevention (RFC 9449 §11.1). Backed by
     /// the shared `TtlCache` with atomic check-and-record — see
-    /// `check_and_record_dpop_jti`. TTL = iat + 120s per entry.
-    pub dpop_jti_seen: TtlCache<String, ()>,
+    /// `check_and_record_dpop_jti`. A BLAKE3-256 digest retains a fixed-size
+    /// key; TTL = iat + 120s per entry.
+    pub dpop_jti_seen: TtlCache<ReplayKey, ()>,
     /// Seen client-assertion JTIs for replay prevention (RFC 7523 §3 /
-    /// atproto OAuth; #1146 T3.3). Keyed `{client_id}\u{1f}{jti}`; TTL =
-    /// the assertion's remaining `exp` lifetime. See
+    /// atproto OAuth; #1146 T3.3). Keyed by a BLAKE3-256 digest of
+    /// `{client_id}\u{1f}{jti}`; TTL = the assertion's remaining `exp`
+    /// lifetime. See
     /// `check_and_record_assertion_jti`.
-    pub assertion_jti_seen: TtlCache<String, ()>,
-    /// One-use ATProto service-auth JTIs, namespaced by issuer and retained
-    /// until the source assertion expires.
-    pub atproto_service_jti_seen: TtlCache<String, ()>,
+    pub assertion_jti_seen: TtlCache<ReplayKey, ()>,
+    /// One-use ATProto service-auth JTIs, keyed by a BLAKE3-256 digest of the
+    /// issuer/JTI composite and retained until the source assertion expires.
+    pub atproto_service_jti_seen: TtlCache<ReplayKey, ()>,
     /// Validated did:plc/did:web document source for service-auth keys.
     pub atproto_did_resolver: Arc<dyn AtprotoDidDocumentResolver>,
     /// Server-issued DPoP nonces. Value = expiry unix timestamp.
@@ -1170,12 +1230,15 @@ fn mesh_kem_public_for_policy(
 
 impl OAuthState {
     /// DPoP JTI replay barrier: 1,000 proofs/s sustained for 120s plus 20%
-    /// headroom. This is deliberately fail-closed: it must hold every live JTI.
+    /// headroom. Keys are fixed BLAKE3-256 digests; 128 bytes/live entry
+    /// before allocator slack plans this at about 17.6 MiB.
     const DPOP_JTI_MAX_ENTRIES: usize = 144_000;
     /// Inline reap budget per access (heap pops). Bounds tail latency.
     const DPOP_JTI_REAP_BUDGET: usize = 64;
     /// Client-assertion replay barrier: 100 assertions/s for the five-minute
-    /// maximum assertion lifetime plus 20% headroom.
+    /// maximum assertion lifetime plus 20% headroom. Fixed 32-byte digest keys
+    /// at 128 bytes/live entry plan 36,000 entries at about 4.4 MiB before
+    /// allocator slack.
     const ASSERTION_JTI_MAX_ENTRIES: usize = 36_000;
     /// Inline reap budget per access (heap pops). Bounds tail latency.
     const ASSERTION_JTI_REAP_BUDGET: usize = 64;
@@ -1236,8 +1299,15 @@ impl OAuthState {
                 Self::ASSERTION_JTI_REAP_BUDGET,
             ),
             atproto_service_jti_seen: TtlCache::new(
-                // ATProto service assertions can live for one hour. Reserve
-                // 100 assertions/s plus 20% headroom for that full window.
+                // ATProto service assertions can live for one hour. This is a
+                // 64 MiB per-barrier memory budget, not an unsupported
+                // traffic estimate. The fixed digest cache uses 120 bytes per
+                // live entry on 64-bit targets (64-byte map allocation at its
+                // 7/8 load factor + 56-byte heap node), rounded to 128 bytes
+                // for planning. At this cap its geometric map and heap arrays
+                // each top out at 524,288 slots: roughly 56.5 MiB including
+                // HashMap control bytes, below the 64 MiB budget. Full barriers
+                // fail closed and are metered.
                 432_000,
                 Self::ASSERTION_JTI_REAP_BUDGET,
             ),
@@ -1579,13 +1649,13 @@ impl OAuthState {
         // Window ends at iat + 120s (±60s skew + 60s buffer); TTL = remainder.
         let ttl_secs = ((iat + 120) - now).max(0) as u64;
         let result = self.dpop_jti_seen.insert_if_absent_no_evict(
-            jti.to_owned(),
+            super::replay_key::dpop_jti(jti),
             (),
             Duration::from_secs(ttl_secs),
         );
         if result != InsertIfAbsentNoEvictResult::Inserted {
             super::replay_metrics::record_rejection(super::replay_metrics::DPOP, result);
-            if result == InsertIfAbsentNoEvictResult::Full {
+            if super::replay_metrics::should_warn_full(super::replay_metrics::DPOP, result) {
                 tracing::warn!("DPoP replay barrier is full; refusing fresh proof");
             }
         }
@@ -1600,7 +1670,7 @@ impl OAuthState {
         }
         let ttl_secs = remaining as u64;
         let result = self.atproto_service_jti_seen.insert_if_absent_no_evict(
-            format!("{issuer}\u{1f}{jti}"),
+            super::replay_key::atproto_service_assertion_jti(issuer, jti),
             (),
             Duration::from_secs(ttl_secs),
         );
@@ -1609,7 +1679,10 @@ impl OAuthState {
                 super::replay_metrics::ATPROTO_SERVICE_ASSERTION,
                 result,
             );
-            if result == InsertIfAbsentNoEvictResult::Full {
+            if super::replay_metrics::should_warn_full(
+                super::replay_metrics::ATPROTO_SERVICE_ASSERTION,
+                result,
+            ) {
                 tracing::warn!(
                     "ATProto service-assertion replay barrier is full; refusing fresh assertion"
                 );
@@ -1633,7 +1706,7 @@ impl OAuthState {
         let now = chrono::Utc::now().timestamp();
         let ttl_secs = (exp - now).max(0) as u64;
         let result = self.assertion_jti_seen.insert_if_absent_no_evict(
-            format!("{client_id}\u{1f}{jti}"),
+            super::replay_key::client_assertion_jti(client_id, jti),
             (),
             Duration::from_secs(ttl_secs),
         );
@@ -1642,7 +1715,10 @@ impl OAuthState {
                 super::replay_metrics::CLIENT_ASSERTION,
                 result,
             );
-            if result == InsertIfAbsentNoEvictResult::Full {
+            if super::replay_metrics::should_warn_full(
+                super::replay_metrics::CLIENT_ASSERTION,
+                result,
+            ) {
                 tracing::warn!("client-assertion replay barrier is full; refusing fresh assertion");
             }
         }
@@ -1830,7 +1906,7 @@ impl OAuthState {
                 // Sweep expired DPoP JTIs and nonces
                 {
                     let now = chrono::Utc::now().timestamp();
-                    // dpop_jti_seen is a TtlCache (self-evicting); sweep the
+                    // dpop_jti_seen reaps expired entries on access; sweep the
                     // nonce + client-dedup maps only.
                     state.dpop_nonces.write().await.retain(|_, exp| *exp > now);
                     state

--- a/crates/hyprstream/src/services/oauth/token.rs
+++ b/crates/hyprstream/src/services/oauth/token.rs
@@ -22,7 +22,7 @@ use serde::Deserialize;
 use sha2::{Digest, Sha256};
 use subtle::ConstantTimeEq;
 
-use super::state::{DeviceCodeStatus, OAuthState, RefreshTokenEntry};
+use super::state::{DeviceCodeStatus, DpopJtiAdmission, OAuthState, RefreshTokenEntry};
 use crate::services::generated::policy_client::IssueToken;
 use hyprstream_pds::repo_authority::is_path_form_did_web;
 use hyprstream_rpc::auth::{jwk_thumbprint, JwkThumbprintInput};
@@ -491,13 +491,17 @@ async fn verify_dpop_at_token_endpoint(
             )));
         }
     };
-    // JTI replay check.
-    if !state.check_and_record_dpop_jti(&proof.jti, proof.iat) {
-        tracing::warn!(jti = %proof.jti, "DPoP JTI replay detected");
+    // JTI replay check. A full barrier is already metered and warning-rate-
+    // limited at insertion; only a duplicate emits a generic debug event.
+    let admission = state.check_and_record_dpop_jti_admission(&proof.jti, proof.iat);
+    if !admission.is_inserted() {
+        if let Some(message) = dpop_jti_rejection_log_message(admission) {
+            tracing::debug!("{message}");
+        }
         return Some(Err(token_error(
             StatusCode::BAD_REQUEST,
             "invalid_dpop_proof",
-            Some("DPoP proof jti already used"),
+            Some("DPoP proof rejected"),
         )));
     }
 
@@ -535,6 +539,12 @@ async fn verify_dpop_at_token_endpoint(
     }
 
     Some(Ok(proof.jkt))
+}
+
+/// A saturated barrier is logged only by its rate-limited insertion path.
+/// Duplicate proofs receive a generic diagnostic that never includes a JTI.
+fn dpop_jti_rejection_log_message(admission: DpopJtiAdmission) -> Option<&'static str> {
+    (admission == DpopJtiAdmission::Duplicate).then_some("DPoP JTI replay rejected")
 }
 
 /// Build a `400 use_dpop_nonce` response with the current nonce in the
@@ -1558,6 +1568,19 @@ fn token_error_body(error: &str, description: Option<&str>) -> serde_json::Value
 #[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn dpop_replay_logging_is_generic_and_never_bypasses_full_rate_limit() {
+        assert_eq!(
+            dpop_jti_rejection_log_message(DpopJtiAdmission::Duplicate),
+            Some("DPoP JTI replay rejected")
+        );
+        assert_eq!(dpop_jti_rejection_log_message(DpopJtiAdmission::Full), None);
+        assert_eq!(
+            dpop_jti_rejection_log_message(DpopJtiAdmission::InvalidLifetime),
+            None
+        );
+    }
 
     #[test]
     fn hosted_account_tenant_is_zone_bound_into_host_form_did() {

--- a/crates/hyprstream/src/services/oauth/token_exchange.rs
+++ b/crates/hyprstream/src/services/oauth/token_exchange.rs
@@ -399,12 +399,14 @@ pub(super) async fn verify_atproto_service_jwt(
     if claims.exp <= now {
         return Err("ATProto service JWT is expired".to_owned());
     }
-    if claims.iat > now + 5 || claims.exp <= claims.iat {
+    if claims.iat > now.saturating_add(5) || claims.exp <= claims.iat {
         return Err("ATProto service JWT has an invalid iat/exp interval".to_owned());
     }
-    if claims.exp - claims.iat > MAX_ATPROTO_SERVICE_TOKEN_LIFETIME {
-        return Err("ATProto service JWT lifetime exceeds one hour".to_owned());
-    }
+    let _lifetime = claims
+        .exp
+        .checked_sub(claims.iat)
+        .filter(|lifetime| *lifetime > 0 && *lifetime <= MAX_ATPROTO_SERVICE_TOKEN_LIFETIME)
+        .ok_or_else(|| "ATProto service JWT has an invalid iat/exp interval".to_owned())?;
     if claims.jti.is_empty() || claims.jti.len() > 256 {
         return Err("ATProto service JWT jti must be 1..=256 bytes".to_owned());
     }


### PR DESCRIPTION
Security replay-barrier hardening.

- Retains only fixed 32-byte BLAKE3 replay digests, now domain-separated and length-framed.
- Mount tickets require the exact local issuer, MAC-bound tenant and clearance, JTI, and a checked maximum five-minute lifetime before replay insertion; issued tickets now include a JTI.
- OAuth/MCP DPoP capacity covers admitted 60s future skew (180s residency); client assertions cover their 360s maximum admitted residency.
- Full barriers are metered and warning-rate-limited; only true duplicates produce debug logging, without raw JTIs.

Validation: focused replay-key and mount-ticket producer tests; clean isolated workspace release Clippy hook. Hosted checks have been started for this revision.