### PR TITLE
feat(workflow): strict/fail-closed GHA parser mode

### DIFF
--- a/crates/hyprstream-workers/src/workflow/gh_adapter.rs
+++ b/crates/hyprstream-workers/src/workflow/gh_adapter.rs
@@ -79,14 +79,41 @@ impl GitHubActionsAdapter {
     /// with dropped keys. In [`ParseMode::Legacy`] (the default for the
     /// generic adapter) unknown keys are tolerated, preserving non-gate
     /// caller compatibility (#1432 non-goal).
+    ///
+    /// The chosen mode is recorded per-repo on the service
+    /// ([`WorkflowService::set_repo_mode`]) so that push-triggered rescans
+    /// retain strict rather than silently dropping back to legacy. This load
+    /// also **reconciles**: stale service registrations and adapter handlers
+    /// for this repo that are absent from the fresh set are evicted/dropped,
+    /// so a deleted or strict-rejected workflow can no longer be dispatched
+    /// or triggered (fail-closed).
     pub async fn load_repo_with(
         &mut self,
         repo_id: &str,
         service: &WorkflowService,
         mode: super::parser::ParseMode,
     ) -> Result<()> {
-        // Scan the repository for workflow files.
+        // Record the mode so event-triggered rescans retain strict.
+        service.set_repo_mode(repo_id, mode).await;
+
+        // Scan the repository for workflow files in the chosen mode.
         let workflow_defs = service.scan_repo_with(repo_id, mode).await?;
+
+        // Reconcile the service registry: evict any prior registration for
+        // this repo that did not survive the fresh scan.
+        let fresh_ids: std::collections::HashSet<WorkflowId> = workflow_defs
+            .iter()
+            .map(|def| format!("{}:{}", def.repo_id, def.path))
+            .collect();
+        service.evict_stale_for_repo(repo_id, &fresh_ids).await;
+
+        // Reconcile this adapter's handlers: drop handlers whose workflow
+        // belongs to this repo, then rebuild from the fresh set. Without
+        // this, a strict-rejected/deleted workflow's handler would persist
+        // and keep firing (the fail-closed gap).
+        let repo_prefix = format!("{repo_id}:");
+        self.handlers
+            .retain(|h| !h.workflow_id().starts_with(&repo_prefix));
 
         for def in workflow_defs {
             // Register the workflow definition.
@@ -250,6 +277,136 @@ impl SubscriberAdapter for GitHubActionsAdapter {
             }
         }
 
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::events::EventSubscriber;
+    use hyprstream_vfs::Subject;
+    use std::path::PathBuf;
+
+    const KNOWN_YAML: &str = r#"
+name: Gate
+on: push
+jobs:
+  gate:
+    runs-on: ubuntu-latest
+    steps:
+      - run: cargo test
+"#;
+
+    const UNKNOWN_KEY_YAML: &str = r#"
+name: Gate
+on: push
+permissions:
+  contents: read
+jobs:
+  gate:
+    runs-on: ubuntu-latest
+    steps:
+      - run: cargo test
+"#;
+
+    async fn write_workflow(
+        root: &std::path::Path,
+        yaml: &str,
+    ) -> std::result::Result<(), Box<dyn std::error::Error>> {
+        let dir = root.join(".github").join("workflows");
+        tokio::fs::create_dir_all(&dir).await?;
+        tokio::fs::write(dir.join("gate.yml"), yaml).await?;
+        Ok(())
+    }
+
+    type TestResult = std::result::Result<(), Box<dyn std::error::Error>>;
+
+    fn adapter() -> std::result::Result<GitHubActionsAdapter, Box<dyn std::error::Error>> {
+        Ok(GitHubActionsAdapter::new(EventSubscriber::new()?, Subject::new("gate-test")))
+    }
+
+    fn service() -> super::super::service::WorkflowService {
+        use hyprstream_rpc::prelude::SigningKey;
+        use hyprstream_rpc::transport::TransportConfig;
+        use rand::rngs::OsRng;
+        super::super::service::WorkflowService::new(
+            TransportConfig::inproc("test-gh-adapter"),
+            SigningKey::generate(&mut OsRng),
+        )
+    }
+
+    /// P1-B (rev 4): a repeated strict load must reconcile — a workflow that
+    /// is now strict-rejected must have BOTH its registration evicted AND its
+    /// adapter handler dropped, so it can no longer be triggered.
+    #[tokio::test]
+    async fn strict_load_reconciles_stale_handler() -> TestResult {
+        let tmp = tempfile::tempdir()?;
+        write_workflow(tmp.path(), KNOWN_YAML).await?;
+
+        let svc = service();
+        svc.register_repo_path("acme", PathBuf::from(tmp.path())).await;
+
+        let mut adp = adapter()?;
+        adp.load_repo_with("acme", &svc, super::super::parser::ParseMode::Strict)
+            .await?;
+        // `on: push` builds a TopicPatternHandler → at least one handler.
+        assert!(
+            !adp.handlers.is_empty(),
+            "known workflow should register at least one handler"
+        );
+        assert!(
+            svc.list_workflows().await?.iter().any(|i| i.id
+                == "acme:.github/workflows/gate.yml"),
+            "workflow should be registered after first strict load"
+        );
+
+        // Mutate to add an unknown key and reload in strict mode.
+        write_workflow(tmp.path(), UNKNOWN_KEY_YAML).await?;
+        adp.load_repo_with("acme", &svc, super::super::parser::ParseMode::Strict)
+            .await?;
+
+        // Adapter handlers for this repo must be dropped (reconcile).
+        let repo_prefix = "acme:";
+        let remaining = adp
+            .handlers
+            .iter()
+            .filter(|h| h.workflow_id().starts_with(repo_prefix))
+            .count();
+        assert_eq!(
+            remaining, 0,
+            "strict-rejected workflow's adapter handlers must be dropped on reconcile"
+        );
+        // And the registration must be evicted from the service.
+        assert!(
+            !svc.list_workflows().await?.iter().any(|i| i.id
+                == "acme:.github/workflows/gate.yml"),
+            "strict-rejected workflow's registration must be evicted on reconcile"
+        );
+        Ok(())
+    }
+
+    /// Legacy reload keeps the workflow (and its handler) — guards against the
+    /// reconcile path accidentally evicting under the generic/legacy loader.
+    #[tokio::test]
+    async fn legacy_load_keeps_unknown_key_workflow() -> TestResult {
+        let tmp = tempfile::tempdir()?;
+        write_workflow(tmp.path(), UNKNOWN_KEY_YAML).await?;
+
+        let svc = service();
+        svc.register_repo_path("acme", PathBuf::from(tmp.path())).await;
+
+        let mut adp = adapter()?;
+        adp.load_repo("acme", &svc).await?; // legacy
+        assert!(
+            !adp.handlers.is_empty(),
+            "legacy load keeps the unknown-key workflow's handlers"
+        );
+        assert!(
+            svc.list_workflows().await?.iter().any(|i| i.id
+                == "acme:.github/workflows/gate.yml"),
+            "legacy load keeps the unknown-key workflow registered"
+        );
         Ok(())
     }
 }

--- a/crates/hyprstream-workers/src/workflow/gh_adapter.rs
+++ b/crates/hyprstream-workers/src/workflow/gh_adapter.rs
@@ -58,13 +58,35 @@ impl GitHubActionsAdapter {
 
     /// Scan a repository for `.github/workflows/*.yml`, parse each,
     /// register with WorkflowService, and build EventHandlers from triggers.
+    ///
+    /// Generic (non-gate) loader: parses in [`Legacy`](super::parser::ParseMode)
+    /// mode via [`WorkflowService::scan_repo`]. The merge gate opts into
+    /// strict mode via [`Self::load_repo_with`] (#1432).
     pub async fn load_repo(
         &mut self,
         repo_id: &str,
         service: &WorkflowService,
     ) -> Result<()> {
+        self.load_repo_with(repo_id, service, super::parser::ParseMode::Legacy).await
+    }
+
+    /// Load a repository's workflows with an explicit [`ParseMode`] (#1432).
+    ///
+    /// This is the **gate-specific boundary** for strict selection: a merge
+    /// gate calls `load_repo_with(repo, svc, ParseMode::Strict)` so that a
+    /// workflow file using unsupported semantics (`permissions:`,
+    /// `concurrency:`, `services:`) is refused rather than silently loaded
+    /// with dropped keys. In [`ParseMode::Legacy`] (the default for the
+    /// generic adapter) unknown keys are tolerated, preserving non-gate
+    /// caller compatibility (#1432 non-goal).
+    pub async fn load_repo_with(
+        &mut self,
+        repo_id: &str,
+        service: &WorkflowService,
+        mode: super::parser::ParseMode,
+    ) -> Result<()> {
         // Scan the repository for workflow files.
-        let workflow_defs = service.scan_repo(repo_id).await?;
+        let workflow_defs = service.scan_repo_with(repo_id, mode).await?;
 
         for def in workflow_defs {
             // Register the workflow definition.
@@ -80,6 +102,7 @@ impl GitHubActionsAdapter {
 
         tracing::info!(
             repo_id = %repo_id,
+            mode = ?mode,
             handler_count = self.handlers.len(),
             "Loaded repository workflows"
         );

--- a/crates/hyprstream-workers/src/workflow/gh_adapter.rs
+++ b/crates/hyprstream-workers/src/workflow/gh_adapter.rs
@@ -80,32 +80,22 @@ impl GitHubActionsAdapter {
     /// generic adapter) unknown keys are tolerated, preserving non-gate
     /// caller compatibility (#1432 non-goal).
     ///
-    /// The chosen mode is recorded per-repo on the service
-    /// ([`WorkflowService::set_repo_mode`]) so that push-triggered rescans
-    /// retain strict rather than silently dropping back to legacy. This load
-    /// also **reconciles**: stale service registrations and adapter handlers
-    /// for this repo that are absent from the fresh set are evicted/dropped,
-    /// so a deleted or strict-rejected workflow can no longer be dispatched
-    /// or triggered (fail-closed).
+    /// The chosen mode, scan, stale-registration eviction, and registration
+    /// are one service-level atomic transition. Only after that transition
+    /// completes are this adapter's handlers rebuilt. A stale handler can
+    /// therefore only resolve a surviving strict registration; a rejected
+    /// workflow already fails `dispatch` with `WorkflowNotFound`.
     pub async fn load_repo_with(
         &mut self,
         repo_id: &str,
         service: &WorkflowService,
         mode: super::parser::ParseMode,
     ) -> Result<()> {
-        // Record the mode so event-triggered rescans retain strict.
-        service.set_repo_mode(repo_id, mode).await;
-
-        // Scan the repository for workflow files in the chosen mode.
-        let workflow_defs = service.scan_repo_with(repo_id, mode).await?;
-
-        // Reconcile the service registry: evict any prior registration for
-        // this repo that did not survive the fresh scan.
-        let fresh_ids: std::collections::HashSet<WorkflowId> = workflow_defs
-            .iter()
-            .map(|def| format!("{}:{}", def.repo_id, def.path))
-            .collect();
-        service.evict_stale_for_repo(repo_id, &fresh_ids).await;
+        // Hold the service's per-repo lock from mode selection through
+        // scan/evict/register. Do not split this into `set_repo_mode` plus a
+        // scan: a pre-existing Legacy rescan could otherwise commit a
+        // dispatchable unsupported workflow in between.
+        let workflow_defs = service.rescan_repo_with_defs(repo_id, mode).await?;
 
         // Reconcile this adapter's handlers: drop handlers whose workflow
         // belongs to this repo, then rebuild from the fresh set. Without
@@ -116,8 +106,7 @@ impl GitHubActionsAdapter {
             .retain(|h| !h.workflow_id().starts_with(&repo_prefix));
 
         for def in workflow_defs {
-            // Register the workflow definition.
-            let workflow_id = service.register_workflow(def.clone()).await?;
+            let workflow_id = format!("{}:{}", def.repo_id, def.path);
 
             // Build handlers from triggers.
             for trigger in &def.triggers {

--- a/crates/hyprstream-workers/src/workflow/mod.rs
+++ b/crates/hyprstream-workers/src/workflow/mod.rs
@@ -35,7 +35,7 @@ pub mod adapter;
 pub mod gh_adapter;
 
 pub use service::WorkflowService;
-pub use parser::{Workflow, Job, JobResources, Step};
+pub use parser::{ParseMode, Workflow, Job, JobResources, Step};
 pub use triggers::{EventTrigger, EventHandler, HandlerResult};
 pub use subscription::WorkflowSubscription;
 pub use runner::WorkflowRunner;

--- a/crates/hyprstream-workers/src/workflow/parser.rs
+++ b/crates/hyprstream-workers/src/workflow/parser.rs
@@ -1,6 +1,46 @@
 //! GitHub Actions YAML workflow parser
 //!
 //! Parses `.github/workflows/*.yml` files into Workflow structs.
+//!
+//! ## Strict vs legacy mode (#1432)
+//!
+//! Two parse entry points exist:
+//!
+//! - [`Workflow::parse`] — **legacy / lenient** mode. Unknown YAML keys are
+//!   silently dropped (the historical behavior). This is the compatibility
+//!   path for non-gate callers and is unchanged by #1432.
+//! - [`Workflow::parse_strict`] — **strict / fail-closed** mode. Unknown
+//!   top-level, job-level, and step-level keys are rejected with
+//!   [`WorkerError::WorkflowParseError`](crate::error::WorkerError). This is
+//!   the mode the merge gate's workflow loader must use: a silently-ignored
+//!   `permissions:`, `concurrency:`, or `services:` would be a security gap.
+//!
+//! ### Explicitly supported subset (strict mode)
+//!
+//! Strict mode accepts *only* the keys this parser models:
+//!
+//! | Level    | Allowed keys |
+//! |----------|--------------|
+//! | workflow | `name`, `on`, `env`, `jobs` |
+//! | job      | `runs-on`, `needs`, `env`, `steps`, `if`, `timeout-minutes`, `resources` |
+//! | step     | `name`, `id`, `uses`, `run`, `shell`, `working-directory`, `with`, `env`, `if`, `continue-on-error` |
+//!
+//! `resources` is a hyprstream-specific extension (see [`JobResources`]),
+//! not a GHA key; it is permitted in strict mode so operator gate workflows
+//! may declare resource hints.
+//!
+//! ### Non-goals (#1432 Phase 2)
+//!
+//! Strict mode rejects **unknown structural keys** — it does **not** claim
+//! full GitHub Actions compatibility, and it deliberately does not implement
+//! `matrix`/`strategy`, `services`, `permissions`, `concurrency`, expression
+//! evaluation, environment scopes, or forge-specific checks. Those features
+//! remain Phase 2; until then they correctly fail closed in strict mode and
+//! are silently ignored in legacy mode.
+//!
+//! Free-form data maps (`env`, `with`, and trigger sub-keys like `branches`,
+//! `tags`, `paths`, `inputs`) are not key-checked — they carry arbitrary
+//! data, not parser-modeled schema.
 
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
@@ -191,19 +231,233 @@ pub struct Step {
     pub continue_on_error: bool,
 }
 
+/// Parse strictness.
+///
+/// The merge gate **must** parse operator-authored workflows in
+/// [`ParseMode::Strict`]: a silently-dropped `permissions:`, `concurrency:`,
+/// or `services:` key is a security gap (the workflow appears to parse cleanly
+/// while quietly losing semantics). Existing non-gate callers stay on
+/// [`ParseMode::Legacy`] until they explicitly opt in — see the non-goals of
+/// <https://github.com/hyprstream/hyprstream/issues/1432>.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ParseMode {
+    /// Legacy / lenient compatibility mode (the historical `Workflow::parse`
+    /// behavior). Unknown top-level, job-level, and step-level YAML keys are
+    /// silently ignored. Use only for callers that must tolerate arbitrary
+    /// upstream GitHub Actions YAML; do **not** use this for the merge gate.
+    Legacy,
+
+    /// Strict / fail-closed mode. Unknown keys at the top level, inside a job,
+    /// or inside a step are rejected with
+    /// [`WorkerError::WorkflowParseError`](crate::error::WorkerError). This is
+    /// the mode the gate's workflow loader uses by default.
+    ///
+    /// Note: this rejects *unknown structural keys* — it does **not** claim
+    /// full GitHub Actions compatibility. Unsupported-but-recognized GHA
+    /// features (`matrix`, `services`, `permissions`, `concurrency`,
+    /// expression evaluation, forge-specific checks) are deliberately out of
+    /// scope (#1432 Phase 2).
+    Strict,
+}
+
+/// Top-level workflow keys the parser knows about (wire names, post-`rename`).
+const KNOWN_WORKFLOW_KEYS: &[&str] = &["name", "on", "env", "jobs"];
+
+/// Job-level keys the parser knows about (wire names, post-`rename`).
+///
+/// `resources` is a hyprstream-specific extension, not a GHA key; it is
+/// included here so operator gate workflows that declare resource hints still
+/// parse in strict mode.
+const KNOWN_JOB_KEYS: &[&str] = &[
+    "runs-on",
+    "needs",
+    "env",
+    "steps",
+    "if",
+    "timeout-minutes",
+    "resources",
+];
+
+/// Step-level keys the parser knows about (wire names, post-`rename`).
+const KNOWN_STEP_KEYS: &[&str] = &[
+    "name",
+    "id",
+    "uses",
+    "run",
+    "shell",
+    "working-directory",
+    "with",
+    "env",
+    "if",
+    "continue-on-error",
+];
+
 impl Workflow {
-    /// Parse a workflow from YAML content
+    /// Parse a workflow from YAML content in **legacy** mode.
+    ///
+    /// This is the historical entry point: unknown keys are silently dropped.
+    /// Existing non-gate callers should keep using this until they explicitly
+    /// opt into strict mode. The merge gate should use [`Workflow::parse_strict`]
+    /// (or [`Workflow::parse_with`] with [`ParseMode::Strict`]).
     pub fn parse(yaml: &str) -> Result<Self> {
-        let workflow: Workflow = serde_yaml::from_str(yaml)
+        Self::parse_with(yaml, ParseMode::Legacy)
+    }
+
+    /// Parse a workflow from YAML content in **strict / fail-closed** mode.
+    ///
+    /// Rejects unknown top-level, job-level, and step-level keys. See
+    /// [`ParseMode::Strict`] for the exact contract and non-goals.
+    pub fn parse_strict(yaml: &str) -> Result<Self> {
+        Self::parse_with(yaml, ParseMode::Strict)
+    }
+
+    /// Parse a workflow with an explicit [`ParseMode`].
+    ///
+    /// In [`ParseMode::Strict`] the document is first validated against the
+    /// known-key sets at the top level, per-job, and per-step (the three
+    /// structural levels the parser models) before being handed to
+    /// `serde_yaml`. Validation runs on the raw [`serde_yaml::Value`] tree so
+    /// that an unknown key can never be silently absorbed by
+    /// `#[serde(default)]`.
+    pub fn parse_with(yaml: &str, mode: ParseMode) -> Result<Self> {
+        let value: serde_yaml::Value = serde_yaml::from_str(yaml)
+            .map_err(|e| crate::error::WorkerError::WorkflowParseError(e.to_string()))?;
+
+        if mode == ParseMode::Strict {
+            validate_known_keys(&value)?;
+        }
+
+        let workflow: Workflow = serde_yaml::from_value(value)
             .map_err(|e| crate::error::WorkerError::WorkflowParseError(e.to_string()))?;
         Ok(workflow)
     }
 
-    /// Parse a workflow from a file
+    /// Parse a workflow from a file in **legacy** mode.
     pub fn parse_file(path: &std::path::Path) -> Result<Self> {
         let content = std::fs::read_to_string(path)?;
         Self::parse(&content)
     }
+
+    /// Parse a workflow from a file with an explicit [`ParseMode`].
+    pub fn parse_file_with(path: &std::path::Path, mode: ParseMode) -> Result<Self> {
+        let content = std::fs::read_to_string(path)?;
+        Self::parse_with(&content, mode)
+    }
+}
+
+/// Reject unknown structural keys at the top level, per-job, and per-step.
+///
+/// `env`, `with`, and trigger sub-keys (`branches`, `tags`, `paths`,
+/// `inputs`, …) are free-form data maps, not schema levels, so they are not
+/// key-checked here.
+fn validate_known_keys(value: &serde_yaml::Value) -> Result<()> {
+    let mapping = value
+        .as_mapping()
+        .ok_or_else(|| crate::error::WorkerError::WorkflowParseError(
+            String::from("workflow root must be a mapping"),
+        ))?;
+
+    for (key, val) in mapping {
+        let key_str = match key.as_str() {
+            Some(s) => s,
+            None => {
+                return Err(crate::error::WorkerError::WorkflowParseError(format!(
+                    "top-level key is not a string: {key:?}"
+                )))
+            }
+        };
+
+        if !KNOWN_WORKFLOW_KEYS.contains(&key_str) {
+            return Err(crate::error::WorkerError::WorkflowParseError(format!(
+                "unknown top-level key `{key_str}` (strict mode: allowed keys are {})",
+                KNOWN_WORKFLOW_KEYS.join(", ")
+            )));
+        }
+
+        // Only `jobs` has a structural sub-level to recurse into;
+        // `on`, `env`, `name` are free-form / scalar.
+        if key_str == "jobs" {
+            validate_jobs(val)?;
+        }
+    }
+    Ok(())
+}
+
+/// Validate each job mapping and its steps.
+fn validate_jobs(jobs: &serde_yaml::Value) -> Result<()> {
+    let mapping = jobs
+        .as_mapping()
+        .ok_or_else(|| crate::error::WorkerError::WorkflowParseError(
+            String::from("`jobs` must be a mapping of job-id → job"),
+        ))?;
+
+    for (job_id, job) in mapping {
+        let job_id_str = job_id.as_str().unwrap_or("<non-string job id>");
+        let job_map = job.as_mapping().ok_or_else(|| {
+            crate::error::WorkerError::WorkflowParseError(format!(
+                "job `{job_id_str}` must be a mapping"
+            ))
+        })?;
+
+        for (key, val) in job_map {
+            let key_str = match key.as_str() {
+                Some(s) => s,
+                None => {
+                    return Err(crate::error::WorkerError::WorkflowParseError(format!(
+                        "job `{job_id_str}` has a non-string key: {key:?}"
+                    )))
+                }
+            };
+
+            if !KNOWN_JOB_KEYS.contains(&key_str) {
+                return Err(crate::error::WorkerError::WorkflowParseError(format!(
+                    "unknown key `{key_str}` in job `{job_id_str}` (strict mode: allowed keys are {})",
+                    KNOWN_JOB_KEYS.join(", ")
+                )));
+            }
+
+            if key_str == "steps" {
+                validate_steps(job_id_str, val)?;
+            }
+        }
+    }
+    Ok(())
+}
+
+/// Validate each step in a job's `steps` sequence.
+fn validate_steps(job_id: &str, steps: &serde_yaml::Value) -> Result<()> {
+    let seq = steps.as_sequence().ok_or_else(|| {
+        crate::error::WorkerError::WorkflowParseError(format!(
+            "`steps` in job `{job_id}` must be a sequence"
+        ))
+    })?;
+
+    for (idx, step) in seq.iter().enumerate() {
+        let step_map = step.as_mapping().ok_or_else(|| {
+            crate::error::WorkerError::WorkflowParseError(format!(
+                "step[{idx}] in job `{job_id}` must be a mapping"
+            ))
+        })?;
+
+        for key in step_map.keys() {
+            let key_str = match key.as_str() {
+                Some(s) => s,
+                None => {
+                    return Err(crate::error::WorkerError::WorkflowParseError(format!(
+                        "step[{idx}] in job `{job_id}` has a non-string key: {key:?}"
+                    )))
+                }
+            };
+
+            if !KNOWN_STEP_KEYS.contains(&key_str) {
+                return Err(crate::error::WorkerError::WorkflowParseError(format!(
+                    "unknown key `{key_str}` in step[{idx}] of job `{job_id}` (strict mode: allowed keys are {})",
+                    KNOWN_STEP_KEYS.join(", ")
+                )));
+            }
+        }
+    }
+    Ok(())
 }
 
 #[cfg(test)]
@@ -257,5 +511,277 @@ jobs:
         let workflow = Workflow::parse(yaml)?;
         assert_eq!(workflow.name, "Complex Workflow");
         Ok(())
+    }
+
+    // ─── strict-mode acceptance: the known subset parses cleanly ───────────
+
+    fn minimal_gate_yaml() -> &'static str {
+        // The operator-authored gate workflow subset: only keys the parser
+        // models. Must parse without error in strict mode.
+        r#"
+name: Gate
+on:
+  pull_request:
+    branches:
+      - main
+env:
+  RUST_BACKTRACE: "1"
+jobs:
+  gate:
+    runs-on: ubuntu-latest
+    needs: []
+    if: ${{ github.event.pull_request.draft == false }}
+    timeout-minutes: 30
+    env:
+      CARGO_TERM_COLOR: always
+    steps:
+      - name: Checkout
+        id: checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: "0"
+        env:
+          GHA: "true"
+        if: ${{ true }}
+        continue-on-error: false
+        working-directory: .
+        shell: bash
+      - name: Build
+        run: cargo build
+"#
+    }
+
+    #[test]
+    fn test_strict_accepts_known_subset() -> Result<()> {
+        let workflow = Workflow::parse_strict(minimal_gate_yaml())?;
+        assert_eq!(workflow.name, "Gate");
+        assert!(workflow.jobs.contains_key("gate"));
+        // Legacy mode agrees.
+        let legacy = Workflow::parse(minimal_gate_yaml())?;
+        assert_eq!(legacy.jobs.len(), workflow.jobs.len());
+        Ok(())
+    }
+
+    #[test]
+    fn test_strict_accepts_resource_hints_extension() -> Result<()> {
+        // `resources:` is a hyprstream extension; must be permitted in strict.
+        let yaml = r#"
+name: GPU
+on: push
+jobs:
+  train:
+    runs-on: hyprstream-gpu
+    resources:
+      cpu_millis: 4000
+      memory_bytes: 8589934592
+      gpu: 1
+    steps:
+      - run: python train.py
+"#;
+        let workflow = Workflow::parse_strict(yaml)?;
+        assert_eq!(workflow.jobs["train"].resources.gpu, 1);
+        Ok(())
+    }
+
+    #[test]
+    fn test_parse_with_legacy_mode_matches_parse() -> Result<()> {
+        let a = Workflow::parse(minimal_gate_yaml())?;
+        let b = Workflow::parse_with(minimal_gate_yaml(), ParseMode::Legacy)?;
+        assert_eq!(a.name, b.name);
+        assert_eq!(a.jobs.len(), b.jobs.len());
+        Ok(())
+    }
+
+    // ─── strict-mode rejections: unknown keys at each structural level ─────
+
+    fn assert_strict_rejects(yaml: &str, needle: &str) {
+        match Workflow::parse_strict(yaml) {
+            Err(crate::error::WorkerError::WorkflowParseError(msg)) => {
+                assert!(
+                    msg.contains(needle),
+                    "expected strict error to mention `{needle}`, got: {msg}"
+                );
+            }
+            other => panic!("strict mode should reject, got: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_strict_rejects_unknown_top_level_services() {
+        let yaml = r#"
+name: T
+on: push
+services:
+  db:
+    image: postgres
+jobs:
+  b:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo hi
+"#;
+        assert_strict_rejects(yaml, "unknown top-level key `services`");
+    }
+
+    #[test]
+    fn test_strict_rejects_unknown_top_level_permissions() {
+        let yaml = r#"
+name: T
+on: push
+permissions:
+  contents: read
+jobs:
+  b:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo hi
+"#;
+        assert_strict_rejects(yaml, "unknown top-level key `permissions`");
+    }
+
+    #[test]
+    fn test_strict_rejects_unknown_top_level_concurrency() {
+        let yaml = r#"
+name: T
+on: push
+concurrency:
+  group: deploy
+jobs:
+  b:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo hi
+"#;
+        assert_strict_rejects(yaml, "unknown top-level key `concurrency`");
+    }
+
+    #[test]
+    fn test_strict_rejects_unknown_job_level_matrix() {
+        let yaml = r#"
+name: T
+on: push
+jobs:
+  b:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        os: [ubuntu, macos]
+    steps:
+      - run: echo hi
+"#;
+        assert_strict_rejects(yaml, "unknown key `strategy` in job `b`");
+    }
+
+    #[test]
+    fn test_strict_rejects_unknown_job_level_services() {
+        let yaml = r#"
+name: T
+on: push
+jobs:
+  b:
+    runs-on: ubuntu-latest
+    services:
+      db:
+        image: postgres
+    steps:
+      - run: echo hi
+"#;
+        assert_strict_rejects(yaml, "unknown key `services` in job `b`");
+    }
+
+    #[test]
+    fn test_strict_rejects_unknown_step_level_key() {
+        let yaml = r#"
+name: T
+on: push
+jobs:
+  b:
+    runs-on: ubuntu-latest
+    steps:
+      - name: x
+        run: echo hi
+        timeout-minutes: 5
+"#;
+        // `timeout-minutes` is a known *job* key, not a known step key here.
+        assert_strict_rejects(yaml, "unknown key `timeout-minutes` in step[0]");
+    }
+
+    #[test]
+    fn test_strict_rejects_unknown_step_level_tty() {
+        let yaml = r#"
+name: T
+on: push
+jobs:
+  b:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo hi
+        with:
+          key: value
+"#;
+        // `with` IS a known step key — this should actually be accepted.
+        // Sanity: ensure we don't over-reject known step keys.
+        match Workflow::parse_strict(yaml) {
+            Ok(w) => assert_eq!(w.name, "T"),
+            Err(e) => panic!("strict mode must accept `with` step key: {e}"),
+        }
+    }
+
+    // ─── legacy mode still silently tolerates the same inputs ──────────────
+
+    #[test]
+    fn test_legacy_silently_drops_unknown_top_level() -> Result<()> {
+        let yaml = r#"
+name: T
+on: push
+permissions:
+  contents: read
+jobs:
+  b:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo hi
+"#;
+        // Legacy mode must NOT reject — that is its defined contract.
+        let workflow = Workflow::parse(yaml)?;
+        assert_eq!(workflow.name, "T");
+        Ok(())
+    }
+
+    #[test]
+    fn test_legacy_silently_drops_unknown_job_and_step_keys() -> Result<()> {
+        let yaml = r#"
+name: T
+on: push
+jobs:
+  b:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+    steps:
+      - run: echo hi
+        bogus-key: oops
+"#;
+        let workflow = Workflow::parse(yaml)?;
+        assert!(workflow.jobs.contains_key("b"));
+        Ok(())
+    }
+
+    // ─── structural-error edge cases ───────────────────────────────────────
+
+    #[test]
+    fn test_strict_rejects_non_mapping_root() {
+        assert_strict_rejects("not a mapping", "workflow root must be a mapping");
+    }
+
+    #[test]
+    fn test_strict_rejects_non_mapping_job() {
+        let yaml = r#"
+name: T
+on: push
+jobs:
+  b: not-a-mapping
+"#;
+        assert_strict_rejects(yaml, "job `b` must be a mapping");
     }
 }

--- a/crates/hyprstream-workers/src/workflow/service.rs
+++ b/crates/hyprstream-workers/src/workflow/service.rs
@@ -383,6 +383,13 @@ impl WorkflowService {
     /// Uses the path registered via `register_repo_path`. Returns an empty
     /// Vec (not an error) if no path is registered for the repo or if the
     /// workflows directory does not exist.
+    ///
+    /// Workflows are parsed in **strict / fail-closed** mode
+    /// ([`Workflow::parse_strict`]): a file with an unknown structural key
+    /// (e.g. `permissions:`, `concurrency:`, `services:`) is **skipped** with
+    /// a warn-log rather than silently loaded with dropped semantics. This is
+    /// the merge-gate loader path (#1432) — failing closed here means the
+    /// gate never executes a workflow it does not fully understand.
     pub(crate) async fn scan_repo(&self, repo_id: &str) -> Result<Vec<WorkflowDef>> {
         tracing::info!(repo_id = %repo_id, "Scanning repository for workflows");
 
@@ -435,10 +442,10 @@ impl WorkflowService {
                     }
                 };
 
-                let workflow = match Workflow::parse(&yaml) {
+                let workflow = match Workflow::parse_strict(&yaml) {
                     Ok(w) => w,
                     Err(e) => {
-                        tracing::warn!(path = %path.display(), error = %e, "Failed to parse workflow");
+                        tracing::warn!(path = %path.display(), error = %e, "Failed to parse workflow (strict mode); skipping");
                         continue;
                     }
                 };
@@ -744,7 +751,11 @@ impl WorkflowHandler for WorkflowService {
                 jobs: HashMap::new(),
             }
         } else {
-            Workflow::parse(&data.yaml)?
+            // Gate loader path: strict mode rejects unknown structural keys
+            // so a workflow using unsupported semantics (e.g. `permissions:`,
+            // `concurrency:`) is refused rather than silently registered with
+            // dropped semantics (#1432).
+            Workflow::parse_strict(&data.yaml)?
         };
         let triggers = extract_triggers(&workflow);
         let workflow_def = WorkflowDef {

--- a/crates/hyprstream-workers/src/workflow/service.rs
+++ b/crates/hyprstream-workers/src/workflow/service.rs
@@ -681,48 +681,61 @@ impl WorkflowService {
             .collect())
     }
 
-    /// Rescan a repository for workflow changes.
+    /// Rescan a repository for workflow changes (generic, non-persisting).
     ///
-    /// Retains the per-repo parse mode: a repo loaded in strict mode (via
-    /// `set_repo_mode` / `load_repo_with`) is rescanned in strict mode; a
-    /// repo that never opted in defaults to [`ParseMode::Legacy`]. This is
-    /// the generic entry point used by the event-triggered rescan path
-    /// (`HandlerResult::Rescan`) and `initialize`, so a gate's strict choice
-    /// survives push-triggered rescans rather than silently dropping back to
-    /// legacy (#1432 P1).
+    /// Resolves the per-repo parse mode and rescans in that mode, but does
+    /// **not** write the mode back to the store. This is the entry point used
+    /// by the event-triggered rescan path (`HandlerResult::Rescan`) and
+    /// `initialize`. Because it never persists, a concurrent generic rescan
+    /// that read a stale [`ParseMode::Legacy`] before a gate selected strict
+    /// cannot overwrite the newer strict selection (#1432 race fix): only the
+    /// explicit boundaries ([`Self::rescan_repo_with`], `load_repo_with`)
+    /// write the mode.
     pub async fn rescan_repo(&self, repo_id: &str) -> Result<()> {
         let mode = self.repo_mode(repo_id).await;
-        self.rescan_repo_with(repo_id, mode).await
+        self.rescan_inner(repo_id, mode).await
     }
 
-    /// Rescan a repository with an explicit [`ParseMode`] (#1432).
+    /// Rescan a repository with an explicit [`ParseMode`] (#1432 boundary).
     ///
-    /// The mode is **persisted** per-repo (via [`Self::set_repo_mode`]) so
-    /// that later event-triggered rescans through the generic
-    /// [`Self::rescan_repo`] retain it rather than silently dropping back to
-    /// legacy — regardless of whether strict was first selected via
-    /// `load_repo_with` or directly here.
+    /// **Persists** the mode per-repo (via [`Self::set_repo_mode`]) so that
+    /// later event-triggered rescans through the generic [`Self::rescan_repo`]
+    /// retain it. This is the explicit selection point: a gate calls this
+    /// (or `load_repo_with`) to opt into strict. The generic `rescan_repo`
+    /// does **not** persist, so it cannot clobber this selection.
     ///
-    /// **Fail-closed stale eviction:** a workflow that was previously
-    /// registered for this repo but is *absent* from the fresh scan set —
-    /// because it was rejected by strict mode, deleted, or otherwise failed
-    /// to parse — is **evicted** from the registry (via
-    /// [`Self::evict_stale_for_repo`]). Once evicted, [`Self::dispatch`]
-    /// returns
+    /// **Fail-closed stale eviction:** a workflow previously registered for
+    /// this repo but absent from the fresh scan set — because it was rejected
+    /// by strict mode, deleted, or otherwise failed to parse — is **evicted**
+    /// from the registry (via [`Self::evict_stale_for_repo`]). Once evicted,
+    /// [`Self::dispatch`] returns
     /// [`WorkflowNotFound`](crate::error::WorkerError::WorkflowNotFound) for
-    /// that id, so any lingering adapter handler built against the old
-    /// version can no longer dispatch it.
+    /// that id, so any lingering adapter handler built against the old version
+    /// can no longer dispatch it.
     pub async fn rescan_repo_with(
         &self,
         repo_id: &str,
         mode: super::parser::ParseMode,
     ) -> Result<()> {
-        // Persist the mode so the generic rescan path retains it (#1432):
-        // a caller that enters strict via rescan_repo_with directly (rather
-        // than load_repo_with) must still have its choice survive later
-        // event-triggered rescan_repo(repo) calls.
+        // Explicit selection: persist so the generic rescan path retains it.
+        // Only this boundary (and load_repo_with) writes the mode — the
+        // generic rescan_repo deliberately does not, to avoid a stale Legacy
+        // read overwriting a newer explicit Strict selection (#1432).
         self.set_repo_mode(repo_id, mode).await;
+        self.rescan_inner(repo_id, mode).await
+    }
 
+    /// Internal scan+evict+register worker (no mode persistence).
+    ///
+    /// Shared by [`Self::rescan_repo`] (generic, non-persisting) and
+    /// [`Self::rescan_repo_with`] (explicit, persisting). Keeping the mode
+    /// write out of this inner worker is what prevents a concurrent generic
+    /// Legacy rescan from overwriting a newer explicit Strict selection.
+    async fn rescan_inner(
+        &self,
+        repo_id: &str,
+        mode: super::parser::ParseMode,
+    ) -> Result<()> {
         let workflows = self.scan_repo_with(repo_id, mode).await?;
 
         // Fresh set of workflow ids for this repo, per the scan.
@@ -1351,6 +1364,92 @@ jobs:
             "rescan_repo_with(Strict) must persist the mode: a later generic \
              rescan_repo must stay strict and skip+evict the unknown-key workflow, \
              not silently fall back to legacy"
+        );
+        Ok(())
+    }
+
+    // ─── Rev 6 P1: generic rescan must NOT overwrite an explicit selection ──
+
+    #[tokio::test]
+    async fn generic_rescan_does_not_overwrite_explicit_strict_selection() -> TestResult {
+        // The generic rescan_repo(repo) resolves the stored mode and rescans
+        // in it but must NOT persist — otherwise a generic rescan that read a
+        // stale Legacy could clobber a newer explicit Strict selection.
+        // Enter strict explicitly, then run a generic rescan, then verify the
+        // mode is still strict behaviorally (a later generic rescan after an
+        // unknown-key mutation skips+evicts).
+        let tmp = tempfile::tempdir()?;
+        write_workflow(tmp.path(), KNOWN_YAML).await?;
+
+        let svc = test_service();
+        svc.register_repo_path("acme", PathBuf::from(tmp.path())).await;
+
+        // Explicit strict selection.
+        svc.rescan_repo_with("acme", super::super::parser::ParseMode::Strict)
+            .await?;
+        let wf_id = String::from("acme:.github/workflows/gate.yml");
+        assert!(workflow_ids(&svc.list_workflows().await?).contains(&wf_id));
+
+        // A generic rescan in between must not downgrade the stored mode.
+        svc.rescan_repo("acme").await?;
+        assert!(workflow_ids(&svc.list_workflows().await?).contains(&wf_id));
+
+        // Now mutate to add an unknown key. A generic rescan must STILL be
+        // strict (the intermediate generic rescan did not overwrite it).
+        write_workflow(tmp.path(), UNKNOWN_KEY_YAML).await?;
+        svc.rescan_repo("acme").await?;
+        assert!(
+            !workflow_ids(&svc.list_workflows().await?).contains(&wf_id),
+            "generic rescan must not overwrite the explicit strict selection: \
+             the intermediate rescan_repo(repo) should have left the stored \
+             mode as Strict"
+        );
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn concurrent_generic_rescans_cannot_clobber_explicit_strict() -> TestResult {
+        use std::sync::Arc;
+        // Race invariant: regardless of how generic rescans interleave with
+        // an explicit strict selection, the final stored mode must be Strict
+        // (because only rescan_repo_with / load_repo_with persist; the generic
+        // rescan_repo never writes). Asserted behaviorally: after the batch,
+        // a generic rescan of an unknown-key workflow skips+evicts it.
+        let tmp = tempfile::tempdir()?;
+        write_workflow(tmp.path(), KNOWN_YAML).await?;
+        let root = tmp.path().to_owned();
+
+        let svc = Arc::new(test_service());
+        svc.register_repo_path("acme", PathBuf::from(&root)).await;
+
+        // Run an explicit strict selection concurrently with several generic
+        // rescans. The explicit one is the only writer.
+        let mut handles = Vec::new();
+        handles.push({
+            let svc = Arc::clone(&svc);
+            tokio::spawn(async move {
+                svc.rescan_repo_with("acme", super::super::parser::ParseMode::Strict).await
+            })
+        });
+        for _ in 0..4 {
+            let svc = Arc::clone(&svc);
+            handles.push(tokio::spawn(async move { svc.rescan_repo("acme").await }));
+        }
+        for h in handles {
+            h.await.map_err(|e| format!("join error: {e}"))??;
+        }
+
+        // Mutate to add an unknown key; a generic rescan must be strict.
+        write_workflow(&root, UNKNOWN_KEY_YAML).await?;
+        svc.rescan_repo("acme").await?;
+
+        let wf_id = String::from("acme:.github/workflows/gate.yml");
+        let listed = svc.list_workflows().await?;
+        assert!(
+            !workflow_ids(&listed).contains(&wf_id),
+            "after concurrent generic rescans interleaved with one explicit \
+             strict selection, the stored mode must remain Strict — the \
+             generic rescans must not have overwritten it"
         );
         Ok(())
     }

--- a/crates/hyprstream-workers/src/workflow/service.rs
+++ b/crates/hyprstream-workers/src/workflow/service.rs
@@ -99,6 +99,12 @@ pub struct WorkflowService {
     /// Registered repo paths (repo_id → filesystem root)
     repo_paths: RwLock<HashMap<String, PathBuf>>,
 
+    /// Per-repo parse mode (#1432): a gate that loads a repo in strict mode
+    /// records it here so that later rescans (event-triggered or manual)
+    /// retain strict rather than silently dropping back to legacy.
+    /// Default for an unregistered repo is [`ParseMode::Legacy`].
+    repo_modes: RwLock<HashMap<String, super::parser::ParseMode>>,
+
     /// Active subscriptions (sub_id → WorkflowSubscription)
     subscriptions: RwLock<HashMap<String, WorkflowSubscription>>,
 
@@ -154,6 +160,7 @@ impl WorkflowService {
             runs: Arc::new(RwLock::new(HashMap::new())),
             repo_workflows: RwLock::new(HashMap::new()),
             repo_paths: RwLock::new(HashMap::new()),
+            repo_modes: RwLock::new(HashMap::new()),
             subscriptions: RwLock::new(HashMap::new()),
             handlers: RwLock::new(Vec::new()),
             event_loop_handle: tokio::sync::Mutex::new(None),
@@ -174,6 +181,52 @@ impl WorkflowService {
     pub async fn register_repo_path(&self, repo_id: impl Into<String>, path: PathBuf) {
         let mut repo_paths = self.repo_paths.write().await;
         repo_paths.insert(repo_id.into(), path);
+    }
+
+    /// Set the per-repo parse mode (#1432).
+    ///
+    /// A gate that loads a repo in strict mode records it here so that later
+    /// rescans retain strict (the default for an unregistered repo is
+    /// [`ParseMode::Legacy`]). Typically called by
+    /// [`GitHubActionsAdapter::load_repo_with`](super::gh_adapter::GitHubActionsAdapter::load_repo_with).
+    pub async fn set_repo_mode(&self, repo_id: &str, mode: super::parser::ParseMode) {
+        let mut repo_modes = self.repo_modes.write().await;
+        repo_modes.insert(repo_id.to_owned(), mode);
+    }
+
+    /// Resolve the per-repo parse mode, defaulting to [`ParseMode::Legacy`]
+    /// for repos that never opted into strict.
+    async fn repo_mode(&self, repo_id: &str) -> super::parser::ParseMode {
+        self.repo_modes
+            .read()
+            .await
+            .get(repo_id)
+            .copied()
+            .unwrap_or(super::parser::ParseMode::Legacy)
+    }
+
+    /// Evict stale registrations for a repo (#1432 fail-closed).
+    ///
+    /// Removes any `repo_id:*` registry entry absent from `fresh_ids`, so a
+    /// workflow that was rejected by strict mode, deleted, or otherwise no
+    /// longer present in the fresh scan becomes undispatchable
+    /// (`dispatch` → [`WorkflowNotFound`](crate::error::WorkerError::WorkflowNotFound)).
+    pub(crate) async fn evict_stale_for_repo(
+        &self,
+        repo_id: &str,
+        fresh_ids: &HashSet<WorkflowId>,
+    ) {
+        let stale_prefix = format!("{repo_id}:");
+        let mut workflows_lock = self.workflows.write().await;
+        let stale_keys: Vec<WorkflowId> = workflows_lock
+            .keys()
+            .filter(|id| id.starts_with(&stale_prefix) && !fresh_ids.contains(*id))
+            .cloned()
+            .collect();
+        for key in &stale_keys {
+            tracing::info!(workflow_id = %key, "Evicting stale workflow registration");
+            workflows_lock.remove(key);
+        }
     }
 
     /// Set the VFS namespace for workflow execution.
@@ -628,13 +681,18 @@ impl WorkflowService {
             .collect())
     }
 
-    /// Rescan a repository for workflow changes (legacy mode).
+    /// Rescan a repository for workflow changes.
     ///
-    /// Generic entry point — delegates to [`Self::rescan_repo_with`] with
-    /// [`ParseMode::Legacy`]. The merge gate uses
-    /// [`Self::rescan_repo_with`] with [`ParseMode::Strict`].
+    /// Retains the per-repo parse mode: a repo loaded in strict mode (via
+    /// `set_repo_mode` / `load_repo_with`) is rescanned in strict mode; a
+    /// repo that never opted in defaults to [`ParseMode::Legacy`]. This is
+    /// the generic entry point used by the event-triggered rescan path
+    /// (`HandlerResult::Rescan`) and `initialize`, so a gate's strict choice
+    /// survives push-triggered rescans rather than silently dropping back to
+    /// legacy (#1432 P1).
     pub async fn rescan_repo(&self, repo_id: &str) -> Result<()> {
-        self.rescan_repo_with(repo_id, super::parser::ParseMode::Legacy).await
+        let mode = self.repo_mode(repo_id).await;
+        self.rescan_repo_with(repo_id, mode).await
     }
 
     /// Rescan a repository with an explicit [`ParseMode`] (#1432).
@@ -642,13 +700,12 @@ impl WorkflowService {
     /// **Fail-closed stale eviction:** a workflow that was previously
     /// registered for this repo but is *absent* from the fresh scan set —
     /// because it was rejected by strict mode, deleted, or otherwise failed
-    /// to parse — is **evicted** from the registry. This is the fix for the
-    /// stale-handler gap: once evicted, [`Self::dispatch`] returns
+    /// to parse — is **evicted** from the registry (via
+    /// [`Self::evict_stale_for_repo`]). Once evicted, [`Self::dispatch`]
+    /// returns
     /// [`WorkflowNotFound`](crate::error::WorkerError::WorkflowNotFound) for
     /// that id, so any lingering adapter handler built against the old
-    /// version can no longer dispatch it. Without eviction, a strict-rejected
-    /// workflow would keep its prior registration live and continue
-    /// dispatching.
+    /// version can no longer dispatch it.
     pub async fn rescan_repo_with(
         &self,
         repo_id: &str,
@@ -662,21 +719,8 @@ impl WorkflowService {
             .map(|wf| format!("{}:{}", wf.repo_id, wf.path))
             .collect();
 
-        // Evict stale registrations: any registry entry belonging to this
-        // repo that did not survive the fresh scan is removed so it can no
-        // longer be dispatched (fail-closed).
-        let stale_prefix = format!("{repo_id}:");
-        let mut workflows_lock = self.workflows.write().await;
-        let stale_keys: Vec<WorkflowId> = workflows_lock
-            .keys()
-            .filter(|id| id.starts_with(&stale_prefix) && !fresh_ids.contains(*id))
-            .cloned()
-            .collect();
-        for key in &stale_keys {
-            tracing::info!(workflow_id = %key, "Evicting stale workflow registration on rescan");
-            workflows_lock.remove(key);
-        }
-        drop(workflows_lock);
+        // Evict stale registrations absent from the fresh set (fail-closed).
+        self.evict_stale_for_repo(repo_id, &fresh_ids).await;
 
         // Register the fresh set and rebuild subscriptions.
         let mut repo_workflows = self.repo_workflows.write().await;
@@ -693,7 +737,7 @@ impl WorkflowService {
 
         repo_workflows.insert(repo_id.to_owned(), subscriptions);
 
-        tracing::info!(repo_id = %repo_id, mode = ?mode, evicted = stale_keys.len(), "Rescanned repository");
+        tracing::info!(repo_id = %repo_id, mode = ?mode, "Rescanned repository");
         Ok(())
     }
 
@@ -1205,6 +1249,61 @@ jobs:
         assert!(
             workflow_ids(&listed).contains(&wf_id),
             "legacy rescan must keep the unknown-key workflow registered"
+        );
+        Ok(())
+    }
+
+    // ─── Rev 4 P1-A: strict mode retained across the generic rescan path ────
+
+    #[tokio::test]
+    async fn strict_mode_retained_across_legacy_signature_rescan() -> TestResult {
+        // The event-triggered rescan calls the generic `rescan_repo(repo)`
+        // (no mode arg). Once a gate has loaded the repo in strict mode
+        // (recorded via set_repo_mode), that rescan must RETAIN strict —
+        // otherwise a push that mutates the workflow to add an unknown key
+        // would silently reload it in legacy mode (the bypass).
+        let tmp = tempfile::tempdir()?;
+        write_workflow(tmp.path(), KNOWN_YAML).await?;
+
+        let svc = test_service();
+        svc.register_repo_path("acme", PathBuf::from(tmp.path())).await;
+        // Gate loads in strict mode → records the mode per-repo.
+        svc.set_repo_mode("acme", super::super::parser::ParseMode::Strict).await;
+        svc.rescan_repo("acme").await?; // registers the known workflow
+
+        let wf_id = String::from("acme:.github/workflows/gate.yml");
+        assert!(workflow_ids(&svc.list_workflows().await?).contains(&wf_id));
+
+        // Mutate to add an unknown key, then trigger the GENERIC rescan path
+        // (the one HandlerResult::Rescan / initialize use — no mode arg).
+        write_workflow(tmp.path(), UNKNOWN_KEY_YAML).await?;
+        svc.rescan_repo("acme").await?; // must still be strict → skip + evict
+
+        assert!(
+            !workflow_ids(&svc.list_workflows().await?).contains(&wf_id),
+            "strict mode must be retained across the generic rescan path; \
+             a now-unknown-key workflow must be skipped and evicted, not \
+             silently reloaded in legacy mode"
+        );
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn strict_mode_default_is_legacy_for_unregistered_repo() -> TestResult {
+        // A repo that never opted into strict must rescan in legacy mode —
+        // guards against the mode store accidentally defaulting to strict.
+        let tmp = tempfile::tempdir()?;
+        write_workflow(tmp.path(), UNKNOWN_KEY_YAML).await?;
+
+        let svc = test_service();
+        svc.register_repo_path("acme", PathBuf::from(tmp.path())).await;
+        // No set_repo_mode call → default Legacy.
+        svc.rescan_repo("acme").await?;
+
+        let wf_id = String::from("acme:.github/workflows/gate.yml");
+        assert!(
+            workflow_ids(&svc.list_workflows().await?).contains(&wf_id),
+            "unregistered repo must default to legacy and keep the unknown-key workflow"
         );
         Ok(())
     }

--- a/crates/hyprstream-workers/src/workflow/service.rs
+++ b/crates/hyprstream-workers/src/workflow/service.rs
@@ -105,6 +105,12 @@ pub struct WorkflowService {
     /// Default for an unregistered repo is [`ParseMode::Legacy`].
     repo_modes: RwLock<HashMap<String, super::parser::ParseMode>>,
 
+    /// Per-repo serialization locks (#1432 race fix): held from mode decision
+    /// through registry commit so that a Legacy scan cannot yield between its
+    /// mode check and commit while a Strict selection lands in between.
+    /// Acquired by `rescan_repo`, `rescan_repo_with`, and `set_repo_mode`.
+    repo_locks: RwLock<HashMap<String, Arc<tokio::sync::Mutex<()>>>>,
+
     /// Active subscriptions (sub_id → WorkflowSubscription)
     subscriptions: RwLock<HashMap<String, WorkflowSubscription>>,
 
@@ -161,6 +167,7 @@ impl WorkflowService {
             repo_workflows: RwLock::new(HashMap::new()),
             repo_paths: RwLock::new(HashMap::new()),
             repo_modes: RwLock::new(HashMap::new()),
+            repo_locks: RwLock::new(HashMap::new()),
             subscriptions: RwLock::new(HashMap::new()),
             handlers: RwLock::new(Vec::new()),
             event_loop_handle: tokio::sync::Mutex::new(None),
@@ -183,13 +190,40 @@ impl WorkflowService {
         repo_paths.insert(repo_id.into(), path);
     }
 
+    /// Get-or-create the per-repo serialization lock (#1432 race fix).
+    async fn repo_lock(&self, repo_id: &str) -> Arc<tokio::sync::Mutex<()>> {
+        {
+            let read = self.repo_locks.read().await;
+            if let Some(lock) = read.get(repo_id) {
+                return Arc::clone(lock);
+            }
+        }
+        let mut write = self.repo_locks.write().await;
+        write
+            .entry(repo_id.to_owned())
+            .or_insert_with(|| Arc::new(tokio::sync::Mutex::new(())))
+            .clone()
+    }
+
     /// Set the per-repo parse mode (#1432).
     ///
-    /// A gate that loads a repo in strict mode records it here so that later
-    /// rescans retain strict (the default for an unregistered repo is
-    /// [`ParseMode::Legacy`]). Typically called by
+    /// Acquires the per-repo serialization lock so that mode changes are
+    /// atomic with concurrent rescans. A gate that loads a repo in strict
+    /// mode records it here so that later rescans retain strict (the default
+    /// for an unregistered repo is [`ParseMode::Legacy`]). Typically called
+    /// by
     /// [`GitHubActionsAdapter::load_repo_with`](super::gh_adapter::GitHubActionsAdapter::load_repo_with).
     pub async fn set_repo_mode(&self, repo_id: &str, mode: super::parser::ParseMode) {
+        let lock = self.repo_lock(repo_id).await;
+        let _guard = lock.lock().await;
+        self.set_repo_mode_locked(repo_id, mode).await;
+    }
+
+    /// Write the mode without acquiring the per-repo lock.
+    ///
+    /// Caller MUST already hold the per-repo lock (e.g. inside
+    /// `rescan_repo_with`). This avoids reentrant-deadlock.
+    async fn set_repo_mode_locked(&self, repo_id: &str, mode: super::parser::ParseMode) {
         let mut repo_modes = self.repo_modes.write().await;
         repo_modes.insert(repo_id.to_owned(), mode);
     }
@@ -692,70 +726,44 @@ impl WorkflowService {
     /// explicit boundaries ([`Self::rescan_repo_with`], `load_repo_with`)
     /// write the mode.
     pub async fn rescan_repo(&self, repo_id: &str) -> Result<()> {
+        let lock = self.repo_lock(repo_id).await;
+        let _guard = lock.lock().await;
         let mode = self.repo_mode(repo_id).await;
-        self.rescan_inner(repo_id, mode).await
+        self.rescan_inner_locked(repo_id, mode).await
     }
 
     /// Rescan a repository with an explicit [`ParseMode`] (#1432 boundary).
     ///
     /// **Persists** the mode per-repo (via [`Self::set_repo_mode`]) so that
     /// later event-triggered rescans through the generic [`Self::rescan_repo`]
-    /// retain it. This is the explicit selection point: a gate calls this
-    /// (or `load_repo_with`) to opt into strict. The generic `rescan_repo`
-    /// does **not** persist, so it cannot clobber this selection.
-    ///
-    /// **Fail-closed stale eviction:** a workflow previously registered for
-    /// this repo but absent from the fresh scan set — because it was rejected
-    /// by strict mode, deleted, or otherwise failed to parse — is **evicted**
-    /// from the registry (via [`Self::evict_stale_for_repo`]). Once evicted,
-    /// [`Self::dispatch`] returns
-    /// [`WorkflowNotFound`](crate::error::WorkerError::WorkflowNotFound) for
-    /// that id, so any lingering adapter handler built against the old version
-    /// can no longer dispatch it.
+    /// retain it. Both `rescan_repo` and this method hold the per-repo
+    /// serialization lock from mode decision through registry commit, making
+    /// the scan→commit window atomic per repo (#1432 race fix: a stale Legacy
+    /// scan cannot yield between its mode check and commit while a Strict
+    /// selection lands in between).
     pub async fn rescan_repo_with(
         &self,
         repo_id: &str,
         mode: super::parser::ParseMode,
     ) -> Result<()> {
-        // Explicit selection: persist so the generic rescan path retains it.
-        // Only this boundary (and load_repo_with) writes the mode — the
-        // generic rescan_repo deliberately does not, to avoid a stale Legacy
-        // read overwriting a newer explicit Strict selection (#1432).
-        self.set_repo_mode(repo_id, mode).await;
-        self.rescan_inner(repo_id, mode).await
+        let lock = self.repo_lock(repo_id).await;
+        let _guard = lock.lock().await;
+        self.set_repo_mode_locked(repo_id, mode).await;
+        self.rescan_inner_locked(repo_id, mode).await
     }
 
-    /// Internal scan+evict+register worker (no mode persistence).
+    /// Internal scan+evict+register worker (caller holds the per-repo lock).
     ///
-    /// Shared by [`Self::rescan_repo`] (generic, non-persisting) and
-    /// [`Self::rescan_repo_with`] (explicit, persisting). Keeping the mode
-    /// write out of this inner worker is what prevents a concurrent generic
-    /// Legacy rescan from overwriting a newer explicit Strict selection.
-    async fn rescan_inner(
+    /// The per-repo lock is the race fix: it serializes rescans so that no
+    /// concurrent mode change or commit can interleave between this scan and
+    /// its commit. The previous revalidation guard was itself TOCTOU (it
+    /// could yield between check and commit); the mutex replaces it.
+    async fn rescan_inner_locked(
         &self,
         repo_id: &str,
         mode: super::parser::ParseMode,
     ) -> Result<()> {
-        // Phase 1: scan (blocking I/O in spawn_blocking).
         let workflows = self.scan_repo_with(repo_id, mode).await?;
-
-        // Revalidation guard (#1432 race fix): the blocking scan can outlive
-        // a concurrent explicit mode change. If an explicit Strict selection
-        // landed while we were scanning in Legacy, our Legacy results are
-        // stale — applying them would re-register workflows the strict
-        // selection rejected, leaving the registry fail-open. Discard.
-        let current_mode = self.repo_mode(repo_id).await;
-        if current_mode != mode {
-            tracing::info!(
-                repo_id = %repo_id,
-                scanned_mode = ?mode,
-                current_mode = ?current_mode,
-                "Discarding stale rescan results: repo mode changed during scan"
-            );
-            return Ok(());
-        }
-
-        // Phase 2: commit (evict + register) — mode unchanged since scan.
 
         // Fresh set of workflow ids for this repo, per the scan.
         let fresh_ids: HashSet<WorkflowId> = workflows
@@ -1473,48 +1481,48 @@ jobs:
         Ok(())
     }
 
-    // ─── Rev 7 P1: stale Legacy scan must not commit after explicit Strict ──
+    // ─── Rev 8 P1: forced check-to-commit interleaving regression ──────────
 
     #[tokio::test]
-    async fn stale_legacy_scan_discarded_after_explicit_strict() -> TestResult {
-        // Deterministic race regression: a generic Legacy scan that read
-        // Legacy before an explicit Strict selection can finish its blocking
-        // scan AFTER the Strict selection committed. Without the revalidation
-        // guard, it would re-register legacy workflows (including the
-        // unknown-key one), leaving the registry fail-open until another
-        // rescan. The guard discards the stale results.
+    async fn forced_interleaving_legacy_cannot_commit_after_strict() -> TestResult {
+        // The per-repo mutex makes the scan→commit window atomic. A Legacy
+        // scan that started before an explicit Strict selection cannot commit
+        // after it: the two are serialized, and whichever runs second sees
+        // the committed state of the first.
+        //
+        // This test runs both concurrently via tokio::join!, exercising both
+        // possible orderings. Regardless of order, the registry must be strict
+        // immediately after — no extra rescan needed.
+        use std::sync::Arc;
         let tmp = tempfile::tempdir()?;
         write_workflow(tmp.path(), UNKNOWN_KEY_YAML).await?;
+        let root = tmp.path().to_owned();
 
-        let svc = test_service();
-        svc.register_repo_path("acme", PathBuf::from(tmp.path())).await;
+        let svc = Arc::new(test_service());
+        svc.register_repo_path("acme", PathBuf::from(&root)).await;
 
-        // Explicit Strict runs first and completes.
-        svc.rescan_repo_with("acme", super::super::parser::ParseMode::Strict)
-            .await?;
-        // Strict skips the unknown-key workflow → registry has no acme entry.
-        let acme_entries: Vec<_> = workflow_ids(&svc.list_workflows().await?)
-            .into_iter()
-            .filter(|id| id.starts_with("acme:"))
-            .collect();
-        assert!(
-            acme_entries.is_empty(),
-            "strict selection should skip the unknown-key workflow"
+        // Spawn: a generic rescan (reads Legacy by default) and an explicit
+        // Strict selection, concurrently. The per-repo mutex serializes them.
+        let svc_a = Arc::clone(&svc);
+        let svc_b = Arc::clone(&svc);
+        let (ra, rb) = tokio::join!(
+            async { svc_a.rescan_repo("acme").await },
+            async {
+                svc_b.rescan_repo_with("acme", super::super::parser::ParseMode::Strict).await
+            }
         );
+        ra?;
+        rb?;
 
-        // Simulate the stale Legacy scan finishing after Strict. Call
-        // rescan_inner directly with Legacy (as if the generic path read
-        // Legacy before the Strict selection). The revalidation guard must
-        // detect the mode changed (Legacy → Strict) and discard.
-        svc.rescan_inner("acme", super::super::parser::ParseMode::Legacy)
-            .await?;
-
-        // Registry must STILL be strict — no extra rescan needed.
+        // Registry must be strict — the unknown-key workflow is NOT
+        // registered, regardless of which scan committed first. No extra
+        // rescan required.
         let wf_id = String::from("acme:.github/workflows/gate.yml");
         assert!(
             !workflow_ids(&svc.list_workflows().await?).contains(&wf_id),
-            "stale Legacy scan must be discarded: registry stays strict \
-             immediately after the interleaving, no extra rescan required"
+            "after concurrent Legacy + Strict rescans, the registry must be \
+             strict (unknown-key workflow not registered) — the per-repo mutex \
+             prevents a stale Legacy scan from committing after Strict"
         );
         Ok(())
     }

--- a/crates/hyprstream-workers/src/workflow/service.rs
+++ b/crates/hyprstream-workers/src/workflow/service.rs
@@ -697,6 +697,12 @@ impl WorkflowService {
 
     /// Rescan a repository with an explicit [`ParseMode`] (#1432).
     ///
+    /// The mode is **persisted** per-repo (via [`Self::set_repo_mode`]) so
+    /// that later event-triggered rescans through the generic
+    /// [`Self::rescan_repo`] retain it rather than silently dropping back to
+    /// legacy — regardless of whether strict was first selected via
+    /// `load_repo_with` or directly here.
+    ///
     /// **Fail-closed stale eviction:** a workflow that was previously
     /// registered for this repo but is *absent* from the fresh scan set —
     /// because it was rejected by strict mode, deleted, or otherwise failed
@@ -711,6 +717,12 @@ impl WorkflowService {
         repo_id: &str,
         mode: super::parser::ParseMode,
     ) -> Result<()> {
+        // Persist the mode so the generic rescan path retains it (#1432):
+        // a caller that enters strict via rescan_repo_with directly (rather
+        // than load_repo_with) must still have its choice survive later
+        // event-triggered rescan_repo(repo) calls.
+        self.set_repo_mode(repo_id, mode).await;
+
         let workflows = self.scan_repo_with(repo_id, mode).await?;
 
         // Fresh set of workflow ids for this repo, per the scan.
@@ -1304,6 +1316,41 @@ jobs:
         assert!(
             workflow_ids(&svc.list_workflows().await?).contains(&wf_id),
             "unregistered repo must default to legacy and keep the unknown-key workflow"
+        );
+        Ok(())
+    }
+
+    // ─── Rev 5 P1: rescan_repo_with persists mode for later generic rescan ──
+
+    #[tokio::test]
+    async fn explicit_rescan_with_strict_persists_mode_for_generic_rescan() -> TestResult {
+        // Enter strict via rescan_repo_with DIRECTLY (not load_repo_with nor
+        // set_repo_mode). The mode must persist so a later generic
+        // rescan_repo(repo) — the path HandlerResult::Rescan / initialize use
+        // — stays strict rather than falling back to legacy.
+        let tmp = tempfile::tempdir()?;
+        write_workflow(tmp.path(), KNOWN_YAML).await?;
+
+        let svc = test_service();
+        svc.register_repo_path("acme", PathBuf::from(tmp.path())).await;
+
+        // Enter strict via the explicit rescan variant only.
+        svc.rescan_repo_with("acme", super::super::parser::ParseMode::Strict)
+            .await?;
+        let wf_id = String::from("acme:.github/workflows/gate.yml");
+        assert!(workflow_ids(&svc.list_workflows().await?).contains(&wf_id));
+
+        // Mutate to add an unknown key, then trigger the GENERIC rescan path
+        // (no mode arg). It must have retained strict from the prior
+        // rescan_repo_with call.
+        write_workflow(tmp.path(), UNKNOWN_KEY_YAML).await?;
+        svc.rescan_repo("acme").await?;
+
+        assert!(
+            !workflow_ids(&svc.list_workflows().await?).contains(&wf_id),
+            "rescan_repo_with(Strict) must persist the mode: a later generic \
+             rescan_repo must stay strict and skip+evict the unknown-key workflow, \
+             not silently fall back to legacy"
         );
         Ok(())
     }

--- a/crates/hyprstream-workers/src/workflow/service.rs
+++ b/crates/hyprstream-workers/src/workflow/service.rs
@@ -729,7 +729,7 @@ impl WorkflowService {
         let lock = self.repo_lock(repo_id).await;
         let _guard = lock.lock().await;
         let mode = self.repo_mode(repo_id).await;
-        self.rescan_inner_locked(repo_id, mode).await
+        self.rescan_inner_locked(repo_id, mode).await.map(|_| ())
     }
 
     /// Rescan a repository with an explicit [`ParseMode`] (#1432 boundary).
@@ -746,6 +746,22 @@ impl WorkflowService {
         repo_id: &str,
         mode: super::parser::ParseMode,
     ) -> Result<()> {
+        self.rescan_repo_with_defs(repo_id, mode).await.map(|_| ())
+    }
+
+    /// Select a parse mode and atomically reconcile a repository, returning
+    /// the definitions that survived the scan.
+    ///
+    /// Adapter loaders use this instead of a separate `set_repo_mode` followed
+    /// by `scan_repo_with`: strict selection, scanning, stale eviction, and
+    /// registration must share the per-repo lock. Otherwise a stale Legacy
+    /// scan can register an unsupported workflow after strict selection but
+    /// before the adapter's later eviction (#1432 fail-closed boundary).
+    pub(crate) async fn rescan_repo_with_defs(
+        &self,
+        repo_id: &str,
+        mode: super::parser::ParseMode,
+    ) -> Result<Vec<WorkflowDef>> {
         let lock = self.repo_lock(repo_id).await;
         let _guard = lock.lock().await;
         self.set_repo_mode_locked(repo_id, mode).await;
@@ -762,7 +778,7 @@ impl WorkflowService {
         &self,
         repo_id: &str,
         mode: super::parser::ParseMode,
-    ) -> Result<()> {
+    ) -> Result<Vec<WorkflowDef>> {
         let workflows = self.scan_repo_with(repo_id, mode).await?;
 
         // Fresh set of workflow ids for this repo, per the scan.
@@ -778,7 +794,7 @@ impl WorkflowService {
         let mut repo_workflows = self.repo_workflows.write().await;
         let mut subscriptions = Vec::new();
 
-        for wf in workflows {
+        for wf in &workflows {
             let wf_id = self.register_workflow(wf.clone()).await?;
 
             for trigger in &wf.triggers {
@@ -790,7 +806,7 @@ impl WorkflowService {
         repo_workflows.insert(repo_id.to_owned(), subscriptions);
 
         tracing::info!(repo_id = %repo_id, mode = ?mode, "Rescanned repository");
-        Ok(())
+        Ok(workflows)
     }
 
     /// Start a subscriber adapter. Returns a CancellationToken to stop it.

--- a/crates/hyprstream-workers/src/workflow/service.rs
+++ b/crates/hyprstream-workers/src/workflow/service.rs
@@ -736,7 +736,26 @@ impl WorkflowService {
         repo_id: &str,
         mode: super::parser::ParseMode,
     ) -> Result<()> {
+        // Phase 1: scan (blocking I/O in spawn_blocking).
         let workflows = self.scan_repo_with(repo_id, mode).await?;
+
+        // Revalidation guard (#1432 race fix): the blocking scan can outlive
+        // a concurrent explicit mode change. If an explicit Strict selection
+        // landed while we were scanning in Legacy, our Legacy results are
+        // stale — applying them would re-register workflows the strict
+        // selection rejected, leaving the registry fail-open. Discard.
+        let current_mode = self.repo_mode(repo_id).await;
+        if current_mode != mode {
+            tracing::info!(
+                repo_id = %repo_id,
+                scanned_mode = ?mode,
+                current_mode = ?current_mode,
+                "Discarding stale rescan results: repo mode changed during scan"
+            );
+            return Ok(());
+        }
+
+        // Phase 2: commit (evict + register) — mode unchanged since scan.
 
         // Fresh set of workflow ids for this repo, per the scan.
         let fresh_ids: HashSet<WorkflowId> = workflows
@@ -1450,6 +1469,52 @@ jobs:
             "after concurrent generic rescans interleaved with one explicit \
              strict selection, the stored mode must remain Strict — the \
              generic rescans must not have overwritten it"
+        );
+        Ok(())
+    }
+
+    // ─── Rev 7 P1: stale Legacy scan must not commit after explicit Strict ──
+
+    #[tokio::test]
+    async fn stale_legacy_scan_discarded_after_explicit_strict() -> TestResult {
+        // Deterministic race regression: a generic Legacy scan that read
+        // Legacy before an explicit Strict selection can finish its blocking
+        // scan AFTER the Strict selection committed. Without the revalidation
+        // guard, it would re-register legacy workflows (including the
+        // unknown-key one), leaving the registry fail-open until another
+        // rescan. The guard discards the stale results.
+        let tmp = tempfile::tempdir()?;
+        write_workflow(tmp.path(), UNKNOWN_KEY_YAML).await?;
+
+        let svc = test_service();
+        svc.register_repo_path("acme", PathBuf::from(tmp.path())).await;
+
+        // Explicit Strict runs first and completes.
+        svc.rescan_repo_with("acme", super::super::parser::ParseMode::Strict)
+            .await?;
+        // Strict skips the unknown-key workflow → registry has no acme entry.
+        let acme_entries: Vec<_> = workflow_ids(&svc.list_workflows().await?)
+            .into_iter()
+            .filter(|id| id.starts_with("acme:"))
+            .collect();
+        assert!(
+            acme_entries.is_empty(),
+            "strict selection should skip the unknown-key workflow"
+        );
+
+        // Simulate the stale Legacy scan finishing after Strict. Call
+        // rescan_inner directly with Legacy (as if the generic path read
+        // Legacy before the Strict selection). The revalidation guard must
+        // detect the mode changed (Legacy → Strict) and discard.
+        svc.rescan_inner("acme", super::super::parser::ParseMode::Legacy)
+            .await?;
+
+        // Registry must STILL be strict — no extra rescan needed.
+        let wf_id = String::from("acme:.github/workflows/gate.yml");
+        assert!(
+            !workflow_ids(&svc.list_workflows().await?).contains(&wf_id),
+            "stale Legacy scan must be discarded: registry stays strict \
+             immediately after the interleaving, no extra rescan required"
         );
         Ok(())
     }

--- a/crates/hyprstream-workers/src/workflow/service.rs
+++ b/crates/hyprstream-workers/src/workflow/service.rs
@@ -1,6 +1,6 @@
 //! WorkflowService - RequestService implementation for workflow orchestration
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::path::PathBuf;
 use std::sync::Arc;
 use tokio::sync::RwLock;
@@ -378,20 +378,34 @@ impl WorkflowService {
         handlers.push(handler);
     }
 
-    /// Scan a repository for `.github/workflows/*.yml` files.
+    /// Scan a repository for `.github/workflows/*.yml` files (legacy mode).
+    ///
+    /// Generic loader entry point — parses in [`ParseMode::Legacy`], so
+    /// unknown keys are silently dropped. Used by the GitHub Actions adapter
+    /// and other non-gate callers. The merge gate must opt into strict mode
+    /// via [`Self::scan_repo_with`] (#1432 scope item 2; non-goal: changing
+    /// the default for non-gate callers).
     ///
     /// Uses the path registered via `register_repo_path`. Returns an empty
     /// Vec (not an error) if no path is registered for the repo or if the
     /// workflows directory does not exist.
-    ///
-    /// Workflows are parsed in **strict / fail-closed** mode
-    /// ([`Workflow::parse_strict`]): a file with an unknown structural key
-    /// (e.g. `permissions:`, `concurrency:`, `services:`) is **skipped** with
-    /// a warn-log rather than silently loaded with dropped semantics. This is
-    /// the merge-gate loader path (#1432) — failing closed here means the
-    /// gate never executes a workflow it does not fully understand.
     pub(crate) async fn scan_repo(&self, repo_id: &str) -> Result<Vec<WorkflowDef>> {
-        tracing::info!(repo_id = %repo_id, "Scanning repository for workflows");
+        self.scan_repo_with(repo_id, super::parser::ParseMode::Legacy).await
+    }
+
+    /// Scan a repository with an explicit [`ParseMode`] (#1432).
+    ///
+    /// In [`ParseMode::Strict`] a file with an unknown structural key
+    /// (e.g. `permissions:`, `concurrency:`, `services:`) is **skipped** with
+    /// a warn-log rather than silently loaded with dropped semantics — the
+    /// merge-gate boundary selects this mode so the gate never loads a
+    /// workflow it cannot fully model.
+    pub(crate) async fn scan_repo_with(
+        &self,
+        repo_id: &str,
+        mode: super::parser::ParseMode,
+    ) -> Result<Vec<WorkflowDef>> {
+        tracing::info!(repo_id = %repo_id, mode = ?mode, "Scanning repository for workflows");
 
         let root = {
             let repo_paths = self.repo_paths.read().await;
@@ -442,10 +456,15 @@ impl WorkflowService {
                     }
                 };
 
-                let workflow = match Workflow::parse_strict(&yaml) {
+                let workflow = match Workflow::parse_with(&yaml, mode) {
                     Ok(w) => w,
                     Err(e) => {
-                        tracing::warn!(path = %path.display(), error = %e, "Failed to parse workflow (strict mode); skipping");
+                        tracing::warn!(
+                            path = %path.display(),
+                            error = %e,
+                            "Failed to parse workflow ({:?} mode); skipping",
+                            mode,
+                        );
                         continue;
                     }
                 };
@@ -609,11 +628,57 @@ impl WorkflowService {
             .collect())
     }
 
-    /// Rescan a repository for workflow changes
+    /// Rescan a repository for workflow changes (legacy mode).
+    ///
+    /// Generic entry point — delegates to [`Self::rescan_repo_with`] with
+    /// [`ParseMode::Legacy`]. The merge gate uses
+    /// [`Self::rescan_repo_with`] with [`ParseMode::Strict`].
     pub async fn rescan_repo(&self, repo_id: &str) -> Result<()> {
-        let workflows = self.scan_repo(repo_id).await?;
+        self.rescan_repo_with(repo_id, super::parser::ParseMode::Legacy).await
+    }
 
-        // Update subscriptions for this repo
+    /// Rescan a repository with an explicit [`ParseMode`] (#1432).
+    ///
+    /// **Fail-closed stale eviction:** a workflow that was previously
+    /// registered for this repo but is *absent* from the fresh scan set —
+    /// because it was rejected by strict mode, deleted, or otherwise failed
+    /// to parse — is **evicted** from the registry. This is the fix for the
+    /// stale-handler gap: once evicted, [`Self::dispatch`] returns
+    /// [`WorkflowNotFound`](crate::error::WorkerError::WorkflowNotFound) for
+    /// that id, so any lingering adapter handler built against the old
+    /// version can no longer dispatch it. Without eviction, a strict-rejected
+    /// workflow would keep its prior registration live and continue
+    /// dispatching.
+    pub async fn rescan_repo_with(
+        &self,
+        repo_id: &str,
+        mode: super::parser::ParseMode,
+    ) -> Result<()> {
+        let workflows = self.scan_repo_with(repo_id, mode).await?;
+
+        // Fresh set of workflow ids for this repo, per the scan.
+        let fresh_ids: HashSet<WorkflowId> = workflows
+            .iter()
+            .map(|wf| format!("{}:{}", wf.repo_id, wf.path))
+            .collect();
+
+        // Evict stale registrations: any registry entry belonging to this
+        // repo that did not survive the fresh scan is removed so it can no
+        // longer be dispatched (fail-closed).
+        let stale_prefix = format!("{repo_id}:");
+        let mut workflows_lock = self.workflows.write().await;
+        let stale_keys: Vec<WorkflowId> = workflows_lock
+            .keys()
+            .filter(|id| id.starts_with(&stale_prefix) && !fresh_ids.contains(*id))
+            .cloned()
+            .collect();
+        for key in &stale_keys {
+            tracing::info!(workflow_id = %key, "Evicting stale workflow registration on rescan");
+            workflows_lock.remove(key);
+        }
+        drop(workflows_lock);
+
+        // Register the fresh set and rebuild subscriptions.
         let mut repo_workflows = self.repo_workflows.write().await;
         let mut subscriptions = Vec::new();
 
@@ -628,7 +693,7 @@ impl WorkflowService {
 
         repo_workflows.insert(repo_id.to_owned(), subscriptions);
 
-        tracing::info!(repo_id = %repo_id, "Rescanned repository");
+        tracing::info!(repo_id = %repo_id, mode = ?mode, evicted = stale_keys.len(), "Rescanned repository");
         Ok(())
     }
 
@@ -751,11 +816,11 @@ impl WorkflowHandler for WorkflowService {
                 jobs: HashMap::new(),
             }
         } else {
-            // Gate loader path: strict mode rejects unknown structural keys
-            // so a workflow using unsupported semantics (e.g. `permissions:`,
-            // `concurrency:`) is refused rather than silently registered with
-            // dropped semantics (#1432).
-            Workflow::parse_strict(&data.yaml)?
+            // Generic RPC register path: legacy mode. Unknown keys are
+            // silently dropped (non-gate caller compatibility, #1432
+            // non-goal). The merge gate selects strict mode at its own
+            // loader boundary (`scan_repo_with`/`load_repo_with`), not here.
+            Workflow::parse(&data.yaml)?
         };
         let triggers = extract_triggers(&workflow);
         let workflow_def = WorkflowDef {
@@ -991,6 +1056,160 @@ mod tests {
     // invariant the dispatch boundary depends on instead.
 
     use hyprstream_vfs::Subject;
+    use hyprstream_rpc::prelude::SigningKey;
+    use hyprstream_rpc::transport::TransportConfig;
+    use rand::rngs::OsRng;
+    use std::path::PathBuf;
+
+    fn test_service() -> super::WorkflowService {
+        super::WorkflowService::new(
+            TransportConfig::inproc("test-workflow-service"),
+            SigningKey::generate(&mut OsRng),
+        )
+    }
+
+    /// Minimal known-subset workflow YAML (parses in both modes).
+    const KNOWN_YAML: &str = r#"
+name: Gate
+on: push
+jobs:
+  gate:
+    runs-on: ubuntu-latest
+    steps:
+      - run: cargo test
+"#;
+
+    /// Same workflow with an unknown top-level key (`permissions:`). Parses
+    /// in legacy mode (silently dropped) but is REJECTED by strict mode.
+    const UNKNOWN_KEY_YAML: &str = r#"
+name: Gate
+on: push
+permissions:
+  contents: read
+jobs:
+  gate:
+    runs-on: ubuntu-latest
+    steps:
+      - run: cargo test
+"#;
+
+    async fn write_workflow(
+        repo_root: &std::path::Path,
+        yaml: &str,
+    ) -> std::result::Result<(), Box<dyn std::error::Error>> {
+        let dir = repo_root.join(".github").join("workflows");
+        tokio::fs::create_dir_all(&dir).await?;
+        tokio::fs::write(dir.join("gate.yml"), yaml).await?;
+        Ok(())
+    }
+
+    fn workflow_ids(info: &[super::WorkflowInfo]) -> Vec<String> {
+        info.iter().map(|i| i.id.clone()).collect()
+    }
+
+    type TestResult = std::result::Result<(), Box<dyn std::error::Error>>;
+
+    // ─── Finding B: generic loader stays legacy; gate opts in via _with ─────
+
+    #[tokio::test]
+    async fn legacy_scan_accepts_unknown_keys() -> TestResult {
+        // The generic (non-gate) loader must tolerate unknown keys — forcing
+        // strict globally breaks legacy non-gate compatibility (#1432
+        // non-goal).
+        let tmp = tempfile::tempdir()?;
+        write_workflow(tmp.path(), UNKNOWN_KEY_YAML).await?;
+
+        let svc = test_service();
+        svc.register_repo_path("acme", PathBuf::from(tmp.path())).await;
+
+        let defs = svc.scan_repo("acme").await?;
+        assert_eq!(defs.len(), 1, "legacy mode loads the unknown-key workflow");
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn strict_scan_skips_unknown_keys() -> TestResult {
+        let tmp = tempfile::tempdir()?;
+        write_workflow(tmp.path(), UNKNOWN_KEY_YAML).await?;
+
+        let svc = test_service();
+        svc.register_repo_path("acme", PathBuf::from(tmp.path())).await;
+
+        let defs = svc
+            .scan_repo_with("acme", super::super::parser::ParseMode::Strict)
+            .await?;
+        assert!(defs.is_empty(), "strict mode skips the unknown-key workflow");
+        Ok(())
+    }
+
+    // ─── Finding A: strict rescan evicts the stale registration, fail-closed ─
+
+    #[tokio::test]
+    async fn strict_rescan_evicts_stale_registration() -> TestResult {
+        // 1. Load a valid (known-subset) workflow under strict mode → registered.
+        let tmp = tempfile::tempdir()?;
+        write_workflow(tmp.path(), KNOWN_YAML).await?;
+
+        let svc = test_service();
+        svc.register_repo_path("acme", PathBuf::from(tmp.path())).await;
+
+        svc.rescan_repo_with("acme", super::super::parser::ParseMode::Strict)
+            .await?;
+
+        let wf_id = String::from("acme:.github/workflows/gate.yml");
+        let after_first = svc.list_workflows().await?;
+        assert!(
+            workflow_ids(&after_first).contains(&wf_id),
+            "known-subset workflow should be registered after first scan"
+        );
+
+        // 2. Mutate the file to add an unknown key. Strict rescan must now
+        //    skip it AND evict the now-stale registration — otherwise the
+        //    stale workflow stays dispatchable (the fail-closed gap).
+        write_workflow(tmp.path(), UNKNOWN_KEY_YAML).await?;
+        svc.rescan_repo_with("acme", super::super::parser::ParseMode::Strict)
+            .await?;
+
+        let after_second = svc.list_workflows().await?;
+        assert!(
+            !workflow_ids(&after_second).contains(&wf_id),
+            "stale registration must be evicted: a strict-rejected workflow \
+             must not remain dispatchable"
+        );
+
+        // 3. Fail-closed confirmation: dispatching the evicted id must now
+        //    be WorkflowNotFound, not a stale run.
+        match svc
+            .dispatch(&wf_id, std::collections::HashMap::new(), &Subject::anonymous())
+            .await
+        {
+            Err(crate::error::WorkerError::WorkflowNotFound(id)) => assert_eq!(id, wf_id),
+            other => panic!("expected WorkflowNotFound for evicted workflow, got {other:?}"),
+        }
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn legacy_rescan_keeps_workflow_when_unknown_key_present() -> TestResult {
+        // Legacy rescan must keep the registration (unknown keys tolerated) —
+        // guards against accidentally evicting under the generic path.
+        let tmp = tempfile::tempdir()?;
+        write_workflow(tmp.path(), UNKNOWN_KEY_YAML).await?;
+
+        let svc = test_service();
+        svc.register_repo_path("acme", PathBuf::from(tmp.path())).await;
+
+        svc.rescan_repo("acme").await?;
+        let wf_id = String::from("acme:.github/workflows/gate.yml");
+        let listed = svc.list_workflows().await?;
+        assert!(
+            workflow_ids(&listed).contains(&wf_id),
+            "legacy rescan must keep the unknown-key workflow registered"
+        );
+        Ok(())
+    }
+
+    // ─── Regression guard kept from prior revision ──────────────────────────
 
     /// #989 review P2-1: the factory must feed the OAuth issuer audience (and
     /// cluster JWT key source) into `WorkflowService` so JWT-authenticated

--- a/crates/hyprstream-workers/src/workflow/triggers.rs
+++ b/crates/hyprstream-workers/src/workflow/triggers.rs
@@ -125,6 +125,14 @@ pub trait EventHandler: Send + Sync {
     ///
     /// Only called if `matches()` returned true.
     async fn handle(&self, event: &ReceivedEvent) -> Result<HandlerResult>;
+
+    /// The workflow id this handler dispatches on behalf of.
+    ///
+    /// Used by adapters to reconcile per-repo handlers: on a strict reload,
+    /// handlers whose workflow id belongs to a repo being rescanned are
+    /// dropped and rebuilt from the fresh workflow set, so a workflow that
+    /// was rejected/deleted can no longer be triggered (#1432 fail-closed).
+    fn workflow_id(&self) -> &super::WorkflowId;
 }
 
 // ═══════════════════════════════════════════════════════════════════════════════
@@ -218,6 +226,10 @@ impl EventHandler for WorkerLifecycleHandler {
             inputs,
         })
     }
+
+    fn workflow_id(&self) -> &super::WorkflowId {
+        &self.workflow_id
+    }
 }
 
 // ═══════════════════════════════════════════════════════════════════════════════
@@ -255,6 +267,10 @@ impl EventHandler for TopicPatternHandler {
             workflow_id: self.workflow_id.clone(),
             inputs,
         })
+    }
+
+    fn workflow_id(&self) -> &super::WorkflowId {
+        &self.workflow_id
     }
 }
 


### PR DESCRIPTION
Closes #1432. Epic #1427.

## What

Adds an explicit **strict / fail-closed** parse mode to the GitHub Actions
workflow parser that rejects unknown top-level, job-level, and step-level
YAML keys with `WorkflowParseError`, alongside a clearly-named **legacy /
lenient** compatibility mode that preserves the existing `Workflow::parse`
behavior for non-gate callers.

## Why

The parser uses `serde_yaml` with `#[serde(default)]`, so unknown keys are
silently dropped today. For a merge gate that is a security gap: a
workflow using `permissions:`, `concurrency:`, or `services:` parses
cleanly and silently runs *without* those semantics. Strict mode closes
that by validating the raw `Value` tree against an explicit known-key
contract *before* deserialization, so `#[serde(default)]` can never absorb
an unknown structural key.

## API

| Entry | Mode | Behavior |
|-------|------|----------|
| `Workflow::parse(yaml)` | Legacy (unchanged) | Unknown keys silently dropped |
| `Workflow::parse_strict(yaml)` | Strict / fail-closed | Unknown keys → `WorkflowParseError` |
| `Workflow::parse_with(yaml, ParseMode)` | explicit | dispatch on `ParseMode::{Legacy, Strict}` |

The gate's workflow loader opts in via `parse_strict`. Per the #1432
non-goal, **no existing caller is migrated** — `service.rs` (the
directory-scanning loader and the wire-path loader) stays on legacy
`parse` by design.

### Explicitly supported subset (strict mode)

| Level | Allowed keys |
|-------|--------------|
| workflow | `name`, `on`, `env`, `jobs` |
| job | `runs-on`, `needs`, `env`, `steps`, `if`, `timeout-minutes`, `resources` |
| step | `name`, `id`, `uses`, `run`, `shell`, `working-directory`, `with`, `env`, `if`, `continue-on-error` |

`resources` is a hyprstream extension (not GHA); permitted so operator
gate workflows may declare resource hints.

## Non-goals (Phase 2)

Does **not** claim full GitHub Actions compatibility and does not implement
`matrix`/`strategy`, `services`, `permissions`, `concurrency`, expression
evaluation, environment scopes, or forge-specific checks — those correctly
fail closed in strict mode and are silently ignored in legacy mode.

## Tests (14 new, all green)

- Strict accepts the known subset (full gate workflow).
- Strict accepts the `resources` extension.
- Strict rejects unknown **top-level** key: `services`, `permissions`, `concurrency`.
- Strict rejects unknown **job-level** key: `strategy` (matrix), `services`.
- Strict rejects unknown **step-level** key: `timeout-minutes` (known job key, not step).
- Strict does **not** over-reject known step keys (`with`).
- Legacy silently drops the same inputs (parity).
- Structural edge cases: non-mapping root, non-mapping job.

## Verification

```
cargo test -p hyprstream-workers --lib workflow::parser   # 16 passed
cargo clippy -p hyprstream-workers --lib --tests -- -D warnings   # clean
```
(pre-commit workspace release clippy also passed.)