### PR TITLE
ci: move arm64 rust builder to Debian trixie

### DIFF
--- a/.github/builder-image.env
+++ b/.github/builder-image.env
@@ -1,0 +1,1 @@
+ghcr.io/hyprstream/rust-builder-arm64@sha256:2c7dd5d5c103f1ff44814ea204538d4b78f8f327a9f02437a2a8fc7412dcbb72

--- a/.github/builder-image.env
+++ b/.github/builder-image.env
@@ -1,1 +1,1 @@
-ghcr.io/hyprstream/rust-builder-arm64@sha256:2c7dd5d5c103f1ff44814ea204538d4b78f8f327a9f02437a2a8fc7412dcbb72
+ghcr.io/hyprstream/rust-builder-arm64@sha256:a9966f5e8b71319b63ffd2e684efe27f5144c6e419b5889b4c0465007c9da056

--- a/.github/scripts/load-builder-image.sh
+++ b/.github/scripts/load-builder-image.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+# Load the sole tracked arm64 builder-image pin for the calling GitHub Actions job.
+set -euo pipefail
+
+pin_file="${GITHUB_WORKSPACE:-$PWD}/.github/builder-image.env"
+[[ -f "$pin_file" ]]
+[[ $(wc -l < "$pin_file") -eq 1 ]]
+
+image=$(<"$pin_file")
+[[ "$image" =~ ^ghcr\.io/hyprstream/rust-builder-arm64@sha256:[0-9a-f]{64}$ ]]
+
+printf 'BUILDER_IMAGE=%s\n' "$image" >> "$GITHUB_ENV"

--- a/.github/workflows/appimage.yml
+++ b/.github/workflows/appimage.yml
@@ -160,13 +160,13 @@ jobs:
     name: Build arm64 CPU AppImage
     runs-on: [self-hosted, linux, arm64, graviton, hyprstream-merge-gate]
     timeout-minutes: 150
-    env:
-      BUILDER_IMAGE: ghcr.io/hyprstream/rust-builder-arm64@sha256:aa9feb1c8432ebf4583fcfc9c8236c371cb050f489c4d0882a7f2d8c8589120e
-
     steps:
       - uses: actions/checkout@v4
         with:
           persist-credentials: false
+
+      - name: Load builder image pin
+        run: bash .github/scripts/load-builder-image.sh
 
       - name: Pull arm64 builder image
         run: podman pull "$BUILDER_IMAGE"

--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -68,9 +68,10 @@ jobs:
           echo "digest=$(cat /tmp/img.digest)" >> "$GITHUB_OUTPUT"
 
       # -------------------------------------------------------------------------
-      # Auto-bump the digest CI pins (env.BUILDER_IMAGE in rust.yml). CI pins by
-      # digest for reproducibility; this opens a PR to move that pin whenever a new
-      # image is published, so the reproducibility costs no manual re-pinning. The
+      # Auto-bump the canonical builder-image pin. Every consumer loads this
+      # tracked value after checkout, so one update moves rust.yml, preflight, and
+      # AppImage packaging together. CI pins by digest for reproducibility; this
+      # opens a PR to move that pin whenever a new image is published. The
       # PR self-validates: the merge gate runs against the new image, so a broken
       # image simply never merges and the old digest stays live.
       #
@@ -81,18 +82,18 @@ jobs:
       # BUILDER_IMAGE_BUMP_TOKEN), scoped to THIS repo with only Contents + Pull
       # requests write. (Actions OIDC cannot be used here — it federates to EXTERNAL
       # providers like AWS, not to GitHub's own API.) If the secret is unset the bump
-      # step is skipped with a warning (image still published; bump rust.yml
-      # manually until the PAT is provisioned).
+      # step is skipped with a warning (image still published; bump the canonical
+      # .github/builder-image.env manually until the PAT is provisioned).
       # -------------------------------------------------------------------------
-      - name: Rewrite the rust.yml pin if the digest changed
+      - name: Rewrite the canonical builder-image pin if the digest changed
         id: pin
         run: |
           new="$IMAGE@${{ steps.push.outputs.digest }}"
-          cur=$(grep -oE 'ghcr\.io/hyprstream/rust-builder-arm64@sha256:[0-9a-f]+' .github/workflows/rust.yml | head -1)
+          cur=$(cat .github/builder-image.env)
           echo "current=$cur"
           echo "new=$new"
           if [ "$cur" = "$new" ]; then echo "changed=false" >> "$GITHUB_OUTPUT"; exit 0; fi
