### PR TITLE
docs: add license attribution notices

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,19 @@
+# Hyprstream MIT-origin attribution notice
+
+Copyright 2025 Erica Windisch, Cyberdione Labs.
+
+Portions of this source distribution were originally released under the MIT
+License by the copyright holder above. Their MIT-origin attribution and
+permission notice are preserved in `LICENSE-MIT` and must accompany copies or
+substantial portions of that MIT-origin source.
+
+This attribution is intentionally non-exhaustive: it applies to every
+MIT-origin portion of the repository, including portions now distributed in a
+package classified Apache-2.0, AGPL-3.0-only, MIT, or under a later package
+classification. It is not a list of AGPL packages and must not be used as one.
+
+Current package licensing is stated by each package manifest and enforced by
+`.github/license-boundary.toml`. `LICENSE-APACHE` and `LICENSE-AGPLV3` remain
+the canonical texts for their respective current classifications. This notice
+records MIT provenance and attribution; it does not grant a new MIT license for
+later contributions.

--- a/README.md
+++ b/README.md
@@ -554,7 +554,8 @@ against acquiring an AGPL dependency in
 `.github/license-boundary.toml`. The policy is exhaustive and CI requires every
 local package manifest to match it exactly.
 
-See [LICENSE-MIT](LICENSE-MIT), [LICENSE-AGPLV3](LICENSE-AGPLV3), and
+See [NOTICE](NOTICE) for MIT-origin source attribution, and
+[LICENSE-MIT](LICENSE-MIT), [LICENSE-AGPLV3](LICENSE-AGPLV3), and
 [LICENSE-APACHE](LICENSE-APACHE) for the corresponding license terms.
 
 ## Acknowledgments


### PR DESCRIPTION
## Summary
- add one non-exhaustive MIT-origin attribution notice
- preserve the original MIT copyright holder and require the existing `LICENSE-MIT` notice to accompany MIT-origin copies or substantial portions
- make explicit that the notice is not a package or AGPL inventory; current package classifications remain in manifests and the policy file
- link the notice from the README

## Deliberate non-changes
- no duplicate `COPYING` files: the repository already has canonical Apache and AGPL texts
- no package lists in this attribution notice
- no source-license reclassification

## Scope
Stacked on #1417 because its policy change is the relevant licensing context.

## Validation
- `git diff --check`
- notice includes the MIT copyright holder and explicitly rejects use as an AGPL package inventory
- confirmed no duplicate COPYING files or package-local NOTICE were added

The full workspace clippy pre-commit hook was intentionally stopped at human direction: this is an attribution-only documentation change.