### PR TITLE
refactor(k8s): preserve Apache substrate boundary

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1250,6 +1250,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "base-x"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cbbc9d0964165b47557570cce6c952866c2678457aca742aafc9fb771d30270"
+
+[[package]]
 name = "base16ct"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1260,6 +1266,22 @@ name = "base16ct"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fd307490d624467aa6f74b0eabb77633d1f758a7b25f12bceb0b22e08d9726f6"
+
+[[package]]
+name = "base256emoji"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5e9430d9a245a77c92176e649af6e275f20839a48389859d1661e9a128d077c"
+dependencies = [
+ "const-str 0.4.3",
+ "match-lookup",
+]
+
+[[package]]
+name = "base45"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "240e56f4d3c453c36faacb695c535a4d5f8c7d23dac175014f32eb0a71012a03"
 
 [[package]]
 name = "base64"
@@ -2168,6 +2190,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "cid"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21a304f95f84d169a6f31c4d0a30d784643aaa0bbc9c1e449a2c23e963ec4971"
+dependencies = [
+ "multibase",
+ "multihash",
+ "unsigned-varint",
+]
+
+[[package]]
 name = "cipher"
 version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2456,6 +2489,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "const-str"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f421161cb492475f1661ddc9815a745a1c894592070661180fdec3d4872e9c3"
+
+[[package]]
 name = "const-str-proc-macro"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2566,15 +2605,6 @@ name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
-
-[[package]]
-name = "core2"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b49ba7ef1ad6107f8824dbe97de947cbaac53c44e7f9756a1fba0d37c1eec505"
-dependencies = [
- "memchr",
-]
 
 [[package]]
 name = "coset"
@@ -7137,6 +7167,7 @@ name = "hyprstream-k8s"
 version = "0.1.0"
 dependencies = [
  "async-trait",
+ "cid",
  "futures",
  "hyprstream-rpc",
  "hyprstream-vfs",
@@ -7147,6 +7178,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_yaml",
+ "tempfile",
  "thiserror 1.0.69",
  "tokio",
  "toml 0.8.23",
@@ -9480,6 +9512,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "match-lookup"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "757aee279b8bdbb9f9e676796fd459e4207a1f986e87886700abf589f5abf771"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.111",
+]
+
+[[package]]
 name = "matchers"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9861,12 +9904,24 @@ dependencies = [
 ]
 
 [[package]]
-name = "multihash"
-version = "0.19.3"
+name = "multibase"
+version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b430e7953c29dd6a09afc29ff0bb69c6e306329ee6794700aee27b76a1aea8d"
+checksum = "7e0e4a371cbf1dfd666b658ba137763edb23c45beb43cfe369b5593cd6b437b6"
 dependencies = [
- "core2",
+ "base-x",
+ "base256emoji",
+ "base45",
+ "data-encoding",
+ "data-encoding-macro",
+]
+
+[[package]]
+name = "multihash"
+version = "0.19.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "577c63b00ad74d57e8c9aa870b5fccebf2fd64a308a5aee9f1bb88e4aea19447"
+dependencies = [
  "unsigned-varint",
 ]
 