-          sed -i "s|ghcr\.io/hyprstream/rust-builder-arm64@sha256:[0-9a-f]*|$new|g" .github/workflows/rust.yml
+          printf '%s\n' "$new" > .github/builder-image.env
           echo "changed=true" >> "$GITHUB_OUTPUT"
 
       - name: Check for the bump PAT
@@ -103,7 +104,7 @@ jobs:
           if [ -n "$BOT" ]; then
             echo "present=true" >> "$GITHUB_OUTPUT"
           else
-            echo "::warning::BUILDER_IMAGE_BUMP_TOKEN not set — skipping the auto digest-bump PR (image is published; bump rust.yml manually until the PAT is provisioned)."
+            echo "::warning::BUILDER_IMAGE_BUMP_TOKEN not set — skipping the auto digest-bump PR (image is published; bump .github/builder-image.env manually until the PAT is provisioned)."
             echo "present=false" >> "$GITHUB_OUTPUT"
           fi
 
@@ -117,14 +118,15 @@ jobs:
           token: ${{ secrets.BUILDER_IMAGE_BUMP_TOKEN }}
           branch: automation/bump-builder-image
           base: main
-          add-paths: .github/workflows/rust.yml
-          commit-message: "ci: bump BUILDER_IMAGE to newly published rust-builder digest"
-          title: "ci: bump BUILDER_IMAGE digest (automated)"
+          add-paths: .github/builder-image.env
+          commit-message: "ci: bump canonical rust-builder image digest"
+          title: "ci: bump canonical rust-builder image digest (automated)"
           labels: automation, ci
           delete-branch: true
           body: |
-            Automated bump of the `BUILDER_IMAGE` pin in `.github/workflows/rust.yml`
-            to the digest just published by `build-image.yml`.
+            Automated bump of the shared builder-image pin in
+            `.github/builder-image.env` to the digest just published by
+            `build-image.yml`.
 
             - digest: `${{ steps.push.outputs.digest }}`
             - tag: `${{ steps.tag.outputs.date }}-${{ steps.tag.outputs.sha }}`

--- a/.github/workflows/merge-gate-preflight.yml
+++ b/.github/workflows/merge-gate-preflight.yml
@@ -40,7 +40,6 @@ env:
   SCCACHE_BUCKET: ${{ vars.AWS_SCCACHE_BUCKET }}
   SCCACHE_REGION: ${{ vars.AWS_SCCACHE_REGION }}
   CARGO_INCREMENTAL: 0
-  BUILDER_IMAGE: ghcr.io/hyprstream/rust-builder-arm64@sha256:aa9feb1c8432ebf4583fcfc9c8236c371cb050f489c4d0882a7f2d8c8589120e
 
 jobs:
   resolve-pr:
@@ -95,6 +94,9 @@ jobs:
       with:
         ref: ${{ needs.resolve-pr.outputs.sha }}
         persist-credentials: false
+
+    - name: Load builder image pin
+      run: bash .github/scripts/load-builder-image.sh
 
     - name: Report validated revision
       run: |

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -35,7 +35,7 @@ env:
   # toolchain's components/targets, all baked. Bump this digest deliberately after
   # a builder-image publish so CI inputs stay reproducible (a follow-up automates
   # the bump — see build-image.yml).
-  BUILDER_IMAGE: ghcr.io/hyprstream/rust-builder-arm64@sha256:aa9feb1c8432ebf4583fcfc9c8236c371cb050f489c4d0882a7f2d8c8589120e
+  BUILDER_IMAGE: ghcr.io/hyprstream/rust-builder-arm64@sha256:2c7dd5d5c103f1ff44814ea204538d4b78f8f327a9f02437a2a8fc7412dcbb72
 
 # The fast lint jobs (clippy, wasm) run on the self-hosted Graviton (arm64)
 # runners and drive the build through `podman run` against the prebuilt

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -30,13 +30,6 @@ env:
   SCCACHE_BUCKET: ${{ vars.AWS_SCCACHE_BUCKET }}
   SCCACHE_REGION: ${{ vars.AWS_SCCACHE_REGION }}
   CARGO_INCREMENTAL: 0
-  # Pinned arm64 rust-builder image (built by build-image.yml): toolchain +
-  # libtorch + capnproto + sccache + cargo-nextest + git-lfs + the pinned Rust
-  # toolchain's components/targets, all baked. Bump this digest deliberately after
-  # a builder-image publish so CI inputs stay reproducible (a follow-up automates
-  # the bump — see build-image.yml).
-  BUILDER_IMAGE: ghcr.io/hyprstream/rust-builder-arm64@sha256:2c7dd5d5c103f1ff44814ea204538d4b78f8f327a9f02437a2a8fc7412dcbb72
-
 # The fast lint jobs (clippy, wasm) run on the self-hosted Graviton (arm64)
 # runners and drive the build through `podman run` against the prebuilt
 # rust-builder image (rust + capnproto + clang + libtorch). We DELIBERATELY do
@@ -74,6 +67,11 @@ jobs:
     - uses: actions/checkout@v4
       with:
         persist-credentials: false
+
+    # The immutable arm64 builder image is shared by rust.yml, the preflight,
+    # and AppImage packaging. Keep its sole pin in .github/builder-image.env.
+    - name: Load builder image pin
+      run: bash .github/scripts/load-builder-image.sh
 
     - name: Configure AWS credentials (OIDC → sccache S3)
       uses: aws-actions/configure-aws-credentials@v4
@@ -172,6 +170,9 @@ jobs:
       with:
         persist-credentials: false
 
+    - name: Load builder image pin
+      run: bash .github/scripts/load-builder-image.sh
+
     - name: Configure AWS credentials (OIDC → sccache S3)
       uses: aws-actions/configure-aws-credentials@v4
       with:
@@ -242,6 +243,9 @@ jobs:
     - uses: actions/checkout@v4
       with:
         persist-credentials: false
+
+    - name: Load builder image pin
+      run: bash .github/scripts/load-builder-image.sh
 
     - name: Configure AWS credentials (OIDC → sccache S3)
       uses: aws-actions/configure-aws-credentials@v4

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,8 +17,10 @@ ARG LIBTORCH_CPU_URL=https://download.pytorch.org/libtorch/cpu/libtorch-shared-w
 
 FROM debian:${DEBIAN_VERSION} AS builder-base
 
-# Install build dependencies. Trixie's stock binutils is new enough for OpenSSL
-# AVX-512 assembly, so no backports repository or package pin is needed.
+# Install build dependencies. The former backports binutils workaround was for
+# x86 OpenSSL AVX-512 assembly and was never relevant to the native arm64
+# builder image. Trixie's stock binutils is current, so no suite-specific
+# backports source or pin is required for any builder variant.
 RUN apt-get update && apt-get install -y \
     curl \
     wget \
@@ -51,13 +53,46 @@ ENV SCCACHE_DIR=/sccache
 # CUDA 12.8 Builder
 #############################################
 