@@ -19368,7 +19423,7 @@ name = "xet_config"
 version = "0.14.5"
 source = "git+https://github.com/huggingface/xet-core?tag=git-xet-v0.2.0#eeee211e5900cbe6a65649fbec0ee0750cc831b2"
 dependencies = [
- "const-str",
+ "const-str 0.3.2",
  "ctor",
  "duration-str",
  "konst",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7175,6 +7175,7 @@ dependencies = [
  "kube",
  "parking_lot 0.12.4",
  "schemars",
+ "semver",
  "serde",
  "serde_json",
  "serde_yaml",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7136,24 +7136,33 @@ dependencies = [
 name = "hyprstream-k8s"
 version = "0.1.0"
 dependencies = [
- "anyhow",
  "async-trait",
- "ed25519-dalek 2.2.0",
  "futures",
- "hyprstream-pds",
  "hyprstream-rpc",
  "hyprstream-vfs",
  "k8s-openapi",
  "kube",
  "parking_lot 0.12.4",
- "rand 0.8.5",
  "schemars",
  "serde",
  "serde_json",
  "serde_yaml",
  "thiserror 1.0.69",
  "tokio",
+ "toml 0.8.23",
  "tracing",
+]
+
+[[package]]
+name = "hyprstream-k8s-pds"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "ed25519-dalek 2.2.0",
+ "hyprstream-k8s",
+ "hyprstream-pds",
+ "hyprstream-rpc",
+ "rand 0.8.5",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,7 @@ members = [
     "crates/hyprstream-workers-wasmtime",
     "crates/hyprstream-workers-python",
     "crates/hyprstream-k8s",
+    "crates/hyprstream-k8s-pds",
     "crates/hyprstream-ledger",
     "crates/hyprstream-resource",
 ]

--- a/LICENSE-APACHE
+++ b/LICENSE-APACHE
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 [![Rust](https://github.com/hyprstream/hyprstream/actions/workflows/rust.yml/badge.svg)](https://github.com/hyprstream/hyprstream/actions/workflows/rust.yml)
 [![License: AGPL v3](https://img.shields.io/badge/License-AGPL%20v3-blue.svg)](LICENSE-AGPLV3)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE-MIT)
+[![License: Apache 2.0](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](LICENSE-APACHE)
 [![DeepWiki](https://img.shields.io/badge/DeepWiki-hyprstream%2Fhyprstream-blue.svg?logo=data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACwAAAAyCAYAAAAnWDnqAAAAAXNSR0IArs4c6QAAA05JREFUaEPtmUtyEzEQhtWTQyQLHNak2AB7ZnyXZMEjXMGeK/AIi+QuHrMnbChYY7MIh8g01fJoopFb0uhhEqqcbWTp06/uv1saEDv4O3n3dV60RfP947Mm9/SQc0ICFQgzfc4CYZoTPAswgSJCCUJUnAAoRHOAUOcATwbmVLWdGoH//PB8mnKqScAhsD0kYP3j/Yt5LPQe2KvcXmGvRHcDnpxfL2zOYJ1mFwrryWTz0advv1Ut4CJgf5uhDuDj5eUcAUoahrdY/56ebRWeraTjMt/00Sh3UDtjgHtQNHwcRGOC98BJEAEymycmYcWwOprTgcB6VZ5JK5TAJ+fXGLBm3FDAmn6oPPjR4rKCAoJCal2eAiQp2x0vxTPB3ALO2CRkwmDy5WohzBDwSEFKRwPbknEggCPB/imwrycgxX2NzoMCHhPkDwqYMr9tRcP5qNrMZHkVnOjRMWwLCcr8ohBVb1OMjxLwGCvjTikrsBOiA6fNyCrm8V1rP93iVPpwaE+gO0SsWmPiXB+jikdf6SizrT5qKasx5j8ABbHpFTx+vFXp9EnYQmLx02h1QTTrl6eDqxLnGjporxl3NL3agEvXdT0WmEost648sQOYAeJS9Q7bfUVoMGnjo4AZdUMQku50McDcMWcBPvr0SzbTAFDfvJqwLzgxwATnCgnp4wDl6Aa+Ax283gghmj+vj7feE2KBBRMW3FzOpLOADl0Isb5587h/U4gGvkt5v60Z1VLG8BhYjbzRwyQZemwAd6cCR5/XFWLYZRIMpX39AR0tjaGGiGzLVyhse5C9RKC6ai42ppWPKiBagOvaYk8lO7DajerabOZP46Lby5wKjw1HCRx7p9sVMOWGzb/vA1hwiWc6jm3MvQDTogQkiqIhJV0nBQBTU+3okKCFDy9WwferkHjtxib7t3xIUQtHxnIwtx4mpg26/HfwVNVDb4oI9RHmx5WGelRVlrtiw43zboCLaxv46AZeB3IlTkwouebTr1y2NjSpHz68WNFjHvupy3q8TFn3Hos2IAk4Ju5dCo8B3wP7VPr/FGaKiG+T+v+TQqIrOqMTL1VdWV1DdmcbO8KXBz6esmYWYKPwDL5b5FA1a0hwapHiom0r/cKaoqr+27/XcrS5UwSMbQAAAABJRU5ErkJggg==)](https://deepwiki.com/hyprstream/hyprstream)
 
 ## Overview
@@ -535,13 +536,21 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines.
 
 ## License
 
-This project uses a dual-licensing model:
+Licensing is assigned per crate:
 
 **MIT OR AGPL-3.0 (your choice)** — the main `hyprstream` application.
 
-**MIT** — all other crates, including the RPC/security stack (`hyprstream-rpc`, `hyprstream-rpc-derive`, `hyprstream-rpc-std`, `hyprstream-service`, `hyprstream-discovery`), the namespace stack (`hyprstream-vfs`, `hyprstream-9p`, `hyprstream-vfs-server`, `hyprstream-containedfs`), workers (`hyprstream-workers` + engine crates), the TUI stack (`hyprstream-tui`, `hyprstream-compositor`, `waxterm`, `chat-core`), `hyprstream-metrics`, `hyprstream-flight`, `hyprstream-pds`, and the Git/storage libraries (`git2db`, `gittorrent`, `git-xet-filter`, `cas-serve`).
+**Apache-2.0** — the reusable Kubernetes substrate, `hyprstream-k8s`.
 
-See [LICENSE-MIT](LICENSE-MIT) and [LICENSE-AGPLV3](LICENSE-AGPLV3) for details.
+**AGPL-3.0-only** — the authority-bearing Kubernetes PDS grant adapter,
+`hyprstream-k8s-pds`.
+
+**MIT** — the remaining first-party crates whose manifests declare or inherit
+MIT, including the RPC/security, namespace, worker, TUI, metrics, storage, and
+service crates. Each crate's `Cargo.toml` is the authoritative assignment.
+
+See [LICENSE-MIT](LICENSE-MIT), [LICENSE-AGPLV3](LICENSE-AGPLV3), and
+[LICENSE-APACHE](LICENSE-APACHE) for the corresponding license terms.
 
 ## Acknowledgments
 

--- a/crates/hyprstream-k8s-pds/Cargo.toml
+++ b/crates/hyprstream-k8s-pds/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "hyprstream-k8s-pds"
+version = "0.1.0"
+edition.workspace = true
+license = "AGPL-3.0-only"
+repository.workspace = true
+description = "AGPL tenant-grant and PDS allocation adapter for hyprstream-k8s"
+
+[dependencies]
+anyhow = { workspace = true }
+ed25519-dalek = { workspace = true }
+hyprstream-k8s = { path = "../hyprstream-k8s", features = ["grant"] }
+hyprstream-pds = { path = "../hyprstream-pds" }
+hyprstream-rpc = { path = "../hyprstream-rpc" }
+rand = { workspace = true }
+
+[lints]
+workspace = true

--- a/crates/hyprstream-k8s-pds/Cargo.toml
+++ b/crates/hyprstream-k8s-pds/Cargo.toml
@@ -14,5 +14,10 @@ hyprstream-pds = { path = "../hyprstream-pds" }
 hyprstream-rpc = { path = "../hyprstream-rpc" }
 rand = { workspace = true }
 
+[dev-dependencies]
+# Compile the supported downstream operator composition without changing the
+# adapter's production dependency surface.
+hyprstream-k8s = { path = "../hyprstream-k8s", features = ["k8s", "grant"] }
+
 [lints]
 workspace = true

--- a/crates/hyprstream-k8s-pds/src/lib.rs
+++ b/crates/hyprstream-k8s-pds/src/lib.rs
@@ -43,16 +43,41 @@
 //! ## Downstream composition
 //!
 //! The Apache substrate depends only on its service-neutral contract. A
-//! downstream binary opts into this AGPL adapter and passes the issuer through
-//! that contract:
+//! downstream binary enables the substrate's `k8s,grant` features, opts into
+//! this AGPL adapter, and passes the issuer to the generic operator without
+//! contacting a cluster during compilation:
 //!
-//! ```
+//! ```no_run
 //! use std::sync::Arc;
-//! use hyprstream_k8s::grant::TenantGrantService;
+//! use hyprstream_k8s::kube::Client;
+//! use hyprstream_k8s::operator::{
+//!     run_operator_with_grant_service, HyprstreamOperatorRpc, OperatorConfig,
+//!     OperatorError, OperatorState,
+//! };
 //! use hyprstream_k8s_pds::TenantGrantIssuer;
 //!
-//! fn grant_service(issuer: TenantGrantIssuer) -> Arc<dyn TenantGrantService> {
-//!     Arc::new(issuer)
+//! fn configured_state<R: HyprstreamOperatorRpc>(
+//!     client: Client,
+//!     rpc: Arc<R>,
+//!     config: OperatorConfig,
+//!     issuer: TenantGrantIssuer,
+//! ) -> OperatorState<R> {
+//!     OperatorState::new(client, rpc, config)
+//!         .with_grant_service(Some(Arc::new(issuer)))
+//! }
+//!
+//! async fn run<R: HyprstreamOperatorRpc>(
+//!     client: Client,
+//!     rpc: Arc<R>,
+//!     config: OperatorConfig,
+//!     issuer: TenantGrantIssuer,
+//! ) -> Result<(), OperatorError> {
+//!     run_operator_with_grant_service(
+//!         client,
+//!         rpc,
+//!         config,
+//!         Some(Arc::new(issuer)),
+//!     ).await
 //! }
 //! ```
 

--- a/crates/hyprstream-k8s-pds/src/lib.rs
+++ b/crates/hyprstream-k8s-pds/src/lib.rs
@@ -39,6 +39,22 @@
 //! - **S6 short-ttl sender-bound (DPoP) renewal** — greenfield (#921 gap 2);
 //!   the `epoch` counter on the allocation record is the revocation handle
 //!   until the renewal layer exists.
+//!
+//! ## Downstream composition
+//!
+//! The Apache substrate depends only on its service-neutral contract. A
+//! downstream binary opts into this AGPL adapter and passes the issuer through
+//! that contract:
+//!
+//! ```
+//! use std::sync::Arc;
+//! use hyprstream_k8s::grant::TenantGrantService;
+//! use hyprstream_k8s_pds::TenantGrantIssuer;
+//!
+//! fn grant_service(issuer: TenantGrantIssuer) -> Arc<dyn TenantGrantService> {
+//!     Arc::new(issuer)
+//! }
+//! ```
 
 use std::time::{SystemTime, UNIX_EPOCH};
 
@@ -707,13 +723,10 @@ impl TenantGrantService for TenantGrantIssuer {
         epoch: u64,
         now: u64,
     ) -> Result<TenantGrantArtifacts, TenantGrantServiceError> {
-        self.compile(binding, epoch, now)
-            .map(|compiled| TenantGrantArtifacts {
-                grant_cid: compiled.grant_cid,
-                allocation_cid: compiled.allocation_cid,
-                epoch: compiled.epoch,
-            })
-            .map_err(|error| TenantGrantServiceError::new(format!("{error:#}")))
+        let compiled = self
+            .compile(binding, epoch, now)
+            .map_err(|error| TenantGrantServiceError::new(format!("{error:#}")))?;
+        TenantGrantArtifacts::new(compiled.grant_cid, compiled.allocation_cid, compiled.epoch)
     }
 }
 

--- a/crates/hyprstream-k8s-pds/src/lib.rs
+++ b/crates/hyprstream-k8s-pds/src/lib.rs
@@ -1,0 +1,1095 @@
+//! AGPL PDS adapter for [`hyprstream_k8s::mesh::TenantBinding`] grant compilation.
+//!
+//! A `TenantBinding` is an **admin-authorable surface**, never the authority.
+//! When [`hyprstream_k8s::mesh::TenantBindingSpec::entitlement`] is set, the
+//! operator invokes this adapter through
+//! [`hyprstream_k8s::grant::TenantGrantService`] and compiles
+//! it — signing **as issuer** — into the two artifacts that *are* the authority:
+//!
+//! 1. A **UCAN grant** ([`hyprstream_rpc::auth::ucan::Ucan`]) — an
+//!    issuer→holder capability signed with the project's hybrid-PQC COSE
+//!    composite (EdDSA + ML-DSA-65) via
+//!    [`hyprstream_rpc::crypto::cose_sign::sign_composite`] with `UCAN_AAD`.
+//!    The operator is the issuer; the tenant is the audience/holder.
+//! 2. An **`ai.hyprstream.ledger.allocation` record**
+//!    ([`hyprstream_pds::ledger::AllocationRecord`]) — the inventory line that
+//!    **lands in the tenant's PDS**, whose `grant` field references the UCAN's
+//!    CID. This is the durable, holder-controlled entitlement; revocation is
+//!    bumping the epoch (stop renewing + reissue), not editing the CRD.
+//!
+//! Enforcers (#781/#787/#790/#793/#794/#527) verify the **presented grant**
+//! (the UCAN CID + its allocation record), never the CRD. [`TenantGrantVerifier`]
+//! is the verification contract — the exact shape of that consume-side check —
+//! so the consumer issues can wire it without re-deriving the compile/verify
+//! correspondence.
+//!
+//! ## What this module deliberately leaves to the consumer issues
+//!
+//! Per #929's narrow scope:
+//! - **PDS publish** of the allocation record into the tenant's MST (the
+//!   physical "lands in inventory") — needs the #910 multi-collection write
+//!   path + the tenant's signing key, both operator-bootstrap concerns. This
+//!   module produces the record; landing it is plumbing.
+//! - **Operator issuer-key bootstrap in-cluster** — [`TenantGrantIssuer`]
+//!   takes already-resolved key material; deriving it from `node_identity`'s
+//!   root store at operator startup is the K5b runtime's job.
+//! - **Enforcer consumption** (admission, receipts, autoscaling bounds) —
+//!   #781/#787/#790/#793/#794/#527/#792/#795/#784. The compiled grant is the
+//!   primitive they consume; [`TenantGrantVerifier`] is the contract.
+//! - **S6 short-ttl sender-bound (DPoP) renewal** — greenfield (#921 gap 2);
+//!   the `epoch` counter on the allocation record is the revocation handle
+//!   until the renewal layer exists.
+
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use anyhow::{anyhow, bail, Context, Result};
+use ed25519_dalek::{SigningKey, VerifyingKey};
+use hyprstream_pds::ledger::{AllocationRecord, GrantClass as PdsGrantClass, Unit as PdsUnit};
+use hyprstream_rpc::auth::ucan::capability::{
+    Ability, Capability, CaveatValue, Caveats, Resource as CapabilityResource,
+};
+use hyprstream_rpc::auth::ucan::chain;
+use hyprstream_rpc::auth::ucan::token::{Ucan, UcanPayload, UCAN_AAD};
+use hyprstream_rpc::crypto::cose_sign::{sign_composite, verify_composite};
+#[cfg(test)]
+use hyprstream_rpc::crypto::pq::ml_dsa_generate_keypair;
+use hyprstream_rpc::crypto::pq::{
+    ml_dsa_sk_from_seed, ml_dsa_sk_to_vk_bytes, ml_dsa_vk_from_bytes, MlDsaSigningKey,
+    MlDsaVerifyingKey,
+};
+use hyprstream_rpc::identity::Did;
+use rand::RngCore;
+
+use hyprstream_k8s::grant::{TenantGrantArtifacts, TenantGrantService, TenantGrantServiceError};
+use hyprstream_k8s::mesh::{TenantBinding, TenantEntitlement, TenantGrantClass};
+
+/// HKDF purpose label for the operator's tenant-grant Ed25519 issuer key.
+///
+/// Key-separated (PQUIP) from the node's mesh/JWT/KEM purposes in
+/// `hyprstream_rpc::node_identity`: a `TenantGrantIssuer` key is bound to
+/// exactly one cryptographic purpose — *issuing tenant entitlement grants* —
+/// so a compromise of any other derived key cannot forge a grant. Use via
+/// [`TenantGrantIssuer::from_node_root`].
+pub const TENANT_GRANT_ED25519_PURPOSE: &str = "hyprstream-tenant-grant-ed25519-v1";
+
+/// The UCAN ability a compiled tenant grant carries.
+///
+/// `ledger/spend` is the resource-class verb an enforcer's
+/// `GrantVerifier`-shaped check attenuates against: a holder may spend the
+/// granted amount of the granted unit, attenuated by the capability caveats
+/// (unit/amount/epoch/class). The action-vocabulary seam (#582) maps this to
+/// concrete enforcer operations later; it is structural here.
+pub const TENANT_GRANT_ABILITY: &str = "ledger/spend";
+
+/// Domain-separation tag included in every compiled grant's capability caveat
+/// map so a tenant grant can never be confused with another UCAN capability
+/// type sharing the `ledger/spend` ability.
+const CAVEAT_KIND: &str = "hs:tenant-grant:v1";
+
+/// The operator's issuer key material for compiling tenant grants.
+///
+/// Holds the Ed25519 + ML-DSA-65 signing keys the operator signs UCANs with,
+/// plus the derived issuer DID. The operator is the **unit issuer** (D8-1:
+/// credits are the unit-issuer's liability), so every grant compiled by one
+/// issuer carries that issuer's DID as both the UCAN `issuer` and the
+/// allocation record `issuer`/`unit.issuer`.
+///
+/// Construct with [`TenantGrantIssuer::from_keys`] (production: keys resolved
+/// from the node identity store) or [`TenantGrantIssuer::from_node_root`]
+/// (derives a purpose-separated key from the operator's persisted root), or
+/// `TenantGrantIssuer::generate_for_test` in unit tests.
+#[derive(Clone)]
+pub struct TenantGrantIssuer {
+    ed_sk: SigningKey,
+    pq_sk: MlDsaSigningKey,
+    // Verifying keys + issuer DID are derived once at construction (the keys are
+    // immutable for the issuer's lifetime) and cached so the hot paths are pure
+    // accessors — no per-call trait dispatch, no re-deriving the DID.
+    ed_vk: VerifyingKey,
+    pq_vk: MlDsaVerifyingKey,
+    issuer_did: Did,
+}
+
+impl std::fmt::Debug for TenantGrantIssuer {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("TenantGrantIssuer")
+            .field("issuer_did", &self.issuer_did.as_str())
+            .finish_non_exhaustive()
+    }
+}
+
+impl TenantGrantIssuer {
+    /// Construct from already-resolved key material.
+    ///
+    /// The issuer DID is derived from `ed_sk`'s verifying key so the two can
+    /// never drift.
+    pub fn from_keys(ed_sk: SigningKey, pq_sk: MlDsaSigningKey) -> Result<Self> {
+        let ed_vk = ed_sk.verifying_key();
+        // Resolve the PQ verifying key through the `hyprstream_crypto::pq` byte
+        // helpers rather than the `Keypair` trait so this crate does not take a
+        // direct dep on the `signature`/`ml_dsa` crates just to call
+        // `sk.verifying_key()`. Decoding can only fail on a malformed signing
+        // key, which is a caller bug — surfaced as an error rather than a panic
+        // so this constructor is clippy-clean under the `-D expect_used` lint.
+        let pq_vk = ml_dsa_vk_from_bytes(&ml_dsa_sk_to_vk_bytes(&pq_sk))
+            .context("decode the ML-DSA-65 verifying key from the signing key")?;
+        let issuer_did = Did::from_ed25519(&ed_vk.to_bytes());
+        Ok(Self {
+            ed_sk,
+            pq_sk,
+            ed_vk,
+            pq_vk,
+            issuer_did,
+        })
+    }
+
+    /// Derive a purpose-separated tenant-grant issuer from the operator's
+    /// persisted node root key.
+    ///
+    /// Mirrors `hyprstream_rpc::node_identity::derive_mesh_mldsa_key` (HKDF
+    /// over the Ed25519 seed) but under the dedicated
+    /// [`TENANT_GRANT_ED25519_PURPOSE`] label, then re-seeds the ML-DSA-65 key
+    /// from the derived Ed25519 bytes. Key-separated from every other derived
+    /// purpose (PQUIP).
+    pub fn from_node_root(root: &SigningKey) -> Result<Self> {
+        let ed_sk =
+            hyprstream_rpc::node_identity::derive_purpose_key(root, TENANT_GRANT_ED25519_PURPOSE);
+        let pq_sk = derive_tenant_grant_mldsa_key(&ed_sk);
+        Self::from_keys(ed_sk, pq_sk)
+    }
+
+    /// Generate a fresh, random issuer keypair (tests only).
+    #[cfg(test)]
+    #[allow(clippy::expect_used)]
+    pub fn generate_for_test() -> Self {
+        let mut ed_bytes = [0u8; 32];
+        rand::thread_rng().fill_bytes(&mut ed_bytes);
+        let ed_sk = SigningKey::from_bytes(&ed_bytes);
+        let pq_sk = ml_dsa_generate_keypair().0;
+        Self::from_keys(ed_sk, pq_sk)
+            .expect("a freshly generated keypair always decodes its verifying key")
+    }
+
+    /// The issuer DID (the operator's `did:key` for this grant purpose).
+    pub fn issuer_did(&self) -> &Did {
+        &self.issuer_did
+    }
+
+    /// The issuer's Ed25519 verifying key (the verifier-side anchor).
+    pub fn issuer_ed_vk(&self) -> VerifyingKey {
+        self.ed_vk
+    }
+
+    /// The issuer's ML-DSA-65 verifying key (the PQ leg of the composite).
+    pub fn issuer_pq_vk(&self) -> MlDsaVerifyingKey {
+        self.pq_vk.clone()
+    }
+
+    /// Compile a [`TenantBinding`]'s entitlement into the issuer-signed grant +
+    /// inventory allocation record (#929).
+    ///
+    /// `epoch` is the issuance epoch (revocation = bump it + reissue); `now` is
+    /// unix seconds used for `not_before` and to sanity-check an author-supplied
+    /// `expiration`. The CRD's [`TenantEntitlement`] is the authoring surface;
+    /// the returned [`CompiledTenantGrant`] is the authority that lands in the
+    /// tenant's inventory.
+    ///
+    /// Fails closed on any malformation: an absent entitlement, a tenant DID
+    /// that cannot anchor an Ed25519 audience, an inverted expiry, or a signing
+    /// error. It never emits a half-signed grant.
+    pub fn compile(
+        &self,
+        binding: &TenantBinding,
+        epoch: u64,
+        now: u64,
+    ) -> Result<CompiledTenantGrant> {
+        let entitlement = binding
+            .spec
+            .entitlement
+            .as_ref()
+            .context("TenantBinding carries no entitlement — nothing to compile")?;
+
+        validate_entitlement(entitlement, now)?;
+
+        // The holder/audience is the tenant DID. UCAN audiences are did:key
+        // (Ed25519) for signature linkage; we accept any did: method the PDS
+        // already classifies, but the UCAN payload's audience is stored as the
+        // tenant string verbatim. A non-did:key audience is still a valid
+        // *allocation record* holder (pairwise or did:web), but the UCAN chain
+        // validator requires did:key, so we issue the UCAN to the operator's
+        // own issuer DID as the capability owner and encode the holder in the
+        // capability resource + caveats. The allocation record's `holder`
+        // (below) is the authoritative subject.
+        let holder = binding.spec.tenant.as_str();
+
+        let capability = tenant_grant_capability(&self.issuer_did, holder, entitlement, epoch)?;
+
+        let payload = UcanPayload {
+            issuer: self.issuer_did.clone(),
+            audience: self.issuer_did.clone(),
+            capabilities: vec![capability],
+            not_before: Some(now),
+            expiration: entitlement.expiration,
+            // Replay-uniqueness: a fresh random nonce per compiled grant. Two
+            // compiles of the same binding at the same epoch (e.g. operator
+            // restart) yield distinct UCANs/CIDs by construction.
+            nonce: fresh_nonce(),
+        };
+        let signing_bytes = payload
+            .signing_bytes()
+            .context("encode UCAN payload signing bytes")?;
+        let signature = sign_composite(&self.ed_sk, Some(&self.pq_sk), &signing_bytes, UCAN_AAD)
+            .context("hybrid-PQC sign of UCAN payload")?;
+        let ucan = Ucan {
+            payload,
+            proofs: Vec::new(),
+            signature,
+        };
+
+        // The grant CID is the atproto-canonical content address of the UCAN:
+        // CIDv1 dag-cbor (sha2-256) over its canonical CBOR. This is the
+        // `format: "cid"` string the allocation record's `grant` field
+        // references and enforcers present.
+        let grant_cid = cid_v1_string(&ucan)?;
+
+        let allocation = AllocationRecord::new(
+            grant_cid.clone(),
+            PdsUnit {
+                code: entitlement.unit.clone(),
+                issuer: self.issuer_did.as_str().to_owned(),
+            },
+            entitlement.amount,
+            epoch,
+            self.issuer_did.as_str(),
+            holder,
+            pds_grant_class(entitlement.class),
+        )
+        .context("construct allocation record")?;
+
+        let allocation_cid = allocation.cid().encode();
+
+        Ok(CompiledTenantGrant {
+            ucan,
+            allocation,
+            grant_cid,
+            allocation_cid,
+            epoch,
+        })
+    }
+}
+
+/// The output of compiling a [`TenantBinding`]: the authority artifacts.
+///
+/// - [`Self::ucan`] is the issuer-signed capability (presented by the holder,
+///   verified by enforcers).
+/// - [`Self::allocation`] is the `ai.hyprstream.ledger.allocation` record that
+///   lands in the tenant's PDS inventory (whose `grant` field references
+///   [`Self::grant_cid`]).
+/// - [`Self::grant_cid`] / [`Self::allocation_cid`] are the CIDv1 strings the
+///   operator records in [`hyprstream_k8s::mesh::TenantBindingStatus`] as
+///   observed truth.
+#[derive(Clone, Debug)]
+pub struct CompiledTenantGrant {
+    /// The issuer-signed UCAN grant.
+    pub ucan: Ucan,
+    /// The inventory allocation record (lands in the tenant's PDS).
+    pub allocation: AllocationRecord,
+    /// CIDv1 of [`Self::ucan`] — what enforcers present + what
+    /// `allocation.grant` references.
+    pub grant_cid: String,
+    /// CIDv1 of [`Self::allocation`] — the durable inventory line.
+    pub allocation_cid: String,
+    /// The issuance epoch recorded on the allocation.
+    pub epoch: u64,
+}
+
+/// The verification contract for enforcers (#781/#787/#790/#793/#794/#527).
+///
+/// This is the exact check a consumer enforcer performs on a *presented* grant:
+/// structural UCAN validation → hybrid-PQC composite signature verification
+/// against the issuer's anchored keys (require_pq = true, fail-closed) →
+/// delegation-chain liveness at `now` → allocation record round-trip →
+/// grant-CID↔allocation binding. On success it yields a
+/// [`VerifiedTenantGrant`] shaped exactly like the enforcer-plane
+/// `VerifiedGrant { holder, unit, cap_amount, exp, epoch }` so the consumer
+/// issues map it 1:1.
+///
+/// A production `GrantVerifier` impl resolves `grant_cid → (Ucan,
+/// AllocationRecord)` by fetching from the holder's PDS, then calls
+/// [`TenantGrantVerifier::verify`]; this struct owns only the verify-once
+/// half so it is trivially testable without a PDS.
+#[derive(Clone)]
+pub struct TenantGrantVerifier {
+    issuer_ed_vk: VerifyingKey,
+    issuer_pq_vk: MlDsaVerifyingKey,
+}
+
+impl std::fmt::Debug for TenantGrantVerifier {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("TenantGrantVerifier")
+            .field("issuer_ed_vk", &self.issuer_ed_vk.to_bytes())
+            .finish_non_exhaustive()
+    }
+}
+
+impl TenantGrantVerifier {
+    /// Construct from the issuer's verifying keys (the anchored side of
+    /// [`TenantGrantIssuer`]).
+    pub fn new(issuer_ed_vk: VerifyingKey, issuer_pq_vk: MlDsaVerifyingKey) -> Self {
+        Self {
+            issuer_ed_vk,
+            issuer_pq_vk,
+        }
+    }
+
+    /// Construct from an issuer (mirrors its public keys).
+    pub fn from_issuer(issuer: &TenantGrantIssuer) -> Self {
+        Self::new(issuer.issuer_ed_vk(), issuer.issuer_pq_vk())
+    }
+
+    /// Verify a compiled grant the way an enforcer will.
+    ///
+    /// `now` is unix seconds; the UCAN's `not_before`/`expiration` window is
+    /// checked against it via [`chain::validate`].
+    pub fn verify(&self, compiled: &CompiledTenantGrant, now: u64) -> Result<VerifiedTenantGrant> {
+        // 1. Structural validity (DIDs resolve, window is well-ordered).
+        compiled
+            .ucan
+            .validate_structure()
+            .context("UCAN structural validation failed")?;
+
+        // 2. Hybrid-PQC composite signature over the payload signing bytes,
+        //    against the issuer's anchored keys. require_pq = true: a
+        //    classical-only signature on a tenant grant is a fail-closed
+        //    reject (a long-lived authority artifact must be HNDL-resistant).
+        let signing_bytes = compiled
+            .ucan
+            .payload
+            .signing_bytes()
+            .context("encode UCAN payload signing bytes for verify")?;
+        let verified = verify_composite(
+            &compiled.ucan.signature,
+            &self.issuer_ed_vk,
+            Some(&self.issuer_pq_vk),
+            &signing_bytes,
+            UCAN_AAD,
+            true,
+        )
+        .context("UCAN composite signature verification failed")?;
+        if !verified.ml_dsa {
+            bail!("tenant grant signature missing the ML-DSA-65 leg (require_pq)");
+        }
+
+        // 2b. The signed payload's issuer MUST be the DID of the anchored
+        //     Ed25519 key. Without this, a UCAN validly signed by the anchored
+        //     key could claim a different issuer identity in its payload.
+        let anchored_issuer = Did::from_ed25519(&self.issuer_ed_vk.to_bytes());
+        if compiled.ucan.payload.issuer != anchored_issuer {
+            bail!(
+                "UCAN payload issuer ({}) does not match the anchored issuer key ({})",
+                compiled.ucan.payload.issuer.as_str(),
+                anchored_issuer.as_str()
+            );
+        }
+
+        // 2c. The presented `grant_cid` MUST be the recomputed CID of the
+        //     presented UCAN. The signature covers only the UCAN payload — the
+        //     CID strings arrive alongside it, so an attacker could otherwise
+        //     pair a valid UCAN with an arbitrary `grant_cid` and a forged
+        //     allocation that references that same arbitrary string.
+        let recomputed_grant_cid = cid_v1_string(&compiled.ucan)?;
+        if recomputed_grant_cid != compiled.grant_cid {
+            bail!(
+                "presented grant CID ({}) does not match the UCAN's recomputed CID ({})",
+                compiled.grant_cid,
+                recomputed_grant_cid
+            );
+        }
+
+        // 3. Delegation-chain liveness. A compiled tenant grant is a root
+        //    (empty proofs), so this re-checks the not_before/expiration window
+        //    against `now` — enforcers MUST reject an expired grant even if the
+        //    signature is valid.
+        chain::validate_chain(&compiled.ucan, now)
+            .context("UCAN chain/liveness validation failed")?;
+
+        // 4. The allocation record round-trips through its canonical DAG-CBOR
+        //    — a tampered record cannot survive this.
+        let record_bytes = compiled.allocation.to_dag_cbor();
+        let redecoded = AllocationRecord::from_dag_cbor(&record_bytes)
+            .context("allocation record failed canonical round-trip")?;
+        if redecoded != compiled.allocation {
+            bail!("allocation record canonical round-trip mismatch");
+        }
+
+        // 4b. The presented `allocation_cid` MUST be the recomputed CID of the
+        //     presented record — same reasoning as the grant CID: the CID
+        //     string is unsigned transport metadata, never trusted as given.
+        let recomputed_allocation_cid = redecoded.cid().encode();
+        if recomputed_allocation_cid != compiled.allocation_cid {
+            bail!(
+                "presented allocation CID ({}) does not match the record's recomputed CID ({})",
+                compiled.allocation_cid,
+                recomputed_allocation_cid
+            );
+        }
+
+        // 4c. The allocation's issuer fields MUST be the anchored issuer: the
+        //     signature proves who signed the UCAN, but the allocation record
+        //     itself is unsigned here — an attacker could otherwise attach a
+        //     record naming a different issuer/unit-issuer to a valid UCAN.
+        if redecoded.issuer != anchored_issuer.as_str() {
+            bail!(
+                "allocation.issuer ({}) does not match the anchored issuer ({})",
+                redecoded.issuer,
+                anchored_issuer.as_str()
+            );
+        }
+        if redecoded.unit.issuer != anchored_issuer.as_str() {
+            bail!(
+                "allocation.unit.issuer ({}) does not match the anchored issuer ({})",
+                redecoded.unit.issuer,
+                anchored_issuer.as_str()
+            );
+        }
+
+        // 5. The allocation's `grant` field MUST reference the presented UCAN's
+        //    CID, binding the inventory line to the capability it draws down.
+        if redecoded.grant != compiled.grant_cid {
+            bail!(
+                "allocation.grant ({}) does not reference the presented grant CID ({})",
+                redecoded.grant,
+                compiled.grant_cid
+            );
+        }
+
+        // 6. The capability must agree with the allocation record: exact
+        //    ability, holder bound through the signed resource, and caveats
+        //    matching the record fields (unit/amount/epoch/class). This is
+        //    what stops a holder-substitution: the holder lives in the
+        //    *signed* capability resource, so a forged record naming a
+        //    different holder cannot match it.
+        verify_capability_matches_record(&compiled.ucan, &anchored_issuer, &redecoded)?;
+
+        Ok(VerifiedTenantGrant {
+            holder: redecoded.holder,
+            unit: redecoded.unit.code,
+            cap_amount: redecoded.amount,
+            exp: compiled.ucan.payload.expiration,
+            epoch: redecoded.epoch,
+            class: redecoded.class,
+        })
+    }
+}
+
+/// The verified shape of a compiled tenant grant — the data an enforcer admits
+/// against.
+///
+/// Field-for-field compatible with the enforcer-plane
+/// `hyprstream::services::ledger::VerifiedGrant { holder, unit, cap_amount, exp,
+/// epoch }`; the consumer issues implement their `GrantVerifier` by resolving a
+/// presented `grant_cid` to a [`CompiledTenantGrant`] and calling
+/// [`TenantGrantVerifier::verify`].
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct VerifiedTenantGrant {
+    /// The holder (tenant DID / pairwise id) whose inventory this grant is.
+    pub holder: String,
+    /// The issuer-scoped credit unit code (the unit's issuer is the operator).
+    pub unit: String,
+    /// The total cap authorized (smallest quantum).
+    pub cap_amount: u64,
+    /// Grant expiry (unix seconds), if the UCAN carries one.
+    pub exp: Option<u64>,
+    /// Allocation epoch (revocation counter).
+    pub epoch: u64,
+    /// Grant class.
+    pub class: PdsGrantClass,
+}
+
+// ────────────────────────────────────────────────────────────────────────────
+// Helpers
+// ────────────────────────────────────────────────────────────────────────────
+
+/// Derive the tenant-grant ML-DSA-65 key from a derived Ed25519 purpose key.
+///
+/// Mirrors `node_identity::derive_mesh_mldsa_key` (re-seed ML-DSA-65 from the
+/// derived Ed25519 bytes) but is kept local so the `TENANT_GRANT_ED25519_PURPOSE`
+/// separation is the single source of truth for both legs.
+fn derive_tenant_grant_mldsa_key(ed25519_key: &SigningKey) -> MlDsaSigningKey {
+    let derived = hyprstream_rpc::node_identity::derive_purpose_key(
+        ed25519_key,
+        "hyprstream-tenant-grant-mldsa-v1",
+    );
+    let seed = derived.to_bytes();
+    // NOTE: the reference derivation in `node_identity::derive_mesh_mldsa_key`
+    // zeroizes the seed here; we omit that only to avoid taking a direct dep on
+    // the `zeroize` crate in this otherwise-light crate. The seed is a 32-byte
+    // stack value derived from an already-purpose-separated HKDF output, dropped
+    // immediately; the key-separation (distinct HKDF label) is the load-bearing
+    // property, not the in-memory wipe.
+    ml_dsa_sk_from_seed(&seed)
+}
+
+/// Build the single capability a tenant grant carries.
+///
+/// - `resource` = `hs://tenant/<issuer>/<holder>` — names *whose inventory* the
+///   grant is in (the issuer's liability, the holder's balance), scoped under
+///   the issuer so two operators' grants cannot cross-contend.
+/// - `ability` = `ledger/spend` ([`TENANT_GRANT_ABILITY`]).
+/// - `caveats` bind the unit / amount / epoch / class / kind so attenuation is
+///   value-aware at the enforcer (a delegated subset cannot widen amount or
+///   flip class).
+fn tenant_grant_capability(
+    issuer: &Did,
+    holder: &str,
+    entitlement: &TenantEntitlement,
+    epoch: u64,
+) -> Result<Capability> {
+    let resource = CapabilityResource::new(tenant_grant_resource(issuer, holder));
+    let ability = Ability::new(TENANT_GRANT_ABILITY);
+    // `CaveatValue::Int` is signed; a value that cannot be represented is a
+    // hard error, never a clamp — a clamped amount would mint a grant that
+    // fails its own verification, and a wrapped epoch would encode as negative.
+    let amount = i64::try_from(entitlement.amount)
+        .context("entitlement.amount exceeds i64::MAX and cannot be encoded as a caveat")?;
+    let epoch = i64::try_from(epoch)
+        .context("allocation epoch exceeds i64::MAX and cannot be encoded as a caveat")?;
+    let mut caveats = Caveats::empty();
+    caveats
+        .0
+        .insert("kind".to_owned(), CaveatValue::Text(CAVEAT_KIND.to_owned()));
+    caveats.0.insert(
+        "unit".to_owned(),
+        CaveatValue::Text(entitlement.unit.clone()),
+    );
+    caveats
+        .0
+        .insert("amount".to_owned(), CaveatValue::Int(amount));
+    caveats
+        .0
+        .insert("epoch".to_owned(), CaveatValue::Int(epoch));
+    caveats.0.insert(
+        "class".to_owned(),
+        CaveatValue::Text(entitlement.class.as_str().to_owned()),
+    );
+    Ok(Capability {
+        resource,
+        ability,
+        caveats,
+    })
+}
+
+/// The capability resource string binding an issuer's liability to a holder's
+/// balance: `hs://tenant/<issuer>/<holder>`. Single source of truth for both
+/// the compile side and the verify side's holder-binding check.
+fn tenant_grant_resource(issuer: &Did, holder: &str) -> String {
+    format!("hs://tenant/{}/{}", issuer.as_str(), holder)
+}
+
+/// Verify the UCAN capability matches the allocation record: exactly one
+/// capability with exactly [`TENANT_GRANT_ABILITY`], the holder bound through
+/// the signed resource string, and caveats matching the record's fields.
+fn verify_capability_matches_record(
+    ucan: &Ucan,
+    anchored_issuer: &Did,
+    record: &AllocationRecord,
+) -> Result<()> {
+    let caps = ucan.capabilities();
+    let cap = caps
+        .first()
+        .ok_or_else(|| anyhow!("tenant grant UCAN carries no capability"))?;
+    if cap.ability.as_str() != TENANT_GRANT_ABILITY {
+        bail!(
+            "tenant grant capability has unexpected ability {} (require exactly {})",
+            cap.ability,
+            TENANT_GRANT_ABILITY
+        );
+    }
+    // The holder is not a caveat — it lives in the signed resource string. The
+    // record's holder MUST reconstruct the exact resource the issuer signed,
+    // or the record names a substituted holder.
+    let expected_resource = tenant_grant_resource(anchored_issuer, &record.holder);
+    if cap.resource.as_str() != expected_resource {
+        bail!(
+            "grant capability resource ({}) does not bind the allocation holder ({})",
+            cap.resource.as_str(),
+            record.holder
+        );
+    }
+    let cv = |key: &str| -> Result<&CaveatValue> {
+        cap.caveats
+            .0
+            .get(key)
+            .ok_or_else(|| anyhow!("tenant grant caveat missing {key:?}"))
+    };
+    match cv("kind")? {
+        CaveatValue::Text(t) if t == CAVEAT_KIND => {}
+        other => bail!("grant caveat kind mismatch: {other:?}"),
+    }
+    match cv("unit")? {
+        CaveatValue::Text(t) if t == &record.unit.code => {}
+        other => bail!("grant caveat unit does not match record: {other:?}"),
+    }
+    // Lossless compare: a negative caveat can never equal a u64 field.
+    match cv("amount")? {
+        CaveatValue::Int(a) if u64::try_from(*a) == Ok(record.amount) => {}
+        other => bail!("grant caveat amount does not match record: {other:?}"),
+    }
+    match cv("epoch")? {
+        CaveatValue::Int(e) if u64::try_from(*e) == Ok(record.epoch) => {}
+        other => bail!("grant caveat epoch does not match record: {other:?}"),
+    }
+    match cv("class")? {
+        CaveatValue::Text(t) if t == &record.class.as_str().to_owned() => {}
+        other => bail!("grant caveat class does not match record: {other:?}"),
+    }
+    Ok(())
+}
+
+fn validate_entitlement(entitlement: &TenantEntitlement, now: u64) -> Result<()> {
+    if entitlement.unit.is_empty() {
+        bail!("entitlement.unit must not be empty");
+    }
+    if entitlement.unit.chars().any(char::is_whitespace) {
+        bail!("entitlement.unit must not contain whitespace");
+    }
+    if let Some(exp) = entitlement.expiration {
+        if exp <= now {
+            bail!(
+                "entitlement.expiration ({exp}) must be in the future (now {now}); a grant that \
+                 is born expired is never valid"
+            );
+        }
+    }
+    Ok(())
+}
+
+/// 16-byte random nonce, fresh per compile.
+fn fresh_nonce() -> Vec<u8> {
+    let mut buf = [0u8; 16];
+    rand::thread_rng().fill_bytes(&mut buf);
+    buf.to_vec()
+}
+
+/// The atproto-canonical CIDv1 string of a UCAN (dag-cbor, sha2-256) over its
+/// canonical CBOR encoding. This is the `format: "cid"` string the allocation
+/// record's `grant` field references and enforcers present.
+fn cid_v1_string(ucan: &Ucan) -> Result<String> {
+    let bytes = ucan
+        .to_cbor()
+        .context("UCAN CBOR encoding is infallible for this shape; encoding error is a bug")?;
+    Ok(hyprstream_pds::cid::Cid::from_dag_cbor(&bytes).encode())
+}
+
+/// Unix seconds from the system wall clock; never panics on platforms without a
+/// wall clock (returns 0, which fails the expiry check closed). Used by the
+/// operator's `TenantBinding` reconcile to stamp `not_before` and check
+/// author-supplied expiries.
+pub fn now_unix() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .unwrap_or(0)
+}
+
+/// Map the Apache data contract to the PDS lexicon.
+fn pds_grant_class(class: TenantGrantClass) -> PdsGrantClass {
+    match class {
+        TenantGrantClass::Prepaid => PdsGrantClass::Prepaid,
+        TenantGrantClass::Underwritten => PdsGrantClass::Underwritten,
+    }
+}
+
+impl TenantGrantService for TenantGrantIssuer {
+    fn compile_grant(
+        &self,
+        binding: &TenantBinding,
+        epoch: u64,
+        now: u64,
+    ) -> Result<TenantGrantArtifacts, TenantGrantServiceError> {
+        self.compile(binding, epoch, now)
+            .map(|compiled| TenantGrantArtifacts {
+                grant_cid: compiled.grant_cid,
+                allocation_cid: compiled.allocation_cid,
+                epoch: compiled.epoch,
+            })
+            .map_err(|error| TenantGrantServiceError::new(format!("{error:#}")))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #![allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
+    use super::*;
+    use hyprstream_k8s::mesh::{TenantBindingSpec, TenantEntitlement};
+
+    fn binding(unit: &str, amount: u64, class: TenantGrantClass) -> TenantBinding {
+        TenantBinding::new(
+            "acme",
+            TenantBindingSpec {
+                namespace: "acme".to_owned(),
+                tenant: "did:web:tenant.acme.example".to_owned(),
+                entitlement: Some(TenantEntitlement {
+                    unit: unit.to_owned(),
+                    amount,
+                    class,
+                    expiration: None,
+                }),
+            },
+        )
+    }
+
+    #[test]
+    fn compile_then_verify_round_trips() {
+        let issuer = TenantGrantIssuer::generate_for_test();
+        let verifier = TenantGrantVerifier::from_issuer(&issuer);
+        let now = 1_700_000_000u64;
+        let binding = binding("compute-second", 3_600, TenantGrantClass::Underwritten);
+
+        let compiled = issuer
+            .compile(&binding, 7, now)
+            .expect("compile must succeed for a valid entitlement");
+
+        // The allocation record references the grant CID.
+        assert_eq!(compiled.allocation.grant, compiled.grant_cid);
+        // The grant CID is a CIDv1 string.
+        assert!(compiled.grant_cid.starts_with('b'));
+        assert!(compiled.allocation_cid.starts_with('b'));
+
+        let verified = verifier
+            .verify(&compiled, now)
+            .expect("verify must succeed");
+        assert_eq!(verified.holder, "did:web:tenant.acme.example");
+        assert_eq!(verified.unit, "compute-second");
+        assert_eq!(verified.cap_amount, 3_600);
+        assert_eq!(verified.epoch, 7);
+        assert_eq!(verified.class, PdsGrantClass::Underwritten);
+        assert_eq!(verified.exp, None);
+    }
+
+    #[test]
+    fn tenant_grant_issuer_implements_k8s_service_boundary() {
+        let issuer = TenantGrantIssuer::generate_for_test();
+        let binding = binding("compute-second", 3_600, TenantGrantClass::Underwritten);
+        let status = hyprstream_k8s::grant::compile_tenant_binding_status(
+            &binding,
+            Some(&issuer),
+            7,
+            1_700_000_000,
+        );
+
+        assert_eq!(status.bound, Some(true));
+        assert_eq!(status.phase.as_deref(), Some("Bound"));
+        assert!(status
+            .grant_cid
+            .as_deref()
+            .is_some_and(|cid| cid.starts_with('b')));
+        assert!(status
+            .allocation_cid
+            .as_deref()
+            .is_some_and(|cid| cid.starts_with('b')));
+        assert_eq!(status.epoch, Some(7));
+    }
+
+    #[test]
+    fn two_compiles_of_the_same_binding_yield_distinct_grants() {
+        // The nonce makes each compile unique even at the same epoch.
+        let issuer = TenantGrantIssuer::generate_for_test();
+        let now = 1_700_000_000u64;
+        let binding = binding("gpu-hour", 8, TenantGrantClass::Prepaid);
+        let a = issuer.compile(&binding, 1, now).unwrap();
+        let b = issuer.compile(&binding, 1, now).unwrap();
+        assert_ne!(a.grant_cid, b.grant_cid, "fresh nonce ⇒ distinct CIDs");
+        assert_ne!(a.allocation_cid, b.allocation_cid);
+    }
+
+    #[test]
+    fn verify_rejects_a_tampered_allocation_amount() {
+        let issuer = TenantGrantIssuer::generate_for_test();
+        let verifier = TenantGrantVerifier::from_issuer(&issuer);
+        let now = 1_700_000_000u64;
+        let binding = binding("compute-second", 100, TenantGrantClass::Underwritten);
+        let mut compiled = issuer.compile(&binding, 1, now).unwrap();
+
+        // Tamper: bump the allocation amount without re-signing the UCAN. The
+        // capability caveat (amount=100) no longer matches the record (200).
+        compiled.allocation = AllocationRecord::new(
+            compiled.grant_cid.clone(),
+            PdsUnit {
+                code: "compute-second".to_owned(),
+                issuer: issuer.issuer_did().as_str().to_owned(),
+            },
+            200,
+            1,
+            issuer.issuer_did().as_str(),
+            "did:web:tenant.acme.example",
+            PdsGrantClass::Underwritten,
+        )
+        .unwrap();
+        // Keep the presented allocation CID consistent with the tampered
+        // record so the signed amount caveat is what catches the tamper.
+        compiled.allocation_cid = compiled.allocation.cid().encode();
+
+        let err = verifier.verify(&compiled, now).unwrap_err();
+        assert!(
+            err.to_string().contains("amount"),
+            "tampered amount must be caught: {err}"
+        );
+    }
+
+    #[test]
+    fn verify_rejects_a_classical_only_signature() {
+        // A grant signed without the PQ leg must fail closed at verify
+        // (require_pq = true) — the long-lived authority must be HNDL-resistant.
+        let issuer_ed_sk = {
+            let mut b = [0u8; 32];
+            rand::thread_rng().fill_bytes(&mut b);
+            SigningKey::from_bytes(&b)
+        };
+        let issuer_did = Did::from_ed25519(&issuer_ed_sk.verifying_key().to_bytes());
+        let now = 1_700_000_000u64;
+        let binding = binding("compute-second", 5, TenantGrantClass::Prepaid);
+
+        let entitlement = binding.spec.entitlement.as_ref().unwrap();
+        let capability =
+            tenant_grant_capability(&issuer_did, &binding.spec.tenant, entitlement, 1).unwrap();
+        let payload = UcanPayload {
+            issuer: issuer_did.clone(),
+            audience: issuer_did.clone(),
+            capabilities: vec![capability],
+            not_before: Some(now),
+            expiration: None,
+            nonce: fresh_nonce(),
+        };
+        let signing_bytes = payload.signing_bytes().unwrap();
+        // Classical-only sign (pq_sk = None).
+        let signature = sign_composite(&issuer_ed_sk, None, &signing_bytes, UCAN_AAD).unwrap();
+        let ucan = Ucan {
+            payload,
+            proofs: Vec::new(),
+            signature,
+        };
+        let grant_cid = cid_v1_string(&ucan).unwrap();
+        let allocation = AllocationRecord::new(
+            grant_cid.clone(),
+            PdsUnit {
+                code: "compute-second".to_owned(),
+                issuer: issuer_did.as_str().to_owned(),
+            },
+            5,
+            1,
+            issuer_did.as_str(),
+            "did:web:tenant.acme.example",
+            PdsGrantClass::Prepaid,
+        )
+        .unwrap();
+        let compiled = CompiledTenantGrant {
+            ucan,
+            allocation_cid: allocation.cid().encode(),
+            allocation,
+            grant_cid,
+            epoch: 1,
+        };
+
+        // Verifier anchored on the Ed25519 key but WITH a PQ key requirement.
+        let verifier = TenantGrantVerifier::new(
+            issuer_ed_sk.verifying_key(),
+            // A throwaway, *wrong* PQ key: a classical-only signature cannot
+            // satisfy require_pq regardless of the anchored PQ key.
+            ml_dsa_generate_keypair().1,
+        );
+        let err = verifier.verify(&compiled, now).unwrap_err();
+        assert!(
+            err.to_string().to_lowercase().contains("signature")
+                || err.to_string().contains("ML-DSA"),
+            "classical-only signature must fail closed: {err}"
+        );
+    }
+
+    #[test]
+    fn verify_rejects_an_expired_grant() {
+        let issuer = TenantGrantIssuer::generate_for_test();
+        let verifier = TenantGrantVerifier::from_issuer(&issuer);
+        let now = 1_700_000_000u64;
+
+        let mut binding = binding("compute-second", 1, TenantGrantClass::Underwritten);
+        binding.spec.entitlement.as_mut().unwrap().expiration = Some(now + 10);
+
+        let compiled = issuer.compile(&binding, 1, now).unwrap();
+        // Verify at `now + 100`: past expiration.
+        let err = verifier.verify(&compiled, now + 100).unwrap_err();
+        assert!(
+            err.to_string().to_lowercase().contains("expir")
+                || err.to_string().contains("liveness")
+                || err.to_string().contains("window"),
+            "expired grant must be rejected: {err}"
+        );
+    }
+
+    #[test]
+    fn verify_rejects_a_substituted_holder() {
+        // A valid signed UCAN paired with a forged allocation record naming a
+        // different holder: every unsigned field (grant ref, unit, amount,
+        // epoch, class, issuer, allocation CID) is made self-consistent, so
+        // only the signed capability resource can catch the substitution.
+        let issuer = TenantGrantIssuer::generate_for_test();
+        let verifier = TenantGrantVerifier::from_issuer(&issuer);
+        let now = 1_700_000_000u64;
+        let binding = binding("compute-second", 100, TenantGrantClass::Underwritten);
+        let mut compiled = issuer.compile(&binding, 1, now).unwrap();
+
+        compiled.allocation = AllocationRecord::new(
+            compiled.grant_cid.clone(),
+            PdsUnit {
+                code: "compute-second".to_owned(),
+                issuer: issuer.issuer_did().as_str().to_owned(),
+            },
+            100,
+            1,
+            issuer.issuer_did().as_str(),
+            "did:web:evil.example",
+            PdsGrantClass::Underwritten,
+        )
+        .unwrap();
+        compiled.allocation_cid = compiled.allocation.cid().encode();
+
+        let err = verifier.verify(&compiled, now).unwrap_err();
+        assert!(
+            err.to_string().contains("holder") || err.to_string().contains("resource"),
+            "substituted holder must be caught by the signed resource binding: {err}"
+        );
+    }
+
+    #[test]
+    fn verify_rejects_a_forged_grant_cid_binding() {
+        // The attacker controls both `grant_cid` and `allocation.grant`
+        // (neither is covered by the UCAN signature), so making them agree on
+        // an arbitrary string must still fail: the grant CID is recomputed
+        // from the presented UCAN, never trusted as given.
+        let issuer = TenantGrantIssuer::generate_for_test();
+        let verifier = TenantGrantVerifier::from_issuer(&issuer);
+        let now = 1_700_000_000u64;
+        let binding = binding("compute-second", 100, TenantGrantClass::Underwritten);
+        let mut compiled = issuer.compile(&binding, 1, now).unwrap();
+
+        let fake_cid = "bafyreifakefakefakefakefakefakefakefakefakefakefakefakefake".to_owned();
+        compiled.allocation.grant = fake_cid.clone();
+        compiled.grant_cid = fake_cid;
+        compiled.allocation_cid = compiled.allocation.cid().encode();
+
+        let err = verifier.verify(&compiled, now).unwrap_err();
+        assert!(
+            err.to_string().contains("recomputed"),
+            "forged grant CID must be caught by recomputation: {err}"
+        );
+    }
+
+    #[test]
+    fn verify_rejects_a_foreign_allocation_issuer() {
+        let issuer = TenantGrantIssuer::generate_for_test();
+        let verifier = TenantGrantVerifier::from_issuer(&issuer);
+        let now = 1_700_000_000u64;
+        let binding = binding("compute-second", 100, TenantGrantClass::Underwritten);
+        let mut compiled = issuer.compile(&binding, 1, now).unwrap();
+
+        compiled.allocation = AllocationRecord::new(
+            compiled.grant_cid.clone(),
+            PdsUnit {
+                code: "compute-second".to_owned(),
+                issuer: "did:web:other-operator.example".to_owned(),
+            },
+            100,
+            1,
+            "did:web:other-operator.example",
+            "did:web:tenant.acme.example",
+            PdsGrantClass::Underwritten,
+        )
+        .unwrap();
+        compiled.allocation_cid = compiled.allocation.cid().encode();
+
+        let err = verifier.verify(&compiled, now).unwrap_err();
+        assert!(
+            err.to_string().contains("issuer"),
+            "foreign allocation issuer must be rejected: {err}"
+        );
+    }
+
+    #[test]
+    fn verify_rejects_a_mismatched_allocation_cid() {
+        let issuer = TenantGrantIssuer::generate_for_test();
+        let verifier = TenantGrantVerifier::from_issuer(&issuer);
+        let now = 1_700_000_000u64;
+        let binding = binding("compute-second", 100, TenantGrantClass::Underwritten);
+        let mut compiled = issuer.compile(&binding, 1, now).unwrap();
+
+        compiled.allocation_cid = "bafyreinotwhatwascomputed".to_owned();
+
+        let err = verifier.verify(&compiled, now).unwrap_err();
+        assert!(
+            err.to_string().contains("allocation CID"),
+            "mismatched allocation CID must be rejected: {err}"
+        );
+    }
+
+    #[test]
+    fn compile_rejects_amount_above_i64_max() {
+        // No silent clamp: an amount that cannot be a signed caveat is a
+        // compile error, never a grant that fails its own verification.
+        let issuer = TenantGrantIssuer::generate_for_test();
+        let binding = binding("compute-second", u64::MAX, TenantGrantClass::Underwritten);
+        let err = issuer.compile(&binding, 1, 1_700_000_000).unwrap_err();
+        assert!(err.to_string().contains("amount"), "{err}");
+    }
+
+    #[test]
+    fn compile_rejects_epoch_above_i64_max() {
+        let issuer = TenantGrantIssuer::generate_for_test();
+        let binding = binding("compute-second", 1, TenantGrantClass::Underwritten);
+        let err = issuer
+            .compile(&binding, u64::MAX, 1_700_000_000)
+            .unwrap_err();
+        assert!(err.to_string().contains("epoch"), "{err}");
+    }
+
+    #[test]
+    fn compile_without_entitlement_is_an_error() {
+        let issuer = TenantGrantIssuer::generate_for_test();
+        let binding = TenantBinding::new(
+            "acme",
+            TenantBindingSpec {
+                namespace: "acme".to_owned(),
+                tenant: "did:web:t".to_owned(),
+                entitlement: None,
+            },
+        );
+        assert!(issuer.compile(&binding, 1, 1_700_000_000).is_err());
+    }
+
+    #[test]
+    fn compile_rejects_inverted_expiration() {
+        let issuer = TenantGrantIssuer::generate_for_test();
+        let now = 1_700_000_000u64;
+        let mut binding = binding("compute-second", 1, TenantGrantClass::Underwritten);
+        binding.spec.entitlement.as_mut().unwrap().expiration = Some(now - 1);
+        assert!(issuer.compile(&binding, 1, now).is_err());
+    }
+
+    #[test]
+    fn from_node_root_is_deterministic() {
+        let mut seed = [0u8; 32];
+        rand::thread_rng().fill_bytes(&mut seed);
+        let root = SigningKey::from_bytes(&seed);
+        let a = TenantGrantIssuer::from_node_root(&root).unwrap();
+        let b = TenantGrantIssuer::from_node_root(&root).unwrap();
+        assert_eq!(
+            a.issuer_did(),
+            b.issuer_did(),
+            "same root ⇒ same issuer DID"
+        );
+        assert_eq!(
+            a.issuer_ed_vk().to_bytes(),
+            b.issuer_ed_vk().to_bytes(),
+            "purpose derivation is deterministic"
+        );
+    }
+}

--- a/crates/hyprstream-k8s-pds/tests/operator_composition.rs
+++ b/crates/hyprstream-k8s-pds/tests/operator_composition.rs
@@ -1,0 +1,40 @@
+//! Compile-only proof of the supported Apache substrate + AGPL adapter wiring.
+//!
+//! The adapter's dev dependency enables `hyprstream-k8s/k8s,grant`. These
+//! generic functions are type-checked but never invoked, so no Kubernetes
+//! client is created and no cluster is contacted.
+
+use std::sync::Arc;
+
+use hyprstream_k8s::kube::Client;
+use hyprstream_k8s::operator::{
+    run_operator_with_grant_service, HyprstreamOperatorRpc, OperatorConfig, OperatorError,
+    OperatorState,
+};
+use hyprstream_k8s_pds::TenantGrantIssuer;
+
+#[allow(dead_code)]
+fn configured_state<R: HyprstreamOperatorRpc>(
+    client: Client,
+    rpc: Arc<R>,
+    config: OperatorConfig,
+    issuer: TenantGrantIssuer,
+) -> OperatorState<R> {
+    OperatorState::new(client, rpc, config).with_grant_service(Some(Arc::new(issuer)))
+}
+
+#[allow(dead_code)]
+async fn configured_operator<R: HyprstreamOperatorRpc>(
+    client: Client,
+    rpc: Arc<R>,
+    config: OperatorConfig,
+    issuer: TenantGrantIssuer,
+) -> Result<(), OperatorError> {
+    run_operator_with_grant_service(client, rpc, config, Some(Arc::new(issuer))).await
+}
+
+#[test]
+fn k8s_grant_adapter_operator_composition_type_checks() {
+    // Compiling this integration target is the assertion. The functions above
+    // exercise both supported public wiring surfaces without runtime effects.
+}

--- a/crates/hyprstream-k8s/Cargo.toml
+++ b/crates/hyprstream-k8s/Cargo.toml
@@ -34,7 +34,7 @@ k8s = [
 # Service-neutral TenantBinding → grant reconciliation boundary (#929/#1422).
 # The authority-bearing implementation lives downstream in
 # `hyprstream-k8s-pds`; this feature contains no service dependency.
-grant = []
+grant = ["dep:cid"]
 
 [dependencies]
 # `derive` gives the CustomResource derive + CustomResourceExt (kube-core, no client).
@@ -56,10 +56,12 @@ hyprstream-vfs = { path = "../hyprstream-vfs", optional = true }
 hyprstream-rpc = { path = "../hyprstream-rpc", optional = true }
 async-trait = { version = "0.1", optional = true }
 parking_lot = { workspace = true, optional = true }
+cid = { version = "0.11", optional = true }
 
 [dev-dependencies]
 tokio = { version = "1", features = ["macros", "rt", "rt-multi-thread", "sync"] }
 toml = { workspace = true }
+tempfile = { workspace = true }
 
 [lints]
 workspace = true

--- a/crates/hyprstream-k8s/Cargo.toml
+++ b/crates/hyprstream-k8s/Cargo.toml
@@ -62,6 +62,7 @@ cid = { version = "0.11", optional = true }
 tokio = { version = "1", features = ["macros", "rt", "rt-multi-thread", "sync"] }
 toml = { workspace = true }
 tempfile = { workspace = true }
+semver = "1"
 
 [lints]
 workspace = true

--- a/crates/hyprstream-k8s/Cargo.toml
+++ b/crates/hyprstream-k8s/Cargo.toml
@@ -2,7 +2,7 @@
 name = "hyprstream-k8s"
 version = "0.1.0"
 edition = "2021"
-license = "MIT"
+license = "Apache-2.0"
 repository = "https://github.com/hyprstream/hyprstream"
 description = "Kubernetes CRD schemas for hyprstream resources under *.hyprstream.io (Model, Adapter, TrainingRun, InferenceService, TenantBinding)"
 
@@ -31,20 +31,10 @@ k8s = [
     "dep:async-trait",
     "dep:parking_lot",
 ]
-# CRD → grant compilation (#929): a `TenantBinding`'s authorable entitlement
-# compiles into an issuer-signed UCAN grant + an `ai.hyprstream.ledger.allocation`
-# record. Pure logic — no cluster, no kube client — so it is a feature separate
-# from `k8s`. Pulls the UCAN/COSE primitives (`hyprstream-rpc`) and the
-# allocation lexicon (`hyprstream-pds`); the CRD *types* it lowers never require
-# them. `k8s` + `grant` together enable the operator reconcile wiring that
-# compiles a binding's entitlement into a grant on observe.
-grant = [
-    "dep:hyprstream-rpc",
-    "dep:hyprstream-pds",
-    "dep:ed25519-dalek",
-    "dep:anyhow",
-    "dep:rand",
-]
+# Service-neutral TenantBinding → grant reconciliation boundary (#929/#1422).
+# The authority-bearing implementation lives downstream in
+# `hyprstream-k8s-pds`; this feature contains no service dependency.
+grant = []
 
 [dependencies]
 # `derive` gives the CustomResource derive + CustomResourceExt (kube-core, no client).
@@ -67,14 +57,9 @@ hyprstream-rpc = { path = "../hyprstream-rpc", optional = true }
 async-trait = { version = "0.1", optional = true }
 parking_lot = { workspace = true, optional = true }
 
-# CRD → grant compilation (#929), gated behind the `grant` feature.
-hyprstream-pds = { path = "../hyprstream-pds", optional = true }
-ed25519-dalek = { workspace = true, optional = true }
-anyhow = { workspace = true, optional = true }
-rand = { workspace = true, optional = true }
-
 [dev-dependencies]
 tokio = { version = "1", features = ["macros", "rt", "rt-multi-thread", "sync"] }
+toml = { workspace = true }
 
 [lints]
 workspace = true

--- a/crates/hyprstream-k8s/src/grant.rs
+++ b/crates/hyprstream-k8s/src/grant.rs
@@ -1,726 +1,73 @@
-//! CRD → grant compilation for [`mesh::TenantBinding`] (issue #929).
+//! Service-neutral tenant-grant boundary for the Kubernetes operator.
 //!
-//! A `TenantBinding` is an **admin-authorable surface**, never the authority.
-//! When [`mesh::TenantBindingSpec::entitlement`] is set, the operator compiles
-//! it — signing **as issuer** — into the two artifacts that *are* the authority:
-//!
-//! 1. A **UCAN grant** ([`hyprstream_rpc::auth::ucan::Ucan`]) — an
-//!    issuer→holder capability signed with the project's hybrid-PQC COSE
-//!    composite (EdDSA + ML-DSA-65) via
-//!    [`hyprstream_rpc::crypto::cose_sign::sign_composite`] with `UCAN_AAD`.
-//!    The operator is the issuer; the tenant is the audience/holder.
-//! 2. An **`ai.hyprstream.ledger.allocation` record**
-//!    ([`hyprstream_pds::ledger::AllocationRecord`]) — the inventory line that
-//!    **lands in the tenant's PDS**, whose `grant` field references the UCAN's
-//!    CID. This is the durable, holder-controlled entitlement; revocation is
-//!    bumping the epoch (stop renewing + reissue), not editing the CRD.
-//!
-//! Enforcers (#781/#787/#790/#793/#794/#527) verify the **presented grant**
-//! (the UCAN CID + its allocation record), never the CRD. [`TenantGrantVerifier`]
-//! is the verification contract — the exact shape of that consume-side check —
-//! so the consumer issues can wire it without re-deriving the compile/verify
-//! correspondence.
-//!
-//! ## What this module deliberately leaves to the consumer issues
-//!
-//! Per #929's narrow scope:
-//! - **PDS publish** of the allocation record into the tenant's MST (the
-//!   physical "lands in inventory") — needs the #910 multi-collection write
-//!   path + the tenant's signing key, both operator-bootstrap concerns. This
-//!   module produces the record; landing it is plumbing.
-//! - **Operator issuer-key bootstrap in-cluster** — [`TenantGrantIssuer`]
-//!   takes already-resolved key material; deriving it from `node_identity`'s
-//!   root store at operator startup is the K5b runtime's job.
-//! - **Enforcer consumption** (admission, receipts, autoscaling bounds) —
-//!   #781/#787/#790/#793/#794/#527/#792/#795/#784. The compiled grant is the
-//!   primitive they consume; [`TenantGrantVerifier`] is the contract.
-//! - **S6 short-ttl sender-bound (DPoP) renewal** — greenfield (#921 gap 2);
-//!   the `epoch` counter on the allocation record is the revocation handle
-//!   until the renewal layer exists.
+//! This Apache-licensed module owns only the generic reconciliation contract:
+//! an AGPL service adapter may compile an authored [`TenantBinding`]
+//! entitlement and return opaque content-addressed references. Cryptographic
+//! issuer keys, signed grant verification, PDS allocation records, and their
+//! CID implementation belong downstream of this crate.
 
+use std::fmt;
 use std::time::{SystemTime, UNIX_EPOCH};
 
-use anyhow::{anyhow, bail, Context, Result};
-use ed25519_dalek::{SigningKey, VerifyingKey};
-use hyprstream_pds::ledger::{AllocationRecord, GrantClass as PdsGrantClass, Unit as PdsUnit};
-use hyprstream_rpc::auth::ucan::capability::{
-    Ability, Capability, CaveatValue, Caveats, Resource as CapabilityResource,
-};
-use hyprstream_rpc::auth::ucan::chain;
-use hyprstream_rpc::auth::ucan::token::{Ucan, UcanPayload, UCAN_AAD};
-use hyprstream_rpc::crypto::cose_sign::{sign_composite, verify_composite};
-#[cfg(test)]
-use hyprstream_rpc::crypto::pq::ml_dsa_generate_keypair;
-use hyprstream_rpc::crypto::pq::{
-    ml_dsa_sk_from_seed, ml_dsa_sk_to_vk_bytes, ml_dsa_vk_from_bytes, MlDsaSigningKey,
-    MlDsaVerifyingKey,
-};
-use hyprstream_rpc::identity::Did;
 use kube::Resource;
-use rand::RngCore;
 
-use crate::mesh::{TenantBinding, TenantBindingStatus, TenantEntitlement, TenantGrantClass};
+use crate::mesh::{TenantBinding, TenantBindingStatus};
 
-/// HKDF purpose label for the operator's tenant-grant Ed25519 issuer key.
+/// Opaque references produced by a service-specific grant compiler.
 ///
-/// Key-separated (PQUIP) from the node's mesh/JWT/KEM purposes in
-/// `hyprstream_rpc::node_identity`: a `TenantGrantIssuer` key is bound to
-/// exactly one cryptographic purpose — *issuing tenant entitlement grants* —
-/// so a compromise of any other derived key cannot forge a grant. Use via
-/// [`TenantGrantIssuer::from_node_root`].
-pub const TENANT_GRANT_ED25519_PURPOSE: &str = "hyprstream-tenant-grant-ed25519-v1";
-
-/// The UCAN ability a compiled tenant grant carries.
-///
-/// `ledger/spend` is the resource-class verb an enforcer's
-/// `GrantVerifier`-shaped check attenuates against: a holder may spend the
-/// granted amount of the granted unit, attenuated by the capability caveats
-/// (unit/amount/epoch/class). The action-vocabulary seam (#582) maps this to
-/// concrete enforcer operations later; it is structural here.
-pub const TENANT_GRANT_ABILITY: &str = "ledger/spend";
-
-/// Domain-separation tag included in every compiled grant's capability caveat
-/// map so a tenant grant can never be confused with another UCAN capability
-/// type sharing the `ledger/spend` ability.
-const CAVEAT_KIND: &str = "hs:tenant-grant:v1";
-
-/// The operator's issuer key material for compiling tenant grants.
-///
-/// Holds the Ed25519 + ML-DSA-65 signing keys the operator signs UCANs with,
-/// plus the derived issuer DID. The operator is the **unit issuer** (D8-1:
-/// credits are the unit-issuer's liability), so every grant compiled by one
-/// issuer carries that issuer's DID as both the UCAN `issuer` and the
-/// allocation record `issuer`/`unit.issuer`.
-///
-/// Construct with [`TenantGrantIssuer::from_keys`] (production: keys resolved
-/// from the node identity store) or [`TenantGrantIssuer::from_node_root`]
-/// (derives a purpose-separated key from the operator's persisted root), or
-/// [`TenantGrantIssuer::generate_for_test`] in tests.
-#[derive(Clone)]
-pub struct TenantGrantIssuer {
-    ed_sk: SigningKey,
-    pq_sk: MlDsaSigningKey,
-    // Verifying keys + issuer DID are derived once at construction (the keys are
-    // immutable for the issuer's lifetime) and cached so the hot paths are pure
-    // accessors — no per-call trait dispatch, no re-deriving the DID.
-    ed_vk: VerifyingKey,
-    pq_vk: MlDsaVerifyingKey,
-    issuer_did: Did,
+/// The Kubernetes substrate records these values as observed status but never
+/// interprets their service-specific contents.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct TenantGrantArtifacts {
+    pub grant_cid: String,
+    pub allocation_cid: String,
+    pub epoch: u64,
 }
 
-impl std::fmt::Debug for TenantGrantIssuer {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("TenantGrantIssuer")
-            .field("issuer_did", &self.issuer_did.as_str())
-            .finish_non_exhaustive()
+/// A fail-closed service error safe to reflect in Kubernetes status.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct TenantGrantServiceError {
+    message: String,
+}
+
+impl TenantGrantServiceError {
+    pub fn new(message: impl Into<String>) -> Self {
+        Self {
+            message: message.into(),
+        }
     }
 }
 
-impl TenantGrantIssuer {
-    /// Construct from already-resolved key material.
-    ///
-    /// The issuer DID is derived from `ed_sk`'s verifying key so the two can
-    /// never drift.
-    pub fn from_keys(ed_sk: SigningKey, pq_sk: MlDsaSigningKey) -> Result<Self> {
-        let ed_vk = ed_sk.verifying_key();
-        // Resolve the PQ verifying key through the `hyprstream_crypto::pq` byte
-        // helpers rather than the `Keypair` trait so this crate does not take a
-        // direct dep on the `signature`/`ml_dsa` crates just to call
-        // `sk.verifying_key()`. Decoding can only fail on a malformed signing
-        // key, which is a caller bug — surfaced as an error rather than a panic
-        // so this constructor is clippy-clean under the `-D expect_used` lint.
-        let pq_vk = ml_dsa_vk_from_bytes(&ml_dsa_sk_to_vk_bytes(&pq_sk))
-            .context("decode the ML-DSA-65 verifying key from the signing key")?;
-        let issuer_did = Did::from_ed25519(&ed_vk.to_bytes());
-        Ok(Self {
-            ed_sk,
-            pq_sk,
-            ed_vk,
-            pq_vk,
-            issuer_did,
-        })
+impl fmt::Display for TenantGrantServiceError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(&self.message)
     }
+}
 
-    /// Derive a purpose-separated tenant-grant issuer from the operator's
-    /// persisted node root key.
-    ///
-    /// Mirrors `hyprstream_rpc::node_identity::derive_mesh_mldsa_key` (HKDF
-    /// over the Ed25519 seed) but under the dedicated
-    /// [`TENANT_GRANT_ED25519_PURPOSE`] label, then re-seeds the ML-DSA-65 key
-    /// from the derived Ed25519 bytes. Key-separated from every other derived
-    /// purpose (PQUIP).
-    pub fn from_node_root(root: &SigningKey) -> Result<Self> {
-        let ed_sk =
-            hyprstream_rpc::node_identity::derive_purpose_key(root, TENANT_GRANT_ED25519_PURPOSE);
-        let pq_sk = derive_tenant_grant_mldsa_key(&ed_sk);
-        Self::from_keys(ed_sk, pq_sk)
-    }
+impl std::error::Error for TenantGrantServiceError {}
 
-    /// Generate a fresh, random issuer keypair (tests only).
-    #[cfg(test)]
-    #[allow(clippy::expect_used)]
-    pub fn generate_for_test() -> Self {
-        let mut ed_bytes = [0u8; 32];
-        rand::thread_rng().fill_bytes(&mut ed_bytes);
-        let ed_sk = SigningKey::from_bytes(&ed_bytes);
-        let pq_sk = ml_dsa_generate_keypair().0;
-        Self::from_keys(ed_sk, pq_sk)
-            .expect("a freshly generated keypair always decodes its verifying key")
-    }
-
-    /// The issuer DID (the operator's `did:key` for this grant purpose).
-    pub fn issuer_did(&self) -> &Did {
-        &self.issuer_did
-    }
-
-    /// The issuer's Ed25519 verifying key (the verifier-side anchor).
-    pub fn issuer_ed_vk(&self) -> VerifyingKey {
-        self.ed_vk
-    }
-
-    /// The issuer's ML-DSA-65 verifying key (the PQ leg of the composite).
-    pub fn issuer_pq_vk(&self) -> MlDsaVerifyingKey {
-        self.pq_vk.clone()
-    }
-
-    /// Compile a [`TenantBinding`]'s entitlement into the issuer-signed grant +
-    /// inventory allocation record (#929).
-    ///
-    /// `epoch` is the issuance epoch (revocation = bump it + reissue); `now` is
-    /// unix seconds used for `not_before` and to sanity-check an author-supplied
-    /// `expiration`. The CRD's [`TenantEntitlement`] is the authoring surface;
-    /// the returned [`CompiledTenantGrant`] is the authority that lands in the
-    /// tenant's inventory.
-    ///
-    /// Fails closed on any malformation: an absent entitlement, a tenant DID
-    /// that cannot anchor an Ed25519 audience, an inverted expiry, or a signing
-    /// error. It never emits a half-signed grant.
-    pub fn compile(
+/// Service behavior invoked by the generic `TenantBinding` reconciler.
+///
+/// Implementations are authority-bearing and therefore live in downstream
+/// service crates. They must validate the binding, issue/sign the grant, bind
+/// it to the allocation record, and fail closed on any error. The Apache
+/// operator receives only the resulting opaque content references.
+pub trait TenantGrantService: Send + Sync {
+    fn compile_grant(
         &self,
         binding: &TenantBinding,
         epoch: u64,
         now: u64,
-    ) -> Result<CompiledTenantGrant> {
-        let entitlement = binding
-            .spec
-            .entitlement
-            .as_ref()
-            .context("TenantBinding carries no entitlement — nothing to compile")?;
-
-        validate_entitlement(entitlement, now)?;
-
-        // The holder/audience is the tenant DID. UCAN audiences are did:key
-        // (Ed25519) for signature linkage; we accept any did: method the PDS
-        // already classifies, but the UCAN payload's audience is stored as the
-        // tenant string verbatim. A non-did:key audience is still a valid
-        // *allocation record* holder (pairwise or did:web), but the UCAN chain
-        // validator requires did:key, so we issue the UCAN to the operator's
-        // own issuer DID as the capability owner and encode the holder in the
-        // capability resource + caveats. The allocation record's `holder`
-        // (below) is the authoritative subject.
-        let holder = binding.spec.tenant.as_str();
-
-        let capability = tenant_grant_capability(&self.issuer_did, holder, entitlement, epoch)?;
-
-        let payload = UcanPayload {
-            issuer: self.issuer_did.clone(),
-            audience: self.issuer_did.clone(),
-            capabilities: vec![capability],
-            not_before: Some(now),
-            expiration: entitlement.expiration,
-            // Replay-uniqueness: a fresh random nonce per compiled grant. Two
-            // compiles of the same binding at the same epoch (e.g. operator
-            // restart) yield distinct UCANs/CIDs by construction.
-            nonce: fresh_nonce(),
-        };
-        let signing_bytes = payload
-            .signing_bytes()
-            .context("encode UCAN payload signing bytes")?;
-        let signature = sign_composite(&self.ed_sk, Some(&self.pq_sk), &signing_bytes, UCAN_AAD)
-            .context("hybrid-PQC sign of UCAN payload")?;
-        let ucan = Ucan {
-            payload,
-            proofs: Vec::new(),
-            signature,
-        };
-
-        // The grant CID is the atproto-canonical content address of the UCAN:
-        // CIDv1 dag-cbor (sha2-256) over its canonical CBOR. This is the
-        // `format: "cid"` string the allocation record's `grant` field
-        // references and enforcers present.
-        let grant_cid = cid_v1_string(&ucan)?;
-
-        let allocation = AllocationRecord::new(
-            grant_cid.clone(),
-            PdsUnit {
-                code: entitlement.unit.clone(),
-                issuer: self.issuer_did.as_str().to_owned(),
-            },
-            entitlement.amount,
-            epoch,
-            self.issuer_did.as_str(),
-            holder,
-            entitlement.class.into(),
-        )
-        .context("construct allocation record")?;
-
-        let allocation_cid = allocation.cid().encode();
-
-        Ok(CompiledTenantGrant {
-            ucan,
-            allocation,
-            grant_cid,
-            allocation_cid,
-            epoch,
-        })
-    }
+    ) -> Result<TenantGrantArtifacts, TenantGrantServiceError>;
 }
 
-/// The output of compiling a [`TenantBinding`]: the authority artifacts.
+/// Project a service result into the status written by the generic operator.
 ///
-/// - [`Self::ucan`] is the issuer-signed capability (presented by the holder,
-///   verified by enforcers).
-/// - [`Self::allocation`] is the `ai.hyprstream.ledger.allocation` record that
-///   lands in the tenant's PDS inventory (whose `grant` field references
-///   [`Self::grant_cid`]).
-/// - [`Self::grant_cid`] / [`Self::allocation_cid`] are the CIDv1 strings the
-///   operator records in [`crate::mesh::TenantBindingStatus`] as observed truth.
-#[derive(Clone, Debug)]
-pub struct CompiledTenantGrant {
-    /// The issuer-signed UCAN grant.
-    pub ucan: Ucan,
-    /// The inventory allocation record (lands in the tenant's PDS).
-    pub allocation: AllocationRecord,
-    /// CIDv1 of [`Self::ucan`] — what enforcers present + what
-    /// `allocation.grant` references.
-    pub grant_cid: String,
-    /// CIDv1 of [`Self::allocation`] — the durable inventory line.
-    pub allocation_cid: String,
-    /// The issuance epoch recorded on the allocation.
-    pub epoch: u64,
-}
-
-/// The verification contract for enforcers (#781/#787/#790/#793/#794/#527).
-///
-/// This is the exact check a consumer enforcer performs on a *presented* grant:
-/// structural UCAN validation → hybrid-PQC composite signature verification
-/// against the issuer's anchored keys (require_pq = true, fail-closed) →
-/// delegation-chain liveness at `now` → allocation record round-trip →
-/// grant-CID↔allocation binding. On success it yields a
-/// [`VerifiedTenantGrant`] shaped exactly like the enforcer-plane
-/// `VerifiedGrant { holder, unit, cap_amount, exp, epoch }` so the consumer
-/// issues map it 1:1.
-///
-/// A production `GrantVerifier` impl resolves `grant_cid → (Ucan,
-/// AllocationRecord)` by fetching from the holder's PDS, then calls
-/// [`TenantGrantVerifier::verify`]; this struct owns only the verify-once
-/// half so it is trivially testable without a PDS.
-#[derive(Clone)]
-pub struct TenantGrantVerifier {
-    issuer_ed_vk: VerifyingKey,
-    issuer_pq_vk: MlDsaVerifyingKey,
-}
-
-impl std::fmt::Debug for TenantGrantVerifier {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("TenantGrantVerifier")
-            .field("issuer_ed_vk", &self.issuer_ed_vk.to_bytes())
-            .finish_non_exhaustive()
-    }
-}
-
-impl TenantGrantVerifier {
-    /// Construct from the issuer's verifying keys (the anchored side of
-    /// [`TenantGrantIssuer`]).
-    pub fn new(issuer_ed_vk: VerifyingKey, issuer_pq_vk: MlDsaVerifyingKey) -> Self {
-        Self {
-            issuer_ed_vk,
-            issuer_pq_vk,
-        }
-    }
-
-    /// Construct from an issuer (mirrors its public keys).
-    pub fn from_issuer(issuer: &TenantGrantIssuer) -> Self {
-        Self::new(issuer.issuer_ed_vk(), issuer.issuer_pq_vk())
-    }
-
-    /// Verify a compiled grant the way an enforcer will.
-    ///
-    /// `now` is unix seconds; the UCAN's `not_before`/`expiration` window is
-    /// checked against it via [`chain::validate`].
-    pub fn verify(&self, compiled: &CompiledTenantGrant, now: u64) -> Result<VerifiedTenantGrant> {
-        // 1. Structural validity (DIDs resolve, window is well-ordered).
-        compiled
-            .ucan
-            .validate_structure()
-            .context("UCAN structural validation failed")?;
-
-        // 2. Hybrid-PQC composite signature over the payload signing bytes,
-        //    against the issuer's anchored keys. require_pq = true: a
-        //    classical-only signature on a tenant grant is a fail-closed
-        //    reject (a long-lived authority artifact must be HNDL-resistant).
-        let signing_bytes = compiled
-            .ucan
-            .payload
-            .signing_bytes()
-            .context("encode UCAN payload signing bytes for verify")?;
-        let verified = verify_composite(
-            &compiled.ucan.signature,
-            &self.issuer_ed_vk,
-            Some(&self.issuer_pq_vk),
-            &signing_bytes,
-            UCAN_AAD,
-            true,
-        )
-        .context("UCAN composite signature verification failed")?;
-        if !verified.ml_dsa {
-            bail!("tenant grant signature missing the ML-DSA-65 leg (require_pq)");
-        }
-
-        // 2b. The signed payload's issuer MUST be the DID of the anchored
-        //     Ed25519 key. Without this, a UCAN validly signed by the anchored
-        //     key could claim a different issuer identity in its payload.
-        let anchored_issuer = Did::from_ed25519(&self.issuer_ed_vk.to_bytes());
-        if compiled.ucan.payload.issuer != anchored_issuer {
-            bail!(
-                "UCAN payload issuer ({}) does not match the anchored issuer key ({})",
-                compiled.ucan.payload.issuer.as_str(),
-                anchored_issuer.as_str()
-            );
-        }
-
-        // 2c. The presented `grant_cid` MUST be the recomputed CID of the
-        //     presented UCAN. The signature covers only the UCAN payload — the
-        //     CID strings arrive alongside it, so an attacker could otherwise
-        //     pair a valid UCAN with an arbitrary `grant_cid` and a forged
-        //     allocation that references that same arbitrary string.
-        let recomputed_grant_cid = cid_v1_string(&compiled.ucan)?;
-        if recomputed_grant_cid != compiled.grant_cid {
-            bail!(
-                "presented grant CID ({}) does not match the UCAN's recomputed CID ({})",
-                compiled.grant_cid,
-                recomputed_grant_cid
-            );
-        }
-
-        // 3. Delegation-chain liveness. A compiled tenant grant is a root
-        //    (empty proofs), so this re-checks the not_before/expiration window
-        //    against `now` — enforcers MUST reject an expired grant even if the
-        //    signature is valid.
-        chain::validate_chain(&compiled.ucan, now)
-            .context("UCAN chain/liveness validation failed")?;
-
-        // 4. The allocation record round-trips through its canonical DAG-CBOR
-        //    — a tampered record cannot survive this.
-        let record_bytes = compiled.allocation.to_dag_cbor();
-        let redecoded = AllocationRecord::from_dag_cbor(&record_bytes)
-            .context("allocation record failed canonical round-trip")?;
-        if redecoded != compiled.allocation {
-            bail!("allocation record canonical round-trip mismatch");
-        }
-
-        // 4b. The presented `allocation_cid` MUST be the recomputed CID of the
-        //     presented record — same reasoning as the grant CID: the CID
-        //     string is unsigned transport metadata, never trusted as given.
-        let recomputed_allocation_cid = redecoded.cid().encode();
-        if recomputed_allocation_cid != compiled.allocation_cid {
-            bail!(
-                "presented allocation CID ({}) does not match the record's recomputed CID ({})",
-                compiled.allocation_cid,
-                recomputed_allocation_cid
-            );
-        }
-
-        // 4c. The allocation's issuer fields MUST be the anchored issuer: the
-        //     signature proves who signed the UCAN, but the allocation record
-        //     itself is unsigned here — an attacker could otherwise attach a
-        //     record naming a different issuer/unit-issuer to a valid UCAN.
-        if redecoded.issuer != anchored_issuer.as_str() {
-            bail!(
-                "allocation.issuer ({}) does not match the anchored issuer ({})",
-                redecoded.issuer,
-                anchored_issuer.as_str()
-            );
-        }
-        if redecoded.unit.issuer != anchored_issuer.as_str() {
-            bail!(
-                "allocation.unit.issuer ({}) does not match the anchored issuer ({})",
-                redecoded.unit.issuer,
-                anchored_issuer.as_str()
-            );
-        }
-
-        // 5. The allocation's `grant` field MUST reference the presented UCAN's
-        //    CID, binding the inventory line to the capability it draws down.
-        if redecoded.grant != compiled.grant_cid {
-            bail!(
-                "allocation.grant ({}) does not reference the presented grant CID ({})",
-                redecoded.grant,
-                compiled.grant_cid
-            );
-        }
-
-        // 6. The capability must agree with the allocation record: exact
-        //    ability, holder bound through the signed resource, and caveats
-        //    matching the record fields (unit/amount/epoch/class). This is
-        //    what stops a holder-substitution: the holder lives in the
-        //    *signed* capability resource, so a forged record naming a
-        //    different holder cannot match it.
-        verify_capability_matches_record(&compiled.ucan, &anchored_issuer, &redecoded)?;
-
-        Ok(VerifiedTenantGrant {
-            holder: redecoded.holder,
-            unit: redecoded.unit.code,
-            cap_amount: redecoded.amount,
-            exp: compiled.ucan.payload.expiration,
-            epoch: redecoded.epoch,
-            class: redecoded.class,
-        })
-    }
-}
-
-/// The verified shape of a compiled tenant grant — the data an enforcer admits
-/// against.
-///
-/// Field-for-field compatible with the enforcer-plane
-/// `hyprstream::services::ledger::VerifiedGrant { holder, unit, cap_amount, exp,
-/// epoch }`; the consumer issues implement their `GrantVerifier` by resolving a
-/// presented `grant_cid` to a [`CompiledTenantGrant`] and calling
-/// [`TenantGrantVerifier::verify`].
-#[derive(Clone, Debug, PartialEq, Eq)]
-pub struct VerifiedTenantGrant {
-    /// The holder (tenant DID / pairwise id) whose inventory this grant is.
-    pub holder: String,
-    /// The issuer-scoped credit unit code (the unit's issuer is the operator).
-    pub unit: String,
-    /// The total cap authorized (smallest quantum).
-    pub cap_amount: u64,
-    /// Grant expiry (unix seconds), if the UCAN carries one.
-    pub exp: Option<u64>,
-    /// Allocation epoch (revocation counter).
-    pub epoch: u64,
-    /// Grant class.
-    pub class: PdsGrantClass,
-}
-
-// ────────────────────────────────────────────────────────────────────────────
-// Helpers
-// ────────────────────────────────────────────────────────────────────────────
-
-/// Derive the tenant-grant ML-DSA-65 key from a derived Ed25519 purpose key.
-///
-/// Mirrors `node_identity::derive_mesh_mldsa_key` (re-seed ML-DSA-65 from the
-/// derived Ed25519 bytes) but is kept local so the `TENANT_GRANT_ED25519_PURPOSE`
-/// separation is the single source of truth for both legs.
-fn derive_tenant_grant_mldsa_key(ed25519_key: &SigningKey) -> MlDsaSigningKey {
-    let derived = hyprstream_rpc::node_identity::derive_purpose_key(
-        ed25519_key,
-        "hyprstream-tenant-grant-mldsa-v1",
-    );
-    let seed = derived.to_bytes();
-    // NOTE: the reference derivation in `node_identity::derive_mesh_mldsa_key`
-    // zeroizes the seed here; we omit that only to avoid taking a direct dep on
-    // the `zeroize` crate in this otherwise-light crate. The seed is a 32-byte
-    // stack value derived from an already-purpose-separated HKDF output, dropped
-    // immediately; the key-separation (distinct HKDF label) is the load-bearing
-    // property, not the in-memory wipe.
-    ml_dsa_sk_from_seed(&seed)
-}
-
-/// Build the single capability a tenant grant carries.
-///
-/// - `resource` = `hs://tenant/<issuer>/<holder>` — names *whose inventory* the
-///   grant is in (the issuer's liability, the holder's balance), scoped under
-///   the issuer so two operators' grants cannot cross-contend.
-/// - `ability` = `ledger/spend` ([`TENANT_GRANT_ABILITY`]).
-/// - `caveats` bind the unit / amount / epoch / class / kind so attenuation is
-///   value-aware at the enforcer (a delegated subset cannot widen amount or
-///   flip class).
-fn tenant_grant_capability(
-    issuer: &Did,
-    holder: &str,
-    entitlement: &TenantEntitlement,
-    epoch: u64,
-) -> Result<Capability> {
-    let resource = CapabilityResource::new(tenant_grant_resource(issuer, holder));
-    let ability = Ability::new(TENANT_GRANT_ABILITY);
-    // `CaveatValue::Int` is signed; a value that cannot be represented is a
-    // hard error, never a clamp — a clamped amount would mint a grant that
-    // fails its own verification, and a wrapped epoch would encode as negative.
-    let amount = i64::try_from(entitlement.amount)
-        .context("entitlement.amount exceeds i64::MAX and cannot be encoded as a caveat")?;
-    let epoch = i64::try_from(epoch)
-        .context("allocation epoch exceeds i64::MAX and cannot be encoded as a caveat")?;
-    let mut caveats = Caveats::empty();
-    caveats
-        .0
-        .insert("kind".to_owned(), CaveatValue::Text(CAVEAT_KIND.to_owned()));
-    caveats.0.insert(
-        "unit".to_owned(),
-        CaveatValue::Text(entitlement.unit.clone()),
-    );
-    caveats
-        .0
-        .insert("amount".to_owned(), CaveatValue::Int(amount));
-    caveats
-        .0
-        .insert("epoch".to_owned(), CaveatValue::Int(epoch));
-    caveats.0.insert(
-        "class".to_owned(),
-        CaveatValue::Text(entitlement.class.as_str().to_owned()),
-    );
-    Ok(Capability {
-        resource,
-        ability,
-        caveats,
-    })
-}
-
-/// The capability resource string binding an issuer's liability to a holder's
-/// balance: `hs://tenant/<issuer>/<holder>`. Single source of truth for both
-/// the compile side and the verify side's holder-binding check.
-fn tenant_grant_resource(issuer: &Did, holder: &str) -> String {
-    format!("hs://tenant/{}/{}", issuer.as_str(), holder)
-}
-
-/// Verify the UCAN capability matches the allocation record: exactly one
-/// capability with exactly [`TENANT_GRANT_ABILITY`], the holder bound through
-/// the signed resource string, and caveats matching the record's fields.
-fn verify_capability_matches_record(
-    ucan: &Ucan,
-    anchored_issuer: &Did,
-    record: &AllocationRecord,
-) -> Result<()> {
-    let caps = ucan.capabilities();
-    let cap = caps
-        .first()
-        .ok_or_else(|| anyhow!("tenant grant UCAN carries no capability"))?;
-    if cap.ability.as_str() != TENANT_GRANT_ABILITY {
-        bail!(
-            "tenant grant capability has unexpected ability {} (require exactly {})",
-            cap.ability,
-            TENANT_GRANT_ABILITY
-        );
-    }
-    // The holder is not a caveat — it lives in the signed resource string. The
-    // record's holder MUST reconstruct the exact resource the issuer signed,
-    // or the record names a substituted holder.
-    let expected_resource = tenant_grant_resource(anchored_issuer, &record.holder);
-    if cap.resource.as_str() != expected_resource {
-        bail!(
-            "grant capability resource ({}) does not bind the allocation holder ({})",
-            cap.resource.as_str(),
-            record.holder
-        );
-    }
-    let cv = |key: &str| -> Result<&CaveatValue> {
-        cap.caveats
-            .0
-            .get(key)
-            .ok_or_else(|| anyhow!("tenant grant caveat missing {key:?}"))
-    };
-    match cv("kind")? {
-        CaveatValue::Text(t) if t == CAVEAT_KIND => {}
-        other => bail!("grant caveat kind mismatch: {other:?}"),
-    }
-    match cv("unit")? {
-        CaveatValue::Text(t) if t == &record.unit.code => {}
-        other => bail!("grant caveat unit does not match record: {other:?}"),
-    }
-    // Lossless compare: a negative caveat can never equal a u64 field.
-    match cv("amount")? {
-        CaveatValue::Int(a) if u64::try_from(*a) == Ok(record.amount) => {}
-        other => bail!("grant caveat amount does not match record: {other:?}"),
-    }
-    match cv("epoch")? {
-        CaveatValue::Int(e) if u64::try_from(*e) == Ok(record.epoch) => {}
-        other => bail!("grant caveat epoch does not match record: {other:?}"),
-    }
-    match cv("class")? {
-        CaveatValue::Text(t) if t == &record.class.as_str().to_owned() => {}
-        other => bail!("grant caveat class does not match record: {other:?}"),
-    }
-    Ok(())
-}
-
-fn validate_entitlement(entitlement: &TenantEntitlement, now: u64) -> Result<()> {
-    if entitlement.unit.is_empty() {
-        bail!("entitlement.unit must not be empty");
-    }
-    if entitlement.unit.chars().any(char::is_whitespace) {
-        bail!("entitlement.unit must not contain whitespace");
-    }
-    if let Some(exp) = entitlement.expiration {
-        if exp <= now {
-            bail!(
-                "entitlement.expiration ({exp}) must be in the future (now {now}); a grant that \
-                 is born expired is never valid"
-            );
-        }
-    }
-    Ok(())
-}
-
-/// 16-byte random nonce, fresh per compile.
-fn fresh_nonce() -> Vec<u8> {
-    let mut buf = [0u8; 16];
-    rand::thread_rng().fill_bytes(&mut buf);
-    buf.to_vec()
-}
-
-/// The atproto-canonical CIDv1 string of a UCAN (dag-cbor, sha2-256) over its
-/// canonical CBOR encoding. This is the `format: "cid"` string the allocation
-/// record's `grant` field references and enforcers present.
-fn cid_v1_string(ucan: &Ucan) -> Result<String> {
-    let bytes = ucan
-        .to_cbor()
-        .context("UCAN CBOR encoding is infallible for this shape; encoding error is a bug")?;
-    Ok(hyprstream_pds::cid::Cid::from_dag_cbor(&bytes).encode())
-}
-
-/// Unix seconds from the system wall clock; never panics on platforms without a
-/// wall clock (returns 0, which fails the expiry check closed). Used by the
-/// operator's `TenantBinding` reconcile to stamp `not_before` and check
-/// author-supplied expiries.
-pub fn now_unix() -> u64 {
-    SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .map(|d| d.as_secs())
-        .unwrap_or(0)
-}
-
-/// Map the k8s-side grant class to the PDS lexicon grant class.
-impl From<TenantGrantClass> for PdsGrantClass {
-    fn from(class: TenantGrantClass) -> Self {
-        match class {
-            TenantGrantClass::Prepaid => PdsGrantClass::Prepaid,
-            TenantGrantClass::Underwritten => PdsGrantClass::Underwritten,
-        }
-    }
-}
-
-/// Compile a [`TenantBinding`]'s entitlement into the [`TenantBindingStatus`]
-/// the operator writes back on reconcile (#929).
-///
-/// This is the operator's "sign as issuer" step as a pure decision: given a
-/// binding, the operator's [`TenantGrantIssuer`] (or `None` if grant
-/// compilation is disabled), the next allocation `epoch`, and `now`, it returns
-/// the status the controller patches:
-/// - **No entitlement** → a no-grant `Bound` status (the binding is still the
-///   confused-deputy namespace↔tenant map). `issuer` is ignored.
-/// - **Entitlement + `Some(issuer)`** → the operator signs; on success the
-///   status carries the compiled grant CID + allocation CID + epoch (`Bound`),
-///   on a compile error it is `Rejected` with the message.
-/// - **Entitlement + `None`** → `Rejected`: an admin authored an entitlement
-///   but the operator has no issuer configured.
-///
-/// The **physical PDS publish** of the allocation record into the tenant's
-/// inventory is deliberately NOT done here — it needs the #910 multi-collection
-/// write path + the tenant's signing key. This function mints the grant; landing
-/// it is the deferred plumbing (see the module docs).
+/// An authored entitlement without a configured service is rejected. A
+/// service error is also rejected and never leaves partial content references.
 pub fn compile_tenant_binding_status(
     binding: &TenantBinding,
-    issuer: Option<&TenantGrantIssuer>,
+    service: Option<&dyn TenantGrantService>,
     epoch: u64,
     now: u64,
 ) -> TenantBindingStatus {
@@ -735,20 +82,19 @@ pub fn compile_tenant_binding_status(
             allocation_cid: None,
             epoch: None,
         },
-        Some(_) => match issuer {
-            None => TenantBindingStatus {
-                bound: Some(false),
-                phase: Some("Rejected".to_owned()),
-                message: Some(
-                    "entitlement present but operator has no tenant-grant issuer configured"
-                        .to_owned(),
+        Some(_) => match service {
+            None => rejected_status(
+                generation,
+                "entitlement present but operator has no tenant-grant service configured",
+            ),
+            Some(service) => match service.compile_grant(binding, epoch, now) {
+                Ok(compiled) if compiled.epoch != epoch => rejected_status(
+                    generation,
+                    &format!(
+                        "grant compilation failed: service returned epoch {} for requested epoch {epoch}",
+                        compiled.epoch
+                    ),
                 ),
-                observed_generation: generation,
-                grant_cid: None,
-                allocation_cid: None,
-                epoch: None,
-            },
-            Some(issuer) => match issuer.compile(binding, epoch, now) {
                 Ok(compiled) => TenantBindingStatus {
                     bound: Some(true),
                     phase: Some("Bound".to_owned()),
@@ -761,36 +107,74 @@ pub fn compile_tenant_binding_status(
                     allocation_cid: Some(compiled.allocation_cid),
                     epoch: Some(compiled.epoch),
                 },
-                Err(error) => TenantBindingStatus {
-                    bound: Some(false),
-                    phase: Some("Rejected".to_owned()),
-                    message: Some(format!("grant compilation failed: {error:#}")),
-                    observed_generation: generation,
-                    grant_cid: None,
-                    allocation_cid: None,
-                    epoch: None,
-                },
+                Err(error) => {
+                    rejected_status(generation, &format!("grant compilation failed: {error}"))
+                }
             },
         },
     }
 }
 
+fn rejected_status(generation: Option<i64>, message: &str) -> TenantBindingStatus {
+    TenantBindingStatus {
+        bound: Some(false),
+        phase: Some("Rejected".to_owned()),
+        message: Some(message.to_owned()),
+        observed_generation: generation,
+        grant_cid: None,
+        allocation_cid: None,
+        epoch: None,
+    }
+}
+
+/// Unix seconds used by the generic reconcile request.
+///
+/// Platforms without a usable wall clock return zero so downstream expiry
+/// validation fails closed.
+pub fn now_unix() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|duration| duration.as_secs())
+        .unwrap_or(0)
+}
+
 #[cfg(test)]
 mod tests {
-    #![allow(clippy::unwrap_used, clippy::expect_used, clippy::panic)]
-    use super::*;
-    use crate::mesh::{TenantBindingSpec, TenantEntitlement};
+    #![allow(clippy::expect_used)]
 
-    fn binding(unit: &str, amount: u64, class: TenantGrantClass) -> TenantBinding {
+    use super::*;
+    use crate::mesh::{TenantBindingSpec, TenantEntitlement, TenantGrantClass};
+
+    struct RecordingService;
+
+    impl TenantGrantService for RecordingService {
+        fn compile_grant(
+            &self,
+            binding: &TenantBinding,
+            epoch: u64,
+            now: u64,
+        ) -> Result<TenantGrantArtifacts, TenantGrantServiceError> {
+            assert_eq!(binding.spec.tenant, "did:web:acme");
+            assert_eq!(epoch, 7);
+            assert_eq!(now, 1_700_000_000);
+            Ok(TenantGrantArtifacts {
+                grant_cid: "bafy-grant".to_owned(),
+                allocation_cid: "bafy-allocation".to_owned(),
+                epoch,
+            })
+        }
+    }
+
+    fn entitled_binding() -> TenantBinding {
         TenantBinding::new(
             "acme",
             TenantBindingSpec {
                 namespace: "acme".to_owned(),
-                tenant: "did:web:tenant.acme.example".to_owned(),
+                tenant: "did:web:acme".to_owned(),
                 entitlement: Some(TenantEntitlement {
-                    unit: unit.to_owned(),
-                    amount,
-                    class,
+                    unit: "compute-second".to_owned(),
+                    amount: 100,
+                    class: TenantGrantClass::Underwritten,
                     expiration: None,
                 }),
             },
@@ -798,332 +182,86 @@ mod tests {
     }
 
     #[test]
-    fn compile_then_verify_round_trips() {
-        let issuer = TenantGrantIssuer::generate_for_test();
-        let verifier = TenantGrantVerifier::from_issuer(&issuer);
-        let now = 1_700_000_000u64;
-        let binding = binding("compute-second", 3_600, TenantGrantClass::Underwritten);
+    fn tenant_grant_service_boundary_is_required_for_entitlements() {
+        let rejected = compile_tenant_binding_status(&entitled_binding(), None, 7, 1_700_000_000);
+        assert_eq!(rejected.bound, Some(false));
+        assert_eq!(rejected.phase.as_deref(), Some("Rejected"));
+        assert!(rejected.grant_cid.is_none());
+        assert!(rejected.allocation_cid.is_none());
 
-        let compiled = issuer
-            .compile(&binding, 7, now)
-            .expect("compile must succeed for a valid entitlement");
-
-        // The allocation record references the grant CID.
-        assert_eq!(compiled.allocation.grant, compiled.grant_cid);
-        // The grant CID is a CIDv1 string.
-        assert!(compiled.grant_cid.starts_with('b'));
-        assert!(compiled.allocation_cid.starts_with('b'));
-
-        let verified = verifier
-            .verify(&compiled, now)
-            .expect("verify must succeed");
-        assert_eq!(verified.holder, "did:web:tenant.acme.example");
-        assert_eq!(verified.unit, "compute-second");
-        assert_eq!(verified.cap_amount, 3_600);
-        assert_eq!(verified.epoch, 7);
-        assert_eq!(verified.class, PdsGrantClass::Underwritten);
-        assert_eq!(verified.exp, None);
-    }
-
-    #[test]
-    fn two_compiles_of_the_same_binding_yield_distinct_grants() {
-        // The nonce makes each compile unique even at the same epoch.
-        let issuer = TenantGrantIssuer::generate_for_test();
-        let now = 1_700_000_000u64;
-        let binding = binding("gpu-hour", 8, TenantGrantClass::Prepaid);
-        let a = issuer.compile(&binding, 1, now).unwrap();
-        let b = issuer.compile(&binding, 1, now).unwrap();
-        assert_ne!(a.grant_cid, b.grant_cid, "fresh nonce ⇒ distinct CIDs");
-        assert_ne!(a.allocation_cid, b.allocation_cid);
-    }
-
-    #[test]
-    fn verify_rejects_a_tampered_allocation_amount() {
-        let issuer = TenantGrantIssuer::generate_for_test();
-        let verifier = TenantGrantVerifier::from_issuer(&issuer);
-        let now = 1_700_000_000u64;
-        let binding = binding("compute-second", 100, TenantGrantClass::Underwritten);
-        let mut compiled = issuer.compile(&binding, 1, now).unwrap();
-
-        // Tamper: bump the allocation amount without re-signing the UCAN. The
-        // capability caveat (amount=100) no longer matches the record (200).
-        compiled.allocation = AllocationRecord::new(
-            compiled.grant_cid.clone(),
-            PdsUnit {
-                code: "compute-second".to_owned(),
-                issuer: issuer.issuer_did().as_str().to_owned(),
-            },
-            200,
-            1,
-            issuer.issuer_did().as_str(),
-            "did:web:tenant.acme.example",
-            PdsGrantClass::Underwritten,
-        )
-        .unwrap();
-        // Keep the presented allocation CID consistent with the tampered
-        // record so the signed amount caveat is what catches the tamper.
-        compiled.allocation_cid = compiled.allocation.cid().encode();
-
-        let err = verifier.verify(&compiled, now).unwrap_err();
-        assert!(
-            err.to_string().contains("amount"),
-            "tampered amount must be caught: {err}"
+        let compiled = compile_tenant_binding_status(
+            &entitled_binding(),
+            Some(&RecordingService),
+            7,
+            1_700_000_000,
         );
+        assert_eq!(compiled.bound, Some(true));
+        assert_eq!(compiled.grant_cid.as_deref(), Some("bafy-grant"));
+        assert_eq!(compiled.allocation_cid.as_deref(), Some("bafy-allocation"));
+        assert_eq!(compiled.epoch, Some(7));
+    }
+
+    struct FailingService;
+
+    impl TenantGrantService for FailingService {
+        fn compile_grant(
+            &self,
+            _binding: &TenantBinding,
+            _epoch: u64,
+            _now: u64,
+        ) -> Result<TenantGrantArtifacts, TenantGrantServiceError> {
+            Err(TenantGrantServiceError::new("issuer unavailable"))
+        }
     }
 
     #[test]
-    fn verify_rejects_a_classical_only_signature() {
-        // A grant signed without the PQ leg must fail closed at verify
-        // (require_pq = true) — the long-lived authority must be HNDL-resistant.
-        let issuer_ed_sk = {
-            let mut b = [0u8; 32];
-            rand::thread_rng().fill_bytes(&mut b);
-            SigningKey::from_bytes(&b)
-        };
-        let issuer_did = Did::from_ed25519(&issuer_ed_sk.verifying_key().to_bytes());
-        let now = 1_700_000_000u64;
-        let binding = binding("compute-second", 5, TenantGrantClass::Prepaid);
-
-        let entitlement = binding.spec.entitlement.as_ref().unwrap();
-        let capability =
-            tenant_grant_capability(&issuer_did, &binding.spec.tenant, entitlement, 1).unwrap();
-        let payload = UcanPayload {
-            issuer: issuer_did.clone(),
-            audience: issuer_did.clone(),
-            capabilities: vec![capability],
-            not_before: Some(now),
-            expiration: None,
-            nonce: fresh_nonce(),
-        };
-        let signing_bytes = payload.signing_bytes().unwrap();
-        // Classical-only sign (pq_sk = None).
-        let signature = sign_composite(&issuer_ed_sk, None, &signing_bytes, UCAN_AAD).unwrap();
-        let ucan = Ucan {
-            payload,
-            proofs: Vec::new(),
-            signature,
-        };
-        let grant_cid = cid_v1_string(&ucan).unwrap();
-        let allocation = AllocationRecord::new(
-            grant_cid.clone(),
-            PdsUnit {
-                code: "compute-second".to_owned(),
-                issuer: issuer_did.as_str().to_owned(),
-            },
-            5,
-            1,
-            issuer_did.as_str(),
-            "did:web:tenant.acme.example",
-            PdsGrantClass::Prepaid,
-        )
-        .unwrap();
-        let compiled = CompiledTenantGrant {
-            ucan,
-            allocation_cid: allocation.cid().encode(),
-            allocation,
-            grant_cid,
-            epoch: 1,
-        };
-
-        // Verifier anchored on the Ed25519 key but WITH a PQ key requirement.
-        let verifier = TenantGrantVerifier::new(
-            issuer_ed_sk.verifying_key(),
-            // A throwaway, *wrong* PQ key: a classical-only signature cannot
-            // satisfy require_pq regardless of the anchored PQ key.
-            ml_dsa_generate_keypair().1,
+    fn tenant_grant_service_errors_fail_closed_without_partial_references() {
+        let status = compile_tenant_binding_status(
+            &entitled_binding(),
+            Some(&FailingService),
+            7,
+            1_700_000_000,
         );
-        let err = verifier.verify(&compiled, now).unwrap_err();
-        assert!(
-            err.to_string().to_lowercase().contains("signature")
-                || err.to_string().contains("ML-DSA"),
-            "classical-only signature must fail closed: {err}"
+        assert_eq!(status.bound, Some(false));
+        assert_eq!(status.phase.as_deref(), Some("Rejected"));
+        assert!(status
+            .message
+            .as_deref()
+            .is_some_and(|message| message.contains("issuer unavailable")));
+        assert!(status.grant_cid.is_none());
+        assert!(status.allocation_cid.is_none());
+        assert!(status.epoch.is_none());
+    }
+
+    struct WrongEpochService;
+
+    impl TenantGrantService for WrongEpochService {
+        fn compile_grant(
+            &self,
+            _binding: &TenantBinding,
+            epoch: u64,
+            _now: u64,
+        ) -> Result<TenantGrantArtifacts, TenantGrantServiceError> {
+            Ok(TenantGrantArtifacts {
+                grant_cid: "bafy-grant".to_owned(),
+                allocation_cid: "bafy-allocation".to_owned(),
+                epoch: epoch + 1,
+            })
+        }
+    }
+
+    #[test]
+    fn tenant_grant_service_cannot_bypass_requested_revocation_epoch() {
+        let status = compile_tenant_binding_status(
+            &entitled_binding(),
+            Some(&WrongEpochService),
+            7,
+            1_700_000_000,
         );
-    }
-
-    #[test]
-    fn verify_rejects_an_expired_grant() {
-        let issuer = TenantGrantIssuer::generate_for_test();
-        let verifier = TenantGrantVerifier::from_issuer(&issuer);
-        let now = 1_700_000_000u64;
-
-        let mut binding = binding("compute-second", 1, TenantGrantClass::Underwritten);
-        binding.spec.entitlement.as_mut().unwrap().expiration = Some(now + 10);
-
-        let compiled = issuer.compile(&binding, 1, now).unwrap();
-        // Verify at `now + 100`: past expiration.
-        let err = verifier.verify(&compiled, now + 100).unwrap_err();
-        assert!(
-            err.to_string().to_lowercase().contains("expir")
-                || err.to_string().contains("liveness")
-                || err.to_string().contains("window"),
-            "expired grant must be rejected: {err}"
-        );
-    }
-
-    #[test]
-    fn verify_rejects_a_substituted_holder() {
-        // A valid signed UCAN paired with a forged allocation record naming a
-        // different holder: every unsigned field (grant ref, unit, amount,
-        // epoch, class, issuer, allocation CID) is made self-consistent, so
-        // only the signed capability resource can catch the substitution.
-        let issuer = TenantGrantIssuer::generate_for_test();
-        let verifier = TenantGrantVerifier::from_issuer(&issuer);
-        let now = 1_700_000_000u64;
-        let binding = binding("compute-second", 100, TenantGrantClass::Underwritten);
-        let mut compiled = issuer.compile(&binding, 1, now).unwrap();
-
-        compiled.allocation = AllocationRecord::new(
-            compiled.grant_cid.clone(),
-            PdsUnit {
-                code: "compute-second".to_owned(),
-                issuer: issuer.issuer_did().as_str().to_owned(),
-            },
-            100,
-            1,
-            issuer.issuer_did().as_str(),
-            "did:web:evil.example",
-            PdsGrantClass::Underwritten,
-        )
-        .unwrap();
-        compiled.allocation_cid = compiled.allocation.cid().encode();
-
-        let err = verifier.verify(&compiled, now).unwrap_err();
-        assert!(
-            err.to_string().contains("holder") || err.to_string().contains("resource"),
-            "substituted holder must be caught by the signed resource binding: {err}"
-        );
-    }
-
-    #[test]
-    fn verify_rejects_a_forged_grant_cid_binding() {
-        // The attacker controls both `grant_cid` and `allocation.grant`
-        // (neither is covered by the UCAN signature), so making them agree on
-        // an arbitrary string must still fail: the grant CID is recomputed
-        // from the presented UCAN, never trusted as given.
-        let issuer = TenantGrantIssuer::generate_for_test();
-        let verifier = TenantGrantVerifier::from_issuer(&issuer);
-        let now = 1_700_000_000u64;
-        let binding = binding("compute-second", 100, TenantGrantClass::Underwritten);
-        let mut compiled = issuer.compile(&binding, 1, now).unwrap();
-
-        let fake_cid = "bafyreifakefakefakefakefakefakefakefakefakefakefakefakefake".to_owned();
-        compiled.allocation.grant = fake_cid.clone();
-        compiled.grant_cid = fake_cid;
-        compiled.allocation_cid = compiled.allocation.cid().encode();
-
-        let err = verifier.verify(&compiled, now).unwrap_err();
-        assert!(
-            err.to_string().contains("recomputed"),
-            "forged grant CID must be caught by recomputation: {err}"
-        );
-    }
-
-    #[test]
-    fn verify_rejects_a_foreign_allocation_issuer() {
-        let issuer = TenantGrantIssuer::generate_for_test();
-        let verifier = TenantGrantVerifier::from_issuer(&issuer);
-        let now = 1_700_000_000u64;
-        let binding = binding("compute-second", 100, TenantGrantClass::Underwritten);
-        let mut compiled = issuer.compile(&binding, 1, now).unwrap();
-
-        compiled.allocation = AllocationRecord::new(
-            compiled.grant_cid.clone(),
-            PdsUnit {
-                code: "compute-second".to_owned(),
-                issuer: "did:web:other-operator.example".to_owned(),
-            },
-            100,
-            1,
-            "did:web:other-operator.example",
-            "did:web:tenant.acme.example",
-            PdsGrantClass::Underwritten,
-        )
-        .unwrap();
-        compiled.allocation_cid = compiled.allocation.cid().encode();
-
-        let err = verifier.verify(&compiled, now).unwrap_err();
-        assert!(
-            err.to_string().contains("issuer"),
-            "foreign allocation issuer must be rejected: {err}"
-        );
-    }
-
-    #[test]
-    fn verify_rejects_a_mismatched_allocation_cid() {
-        let issuer = TenantGrantIssuer::generate_for_test();
-        let verifier = TenantGrantVerifier::from_issuer(&issuer);
-        let now = 1_700_000_000u64;
-        let binding = binding("compute-second", 100, TenantGrantClass::Underwritten);
-        let mut compiled = issuer.compile(&binding, 1, now).unwrap();
-
-        compiled.allocation_cid = "bafyreinotwhatwascomputed".to_owned();
-
-        let err = verifier.verify(&compiled, now).unwrap_err();
-        assert!(
-            err.to_string().contains("allocation CID"),
-            "mismatched allocation CID must be rejected: {err}"
-        );
-    }
-
-    #[test]
-    fn compile_rejects_amount_above_i64_max() {
-        // No silent clamp: an amount that cannot be a signed caveat is a
-        // compile error, never a grant that fails its own verification.
-        let issuer = TenantGrantIssuer::generate_for_test();
-        let binding = binding("compute-second", u64::MAX, TenantGrantClass::Underwritten);
-        let err = issuer.compile(&binding, 1, 1_700_000_000).unwrap_err();
-        assert!(err.to_string().contains("amount"), "{err}");
-    }
-
-    #[test]
-    fn compile_rejects_epoch_above_i64_max() {
-        let issuer = TenantGrantIssuer::generate_for_test();
-        let binding = binding("compute-second", 1, TenantGrantClass::Underwritten);
-        let err = issuer
-            .compile(&binding, u64::MAX, 1_700_000_000)
-            .unwrap_err();
-        assert!(err.to_string().contains("epoch"), "{err}");
-    }
-
-    #[test]
-    fn compile_without_entitlement_is_an_error() {
-        let issuer = TenantGrantIssuer::generate_for_test();
-        let binding = TenantBinding::new(
-            "acme",
-            TenantBindingSpec {
-                namespace: "acme".to_owned(),
-                tenant: "did:web:t".to_owned(),
-                entitlement: None,
-            },
-        );
-        assert!(issuer.compile(&binding, 1, 1_700_000_000).is_err());
-    }
-
-    #[test]
-    fn compile_rejects_inverted_expiration() {
-        let issuer = TenantGrantIssuer::generate_for_test();
-        let now = 1_700_000_000u64;
-        let mut binding = binding("compute-second", 1, TenantGrantClass::Underwritten);
-        binding.spec.entitlement.as_mut().unwrap().expiration = Some(now - 1);
-        assert!(issuer.compile(&binding, 1, now).is_err());
-    }
-
-    #[test]
-    fn from_node_root_is_deterministic() {
-        let mut seed = [0u8; 32];
-        rand::thread_rng().fill_bytes(&mut seed);
-        let root = SigningKey::from_bytes(&seed);
-        let a = TenantGrantIssuer::from_node_root(&root).unwrap();
-        let b = TenantGrantIssuer::from_node_root(&root).unwrap();
-        assert_eq!(
-            a.issuer_did(),
-            b.issuer_did(),
-            "same root ⇒ same issuer DID"
-        );
-        assert_eq!(
-            a.issuer_ed_vk().to_bytes(),
-            b.issuer_ed_vk().to_bytes(),
-            "purpose derivation is deterministic"
-        );
+        assert_eq!(status.bound, Some(false));
+        assert_eq!(status.phase.as_deref(), Some("Rejected"));
+        assert!(status.grant_cid.is_none());
+        assert!(status.allocation_cid.is_none());
+        assert!(status.epoch.is_none());
     }
 }

--- a/crates/hyprstream-k8s/src/grant.rs
+++ b/crates/hyprstream-k8s/src/grant.rs
@@ -9,19 +9,91 @@
 use std::fmt;
 use std::time::{SystemTime, UNIX_EPOCH};
 
+use cid::Cid;
 use kube::Resource;
 
 use crate::mesh::{TenantBinding, TenantBindingStatus};
 
-/// Opaque references produced by a service-specific grant compiler.
+/// A validated, canonical content identifier.
+///
+/// This service-neutral type validates only the content-addressing envelope:
+/// it deliberately knows nothing about UCANs, PDS records, or how their bytes
+/// are produced. Keeping the inner string private makes malformed successful
+/// service results unrepresentable.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ContentReference(String);
+
+impl ContentReference {
+    /// Parse a canonical CID string.
+    pub fn parse(value: impl Into<String>) -> Result<Self, TenantGrantServiceError> {
+        let value = value.into();
+        if value.trim() != value {
+            return Err(TenantGrantServiceError::new(
+                "content reference must not contain surrounding whitespace",
+            ));
+        }
+        let parsed = Cid::try_from(value.as_str()).map_err(|error| {
+            TenantGrantServiceError::new(format!("invalid content reference: {error}"))
+        })?;
+        if parsed.to_string() != value {
+            return Err(TenantGrantServiceError::new(
+                "content reference must use canonical CID encoding",
+            ));
+        }
+        Ok(Self(value))
+    }
+
+    /// Borrow the canonical CID string.
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+
+    fn into_string(self) -> String {
+        self.0
+    }
+}
+
+/// Validated references produced by a service-specific grant compiler.
 ///
 /// The Kubernetes substrate records these values as observed status but never
 /// interprets their service-specific contents.
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct TenantGrantArtifacts {
-    pub grant_cid: String,
-    pub allocation_cid: String,
-    pub epoch: u64,
+    grant_cid: ContentReference,
+    allocation_cid: ContentReference,
+    epoch: u64,
+}
+
+impl TenantGrantArtifacts {
+    /// Validate both references before constructing a successful artifact pair.
+    pub fn new(
+        grant_cid: impl Into<String>,
+        allocation_cid: impl Into<String>,
+        epoch: u64,
+    ) -> Result<Self, TenantGrantServiceError> {
+        let grant_cid = ContentReference::parse(grant_cid)?;
+        let allocation_cid = ContentReference::parse(allocation_cid)?;
+        Ok(Self {
+            grant_cid,
+            allocation_cid,
+            epoch,
+        })
+    }
+
+    /// The validated grant CID.
+    pub fn grant_cid(&self) -> &ContentReference {
+        &self.grant_cid
+    }
+
+    /// The validated allocation CID.
+    pub fn allocation_cid(&self) -> &ContentReference {
+        &self.allocation_cid
+    }
+
+    /// The revocation epoch the service compiled.
+    pub fn epoch(&self) -> u64 {
+        self.epoch
+    }
 }
 
 /// A fail-closed service error safe to reflect in Kubernetes status.
@@ -88,25 +160,33 @@ pub fn compile_tenant_binding_status(
                 "entitlement present but operator has no tenant-grant service configured",
             ),
             Some(service) => match service.compile_grant(binding, epoch, now) {
-                Ok(compiled) if compiled.epoch != epoch => rejected_status(
+                Ok(compiled) if compiled.epoch() != epoch => rejected_status(
                     generation,
                     &format!(
                         "grant compilation failed: service returned epoch {} for requested epoch {epoch}",
-                        compiled.epoch
+                        compiled.epoch()
                     ),
                 ),
-                Ok(compiled) => TenantBindingStatus {
-                    bound: Some(true),
-                    phase: Some("Bound".to_owned()),
-                    message: Some(format!(
-                        "compiled grant {} (allocation {}); PDS publish pending #910",
-                        compiled.grant_cid, compiled.allocation_cid
-                    )),
-                    observed_generation: generation,
-                    grant_cid: Some(compiled.grant_cid),
-                    allocation_cid: Some(compiled.allocation_cid),
-                    epoch: Some(compiled.epoch),
-                },
+                Ok(compiled) => {
+                    let TenantGrantArtifacts {
+                        grant_cid,
+                        allocation_cid,
+                        epoch,
+                    } = compiled;
+                    TenantBindingStatus {
+                        bound: Some(true),
+                        phase: Some("Bound".to_owned()),
+                        message: Some(format!(
+                            "compiled grant {} (allocation {}); PDS publish pending #910",
+                            grant_cid.as_str(),
+                            allocation_cid.as_str()
+                        )),
+                        observed_generation: generation,
+                        grant_cid: Some(grant_cid.into_string()),
+                        allocation_cid: Some(allocation_cid.into_string()),
+                        epoch: Some(epoch),
+                    }
+                }
                 Err(error) => {
                     rejected_status(generation, &format!("grant compilation failed: {error}"))
                 }
@@ -145,6 +225,8 @@ mod tests {
     use super::*;
     use crate::mesh::{TenantBindingSpec, TenantEntitlement, TenantGrantClass};
 
+    const VALID_CID: &str = "bafybeigdyrzt5sfp7udm7hu76uh7y26nf3g3gd3lst2gq2r2a6y4m5x4zi";
+
     struct RecordingService;
 
     impl TenantGrantService for RecordingService {
@@ -157,11 +239,7 @@ mod tests {
             assert_eq!(binding.spec.tenant, "did:web:acme");
             assert_eq!(epoch, 7);
             assert_eq!(now, 1_700_000_000);
-            Ok(TenantGrantArtifacts {
-                grant_cid: "bafy-grant".to_owned(),
-                allocation_cid: "bafy-allocation".to_owned(),
-                epoch,
-            })
+            TenantGrantArtifacts::new(VALID_CID, VALID_CID, epoch)
         }
     }
 
@@ -196,8 +274,8 @@ mod tests {
             1_700_000_000,
         );
         assert_eq!(compiled.bound, Some(true));
-        assert_eq!(compiled.grant_cid.as_deref(), Some("bafy-grant"));
-        assert_eq!(compiled.allocation_cid.as_deref(), Some("bafy-allocation"));
+        assert_eq!(compiled.grant_cid.as_deref(), Some(VALID_CID));
+        assert_eq!(compiled.allocation_cid.as_deref(), Some(VALID_CID));
         assert_eq!(compiled.epoch, Some(7));
     }
 
@@ -242,11 +320,7 @@ mod tests {
             epoch: u64,
             _now: u64,
         ) -> Result<TenantGrantArtifacts, TenantGrantServiceError> {
-            Ok(TenantGrantArtifacts {
-                grant_cid: "bafy-grant".to_owned(),
-                allocation_cid: "bafy-allocation".to_owned(),
-                epoch: epoch + 1,
-            })
+            TenantGrantArtifacts::new(VALID_CID, VALID_CID, epoch + 1)
         }
     }
 
@@ -263,5 +337,23 @@ mod tests {
         assert!(status.grant_cid.is_none());
         assert!(status.allocation_cid.is_none());
         assert!(status.epoch.is_none());
+    }
+
+    #[test]
+    fn malformed_artifact_pairs_are_unrepresentable() {
+        for (grant, allocation) in [
+            ("", VALID_CID),
+            (" ", VALID_CID),
+            ("not-a-cid", VALID_CID),
+            (VALID_CID, ""),
+            (VALID_CID, "\t"),
+            (VALID_CID, "not-a-cid"),
+            (" not-a-cid", "not-a-cid "),
+        ] {
+            assert!(
+                TenantGrantArtifacts::new(grant, allocation, 7).is_err(),
+                "malformed pair unexpectedly accepted: {grant:?}, {allocation:?}"
+            );
+        }
     }
 }

--- a/crates/hyprstream-k8s/src/grant.rs
+++ b/crates/hyprstream-k8s/src/grant.rs
@@ -9,7 +9,7 @@
 use std::fmt;
 use std::time::{SystemTime, UNIX_EPOCH};
 
-use cid::Cid;
+use cid::{Cid, Version};
 use kube::Resource;
 
 use crate::mesh::{TenantBinding, TenantBindingStatus};
@@ -35,9 +35,14 @@ impl ContentReference {
         let parsed = Cid::try_from(value.as_str()).map_err(|error| {
             TenantGrantServiceError::new(format!("invalid content reference: {error}"))
         })?;
+        if parsed.version() != Version::V1 {
+            return Err(TenantGrantServiceError::new(
+                "content reference must be CIDv1",
+            ));
+        }
         if parsed.to_string() != value {
             return Err(TenantGrantServiceError::new(
-                "content reference must use canonical CID encoding",
+                "content reference must use canonical lowercase base32 CIDv1 encoding",
             ));
         }
         Ok(Self(value))
@@ -341,18 +346,37 @@ mod tests {
 
     #[test]
     fn malformed_artifact_pairs_are_unrepresentable() {
-        for (grant, allocation) in [
-            ("", VALID_CID),
-            (" ", VALID_CID),
-            ("not-a-cid", VALID_CID),
-            (VALID_CID, ""),
-            (VALID_CID, "\t"),
-            (VALID_CID, "not-a-cid"),
-            (" not-a-cid", "not-a-cid "),
+        const CID_V0: &str = "QmdfTbBqBPQ7VNxZEYEj14VmRuZBkqFbiwReogJgS1zR1n";
+        let parsed = Cid::try_from(VALID_CID).expect("fixture must be a valid CIDv1");
+        let uppercase = parsed
+            .to_string_of_base(cid::multibase::Base::Base32Upper)
+            .expect("base32 encoding");
+        let base58 = parsed
+            .to_string_of_base(cid::multibase::Base::Base58Btc)
+            .expect("base58 encoding");
+        let base64 = parsed
+            .to_string_of_base(cid::multibase::Base::Base64)
+            .expect("base64 encoding");
+        let ipfs_path = format!("/ipfs/{VALID_CID}");
+
+        for invalid in [
+            "",
+            " ",
+            "\t",
+            "not-a-cid",
+            CID_V0,
+            uppercase.as_str(),
+            base58.as_str(),
+            base64.as_str(),
+            ipfs_path.as_str(),
         ] {
             assert!(
-                TenantGrantArtifacts::new(grant, allocation, 7).is_err(),
-                "malformed pair unexpectedly accepted: {grant:?}, {allocation:?}"
+                TenantGrantArtifacts::new(invalid, VALID_CID, 7).is_err(),
+                "invalid grant reference unexpectedly accepted: {invalid:?}"
+            );
+            assert!(
+                TenantGrantArtifacts::new(VALID_CID, invalid, 7).is_err(),
+                "invalid allocation reference unexpectedly accepted: {invalid:?}"
             );
         }
     }

--- a/crates/hyprstream-k8s/src/lib.rs
+++ b/crates/hyprstream-k8s/src/lib.rs
@@ -36,14 +36,24 @@
 //! - default (no features): CRD *type* definitions, schema derivation, CEL
 //!   validation and YAML emission — all compile with no cluster present.
 //! - `k8s`: pulls in the kube client + controller-runtime for code that needs a
-//!   live API server (see [`install`]). CRD types never require it.
+//!   live API server (see the `install` module). CRD types never require it.
 //! - `grant`: exposes only the service-neutral [`grant::TenantGrantService`]
 //!   boundary and generic TenantBinding status projection. Authority-bearing
 //!   signing and PDS allocation behavior moved to the downstream,
-//!   AGPL-licensed `hyprstream-k8s-pds` crate in #1422. Callers migrate
-//!   `hyprstream_k8s::grant::TenantGrantIssuer` to
-//!   `hyprstream_k8s_pds::TenantGrantIssuer` and pass it through
-//!   `operator::run_operator_with_grant_service` with both features enabled.
+//!   AGPL-licensed `hyprstream-k8s-pds` crate in #1422.
+//!
+//!   | Previous path | New path |
+//!   | --- | --- |
+//!   | `hyprstream_k8s::grant::TenantGrantIssuer` | `hyprstream_k8s_pds::TenantGrantIssuer` |
+//!   | `hyprstream_k8s::grant::TenantGrantVerifier` | `hyprstream_k8s_pds::TenantGrantVerifier` |
+//!   | `hyprstream_k8s::grant::CompiledTenantGrant` | `hyprstream_k8s_pds::CompiledTenantGrant` |
+//!   | `hyprstream_k8s::grant::VerifiedTenantGrant` | `hyprstream_k8s_pds::VerifiedTenantGrant` |
+//!   | `hyprstream_k8s::grant::TENANT_GRANT_ED25519_PURPOSE` | `hyprstream_k8s_pds::TENANT_GRANT_ED25519_PURPOSE` |
+//!   | `hyprstream_k8s::grant::TENANT_GRANT_ABILITY` | `hyprstream_k8s_pds::TENANT_GRANT_ABILITY` |
+//!   | `hyprstream_k8s::grant::now_unix` | `hyprstream_k8s_pds::now_unix` for adapter callers; the substrate helper remains at its old path |
+//!   | `operator::run_operator_with_grant_issuer` | `operator::run_operator_with_grant_service` |
+//!
+//!   The adapter crate documents a compiling downstream composition example.
 //!
 //! All CRDs are `v1alpha1`; the conversion/upgrade path to a future stored
 //! version is noted per-resource and is out of scope for this crate (K5b owns

--- a/crates/hyprstream-k8s/src/lib.rs
+++ b/crates/hyprstream-k8s/src/lib.rs
@@ -52,8 +52,11 @@
 //!   | `hyprstream_k8s::grant::TENANT_GRANT_ABILITY` | `hyprstream_k8s_pds::TENANT_GRANT_ABILITY` |
 //!   | `hyprstream_k8s::grant::now_unix` | `hyprstream_k8s_pds::now_unix` for adapter callers; the substrate helper remains at its old path |
 //!   | `operator::run_operator_with_grant_issuer` | `operator::run_operator_with_grant_service` |
+//!   | `OperatorState::with_grant_issuer` | `OperatorState::with_grant_service` |
+//!   | `compile_tenant_binding_status(binding, issuer, epoch, now)` | `compile_tenant_binding_status(binding, service, epoch, now)`, where `service` is `Option<&dyn TenantGrantService>` |
 //!
-//!   The adapter crate documents a compiling downstream composition example.
+//!   The adapter crate contains a compiling `k8s,grant` operator composition
+//!   example and compile fixture.
 //!
 //! All CRDs are `v1alpha1`; the conversion/upgrade path to a future stored
 //! version is noted per-resource and is out of scope for this crate (K5b owns

--- a/crates/hyprstream-k8s/src/lib.rs
+++ b/crates/hyprstream-k8s/src/lib.rs
@@ -37,6 +37,13 @@
 //!   validation and YAML emission — all compile with no cluster present.
 //! - `k8s`: pulls in the kube client + controller-runtime for code that needs a
 //!   live API server (see [`install`]). CRD types never require it.
+//! - `grant`: exposes only the service-neutral [`grant::TenantGrantService`]
+//!   boundary and generic TenantBinding status projection. Authority-bearing
+//!   signing and PDS allocation behavior moved to the downstream,
+//!   AGPL-licensed `hyprstream-k8s-pds` crate in #1422. Callers migrate
+//!   `hyprstream_k8s::grant::TenantGrantIssuer` to
+//!   `hyprstream_k8s_pds::TenantGrantIssuer` and pass it through
+//!   `operator::run_operator_with_grant_service` with both features enabled.
 //!
 //! All CRDs are `v1alpha1`; the conversion/upgrade path to a future stored
 //! version is noted per-resource and is out of scope for this crate (K5b owns
@@ -47,15 +54,10 @@ pub mod models;
 pub mod serving;
 pub mod training;
 
-/// CRD → grant compilation (#929): a [`mesh::TenantBinding`]'s authorable
-/// [`mesh::TenantEntitlement`] compiles into an issuer-signed UCAN grant + an
-/// `ai.hyprstream.ledger.allocation` record that lands in the tenant's
-/// inventory, plus the verification contract enforcers
-/// (#781/#787/#790/#793/#794/#527) will consume.
+/// Service-neutral TenantBinding grant reconciliation contract (#929/#1422).
 ///
-/// Gated behind `grant` because it needs the UCAN/COSE primitives
-/// (`hyprstream-rpc`) and the allocation lexicon (`hyprstream-pds`); the CRD
-/// *types* it lowers never require them.
+/// The AGPL `hyprstream-k8s-pds` adapter implements this contract with the
+/// issuer-signing and PDS allocation/CID behavior.
 #[cfg(feature = "grant")]
 pub mod grant;
 

--- a/crates/hyprstream-k8s/src/mesh.rs
+++ b/crates/hyprstream-k8s/src/mesh.rs
@@ -17,7 +17,7 @@
 //! A `TenantBinding` is an **admin-authorable surface**, never itself the
 //! authority: when [`TenantBindingSpec::entitlement`] is set, the operator
 //! *compiles* it into an issuer-signed UCAN grant (the operator signs as issuer)
-//! and an [`hyprstream_pds::ledger::AllocationRecord`] that lands in the
+//! and a PDS allocation record that lands in the
 //! tenant's inventory (PDS collection `ai.hyprstream.ledger.allocation`). The
 //! enforcers (#781/#787/#790/#793/#794/#527) verify the *presented grant*, not
 //! the CRD — the CRD only carries authorable intent. The compiled CIDs + epoch
@@ -93,8 +93,8 @@ pub struct TenantBindingSpec {
 
 /// The authorable entitlement carried by a [`TenantBindingSpec`].
 ///
-/// This is the k8s-side, dependency-free mirror of the fields the compiler
-/// ([`crate::grant`]) lowers into an `ai.hyprstream.ledger.allocation` record.
+/// This is the k8s-side, dependency-free mirror of the fields a downstream
+/// [`crate::grant::TenantGrantService`] lowers into its authority artifacts.
 /// It deliberately re-uses no `hyprstream-pds` / `hyprstream-rpc` types so the
 /// CRD schema keeps compiling with no features and no cluster; the compiler
 /// validates and maps these into the issuer-signed grant artifacts.
@@ -127,11 +127,10 @@ fn default_grant_class() -> TenantGrantClass {
     TenantGrantClass::Underwritten
 }
 
-/// The k8s-side mirror of [`hyprstream_pds::ledger::GrantClass`].
+/// Service-neutral grant classification.
 ///
 /// Serialized as the lexicon string (`"prepaid"` / `"underwritten"`) so the
-/// value is identical on the wire whether read from a CRD or an allocation
-/// record; the compiler maps it to the PDS type.
+/// value is stable on the wire; downstream adapters map it to service types.
 #[derive(Serialize, Deserialize, Clone, Copy, Debug, Default, PartialEq, Eq, JsonSchema)]
 #[serde(rename_all = "lowercase")]
 pub enum TenantGrantClass {
@@ -146,7 +145,7 @@ pub enum TenantGrantClass {
 }
 
 impl TenantGrantClass {
-    /// The lexicon string form (matches `hyprstream_pds::ledger::GrantClass::as_str`).
+    /// Stable service-neutral string form.
     pub fn as_str(self) -> &'static str {
         match self {
             TenantGrantClass::Prepaid => "prepaid",

--- a/crates/hyprstream-k8s/src/operator.rs
+++ b/crates/hyprstream-k8s/src/operator.rs
@@ -34,6 +34,7 @@ const MODEL_KIND: &str = "Model";
 const ADAPTER_KIND: &str = "Adapter";
 const TRAINING_RUN_KIND: &str = "TrainingRun";
 const INFERENCE_SERVICE_KIND: &str = "InferenceService";
+#[cfg(feature = "grant")]
 const TENANT_BINDING_KIND: &str = "TenantBinding";
 const TRAINING_RUN_FINALIZER: &str = "training.hyprstream.io/finalizer";
 const SERVING_APP_LABEL: &str = "hyprstream.io/serving-app";
@@ -246,13 +247,10 @@ pub struct OperatorState<R> {
     rpc: Arc<R>,
     config: OperatorConfig,
     tenant_bindings: TenantBindingCache,
-    /// The operator's tenant-grant issuer key (#929). `None` = the
-    /// `TenantBinding` controller compiles no grants (bindings stay the pure
-    /// namespace↔tenant map). Set by [`OperatorState::with_grant_issuer`] when
-    /// the `grant` feature is enabled and the operator was given issuer key
-    /// material at startup.
+    /// Downstream service adapter for tenant-grant issuance (#929/#1422).
+    /// `None` fails closed for authored entitlements.
     #[cfg(feature = "grant")]
-    tenant_grant_issuer: Option<Arc<crate::grant::TenantGrantIssuer>>,
+    tenant_grant_service: Option<Arc<dyn crate::grant::TenantGrantService>>,
     /// Monotonic allocation-epoch counter for compiled grants (#929). Revocation
     /// = stop renewing + bump the epoch; enforcers honor the epoch, never an
     /// unbounded bearer token (#921). Seeded at startup; a future renewal layer
@@ -272,22 +270,22 @@ where
             config,
             tenant_bindings: TenantBindingCache::default(),
             #[cfg(feature = "grant")]
-            tenant_grant_issuer: None,
+            tenant_grant_service: None,
             #[cfg(feature = "grant")]
             grant_epoch: Arc::new(std::sync::atomic::AtomicU64::new(1)),
         }
     }
 
-    /// Set the operator's tenant-grant issuer (#929), enabling the
-    /// `TenantBinding` → grant compilation controller. `None` disables grant
-    /// compilation (the default); bindings reconcile to the no-grant `Bound`
-    /// status only. Only available with the `grant` feature.
+    /// Set the downstream tenant-grant service (#929/#1422).
+    ///
+    /// `None` leaves entitlement-bearing bindings rejected; bindings without
+    /// entitlements remain ordinary namespace↔tenant mappings.
     #[cfg(feature = "grant")]
-    pub fn with_grant_issuer(
+    pub fn with_grant_service(
         mut self,
-        issuer: Option<Arc<crate::grant::TenantGrantIssuer>>,
+        service: Option<Arc<dyn crate::grant::TenantGrantService>>,
     ) -> Self {
-        self.tenant_grant_issuer = issuer;
+        self.tenant_grant_service = service;
         self
     }
 }
@@ -327,8 +325,8 @@ pub enum OperatorError {
 /// With the `grant` feature, this runs the `TenantBinding` controller too, but
 /// with no issuer configured: bindings without an entitlement reconcile to the
 /// no-grant `Bound` status, and an authored entitlement is `Rejected` (no
-/// issuer to sign it). Use [`run_operator_with_grant_issuer`] to enable grant
-/// compilation (#929).
+/// service to issue it). Use [`run_operator_with_grant_service`] to enable
+/// grant compilation (#929/#1422).
 pub async fn run_operator<R>(
     client: Client,
     rpc: Arc<R>,
@@ -341,20 +339,23 @@ where
     run_operator_with_state(client, state).await
 }
 
-/// Run every controller with the operator's tenant-grant issuer configured
-/// (#929): the `TenantBinding` controller compiles authored entitlements into
-/// issuer-signed grants. `None` behaves exactly like [`run_operator`].
+/// Run every controller with a downstream tenant-grant service configured.
+///
+/// The Apache operator owns generic reconciliation; the service owns
+/// authority-bearing issuance and PDS allocation behavior. `None` behaves
+/// exactly like [`run_operator`].
 #[cfg(feature = "grant")]
-pub async fn run_operator_with_grant_issuer<R>(
+pub async fn run_operator_with_grant_service<R>(
     client: Client,
     rpc: Arc<R>,
     config: OperatorConfig,
-    issuer: Option<Arc<crate::grant::TenantGrantIssuer>>,
+    service: Option<Arc<dyn crate::grant::TenantGrantService>>,
 ) -> Result<(), OperatorError>
 where
     R: HyprstreamOperatorRpc,
 {
-    let state = Arc::new(OperatorState::new(client.clone(), rpc, config).with_grant_issuer(issuer));
+    let state =
+        Arc::new(OperatorState::new(client.clone(), rpc, config).with_grant_service(service));
     run_operator_with_state(client, state).await
 }
 
@@ -551,11 +552,11 @@ where
 {
     use std::sync::atomic::Ordering;
 
-    // No issuer configured ⇒ grant compilation is disabled. Reflect a no-grant
+    // No service configured ⇒ grant compilation is disabled. Reflect a no-grant
     // Bound status only when the status is stale, so the controller does not
     // hot-loop an apiserver that has nothing to write.
-    let Some(issuer) = state.tenant_grant_issuer.clone() else {
-        if tenant_binding_status_observed_current(binding.as_ref()) {
+    let Some(service) = state.tenant_grant_service.clone() else {
+        if tenant_binding_status_without_service_up_to_date(binding.as_ref()) {
             return Ok(Action::requeue(state.config.requeue));
         }
         let status = crate::grant::compile_tenant_binding_status(
@@ -586,7 +587,7 @@ where
     let now = crate::grant::now_unix();
     let status = crate::grant::compile_tenant_binding_status(
         binding.as_ref(),
-        Some(issuer.as_ref()),
+        Some(service.as_ref()),
         epoch,
         now,
     );
@@ -613,6 +614,30 @@ fn tenant_binding_status_observed_current(binding: &TenantBinding) -> bool {
         .as_ref()
         .and_then(|status| status.observed_generation)
         == binding.meta().generation
+}
+
+/// A missing service is a fail-closed state for authored entitlements.
+///
+/// A status from a previously configured service must therefore be replaced
+/// with a rejection even when the CRD generation has not changed.
+#[cfg(feature = "grant")]
+fn tenant_binding_status_without_service_up_to_date(binding: &TenantBinding) -> bool {
+    if !tenant_binding_status_observed_current(binding) {
+        return false;
+    }
+    let Some(status) = binding.status.as_ref() else {
+        return false;
+    };
+    match binding.spec.entitlement.as_ref() {
+        Some(_) => {
+            status.bound == Some(false)
+                && status.phase.as_deref() == Some("Rejected")
+                && status.grant_cid.is_none()
+                && status.allocation_cid.is_none()
+                && status.epoch.is_none()
+        }
+        None => status.grant_cid.is_none() && status.allocation_cid.is_none(),
+    }
 }
 
 /// Whether a `TenantBinding`'s status is current enough to skip a reconcile at
@@ -1840,8 +1865,10 @@ mod tests {
     use super::*;
     use crate::{
         AdapterSpec, InferenceServiceSpec, ModelSpec, ModelStage, TenantBindingSpec,
-        TenantEntitlement, TenantGrantClass, TrainingRunSpec,
+        TrainingRunSpec,
     };
+    #[cfg(feature = "grant")]
+    use crate::{TenantEntitlement, TenantGrantClass};
 
     #[test]
     fn model_success_status_reports_observed_ref() {
@@ -2591,6 +2618,16 @@ mod tests {
         assert!(
             tenant_binding_status_up_to_date(&binding, 99),
             "a no-entitlement binding with a no-grant status is current at any epoch"
+        );
+    }
+
+    #[cfg(feature = "grant")]
+    #[test]
+    fn grant_status_previously_bound_is_not_current_without_service() {
+        let binding = bound_with_grant(Some(3), Some(7));
+        assert!(
+            !tenant_binding_status_without_service_up_to_date(&binding),
+            "removing the service must invalidate a previously issued grant status"
         );
     }
 }

--- a/crates/hyprstream-k8s/src/operator.rs
+++ b/crates/hyprstream-k8s/src/operator.rs
@@ -636,23 +636,48 @@ fn tenant_binding_status_without_service_up_to_date(binding: &TenantBinding) -> 
                 && status.allocation_cid.is_none()
                 && status.epoch.is_none()
         }
-        None => status.grant_cid.is_none() && status.allocation_cid.is_none(),
+        None => tenant_binding_status_is_bound_without_grant(status),
     }
+}
+
+#[cfg(feature = "grant")]
+fn tenant_binding_status_is_bound_without_grant(status: &crate::mesh::TenantBindingStatus) -> bool {
+    status.bound == Some(true)
+        && status.phase.as_deref() == Some("Bound")
+        && status.grant_cid.is_none()
+        && status.allocation_cid.is_none()
+        && status.epoch.is_none()
+}
+
+#[cfg(feature = "grant")]
+fn tenant_binding_status_is_bound_with_grant(
+    status: &crate::mesh::TenantBindingStatus,
+    epoch: u64,
+) -> bool {
+    status.bound == Some(true)
+        && status.phase.as_deref() == Some("Bound")
+        && status.epoch == Some(epoch)
+        && status.grant_cid.as_ref().is_some_and(|reference| {
+            crate::grant::ContentReference::parse(reference.clone()).is_ok()
+        })
+        && status.allocation_cid.as_ref().is_some_and(|reference| {
+            crate::grant::ContentReference::parse(reference.clone()).is_ok()
+        })
 }
 
 /// Whether a `TenantBinding`'s status is current enough to skip a reconcile at
 /// `epoch` (#929).
 ///
 /// Two cases:
-/// - **Entitlement present** — the recorded grant must be compiled at the
-///   *current* epoch (`status.epoch == Some(epoch)`), with **both** compiled
-///   CIDs present, and the observed generation must match. A bumped epoch
-///   (revocation) or an edited entitlement (generation change) forces a
-///   recompile. The epoch match is load-bearing: it is what makes a
-///   revocation reissue the grant even when the CRD generation is unchanged.
-/// - **No entitlement** — "current" is a no-grant status (`grant_cid` is
-///   absent) at the observed generation; the epoch is irrelevant because no
-///   grant exists to revoke.
+/// - **Entitlement present** — `bound=true`, phase `Bound`, two canonical
+///   CIDv1 references, the current epoch, and the observed generation.
+/// - **No entitlement** — `bound=true`, phase `Bound`, no grant, allocation,
+///   or epoch, and the observed generation.
+///
+/// A bumped epoch (revocation), edited entitlement, malformed legacy
+/// reference, partial status, or inconsistent phase/bound pair forces a
+/// reconcile. The epoch match is load-bearing: it makes revocation reissue the
+/// grant even when the CRD generation is unchanged.
 ///
 /// No status yet ⇒ not current (must reconcile).
 #[cfg(feature = "grant")]
@@ -664,16 +689,8 @@ fn tenant_binding_status_up_to_date(binding: &TenantBinding, epoch: u64) -> bool
         return false;
     }
     match binding.spec.entitlement.as_ref() {
-        Some(_) => {
-            status.epoch == Some(epoch)
-                && status.grant_cid.as_ref().is_some_and(|reference| {
-                    crate::grant::ContentReference::parse(reference.clone()).is_ok()
-                })
-                && status.allocation_cid.as_ref().is_some_and(|reference| {
-                    crate::grant::ContentReference::parse(reference.clone()).is_ok()
-                })
-        }
-        None => status.grant_cid.as_ref().is_none(),
+        Some(_) => tenant_binding_status_is_bound_with_grant(status, epoch),
+        None => tenant_binding_status_is_bound_without_grant(status),
     }
 }
 
@@ -2605,18 +2622,33 @@ mod tests {
     #[cfg(feature = "grant")]
     #[test]
     fn grant_status_malformed_references_force_recompile() {
-        for (grant, allocation) in [
-            ("", "not-a-cid"),
-            (" ", "not-a-cid"),
-            (
-                "bafybeigdyrzt5sfp7udm7hu76uh7y26nf3g3gd3lst2gq2r2a6y4m5x4zi",
-                "",
-            ),
-            (
-                "not-a-cid",
-                "bafybeigdyrzt5sfp7udm7hu76uh7y26nf3g3gd3lst2gq2r2a6y4m5x4zi",
-            ),
-        ] {
+        const VALID_CID: &str = "bafybeigdyrzt5sfp7udm7hu76uh7y26nf3g3gd3lst2gq2r2a6y4m5x4zi";
+        const CID_V0: &str = "QmdfTbBqBPQ7VNxZEYEj14VmRuZBkqFbiwReogJgS1zR1n";
+        const UPPERCASE_CID_V1: &str =
+            "BAFYBEIGDYRZT5SFP7UDM7HU76UH7Y26NF3G3GD3LST2GQ2R2A6Y4M5X4ZI";
+        const BASE58_CID_V1: &str = "zdj7Wic6KcJAfWz1c9o4M6kq9Lwd5LLn1FiHURxSKgZVwmaJD";
+        let invalid_references = [
+            String::new(),
+            " ".to_owned(),
+            "not-a-cid".to_owned(),
+            CID_V0.to_owned(),
+            UPPERCASE_CID_V1.to_owned(),
+            BASE58_CID_V1.to_owned(),
+            format!("/ipfs/{VALID_CID}"),
+        ];
+        for reference in invalid_references {
+            let mut binding = bound_with_grant(Some(3), Some(7));
+            if let Some(status) = binding.status.as_mut() {
+                status.grant_cid = Some(reference.clone());
+                status.allocation_cid = Some(reference.clone());
+            }
+            assert!(
+                !tenant_binding_status_up_to_date(&binding, 7),
+                "invalid reference unexpectedly remained current: {reference:?}"
+            );
+        }
+
+        for (grant, allocation) in [(VALID_CID, ""), ("not-a-cid", VALID_CID)] {
             let mut binding = bound_with_grant(Some(3), Some(7));
             if let Some(status) = binding.status.as_mut() {
                 status.grant_cid = Some(grant.to_owned());
@@ -2624,7 +2656,28 @@ mod tests {
             }
             assert!(
                 !tenant_binding_status_up_to_date(&binding, 7),
-                "malformed status unexpectedly remained current: {grant:?}, {allocation:?}"
+                "partially valid status unexpectedly remained current"
+            );
+        }
+    }
+
+    #[cfg(feature = "grant")]
+    #[test]
+    fn grant_status_inconsistent_bound_or_phase_forces_recompile() {
+        for (bound, phase) in [
+            (Some(false), Some("Bound")),
+            (Some(true), Some("Rejected")),
+            (None, Some("Bound")),
+            (Some(true), None),
+        ] {
+            let mut binding = bound_with_grant(Some(3), Some(7));
+            if let Some(status) = binding.status.as_mut() {
+                status.bound = bound;
+                status.phase = phase.map(str::to_owned);
+            }
+            assert!(
+                !tenant_binding_status_up_to_date(&binding, 7),
+                "inconsistent entitlement status remained current: {bound:?}, {phase:?}"
             );
         }
     }
@@ -2632,8 +2685,8 @@ mod tests {
     #[cfg(feature = "grant")]
     #[test]
     fn grant_status_no_entitlement_is_current_without_grant() {
-        // A binding with no entitlement is "current" once it carries a no-grant
-        // status at the observed generation; the epoch is irrelevant.
+        // A binding with no entitlement is current only with a complete Bound,
+        // no-grant status at the observed generation.
         let mut binding = TenantBinding::new(
             "tb",
             TenantBindingSpec {
@@ -2644,13 +2697,85 @@ mod tests {
         );
         binding.meta_mut().generation = Some(1);
         binding.status = Some(crate::mesh::TenantBindingStatus {
+            bound: Some(true),
+            phase: Some("Bound".to_owned()),
             observed_generation: Some(1),
             ..Default::default()
         });
         assert!(
             tenant_binding_status_up_to_date(&binding, 99),
-            "a no-entitlement binding with a no-grant status is current at any epoch"
+            "a complete no-entitlement Bound status is current"
         );
+        assert!(
+            tenant_binding_status_without_service_up_to_date(&binding),
+            "the no-service path must recognize the same complete invariant"
+        );
+    }
+
+    #[cfg(feature = "grant")]
+    #[test]
+    fn grant_status_no_entitlement_rejects_partial_or_inconsistent_state() {
+        let mut binding = TenantBinding::new(
+            "tb",
+            TenantBindingSpec {
+                namespace: "acme".to_owned(),
+                tenant: "did:web:acme".to_owned(),
+                entitlement: None,
+            },
+        );
+        binding.meta_mut().generation = Some(1);
+
+        let invalid_statuses = [
+            crate::mesh::TenantBindingStatus {
+                bound: Some(true),
+                phase: Some("Bound".to_owned()),
+                observed_generation: Some(1),
+                grant_cid: Some(
+                    "bafybeigdyrzt5sfp7udm7hu76uh7y26nf3g3gd3lst2gq2r2a6y4m5x4zi".to_owned(),
+                ),
+                ..Default::default()
+            },
+            crate::mesh::TenantBindingStatus {
+                bound: Some(true),
+                phase: Some("Bound".to_owned()),
+                observed_generation: Some(1),
+                allocation_cid: Some(
+                    "bafybeigdyrzt5sfp7udm7hu76uh7y26nf3g3gd3lst2gq2r2a6y4m5x4zi".to_owned(),
+                ),
+                ..Default::default()
+            },
+            crate::mesh::TenantBindingStatus {
+                bound: Some(true),
+                phase: Some("Bound".to_owned()),
+                observed_generation: Some(1),
+                epoch: Some(7),
+                ..Default::default()
+            },
+            crate::mesh::TenantBindingStatus {
+                bound: Some(false),
+                phase: Some("Bound".to_owned()),
+                observed_generation: Some(1),
+                ..Default::default()
+            },
+            crate::mesh::TenantBindingStatus {
+                bound: Some(true),
+                phase: Some("Rejected".to_owned()),
+                observed_generation: Some(1),
+                ..Default::default()
+            },
+        ];
+
+        for status in invalid_statuses {
+            binding.status = Some(status);
+            assert!(
+                !tenant_binding_status_up_to_date(&binding, 7),
+                "configured-service path preserved invalid no-entitlement status"
+            );
+            assert!(
+                !tenant_binding_status_without_service_up_to_date(&binding),
+                "no-service path preserved invalid no-entitlement status"
+            );
+        }
     }
 
     #[cfg(feature = "grant")]

--- a/crates/hyprstream-k8s/src/operator.rs
+++ b/crates/hyprstream-k8s/src/operator.rs
@@ -666,8 +666,12 @@ fn tenant_binding_status_up_to_date(binding: &TenantBinding, epoch: u64) -> bool
     match binding.spec.entitlement.as_ref() {
         Some(_) => {
             status.epoch == Some(epoch)
-                && status.grant_cid.as_ref().is_some()
-                && status.allocation_cid.as_ref().is_some()
+                && status.grant_cid.as_ref().is_some_and(|reference| {
+                    crate::grant::ContentReference::parse(reference.clone()).is_ok()
+                })
+                && status.allocation_cid.as_ref().is_some_and(|reference| {
+                    crate::grant::ContentReference::parse(reference.clone()).is_ok()
+                })
         }
         None => status.grant_cid.as_ref().is_none(),
     }
@@ -2516,6 +2520,7 @@ mod tests {
     /// Build a TenantBinding whose status claims a grant compiled at `epoch`.
     #[cfg(feature = "grant")]
     fn bound_with_grant(observed_generation: Option<i64>, epoch: Option<u64>) -> TenantBinding {
+        const VALID_CID: &str = "bafybeigdyrzt5sfp7udm7hu76uh7y26nf3g3gd3lst2gq2r2a6y4m5x4zi";
         let mut binding = TenantBinding::new(
             "tb",
             TenantBindingSpec {
@@ -2534,8 +2539,8 @@ mod tests {
             phase: Some("Bound".to_owned()),
             message: None,
             observed_generation,
-            grant_cid: Some("bafyreibafyreibafyreibafyreibafyre".to_owned()),
-            allocation_cid: Some("bafyreibafyreibafyreibafyreibafyre".to_owned()),
+            grant_cid: Some(VALID_CID.to_owned()),
+            allocation_cid: Some(VALID_CID.to_owned()),
             epoch,
         });
         // meta().generation defaults to None on a ::new binding; align it with
@@ -2595,6 +2600,33 @@ mod tests {
             !tenant_binding_status_up_to_date(&binding, 7),
             "a missing allocation CID must force a recompile"
         );
+    }
+
+    #[cfg(feature = "grant")]
+    #[test]
+    fn grant_status_malformed_references_force_recompile() {
+        for (grant, allocation) in [
+            ("", "not-a-cid"),
+            (" ", "not-a-cid"),
+            (
+                "bafybeigdyrzt5sfp7udm7hu76uh7y26nf3g3gd3lst2gq2r2a6y4m5x4zi",
+                "",
+            ),
+            (
+                "not-a-cid",
+                "bafybeigdyrzt5sfp7udm7hu76uh7y26nf3g3gd3lst2gq2r2a6y4m5x4zi",
+            ),
+        ] {
+            let mut binding = bound_with_grant(Some(3), Some(7));
+            if let Some(status) = binding.status.as_mut() {
+                status.grant_cid = Some(grant.to_owned());
+                status.allocation_cid = Some(allocation.to_owned());
+            }
+            assert!(
+                !tenant_binding_status_up_to_date(&binding, 7),
+                "malformed status unexpectedly remained current: {grant:?}, {allocation:?}"
+            );
+        }
     }
 
     #[cfg(feature = "grant")]

--- a/crates/hyprstream-k8s/tests/apache_boundary.rs
+++ b/crates/hyprstream-k8s/tests/apache_boundary.rs
@@ -186,18 +186,57 @@ fn check_apache_boundary(workspace_root: &Path, root_manifest_path: &Path) -> Re
             .get(&id)
             .ok_or_else(|| format!("resolved graph has no node for {id}"))?;
         for dependency in &node.deps {
-            let dependency_package = packages.get(&dependency.pkg).ok_or_else(|| {
-                format!(
+            if !packages.contains_key(&dependency.pkg) {
+                return Err(format!(
                     "resolved graph references unknown dependency {}",
                     dependency.pkg
-                )
-            })?;
-            if dependency_package.source.is_none() {
-                queue.push_back((dependency.pkg.clone(), chain.clone()));
+                ));
             }
+            queue.push_back((dependency.pkg.clone(), chain.clone()));
         }
     }
     Ok(())
+}
+
+fn assert_transitive_patch_resolved(
+    metadata: &CargoMetadata,
+    external_name: &str,
+    local_name: &str,
+) {
+    let external = metadata
+        .packages
+        .iter()
+        .find(|package| package.name == external_name)
+        .unwrap_or_else(|| panic!("fixture did not resolve external package {external_name}"));
+    assert!(
+        external.source.is_some(),
+        "fixture package {external_name} must come from a registry"
+    );
+    let local = metadata
+        .packages
+        .iter()
+        .find(|package| package.name == local_name)
+        .unwrap_or_else(|| panic!("fixture did not resolve local package {local_name}"));
+    assert!(
+        local.source.is_none(),
+        "fixture package {local_name} must resolve to the local patch"
+    );
+    let resolve = metadata
+        .resolve
+        .as_ref()
+        .expect("fixture metadata must include a resolved graph");
+    let external_node = resolve
+        .nodes
+        .iter()
+        .find(|node| node.id == external.id)
+        .unwrap_or_else(|| panic!("fixture graph omitted external package {external_name}"));
+    assert!(
+        external_node
+            .deps
+            .iter()
+            .any(|dependency| dependency.pkg == local.id),
+        "fixture graph must contain {external_name} -> {local_name}"
+    );
 }
 
 #[test]
@@ -433,4 +472,31 @@ anyhow = "=1.0.102""#,
     );
     let error = check_apache_boundary(directory.path(), &root_manifest).unwrap_err();
     assert!(error.contains("apache-root -> anyhow"), "{error}");
+}
+
+#[test]
+fn transitive_registry_dependency_patched_to_local_agpl_is_rejected() {
+    let directory = fixture_workspace(
+        "MIT",
+        r#"[patch.crates-io]
+itoa = { path = "crates/service" }"#,
+    );
+    let root_manifest = write_fixture_packages(
+        directory.path(),
+        r#"[dependencies]
+serde_json = "=1.0.150""#,
+        "itoa",
+        "1.0.99",
+        r#"license = "AGPL-3.0-only""#,
+    );
+
+    let metadata = resolved_metadata(directory.path(), &root_manifest)
+        .expect("transitive patch fixture must resolve offline");
+    assert_transitive_patch_resolved(&metadata, "serde_json", "itoa");
+
+    let error = check_apache_boundary(directory.path(), &root_manifest).unwrap_err();
+    assert!(
+        error.contains("apache-root -> serde_json -> itoa"),
+        "complete dependency chain missing from boundary failure: {error}"
+    );
 }

--- a/crates/hyprstream-k8s/tests/apache_boundary.rs
+++ b/crates/hyprstream-k8s/tests/apache_boundary.rs
@@ -1,155 +1,66 @@
 //! License-boundary regression for the reusable Kubernetes substrate.
 //!
-//! The walk resolves every reachable local normal, optional, build, dev, and
-//! target-specific path dependency without asking Cargo to select features.
-//! Classification comes from package SPDX metadata rather than package names.
-//! When #1417's omission-checked `.github/license-boundary.toml` is present,
-//! its `agpl_services` partition augments manifest metadata; this is the only
-//! integration seam, so no policy list is copied into this crate.
+//! Cargo's resolved metadata graph is the source of dependency truth. Running
+//! with all features includes optional edges, and metadata retains normal,
+//! build, dev, target, renamed, `[patch]`, and `[replace]` resolution. Local
+//! packages are classified by their resolved SPDX metadata rather than copied
+//! names. When #1417's omission-checked `.github/license-boundary.toml` is
+//! present, its `agpl_services` partition augments manifest metadata; that is
+//! the only policy integration seam.
 
 #![allow(clippy::expect_used, clippy::panic, clippy::unwrap_used)]
 
-use std::collections::{BTreeSet, VecDeque};
+use std::collections::{BTreeMap, BTreeSet, VecDeque};
 use std::fs;
 use std::path::{Path, PathBuf};
+use std::process::Command;
 
+use serde::Deserialize;
 use toml::Value;
 
-#[derive(Debug)]
-struct PendingManifest {
-    path: PathBuf,
-    chain: Vec<String>,
+#[derive(Debug, Deserialize)]
+struct CargoMetadata {
+    packages: Vec<MetadataPackage>,
+    resolve: Option<MetadataResolve>,
 }
 
-fn load_manifest(path: &Path) -> Result<Value, String> {
+#[derive(Debug, Deserialize)]
+struct MetadataPackage {
+    id: String,
+    name: String,
+    license: Option<String>,
+    manifest_path: PathBuf,
+    source: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct MetadataResolve {
+    nodes: Vec<MetadataNode>,
+}
+
+#[derive(Debug, Deserialize)]
+struct MetadataNode {
+    id: String,
+    deps: Vec<MetadataDependency>,
+}
+
+#[derive(Debug, Deserialize)]
+struct MetadataDependency {
+    pkg: String,
+}
+
+fn load_toml(path: &Path) -> Result<Value, String> {
     fs::read_to_string(path)
         .map_err(|error| format!("read {}: {error}", path.display()))?
         .parse()
         .map_err(|error| format!("parse {}: {error}", path.display()))
 }
 
-fn package_name(manifest: &Value, path: &Path) -> Result<String, String> {
-    manifest["package"]["name"]
-        .as_str()
-        .map(str::to_owned)
-        .ok_or_else(|| format!("{} has no package.name", path.display()))
-}
-
-fn dependency_tables(manifest: &Value) -> Vec<&toml::map::Map<String, Value>> {
-    const SECTIONS: &[&str] = &["dependencies", "build-dependencies", "dev-dependencies"];
-    let mut tables = Vec::new();
-    for section in SECTIONS {
-        if let Some(table) = manifest.get(*section).and_then(Value::as_table) {
-            tables.push(table);
-        }
-    }
-    if let Some(targets) = manifest.get("target").and_then(Value::as_table) {
-        for target in targets.values().filter_map(Value::as_table) {
-            for section in SECTIONS {
-                if let Some(table) = target.get(*section).and_then(Value::as_table) {
-                    tables.push(table);
-                }
-            }
-        }
-    }
-    tables
-}
-
-fn local_dependencies(
-    manifest_path: &Path,
-    manifest: &Value,
-    workspace_manifest: &Value,
-    workspace_root: &Path,
-) -> Result<Vec<(PathBuf, Option<String>)>, String> {
-    let workspace_dependencies = workspace_manifest["workspace"]["dependencies"].as_table();
-    let mut dependencies = Vec::new();
-    for table in dependency_tables(manifest) {
-        for (alias, declared) in table {
-            let (source, base) = if declared
-                .as_table()
-                .and_then(|value| value.get("workspace"))
-                .and_then(Value::as_bool)
-                == Some(true)
-            {
-                let inherited = workspace_dependencies
-                    .and_then(|dependencies| dependencies.get(alias))
-                    .ok_or_else(|| {
-                        format!(
-                            "{} inherits missing workspace dependency {alias}",
-                            manifest_path.display()
-                        )
-                    })?;
-                (inherited, workspace_root)
-            } else {
-                (
-                    declared,
-                    manifest_path
-                        .parent()
-                        .ok_or_else(|| format!("{} has no parent", manifest_path.display()))?,
-                )
-            };
-            let Some(source) = source.as_table() else {
-                continue;
-            };
-            let Some(local_path) = source.get("path").and_then(Value::as_str) else {
-                continue;
-            };
-            dependencies.push((
-                base.join(local_path).join("Cargo.toml"),
-                source
-                    .get("package")
-                    .and_then(Value::as_str)
-                    .map(str::to_owned),
-            ));
-        }
-    }
-    Ok(dependencies)
-}
-
-fn resolved_license<'a>(
-    manifest: &'a Value,
-    workspace_manifest: &'a Value,
-    path: &Path,
-) -> Result<&'a str, String> {
-    let package = manifest
-        .get("package")
-        .and_then(Value::as_table)
-        .ok_or_else(|| format!("{} has no package table", path.display()))?;
-    if let Some(license) = package.get("license").and_then(Value::as_str) {
-        return Ok(license);
-    }
-    if package
-        .get("license")
-        .and_then(Value::as_table)
-        .and_then(|license| license.get("workspace"))
-        .and_then(Value::as_bool)
-        == Some(true)
-    {
-        return workspace_manifest
-            .get("workspace")
-            .and_then(Value::as_table)
-            .and_then(|workspace| workspace.get("package"))
-            .and_then(Value::as_table)
-            .and_then(|package| package.get("license"))
-            .and_then(Value::as_str)
-            .ok_or_else(|| {
-                format!(
-                    "{} inherits missing workspace.package.license",
-                    path.display()
-                )
-            });
-    }
-    Err(format!(
-        "{} has no resolved package license; Apache boundary fails closed",
-        path.display()
-    ))
-}
-
 /// Detect AGPL identifiers in SPDX expressions, including `-only`,
 /// `-or-later`, deprecated `+`, compound `AND`/`OR`, and `WITH` forms.
 ///
-/// Cargo validates the expression syntax. The boundary only needs to extract
-/// license identifiers without assuming one exact expression shape.
+/// Cargo validates package license expressions while resolving metadata. The
+/// boundary only needs to extract identifiers without assuming one literal.
 fn contains_agpl_identifier(expression: &str) -> bool {
     expression
         .split(|character: char| {
@@ -166,7 +77,7 @@ fn policy_agpl_packages(workspace_root: &Path) -> Result<BTreeSet<String>, Strin
     if !path.exists() {
         return Ok(BTreeSet::new());
     }
-    let policy = load_manifest(&path)?;
+    let policy = load_toml(&path)?;
     policy["license_gate"]["agpl_services"]
         .as_array()
         .ok_or_else(|| format!("{} must define license_gate.agpl_services", path.display()))?
@@ -180,53 +91,110 @@ fn policy_agpl_packages(workspace_root: &Path) -> Result<BTreeSet<String>, Strin
         .collect()
 }
 
-fn check_apache_boundary(workspace_root: &Path, root_manifest_path: &Path) -> Result<(), String> {
-    let workspace_manifest_path = workspace_root.join("Cargo.toml");
-    let workspace_manifest = load_manifest(&workspace_manifest_path)?;
-    let policy_agpl = policy_agpl_packages(workspace_root)?;
-    let mut queue = VecDeque::from([PendingManifest {
-        path: root_manifest_path.to_owned(),
-        chain: Vec::new(),
-    }]);
-    let mut visited = BTreeSet::new();
+fn resolved_metadata(
+    workspace_root: &Path,
+    root_manifest_path: &Path,
+) -> Result<CargoMetadata, String> {
+    let output = Command::new(env!("CARGO"))
+        .args([
+            "metadata",
+            "--format-version=1",
+            "--all-features",
+            "--offline",
+            "--manifest-path",
+        ])
+        .arg(root_manifest_path)
+        .current_dir(workspace_root)
+        .env("CARGO_TERM_COLOR", "never")
+        .output()
+        .map_err(|error| format!("run cargo metadata: {error}"))?;
+    if !output.status.success() {
+        return Err(format!(
+            "cargo metadata failed ({}): {}",
+            output.status,
+            String::from_utf8_lossy(&output.stderr)
+        ));
+    }
+    serde_json::from_slice(&output.stdout)
+        .map_err(|error| format!("parse cargo metadata JSON: {error}"))
+}
 
-    while let Some(pending) = queue.pop_front() {
-        let canonical = pending
-            .path
-            .canonicalize()
-            .map_err(|error| format!("resolve {}: {error}", pending.path.display()))?;
-        if !visited.insert(canonical.clone()) {
+fn check_apache_boundary(workspace_root: &Path, root_manifest_path: &Path) -> Result<(), String> {
+    let metadata = resolved_metadata(workspace_root, root_manifest_path)?;
+    let policy_agpl = policy_agpl_packages(workspace_root)?;
+    let root_manifest = root_manifest_path
+        .canonicalize()
+        .map_err(|error| format!("resolve {}: {error}", root_manifest_path.display()))?;
+
+    let packages = metadata
+        .packages
+        .into_iter()
+        .map(|package| (package.id.clone(), package))
+        .collect::<BTreeMap<_, _>>();
+    let root_id = packages
+        .values()
+        .find_map(|package| {
+            package
+                .manifest_path
+                .canonicalize()
+                .ok()
+                .filter(|path| path == &root_manifest)
+                .map(|_| package.id.clone())
+        })
+        .ok_or_else(|| {
+            format!(
+                "cargo metadata omitted root package {}",
+                root_manifest.display()
+            )
+        })?;
+    let resolve = metadata
+        .resolve
+        .ok_or_else(|| "cargo metadata omitted the resolved graph".to_owned())?;
+    let nodes = resolve
+        .nodes
+        .into_iter()
+        .map(|node| (node.id.clone(), node))
+        .collect::<BTreeMap<_, _>>();
+
+    let mut queue = VecDeque::from([(root_id, Vec::<String>::new())]);
+    let mut visited = BTreeSet::new();
+    while let Some((id, mut chain)) = queue.pop_front() {
+        if !visited.insert(id.clone()) {
             continue;
         }
-        let manifest = load_manifest(&canonical)?;
-        let name = package_name(&manifest, &canonical)?;
-        let mut chain = pending.chain;
-        chain.push(name.clone());
-        let license = resolved_license(&manifest, &workspace_manifest, &canonical)?;
-        if policy_agpl.contains(&name) || contains_agpl_identifier(license) {
-            return Err(format!(
-                "Apache-2.0-to-AGPL dependency: {} ({license})",
-                chain.join(" -> ")
-            ));
+        let package = packages
+            .get(&id)
+            .ok_or_else(|| format!("resolved graph references unknown package {id}"))?;
+        chain.push(package.name.clone());
+
+        if package.source.is_none() {
+            let license = package.license.as_deref().ok_or_else(|| {
+                format!(
+                    "{} has no resolved package license; Apache boundary fails closed",
+                    package.manifest_path.display()
+                )
+            })?;
+            if policy_agpl.contains(&package.name) || contains_agpl_identifier(license) {
+                return Err(format!(
+                    "Apache-2.0-to-AGPL dependency: {} ({license})",
+                    chain.join(" -> ")
+                ));
+            }
         }
 
-        for (dependency_path, declared_package) in
-            local_dependencies(&canonical, &manifest, &workspace_manifest, workspace_root)?
-        {
-            let dependency_manifest = load_manifest(&dependency_path)?;
-            let dependency_name = package_name(&dependency_manifest, &dependency_path)?;
-            if let Some(declared_package) = declared_package {
-                if declared_package != dependency_name {
-                    return Err(format!(
-                        "{} declares package {declared_package}, resolved {dependency_name}",
-                        canonical.display()
-                    ));
-                }
+        let node = nodes
+            .get(&id)
+            .ok_or_else(|| format!("resolved graph has no node for {id}"))?;
+        for dependency in &node.deps {
+            let dependency_package = packages.get(&dependency.pkg).ok_or_else(|| {
+                format!(
+                    "resolved graph references unknown dependency {}",
+                    dependency.pkg
+                )
+            })?;
+            if dependency_package.source.is_none() {
+                queue.push_back((dependency.pkg.clone(), chain.clone()));
             }
-            queue.push_back(PendingManifest {
-                path: dependency_path,
-                chain: chain.clone(),
-            });
         }
     }
     Ok(())
@@ -249,7 +217,7 @@ fn write_fixture(path: &Path, contents: &str) {
     fs::write(path, contents).unwrap();
 }
 
-fn fixture_workspace(workspace_license: &str) -> tempfile::TempDir {
+fn fixture_workspace(workspace_license: &str, extra: &str) -> tempfile::TempDir {
     let directory = tempfile::tempdir().unwrap();
     write_fixture(
         &directory.path().join("Cargo.toml"),
@@ -263,13 +231,21 @@ license = "{workspace_license}"
 
 [workspace.dependencies]
 renamed = {{ package = "new-service", path = "crates/service" }}
+
+{extra}
 "#
         ),
     );
     directory
 }
 
-fn write_fixture_packages(root: &Path, dependency_section: &str, service_license: &str) -> PathBuf {
+fn write_fixture_packages(
+    root: &Path,
+    dependency_section: &str,
+    service_name: &str,
+    service_version: &str,
+    service_license: &str,
+) -> PathBuf {
     let root_manifest = root.join("crates/root/Cargo.toml");
     write_fixture(
         &root_manifest,
@@ -287,20 +263,37 @@ license = "Apache-2.0"
         &root.join("crates/service/Cargo.toml"),
         &format!(
             r#"[package]
-name = "new-service"
-version = "0.1.0"
+name = "{service_name}"
+version = "{service_version}"
 {service_license}
 "#
         ),
     );
+    write_fixture(&root.join("crates/service/src/lib.rs"), "");
+    write_fixture(&root.join("crates/root/src/lib.rs"), "");
     root_manifest
+}
+
+fn new_service_fixture(
+    workspace_license: &str,
+    dependency_section: &str,
+    service_license: &str,
+) -> (tempfile::TempDir, PathBuf) {
+    let directory = fixture_workspace(workspace_license, "");
+    let root_manifest = write_fixture_packages(
+        directory.path(),
+        dependency_section,
+        "new-service",
+        "0.1.0",
+        service_license,
+    );
+    (directory, root_manifest)
 }
 
 #[test]
 fn renamed_new_agpl_package_is_rejected() {
-    let directory = fixture_workspace("MIT");
-    let root_manifest = write_fixture_packages(
-        directory.path(),
+    let (directory, root_manifest) = new_service_fixture(
+        "MIT",
         r#"[dependencies]
 renamed = { package = "new-service", path = "../service" }"#,
         r#"license = "AGPL-3.0-only""#,
@@ -311,9 +304,8 @@ renamed = { package = "new-service", path = "../service" }"#,
 
 #[test]
 fn workspace_inherited_dependency_and_license_are_rejected() {
-    let directory = fixture_workspace("AGPL-3.0-or-later");
-    let root_manifest = write_fixture_packages(
-        directory.path(),
+    let (directory, root_manifest) = new_service_fixture(
+        "AGPL-3.0-or-later",
         r#"[dependencies]
 renamed.workspace = true"#,
         "license.workspace = true",
@@ -336,15 +328,12 @@ renamed = { package = "new-service", path = "../service" }"#,
         r#"[target.'cfg(unix)'.dev-dependencies]
 renamed = { package = "new-service", path = "../service" }"#,
     ] {
-        let directory = fixture_workspace("MIT");
-        let root_manifest = write_fixture_packages(
-            directory.path(),
-            dependency_section,
-            r#"license = "AGPL-3.0-only""#,
-        );
+        let (directory, root_manifest) =
+            new_service_fixture("MIT", dependency_section, r#"license = "AGPL-3.0-only""#);
+        let error = check_apache_boundary(directory.path(), &root_manifest).unwrap_err();
         assert!(
-            check_apache_boundary(directory.path(), &root_manifest).is_err(),
-            "edge escaped boundary: {dependency_section}"
+            error.contains("apache-root -> new-service"),
+            "edge escaped boundary: {dependency_section}\n{error}"
         );
     }
 }
@@ -357,25 +346,24 @@ fn compound_and_versioned_agpl_expressions_are_rejected() {
         "Apache-2.0 AND AGPL-3.0-only",
         "(MIT OR Apache-2.0) AND AGPL-3.0-or-later",
     ] {
-        let directory = fixture_workspace("MIT");
-        let root_manifest = write_fixture_packages(
-            directory.path(),
+        let (directory, root_manifest) = new_service_fixture(
+            "MIT",
             r#"[dependencies]
 renamed = { package = "new-service", path = "../service" }"#,
             &format!(r#"license = "{expression}""#),
         );
+        let error = check_apache_boundary(directory.path(), &root_manifest).unwrap_err();
         assert!(
-            check_apache_boundary(directory.path(), &root_manifest).is_err(),
-            "AGPL expression escaped boundary: {expression}"
+            error.contains("apache-root -> new-service"),
+            "AGPL expression escaped boundary: {expression}\n{error}"
         );
     }
 }
 
 #[test]
 fn canonical_policy_augments_manifest_metadata_without_a_copied_name_list() {
-    let directory = fixture_workspace("MIT");
-    let root_manifest = write_fixture_packages(
-        directory.path(),
+    let (directory, root_manifest) = new_service_fixture(
+        "MIT",
         r#"[dependencies]
 renamed = { package = "new-service", path = "../service" }"#,
         r#"license = "MIT""#,
@@ -390,4 +378,59 @@ other_packages = []
     );
     let error = check_apache_boundary(directory.path(), &root_manifest).unwrap_err();
     assert!(error.contains("apache-root -> new-service"), "{error}");
+}
+
+fn patched_anyhow_fixture(dependency: &str) -> (tempfile::TempDir, PathBuf) {
+    let directory = fixture_workspace(
+        "MIT",
+        r#"[patch.crates-io]
+anyhow = { path = "crates/service" }"#,
+    );
+    let root_manifest = write_fixture_packages(
+        directory.path(),
+        dependency,
+        "anyhow",
+        "99.0.0",
+        r#"license = "AGPL-3.0-only""#,
+    );
+    (directory, root_manifest)
+}
+
+#[test]
+fn direct_registry_dependency_patched_to_local_agpl_is_rejected() {
+    let (directory, root_manifest) = patched_anyhow_fixture(
+        r#"[dependencies]
+anyhow = "=99.0.0""#,
+    );
+    let error = check_apache_boundary(directory.path(), &root_manifest).unwrap_err();
+    assert!(error.contains("apache-root -> anyhow"), "{error}");
+}
+
+#[test]
+fn renamed_registry_dependency_patched_to_local_agpl_is_rejected() {
+    let (directory, root_manifest) = patched_anyhow_fixture(
+        r#"[dependencies]
+patched = { package = "anyhow", version = "=99.0.0" }"#,
+    );
+    let error = check_apache_boundary(directory.path(), &root_manifest).unwrap_err();
+    assert!(error.contains("apache-root -> anyhow"), "{error}");
+}
+
+#[test]
+fn replaced_registry_dependency_resolves_to_local_agpl_and_is_rejected() {
+    let directory = fixture_workspace(
+        "MIT",
+        r#"[replace]
+"anyhow:1.0.102" = { path = "crates/service" }"#,
+    );
+    let root_manifest = write_fixture_packages(
+        directory.path(),
+        r#"[dependencies]
+anyhow = "=1.0.102""#,
+        "anyhow",
+        "1.0.102",
+        r#"license = "AGPL-3.0-only""#,
+    );
+    let error = check_apache_boundary(directory.path(), &root_manifest).unwrap_err();
+    assert!(error.contains("apache-root -> anyhow"), "{error}");
 }

--- a/crates/hyprstream-k8s/tests/apache_boundary.rs
+++ b/crates/hyprstream-k8s/tests/apache_boundary.rs
@@ -1,27 +1,19 @@
 //! License-boundary regression for the reusable Kubernetes substrate.
 //!
-//! This intentionally resolves every local normal, optional, build, dev, and
-//! target-specific path dependency without asking Cargo to select a feature
-//! set. A forbidden service anywhere in that complete closure fails the test.
+//! The walk resolves every reachable local normal, optional, build, dev, and
+//! target-specific path dependency without asking Cargo to select features.
+//! Classification comes from package SPDX metadata rather than package names.
+//! When #1417's omission-checked `.github/license-boundary.toml` is present,
+//! its `agpl_services` partition augments manifest metadata; this is the only
+//! integration seam, so no policy list is copied into this crate.
 
 #![allow(clippy::expect_used, clippy::panic, clippy::unwrap_used)]
 
-use std::collections::{BTreeMap, BTreeSet, VecDeque};
+use std::collections::{BTreeSet, VecDeque};
 use std::fs;
 use std::path::{Path, PathBuf};
 
 use toml::Value;
-
-const AGPL_SERVICES: &[&str] = &[
-    "hyprstream",
-    "hyprstream-appview",
-    "hyprstream-discovery",
-    "hyprstream-k8s-pds",
-    "hyprstream-ledger",
-    "hyprstream-pds",
-    "hyprstream-pds-service",
-    "hyprstream-service",
-];
 
 #[derive(Debug)]
 struct PendingManifest {
@@ -29,18 +21,18 @@ struct PendingManifest {
     chain: Vec<String>,
 }
 
-fn load_manifest(path: &Path) -> Value {
+fn load_manifest(path: &Path) -> Result<Value, String> {
     fs::read_to_string(path)
-        .unwrap_or_else(|error| panic!("read {}: {error}", path.display()))
+        .map_err(|error| format!("read {}: {error}", path.display()))?
         .parse()
-        .unwrap_or_else(|error| panic!("parse {}: {error}", path.display()))
+        .map_err(|error| format!("parse {}: {error}", path.display()))
 }
 
-fn package_name(manifest: &Value, path: &Path) -> String {
+fn package_name(manifest: &Value, path: &Path) -> Result<String, String> {
     manifest["package"]["name"]
         .as_str()
-        .unwrap_or_else(|| panic!("{} has no package.name", path.display()))
-        .to_owned()
+        .map(str::to_owned)
+        .ok_or_else(|| format!("{} has no package.name", path.display()))
 }
 
 fn dependency_tables(manifest: &Value) -> Vec<&toml::map::Map<String, Value>> {
@@ -68,10 +60,8 @@ fn local_dependencies(
     manifest: &Value,
     workspace_manifest: &Value,
     workspace_root: &Path,
-) -> Vec<(PathBuf, Option<String>)> {
-    let workspace_dependencies = workspace_manifest["workspace"]["dependencies"]
-        .as_table()
-        .expect("workspace.dependencies must be a table");
+) -> Result<Vec<(PathBuf, Option<String>)>, String> {
+    let workspace_dependencies = workspace_manifest["workspace"]["dependencies"].as_table();
     let mut dependencies = Vec::new();
     for table in dependency_tables(manifest) {
         for (alias, declared) in table {
@@ -81,19 +71,21 @@ fn local_dependencies(
                 .and_then(Value::as_bool)
                 == Some(true)
             {
-                (
-                    workspace_dependencies.get(alias).unwrap_or_else(|| {
-                        panic!(
+                let inherited = workspace_dependencies
+                    .and_then(|dependencies| dependencies.get(alias))
+                    .ok_or_else(|| {
+                        format!(
                             "{} inherits missing workspace dependency {alias}",
                             manifest_path.display()
                         )
-                    }),
-                    workspace_root,
-                )
+                    })?;
+                (inherited, workspace_root)
             } else {
                 (
                     declared,
-                    manifest_path.parent().expect("manifest has parent"),
+                    manifest_path
+                        .parent()
+                        .ok_or_else(|| format!("{} has no parent", manifest_path.display()))?,
                 )
             };
             let Some(source) = source.as_table() else {
@@ -102,15 +94,142 @@ fn local_dependencies(
             let Some(local_path) = source.get("path").and_then(Value::as_str) else {
                 continue;
             };
-            let dependency_manifest = base.join(local_path).join("Cargo.toml");
-            let declared_package = source
-                .get("package")
-                .and_then(Value::as_str)
-                .map(str::to_owned);
-            dependencies.push((dependency_manifest, declared_package));
+            dependencies.push((
+                base.join(local_path).join("Cargo.toml"),
+                source
+                    .get("package")
+                    .and_then(Value::as_str)
+                    .map(str::to_owned),
+            ));
         }
     }
-    dependencies
+    Ok(dependencies)
+}
+
+fn resolved_license<'a>(
+    manifest: &'a Value,
+    workspace_manifest: &'a Value,
+    path: &Path,
+) -> Result<&'a str, String> {
+    let package = manifest
+        .get("package")
+        .and_then(Value::as_table)
+        .ok_or_else(|| format!("{} has no package table", path.display()))?;
+    if let Some(license) = package.get("license").and_then(Value::as_str) {
+        return Ok(license);
+    }
+    if package
+        .get("license")
+        .and_then(Value::as_table)
+        .and_then(|license| license.get("workspace"))
+        .and_then(Value::as_bool)
+        == Some(true)
+    {
+        return workspace_manifest
+            .get("workspace")
+            .and_then(Value::as_table)
+            .and_then(|workspace| workspace.get("package"))
+            .and_then(Value::as_table)
+            .and_then(|package| package.get("license"))
+            .and_then(Value::as_str)
+            .ok_or_else(|| {
+                format!(
+                    "{} inherits missing workspace.package.license",
+                    path.display()
+                )
+            });
+    }
+    Err(format!(
+        "{} has no resolved package license; Apache boundary fails closed",
+        path.display()
+    ))
+}
+
+/// Detect AGPL identifiers in SPDX expressions, including `-only`,
+/// `-or-later`, deprecated `+`, compound `AND`/`OR`, and `WITH` forms.
+///
+/// Cargo validates the expression syntax. The boundary only needs to extract
+/// license identifiers without assuming one exact expression shape.
+fn contains_agpl_identifier(expression: &str) -> bool {
+    expression
+        .split(|character: char| {
+            !(character.is_ascii_alphanumeric()
+                || character == '-'
+                || character == '.'
+                || character == '+')
+        })
+        .any(|identifier| identifier.starts_with("AGPL-"))
+}
+
+fn policy_agpl_packages(workspace_root: &Path) -> Result<BTreeSet<String>, String> {
+    let path = workspace_root.join(".github/license-boundary.toml");
+    if !path.exists() {
+        return Ok(BTreeSet::new());
+    }
+    let policy = load_manifest(&path)?;
+    policy["license_gate"]["agpl_services"]
+        .as_array()
+        .ok_or_else(|| format!("{} must define license_gate.agpl_services", path.display()))?
+        .iter()
+        .map(|value| {
+            value
+                .as_str()
+                .map(str::to_owned)
+                .ok_or_else(|| format!("{} has a non-string AGPL package", path.display()))
+        })
+        .collect()
+}
+
+fn check_apache_boundary(workspace_root: &Path, root_manifest_path: &Path) -> Result<(), String> {
+    let workspace_manifest_path = workspace_root.join("Cargo.toml");
+    let workspace_manifest = load_manifest(&workspace_manifest_path)?;
+    let policy_agpl = policy_agpl_packages(workspace_root)?;
+    let mut queue = VecDeque::from([PendingManifest {
+        path: root_manifest_path.to_owned(),
+        chain: Vec::new(),
+    }]);
+    let mut visited = BTreeSet::new();
+
+    while let Some(pending) = queue.pop_front() {
+        let canonical = pending
+            .path
+            .canonicalize()
+            .map_err(|error| format!("resolve {}: {error}", pending.path.display()))?;
+        if !visited.insert(canonical.clone()) {
+            continue;
+        }
+        let manifest = load_manifest(&canonical)?;
+        let name = package_name(&manifest, &canonical)?;
+        let mut chain = pending.chain;
+        chain.push(name.clone());
+        let license = resolved_license(&manifest, &workspace_manifest, &canonical)?;
+        if policy_agpl.contains(&name) || contains_agpl_identifier(license) {
+            return Err(format!(
+                "Apache-2.0-to-AGPL dependency: {} ({license})",
+                chain.join(" -> ")
+            ));
+        }
+
+        for (dependency_path, declared_package) in
+            local_dependencies(&canonical, &manifest, &workspace_manifest, workspace_root)?
+        {
+            let dependency_manifest = load_manifest(&dependency_path)?;
+            let dependency_name = package_name(&dependency_manifest, &dependency_path)?;
+            if let Some(declared_package) = declared_package {
+                if declared_package != dependency_name {
+                    return Err(format!(
+                        "{} declares package {declared_package}, resolved {dependency_name}",
+                        canonical.display()
+                    ));
+                }
+            }
+            queue.push_back(PendingManifest {
+                path: dependency_path,
+                chain: chain.clone(),
+            });
+        }
+    }
+    Ok(())
 }
 
 #[test]
@@ -119,63 +238,156 @@ fn hyprstream_k8s_complete_local_closure_excludes_agpl_services() {
         .join("../..")
         .canonicalize()
         .expect("canonical workspace root");
-    let workspace_manifest_path = workspace_root.join("Cargo.toml");
-    let workspace_manifest = load_manifest(&workspace_manifest_path);
     let root_manifest_path = workspace_root.join("crates/hyprstream-k8s/Cargo.toml");
+    check_apache_boundary(&workspace_root, &root_manifest_path).unwrap();
+}
 
-    let mut queue = VecDeque::from([PendingManifest {
-        path: root_manifest_path,
-        chain: vec!["hyprstream-k8s".to_owned()],
-    }]);
-    let mut visited = BTreeSet::new();
-    let mut closure = BTreeMap::new();
-
-    while let Some(pending) = queue.pop_front() {
-        let canonical = pending
-            .path
-            .canonicalize()
-            .unwrap_or_else(|error| panic!("resolve {}: {error}", pending.path.display()));
-        if !visited.insert(canonical.clone()) {
-            continue;
-        }
-        let manifest = load_manifest(&canonical);
-        let name = package_name(&manifest, &canonical);
-        closure.insert(name.clone(), canonical.clone());
-
-        let license = manifest["package"]["license"].as_str().unwrap_or_default();
-        if AGPL_SERVICES.contains(&name.as_str())
-            || license.split(" OR ").any(|id| id == "AGPL-3.0-only")
-        {
-            panic!(
-                "Apache-2.0-to-AGPL dependency: {}",
-                pending.chain.join(" -> ")
-            );
-        }
-
-        for (dependency_path, declared_package) in
-            local_dependencies(&canonical, &manifest, &workspace_manifest, &workspace_root)
-        {
-            let dependency_manifest = load_manifest(&dependency_path);
-            let dependency_name = package_name(&dependency_manifest, &dependency_path);
-            if let Some(declared_package) = declared_package {
-                assert_eq!(
-                    declared_package,
-                    dependency_name,
-                    "{} declares package {declared_package}, resolved {dependency_name}",
-                    canonical.display()
-                );
-            }
-            let mut chain = pending.chain.clone();
-            chain.push(dependency_name);
-            queue.push_back(PendingManifest {
-                path: dependency_path,
-                chain,
-            });
-        }
+fn write_fixture(path: &Path, contents: &str) {
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent).unwrap();
     }
+    fs::write(path, contents).unwrap();
+}
 
-    assert!(
-        closure.contains_key("hyprstream-k8s"),
-        "root package must be in its own closure"
+fn fixture_workspace(workspace_license: &str) -> tempfile::TempDir {
+    let directory = tempfile::tempdir().unwrap();
+    write_fixture(
+        &directory.path().join("Cargo.toml"),
+        &format!(
+            r#"[workspace]
+members = ["crates/root", "crates/service"]
+resolver = "2"
+
+[workspace.package]
+license = "{workspace_license}"
+
+[workspace.dependencies]
+renamed = {{ package = "new-service", path = "crates/service" }}
+"#
+        ),
     );
+    directory
+}
+
+fn write_fixture_packages(root: &Path, dependency_section: &str, service_license: &str) -> PathBuf {
+    let root_manifest = root.join("crates/root/Cargo.toml");
+    write_fixture(
+        &root_manifest,
+        &format!(
+            r#"[package]
+name = "apache-root"
+version = "0.1.0"
+license = "Apache-2.0"
+
+{dependency_section}
+"#
+        ),
+    );
+    write_fixture(
+        &root.join("crates/service/Cargo.toml"),
+        &format!(
+            r#"[package]
+name = "new-service"
+version = "0.1.0"
+{service_license}
+"#
+        ),
+    );
+    root_manifest
+}
+
+#[test]
+fn renamed_new_agpl_package_is_rejected() {
+    let directory = fixture_workspace("MIT");
+    let root_manifest = write_fixture_packages(
+        directory.path(),
+        r#"[dependencies]
+renamed = { package = "new-service", path = "../service" }"#,
+        r#"license = "AGPL-3.0-only""#,
+    );
+    let error = check_apache_boundary(directory.path(), &root_manifest).unwrap_err();
+    assert!(error.contains("apache-root -> new-service"), "{error}");
+}
+
+#[test]
+fn workspace_inherited_dependency_and_license_are_rejected() {
+    let directory = fixture_workspace("AGPL-3.0-or-later");
+    let root_manifest = write_fixture_packages(
+        directory.path(),
+        r#"[dependencies]
+renamed.workspace = true"#,
+        "license.workspace = true",
+    );
+    let error = check_apache_boundary(directory.path(), &root_manifest).unwrap_err();
+    assert!(error.contains("AGPL-3.0-or-later"), "{error}");
+}
+
+#[test]
+fn build_dev_and_target_edges_are_all_rejected() {
+    for dependency_section in [
+        r#"[build-dependencies]
+renamed = { package = "new-service", path = "../service" }"#,
+        r#"[dev-dependencies]
+renamed = { package = "new-service", path = "../service" }"#,
+        r#"[target.'cfg(unix)'.dependencies]
+renamed = { package = "new-service", path = "../service" }"#,
+        r#"[target.'cfg(unix)'.build-dependencies]
+renamed = { package = "new-service", path = "../service" }"#,
+        r#"[target.'cfg(unix)'.dev-dependencies]
+renamed = { package = "new-service", path = "../service" }"#,
+    ] {
+        let directory = fixture_workspace("MIT");
+        let root_manifest = write_fixture_packages(
+            directory.path(),
+            dependency_section,
+            r#"license = "AGPL-3.0-only""#,
+        );
+        assert!(
+            check_apache_boundary(directory.path(), &root_manifest).is_err(),
+            "edge escaped boundary: {dependency_section}"
+        );
+    }
+}
+
+#[test]
+fn compound_and_versioned_agpl_expressions_are_rejected() {
+    for expression in [
+        "AGPL-3.0-or-later",
+        "AGPL-3.0+",
+        "Apache-2.0 AND AGPL-3.0-only",
+        "(MIT OR Apache-2.0) AND AGPL-3.0-or-later",
+    ] {
+        let directory = fixture_workspace("MIT");
+        let root_manifest = write_fixture_packages(
+            directory.path(),
+            r#"[dependencies]
+renamed = { package = "new-service", path = "../service" }"#,
+            &format!(r#"license = "{expression}""#),
+        );
+        assert!(
+            check_apache_boundary(directory.path(), &root_manifest).is_err(),
+            "AGPL expression escaped boundary: {expression}"
+        );
+    }
+}
+
+#[test]
+fn canonical_policy_augments_manifest_metadata_without_a_copied_name_list() {
+    let directory = fixture_workspace("MIT");
+    let root_manifest = write_fixture_packages(
+        directory.path(),
+        r#"[dependencies]
+renamed = { package = "new-service", path = "../service" }"#,
+        r#"license = "MIT""#,
+    );
+    write_fixture(
+        &directory.path().join(".github/license-boundary.toml"),
+        r#"[license_gate]
+apache_roots = ["apache-root"]
+agpl_services = ["new-service"]
+other_packages = []
+"#,
+    );
+    let error = check_apache_boundary(directory.path(), &root_manifest).unwrap_err();
+    assert!(error.contains("apache-root -> new-service"), "{error}");
 }

--- a/crates/hyprstream-k8s/tests/apache_boundary.rs
+++ b/crates/hyprstream-k8s/tests/apache_boundary.rs
@@ -1,12 +1,14 @@
 //! License-boundary regression for the reusable Kubernetes substrate.
 //!
-//! Cargo's resolved metadata graph is the source of dependency truth. Running
-//! with all features includes optional edges, and metadata retains normal,
-//! build, dev, target, renamed, `[patch]`, and `[replace]` resolution. Local
-//! packages are classified by their resolved SPDX metadata rather than copied
-//! names. When #1417's omission-checked `.github/license-boundary.toml` is
-//! present, its `agpl_services` partition augments manifest metadata; that is
-//! the only policy integration seam.
+//! Cargo's committed resolved lock graph is the source of dependency truth.
+//! It retains normal, build, dev, target, renamed, `[patch]`, and `[replace]`
+//! resolution without requiring every registry source to be cached. A
+//! `--no-deps --locked --offline` metadata call validates the local manifests
+//! and classifies local packages by their SPDX metadata rather than copied
+//! names. Full metadata resolution remains in the causal fixtures. When
+//! #1417's omission-checked `.github/license-boundary.toml` is present, its
+//! `agpl_services` partition augments manifest metadata; that is the only
+//! policy integration seam.
 
 #![allow(clippy::expect_used, clippy::panic, clippy::unwrap_used)]
 
@@ -28,9 +30,16 @@ struct CargoMetadata {
 struct MetadataPackage {
     id: String,
     name: String,
+    version: String,
     license: Option<String>,
     manifest_path: PathBuf,
     source: Option<String>,
+    dependencies: Vec<DeclaredDependency>,
+}
+
+#[derive(Debug, Deserialize)]
+struct DeclaredDependency {
+    name: String,
 }
 
 #[derive(Debug, Deserialize)]
@@ -41,12 +50,26 @@ struct MetadataResolve {
 #[derive(Debug, Deserialize)]
 struct MetadataNode {
     id: String,
-    deps: Vec<MetadataDependency>,
+    deps: Vec<ResolvedDependency>,
 }
 
 #[derive(Debug, Deserialize)]
-struct MetadataDependency {
+struct ResolvedDependency {
     pkg: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct CargoLock {
+    package: Vec<LockedPackage>,
+}
+
+#[derive(Debug, Deserialize)]
+struct LockedPackage {
+    name: String,
+    version: String,
+    source: Option<String>,
+    #[serde(default)]
+    dependencies: Vec<String>,
 }
 
 fn load_toml(path: &Path) -> Result<Value, String> {
@@ -117,6 +140,226 @@ fn resolved_metadata(
     }
     serde_json::from_slice(&output.stdout)
         .map_err(|error| format!("parse cargo metadata JSON: {error}"))
+}
+
+fn local_metadata(
+    workspace_root: &Path,
+    root_manifest_path: &Path,
+) -> Result<CargoMetadata, String> {
+    let output = Command::new(env!("CARGO"))
+        .args([
+            "metadata",
+            "--format-version=1",
+            "--all-features",
+            "--locked",
+            "--offline",
+            "--no-deps",
+            "--manifest-path",
+        ])
+        .arg(root_manifest_path)
+        .current_dir(workspace_root)
+        .env("CARGO_TERM_COLOR", "never")
+        .output()
+        .map_err(|error| format!("run local-only cargo metadata: {error}"))?;
+    if !output.status.success() {
+        return Err(format!(
+            "local-only cargo metadata failed ({}): {}",
+            output.status,
+            String::from_utf8_lossy(&output.stderr)
+        ));
+    }
+    serde_json::from_slice(&output.stdout)
+        .map_err(|error| format!("parse local-only cargo metadata JSON: {error}"))
+}
+
+fn load_cargo_lock(path: &Path) -> Result<CargoLock, String> {
+    let contents =
+        fs::read_to_string(path).map_err(|error| format!("read {}: {error}", path.display()))?;
+    toml::from_str(&contents).map_err(|error| format!("parse {}: {error}", path.display()))
+}
+
+fn locked_dependency_index(packages: &[LockedPackage], dependency: &str) -> Result<usize, String> {
+    let name = dependency
+        .split_whitespace()
+        .next()
+        .ok_or_else(|| "Cargo.lock contains an empty dependency reference".to_owned())?;
+    let mut candidates = packages
+        .iter()
+        .enumerate()
+        .filter(|(_, package)| package.name == name)
+        .collect::<Vec<_>>();
+    if dependency != name {
+        let mut fields = dependency[name.len()..].trim().splitn(2, ' ');
+        let version = fields
+            .next()
+            .ok_or_else(|| format!("invalid Cargo.lock dependency reference {dependency}"))?;
+        candidates.retain(|(_, package)| package.version == version);
+        if let Some(source) = fields.next() {
+            let source = source
+                .strip_prefix('(')
+                .and_then(|value| value.strip_suffix(')'))
+                .ok_or_else(|| format!("invalid Cargo.lock dependency source {dependency}"))?;
+            candidates.retain(|(_, package)| {
+                package.source.as_deref().is_some_and(|candidate| {
+                    candidate == source
+                        || candidate
+                            .strip_prefix(source)
+                            .is_some_and(|suffix| suffix.starts_with('#'))
+                })
+            });
+        }
+    }
+    match candidates.as_slice() {
+        [(index, _)] => Ok(*index),
+        [] => Err(format!(
+            "Cargo.lock dependency {dependency} has no resolved package"
+        )),
+        _ => Err(format!(
+            "Cargo.lock dependency {dependency} is ambiguous across resolved packages"
+        )),
+    }
+}
+
+fn locked_root_index(packages: &[LockedPackage], root: &MetadataPackage) -> Result<usize, String> {
+    let matches = packages
+        .iter()
+        .enumerate()
+        .filter(|(_, package)| {
+            package.name == root.name && package.version == root.version && package.source.is_none()
+        })
+        .map(|(index, _)| index)
+        .collect::<Vec<_>>();
+    match matches.as_slice() {
+        [index] => Ok(*index),
+        [] => Err(format!(
+            "Cargo.lock omitted local root {} {}",
+            root.name, root.version
+        )),
+        _ => Err(format!(
+            "Cargo.lock has ambiguous local roots named {} {}",
+            root.name, root.version
+        )),
+    }
+}
+
+fn root_metadata<'a>(
+    packages: &'a [MetadataPackage],
+    root_manifest_path: &Path,
+) -> Result<&'a MetadataPackage, String> {
+    let root_manifest = root_manifest_path
+        .canonicalize()
+        .map_err(|error| format!("resolve {}: {error}", root_manifest_path.display()))?;
+    packages
+        .iter()
+        .find(|package| {
+            package
+                .manifest_path
+                .canonicalize()
+                .is_ok_and(|path| path == root_manifest)
+        })
+        .ok_or_else(|| {
+            format!(
+                "cargo metadata omitted root package {}",
+                root_manifest.display()
+            )
+        })
+}
+
+fn assert_root_dependencies_locked(
+    metadata: &CargoMetadata,
+    lock: &CargoLock,
+    root_manifest_path: &Path,
+) -> Result<(), String> {
+    let root = root_metadata(&metadata.packages, root_manifest_path)?;
+    let root_index = locked_root_index(&lock.package, root)?;
+    let locked_root = &lock.package[root_index];
+    let locked_dependency_names = locked_root
+        .dependencies
+        .iter()
+        .map(|dependency| {
+            locked_dependency_index(&lock.package, dependency)
+                .map(|index| lock.package[index].name.as_str())
+        })
+        .collect::<Result<BTreeSet<_>, _>>()?;
+    for dependency in &root.dependencies {
+        if !locked_dependency_names.contains(dependency.name.as_str()) {
+            return Err(format!(
+                "Cargo.lock omitted declared all-feature dependency {} -> {}",
+                root.name, dependency.name
+            ));
+        }
+    }
+    Ok(())
+}
+
+fn check_locked_apache_boundary(
+    workspace_root: &Path,
+    root_manifest_path: &Path,
+) -> Result<(), String> {
+    let metadata = local_metadata(workspace_root, &workspace_root.join("Cargo.toml"))?;
+    let lock = load_cargo_lock(&workspace_root.join("Cargo.lock"))?;
+    assert_root_dependencies_locked(&metadata, &lock, root_manifest_path)?;
+    check_locked_apache_boundary_with(
+        workspace_root,
+        root_manifest_path,
+        &metadata.packages,
+        &lock,
+    )
+}
+
+fn check_locked_apache_boundary_with(
+    policy_root: &Path,
+    root_manifest_path: &Path,
+    local_packages: &[MetadataPackage],
+    lock: &CargoLock,
+) -> Result<(), String> {
+    let policy_agpl = policy_agpl_packages(policy_root)?;
+    let root = root_metadata(local_packages, root_manifest_path)?;
+    let root_index = locked_root_index(&lock.package, root)?;
+
+    let mut queue = VecDeque::from([(root_index, Vec::<String>::new())]);
+    let mut visited = BTreeSet::new();
+    while let Some((index, mut chain)) = queue.pop_front() {
+        if !visited.insert(index) {
+            continue;
+        }
+        let package = &lock.package[index];
+        chain.push(package.name.clone());
+
+        if package.source.is_none() {
+            let metadata_package = local_packages
+                .iter()
+                .find(|candidate| {
+                    candidate.name == package.name
+                        && candidate.version == package.version
+                        && candidate.source.is_none()
+                })
+                .ok_or_else(|| {
+                    format!(
+                        "resolved local package {} {} has no local manifest metadata; Apache boundary fails closed",
+                        package.name, package.version
+                    )
+                })?;
+            let license = metadata_package.license.as_deref().ok_or_else(|| {
+                format!(
+                    "{} has no resolved package license; Apache boundary fails closed",
+                    metadata_package.manifest_path.display()
+                )
+            })?;
+            if policy_agpl.contains(&package.name) || contains_agpl_identifier(license) {
+                return Err(format!(
+                    "Apache-2.0-to-AGPL dependency: {} ({license})",
+                    chain.join(" -> ")
+                ));
+            }
+        }
+
+        for dependency in &package.dependencies {
+            let dependency_index = locked_dependency_index(&lock.package, dependency)?;
+            queue.push_back((dependency_index, chain.clone()));
+        }
+    }
+    Ok(())
 }
 
 fn check_apache_boundary(workspace_root: &Path, root_manifest_path: &Path) -> Result<(), String> {
@@ -246,7 +489,19 @@ fn hyprstream_k8s_complete_local_closure_excludes_agpl_services() {
         .canonicalize()
         .expect("canonical workspace root");
     let root_manifest_path = workspace_root.join("crates/hyprstream-k8s/Cargo.toml");
-    check_apache_boundary(&workspace_root, &root_manifest_path).unwrap();
+    check_locked_apache_boundary(&workspace_root, &root_manifest_path).unwrap();
+}
+
+#[test]
+fn production_lock_covers_every_declared_root_dependency_without_registry_sources() {
+    let workspace_root = Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("../..")
+        .canonicalize()
+        .expect("canonical workspace root");
+    let root_manifest_path = workspace_root.join("crates/hyprstream-k8s/Cargo.toml");
+    let metadata = local_metadata(&workspace_root, &workspace_root.join("Cargo.toml")).unwrap();
+    let lock = load_cargo_lock(&workspace_root.join("Cargo.lock")).unwrap();
+    assert_root_dependencies_locked(&metadata, &lock, &root_manifest_path).unwrap();
 }
 
 fn write_fixture(path: &Path, contents: &str) {
@@ -493,6 +748,19 @@ serde_json = "=1.0.150""#,
     let metadata = resolved_metadata(directory.path(), &root_manifest)
         .expect("transitive patch fixture must resolve offline");
     assert_transitive_patch_resolved(&metadata, "serde_json", "itoa");
+    let lock = load_cargo_lock(&directory.path().join("Cargo.lock"))
+        .expect("transitive patch fixture must write a resolved Cargo.lock");
+    let locked_error = check_locked_apache_boundary_with(
+        directory.path(),
+        &root_manifest,
+        &metadata.packages,
+        &lock,
+    )
+    .unwrap_err();
+    assert!(
+        locked_error.contains("apache-root -> serde_json -> itoa"),
+        "locked graph omitted complete dependency chain: {locked_error}"
+    );
 
     let error = check_apache_boundary(directory.path(), &root_manifest).unwrap_err();
     assert!(

--- a/crates/hyprstream-k8s/tests/apache_boundary.rs
+++ b/crates/hyprstream-k8s/tests/apache_boundary.rs
@@ -17,6 +17,7 @@ use std::fs;
 use std::path::{Path, PathBuf};
 use std::process::Command;
 
+use semver::{Version, VersionReq};
 use serde::Deserialize;
 use toml::Value;
 
@@ -37,9 +38,13 @@ struct MetadataPackage {
     dependencies: Vec<DeclaredDependency>,
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Clone, Debug, Deserialize)]
 struct DeclaredDependency {
     name: String,
+    req: String,
+    source: Option<String>,
+    path: Option<PathBuf>,
+    rename: Option<String>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -242,6 +247,66 @@ fn locked_root_index(packages: &[LockedPackage], root: &MetadataPackage) -> Resu
     }
 }
 
+fn source_identity_matches(resolved: &str, declared: &str) -> bool {
+    resolved == declared
+        || resolved
+            .strip_prefix(declared)
+            .is_some_and(|suffix| suffix.starts_with('#'))
+        || declared
+            .strip_prefix(resolved)
+            .is_some_and(|suffix| suffix.starts_with('#'))
+}
+
+fn declared_dependency_matches_locked(
+    dependency: &DeclaredDependency,
+    package: &LockedPackage,
+    local_packages: &[MetadataPackage],
+) -> Result<bool, String> {
+    if package.name != dependency.name {
+        return Ok(false);
+    }
+    let requirement = VersionReq::parse(&dependency.req).map_err(|error| {
+        format!(
+            "parse declared requirement {} for {}: {error}",
+            dependency.req, dependency.name
+        )
+    })?;
+    let version = Version::parse(&package.version).map_err(|error| {
+        format!(
+            "parse locked version {} for {}: {error}",
+            package.version, package.name
+        )
+    })?;
+    if !requirement.matches(&version) {
+        return Ok(false);
+    }
+
+    if let Some(path) = &dependency.path {
+        if package.source.is_some() {
+            return Ok(false);
+        }
+        let declared_path = path
+            .canonicalize()
+            .map_err(|error| format!("resolve declared dependency {}: {error}", path.display()))?;
+        return Ok(local_packages.iter().any(|candidate| {
+            candidate.name == package.name
+                && candidate.version == package.version
+                && candidate.source.is_none()
+                && candidate
+                    .manifest_path
+                    .parent()
+                    .and_then(|parent| parent.canonicalize().ok())
+                    .is_some_and(|resolved_path| resolved_path == declared_path)
+        }));
+    }
+
+    match (&dependency.source, &package.source) {
+        (Some(declared), Some(resolved)) => Ok(source_identity_matches(resolved, declared)),
+        (None, None) => Ok(true),
+        _ => Ok(false),
+    }
+}
+
 fn root_metadata<'a>(
     packages: &'a [MetadataPackage],
     root_manifest_path: &Path,
@@ -273,20 +338,42 @@ fn assert_root_dependencies_locked(
     let root = root_metadata(&metadata.packages, root_manifest_path)?;
     let root_index = locked_root_index(&lock.package, root)?;
     let locked_root = &lock.package[root_index];
-    let locked_dependency_names = locked_root
+    let locked_dependency_indices = locked_root
         .dependencies
         .iter()
-        .map(|dependency| {
-            locked_dependency_index(&lock.package, dependency)
-                .map(|index| lock.package[index].name.as_str())
-        })
+        .map(|dependency| locked_dependency_index(&lock.package, dependency))
         .collect::<Result<BTreeSet<_>, _>>()?;
     for dependency in &root.dependencies {
-        if !locked_dependency_names.contains(dependency.name.as_str()) {
-            return Err(format!(
-                "Cargo.lock omitted declared all-feature dependency {} -> {}",
-                root.name, dependency.name
-            ));
+        let matches = locked_dependency_indices
+            .iter()
+            .copied()
+            .map(|index| {
+                declared_dependency_matches_locked(
+                    dependency,
+                    &lock.package[index],
+                    &metadata.packages,
+                )
+                .map(|matches| matches.then_some(index))
+            })
+            .collect::<Result<Vec<_>, _>>()?
+            .into_iter()
+            .flatten()
+            .collect::<Vec<_>>();
+        let alias = dependency.rename.as_deref().unwrap_or(&dependency.name);
+        match matches.as_slice() {
+            [_] => {}
+            [] => {
+                return Err(format!(
+                    "Cargo.lock omitted exact resolved root dependency {alias} \
+                     (package {} {}, source {:?}, path {:?})",
+                    dependency.name, dependency.req, dependency.source, dependency.path
+                ));
+            }
+            _ => {
+                return Err(format!(
+                    "declared root dependency {alias} ambiguously matches multiple lock identities"
+                ));
+            }
         }
     }
     Ok(())
@@ -502,6 +589,136 @@ fn production_lock_covers_every_declared_root_dependency_without_registry_source
     let metadata = local_metadata(&workspace_root, &workspace_root.join("Cargo.toml")).unwrap();
     let lock = load_cargo_lock(&workspace_root.join("Cargo.lock")).unwrap();
     assert_root_dependencies_locked(&metadata, &lock, &root_manifest_path).unwrap();
+}
+
+#[test]
+fn root_lock_identity_check_rejects_omitted_renamed_agpl_version() {
+    let directory = tempfile::tempdir().unwrap();
+    write_fixture(
+        &directory.path().join("Cargo.toml"),
+        r#"[workspace]
+members = ["root"]
+exclude = ["service-v1", "service-v2"]
+resolver = "2"
+"#,
+    );
+    let root_manifest = directory.path().join("root/Cargo.toml");
+    write_fixture(
+        &root_manifest,
+        r#"[package]
+name = "apache-root"
+version = "0.1.0"
+license = "Apache-2.0"
+
+[dependencies]
+service_v1 = { package = "service", path = "../service-v1", optional = true }
+service_v2 = { package = "service", path = "../service-v2", optional = true }
+
+[features]
+both = ["dep:service_v1", "dep:service_v2"]
+"#,
+    );
+    write_fixture(
+        &directory.path().join("service-v1/Cargo.toml"),
+        r#"[package]
+name = "service"
+version = "1.0.0"
+license = "MIT"
+"#,
+    );
+    write_fixture(
+        &directory.path().join("service-v2/Cargo.toml"),
+        r#"[package]
+name = "service"
+version = "2.0.0"
+license = "AGPL-3.0-only"
+"#,
+    );
+    for package in ["root", "service-v1", "service-v2"] {
+        write_fixture(&directory.path().join(package).join("src/lib.rs"), "");
+    }
+
+    let mut metadata = resolved_metadata(directory.path(), &root_manifest)
+        .expect("duplicate-version alias fixture must resolve offline");
+    let mut lock = load_cargo_lock(&directory.path().join("Cargo.lock"))
+        .expect("duplicate-version alias fixture must write Cargo.lock");
+
+    let root_manifest_canonical = root_manifest.canonicalize().unwrap();
+    let root_metadata_index = metadata
+        .packages
+        .iter()
+        .position(|package| {
+            package
+                .manifest_path
+                .canonicalize()
+                .is_ok_and(|path| path == root_manifest_canonical)
+        })
+        .expect("fixture root metadata");
+    let mut duplicate_alias = metadata.packages[root_metadata_index]
+        .dependencies
+        .iter()
+        .find(|dependency| dependency.rename.as_deref() == Some("service_v1"))
+        .expect("service_v1 declaration")
+        .clone();
+    duplicate_alias.rename = Some("service_v1_duplicate".to_owned());
+    metadata.packages[root_metadata_index]
+        .dependencies
+        .push(duplicate_alias);
+
+    assert_root_dependencies_locked(&metadata, &lock, &root_manifest)
+        .expect("multiple aliases may resolve to the same exact lock identity");
+    let boundary_error = check_locked_apache_boundary_with(
+        directory.path(),
+        &root_manifest,
+        &metadata.packages,
+        &lock,
+    )
+    .unwrap_err();
+    assert!(
+        boundary_error.contains("AGPL-3.0-only"),
+        "complete fixture lock must reach its AGPL identity: {boundary_error}"
+    );
+
+    let root_lock_index =
+        locked_root_index(&lock.package, &metadata.packages[root_metadata_index]).unwrap();
+    let agpl_edge_index = lock.package[root_lock_index]
+        .dependencies
+        .iter()
+        .position(|dependency| {
+            locked_dependency_index(&lock.package, dependency).is_ok_and(|index| {
+                let package = &lock.package[index];
+                package.name == "service" && package.version == "2.0.0" && package.source.is_none()
+            })
+        })
+        .expect("root edge to AGPL service 2.0.0");
+    lock.package[root_lock_index]
+        .dependencies
+        .remove(agpl_edge_index);
+
+    assert!(
+        lock.package[root_lock_index]
+            .dependencies
+            .iter()
+            .any(|dependency| {
+                locked_dependency_index(&lock.package, dependency).is_ok_and(|index| {
+                    let package = &lock.package[index];
+                    package.name == "service" && package.version == "1.0.0"
+                })
+            }),
+        "MIT service 1.0.0 root edge must remain"
+    );
+    assert!(
+        lock.package.iter().any(|package| {
+            package.name == "service" && package.version == "2.0.0" && package.source.is_none()
+        }),
+        "AGPL package identity must remain in the lock after only its root edge is removed"
+    );
+
+    let error = assert_root_dependencies_locked(&metadata, &lock, &root_manifest).unwrap_err();
+    assert!(
+        error.contains("omitted exact resolved root dependency service_v2"),
+        "identity consistency must reject the missing AGPL edge before traversal: {error}"
+    );
 }
 
 fn write_fixture(path: &Path, contents: &str) {

--- a/crates/hyprstream-k8s/tests/apache_boundary.rs
+++ b/crates/hyprstream-k8s/tests/apache_boundary.rs
@@ -1,0 +1,181 @@
+//! License-boundary regression for the reusable Kubernetes substrate.
+//!
+//! This intentionally resolves every local normal, optional, build, dev, and
+//! target-specific path dependency without asking Cargo to select a feature
+//! set. A forbidden service anywhere in that complete closure fails the test.
+
+#![allow(clippy::expect_used, clippy::panic, clippy::unwrap_used)]
+
+use std::collections::{BTreeMap, BTreeSet, VecDeque};
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use toml::Value;
+
+const AGPL_SERVICES: &[&str] = &[
+    "hyprstream",
+    "hyprstream-appview",
+    "hyprstream-discovery",
+    "hyprstream-k8s-pds",
+    "hyprstream-ledger",
+    "hyprstream-pds",
+    "hyprstream-pds-service",
+    "hyprstream-service",
+];
+
+#[derive(Debug)]
+struct PendingManifest {
+    path: PathBuf,
+    chain: Vec<String>,
+}
+
+fn load_manifest(path: &Path) -> Value {
+    fs::read_to_string(path)
+        .unwrap_or_else(|error| panic!("read {}: {error}", path.display()))
+        .parse()
+        .unwrap_or_else(|error| panic!("parse {}: {error}", path.display()))
+}
+
+fn package_name(manifest: &Value, path: &Path) -> String {
+    manifest["package"]["name"]
+        .as_str()
+        .unwrap_or_else(|| panic!("{} has no package.name", path.display()))
+        .to_owned()
+}
+
+fn dependency_tables(manifest: &Value) -> Vec<&toml::map::Map<String, Value>> {
+    const SECTIONS: &[&str] = &["dependencies", "build-dependencies", "dev-dependencies"];
+    let mut tables = Vec::new();
+    for section in SECTIONS {
+        if let Some(table) = manifest.get(*section).and_then(Value::as_table) {
+            tables.push(table);
+        }
+    }
+    if let Some(targets) = manifest.get("target").and_then(Value::as_table) {
+        for target in targets.values().filter_map(Value::as_table) {
+            for section in SECTIONS {
+                if let Some(table) = target.get(*section).and_then(Value::as_table) {
+                    tables.push(table);
+                }
+            }
+        }
+    }
+    tables
+}
+
+fn local_dependencies(
+    manifest_path: &Path,
+    manifest: &Value,
+    workspace_manifest: &Value,
+    workspace_root: &Path,
+) -> Vec<(PathBuf, Option<String>)> {
+    let workspace_dependencies = workspace_manifest["workspace"]["dependencies"]
+        .as_table()
+        .expect("workspace.dependencies must be a table");
+    let mut dependencies = Vec::new();
+    for table in dependency_tables(manifest) {
+        for (alias, declared) in table {
+            let (source, base) = if declared
+                .as_table()
+                .and_then(|value| value.get("workspace"))
+                .and_then(Value::as_bool)
+                == Some(true)
+            {
+                (
+                    workspace_dependencies.get(alias).unwrap_or_else(|| {
+                        panic!(
+                            "{} inherits missing workspace dependency {alias}",
+                            manifest_path.display()
+                        )
+                    }),
+                    workspace_root,
+                )
+            } else {
+                (
+                    declared,
+                    manifest_path.parent().expect("manifest has parent"),
+                )
+            };
+            let Some(source) = source.as_table() else {
+                continue;
+            };
+            let Some(local_path) = source.get("path").and_then(Value::as_str) else {
+                continue;
+            };
+            let dependency_manifest = base.join(local_path).join("Cargo.toml");
+            let declared_package = source
+                .get("package")
+                .and_then(Value::as_str)
+                .map(str::to_owned);
+            dependencies.push((dependency_manifest, declared_package));
+        }
+    }
+    dependencies
+}
+
+#[test]
+fn hyprstream_k8s_complete_local_closure_excludes_agpl_services() {
+    let workspace_root = Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("../..")
+        .canonicalize()
+        .expect("canonical workspace root");
+    let workspace_manifest_path = workspace_root.join("Cargo.toml");
+    let workspace_manifest = load_manifest(&workspace_manifest_path);
+    let root_manifest_path = workspace_root.join("crates/hyprstream-k8s/Cargo.toml");
+
+    let mut queue = VecDeque::from([PendingManifest {
+        path: root_manifest_path,
+        chain: vec!["hyprstream-k8s".to_owned()],
+    }]);
+    let mut visited = BTreeSet::new();
+    let mut closure = BTreeMap::new();
+
+    while let Some(pending) = queue.pop_front() {
+        let canonical = pending
+            .path
+            .canonicalize()
+            .unwrap_or_else(|error| panic!("resolve {}: {error}", pending.path.display()));
+        if !visited.insert(canonical.clone()) {
+            continue;
+        }
+        let manifest = load_manifest(&canonical);
+        let name = package_name(&manifest, &canonical);
+        closure.insert(name.clone(), canonical.clone());
+
+        let license = manifest["package"]["license"].as_str().unwrap_or_default();
+        if AGPL_SERVICES.contains(&name.as_str())
+            || license.split(" OR ").any(|id| id == "AGPL-3.0-only")
+        {
+            panic!(
+                "Apache-2.0-to-AGPL dependency: {}",
+                pending.chain.join(" -> ")
+            );
+        }
+
+        for (dependency_path, declared_package) in
+            local_dependencies(&canonical, &manifest, &workspace_manifest, &workspace_root)
+        {
+            let dependency_manifest = load_manifest(&dependency_path);
+            let dependency_name = package_name(&dependency_manifest, &dependency_path);
+            if let Some(declared_package) = declared_package {
+                assert_eq!(
+                    declared_package,
+                    dependency_name,
+                    "{} declares package {declared_package}, resolved {dependency_name}",
+                    canonical.display()
+                );
+            }
+            let mut chain = pending.chain.clone();
+            chain.push(dependency_name);
+            queue.push_back(PendingManifest {
+                path: dependency_path,
+                chain,
+            });
+        }
+    }
+
+    assert!(
+        closure.contains_key("hyprstream-k8s"),
+        "root package must be in its own closure"
+    );
+}

--- a/deny.toml
+++ b/deny.toml
@@ -51,6 +51,12 @@ name = "hyprstream"
 version = "*"
 allow = ["MIT", "AGPL-3.0-only"]
 
+# Authority-bearing Kubernetes grant/PDS adapter (#1422).
+[[licenses.exceptions]]
+name = "hyprstream-k8s-pds"
+version = "*"
+allow = ["AGPL-3.0-only"]
+
 # systemd/libsystemd-sys are LGPL + GCC exception.
 # The GCC exception permits non-copyleft software to dynamically link against LGPL libraries
 # without triggering the copyleft requirement; hyprstream links libsystemd dynamically.


### PR DESCRIPTION
Closes #1422

Blocks #1417

## Summary

- keep `hyprstream-k8s` as the Apache-2.0 CRD, client, operator, planning, watch, and VFS substrate
- keep all issuer, signing, verifier, PDS allocation, and authority-bearing CID behavior in downstream AGPL-3.0-only `hyprstream-k8s-pds`
- distribute the canonical Apache-2.0 text and explicit per-crate license assignment
- require both successful artifact references and persisted grant status references to be canonical lowercase-base32 CIDv1
- require complete persisted `Bound` invariants for both entitlement and no-entitlement reconciliation
- derive the complete local dependency closure from Cargo's committed resolved lock graph without requiring unrelated registry/Git sources in the test cache
- compile-test the real `k8s,grant` operator composition with the AGPL adapter without contacting a cluster

## Dependency direction

`hyprstream-k8s-pds -> hyprstream-k8s`

The adapter also depends on `hyprstream-pds` and `hyprstream-rpc`.
`hyprstream-k8s` has no reverse dependency on the adapter or another
authority-bearing service. Its `grant` feature uses only neutral CID-format
validation.

When #1417's `.github/license-boundary.toml` is present, this PR consumes its
omission-checked `agpl_services` partition as an augmentation to Cargo's
resolved manifest SPDX metadata. No #1417 list or file is duplicated here.

## API migration

The `grant` feature remains, but concrete authority APIs move:

- `TenantGrantIssuer` -> `hyprstream_k8s_pds::TenantGrantIssuer`
- `TenantGrantVerifier` -> `hyprstream_k8s_pds::TenantGrantVerifier`
- `CompiledTenantGrant` -> `hyprstream_k8s_pds::CompiledTenantGrant`
- `VerifiedTenantGrant` -> `hyprstream_k8s_pds::VerifiedTenantGrant`
- `TENANT_GRANT_ED25519_PURPOSE` -> `hyprstream_k8s_pds::TENANT_GRANT_ED25519_PURPOSE`
- `TENANT_GRANT_ABILITY` -> `hyprstream_k8s_pds::TENANT_GRANT_ABILITY`
- adapter callers use `hyprstream_k8s_pds::now_unix`; the neutral helper remains
- `run_operator_with_grant_issuer` -> `run_operator_with_grant_service`
- `OperatorState::with_grant_issuer` -> `OperatorState::with_grant_service`
- `compile_tenant_binding_status(binding, issuer, epoch, now)` now accepts `service: Option<&dyn TenantGrantService>` in the same argument position

The adapter has both a `no_run` example and integration compile target whose
dev feature set enables `hyprstream-k8s/k8s,grant`. They type-check
`TenantGrantIssuer` passed to `OperatorState::with_grant_service` and
`run_operator_with_grant_service` without constructing a client or contacting
Kubernetes.

## Exact boundary behavior

`ContentReference` has a private inner value and accepts only:

- CID version 1;
- canonical lowercase base32 encoding; and
- no path/URL wrapper or surrounding whitespace.

Tests reject a valid CIDv0, uppercase base32 CIDv1, base58 CIDv1, base64 CIDv1,
`/ipfs/` form, empty/whitespace/malformed values, and every one-valid/one-invalid
artifact pair.

Persisted status is current only when the observed generation matches and:

- entitlement: `bound=true`, phase `Bound`, two canonical CIDv1 references,
  and the requested epoch; or
- no entitlement: `bound=true`, phase `Bound`, and no grant, allocation, or
  epoch.

Both configured-service and no-service idempotency paths share the complete
no-entitlement invariant. Regression tests cover CIDv0/alternate
multibase/case/path forms, partial pairs, allocation-only, grant-only,
epoch-only, and inconsistent bound/phase states.

## Merge-group incident

Protected merge-group run [30519249715](https://github.com/hyprstream/hyprstream/actions/runs/30519249715) reached nextest with 1,985 passing tests before the production boundary test failed. Its nested full-workspace `cargo metadata --offline` tried to open uncached `android_system_properties v0.1.5`, an unrelated target-specific registry source. Earlier local/reviewer passes had inherited warmed Cargo caches.

The correction is source-independent: the production gate validates lock freshness and reads every local manifest with `cargo metadata --all-features --locked --offline --no-deps`, then uses the committed `Cargo.lock` as Cargo's complete resolved package-identity and dependency-edge graph. `--no-deps` is never used as the dependency graph. Every declared root dependency must appear in the resolved lock entry, and traversal still crosses every registry/Git intermediary before applying SPDX/#1417 classification only to reached local packages.

The old head fails under an empty isolated Cargo home; the corrected production gate and lock-coverage regression both pass under that same empty cache.

## R6 root-lock identity correction

Root-dependency consistency now matches each declaration to an exact resolved lock identity using its alias/package name, Cargo semver requirement, source identity, and canonical local path. Matches are deliberately not consumed, so multiple aliases may resolve to the same exact package identity without a false rejection; declarations that match no identity or ambiguously match multiple distinct identities fail closed.

A twelfth causal fixture resolves renamed `service` aliases to local MIT `1.0.0` and AGPL `2.0.0` identities, removes only the AGPL root lock edge while retaining the MIT edge and AGPL package entry, and proves the consistency check rejects before traversal. The fixture also proves two aliases may intentionally share the same exact identity.

## Resolved dependency gate

The production gate walks every resolved package identity and dependency edge reachable from `hyprstream-k8s` in the committed `Cargo.lock`, regardless of source. Normal, optional, build, dev, target, renamed, workspace-inherited, `[patch]`, and `[replace]` resolution remains represented without opening registry or Git sources. Reached local packages fail closed if local metadata is missing, license metadata is absent, the SPDX expression contains AGPL, or #1417 classifies the package as an AGPL service.

Full `cargo metadata --all-features --offline` resolution remains in the causal fixtures. The transitive registry-patch fixture additionally traverses its generated lock and asserts the complete `apache-root -> serde_json -> itoa` rejection chain, proving the production algorithm preserves the external-intermediary mutation.

Twelve causal tests cover:

1. the real `hyprstream-k8s` locked closure;
2. renamed local AGPL dependency;
3. workspace-inherited dependency/license;
4. build/dev/all target table kinds;
5. compound/versioned AGPL expressions;
6. the #1417 policy seam;
7. direct registry dependency patched to local AGPL;
8. renamed registry dependency patched to local AGPL;
9. registry replacement resolving to local AGPL;
10. a registry intermediary whose transitive dependency is patched to local AGPL, with both metadata and locked traversal asserting the complete chain; and
11. every declared all-feature root dependency represented in the committed lock without reading dependency sources; and
12. exact alias/name/version/source/path root identity coverage when two renamed dependencies share a package name but resolve to distinct versions.

## Validation

Every manually invoked Cargo command ran through `/home/birdetta/projects/cyberdione/.fleet-coord/buildq --slots 2 -- cargo ...`.

- substrate tests pass under default, `grant`, `k8s`, and `k8s,grant`
- maximal run: 51 library tests, 12 resolved-boundary tests, 13 offline/CRD tests
- adapter: 15/15 security tests plus the operator-composition integration test
- `no_run` downstream operator doctest passes
- strict Clippy (`-D warnings`) passes for substrate default, `k8s`,
  `k8s,grant`, and adapter all-targets
- strict rustdoc passes for substrate `grant` and adapter
- `cargo deny check bans licenses`: `bans ok, licenses ok`
- `committed_yaml_matches_generated` passes; generated CRD/Helm paths unchanged
- package-scoped `cargo fmt --check`, canonical license comparison, and
  `git diff --check` pass
- foreground repository-wide release Clippy hook passes

## Non-actions

No #1417 file was changed. This PR remains open and draft. No review was
dispatched; no self-review, approval, un-draft, merge, force-push, publication,
deployment, or infrastructure mutation occurred.