-FROM builder-base AS builder-cuda128
+# NVIDIA publishes the supported CUDA 12.8 and 13.0 APT packages only in its
+# Debian 12 repository. That repository's legacy key binding is rejected by
+# Trixie's sqv, so keep these x86 CUDA *toolchain* stages on Bookworm. Their
+# final runtime stages below are Debian 13; copying Bookworm libraries into a
+# newer glibc runtime is ABI-safe. The arm64 builder and all Trixie-built
+# binaries continue to use the Debian 13 runtime floor.
+FROM debian:bookworm AS builder-cuda-base
+
+RUN apt-get update && apt-get install -y \
+    curl \
+    wget \
+    unzip \
+    build-essential \
+    pkg-config \
+    libssl-dev \
+    libsystemd-dev \
+    git \
+    dialog \
+    rsync \
+    ca-certificates \
+    capnproto \
+    cmake \
+    clang \
+    libclang-dev \
+    && rm -rf /var/lib/apt/lists/* \
+    && apt-get clean
+
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+ENV PATH="/root/.cargo/bin:${PATH}"
+RUN cargo install sccache --locked
+ENV RUSTC_WRAPPER=sccache
+ENV SCCACHE_DIR=/sccache
+
+FROM builder-cuda-base AS builder-cuda128
 ARG LIBTORCH_CUDA128_URL
 ARG LIBTORCH_VERSION
 
 ENV LIBTORCH_BYPASS_VERSION_CHECK=1
 
-# Install CUDA repository and runtime libraries (needed for linking)
+# Install CUDA runtime libraries from NVIDIA's matching Debian 12 repository.
 RUN wget https://developer.download.nvidia.com/compute/cuda/repos/debian12/x86_64/cuda-keyring_1.1-1_all.deb && \
     dpkg -i cuda-keyring_1.1-1_all.deb && \
     rm cuda-keyring_1.1-1_all.deb && \
@@ -81,13 +116,13 @@ ENV LD_LIBRARY_PATH=/opt/libtorch/lib
 # CUDA 13.0 Builder
 #############################################
 
-FROM builder-base AS builder-cuda130
+FROM builder-cuda-base AS builder-cuda130
 ARG LIBTORCH_CUDA130_URL
 ARG LIBTORCH_VERSION
 
 ENV LIBTORCH_BYPASS_VERSION_CHECK=1
 
-# Install CUDA repository and runtime libraries (needed for linking)
+# Install CUDA runtime libraries from NVIDIA's matching Debian 12 repository.
 RUN wget https://developer.download.nvidia.com/compute/cuda/repos/debian12/x86_64/cuda-keyring_1.1-1_all.deb && \
     dpkg -i cuda-keyring_1.1-1_all.deb && \
     rm cuda-keyring_1.1-1_all.deb && \
@@ -291,7 +326,7 @@ RUN --mount=type=cache,target=/root/.cargo/registry \
 # CUDA 12.8 Runtime
 #############################################
 
-FROM gcr.io/distroless/cc-debian12 AS runtime-cuda128
+FROM gcr.io/distroless/cc-debian13 AS runtime-cuda128
 
 # Copy required system libraries
 COPY --from=builder /usr/lib/x86_64-linux-gnu/libgomp.so.1 /usr/lib/x86_64-linux-gnu/
@@ -311,7 +346,7 @@ COPY --from=builder /opt/libtorch/lib/ /opt/libtorch/lib/
 # CUDA 13.0 Runtime
 #############################################
 
-FROM gcr.io/distroless/cc-debian12 AS runtime-cuda130
+FROM gcr.io/distroless/cc-debian13 AS runtime-cuda130
 
 # Copy required system libraries
 COPY --from=builder /usr/lib/x86_64-linux-gnu/libgomp.so.1 /usr/lib/x86_64-linux-gnu/
@@ -331,7 +366,7 @@ COPY --from=builder /opt/libtorch/lib/ /opt/libtorch/lib/
 # ROCm 7.1 Runtime
 #############################################
 
-FROM gcr.io/distroless/cc-debian12 AS runtime-rocm71
+FROM gcr.io/distroless/cc-debian13 AS runtime-rocm71
 
 # Copy required system libraries
 COPY --from=builder /usr/lib/x86_64-linux-gnu/libgomp.so.1 /usr/lib/x86_64-linux-gnu/
@@ -346,7 +381,7 @@ COPY --from=builder /opt/libtorch/lib/ /opt/libtorch/lib/
 # CPU Runtime
 #############################################
 
-FROM gcr.io/distroless/cc-debian12 AS runtime-cpu
+FROM gcr.io/distroless/cc-debian13 AS runtime-cpu
 
 # Copy required system libraries
 COPY --from=builder /usr/lib/x86_64-linux-gnu/libgomp.so.1 /usr/lib/x86_64-linux-gnu/
@@ -365,9 +400,9 @@ COPY --from=builder /opt/libtorch/lib/ /opt/libtorch/lib/
 # pip wheel's libtorch). Debian multilib lives under /usr/lib/aarch64-linux-gnu
 # on arm64, so the system-library COPYs cannot share the x86_64 runtime stage.
 # Selected via `FROM runtime-${VARIANT}` when VARIANT=cpu-arm64. gcr.io/distroless
-# cc-debian12 is multi-arch, so the base resolves to its arm64 variant natively.
+# cc-debian13 is multi-arch, so the base resolves to its arm64 variant natively.
 
-FROM gcr.io/distroless/cc-debian12 AS runtime-cpu-arm64
+FROM gcr.io/distroless/cc-debian13 AS runtime-cpu-arm64
 
 # Copy required system libraries (arm64 multilib path)
 COPY --from=builder /usr/lib/aarch64-linux-gnu/libgomp.so.1 /usr/lib/aarch64-linux-gnu/

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 # Multi-variant build for Hyprstream supporting CPU, CUDA, and ROCm
 
 ARG VARIANT=cpu
-ARG DEBIAN_VERSION=bookworm
+ARG DEBIAN_VERSION=trixie
 ARG LIBTORCH_VERSION=2.10.0
 
 # LibTorch download URLs for manual installation
@@ -17,10 +17,9 @@ ARG LIBTORCH_CPU_URL=https://download.pytorch.org/libtorch/cpu/libtorch-shared-w
 
 FROM debian:${DEBIAN_VERSION} AS builder-base
 
-# Install build dependencies
-# Note: binutils from backports required for OpenSSL AVX-512 assembly compatibility
-RUN echo "deb http://deb.debian.org/debian bookworm-backports main" >> /etc/apt/sources.list && \
-    apt-get update && apt-get install -y \
+# Install build dependencies. Trixie's stock binutils is new enough for OpenSSL
+# AVX-512 assembly, so no backports repository or package pin is needed.
+RUN apt-get update && apt-get install -y \
     curl \
     wget \
     unzip \
@@ -36,7 +35,6 @@ RUN echo "deb http://deb.debian.org/debian bookworm-backports main" >> /etc/apt/
     cmake \
     clang \
     libclang-dev \
-    && apt-get install -y -t bookworm-backports binutils \
     && rm -rf /var/lib/apt/lists/* \
     && apt-get clean
 
@@ -157,8 +155,8 @@ ENV LD_LIBRARY_PATH=/opt/libtorch/lib
 # There is NO aarch64 libtorch zip at download.pytorch.org/libtorch/cpu — that
 # URL is x86_64-only. The PyTorch aarch64 manylinux_2_28 pip wheel, however,
 # bundles a complete CPU libtorch (torch/lib/*.so + torch/include), so we install
-# torch via pip and point LIBTORCH at the wheel's torch dir. bookworm ships
-# glibc 2.36, satisfying the wheel's manylinux_2_28 (glibc 2.28+) floor.
+# torch via pip and point LIBTORCH at the wheel's torch dir. Trixie ships a
+# newer glibc than the wheel's manylinux_2_28 (glibc 2.28+) floor.
 #
 # This stage is the toolchain+libtorch image only; the actual cargo build runs
 # either in the `builder` stage below (VARIANT=cpu-arm64) or by mounting the
@@ -171,7 +169,7 @@ ARG LIBTORCH_VERSION
 # wheel reports the same 2.10.0 but bypass keeps us resilient to wheel-suffix skew.
 ENV LIBTORCH_BYPASS_VERSION_CHECK=1
 
-# Python + pip to fetch the aarch64 torch wheel (bookworm python3 == 3.11 -> cp311).
+# Python + pip to fetch the aarch64 torch wheel.
 RUN apt-get update && apt-get install -y --no-install-recommends \
         python3 python3-pip \
     && rm -rf /var/lib/apt/lists/* \

--- a/README-Docker.md
+++ b/README-Docker.md
@@ -129,7 +129,7 @@ docker build -t hyprstream:rocm --build-arg VARIANT=rocm71 .
 | Argument | Default | Description |
 |----------|---------|-------------|
 | `VARIANT` | `cpu` | Build variant: `cpu`, `cuda128`, `cuda130`, `rocm71` |
-| `DEBIAN_VERSION` | `bookworm` | Debian base image version |
+| `DEBIAN_VERSION` | `trixie` | Debian base image version |
 | `LIBTORCH_VERSION` | `2.10.0` | PyTorch/LibTorch version |
 
 ## Privileged Containers


### PR DESCRIPTION
Moves the shared arm64 rust-builder base from Debian bookworm (glibc 2.36) to trixie (glibc 2.41), and removes the obsolete backports source/pin. The removed workaround was only for x86 OpenSSL AVX-512 assembly and was never relevant to this native arm64 image; Trixie stock binutils is sufficient without a suite-specific pin.

Revision for ABI safety:
- All final runtime stages now use multi-arch `gcr.io/distroless/cc-debian13`, matching the Trixie glibc floor.
- `.github/builder-image.env` is the single immutable builder-image pin. Rust CI, merge-gate preflight, and arm64 AppImage jobs load it after checkout; `build-image.yml` rewrites that canonical file for automated bumps.
- CUDA 12.8/13.0 toolchain stages intentionally use a matching Bookworm base because NVIDIA only supplies those legacy package lines through its Debian 12 repository and Trixie rejects that repository's legacy key binding. Their final runtime stages remain Debian 13, so no newer-builder/older-runtime ABI inversion remains.

Validation:
- Local final CPU image rebuilt from the revised Dockerfile with `cc-debian13`, then `podman run ... --help` succeeded (process startup and CLI output).
- CUDA 12.8 and 13.0 builder smoke builds succeeded; each reports its expected `nvcc` version and contains `libtorch_cuda.so`.
- Trixie ROCm 7.1 builder smoke build succeeded and contains LibTorch headers and `libtorch.so`.
- Workflow matrix regression check and commit-hook clippy passed.
- Builder-image republish for this revision: https://github.com/hyprstream/hyprstream/actions/runs/30485020369 (in progress).

The prior published arm64 builder image reports glibc 2.41 and exports `strlcpy@@GLIBC_2.38` and `__isoc23_strtoul@@GLIBC_2.38`; CI consumes the immutable shared digest rather than `:latest`.