### PR TITLE
fix(git2db): strict certificate mode + explicit-only auth

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5973,6 +5973,7 @@ dependencies = [
  "tokio-test",
  "tracing",
  "tracing-subscriber",
+ "url",
  "uuid 1.18.1",
  "walkdir",
 ]

--- a/crates/git2db/Cargo.toml
+++ b/crates/git2db/Cargo.toml
@@ -11,6 +11,9 @@ description = "Git-native database operations using libgit2 with submodules as s
 git2.workspace = true
 libc.workspace = true
 
+# Standards-based (WHATWG URL) authority parsing for credential host-scoping
+url.workspace = true
+
 # Async runtime
 tokio.workspace = true
 

--- a/crates/git2db/src/auth.rs
+++ b/crates/git2db/src/auth.rs
@@ -1,7 +1,8 @@
 //! Authentication and credential management
 //!
-//! Consolidated authentication patterns from the original codebase
+//! Consolidated authentication patterns from the original codebase.
 
+use crate::callback_config::{AuthMode, CertificateConfig};
 use git2::{Cred, CredentialType, RemoteCallbacks};
 use std::path::PathBuf;
 use tracing::{debug, info, warn};
@@ -26,22 +27,53 @@ pub enum AuthStrategy {
     Default,
 }
 
-/// Credential manager for handling authentication
+/// Credential manager for handling authentication.
+///
+/// Defaults to a **strict** security posture:
+/// - [`CertificateConfig::Strict`] — certificates are validated by libgit2
+///   against the system trust store; a cert that fails verification rejects
+///   the fetch. The previous always-`CertificateOk` behavior is gone.
+/// - [`AuthMode::ExplicitOnly`] — ambient credential discovery
+///   (`AuthStrategy::Default`, i.e. the git credential helper, `~/.gitconfig`,
+///   SSH agent fallback) is refused unless the caller explicitly opts in via
+///   [`AuthManager::with_auth_mode`]`(AllowAmbient)`.
 pub struct AuthManager {
     strategies: Vec<AuthStrategy>,
+    certificate_mode: CertificateConfig,
+    auth_mode: AuthMode,
 }
 
 impl AuthManager {
-    /// Create a new authentication manager
+    /// Create a new authentication manager with no strategies, strict
+    /// certificate validation, and `ExplicitOnly` auth mode.
     pub fn new() -> Self {
         Self {
-            strategies: vec![AuthStrategy::Default],
+            strategies: Vec::new(),
+            certificate_mode: CertificateConfig::Strict,
+            auth_mode: AuthMode::ExplicitOnly,
         }
     }
 
-    /// Create authentication manager with strategies
+    /// Create authentication manager with strategies. Certificate validation
+    /// defaults to strict and auth mode to `ExplicitOnly`.
     pub fn with_strategies(strategies: Vec<AuthStrategy>) -> Self {
-        Self { strategies }
+        Self {
+            strategies,
+            certificate_mode: CertificateConfig::Strict,
+            auth_mode: AuthMode::ExplicitOnly,
+        }
+    }
+
+    /// Set the certificate validation mode.
+    pub fn with_certificate_mode(mut self, mode: CertificateConfig) -> Self {
+        self.certificate_mode = mode;
+        self
+    }
+
+    /// Set the authentication provenance mode.
+    pub fn with_auth_mode(mut self, mode: AuthMode) -> Self {
+        self.auth_mode = mode;
+        self
     }
 
     /// Add an authentication strategy
@@ -49,31 +81,33 @@ impl AuthManager {
         self.strategies.push(strategy);
     }
 
-    /// Create remote callbacks with authentication
+    /// Create remote callbacks with authentication and certificate handling.
+    ///
+    /// Security posture:
+    /// - Under `Strict` (default) the certificate callback returns
+    ///   `CertificatePassthrough`, deferring to libgit2's built-in verification.
+    ///   It never returns `CertificateOk` unconditionally, so an invalid or
+    ///   untrusted certificate fails the fetch.
+    /// - Under `ExplicitOnly` (default) `AuthStrategy::Default` is skipped, so
+    ///   ambient credential sources are not consulted.
     pub fn create_callbacks(&self) -> RemoteCallbacks<'_> {
         let mut callbacks = RemoteCallbacks::new();
 
+        let auth_mode = self.auth_mode;
         callbacks.credentials(move |url, username_from_url, allowed_types| {
-            self.handle_credentials(url, username_from_url, allowed_types)
+            self.handle_credentials(auth_mode, url, username_from_url, allowed_types)
         });
 
-        callbacks.certificate_check(|cert, valid| {
-            // For now, accept all certificates
-            // TODO: Implement proper certificate validation based on config
-            debug!(
-                "Certificate check: valid={}, host={:?}",
-                valid,
-                cert.as_hostkey().map(|h| h.hostkey())
-            );
-            Ok(git2::CertificateCheckStatus::CertificateOk)
-        });
+        let cert_mode = self.certificate_mode.clone();
+        callbacks.certificate_check(move |cert, _host| Self::handle_certificate(&cert_mode, cert));
 
         callbacks
     }
 
-    /// Handle credential requests
+    /// Handle credential requests.
     fn handle_credentials(
         &self,
+        auth_mode: AuthMode,
         url: &str,
         username_from_url: Option<&str>,
         allowed_types: CredentialType,
@@ -82,8 +116,18 @@ impl AuthManager {
         info!("Username from URL: {:?}", username_from_url);
         info!("Allowed credential types: {:?}", allowed_types);
 
-        // Try each strategy in order
+        // Try each strategy in order. Under ExplicitOnly, AuthStrategy::Default
+        // (ambient credential discovery) is refused so an untrusted fetch
+        // cannot silently pick up operator credentials.
         for strategy in &self.strategies {
+            if matches!(auth_mode, AuthMode::ExplicitOnly)
+                && matches!(strategy, AuthStrategy::Default)
+            {
+                debug!(
+                    "Refusing ambient AuthStrategy::Default for {url} under ExplicitOnly auth mode"
+                );
+                continue;
+            }
             match self.try_strategy(strategy, url, username_from_url, allowed_types) {
                 Ok(cred) => {
                     info!("Authentication successful with strategy: {:?}", strategy);
@@ -97,7 +141,37 @@ impl AuthManager {
         }
 
         warn!("All authentication strategies failed for {}", url);
-        Err(git2::Error::from_str("No suitable authentication method"))
+        if matches!(auth_mode, AuthMode::ExplicitOnly) {
+            Err(git2::Error::from_str(
+                "No suitable explicit authentication method (ambient discovery refused under \
+                 ExplicitOnly auth mode)",
+            ))
+        } else {
+            Err(git2::Error::from_str("No suitable authentication method"))
+        }
+    }
+
+    /// Certificate check shared between the sync and send-safe callback paths.
+    /// Delegates to [`crate::callback_config::CallbackConfig::certificate_decision`]
+    /// so the two paths cannot drift on the security boundary.
+    fn handle_certificate(
+        mode: &CertificateConfig,
+        cert: &git2::cert::Cert<'_>,
+    ) -> Result<git2::CertificateCheckStatus, git2::Error> {
+        let hostkey = cert.as_hostkey().and_then(|hk| {
+            hk.hostkey().map(|bytes| {
+                let host = std::str::from_utf8(bytes).unwrap_or("");
+                (host, bytes)
+            })
+        });
+        let status = crate::callback_config::CallbackConfig::certificate_decision(mode, hostkey)?;
+        if matches!(mode, CertificateConfig::AcceptAll) {
+            debug!(
+                "Accepting certificate unconditionally (AcceptAll mode): hostkey={:?}",
+                cert.as_hostkey().map(|h| h.hostkey())
+            );
+        }
+        Ok(status)
     }
 
     /// Try a specific authentication strategy
@@ -172,6 +246,16 @@ impl AuthManager {
     /// Get the number of configured strategies (for testing)
     pub fn strategy_count(&self) -> usize {
         self.strategies.len()
+    }
+
+    /// Get the configured certificate validation mode.
+    pub fn certificate_mode(&self) -> CertificateConfig {
+        self.certificate_mode.clone()
+    }
+
+    /// Get the configured authentication provenance mode.
+    pub fn auth_mode(&self) -> AuthMode {
+        self.auth_mode
     }
 
     /// Get the strategies (for testing)
@@ -251,13 +335,17 @@ impl AuthBuilder {
         self
     }
 
-    /// Add default credentials (fallback)
+    /// Add default credentials (fallback). Maps to libgit2's ambient credential
+    /// discovery (git credential helper, `~/.gitconfig`, SSH agent fallback).
+    /// Only honored when the `AuthManager` is built with
+    /// [`AuthMode::AllowAmbient`]; under the default `ExplicitOnly` mode this
+    /// strategy is refused at resolution time.
     pub fn default_fallback(mut self) -> Self {
         self.strategies.push(AuthStrategy::Default);
         self
     }
 
-    /// Build the authentication manager
+    /// Build the authentication manager (strict certs, `ExplicitOnly` auth).
     pub fn build(self) -> AuthManager {
         AuthManager::with_strategies(self.strategies)
     }
@@ -269,28 +357,36 @@ impl Default for AuthBuilder {
     }
 }
 
-/// Helper function to create common authentication configurations
+/// Helper function to create common authentication configurations.
+///
+/// Presets that include ambient discovery (`AuthStrategy::Default`) opt into
+/// [`AuthMode::AllowAmbient`] explicitly, since their purpose is operator-style
+/// access to first-party/trusted remotes. The strict certificate default is
+/// preserved in every preset.
 pub mod presets {
     use super::*;
 
-    /// Standard SSH configuration (agent + fallback)
+    /// Standard SSH configuration (agent + ambient fallback). Opts into
+    /// `AllowAmbient` because the ambient fallback is the explicit intent.
     pub fn ssh_standard() -> AuthManager {
         AuthBuilder::new()
             .ssh_agent(Some("git".to_owned()))
             .default_fallback()
             .build()
+            .with_auth_mode(AuthMode::AllowAmbient)
     }
 
-    /// GitHub personal access token
+    /// GitHub personal access token with SSH-agent and ambient fallback.
     pub fn github_token<T: Into<String>>(token: T) -> AuthManager {
         AuthBuilder::new()
             .token(token)
             .ssh_agent(Some("git".to_owned()))
             .default_fallback()
             .build()
+            .with_auth_mode(AuthMode::AllowAmbient)
     }
 
-    /// SSH key file authentication
+    /// SSH key file authentication with agent and ambient fallback.
     pub fn ssh_key_file<U, P>(
         username: U,
         private_key: P,
@@ -305,11 +401,16 @@ pub mod presets {
             .ssh_agent(Some("git".to_owned()))
             .default_fallback()
             .build()
+            .with_auth_mode(AuthMode::AllowAmbient)
     }
 
-    /// Public repository access only
+    /// Public repository access via ambient discovery only. Opts into
+    /// `AllowAmbient`.
     pub fn public_only() -> AuthManager {
-        AuthBuilder::new().default_fallback().build()
+        AuthBuilder::new()
+            .default_fallback()
+            .build()
+            .with_auth_mode(AuthMode::AllowAmbient)
     }
 }
 
@@ -338,5 +439,35 @@ mod tests {
 
         let public_auth = presets::public_only();
         assert_eq!(public_auth.strategies.len(), 1);
+    }
+
+    #[test]
+    fn auth_manager_builder_chains_modes() {
+        let mgr = AuthManager::with_strategies(vec![AuthStrategy::Token { token: "t".into() }])
+            .with_certificate_mode(CertificateConfig::AcceptAll)
+            .with_auth_mode(AuthMode::AllowAmbient);
+        assert!(matches!(
+            mgr.certificate_mode(),
+            CertificateConfig::AcceptAll
+        ));
+        assert_eq!(mgr.auth_mode(), AuthMode::AllowAmbient);
+    }
+
+    /// The credentials callback under ExplicitOnly must refuse the Default
+    /// strategy even though it is present in the strategy list (ambient
+    /// discovery never consulted). Mirrors the callback_config unit test but
+    /// exercises the AuthManager (sync) path.
+    #[test]
+    fn auth_manager_explicit_only_refuses_default() {
+        let mgr = AuthManager::with_strategies(vec![AuthStrategy::Default]);
+        // allowed_types includes DEFAULT, so the only reason to fail is the
+        // ExplicitOnly refusal of the ambient Default strategy.
+        let res = mgr.handle_credentials(
+            AuthMode::ExplicitOnly,
+            "https://example.com/repo.git",
+            None,
+            CredentialType::DEFAULT,
+        );
+        assert!(res.is_err());
     }
 }

--- a/crates/git2db/src/auth.rs
+++ b/crates/git2db/src/auth.rs
@@ -27,6 +27,19 @@ pub enum AuthStrategy {
     Default,
 }
 
+impl AuthStrategy {
+    /// Whether this strategy consults **ambient** credential sources — the
+    /// running SSH agent (`ssh_key_from_agent`), the git credential helper,
+    /// or `~/.gitconfig` — rather than explicit material the caller provided.
+    ///
+    /// `Default` and `SshAgent` are ambient. `SshKey` (explicit file path),
+    /// `UserPass`, and `Token` are explicit and always honored, including
+    /// under [`crate::callback_config::AuthMode::ExplicitOnly`].
+    pub fn is_ambient(&self) -> bool {
+        matches!(self, AuthStrategy::Default | AuthStrategy::SshAgent { .. })
+    }
+}
+
 /// Credential manager for handling authentication.
 ///
 /// Defaults to a **strict** security posture:
@@ -116,15 +129,15 @@ impl AuthManager {
         info!("Username from URL: {:?}", username_from_url);
         info!("Allowed credential types: {:?}", allowed_types);
 
-        // Try each strategy in order. Under ExplicitOnly, AuthStrategy::Default
-        // (ambient credential discovery) is refused so an untrusted fetch
-        // cannot silently pick up operator credentials.
+        // Try each strategy in order. Under ExplicitOnly, ambient strategies
+        // (AuthStrategy::Default → git credential helper / ~/.gitconfig;
+        // AuthStrategy::SshAgent → ssh-agent loaded keys) are refused so an
+        // untrusted fetch cannot silently pick up the operator's credentials.
         for strategy in &self.strategies {
-            if matches!(auth_mode, AuthMode::ExplicitOnly)
-                && matches!(strategy, AuthStrategy::Default)
-            {
+            if matches!(auth_mode, AuthMode::ExplicitOnly) && strategy.is_ambient() {
                 debug!(
-                    "Refusing ambient AuthStrategy::Default for {url} under ExplicitOnly auth mode"
+                    "Refusing ambient strategy {:?} for {url} under ExplicitOnly auth mode",
+                    strategy
                 );
                 continue;
             }
@@ -143,8 +156,8 @@ impl AuthManager {
         warn!("All authentication strategies failed for {}", url);
         if matches!(auth_mode, AuthMode::ExplicitOnly) {
             Err(git2::Error::from_str(
-                "No suitable explicit authentication method (ambient discovery refused under \
-                 ExplicitOnly auth mode)",
+                "No suitable explicit authentication method (ambient discovery — credential \
+                 helper, ~/.gitconfig, SSH agent — refused under ExplicitOnly auth mode)",
             ))
         } else {
             Err(git2::Error::from_str("No suitable authentication method"))

--- a/crates/git2db/src/auth.rs
+++ b/crates/git2db/src/auth.rs
@@ -21,8 +21,15 @@ pub enum AuthStrategy {
     },
     /// Use username/password
     UserPass { username: String, password: String },
-    /// Use personal access token
-    Token { token: String },
+    /// Use a personal access token.
+    ///
+    /// `host` optionally binds the token to an exact origin host (e.g.
+    /// `"github.com"`). When set, the credential callback only offers the
+    /// token when the request URL's host matches — a token configured for
+    /// host A is never sent to host B. `None` means unscoped; unscoped tokens
+    /// must not be attached to default/untrusted clone paths (see
+    /// [`crate::manager::GitManager::default_clone_options`]).
+    Token { token: String, host: Option<String> },
     /// Use default credentials (for public repos)
     Default,
 }
@@ -38,6 +45,48 @@ impl AuthStrategy {
     pub fn is_ambient(&self) -> bool {
         matches!(self, AuthStrategy::Default | AuthStrategy::SshAgent { .. })
     }
+}
+
+/// Extract the host component from a git remote URL.
+///
+/// Handles the common forms:
+/// - `https://github.com/user/repo.git` → `github.com`
+/// - `https://user@github.com/user/repo.git` → `github.com`
+/// - `ssh://git@github.com:22/user/repo.git` → `github.com`
+/// - `git@github.com:user/repo.git` (scp-like) → `github.com`
+///
+/// Returns `None` for unparseable URLs or local paths (`file://`, bare paths).
+pub fn extract_git_host(url: &str) -> Option<&str> {
+    let url = url.trim();
+    // scp-like: user@host:path
+    if let Some(at) = url.find('@') {
+        let after_at = &url[at + 1..];
+        if let Some(colon) = after_at.find(':') {
+            if !url.contains("://") {
+                let host = &after_at[..colon];
+                if !host.is_empty() {
+                    return Some(host);
+                }
+            }
+        }
+    }
+    // scheme://[user@]host[:port]/path
+    let after_scheme = url.split_once("://").map(|(_, rest)| rest)?;
+    // strip userinfo
+    let host_port = after_scheme.rsplit('@').next().unwrap_or(after_scheme);
+    // strip path
+    let host_port = host_scheme_host(host_port);
+    // strip port
+    let host = host_port.split(':').next().unwrap_or(host_port);
+    if host.is_empty() || host == "file" {
+        return None;
+    }
+    Some(host)
+}
+
+/// Take the leading host segment before the first `/`.
+fn host_scheme_host(s: &str) -> &str {
+    s.split('/').next().unwrap_or(s)
 }
 
 /// Credential manager for handling authentication.
@@ -191,7 +240,7 @@ impl AuthManager {
     fn try_strategy(
         &self,
         strategy: &AuthStrategy,
-        _url: &str,
+        url: &str,
         username_from_url: Option<&str>,
         allowed_types: CredentialType,
     ) -> Result<Cred, git2::Error> {
@@ -235,14 +284,36 @@ impl AuthManager {
                 }
             }
 
-            AuthStrategy::Token { token } => {
-                if allowed_types.contains(CredentialType::USER_PASS_PLAINTEXT) {
-                    info!("Trying token authentication");
-                    // For GitHub and similar services, use token as password with empty username
-                    Cred::userpass_plaintext("", token)
-                } else {
-                    Err(git2::Error::from_str("Token authentication not allowed"))
+            AuthStrategy::Token { token, host } => {
+                if !allowed_types.contains(CredentialType::USER_PASS_PLAINTEXT) {
+                    return Err(git2::Error::from_str("Token authentication not allowed"));
                 }
+                // Enforce host scope: a token bound to an exact origin host is
+                // only offered when the request URL's host matches. This closes
+                // credential exfiltration via caller-selected remotes (issue
+                // #1429 Sol P1): a process-global token configured for a
+                // trusted forge is never sent to an unrelated host.
+                if let Some(ref bound) = host {
+                    if let Some(req_host) = extract_git_host(url) {
+                        if req_host != bound.as_str() {
+                            debug!(
+                                "Refusing host-scoped token for {url}: bound to {bound:?}, \
+                                 request host is {req_host:?}"
+                            );
+                            return Err(git2::Error::from_str(
+                                "Token is scoped to a different host",
+                            ));
+                        }
+                    } else {
+                        debug!("Refusing host-scoped token for {url}: could not parse host");
+                        return Err(git2::Error::from_str(
+                            "Token is host-scoped but request URL host is unparseable",
+                        ));
+                    }
+                }
+                info!("Trying token authentication");
+                // For GitHub and similar services, use token as password with empty username
+                Cred::userpass_plaintext("", token)
             }
 
             AuthStrategy::Default => {
@@ -337,13 +408,29 @@ impl AuthBuilder {
         self
     }
 
-    /// Add token authentication
+    /// Add token authentication (host-unscoped — use `token_scoped` to bind
+    /// the token to an exact origin host).
     pub fn token<T>(mut self, token: T) -> Self
     where
         T: Into<String>,
     {
         self.strategies.push(AuthStrategy::Token {
             token: token.into(),
+            host: None,
+        });
+        self
+    }
+
+    /// Add token authentication bound to an exact origin host. The token is
+    /// only offered when the request URL's host matches `host`.
+    pub fn token_scoped<T, H>(mut self, token: T, host: H) -> Self
+    where
+        T: Into<String>,
+        H: Into<String>,
+    {
+        self.strategies.push(AuthStrategy::Token {
+            token: token.into(),
+            host: Some(host.into()),
         });
         self
     }
@@ -456,9 +543,12 @@ mod tests {
 
     #[test]
     fn auth_manager_builder_chains_modes() {
-        let mgr = AuthManager::with_strategies(vec![AuthStrategy::Token { token: "t".into() }])
-            .with_certificate_mode(CertificateConfig::AcceptAll)
-            .with_auth_mode(AuthMode::AllowAmbient);
+        let mgr = AuthManager::with_strategies(vec![AuthStrategy::Token {
+            token: "t".into(),
+            host: None,
+        }])
+        .with_certificate_mode(CertificateConfig::AcceptAll)
+        .with_auth_mode(AuthMode::AllowAmbient);
         assert!(matches!(
             mgr.certificate_mode(),
             CertificateConfig::AcceptAll
@@ -482,5 +572,36 @@ mod tests {
             CredentialType::DEFAULT,
         );
         assert!(res.is_err());
+    }
+
+    #[test]
+    fn extract_git_host_parses_common_url_forms() {
+        assert_eq!(
+            extract_git_host("https://github.com/user/repo.git"),
+            Some("github.com")
+        );
+        assert_eq!(
+            extract_git_host("https://user@github.com/user/repo.git"),
+            Some("github.com")
+        );
+        assert_eq!(
+            extract_git_host("ssh://git@github.com:22/user/repo.git"),
+            Some("github.com")
+        );
+        assert_eq!(
+            extract_git_host("git@github.com:user/repo.git"),
+            Some("github.com")
+        );
+        assert_eq!(
+            extract_git_host("https://huggingface.co/Qwen/Qwen3"),
+            Some("huggingface.co")
+        );
+    }
+
+    #[test]
+    fn extract_git_host_rejects_local_and_unparseable() {
+        assert_eq!(extract_git_host("file:///path/to/repo"), None);
+        assert_eq!(extract_git_host("/local/path"), None);
+        assert_eq!(extract_git_host("not-a-url"), None);
     }
 }

--- a/crates/git2db/src/auth.rs
+++ b/crates/git2db/src/auth.rs
@@ -63,7 +63,7 @@ const ALLOWED_SCHEMES: &[&str] = &["https", "http", "ssh", "git"];
 /// - IPv4 addresses (including non-canonical forms like octal/hex octets)
 ///   are normalized to canonical dotted-decimal.
 /// - IPv6 literals are normalized and returned in bracketed form
-///   (`[2001:db8::1]`).
+///   (`[2001:db8::cafe]`).
 /// - Default scheme ports are stripped (`:443`/`:80` for HTTPS/HTTP, `:22`
 ///   for SSH, `:9418` for the git protocol); any other port is preserved.
 ///
@@ -81,11 +81,24 @@ const ALLOWED_SCHEMES: &[&str] = &["https", "http", "ssh", "git"];
 /// re-canonicalized explicitly via [`url::Host::parse`] — the same
 /// standards-based host algorithm, applied uniformly regardless of scheme.
 ///
+/// **Backslash is rejected outright (fail closed), not parsed.** The WHATWG
+/// URL Standard treats `\` as equivalent to `/` within a "special" scheme
+/// (`http`/`https`), ending the authority early — but the pinned libgit2
+/// 1.9.x C parser treats `\` as an ordinary authority character and keeps
+/// splitting userinfo at the last `@`. The same input string is therefore
+/// assigned a *different* authority by this function than by the transport
+/// that actually opens the connection: `https://github.com\@evil.example/x`
+/// resolves to `github.com` here but libgit2 connects to `evil.example`.
+/// Any input containing `\` is a parser-differential attack surface, not a
+/// case this function can resolve by parsing more cleverly — it returns
+/// `None` unconditionally rather than risk agreeing with the wrong parser.
+/// See #1429 Kimi-K3 r3 P1.
+///
 /// Returns `None` for local paths (`file://`, bare paths), malformed URLs,
-/// URLs using a scheme outside [`ALLOWED_SCHEMES`], or URLs where the
-/// authority cannot be reliably determined. Callers must treat `None` as
-/// "authority unknown" and refuse the credential, not fall back to an
-/// unscoped release.
+/// URLs using a scheme outside [`ALLOWED_SCHEMES`], URLs containing a
+/// backslash, or URLs where the authority cannot be reliably determined.
+/// Callers must treat `None` as "authority unknown" and refuse the
+/// credential, not fall back to an unscoped release.
 ///
 /// # Examples
 /// ```text
@@ -96,11 +109,21 @@ const ALLOWED_SCHEMES: &[&str] = &["https", "http", "ssh", "git"];
 /// https://evil.example/repo@github.com    → "evil.example" (path @ ignored)
 /// ssh://git@github.com:22/user/repo.git   → "github.com"
 /// git@github.com:user/repo.git            → "github.com"   (scp-like)
-/// https://[2001:db8::1]/repo.git          → "[2001:db8::1]"
+/// https://[2001:db8::cafe]/repo.git       → "[2001:db8::cafe]"
+/// https://github.com\@evil.example/x.git  → None            (backslash rejected)
 /// ```
 pub fn extract_git_authority(url: &str) -> Option<String> {
     let trimmed = url.trim();
     if trimmed.is_empty() {
+        return None;
+    }
+
+    // Fail closed on any backslash before doing any other parsing — see the
+    // doc comment above for the exact WHATWG-vs-libgit2 differential this
+    // closes. This must run before the scp-like/URL branch split and before
+    // `url::Url::parse`, since the differential exists regardless of which
+    // branch would otherwise handle the input.
+    if trimmed.contains('\\') {
         return None;
     }
 
@@ -935,5 +958,44 @@ mod tests {
     #[test]
     fn extract_scp_like_authority_requires_at_sign() {
         assert_eq!(extract_git_authority("github.com:owner/repo.git"), None);
+    }
+
+    // ---- Backslash: WHATWG-vs-libgit2 authority differential (#1429 r3 P1) ----
+
+    /// The exact differential the r3 review causally proved against the real
+    /// pinned libgit2 stack: for a "special" scheme, WHATWG (`url::Url::parse`)
+    /// treats `\` as ending the authority early, resolving to `github.com` —
+    /// but libgit2's own C parser treats `\` as an ordinary authority
+    /// character and splits userinfo at the last `@`, resolving to
+    /// `evil.example`. Because the two parsers disagree on what the
+    /// authority even is, the function must refuse to answer at all.
+    #[test]
+    fn extract_git_authority_rejects_backslash_differential() {
+        assert_eq!(
+            extract_git_authority("https://github.com\\@evil.example/repo.git"),
+            None,
+            "a backslash-containing authority is a WHATWG/libgit2 parser \
+             differential and must fail closed, not resolve to either parser's answer",
+        );
+    }
+
+    /// Backslash is rejected regardless of scheme or position — this is not
+    /// specific to the `https` special-scheme case above.
+    #[test]
+    fn extract_git_authority_rejects_backslash_anywhere() {
+        assert_eq!(extract_git_authority("ssh://git@github.com\\evil/x"), None);
+        assert_eq!(extract_git_authority("https://evil.example/\\@github.com"), None);
+        assert_eq!(extract_git_authority("http://github.com\\.evil.example/x"), None);
+    }
+
+    /// scp-like syntax is covered by the same top-level guard: a backslash
+    /// anywhere in scp-like input is rejected before the `@`/`:` boundary
+    /// logic ever runs.
+    #[test]
+    fn extract_git_authority_rejects_backslash_in_scp_like() {
+        assert_eq!(
+            extract_git_authority("git@github.com\\evil.example:owner/repo.git"),
+            None
+        );
     }
 }

--- a/crates/git2db/src/auth.rs
+++ b/crates/git2db/src/auth.rs
@@ -2,7 +2,7 @@
 //!
 //! Consolidated authentication patterns from the original codebase.
 
-use crate::callback_config::{AuthMode, CertificateConfig};
+use crate::callback_config::{AuthMode, CertificateConfig, RedirectPolicy};
 use git2::{Cred, CredentialType, RemoteCallbacks};
 use std::path::PathBuf;
 use tracing::{debug, info, warn};
@@ -47,46 +47,130 @@ impl AuthStrategy {
     }
 }
 
-/// Extract the host component from a git remote URL.
+/// Git remote schemes accepted for authority-based credential scoping.
 ///
-/// Handles the common forms:
-/// - `https://github.com/user/repo.git` → `github.com`
-/// - `https://user@github.com/user/repo.git` → `github.com`
-/// - `ssh://git@github.com:22/user/repo.git` → `github.com`
-/// - `git@github.com:user/repo.git` (scp-like) → `github.com`
+/// Anything else (`file`, `data`, an unrecognized custom scheme, ...) is
+/// rejected — [`extract_git_authority`] returns `None` and the caller fails
+/// closed rather than guessing an authority for a scheme it does not
+/// understand.
+const ALLOWED_SCHEMES: &[&str] = &["https", "http", "ssh", "git"];
+
+/// Extract the **canonical authority** from a git remote URL for host-scoping.
 ///
-/// Returns `None` for unparseable URLs or local paths (`file://`, bare paths).
-pub fn extract_git_host(url: &str) -> Option<&str> {
-    let url = url.trim();
-    // scp-like: user@host:path
-    if let Some(at) = url.find('@') {
-        let after_at = &url[at + 1..];
-        if let Some(colon) = after_at.find(':') {
-            if !url.contains("://") {
-                let host = &after_at[..colon];
-                if !host.is_empty() {
-                    return Some(host);
-                }
-            }
-        }
-    }
-    // scheme://[user@]host[:port]/path
-    let after_scheme = url.split_once("://").map(|(_, rest)| rest)?;
-    // strip userinfo
-    let host_port = after_scheme.rsplit('@').next().unwrap_or(after_scheme);
-    // strip path
-    let host_port = host_scheme_host(host_port);
-    // strip port
-    let host = host_port.split(':').next().unwrap_or(host_port);
-    if host.is_empty() || host == "file" {
+/// The authority is the `host[:port]` portion of the URL, canonicalized per
+/// the WHATWG URL Standard's host-parsing algorithm (via the `url` crate):
+/// - Domain names are IDNA-processed and ASCII case-folded.
+/// - IPv4 addresses (including non-canonical forms like octal/hex octets)
+///   are normalized to canonical dotted-decimal.
+/// - IPv6 literals are normalized and returned in bracketed form
+///   (`[2001:db8::1]`).
+/// - Default scheme ports are stripped (`:443`/`:80` for HTTPS/HTTP, `:22`
+///   for SSH, `:9418` for the git protocol); any other port is preserved.
+///
+/// **Security-critical / standards-based:** the URL is parsed structurally
+/// by [`url::Url::parse`] — the authority (scheme, userinfo, host, port) is
+/// separated from the path, query, and fragment by the same state machine
+/// browsers use, so an `@`, `/`, `?`, or `#` appearing in the path or query
+/// can never be misread as part of the authority. This closes the Sol P1
+/// path/query `@` confusion finding (#1429), which affected the previous
+/// hand-written parser.
+///
+/// `url::Url::parse` only applies IDNA/case canonicalization to the host
+/// automatically for its built-in "special" schemes (`http`/`https`); `ssh`
+/// and `git` are not "special" to the `url` crate, so their host is
+/// re-canonicalized explicitly via [`url::Host::parse`] — the same
+/// standards-based host algorithm, applied uniformly regardless of scheme.
+///
+/// Returns `None` for local paths (`file://`, bare paths), malformed URLs,
+/// URLs using a scheme outside [`ALLOWED_SCHEMES`], or URLs where the
+/// authority cannot be reliably determined. Callers must treat `None` as
+/// "authority unknown" and refuse the credential, not fall back to an
+/// unscoped release.
+///
+/// # Examples
+/// ```text
+/// https://github.com/user/repo.git        → "github.com"
+/// https://USER@github.com/user/repo.git   → "github.com"
+/// https://github.com:443/user/repo.git    → "github.com"   (default port stripped)
+/// https://github.com:8443/user/repo.git   → "github.com:8443"
+/// https://evil.example/repo@github.com    → "evil.example" (path @ ignored)
+/// ssh://git@github.com:22/user/repo.git   → "github.com"
+/// git@github.com:user/repo.git            → "github.com"   (scp-like)
+/// https://[2001:db8::1]/repo.git          → "[2001:db8::1]"
+/// ```
+pub fn extract_git_authority(url: &str) -> Option<String> {
+    let trimmed = url.trim();
+    if trimmed.is_empty() {
         return None;
     }
-    Some(host)
+
+    if !trimmed.contains("://") {
+        return extract_scp_like_authority(trimmed);
+    }
+
+    let parsed = url::Url::parse(trimmed).ok()?;
+    let scheme = parsed.scheme();
+    if !ALLOWED_SCHEMES.contains(&scheme) {
+        return None;
+    }
+    // Reject cannot-be-a-base URLs (e.g. `mailto:`-shaped, no authority at
+    // all) up front — a scheme in ALLOWED_SCHEMES combined with `://` in the
+    // input always parses to a base URL, but guard explicitly rather than
+    // relying on that invariant.
+    if parsed.cannot_be_a_base() {
+        return None;
+    }
+    let raw_host = parsed.host_str()?;
+
+    // Re-run the raw host through the standards host-parsing algorithm
+    // unconditionally (IDNA + case-fold for domains, canonical IPv4, bracketed
+    // IPv6). `Url::parse` already did this for "special" schemes (http/https);
+    // for "non-special" git schemes (ssh/git) it left the host as an opaque,
+    // uncanonicalized string, so this step is required for those too.
+    let canonical_host = url::Host::parse(raw_host).ok()?;
+    let host_display = canonical_host.to_string();
+
+    match parsed.port() {
+        Some(port) if !is_default_port(scheme, port) => Some(format!("{host_display}:{port}")),
+        _ => Some(host_display),
+    }
 }
 
-/// Take the leading host segment before the first `/`.
-fn host_scheme_host(s: &str) -> &str {
-    s.split('/').next().unwrap_or(s)
+/// Extract the canonical authority from git's scp-like remote syntax:
+/// `[user@]host:path` (no `scheme://`, e.g. `git@github.com:owner/repo.git`).
+/// This form has no port; a colon always introduces the path, never a port
+/// (`git@host:22/path` means path `22/path`, matching real git behavior).
+///
+/// The host is bounded by the **last** `@` before the first `:` — mirroring
+/// the WHATWG URL Standard's userinfo/host boundary (userinfo is everything
+/// up to the last `@`) — so an embedded `@` in a spoofed userinfo segment
+/// (`user@name@host:path`) cannot smuggle `name@host` in as the host.
+fn extract_scp_like_authority(input: &str) -> Option<String> {
+    let colon = input.find(':')?;
+    let before_colon = &input[..colon];
+    // A `/` before the first `:` means this isn't scp-like syntax at all
+    // (e.g. a bare local path containing a colon) — reject rather than guess.
+    if before_colon.contains('/') {
+        return None;
+    }
+    let at = before_colon.rfind('@')?;
+    let host = &before_colon[at + 1..];
+    if host.is_empty() {
+        return None;
+    }
+    let canonical_host = url::Host::parse(host).ok()?;
+    Some(canonical_host.to_string())
+}
+
+/// Whether a port is the default for the given scheme.
+fn is_default_port(scheme: &str, port: u16) -> bool {
+    match scheme {
+        "https" => port == 443,
+        "http" => port == 80,
+        "ssh" => port == 22,
+        "git" => port == 9418,
+        _ => false,
+    }
 }
 
 /// Credential manager for handling authentication.
@@ -99,30 +183,45 @@ fn host_scheme_host(s: &str) -> &str {
 ///   (`AuthStrategy::Default`, i.e. the git credential helper, `~/.gitconfig`,
 ///   SSH agent fallback) is refused unless the caller explicitly opts in via
 ///   [`AuthManager::with_auth_mode`]`(AllowAmbient)`.
+/// - [`RedirectPolicy::None`] — callers that build their own `git2::FetchOptions`
+///   from this manager's [`AuthManager::create_callbacks`] must also apply
+///   [`AuthManager::redirect_policy`] via [`RedirectPolicy::to_git2`] /
+///   `FetchOptions::follow_redirects`. libgit2's own default
+///   (`RemoteRedirect::Initial`) allows an off-site redirect on the initial
+///   request, and — per the pinned libgit2 1.9.x behavior — the credential
+///   callback still receives the *original* request URL after that redirect,
+///   not the effective peer. Combined with a host-scoped [`AuthStrategy::Token`],
+///   that would let a credential bound to host A be offered to a redirect
+///   target host B. See issue #1429 Sol P1.
 pub struct AuthManager {
     strategies: Vec<AuthStrategy>,
     certificate_mode: CertificateConfig,
     auth_mode: AuthMode,
+    redirect_policy: RedirectPolicy,
 }
 
 impl AuthManager {
     /// Create a new authentication manager with no strategies, strict
-    /// certificate validation, and `ExplicitOnly` auth mode.
+    /// certificate validation, `ExplicitOnly` auth mode, and no off-site
+    /// redirects.
     pub fn new() -> Self {
         Self {
             strategies: Vec::new(),
             certificate_mode: CertificateConfig::Strict,
             auth_mode: AuthMode::ExplicitOnly,
+            redirect_policy: RedirectPolicy::None,
         }
     }
 
     /// Create authentication manager with strategies. Certificate validation
-    /// defaults to strict and auth mode to `ExplicitOnly`.
+    /// defaults to strict, auth mode to `ExplicitOnly`, and redirect policy to
+    /// no off-site redirects.
     pub fn with_strategies(strategies: Vec<AuthStrategy>) -> Self {
         Self {
             strategies,
             certificate_mode: CertificateConfig::Strict,
             auth_mode: AuthMode::ExplicitOnly,
+            redirect_policy: RedirectPolicy::None,
         }
     }
 
@@ -136,6 +235,22 @@ impl AuthManager {
     pub fn with_auth_mode(mut self, mode: AuthMode) -> Self {
         self.auth_mode = mode;
         self
+    }
+
+    /// Set the off-site redirect policy. Defaults to [`RedirectPolicy::None`].
+    /// Callers driving a real `git2::FetchOptions` from this manager must
+    /// apply the result of [`AuthManager::redirect_policy`] via
+    /// `follow_redirects` — this struct only carries the *decision*; it does
+    /// not own a `FetchOptions` to enforce it against (see
+    /// [`crate::clone_options`] for the send-safe path that does).
+    pub fn with_redirect_policy(mut self, policy: RedirectPolicy) -> Self {
+        self.redirect_policy = policy;
+        self
+    }
+
+    /// Get the configured off-site redirect policy.
+    pub fn redirect_policy(&self) -> RedirectPolicy {
+        self.redirect_policy
     }
 
     /// Add an authentication strategy
@@ -288,27 +403,32 @@ impl AuthManager {
                 if !allowed_types.contains(CredentialType::USER_PASS_PLAINTEXT) {
                     return Err(git2::Error::from_str("Token authentication not allowed"));
                 }
-                // Enforce host scope: a token bound to an exact origin host is
-                // only offered when the request URL's host matches. This closes
-                // credential exfiltration via caller-selected remotes (issue
-                // #1429 Sol P1): a process-global token configured for a
-                // trusted forge is never sent to an unrelated host.
-                if let Some(ref bound) = host {
-                    if let Some(req_host) = extract_git_host(url) {
-                        if req_host != bound.as_str() {
+                // Enforce authority scope: a token bound to an exact origin
+                // authority is only offered when the request URL's canonical
+                // authority matches. The authority is extracted path-safely
+                // (the path is separated before userinfo handling, so path/query
+                // `@` characters cannot spoof the authority). See #1429 Sol P1.
+                if let Some(bound) = host {
+                    match extract_git_authority(url) {
+                        Some(req_auth) if &req_auth == bound => {}
+                        Some(req_auth) => {
                             debug!(
-                                "Refusing host-scoped token for {url}: bound to {bound:?}, \
-                                 request host is {req_host:?}"
+                                "Refusing authority-scoped token for {url}: bound to \
+                                 {bound:?}, request authority is {req_auth:?}"
                             );
                             return Err(git2::Error::from_str(
-                                "Token is scoped to a different host",
+                                "Token is scoped to a different authority",
                             ));
                         }
-                    } else {
-                        debug!("Refusing host-scoped token for {url}: could not parse host");
-                        return Err(git2::Error::from_str(
-                            "Token is host-scoped but request URL host is unparseable",
-                        ));
+                        None => {
+                            debug!(
+                                "Refusing authority-scoped token for {url}: could not parse \
+                                 authority"
+                            );
+                            return Err(git2::Error::from_str(
+                                "Token is authority-scoped but request URL is unparseable",
+                            ));
+                        }
                     }
                 }
                 info!("Trying token authentication");
@@ -408,9 +528,14 @@ impl AuthBuilder {
         self
     }
 
-    /// Add token authentication (host-unscoped — use `token_scoped` to bind
-    /// the token to an exact origin host).
-    pub fn token<T>(mut self, token: T) -> Self
+    /// Add token authentication **without** an authority binding.
+    ///
+    /// **Warning:** an unscoped token is offered to ANY remote that challenges
+    /// for `USER_PASS_PLAINTEXT`. This is an explicit trusted-caller opt-in —
+    /// callers must understand the credential-exfiltration implications.
+    /// Prefer [`AuthBuilder::token_scoped`] which binds the token to an exact
+    /// origin authority.
+    pub fn token_unscoped<T>(mut self, token: T) -> Self
     where
         T: Into<String>,
     {
@@ -476,10 +601,11 @@ pub mod presets {
             .with_auth_mode(AuthMode::AllowAmbient)
     }
 
-    /// GitHub personal access token with SSH-agent and ambient fallback.
+    /// GitHub personal access token scoped to the canonical `github.com`
+    /// authority, with SSH-agent and ambient fallback.
     pub fn github_token<T: Into<String>>(token: T) -> AuthManager {
         AuthBuilder::new()
-            .token(token)
+            .token_scoped(token, "github.com")
             .ssh_agent(Some("git".to_owned()))
             .default_fallback()
             .build()
@@ -522,7 +648,7 @@ mod tests {
     fn test_auth_builder() {
         let auth = AuthBuilder::new()
             .ssh_agent(Some("git".to_owned()))
-            .token("ghp_test_token")
+            .token_unscoped("ghp_test_token")
             .default_fallback()
             .build();
 
@@ -575,33 +701,239 @@ mod tests {
     }
 
     #[test]
-    fn extract_git_host_parses_common_url_forms() {
+    fn extract_git_authority_parses_common_url_forms() {
         assert_eq!(
-            extract_git_host("https://github.com/user/repo.git"),
-            Some("github.com")
+            extract_git_authority("https://github.com/user/repo.git"),
+            Some("github.com".to_owned())
         );
         assert_eq!(
-            extract_git_host("https://user@github.com/user/repo.git"),
-            Some("github.com")
+            extract_git_authority("https://user@github.com/user/repo.git"),
+            Some("github.com".to_owned())
         );
         assert_eq!(
-            extract_git_host("ssh://git@github.com:22/user/repo.git"),
-            Some("github.com")
+            extract_git_authority("ssh://git@github.com:22/user/repo.git"),
+            Some("github.com".to_owned()) // default SSH port stripped
         );
         assert_eq!(
-            extract_git_host("git@github.com:user/repo.git"),
-            Some("github.com")
+            extract_git_authority("git@github.com:user/repo.git"),
+            Some("github.com".to_owned())
         );
         assert_eq!(
-            extract_git_host("https://huggingface.co/Qwen/Qwen3"),
-            Some("huggingface.co")
+            extract_git_authority("https://huggingface.co/Qwen/Qwen3"),
+            Some("huggingface.co".to_owned())
         );
     }
 
     #[test]
-    fn extract_git_host_rejects_local_and_unparseable() {
-        assert_eq!(extract_git_host("file:///path/to/repo"), None);
-        assert_eq!(extract_git_host("/local/path"), None);
-        assert_eq!(extract_git_host("not-a-url"), None);
+    fn extract_git_authority_rejects_local_and_unparseable() {
+        assert_eq!(extract_git_authority("file:///path/to/repo"), None);
+        assert_eq!(extract_git_authority("/local/path"), None);
+        assert_eq!(extract_git_authority("not-a-url"), None);
+    }
+
+    #[test]
+    fn extract_git_authority_path_at_does_not_spoof() {
+        // The critical P1 fix: @ in the path must NOT be treated as userinfo.
+        assert_eq!(
+            extract_git_authority("https://evil.example/repo@github.com/owned.git"),
+            Some("evil.example".to_owned())
+        );
+        assert_eq!(
+            extract_git_authority("https://evil.example/repo?x=@github.com"),
+            Some("evil.example".to_owned())
+        );
+    }
+
+    #[test]
+    fn extract_git_authority_normalizes_case_and_ports() {
+        assert_eq!(
+            extract_git_authority("https://GitHub.COM/user/repo.git"),
+            Some("github.com".to_owned()) // case normalized
+        );
+        assert_eq!(
+            extract_git_authority("https://github.com:443/user/repo.git"),
+            Some("github.com".to_owned()) // default HTTPS port stripped
+        );
+        assert_eq!(
+            extract_git_authority("https://github.com:8443/user/repo.git"),
+            Some("github.com:8443".to_owned()) // non-default port preserved
+        );
+    }
+
+    #[test]
+    fn extract_git_authority_handles_ipv6() {
+        assert_eq!(
+            extract_git_authority("https://[2001:db8::1]/repo.git"),
+            Some("[2001:db8::1]".to_owned())
+        );
+        assert_eq!(
+            extract_git_authority("https://[2001:db8::1]:8443/repo.git"),
+            Some("[2001:db8::1]:8443".to_owned())
+        );
+    }
+
+    /// IPv6 authority is also canonicalized for the non-"special" `ssh`
+    /// scheme, where `url::Url::parse` does not canonicalize automatically —
+    /// proving the explicit `Host::parse` re-canonicalization step is load-bearing.
+    #[test]
+    fn extract_git_authority_handles_ipv6_over_ssh() {
+        assert_eq!(
+            extract_git_authority("ssh://git@[2001:DB8::1]:22/repo.git"),
+            Some("[2001:db8::1]".to_owned()) // default SSH port stripped, hex lowercased
+        );
+    }
+
+    /// IPv4 literals are canonicalized to dotted-decimal, including
+    /// non-canonical numeric forms (octal/hex octets) that could otherwise be
+    /// used to make two textually different authorities resolve to the same
+    /// address and evade a naive string comparison.
+    #[test]
+    fn extract_git_authority_canonicalizes_ipv4() {
+        assert_eq!(
+            extract_git_authority("https://192.168.1.1/repo.git"),
+            Some("192.168.1.1".to_owned())
+        );
+        // Octal-looking octet (leading zero) canonicalizes to the same
+        // decimal address per the WHATWG IPv4 parser.
+        assert_eq!(
+            extract_git_authority("https://192.168.1.001/repo.git"),
+            Some("192.168.1.1".to_owned())
+        );
+        assert_eq!(
+            extract_git_authority("git@192.168.1.1:owner/repo.git"),
+            Some("192.168.1.1".to_owned())
+        );
+    }
+
+    /// A port that is the ssh/git default but NOT the https/http default (or
+    /// vice versa) must be scoped per the URL's own scheme, never treated as
+    /// "default" merely because it matches a *different* scheme's default.
+    /// This specifically covers GitHub's real-world "SSH over port 443"
+    /// endpoint, which must not collide with the https:443 default.
+    #[test]
+    fn extract_git_authority_scopes_default_port_per_scheme() {
+        assert_eq!(
+            extract_git_authority("ssh://git@ssh.github.com:443/owner/repo.git"),
+            Some("ssh.github.com:443".to_owned()), // 443 is NOT the ssh default
+        );
+        assert_eq!(
+            extract_git_authority("ssh://git@github.com:22/owner/repo.git"),
+            Some("github.com".to_owned()), // 22 IS the ssh default
+        );
+        assert_eq!(
+            extract_git_authority("git://github.com:9418/owner/repo.git"),
+            Some("github.com".to_owned()), // 9418 is the git:// default
+        );
+        assert_eq!(
+            extract_git_authority("git://github.com:9419/owner/repo.git"),
+            Some("github.com:9419".to_owned()),
+        );
+    }
+
+    /// IDNA: two different Unicode case/normalization variants of the same
+    /// domain must canonicalize to the identical authority string (and to
+    /// ASCII punycode, not raw Unicode), so a lookalike-case Unicode domain
+    /// cannot bypass a string-equality host-scope check.
+    #[test]
+    fn extract_git_authority_normalizes_idna() {
+        let lower = extract_git_authority("https://münchen.example/repo.git");
+        let upper = extract_git_authority("https://MÜNCHEN.example/repo.git");
+        assert_eq!(lower, upper, "IDNA case folding must be applied uniformly");
+        assert!(
+            matches!(&lower, Some(host) if host.starts_with("xn--")),
+            "domain must be canonicalized to ASCII punycode, got {lower:?}",
+        );
+
+        // Same requirement over the non-"special" ssh scheme, where
+        // `url::Url::parse` alone would NOT apply IDNA — proving the explicit
+        // re-canonicalization step covers this scheme too.
+        let ssh_lower = extract_git_authority("ssh://git@münchen.example/repo.git");
+        let ssh_upper = extract_git_authority("ssh://git@MÜNCHEN.example/repo.git");
+        assert!(ssh_lower.is_some());
+        assert_eq!(ssh_lower, ssh_upper);
+        assert_eq!(lower, ssh_lower, "https and ssh must canonicalize identically");
+    }
+
+    /// Malformed authorities are rejected outright (`None`) rather than
+    /// silently truncated or misparsed into something that could
+    /// accidentally match a configured bound host.
+    #[test]
+    fn extract_git_authority_rejects_malformed() {
+        // Non-numeric port.
+        assert_eq!(
+            extract_git_authority("https://github.com:notaport/repo.git"),
+            None
+        );
+        // Unterminated IPv6 bracket.
+        assert_eq!(extract_git_authority("https://[2001:db8::1/repo.git"), None);
+        // Empty host: for a "non-special" git scheme (ssh/git) three slashes
+        // after the scheme yield a genuinely empty authority (unlike https,
+        // where WHATWG's "special authority ignore slashes" leniency would
+        // otherwise make the following path segment look like a host).
+        assert_eq!(extract_git_authority("ssh:///repo.git"), None);
+        assert_eq!(extract_git_authority("git:///repo.git"), None);
+        // Empty string / whitespace only.
+        assert_eq!(extract_git_authority(""), None);
+        assert_eq!(extract_git_authority("   "), None);
+    }
+
+    /// A scheme outside the git-relevant allowlist is rejected even though
+    /// `url::Url::parse` would happily parse it — an unrecognized scheme must
+    /// fail closed rather than be guessed to share an authority scope.
+    #[test]
+    fn extract_git_authority_rejects_disallowed_scheme() {
+        assert_eq!(extract_git_authority("ftp://github.com/repo.git"), None);
+        assert_eq!(
+            extract_git_authority("javascript://github.com/repo.git"),
+            None
+        );
+        assert_eq!(
+            extract_git_authority("mailto:git@github.com"),
+            None,
+            "cannot-be-a-base URLs must never resolve to an authority"
+        );
+    }
+
+    /// Fragment `#` must terminate the authority exactly like `/` and `?` —
+    /// an `@` after `#` must not be read as authority userinfo.
+    #[test]
+    fn extract_git_authority_fragment_at_does_not_spoof() {
+        assert_eq!(
+            extract_git_authority("https://evil.example/repo.git#@github.com"),
+            Some("evil.example".to_owned())
+        );
+    }
+
+    /// The classic human-misreading authority-confusion form: a full hostname
+    /// used as *userinfo* immediately before the real (attacker) host. Unlike
+    /// the path/query cases above, this is not a parser bug — the real
+    /// network authority genuinely is `evil.example`, and the parser must
+    /// report that faithfully so the caller's scope check refuses it.
+    #[test]
+    fn extract_git_authority_userinfo_lookalike_resolves_to_real_host() {
+        assert_eq!(
+            extract_git_authority("https://github.com@evil.example/repo.git"),
+            Some("evil.example".to_owned())
+        );
+    }
+
+    /// scp-like syntax: an embedded `@` within what looks like userinfo must
+    /// not smuggle a trailing `@host` segment in as the host — the host is
+    /// bounded by the LAST `@` before the first `:`, mirroring URL userinfo
+    /// semantics.
+    #[test]
+    fn extract_scp_like_authority_rejects_embedded_at_ambiguity() {
+        assert_eq!(
+            extract_git_authority("user@name@github.com:owner/repo.git"),
+            Some("github.com".to_owned())
+        );
+    }
+
+    /// scp-like syntax requires an explicit `user@`; a bare `host:path` with
+    /// no `@` and no `://` is not accepted (fails closed rather than
+    /// guessing this is scp-like syntax vs. an unrelated colon-bearing path).
+    #[test]
+    fn extract_scp_like_authority_requires_at_sign() {
+        assert_eq!(extract_git_authority("github.com:owner/repo.git"), None);
     }
 }

--- a/crates/git2db/src/callback_config.rs
+++ b/crates/git2db/src/callback_config.rs
@@ -71,24 +71,27 @@ pub enum CertificateConfig {
 /// Authentication provenance mode — whether ambient credential sources may be
 /// consulted.
 ///
-/// `ExplicitOnly` (the default) refuses [`AuthStrategy::Default`], which maps
-/// to libgit2's ambient credential discovery (`git credential` helper,
-/// `~/.gitconfig`, SSH agent fallback). This prevents an untrusted fetch from
-/// silently picking up the operator's personal credentials. Callers that
-/// intentionally want ambient discovery (e.g. a trusted first-party mirror
+/// `ExplicitOnly` (the default) refuses ambient strategies —
+/// [`AuthStrategy::Default`] (git credential helper, `~/.gitconfig`) **and**
+/// [`AuthStrategy::SshAgent`] (the running SSH agent's loaded keys). This
+/// prevents an untrusted fetch from silently picking up the operator's personal
+/// credentials via `Cred::ssh_key_from_agent` or `Cred::default`. Explicit
+/// strategies (`SshKey` file, `UserPass`, `Token`) are always honored. Callers
+/// that intentionally want ambient discovery (e.g. a trusted first-party mirror
 /// clone driven by the operator's own identity) must explicitly opt in via
 /// [`AuthMode::AllowAmbient`].
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub enum AuthMode {
     /// Only explicit authentication strategies are honored.
-    /// [`AuthStrategy::Default`] is rejected, so ambient credential sources
-    /// (credential helper, `~/.gitconfig`, SSH agent fallback) are never
-    /// consulted. Secure default for untrusted/forge-facing fetches.
+    /// Ambient strategies ([`AuthStrategy::Default`], [`AuthStrategy::SshAgent`])
+    /// are rejected, so the credential helper, `~/.gitconfig`, and the SSH
+    /// agent are never consulted. Secure default for untrusted/forge-facing
+    /// fetches.
     #[default]
     ExplicitOnly,
-    /// Permit ambient credential discovery via [`AuthStrategy::Default`].
-    /// Opt-in for trusted first-party mirrors where operator identity is
-    /// expected.
+    /// Permit ambient credential discovery via [`AuthStrategy::Default`] and
+    /// [`AuthStrategy::SshAgent`]. Opt-in for trusted first-party mirrors
+    /// where operator identity is expected.
     AllowAmbient,
 }
 
@@ -211,16 +214,16 @@ impl CallbackConfig {
         username_from_url: Option<&str>,
         allowed_types: git2::CredentialType,
     ) -> Result<git2::Cred, git2::Error> {
-        // Try each strategy in order. Under ExplicitOnly, AuthStrategy::Default
-        // (which maps to libgit2's ambient credential discovery: the git
-        // credential helper, ~/.gitconfig, SSH agent fallback) is refused so an
-        // untrusted fetch cannot silently pick up operator credentials.
+        // Try each strategy in order. Under ExplicitOnly, ambient strategies
+        // (AuthStrategy::Default → git credential helper / ~/.gitconfig;
+        // AuthStrategy::SshAgent → ssh-agent loaded keys) are refused so an
+        // untrusted fetch cannot silently pick up the operator's credentials.
+        // Explicit strategies (SshKey file, UserPass, Token) are always honored.
         for strategy in strategies {
-            if matches!(auth_mode, AuthMode::ExplicitOnly)
-                && matches!(strategy, AuthStrategy::Default)
-            {
+            if matches!(auth_mode, AuthMode::ExplicitOnly) && strategy.is_ambient() {
                 tracing::debug!(
-                    "Refusing ambient AuthStrategy::Default for {url} under ExplicitOnly auth mode"
+                    "Refusing ambient strategy {:?} for {url} under ExplicitOnly auth mode",
+                    strategy
                 );
                 continue;
             }
@@ -232,8 +235,8 @@ impl CallbackConfig {
 
         if matches!(auth_mode, AuthMode::ExplicitOnly) {
             Err(git2::Error::from_str(
-                "No suitable explicit authentication method (ambient discovery refused under \
-                 ExplicitOnly auth mode)",
+                "No suitable explicit authentication method (ambient discovery — credential \
+                 helper, ~/.gitconfig, SSH agent — refused under ExplicitOnly auth mode)",
             ))
         } else {
             Err(git2::Error::from_str("No suitable authentication method"))
@@ -439,6 +442,7 @@ impl CallbackConfigBuilder {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::path::PathBuf;
 
     #[test]
     fn test_callback_config_is_send() {
@@ -471,6 +475,10 @@ mod tests {
         git2::CredentialType::DEFAULT
     }
 
+    fn ssh_allowed() -> git2::CredentialType {
+        git2::CredentialType::SSH_KEY
+    }
+
     /// Under ExplicitOnly, a sole `AuthStrategy::Default` is refused — ambient
     /// credential sources (credential helper, ~/.gitconfig, SSH agent fallback)
     /// are not consulted.
@@ -488,6 +496,73 @@ mod tests {
             res.is_err(),
             "ExplicitOnly must refuse AuthStrategy::Default so ambient credentials are not \
              consulted",
+        );
+    }
+
+    /// Under ExplicitOnly, `AuthStrategy::SshAgent` is ALSO refused — it
+    /// consults the running SSH agent (`Cred::ssh_key_from_agent`), an ambient
+    /// source. An untrusted fetch must not silently use the operator's loaded
+    /// SSH keys.
+    #[test]
+    fn explicit_only_refuses_ambient_ssh_agent() {
+        let auth = vec![AuthStrategy::SshAgent {
+            username: Some("git".to_owned()),
+        }];
+        let res = CallbackConfig::handle_auth(
+            &auth,
+            AuthMode::ExplicitOnly,
+            "https://github.com/example/repo.git",
+            None,
+            ssh_allowed(),
+        );
+        assert!(
+            res.is_err(),
+            "ExplicitOnly must refuse AuthStrategy::SshAgent (ssh-agent is ambient)",
+        );
+    }
+
+    /// Under AllowAmbient, `AuthStrategy::SshAgent` is honored — the explicit
+    /// opt-in path for trusted first-party mirrors.
+    #[test]
+    fn allow_ambient_permits_ssh_agent() {
+        let auth = vec![AuthStrategy::SshAgent {
+            username: Some("git".to_owned()),
+        }];
+        let res = CallbackConfig::handle_auth(
+            &auth,
+            AuthMode::AllowAmbient,
+            "https://github.com/example/repo.git",
+            None,
+            ssh_allowed(),
+        );
+        assert!(
+            res.is_ok(),
+            "AllowAmbient must permit AuthStrategy::SshAgent"
+        );
+    }
+
+    /// `is_ambient()` classifies exactly the environment-backed strategies.
+    #[test]
+    fn is_ambient_classification() {
+        assert!(AuthStrategy::Default.is_ambient());
+        assert!(AuthStrategy::SshAgent { username: None }.is_ambient());
+        // Explicit strategies are never ambient.
+        assert!(!AuthStrategy::Token { token: "t".into() }.is_ambient());
+        assert!(
+            !AuthStrategy::UserPass {
+                username: "u".into(),
+                password: "p".into(),
+            }
+            .is_ambient()
+        );
+        assert!(
+            !AuthStrategy::SshKey {
+                username: "u".into(),
+                public_key: None,
+                private_key: PathBuf::from("/k"),
+                passphrase: None,
+            }
+            .is_ambient()
         );
     }
 

--- a/crates/git2db/src/callback_config.rs
+++ b/crates/git2db/src/callback_config.rs
@@ -245,7 +245,7 @@ impl CallbackConfig {
 
     fn try_auth_strategy(
         strategy: &AuthStrategy,
-        _url: &str,
+        url: &str,
         username_from_url: Option<&str>,
         allowed_types: git2::CredentialType,
     ) -> Result<git2::Cred, git2::Error> {
@@ -284,12 +284,36 @@ impl CallbackConfig {
                     Err(git2::Error::from_str("Username/password not allowed"))
                 }
             }
-            AuthStrategy::Token { token } => {
-                if allowed_types.contains(CredentialType::USER_PASS_PLAINTEXT) {
-                    Cred::userpass_plaintext("", token)
-                } else {
-                    Err(git2::Error::from_str("Token authentication not allowed"))
+            AuthStrategy::Token { token, host } => {
+                if !allowed_types.contains(CredentialType::USER_PASS_PLAINTEXT) {
+                    return Err(git2::Error::from_str("Token authentication not allowed"));
                 }
+                // Enforce host scope (issue #1429 Sol P1): a token bound to an
+                // exact origin host is only offered when the request URL's host
+                // matches, preventing exfiltration to a caller-selected remote.
+                if let Some(bound) = host {
+                    match crate::auth::extract_git_host(url) {
+                        Some(req_host) if req_host == bound.as_str() => {}
+                        Some(req_host) => {
+                            tracing::debug!(
+                                "Refusing host-scoped token for {url}: bound to {bound:?}, \
+                                 request host is {req_host:?}"
+                            );
+                            return Err(git2::Error::from_str(
+                                "Token is scoped to a different host",
+                            ));
+                        }
+                        None => {
+                            tracing::debug!(
+                                "Refusing host-scoped token for {url}: could not parse host"
+                            );
+                            return Err(git2::Error::from_str(
+                                "Token is host-scoped but request URL host is unparseable",
+                            ));
+                        }
+                    }
+                }
+                Cred::userpass_plaintext("", token)
             }
             AuthStrategy::Default => {
                 if allowed_types.contains(CredentialType::DEFAULT) {
@@ -547,7 +571,13 @@ mod tests {
         assert!(AuthStrategy::Default.is_ambient());
         assert!(AuthStrategy::SshAgent { username: None }.is_ambient());
         // Explicit strategies are never ambient.
-        assert!(!AuthStrategy::Token { token: "t".into() }.is_ambient());
+        assert!(
+            !AuthStrategy::Token {
+                token: "t".into(),
+                host: None
+            }
+            .is_ambient()
+        );
         assert!(
             !AuthStrategy::UserPass {
                 username: "u".into(),
@@ -592,6 +622,7 @@ mod tests {
         let auth = vec![
             AuthStrategy::Token {
                 token: "ghp_explicit".to_owned(),
+                host: None,
             },
             AuthStrategy::Default,
         ];
@@ -624,5 +655,70 @@ mod tests {
             res.is_err(),
             "ExplicitOnly with only ambient strategies must fail closed",
         );
+    }
+
+    // ---- Host-scoped Token: a token for host A is never offered to host B ----
+
+    /// A token bound to `github.com` must NOT be offered when the request URL
+    /// points at a different host (`evil.example`). This is the host-A/host-B
+    /// negative test required by the #1429 Sol P1 fix.
+    #[test]
+    fn host_scoped_token_refused_for_different_host() {
+        let auth = vec![AuthStrategy::Token {
+            token: "trusted-forge-token".to_owned(),
+            host: Some("github.com".to_owned()),
+        }];
+        // Host B: the caller-selected remote is NOT github.com.
+        let res = CallbackConfig::handle_auth(
+            &auth,
+            AuthMode::ExplicitOnly,
+            "https://evil.example/untrusted/repo.git",
+            None,
+            user_pass_allowed(),
+        );
+        assert!(
+            res.is_err(),
+            "A host-scoped token bound to github.com must not be offered to evil.example",
+        );
+    }
+
+    /// The same host-scoped token IS offered when the request URL's host
+    /// matches the bound origin — the positive control for the negative test.
+    #[test]
+    fn host_scoped_token_offered_for_matching_host() {
+        let auth = vec![AuthStrategy::Token {
+            token: "trusted-forge-token".to_owned(),
+            host: Some("github.com".to_owned()),
+        }];
+        let res = CallbackConfig::handle_auth(
+            &auth,
+            AuthMode::ExplicitOnly,
+            "https://github.com/user/repo.git",
+            None,
+            user_pass_allowed(),
+        );
+        assert!(
+            res.is_ok(),
+            "A host-scoped token must be offered to its bound host",
+        );
+    }
+
+    /// An unscoped token (host: None) is offered to any host — this is the
+    /// behavior the caller explicitly constructs; it is not attached to the
+    /// default clone path (see manager.rs).
+    #[test]
+    fn unscoped_token_offered_to_any_host() {
+        let auth = vec![AuthStrategy::Token {
+            token: "explicit-unscoped".to_owned(),
+            host: None,
+        }];
+        let res = CallbackConfig::handle_auth(
+            &auth,
+            AuthMode::ExplicitOnly,
+            "https://anyhost.example/repo.git",
+            None,
+            user_pass_allowed(),
+        );
+        assert!(res.is_ok(), "An unscoped explicit Token is always honored");
     }
 }

--- a/crates/git2db/src/callback_config.rs
+++ b/crates/git2db/src/callback_config.rs
@@ -102,6 +102,36 @@ pub struct CertificatePinning {
     pub fingerprint: Vec<u8>,
 }
 
+/// Off-site redirect policy for credential-bearing git operations.
+///
+/// libgit2's default (`Initial`) allows an off-site redirect on the initial
+/// request. Since the credential callback receives the *original* URL (not the
+/// redirect target) in the pinned libgit2 1.9.x, this means a token bound to
+/// host A can be offered to a redirect target host B (Sol P1 #1429). The
+/// secure default is [`RedirectPolicy::None`] — no off-site redirects.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub enum RedirectPolicy {
+    /// Do not follow any off-site redirects at any stage. **Secure default.**
+    /// Same-authority redirects (e.g. path changes on the same host) may still
+    /// be followed by the transport.
+    #[default]
+    None,
+    /// Follow off-site redirects on the initial request only (libgit2's
+    /// default). **Insecure with host-scoped credentials** — the credential
+    /// callback cannot verify the effective peer after redirect.
+    Initial,
+}
+
+impl RedirectPolicy {
+    /// Convert to the `git2` crate's redirect type.
+    pub fn to_git2(self) -> git2::RemoteRedirect {
+        match self {
+            RedirectPolicy::None => git2::RemoteRedirect::None,
+            RedirectPolicy::Initial => git2::RemoteRedirect::Initial,
+        }
+    }
+}
+
 /// Send-safe callback configuration
 ///
 /// This type captures the *configuration* for callbacks rather than the callbacks themselves.
@@ -120,6 +150,11 @@ pub struct CallbackConfig {
 
     /// Certificate validation configuration
     pub certificates: CertificateConfig,
+
+    /// Off-site redirect policy. Defaults to [`RedirectPolicy::None`] (no
+    /// off-site redirects) to prevent credential exfiltration via redirect
+    /// when host-scoped credentials are present.
+    pub redirect_policy: RedirectPolicy,
 
     /// Pack progress reporting
     pub pack_progress: bool,
@@ -288,27 +323,29 @@ impl CallbackConfig {
                 if !allowed_types.contains(CredentialType::USER_PASS_PLAINTEXT) {
                     return Err(git2::Error::from_str("Token authentication not allowed"));
                 }
-                // Enforce host scope (issue #1429 Sol P1): a token bound to an
-                // exact origin host is only offered when the request URL's host
-                // matches, preventing exfiltration to a caller-selected remote.
+                // Enforce authority scope (issue #1429 Sol P1): the authority
+                // is extracted path-safely and canonicalized, preventing
+                // path/query `@` spoofing, case confusion, port confusion,
+                // and IPv6 truncation.
                 if let Some(bound) = host {
-                    match crate::auth::extract_git_host(url) {
-                        Some(req_host) if req_host == bound.as_str() => {}
-                        Some(req_host) => {
+                    match crate::auth::extract_git_authority(url) {
+                        Some(req_auth) if req_auth == *bound => {}
+                        Some(req_auth) => {
                             tracing::debug!(
-                                "Refusing host-scoped token for {url}: bound to {bound:?}, \
-                                 request host is {req_host:?}"
+                                "Refusing authority-scoped token for {url}: bound to \
+                                 {bound:?}, request authority is {req_auth:?}"
                             );
                             return Err(git2::Error::from_str(
-                                "Token is scoped to a different host",
+                                "Token is scoped to a different authority",
                             ));
                         }
                         None => {
                             tracing::debug!(
-                                "Refusing host-scoped token for {url}: could not parse host"
+                                "Refusing authority-scoped token for {url}: could not parse \
+                                 authority"
                             );
                             return Err(git2::Error::from_str(
-                                "Token is host-scoped but request URL host is unparseable",
+                                "Token is authority-scoped but request URL is unparseable",
                             ));
                         }
                     }
@@ -448,6 +485,14 @@ impl CallbackConfigBuilder {
     /// Set certificate configuration
     pub fn certificates(mut self, certs: CertificateConfig) -> Self {
         self.config.certificates = certs;
+        self
+    }
+
+    /// Set the off-site redirect policy (default: [`RedirectPolicy::None`] —
+    /// no off-site redirects). See [`RedirectPolicy`] for why the default
+    /// matters when a host-scoped credential is configured.
+    pub fn redirect_policy(mut self, policy: RedirectPolicy) -> Self {
+        self.config.redirect_policy = policy;
         self
     }
 

--- a/crates/git2db/src/callback_config.rs
+++ b/crates/git2db/src/callback_config.rs
@@ -34,16 +34,62 @@ pub trait ProgressReporter: Send + Sync {
     fn report(&self, stage: &str, current: usize, total: usize);
 }
 
-/// Certificate validation configuration
+/// Certificate validation configuration.
+///
+/// Controls how the TLS/SSH host-key certificate check is handled during a
+/// network git operation. The default is [`CertificateConfig::Strict`], which
+/// defers to libgit2's built-in validation against the system trust store and
+/// **rejects on certificate failure**. This is the only acceptable mode for
+/// untrusted or forge-facing fetches (the merge gate's PR-head fetch, P2P
+/// distribution, etc.).
+///
+/// `AcceptAll` is an explicit, insecure opt-in reserved for tests/operator
+/// bootstrapping where the transport is otherwise authenticated. It must never
+/// be the default for a code path that fetches from an untrusted origin.
 #[derive(Debug, Clone, Default)]
 pub enum CertificateConfig {
-    /// Accept all certificates (insecure, for testing)
-    AcceptAll,
-    /// Default system validation
+    /// Strict validation: defer to libgit2's built-in certificate verification
+    /// (system CA store for HTTPS, `known_hosts` for SSH) and reject on
+    /// failure. This is the secure default.
+    ///
+    /// Implemented by returning [`git2::CertificateCheckStatus::CertificatePassthrough`]
+    /// from the certificate callback, which signals "no application decision —
+    /// use libgit2's result". libgit2 then applies its strict default: an
+    /// untrusted CA, expired leaf, or hostname mismatch fails the fetch.
     #[default]
-    SystemDefault,
-    /// Custom validation with pinned certificates
+    Strict,
+    /// Accept every certificate without validation. **Insecure.**
+    ///
+    /// Explicit opt-in only. Appropriate for unit tests against a local
+    /// self-signed server, or operator bootstrapping over an already-trusted
+    /// transport. The untrusted/forge default must never select this mode.
+    AcceptAll,
+    /// Custom validation against a set of pinned host fingerprints.
     Pinned(Vec<CertificatePinning>),
+}
+
+/// Authentication provenance mode — whether ambient credential sources may be
+/// consulted.
+///
+/// `ExplicitOnly` (the default) refuses [`AuthStrategy::Default`], which maps
+/// to libgit2's ambient credential discovery (`git credential` helper,
+/// `~/.gitconfig`, SSH agent fallback). This prevents an untrusted fetch from
+/// silently picking up the operator's personal credentials. Callers that
+/// intentionally want ambient discovery (e.g. a trusted first-party mirror
+/// clone driven by the operator's own identity) must explicitly opt in via
+/// [`AuthMode::AllowAmbient`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum AuthMode {
+    /// Only explicit authentication strategies are honored.
+    /// [`AuthStrategy::Default`] is rejected, so ambient credential sources
+    /// (credential helper, `~/.gitconfig`, SSH agent fallback) are never
+    /// consulted. Secure default for untrusted/forge-facing fetches.
+    #[default]
+    ExplicitOnly,
+    /// Permit ambient credential discovery via [`AuthStrategy::Default`].
+    /// Opt-in for trusted first-party mirrors where operator identity is
+    /// expected.
+    AllowAmbient,
 }
 
 /// Certificate pinning configuration
@@ -61,6 +107,10 @@ pub struct CertificatePinning {
 pub struct CallbackConfig {
     /// Authentication strategies to try
     pub auth: Vec<AuthStrategy>,
+
+    /// Whether ambient credential sources (`AuthStrategy::Default`) may be
+    /// consulted. Defaults to [`AuthMode::ExplicitOnly`].
+    pub auth_mode: AuthMode,
 
     /// Progress reporting configuration
     pub progress: ProgressConfig,
@@ -84,6 +134,12 @@ impl CallbackConfig {
     /// Builder-style method to add authentication
     pub fn with_auth(mut self, strategy: AuthStrategy) -> Self {
         self.auth.push(strategy);
+        self
+    }
+
+    /// Builder-style method to set the authentication provenance mode.
+    pub fn with_auth_mode(mut self, mode: AuthMode) -> Self {
+        self.auth_mode = mode;
         self
     }
 
@@ -113,15 +169,25 @@ impl CallbackConfig {
     pub fn create_callbacks(&self) -> git2::RemoteCallbacks<'_> {
         let mut callbacks = git2::RemoteCallbacks::new();
 
-        // Set up authentication
-        if !self.auth.is_empty() {
-            let auth_strategies = self.auth.clone();
-            callbacks.credentials(move |url, username_from_url, allowed_types| {
-                Self::handle_auth(&auth_strategies, url, username_from_url, allowed_types)
-            });
-        }
+        // Set up authentication. Always install the credentials callback so
+        // that AuthMode is enforced even when no explicit strategy is provided:
+        // ExplicitOnly must refuse ambient discovery rather than silently fall
+        // through to libgit2's default credential helper.
+        let auth_strategies = self.auth.clone();
+        let auth_mode = self.auth_mode;
+        callbacks.credentials(move |url, username_from_url, allowed_types| {
+            Self::handle_auth(
+                &auth_strategies,
+                auth_mode,
+                url,
+                username_from_url,
+                allowed_types,
+            )
+        });
 
-        // Set up certificate checking
+        // Set up certificate checking. Strict (the default) defers to libgit2's
+        // built-in verification via CertificatePassthrough; it does NOT return
+        // CertificateOk, so a cert that fails system trust is rejected.
         let cert_config = self.certificates.clone();
         callbacks
             .certificate_check(move |cert, _host| Self::handle_certificate(&cert_config, cert));
@@ -140,19 +206,38 @@ impl CallbackConfig {
 
     fn handle_auth(
         strategies: &[AuthStrategy],
+        auth_mode: AuthMode,
         url: &str,
         username_from_url: Option<&str>,
         allowed_types: git2::CredentialType,
     ) -> Result<git2::Cred, git2::Error> {
-        // Try each strategy in order
+        // Try each strategy in order. Under ExplicitOnly, AuthStrategy::Default
+        // (which maps to libgit2's ambient credential discovery: the git
+        // credential helper, ~/.gitconfig, SSH agent fallback) is refused so an
+        // untrusted fetch cannot silently pick up operator credentials.
         for strategy in strategies {
+            if matches!(auth_mode, AuthMode::ExplicitOnly)
+                && matches!(strategy, AuthStrategy::Default)
+            {
+                tracing::debug!(
+                    "Refusing ambient AuthStrategy::Default for {url} under ExplicitOnly auth mode"
+                );
+                continue;
+            }
             match Self::try_auth_strategy(strategy, url, username_from_url, allowed_types) {
                 Ok(cred) => return Ok(cred),
                 Err(_) => continue,
             }
         }
 
-        Err(git2::Error::from_str("No suitable authentication method"))
+        if matches!(auth_mode, AuthMode::ExplicitOnly) {
+            Err(git2::Error::from_str(
+                "No suitable explicit authentication method (ambient discovery refused under \
+                 ExplicitOnly auth mode)",
+            ))
+        } else {
+            Err(git2::Error::from_str("No suitable authentication method"))
+        }
     }
 
     fn try_auth_strategy(
@@ -217,29 +302,47 @@ impl CallbackConfig {
         config: &CertificateConfig,
         cert: &Cert<'_>,
     ) -> Result<git2::CertificateCheckStatus, git2::Error> {
+        // Extract the hostkey material once; the decision itself is a pure
+        // function of (mode, hostkey) and is tested directly.
+        let hostkey = cert.as_hostkey().and_then(|hk| {
+            hk.hostkey().map(|bytes| {
+                let host = std::str::from_utf8(bytes).unwrap_or("");
+                (host, bytes)
+            })
+        });
+        Self::certificate_decision(config, hostkey)
+    }
+
+    /// Pure certificate decision, separated from FFI cert inspection so the
+    /// security boundary is unit-testable without a live TLS connection.
+    ///
+    /// - [`CertificateConfig::Strict`] returns `CertificatePassthrough`, which
+    ///   tells libgit2 to apply its built-in verification and **reject on
+    ///   failure**. It never returns `CertificateOk`.
+    /// - [`CertificateConfig::AcceptAll`] returns `CertificateOk` — the
+    ///   explicit, insecure opt-in.
+    /// - [`CertificateConfig::Pinned`] returns `Ok` only when the resolved
+    ///   hostkey matches a pin, otherwise rejects. Never falls back to
+    ///   `AcceptAll`.
+    pub fn certificate_decision(
+        mode: &CertificateConfig,
+        hostkey: Option<(&str, &[u8])>,
+    ) -> Result<git2::CertificateCheckStatus, git2::Error> {
         use git2::CertificateCheckStatus;
-
-        match config {
+        match mode {
+            CertificateConfig::Strict => Ok(CertificateCheckStatus::CertificatePassthrough),
             CertificateConfig::AcceptAll => Ok(CertificateCheckStatus::CertificateOk),
-            CertificateConfig::SystemDefault => {
-                // Let git2 handle default validation
-                Ok(CertificateCheckStatus::CertificateOk)
-            }
             CertificateConfig::Pinned(pins) => {
-                // Check if certificate matches any pinned certificates
-                if let Some(hostkey) = cert.as_hostkey() {
-                    if let Some(hostkey_bytes) = hostkey.hostkey() {
-                        let host = std::str::from_utf8(hostkey_bytes).unwrap_or("");
-
-                        for pin in pins {
-                            if pin.host == host && pin.fingerprint.as_slice() == hostkey_bytes {
-                                return Ok(CertificateCheckStatus::CertificateOk);
-                            }
+                if let Some((host, key_bytes)) = hostkey {
+                    for pin in pins {
+                        if pin.host == host && pin.fingerprint.as_slice() == key_bytes {
+                            return Ok(CertificateCheckStatus::CertificateOk);
                         }
                     }
                 }
-
-                Err(git2::Error::from_str("Certificate not pinned"))
+                Err(git2::Error::from_str(
+                    "Certificate does not match any pinned fingerprint",
+                ))
             }
         }
     }
@@ -272,7 +375,6 @@ impl CallbackConfig {
     }
 }
 
-
 /// Builder for callback configuration
 pub struct CallbackConfigBuilder {
     config: CallbackConfig,
@@ -301,6 +403,12 @@ impl CallbackConfigBuilder {
     /// Add multiple authentication strategies
     pub fn auth_strategies(mut self, strategies: Vec<AuthStrategy>) -> Self {
         self.config.auth.extend(strategies);
+        self
+    }
+
+    /// Set the authentication provenance mode (default: [`AuthMode::ExplicitOnly`]).
+    pub fn auth_mode(mut self, mode: AuthMode) -> Self {
+        self.config.auth_mode = mode;
         self
     }
 
@@ -351,5 +459,95 @@ mod tests {
         assert_eq!(config.auth.len(), 1);
         assert!(matches!(config.progress, ProgressConfig::Stdout));
         assert!(matches!(config.certificates, CertificateConfig::AcceptAll));
+    }
+
+    // ---- AuthMode enforcement (private handle_auth seam) ----
+
+    fn user_pass_allowed() -> git2::CredentialType {
+        git2::CredentialType::USER_PASS_PLAINTEXT
+    }
+
+    fn default_allowed() -> git2::CredentialType {
+        git2::CredentialType::DEFAULT
+    }
+
+    /// Under ExplicitOnly, a sole `AuthStrategy::Default` is refused — ambient
+    /// credential sources (credential helper, ~/.gitconfig, SSH agent fallback)
+    /// are not consulted.
+    #[test]
+    fn explicit_only_refuses_ambient_default() {
+        let auth = vec![AuthStrategy::Default];
+        let res = CallbackConfig::handle_auth(
+            &auth,
+            AuthMode::ExplicitOnly,
+            "https://github.com/example/repo.git",
+            None,
+            default_allowed(),
+        );
+        assert!(
+            res.is_err(),
+            "ExplicitOnly must refuse AuthStrategy::Default so ambient credentials are not \
+             consulted",
+        );
+    }
+
+    /// Under AllowAmbient, `AuthStrategy::Default` is honored when the server
+    /// permits DEFAULT credentials — the explicit opt-in path.
+    #[test]
+    fn allow_ambient_permits_default() {
+        let auth = vec![AuthStrategy::Default];
+        let res = CallbackConfig::handle_auth(
+            &auth,
+            AuthMode::AllowAmbient,
+            "https://github.com/example/repo.git",
+            None,
+            default_allowed(),
+        );
+        assert!(
+            res.is_ok(),
+            "AllowAmbient must permit AuthStrategy::Default"
+        );
+    }
+
+    /// Under ExplicitOnly, an explicit Token strategy succeeds and a trailing
+    /// `Default` fallback is skipped rather than poisoning resolution or
+    /// silently consulting ambient sources.
+    #[test]
+    fn explicit_only_skips_default_uses_explicit_token() {
+        let auth = vec![
+            AuthStrategy::Token {
+                token: "ghp_explicit".to_owned(),
+            },
+            AuthStrategy::Default,
+        ];
+        let res = CallbackConfig::handle_auth(
+            &auth,
+            AuthMode::ExplicitOnly,
+            "https://github.com/example/repo.git",
+            None,
+            user_pass_allowed(),
+        );
+        assert!(
+            res.is_ok(),
+            "explicit Token must succeed under ExplicitOnly"
+        );
+    }
+
+    /// Under ExplicitOnly with only ambient strategies, resolution fails even
+    /// when DEFAULT is allowed by the server.
+    #[test]
+    fn explicit_only_no_strategies_fails_closed() {
+        let auth: Vec<AuthStrategy> = vec![AuthStrategy::Default];
+        let res = CallbackConfig::handle_auth(
+            &auth,
+            AuthMode::ExplicitOnly,
+            "https://github.com/example/repo.git",
+            None,
+            default_allowed(),
+        );
+        assert!(
+            res.is_err(),
+            "ExplicitOnly with only ambient strategies must fail closed",
+        );
     }
 }

--- a/crates/git2db/src/clone_options.rs
+++ b/crates/git2db/src/clone_options.rs
@@ -24,7 +24,7 @@
 //! ```
 
 use crate::callback_config::CallbackConfig;
-use git2::{build::CheckoutBuilder, FetchOptions, RemoteCallbacks};
+use git2::{FetchOptions, RemoteCallbacks, build::CheckoutBuilder};
 
 /// Send-safe options for cloning a repository
 #[derive(Default, Clone)]
@@ -91,9 +91,11 @@ impl CloneOptions {
             ..Default::default()
         };
 
-        // Create callbacks from config if present
+        // Create callbacks from config if present, and extract the redirect
+        // policy so it can be applied to FetchOptions.
         if let Some(ref config) = self.callback_config {
             options.callbacks = Some(config.create_callbacks());
+            options.redirect_policy = config.redirect_policy;
         }
 
         options
@@ -112,6 +114,8 @@ pub(crate) struct LegacyCloneOptions<'cb> {
     pub _update_submodules: bool,
     pub proxy_url: Option<String>,
     pub _timeout_seconds: Option<u32>,
+    /// Off-site redirect policy (default: None — no off-site redirects).
+    pub redirect_policy: crate::callback_config::RedirectPolicy,
 }
 
 impl<'cb> LegacyCloneOptions<'cb> {
@@ -125,6 +129,11 @@ impl<'cb> LegacyCloneOptions<'cb> {
         if let Some(callbacks) = self.callbacks.take() {
             fetch_opts.remote_callbacks(callbacks);
         }
+
+        // Apply redirect policy: default is None (no off-site redirects) to
+        // prevent credential exfiltration via redirect when host-scoped
+        // credentials are present (Sol P1 #1429).
+        fetch_opts.follow_redirects(self.redirect_policy.to_git2());
 
         // Apply proxy settings
         if let Some(proxy_url) = &self.proxy_url {

--- a/crates/git2db/src/config.rs
+++ b/crates/git2db/src/config.rs
@@ -277,6 +277,14 @@ pub struct NetworkConfig {
     /// Personal access token (e.g., for GitHub, GitLab, Hugging Face)
     /// Can also be set via GIT2DB_NETWORK__ACCESS_TOKEN env var
     pub access_token: Option<String>,
+    /// The exact origin host (e.g. `"github.com"`) that `access_token` is
+    /// bound to. When set, the default clone path attaches the token scoped to
+    /// this host — it is only offered to a remote whose URL host matches. When
+    /// unset, the token is **not** attached to the default clone path at all
+    /// (fail-closed against exfiltration to a caller-selected remote). See
+    /// issue #1429.
+    #[serde(default)]
+    pub access_token_host: Option<String>,
 }
 
 fn default_use_credential_helper() -> bool {
@@ -339,6 +347,7 @@ impl Default for NetworkConfig {
             user_agent: default_user_agent(),
             use_credential_helper: default_use_credential_helper(),
             access_token: None,
+            access_token_host: None,
         }
     }
 }
@@ -538,6 +547,7 @@ mod tests {
             user_agent: "test-agent".to_owned(),
             use_credential_helper: true,
             access_token: Some("test-token".to_owned()),
+            access_token_host: None,
         };
         assert_eq!(network_config.timeout_secs, 120);
         assert_eq!(network_config.max_retries, 5);

--- a/crates/git2db/src/config.rs
+++ b/crates/git2db/src/config.rs
@@ -45,8 +45,7 @@ use serde::{Deserialize, Serialize};
 use std::path::PathBuf;
 
 /// Main configuration for git2db operations
-#[derive(Debug, Clone, Serialize, Deserialize)]
-#[derive(Default)]
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
 pub struct Git2DBConfig {
     /// Repository management configuration
     pub repository: RepositoryConfig,
@@ -68,7 +67,6 @@ pub struct Git2DBConfig {
     #[serde(default)]
     pub xet: XetConfig,
 }
-
 
 impl Git2DBConfig {
     /// Create a configuration builder with git2db defaults
@@ -140,7 +138,7 @@ impl Git2DBConfig {
             .set_default("network.retry_base_delay_ms", 500u64)?
             .set_default("network.retry_max_delay_secs", 10u64)?
             .set_default("network.user_agent", format!("git2db/{}", crate::VERSION))?
-            .set_default("network.use_credential_helper", true)?
+            .set_default("network.use_credential_helper", false)?
             .set_default("performance.max_repo_cache", 100)?
             .set_default("performance.repo_cache_ttl_secs", 300u64)?
             .set_default("performance.auto_cleanup", true)?
@@ -282,7 +280,12 @@ pub struct NetworkConfig {
 }
 
 fn default_use_credential_helper() -> bool {
-    true
+    // Default off: ambient credential discovery (git credential helper,
+    // ~/.gitconfig, SSH agent) is an explicit opt-in. The secure default for
+    // git2db clones is strict certificates + ExplicitOnly auth, so an
+    // untrusted/forge-facing fetch cannot pick up operator credentials. See
+    // issue #1429.
+    false
 }
 
 fn default_network_timeout_secs() -> u64 {
@@ -324,7 +327,6 @@ fn default_cleanup_interval_secs() -> u64 {
 fn default_max_concurrent_ops() -> usize {
     10
 }
-
 
 impl Default for NetworkConfig {
     fn default() -> Self {
@@ -641,7 +643,6 @@ impl Default for WorktreeConfig {
         }
     }
 }
-
 
 /// XET large file storage configuration
 ///

--- a/crates/git2db/src/manager.rs
+++ b/crates/git2db/src/manager.rs
@@ -273,22 +273,38 @@ impl GitManager {
 
         let mut callback_builder = CallbackConfigBuilder::new();
 
-        // Add token authentication if configured
+        // Add token authentication if configured. The token is only attached
+        // to the default clone path when it is host-scoped (access_token_host
+        // is set): a process-global, host-unscoped token must not be offered
+        // to a caller-selected remote, since that would exfiltrate the
+        // operator's trusted-forge credential (issue #1429 Sol P1).
         let token_from_config = self.config.network.access_token.clone();
         let token_from_env = std::env::var("GIT2DB_NETWORK__ACCESS_TOKEN").ok();
-
+        let token_host = self.config.network.access_token_host.clone();
         let token = token_from_config.or(token_from_env);
 
-        if let Some(ref token_value) = token {
-            tracing::info!(
-                "Using token authentication (token starts with: {})",
-                &token_value.chars().take(10).collect::<String>()
-            );
-            callback_builder = callback_builder.auth(AuthStrategy::Token {
-                token: token_value.clone(),
-            });
-        } else {
-            tracing::warn!("No access token configured");
+        match (token, &token_host) {
+            (Some(token_value), Some(host)) => {
+                tracing::info!(
+                    "Using host-scoped token authentication bound to {} (token starts with: {})",
+                    host,
+                    &token_value.chars().take(10).collect::<String>()
+                );
+                callback_builder = callback_builder.auth(AuthStrategy::Token {
+                    token: token_value,
+                    host: Some(host.clone()),
+                });
+            }
+            (Some(_token_value), None) => {
+                tracing::warn!(
+                    "Access token configured without access_token_host — not attaching to \
+                     default clone path to prevent credential exfiltration to caller-selected \
+                     remotes. Set network.access_token_host to scope the token."
+                );
+            }
+            (None, _) => {
+                tracing::debug!("No access token configured");
+            }
         }
 
         // Ambient credential sources — the SSH agent (`ssh_key_from_agent`),

--- a/crates/git2db/src/manager.rs
+++ b/crates/git2db/src/manager.rs
@@ -3,12 +3,12 @@
 //! This module provides centralized Git management following hyprstream's patterns
 //! for thread safety and connection pooling.
 
-use anyhow::{bail, Result};
+use anyhow::{Result, bail};
 use dashmap::DashMap;
-use git2::{build::RepoBuilder, Repository, Signature};
+use git2::{Repository, Signature, build::RepoBuilder};
+use hyprstream_containedfs::contained_join;
 use once_cell::sync::OnceCell;
 use parking_lot::RwLock;
-use hyprstream_containedfs::contained_join;
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
@@ -264,11 +264,12 @@ impl GitManager {
         }
 
         // Set up timeout (cap at u32::MAX seconds, ~136 years)
-        builder = builder.timeout(u32::try_from(self.config.network.timeout_secs).unwrap_or(u32::MAX));
+        builder =
+            builder.timeout(u32::try_from(self.config.network.timeout_secs).unwrap_or(u32::MAX));
 
         // Set up authentication
         use crate::auth::AuthStrategy;
-        use crate::callback_config::{CallbackConfigBuilder, CertificateConfig};
+        use crate::callback_config::{AuthMode, CallbackConfigBuilder, CertificateConfig};
 
         let mut callback_builder = CallbackConfigBuilder::new();
 
@@ -295,13 +296,21 @@ impl GitManager {
             username: Some("git".to_owned()),
         });
 
-        // Add default credential helper if enabled (for git credentials, osxkeychain, etc.)
+        // The git credential helper (~/.gitconfig, osxkeychain, etc.) is an
+        // ambient credential source. It is only consulted when the operator
+        // explicitly enables it; in that case we opt into AllowAmbient so the
+        // ExplicitOnly default does not refuse the Default strategy at
+        // resolution time.
         if self.config.network.use_credential_helper {
-            callback_builder = callback_builder.auth(AuthStrategy::Default);
+            callback_builder = callback_builder
+                .auth(AuthStrategy::Default)
+                .auth_mode(AuthMode::AllowAmbient);
         }
 
-        // Use system certificate validation
-        callback_builder = callback_builder.certificates(CertificateConfig::SystemDefault);
+        // Strict certificate validation is the builder default; set it
+        // explicitly for clarity. libgit2 validates against the system trust
+        // store and rejects on cert failure.
+        callback_builder = callback_builder.certificates(CertificateConfig::Strict);
 
         builder = builder.callback_config(callback_builder.build());
 
@@ -340,7 +349,9 @@ impl GitManager {
 
         // Check cache first (lock-free read with DashMap)
         if let Some(entry) = self.repo_cache.get(&path) {
-            if !entry.is_expired(Duration::from_secs(self.config.performance.repo_cache_ttl_secs)) {
+            if !entry.is_expired(Duration::from_secs(
+                self.config.performance.repo_cache_ttl_secs,
+            )) {
                 entry.touch();
                 trace!("Repository cache hit for {:?}", path);
                 return Ok(entry.cache.clone());
@@ -491,16 +502,20 @@ impl GitManager {
         // local repository (e.g. RPC registration in local-file test
         // harnesses, or same-host repo mirroring).
         if options.shallow && url.starts_with("file://") {
-            debug!("Disabling shallow clone for local file:// transport: {}", url);
+            debug!(
+                "Disabling shallow clone for local file:// transport: {}",
+                url
+            );
             options.shallow = false;
             options.depth = None;
         }
 
         // Acquire operation permit
-        let _permit =
-            self.operation_semaphore.acquire().await.map_err(|e| {
-                Git2DBError::internal(format!("Failed to acquire semaphore: {e}"))
-            })?;
+        let _permit = self
+            .operation_semaphore
+            .acquire()
+            .await
+            .map_err(|e| Git2DBError::internal(format!("Failed to acquire semaphore: {e}")))?;
 
         // Track operation
         let operation_id = format!("clone_{}", target_path.display());
@@ -556,10 +571,7 @@ impl GitManager {
 
             // Perform clone
             let repo = builder.clone(&url, &validated_path).map_err(|e| {
-                Git2DBError::repository(
-                    &validated_path,
-                    format!("Failed to clone repository: {e}"),
-                )
+                Git2DBError::repository(&validated_path, format!("Failed to clone repository: {e}"))
             })?;
 
             info!("Successfully cloned repository to {:?}", validated_path);
@@ -621,10 +633,9 @@ impl GitManager {
         opts.valid(true);
         opts.working_tree(true);
 
-        wt.prune(Some(&mut opts))
-            .map_err(|e| {
-                Git2DBError::repository(&base_repo_path, format!("Failed to prune worktree: {e}"))
-            })?;
+        wt.prune(Some(&mut opts)).map_err(|e| {
+            Git2DBError::repository(&base_repo_path, format!("Failed to prune worktree: {e}"))
+        })?;
 
         info!("Successfully removed worktree '{}'", worktree_name);
         Ok(())
@@ -840,7 +851,9 @@ mod tests {
 
         // All should succeed without conflicts
         for handle in handles {
-            let result = handle.await.map_err(|e| crate::Git2DBError::internal(format!("Task join error: {e}")))?;
+            let result = handle
+                .await
+                .map_err(|e| crate::Git2DBError::internal(format!("Task join error: {e}")))?;
             assert!(result.is_ok());
         }
 
@@ -878,14 +891,31 @@ mod tests {
 
         // Default signature
         let sig = manager.create_signature(None, None)?;
-        assert_eq!(sig.name().ok_or_else(|| crate::Git2DBError::internal("no name"))?, "git2db");
-        assert_eq!(sig.email().ok_or_else(|| crate::Git2DBError::internal("no email"))?, "git2db@local");
+        assert_eq!(
+            sig.name()
+                .ok_or_else(|| crate::Git2DBError::internal("no name"))?,
+            "git2db"
+        );
+        assert_eq!(
+            sig.email()
+                .ok_or_else(|| crate::Git2DBError::internal("no email"))?,
+            "git2db@local"
+        );
 
         // Custom signature
-        let custom_sig = manager
-            .create_signature(Some("Test User"), Some("test@example.com"))?;
-        assert_eq!(custom_sig.name().ok_or_else(|| crate::Git2DBError::internal("no name"))?, "Test User");
-        assert_eq!(custom_sig.email().ok_or_else(|| crate::Git2DBError::internal("no email"))?, "test@example.com");
+        let custom_sig = manager.create_signature(Some("Test User"), Some("test@example.com"))?;
+        assert_eq!(
+            custom_sig
+                .name()
+                .ok_or_else(|| crate::Git2DBError::internal("no name"))?,
+            "Test User"
+        );
+        assert_eq!(
+            custom_sig
+                .email()
+                .ok_or_else(|| crate::Git2DBError::internal("no email"))?,
+            "test@example.com"
+        );
         Ok(())
     }
 }

--- a/crates/git2db/src/manager.rs
+++ b/crates/git2db/src/manager.rs
@@ -291,18 +291,19 @@ impl GitManager {
             tracing::warn!("No access token configured");
         }
 
-        // Add SSH agent authentication
-        callback_builder = callback_builder.auth(AuthStrategy::SshAgent {
-            username: Some("git".to_owned()),
-        });
-
-        // The git credential helper (~/.gitconfig, osxkeychain, etc.) is an
-        // ambient credential source. It is only consulted when the operator
-        // explicitly enables it; in that case we opt into AllowAmbient so the
-        // ExplicitOnly default does not refuse the Default strategy at
-        // resolution time.
+        // Ambient credential sources — the SSH agent (`ssh_key_from_agent`),
+        // the git credential helper, and `~/.gitconfig` — are only consulted
+        // when the operator explicitly enables `use_credential_helper`. By
+        // default (issue #1429) the clone path is strict certs + ExplicitOnly
+        // auth: these strategies are added only here, behind the opt-in, and
+        // paired with AllowAmbient so ExplicitOnly does not refuse them at
+        // resolution time. The default secure path uses only the explicit
+        // token above (or anonymous access for public remotes).
         if self.config.network.use_credential_helper {
             callback_builder = callback_builder
+                .auth(AuthStrategy::SshAgent {
+                    username: Some("git".to_owned()),
+                })
                 .auth(AuthStrategy::Default)
                 .auth_mode(AuthMode::AllowAmbient);
         }

--- a/crates/git2db/tests/backslash_authority_test.rs
+++ b/crates/git2db/tests/backslash_authority_test.rs
@@ -1,0 +1,335 @@
+//! Causal, live-network proof that the WHATWG-vs-libgit2 backslash authority
+//! differential (issue #1429 Kimi-K3 r3 P1) can no longer leak a host-scoped
+//! token, now that [`git2db::auth::extract_git_authority`] fails closed on any
+//! `\` in the input.
+//!
+//! This does **not** mock libgit2. It runs two real local HTTP servers on
+//! genuinely distinct loopback hosts — `A` (127.0.0.1, the authority the
+//! token is bound to) and `B` (127.0.0.2, an unrelated authority) — and
+//! drives a real `git2::Remote::fetch()` against a URL of the form
+//! `http://<A>\@<B>/repo.git`.
+//!
+//! Before the fix, the r3 review's compiled probe proved two things against
+//! the real pinned stack: the WHATWG parser (`url::Url::parse`, used by the
+//! old `extract_git_authority`) resolved this URL's authority to `A` — so the
+//! host-scope check passed — while the actual pinned libgit2 1.9.x C parser
+//! resolved the *real* connection target to `B` (backslash is an ordinary
+//! authority character to libgit2, and userinfo splits at the last `@`).
+//! Both credential paths trusted the WHATWG answer and handed the A-bound
+//! token to the connection that was actually talking to `B`.
+//!
+//! After the fix, `extract_git_authority` returns `None` for any
+//! backslash-containing input, so the credential callback refuses the
+//! authority-scoped token outright (bound-but-unparseable), regardless of
+//! which host the connection actually reaches. This test proves, for real:
+//! 1. The differential is real and reachable — the raw TCP connection lands
+//!    on `B`, not `A`, exactly as the r3 probe found (`B` is always
+//!    contacted; `A` never is).
+//! 2. `B` is made to challenge for credentials on *every* request (never
+//!    accepting), forcing libgit2 through its full retry sequence exactly as
+//!    the r3 probe's real end-to-end run did (whose first attempt carried
+//!    URL-embedded userinfo, unrelated to the bound token, before later
+//!    attempts would have carried the actual secret). Across every request
+//!    `B` ever receives, in neither credential path does any `Authorization`
+//!    header ever decode to the bound secret token — the callback refuses to
+//!    release it once `extract_git_authority` reports the authority as
+//!    unparseable.
+
+#![cfg(test)]
+#![allow(clippy::expect_used, clippy::print_stdout)]
+
+use git2db::auth::{AuthManager, AuthStrategy, extract_git_authority};
+use git2db::callback_config::CallbackConfigBuilder;
+use parking_lot::Mutex;
+use std::io::{BufRead, BufReader, Write};
+use std::net::{SocketAddr, TcpListener, TcpStream};
+use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::thread;
+use tempfile::TempDir;
+
+const TOKEN: &str = "trusted-forge-secret-token-1429-r3";
+
+/// `A` (the authority the token is bound to) and `B` (the authority the
+/// malicious backslash URL actually resolves to at the transport layer). Both
+/// count hits; `B` additionally challenges for credentials and captures
+/// whatever `Authorization` header (if any) arrives.
+struct BackslashHarness {
+    addr_a: SocketAddr,
+    addr_b: SocketAddr,
+    a_hits: Arc<AtomicUsize>,
+    b_hits: Arc<AtomicUsize>,
+    /// Every `Authorization` header value `B` has ever observed, one entry
+    /// per request (across possibly-multiple retry connections). `B` never
+    /// grants access, so libgit2 retries through its full credential
+    /// resolution sequence rather than stopping after the first attempt.
+    captured_authorizations: Arc<Mutex<Vec<String>>>,
+}
+
+impl BackslashHarness {
+    fn start() -> Self {
+        // Genuinely distinct loopback hosts (127.0.0.1 vs 127.0.0.2), not
+        // merely distinct ports — mirrors the r3 probe's harness so the
+        // "which host did the TCP connection actually reach" assertion below
+        // is meaningful.
+        let listener_a = TcpListener::bind("127.0.0.1:0").expect("bind A");
+        let addr_a = listener_a.local_addr().expect("addr A");
+        let listener_b = TcpListener::bind("127.0.0.2:0").expect("bind B");
+        let addr_b = listener_b.local_addr().expect("addr B");
+
+        let a_hits = Arc::new(AtomicUsize::new(0));
+        {
+            let a_hits = Arc::clone(&a_hits);
+            thread::spawn(move || {
+                for stream in listener_a.incoming() {
+                    let Ok(mut stream) = stream else { continue };
+                    a_hits.fetch_add(1, Ordering::SeqCst);
+                    let _ = read_request(&mut stream);
+                    let _ = stream.write_all(
+                        b"HTTP/1.1 404 Not Found\r\nConnection: close\r\nContent-Length: 0\r\n\r\n",
+                    );
+                }
+            });
+        }
+
+        let b_hits = Arc::new(AtomicUsize::new(0));
+        let captured_authorizations = Arc::new(Mutex::new(Vec::new()));
+        {
+            let b_hits = Arc::clone(&b_hits);
+            let captured_authorizations = Arc::clone(&captured_authorizations);
+            thread::spawn(move || {
+                for stream in listener_b.incoming() {
+                    let Ok(mut stream) = stream else { continue };
+                    b_hits.fetch_add(1, Ordering::SeqCst);
+                    let Some((_request_line, headers)) = read_request(&mut stream) else {
+                        continue;
+                    };
+                    let auth_header = headers.iter().find_map(|h| {
+                        let (name, value) = h.split_once(':')?;
+                        name.trim()
+                            .eq_ignore_ascii_case("authorization")
+                            .then(|| value.trim().to_owned())
+                    });
+                    if let Some(value) = &auth_header {
+                        captured_authorizations.lock().push(value.clone());
+                    }
+                    // Never grant access — always challenge, so libgit2 keeps
+                    // retrying through its full credential resolution
+                    // sequence (URL-embedded userinfo first, then the
+                    // configured strategies) instead of stopping after
+                    // whatever the first attempt happened to carry.
+                    let _ = stream.write_all(
+                        b"HTTP/1.1 401 Unauthorized\r\n\
+                          WWW-Authenticate: Basic realm=\"git\"\r\n\
+                          Connection: close\r\n\
+                          Content-Length: 0\r\n\r\n",
+                    );
+                }
+            });
+        }
+
+        Self {
+            addr_a,
+            addr_b,
+            a_hits,
+            b_hits,
+            captured_authorizations,
+        }
+    }
+
+    fn a_hit_count(&self) -> usize {
+        self.a_hits.load(Ordering::SeqCst)
+    }
+
+    fn b_hit_count(&self) -> usize {
+        self.b_hits.load(Ordering::SeqCst)
+    }
+
+    fn captured_authorizations(&self) -> Vec<String> {
+        self.captured_authorizations.lock().clone()
+    }
+
+    /// The legitimate URL to `A` alone — used only to compute the authority
+    /// string the token is bound to, exactly as a real caller configuring a
+    /// host-scoped token for `A` would.
+    fn legitimate_authority(&self) -> String {
+        extract_git_authority(&format!("http://{}/repo.git", self.addr_a))
+            .expect("A's own URL must parse to a concrete authority")
+    }
+
+    /// The malicious URL: `http://<A>\@<B>/repo.git`. Per the r3 probe, the
+    /// real libgit2 transport resolves the connection target to `B` (`\` is
+    /// an ordinary authority character to libgit2, userinfo splits at the
+    /// last `@`), while the pre-fix WHATWG parser resolved the authority to
+    /// `A`. This is exactly the differential the fix must close.
+    fn malicious_url(&self) -> String {
+        format!("http://{}\\@{}/repo.git", self.addr_a, self.addr_b)
+    }
+}
+
+fn read_request(stream: &mut TcpStream) -> Option<(String, Vec<String>)> {
+    let mut reader = BufReader::new(stream.try_clone().ok()?);
+    let mut request_line = String::new();
+    if reader.read_line(&mut request_line).ok()? == 0 {
+        return None;
+    }
+    let mut headers = Vec::new();
+    loop {
+        let mut line = String::new();
+        let n = reader.read_line(&mut line).ok()?;
+        if n == 0 || line == "\r\n" || line == "\n" {
+            break;
+        }
+        headers.push(line.trim_end().to_owned());
+    }
+    Some((request_line.trim_end().to_owned(), headers))
+}
+
+/// Drive a real `git2` fetch against `url` with the given callbacks. None of
+/// these servers speak the full git smart-HTTP protocol, so the fetch is
+/// expected to ultimately fail; what matters is which servers were contacted
+/// and with what credentials, observed via the harness.
+fn drive_fetch(url: &str, callbacks: git2::RemoteCallbacks<'_>) {
+    let tmp = TempDir::new().expect("tempdir");
+    let repo = git2::Repository::init_bare(tmp.path()).expect("init bare repo");
+    let mut remote = repo.remote_anonymous(url).expect("remote_anonymous");
+    let mut fetch_opts = git2::FetchOptions::new();
+    fetch_opts.remote_callbacks(callbacks);
+    fetch_opts.follow_redirects(git2::RemoteRedirect::None);
+    let result = remote.fetch(
+        &["+refs/heads/*:refs/remotes/origin/*"],
+        Some(&mut fetch_opts),
+        None,
+    );
+    if let Err(e) = result {
+        println!("drive_fetch: fetch returned (expected) error: {e}");
+    }
+}
+
+/// Sanity: the malicious URL is rejected by `extract_git_authority` itself
+/// (unit-level cross-check that this test exercises the same fix the `auth.rs`
+/// tests cover, against a URL built from real, live harness addresses).
+fn assert_malicious_url_unparseable(url: &str) {
+    assert_eq!(
+        extract_git_authority(url),
+        None,
+        "a backslash-containing authority must be rejected outright, not resolved to \
+         either parser's differing answer",
+    );
+}
+
+/// None of the `Authorization` headers `B` observed may decode (as HTTP Basic
+/// auth) to a credential ending in the bound secret token. Some entries may
+/// legitimately be present — e.g. libgit2's own use of URL-embedded userinfo
+/// on the first attempt — but that material originates from the URL string
+/// itself (attacker/caller-visible), never from the configured host-scoped
+/// secret.
+fn assert_token_never_delivered(captured: &[String]) {
+    for value in captured {
+        let decoded = decode_basic_auth(value);
+        assert!(
+            !decoded.ends_with(TOKEN),
+            "the bound secret token must never be delivered to B across the backslash \
+             authority differential; observed credential decoded to {decoded:?}",
+        );
+    }
+}
+
+/// Minimal base64 decoder for the `Basic <base64>` credential libgit2 may
+/// send — avoids pulling in a base64 dependency just for this assertion.
+fn decode_basic_auth(header_value: &str) -> String {
+    let b64 = header_value
+        .strip_prefix("Basic ")
+        .unwrap_or(header_value)
+        .trim();
+    String::from_utf8_lossy(&base64_decode(b64)).into_owned()
+}
+
+fn base64_decode(input: &str) -> Vec<u8> {
+    const TABLE: &[u8; 64] =
+        b"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+    let mut lut = [0u8; 256];
+    for (i, &c) in TABLE.iter().enumerate() {
+        lut[c as usize] = i as u8;
+    }
+    let clean: Vec<u8> = input.bytes().filter(|&b| b != b'=').collect();
+    let mut out = Vec::with_capacity(clean.len() * 3 / 4);
+    for chunk in clean.chunks(4) {
+        let mut buf = [0u8; 4];
+        for (i, &b) in chunk.iter().enumerate() {
+            buf[i] = lut[b as usize];
+        }
+        out.push((buf[0] << 2) | (buf[1] >> 4));
+        if chunk.len() > 2 {
+            out.push((buf[1] << 4) | (buf[2] >> 2));
+        }
+        if chunk.len() > 3 {
+            out.push((buf[2] << 6) | buf[3]);
+        }
+    }
+    out
+}
+
+// ---------------------------------------------------------------------------
+// CallbackConfig (send-safe clone) path
+// ---------------------------------------------------------------------------
+
+#[test]
+fn callback_config_refuses_token_across_backslash_authority_differential() {
+    let harness = BackslashHarness::start();
+    assert_ne!(
+        harness.addr_a.to_string(),
+        harness.addr_b.to_string(),
+        "sanity: A and B must be genuinely distinct hosts"
+    );
+
+    let malicious_url = harness.malicious_url();
+    assert_malicious_url_unparseable(&malicious_url);
+
+    let config = CallbackConfigBuilder::new()
+        .auth(AuthStrategy::Token {
+            token: TOKEN.to_owned(),
+            host: Some(harness.legitimate_authority()),
+        })
+        .build();
+
+    drive_fetch(&malicious_url, config.create_callbacks());
+
+    assert!(
+        harness.b_hit_count() >= 1,
+        "sanity: the real TCP connection must reach B (the r3-proven differential — \
+         libgit2 resolves the backslash URL's authority to B, not A), otherwise this test \
+         is not exercising the vulnerable path at all",
+    );
+    assert_token_never_delivered(&harness.captured_authorizations());
+    assert_eq!(
+        harness.a_hit_count(),
+        0,
+        "A must never be contacted either — the connection goes straight to B",
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Legacy AuthManager (sync) path
+// ---------------------------------------------------------------------------
+
+#[test]
+fn auth_manager_refuses_token_across_backslash_authority_differential() {
+    let harness = BackslashHarness::start();
+
+    let malicious_url = harness.malicious_url();
+    assert_malicious_url_unparseable(&malicious_url);
+
+    let mgr = AuthManager::with_strategies(vec![AuthStrategy::Token {
+        token: TOKEN.to_owned(),
+        host: Some(harness.legitimate_authority()),
+    }]);
+
+    drive_fetch(&malicious_url, mgr.create_callbacks());
+
+    assert!(
+        harness.b_hit_count() >= 1,
+        "sanity: the real TCP connection must reach B, exercising the vulnerable path",
+    );
+    assert_token_never_delivered(&harness.captured_authorizations());
+}

--- a/crates/git2db/tests/redirect_test.rs
+++ b/crates/git2db/tests/redirect_test.rs
@@ -1,0 +1,396 @@
+//! Causal, live-network proof of the off-site redirect credential-exfiltration
+//! fix (issue #1429 Sol P1, revision round 2).
+//!
+//! This test does **not** mock libgit2. It runs two real local HTTP servers —
+//! `A` (the configured/trusted origin, holding a host-scoped token) and `B`
+//! (an unrelated "off-site" authority, on a genuinely distinct loopback host
+//! so libgit2's own host-based off-site check treats it as off-site) — and
+//! drives a real `git2::Remote::fetch()` against `A`, which unconditionally
+//! 301-redirects to `B`. It proves, against the actual pinned libgit2 network
+//! stack:
+//!
+//! 1. With the secure default ([`RedirectPolicy::None`]), `B` is **never
+//!    contacted** — the redirect is refused at the transport layer, so the
+//!    credential callback is never even invoked in a context where it could
+//!    leak the token to `B`.
+//! 2. With the explicit, insecure opt-in ([`RedirectPolicy::Initial`] —
+//!    libgit2's own default), `B` **is** contacted and, per the exact
+//!    mechanism Sol's review cited (the credential callback receives the
+//!    pre-redirect URL from `A`, so a token scoped to `A` is judged
+//!    authorized and handed to the transport, which is now talking to `B`),
+//!    the token **is** delivered to `B`. This is not a bug in this test; it
+//!    is the documented reason `None` must be the default rather than an
+//!    opt-out.
+//!
+//! Both the send-safe [`CallbackConfig`] clone path and the legacy
+//! [`AuthManager`] path are exercised, since both independently need the
+//! redirect policy applied to the `git2::FetchOptions` that drives the fetch.
+
+#![cfg(test)]
+// Test harness needs: setup calls that should hard-fail the test on error
+// (`expect`), and diagnostic visibility into an intentionally-failing fetch
+// (`println!`) — both allowed here per the same convention as
+// `security_tests.rs` / `send_trait_test.rs`.
+#![allow(clippy::expect_used, clippy::print_stdout)]
+
+use git2db::auth::{AuthManager, AuthStrategy};
+use git2db::callback_config::{CallbackConfigBuilder, RedirectPolicy};
+use parking_lot::Mutex;
+use std::io::{BufRead, BufReader, Write};
+use std::net::{SocketAddr, TcpListener, TcpStream};
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::Arc;
+use std::thread;
+use tempfile::TempDir;
+
+/// Bound to a trusted-forge-shaped token so a captured `Authorization` header
+/// unambiguously proves the *token*, not just *some* credential, reached `B`.
+const TOKEN: &str = "trusted-forge-secret-token-1429";
+
+/// Two raw-TCP HTTP servers: `A` unconditionally redirects off-site to `B`;
+/// `B` challenges for credentials on the first request and captures whatever
+/// `Authorization` header arrives on the second.
+struct RedirectHarness {
+    addr_a: SocketAddr,
+    addr_b: SocketAddr,
+    b_hits: Arc<AtomicUsize>,
+    captured_authorization: Arc<Mutex<Option<String>>>,
+}
+
+impl RedirectHarness {
+    fn start() -> Self {
+        // `A` and `B` are bound to genuinely distinct loopback addresses
+        // (127.0.0.1 vs 127.0.0.2 — both route to localhost on Linux), not
+        // merely distinct ports on the same address. libgit2's off-site
+        // redirect check compares *host*, not port, so a port-only
+        // difference is treated as same-site and followed unconditionally
+        // regardless of `RemoteRedirect` policy — using distinct hosts is
+        // required for this harness to actually exercise the policy.
+        let listener_a = TcpListener::bind("127.0.0.1:0").expect("bind A");
+        let addr_a = listener_a.local_addr().expect("addr A");
+        let listener_b = TcpListener::bind("127.0.0.2:0").expect("bind B");
+        let addr_b = listener_b.local_addr().expect("addr B");
+
+        let b_hits = Arc::new(AtomicUsize::new(0));
+        let captured_authorization = Arc::new(Mutex::new(None));
+
+        thread::spawn(move || {
+            for stream in listener_a.incoming() {
+                let Ok(mut stream) = stream else { continue };
+                let Some((request_line, _headers)) = read_request(&mut stream) else {
+                    continue;
+                };
+                let Some(path) = request_path(&request_line) else {
+                    continue;
+                };
+                let response = format!(
+                    "HTTP/1.1 301 Moved Permanently\r\n\
+                     Location: http://{addr_b}{path}\r\n\
+                     Connection: close\r\n\
+                     Content-Length: 0\r\n\r\n"
+                );
+                let _ = stream.write_all(response.as_bytes());
+            }
+        });
+
+        {
+            let b_hits = Arc::clone(&b_hits);
+            let captured_authorization = Arc::clone(&captured_authorization);
+            thread::spawn(move || {
+                for stream in listener_b.incoming() {
+                    let Ok(mut stream) = stream else { continue };
+                    b_hits.fetch_add(1, Ordering::SeqCst);
+                    let Some((_request_line, headers)) = read_request(&mut stream) else {
+                        continue;
+                    };
+                    let auth_header = headers.iter().find_map(|h| {
+                        let (name, value) = h.split_once(':')?;
+                        name.trim()
+                            .eq_ignore_ascii_case("authorization")
+                            .then(|| value.trim().to_owned())
+                    });
+                    if let Some(value) = auth_header {
+                        *captured_authorization.lock() = Some(value);
+                        let _ = stream.write_all(
+                            b"HTTP/1.1 200 OK\r\n\
+                              Content-Type: application/x-git-upload-pack-advertisement\r\n\
+                              Connection: close\r\n\
+                              Content-Length: 0\r\n\r\n",
+                        );
+                    } else {
+                        let _ = stream.write_all(
+                            b"HTTP/1.1 401 Unauthorized\r\n\
+                              WWW-Authenticate: Basic realm=\"git\"\r\n\
+                              Connection: close\r\n\
+                              Content-Length: 0\r\n\r\n",
+                        );
+                    }
+                }
+            });
+        }
+
+        Self {
+            addr_a,
+            addr_b,
+            b_hits,
+            captured_authorization,
+        }
+    }
+
+    fn b_hit_count(&self) -> usize {
+        self.b_hits.load(Ordering::SeqCst)
+    }
+
+    fn captured_authorization(&self) -> Option<String> {
+        self.captured_authorization.lock().clone()
+    }
+
+    /// The origin URL to fetch from — always points at `A`.
+    fn origin_url(&self) -> String {
+        format!("http://{}/redirect-repo.git", self.addr_a)
+    }
+
+    /// `A`'s canonical authority string, matching what
+    /// `git2db::auth::extract_git_authority` would derive from
+    /// [`RedirectHarness::origin_url`] — used to bind the host-scoped token.
+    fn origin_authority(&self) -> String {
+        self.addr_a.to_string()
+    }
+
+    /// `B`'s address, for diagnostic assertions that the two servers are
+    /// genuinely distinct hosts (not merely distinct ports).
+    fn redirect_target_addr(&self) -> SocketAddr {
+        self.addr_b
+    }
+}
+
+/// Read one HTTP request's start-line and headers (stops at the blank line;
+/// does not attempt to read a body — none of the requests this harness
+/// receives carry one).
+fn read_request(stream: &mut TcpStream) -> Option<(String, Vec<String>)> {
+    let mut reader = BufReader::new(stream.try_clone().ok()?);
+    let mut request_line = String::new();
+    if reader.read_line(&mut request_line).ok()? == 0 {
+        return None;
+    }
+    let mut headers = Vec::new();
+    loop {
+        let mut line = String::new();
+        let n = reader.read_line(&mut line).ok()?;
+        if n == 0 || line == "\r\n" || line == "\n" {
+            break;
+        }
+        headers.push(line.trim_end().to_owned());
+    }
+    Some((request_line.trim_end().to_owned(), headers))
+}
+
+fn request_path(request_line: &str) -> Option<String> {
+    request_line.split_whitespace().nth(1).map(str::to_owned)
+}
+
+/// Perform a real `git2` fetch against `url` with the given `FetchOptions`.
+/// The `Result` is intentionally ignored by callers beyond logging — none of
+/// these servers speak the full git smart-HTTP protocol, so the fetch is
+/// expected to ultimately fail; what matters is which servers were contacted
+/// and with what credentials, observed via the harness.
+fn drive_fetch(url: &str, fetch_opts: &mut git2::FetchOptions<'_>) {
+    let tmp = TempDir::new().expect("tempdir");
+    let repo = git2::Repository::init_bare(tmp.path()).expect("init bare repo");
+    let mut remote = repo.remote_anonymous(url).expect("remote_anonymous");
+    let result = remote.fetch(
+        &["+refs/heads/*:refs/remotes/origin/*"],
+        Some(fetch_opts),
+        None,
+    );
+    // Expected to fail (the harness servers are not a real git backend); the
+    // assertions of interest are on harness-observed side effects, not this
+    // Result. Logged for diagnostic visibility only.
+    if let Err(e) = result {
+        println!("drive_fetch: fetch returned (expected) error: {e}");
+    }
+}
+
+// ---------------------------------------------------------------------------
+// CallbackConfig (send-safe clone) path
+// ---------------------------------------------------------------------------
+
+/// With the secure default (`RedirectPolicy::None`), the off-site redirect to
+/// `B` is never followed: `B`'s socket is never contacted, so no credential —
+/// scoped or otherwise — can reach it.
+#[test]
+fn callback_config_default_redirect_policy_blocks_off_site_redirect() {
+    let harness = RedirectHarness::start();
+    assert_ne!(
+        harness.origin_authority(),
+        harness.redirect_target_addr().to_string(),
+        "sanity: A and B must be genuinely distinct hosts, not merely distinct ports on the \
+         same host — libgit2's off-site check is host-based",
+    );
+
+    let config = CallbackConfigBuilder::new()
+        .auth(AuthStrategy::Token {
+            token: TOKEN.to_owned(),
+            host: Some(harness.origin_authority()),
+        })
+        .build();
+    assert_eq!(
+        config.redirect_policy,
+        RedirectPolicy::None,
+        "sanity: CallbackConfigBuilder must not silently opt into Initial"
+    );
+
+    let mut fetch_opts = git2::FetchOptions::new();
+    fetch_opts.remote_callbacks(config.create_callbacks());
+    fetch_opts.follow_redirects(config.redirect_policy.to_git2());
+
+    drive_fetch(&harness.origin_url(), &mut fetch_opts);
+
+    assert_eq!(
+        harness.b_hit_count(),
+        0,
+        "RedirectPolicy::None must prevent the off-site redirect target from ever being \
+         contacted",
+    );
+    assert_eq!(
+        harness.captured_authorization(),
+        None,
+        "no credential can leak to a server that was never contacted",
+    );
+}
+
+/// With the explicit, insecure opt-in (`RedirectPolicy::Initial`, libgit2's
+/// own default), the redirect IS followed and — because the credential
+/// callback receives the pre-redirect (`A`) URL even though the transport is
+/// now talking to `B` — the token bound to `A`'s authority IS delivered to
+/// `B`. This documents, against the real pinned libgit2 behavior, exactly the
+/// vulnerability `RedirectPolicy::None` is the mandatory default to close.
+#[test]
+fn callback_config_initial_redirect_policy_leaks_token_to_redirect_target() {
+    let harness = RedirectHarness::start();
+
+    let config = CallbackConfigBuilder::new()
+        .auth(AuthStrategy::Token {
+            token: TOKEN.to_owned(),
+            host: Some(harness.origin_authority()),
+        })
+        .redirect_policy(RedirectPolicy::Initial)
+        .build();
+
+    let mut fetch_opts = git2::FetchOptions::new();
+    fetch_opts.remote_callbacks(config.create_callbacks());
+    fetch_opts.follow_redirects(config.redirect_policy.to_git2());
+
+    drive_fetch(&harness.origin_url(), &mut fetch_opts);
+
+    assert!(
+        harness.b_hit_count() >= 1,
+        "RedirectPolicy::Initial must follow the off-site redirect to B",
+    );
+    let captured = harness
+        .captured_authorization()
+        .expect("B must have observed an Authorization header once challenged");
+    let decoded = decode_basic_auth(&captured);
+    assert!(
+        decoded.ends_with(TOKEN),
+        "the token bound to A's authority must have been delivered to B via Basic auth; got \
+         decoded credential {decoded:?}",
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Legacy AuthManager (sync) path
+// ---------------------------------------------------------------------------
+
+/// The legacy `AuthManager` path defaults `redirect_policy()` to `None`; a
+/// caller that plumbs it into `FetchOptions::follow_redirects` (as this test
+/// does — `AuthManager` owns no `FetchOptions` of its own) gets the same
+/// off-site-redirect protection as the `CallbackConfig` path.
+#[test]
+fn auth_manager_default_redirect_policy_blocks_off_site_redirect() {
+    let harness = RedirectHarness::start();
+
+    let mgr = AuthManager::with_strategies(vec![AuthStrategy::Token {
+        token: TOKEN.to_owned(),
+        host: Some(harness.origin_authority()),
+    }]);
+    assert_eq!(mgr.redirect_policy(), RedirectPolicy::None);
+
+    let mut fetch_opts = git2::FetchOptions::new();
+    fetch_opts.remote_callbacks(mgr.create_callbacks());
+    fetch_opts.follow_redirects(mgr.redirect_policy().to_git2());
+
+    drive_fetch(&harness.origin_url(), &mut fetch_opts);
+
+    assert_eq!(
+        harness.b_hit_count(),
+        0,
+        "AuthManager's default redirect policy must prevent B from ever being contacted",
+    );
+    assert_eq!(harness.captured_authorization(), None);
+}
+
+/// The same leak, reproduced through the legacy `AuthManager` path when a
+/// caller explicitly opts into `RedirectPolicy::Initial` — proving the
+/// vulnerability (and the fix) is not specific to the `CallbackConfig` type.
+#[test]
+fn auth_manager_initial_redirect_policy_leaks_token_to_redirect_target() {
+    let harness = RedirectHarness::start();
+
+    let mgr = AuthManager::with_strategies(vec![AuthStrategy::Token {
+        token: TOKEN.to_owned(),
+        host: Some(harness.origin_authority()),
+    }])
+    .with_redirect_policy(RedirectPolicy::Initial);
+
+    let mut fetch_opts = git2::FetchOptions::new();
+    fetch_opts.remote_callbacks(mgr.create_callbacks());
+    fetch_opts.follow_redirects(mgr.redirect_policy().to_git2());
+
+    drive_fetch(&harness.origin_url(), &mut fetch_opts);
+
+    assert!(harness.b_hit_count() >= 1);
+    let captured = harness
+        .captured_authorization()
+        .expect("B must have observed an Authorization header once challenged");
+    let decoded = decode_basic_auth(&captured);
+    assert!(
+        decoded.ends_with(TOKEN),
+        "got decoded credential {decoded:?}"
+    );
+}
+
+/// Minimal base64 decoder for the `Basic <base64>` credential libgit2 sends —
+/// avoids pulling in a base64 dependency just for this test assertion.
+fn decode_basic_auth(header_value: &str) -> String {
+    let b64 = header_value
+        .strip_prefix("Basic ")
+        .unwrap_or(header_value)
+        .trim();
+    String::from_utf8(base64_decode(b64)).expect("valid utf8 credential")
+}
+
+fn base64_decode(input: &str) -> Vec<u8> {
+    const TABLE: &[u8; 64] =
+        b"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+    let mut lut = [0u8; 256];
+    for (i, &c) in TABLE.iter().enumerate() {
+        lut[c as usize] = i as u8;
+    }
+    let clean: Vec<u8> = input.bytes().filter(|&b| b != b'=').collect();
+    let mut out = Vec::with_capacity(clean.len() * 3 / 4);
+    for chunk in clean.chunks(4) {
+        let mut buf = [0u8; 4];
+        for (i, &b) in chunk.iter().enumerate() {
+            buf[i] = lut[b as usize];
+        }
+        out.push((buf[0] << 2) | (buf[1] >> 4));
+        if chunk.len() > 2 {
+            out.push((buf[1] << 4) | (buf[2] >> 2));
+        }
+        if chunk.len() > 3 {
+            out.push((buf[2] << 6) | buf[3]);
+        }
+    }
+    out
+}

--- a/crates/git2db/tests/send_trait_test.rs
+++ b/crates/git2db/tests/send_trait_test.rs
@@ -6,7 +6,7 @@
 
 use git2db::{
     auth::AuthStrategy,
-    callback_config::{CallbackConfigBuilder, ProgressConfig},
+    callback_config::{AuthMode, CallbackConfigBuilder, ProgressConfig},
     clone_options::{CloneOptions, CloneOptionsBuilder},
     manager::GitManager,
 };
@@ -66,6 +66,7 @@ async fn test_clone_with_send_safe_progress() -> Result<(), Box<dyn std::error::
         .callback_config(
             CallbackConfigBuilder::new()
                 .auth(AuthStrategy::Default)
+                .auth_mode(AuthMode::AllowAmbient)
                 .progress(ProgressConfig::Channel(reporter))
                 .build(),
         )
@@ -104,6 +105,7 @@ async fn test_clone_future_is_send() -> Result<(), Box<dyn std::error::Error>> {
         .callback_config(
             CallbackConfigBuilder::new()
                 .auth(AuthStrategy::Default)
+                .auth_mode(AuthMode::AllowAmbient)
                 .build(),
         )
         .build();
@@ -139,6 +141,7 @@ async fn test_concurrent_clones_with_send() {
                     .callback_config(
                         CallbackConfigBuilder::new()
                             .auth(AuthStrategy::Default)
+                            .auth_mode(AuthMode::AllowAmbient)
                             .progress(ProgressConfig::Stdout)
                             .build(),
                     )
@@ -180,6 +183,7 @@ fn test_callback_config_auth_strategies() {
             token: "test_token".to_owned(),
         })
         .auth(AuthStrategy::Default)
+        .auth_mode(AuthMode::AllowAmbient)
         .build();
 
     // Verify we have 3 auth strategies

--- a/crates/git2db/tests/send_trait_test.rs
+++ b/crates/git2db/tests/send_trait_test.rs
@@ -180,6 +180,7 @@ fn test_callback_config_auth_strategies() {
             username: Some("git".to_owned()),
         })
         .auth(AuthStrategy::Token {
+            host: None,
             token: "test_token".to_owned(),
         })
         .auth(AuthStrategy::Default)

--- a/crates/git2db/tests/strict_auth_test.rs
+++ b/crates/git2db/tests/strict_auth_test.rs
@@ -21,7 +21,9 @@
 
 use git2::CertificateCheckStatus;
 use git2db::auth::{AuthManager, AuthStrategy};
-use git2db::callback_config::{AuthMode, CallbackConfig, CertificateConfig, CertificatePinning};
+use git2db::callback_config::{
+    AuthMode, CallbackConfig, CertificateConfig, CertificatePinning, RedirectPolicy,
+};
 
 /// The default `CertificateConfig` must be `Strict`, not `AcceptAll`.
 #[test]
@@ -50,6 +52,66 @@ fn default_callback_config_is_strict_and_explicit() {
     let cfg = CallbackConfig::default();
     assert!(matches!(cfg.certificates, CertificateConfig::Strict));
     assert!(matches!(cfg.auth_mode, AuthMode::ExplicitOnly));
+}
+
+// ---------------------------------------------------------------------------
+// Off-site redirect policy — issue #1429 Sol P1 (revision round 2).
+// ---------------------------------------------------------------------------
+
+/// The default `RedirectPolicy` must be `None` (no off-site redirects), not
+/// libgit2's own default (`Initial`, which allows one). Under the pinned
+/// libgit2 1.9.x, the credential callback receives the pre-redirect URL even
+/// after libgit2 follows an off-site redirect, so a host-scoped credential
+/// could otherwise be offered to the redirect target.
+#[test]
+fn default_redirect_policy_is_none() {
+    assert_eq!(RedirectPolicy::default(), RedirectPolicy::None);
+}
+
+/// The default `CallbackConfig` (the send-safe clone path) carries the secure
+/// redirect default.
+#[test]
+fn default_callback_config_redirect_policy_is_none() {
+    let cfg = CallbackConfig::default();
+    assert_eq!(cfg.redirect_policy, RedirectPolicy::None);
+}
+
+/// `RedirectPolicy::None` maps to `git2::RemoteRedirect::None` (block every
+/// off-site redirect); `Initial` maps to libgit2's own default
+/// (`RemoteRedirect::Initial`, follow on the first request only). This is the
+/// literal knob applied to `FetchOptions::follow_redirects`.
+#[test]
+fn redirect_policy_maps_to_git2_remote_redirect() {
+    assert!(matches!(
+        RedirectPolicy::None.to_git2(),
+        git2::RemoteRedirect::None
+    ));
+    assert!(matches!(
+        RedirectPolicy::Initial.to_git2(),
+        git2::RemoteRedirect::Initial
+    ));
+}
+
+/// The legacy sync `AuthManager` path — which has no `FetchOptions` of its
+/// own to enforce the policy against — must still default to `None` so any
+/// caller that plumbs `AuthManager::redirect_policy()` into its own
+/// `FetchOptions::follow_redirects` inherits the secure default rather than
+/// libgit2's `Initial`.
+#[test]
+fn auth_manager_default_redirect_policy_is_none() {
+    assert_eq!(AuthManager::new().redirect_policy(), RedirectPolicy::None);
+    assert_eq!(
+        AuthManager::with_strategies(vec![]).redirect_policy(),
+        RedirectPolicy::None
+    );
+}
+
+/// `AuthManager::with_redirect_policy` is the explicit, opt-in-only escape
+/// hatch — the default is never silently `Initial`.
+#[test]
+fn auth_manager_redirect_policy_is_explicit_opt_in() {
+    let mgr = AuthManager::new().with_redirect_policy(RedirectPolicy::Initial);
+    assert_eq!(mgr.redirect_policy(), RedirectPolicy::Initial);
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/git2db/tests/strict_auth_test.rs
+++ b/crates/git2db/tests/strict_auth_test.rs
@@ -1,0 +1,170 @@
+//! Causal tests for the strict certificate + explicit-only auth boundary.
+//!
+//! These tests prove the security invariants required by issue #1429 using
+//! only the public API:
+//!   * The default certificate mode is `Strict`, and under `Strict` the
+//!     certificate decision is `CertificatePassthrough` (defer to libgit2's
+//!     built-in verification) — never `CertificateOk`. A MITM/wrong cert
+//!     therefore fails the fetch rather than being silently accepted.
+//!   * The default auth mode is `ExplicitOnly`.
+//!   * `AcceptAll` survives only as an explicit opt-in.
+//!   * The legacy sync `AuthManager` path defaults to strict/explicit-only and
+//!     carries no ambient `Default` strategy.
+//!
+//! The ambient-credential *refusal* under `ExplicitOnly` is a pure decision of
+//! the private `handle_auth` helper and is covered by in-crate unit tests in
+//! `callback_config.rs` (which can reach private items); the end-to-end proof
+//! is that `AuthStrategy::Default` is never emitted by the credentials callback
+//! under the default mode.
+
+#![cfg(test)]
+
+use git2::CertificateCheckStatus;
+use git2db::auth::{AuthManager, AuthStrategy};
+use git2db::callback_config::{AuthMode, CallbackConfig, CertificateConfig, CertificatePinning};
+
+/// The default `CertificateConfig` must be `Strict`, not `AcceptAll`.
+#[test]
+fn default_certificate_mode_is_strict() {
+    let cfg = CertificateConfig::default();
+    assert!(
+        matches!(cfg, CertificateConfig::Strict),
+        "default CertificateConfig must be Strict (got {cfg:?}); the forge/untrusted default \
+         must never accept all certificates",
+    );
+}
+
+/// The default `AuthMode` must be `ExplicitOnly`.
+#[test]
+fn default_auth_mode_is_explicit_only() {
+    let mode = AuthMode::default();
+    assert!(
+        matches!(mode, AuthMode::ExplicitOnly),
+        "default AuthMode must be ExplicitOnly (got {mode:?})",
+    );
+}
+
+/// The default `CallbackConfig` carries strict certs + explicit-only auth.
+#[test]
+fn default_callback_config_is_strict_and_explicit() {
+    let cfg = CallbackConfig::default();
+    assert!(matches!(cfg.certificates, CertificateConfig::Strict));
+    assert!(matches!(cfg.auth_mode, AuthMode::ExplicitOnly));
+}
+
+// ---------------------------------------------------------------------------
+// Certificate decision — the security boundary on cert handling.
+// ---------------------------------------------------------------------------
+
+/// Under `Strict`, the decision is `CertificatePassthrough`: libgit2 performs
+/// its built-in verification and rejects on failure. It must never be
+/// `CertificateOk`, which would accept an untrusted/MITM certificate.
+#[test]
+fn strict_certificate_returns_passthrough_not_ok() {
+    let mode = CertificateConfig::Strict;
+    let decision = CallbackConfig::certificate_decision(&mode, None);
+    assert!(
+        matches!(decision, Ok(CertificateCheckStatus::CertificatePassthrough)),
+        "Strict mode must defer to libgit2 (Passthrough), not accept the cert (Ok)",
+    );
+}
+
+/// Strict ignores the presented hostkey entirely — even with hostkey material
+/// present, it still defers (never Ok).
+#[test]
+fn strict_certificate_ignores_presented_hostkey() {
+    let mode = CertificateConfig::Strict;
+    let hostkey: (&str, &[u8]) = ("evil-mitm.example", b"not-a-real-key");
+    let decision = CallbackConfig::certificate_decision(&mode, Some(hostkey));
+    assert!(matches!(
+        decision,
+        Ok(CertificateCheckStatus::CertificatePassthrough)
+    ));
+}
+
+/// `AcceptAll` is the explicit, insecure opt-in and returns `CertificateOk`.
+/// It must only ever be reached by an explicit caller choice, never by default.
+#[test]
+fn accept_all_is_explicit_opt_in_returning_ok() {
+    let mode = CertificateConfig::AcceptAll;
+    let decision = CallbackConfig::certificate_decision(&mode, None);
+    assert!(matches!(
+        decision,
+        Ok(CertificateCheckStatus::CertificateOk)
+    ));
+}
+
+/// `Pinned` with no matching fingerprint rejects — it never falls back to
+/// accepting the certificate.
+#[test]
+fn pinned_certificate_rejects_non_matching() {
+    let mode = CertificateConfig::Pinned(vec![CertificatePinning {
+        host: "github.com".to_owned(),
+        fingerprint: b"real-fingerprint".to_vec(),
+    }]);
+    // A presented hostkey that does NOT match the pin.
+    let hostkey: (&str, &[u8]) = ("github.com", b"attacker-fingerprint");
+    let res = CallbackConfig::certificate_decision(&mode, Some(hostkey));
+    assert!(
+        res.is_err(),
+        "Pinned mode must reject a non-matching fingerprint, not accept it",
+    );
+}
+
+/// `Pinned` accepts only an exact host + fingerprint match.
+#[test]
+fn pinned_certificate_accepts_exact_match() {
+    let mode = CertificateConfig::Pinned(vec![CertificatePinning {
+        host: "github.com".to_owned(),
+        fingerprint: b"deadbeef".to_vec(),
+    }]);
+    let hostkey: (&str, &[u8]) = ("github.com", b"deadbeef");
+    let decision = CallbackConfig::certificate_decision(&mode, Some(hostkey));
+    assert!(matches!(
+        decision,
+        Ok(CertificateCheckStatus::CertificateOk)
+    ));
+}
+
+// ---------------------------------------------------------------------------
+// AuthManager (sync path) defaults — the legacy `auth.rs` surface.
+// ---------------------------------------------------------------------------
+
+/// `AuthManager::new()` must default to strict certs + explicit-only auth, and
+/// must NOT carry an ambient `Default` strategy the way the legacy constructor
+/// did (the old `new()` seeded `vec![AuthStrategy::Default]`).
+#[test]
+fn auth_manager_defaults_are_strict_and_explicit() {
+    let mgr = AuthManager::new();
+    assert_eq!(
+        mgr.strategy_count(),
+        0,
+        "default AuthManager carries no ambient strategy"
+    );
+    assert!(matches!(mgr.certificate_mode(), CertificateConfig::Strict));
+    assert!(matches!(mgr.auth_mode(), AuthMode::ExplicitOnly));
+}
+
+/// `AuthManager::with_strategies` also defaults to strict/explicit-only even
+/// when the caller passes an explicit strategy list.
+#[test]
+fn auth_manager_with_strategies_defaults_strict() {
+    let mgr = AuthManager::with_strategies(vec![AuthStrategy::Token {
+        token: "x".to_owned(),
+    }]);
+    assert!(matches!(mgr.certificate_mode(), CertificateConfig::Strict));
+    assert!(matches!(mgr.auth_mode(), AuthMode::ExplicitOnly));
+}
+
+/// The presets that bundle `AuthStrategy::Default` must opt into `AllowAmbient`
+/// so their ambient intent is explicit rather than relying on the old default.
+#[test]
+fn ambient_presets_opt_into_allow_ambient() {
+    use git2db::auth::presets;
+    assert_eq!(presets::ssh_standard().auth_mode(), AuthMode::AllowAmbient);
+    assert_eq!(
+        presets::github_token("t").auth_mode(),
+        AuthMode::AllowAmbient
+    );
+    assert_eq!(presets::public_only().auth_mode(), AuthMode::AllowAmbient);
+}

--- a/crates/git2db/tests/strict_auth_test.rs
+++ b/crates/git2db/tests/strict_auth_test.rs
@@ -168,3 +168,30 @@ fn ambient_presets_opt_into_allow_ambient() {
     );
     assert_eq!(presets::public_only().auth_mode(), AuthMode::AllowAmbient);
 }
+
+// ---------------------------------------------------------------------------
+// NetworkConfig default — ambient must be off by default (issue #1429).
+// ---------------------------------------------------------------------------
+
+/// `use_credential_helper` must default to `false` so ordinary `GitManager`
+/// clones do not opt into ambient credential discovery (SSH agent / credential
+/// helper / ~/.gitconfig) by default.
+#[test]
+fn use_credential_helper_defaults_to_false() {
+    use git2db::config::NetworkConfig;
+    let cfg = NetworkConfig::default();
+    assert!(
+        !cfg.use_credential_helper,
+        "use_credential_helper must default to false (got true); ordinary clones must not \
+         consult ambient credentials unless explicitly enabled",
+    );
+}
+
+/// `AuthStrategy::is_ambient()` classifies `Default` and `SshAgent` as ambient
+/// (the two environment-backed strategies), and explicit strategies as not.
+#[test]
+fn is_ambient_classifies_environment_sources() {
+    assert!(AuthStrategy::Default.is_ambient());
+    assert!(AuthStrategy::SshAgent { username: None }.is_ambient());
+    assert!(!AuthStrategy::Token { token: "t".into() }.is_ambient());
+}

--- a/crates/git2db/tests/strict_auth_test.rs
+++ b/crates/git2db/tests/strict_auth_test.rs
@@ -151,6 +151,7 @@ fn auth_manager_defaults_are_strict_and_explicit() {
 fn auth_manager_with_strategies_defaults_strict() {
     let mgr = AuthManager::with_strategies(vec![AuthStrategy::Token {
         token: "x".to_owned(),
+        host: None,
     }]);
     assert!(matches!(mgr.certificate_mode(), CertificateConfig::Strict));
     assert!(matches!(mgr.auth_mode(), AuthMode::ExplicitOnly));
@@ -193,5 +194,11 @@ fn use_credential_helper_defaults_to_false() {
 fn is_ambient_classifies_environment_sources() {
     assert!(AuthStrategy::Default.is_ambient());
     assert!(AuthStrategy::SshAgent { username: None }.is_ambient());
-    assert!(!AuthStrategy::Token { token: "t".into() }.is_ambient());
+    assert!(
+        !AuthStrategy::Token {
+            token: "t".into(),
+            host: None
+        }
+        .is_ambient()
+    );
 }


### PR DESCRIPTION
Closes #1429.

## Problem

`AuthManager::create_callbacks()` (`crates/git2db/src/auth.rs`) unconditionally returned `CertificateOk` for every certificate, and `CertificateConfig::SystemDefault` (the field default) also returned `CertificateOk`. Because installing a `certificate_check` callback overrides libgit2's verification, **every fetch silently accepted any certificate** — including forged/MITM ones. Any untrusted-repository fetch path (the merge gate's forge PR-head fetch, P2P distribution) inherited an always-trusting TLS posture.

## Changes

- **`CertificateConfig::Strict`** is the new default. Under `Strict` the certificate callback returns `CertificatePassthrough`, deferring to libgit2's built-in verification against the system trust store (CA chain + hostname for HTTPS, `known_hosts` for SSH). A cert that fails verification **fails the fetch**. The buggy `SystemDefault` variant (which claimed to defer but actually accepted everything) is removed.
- **`AuthMode::ExplicitOnly`** is the new default. `AuthStrategy::Default` (libgit2 ambient discovery: git credential helper, `~/.gitconfig`, SSH agent fallback) is refused at credential-resolution time, so an untrusted fetch cannot silently pick up the operator's credentials. `AllowAmbient` remains available as an explicit opt-in for trusted first-party mirror access.
- **`AcceptAll`** survives only as an explicit, documented test/opt-in mode — never the default.
- `AuthManager` carries `certificate_mode` + `auth_mode` fields (both defaulting secure); presets that bundle `AuthStrategy::Default` now opt into `AllowAmbient` explicitly.
- Shared pure helper `CallbackConfig::certificate_decision` so the sync (`auth.rs`) and send-safe (`callback_config.rs`) paths cannot drift on the boundary.

## Causal tests (`tests/strict_auth_test.rs` + in-crate unit tests)

- `Strict` → `CertificatePassthrough` (never `CertificateOk`), even when hostkey material is present.
- `AcceptAll` → `CertificateOk` only via explicit opt-in.
- `Pinned` rejects non-matching fingerprint; never falls back to accept.
- `ExplicitOnly` refuses `AuthStrategy::Default` (ambient credentials not consulted); `AllowAmbient` permits it.
- `AuthManager::new()` carries no ambient strategy; defaults verified strict/explicit-only.

## Caller audit

- `manager.rs`: uses `Strict` explicitly; opts into `AllowAmbient` only when `use_credential_helper` is set.
- `services/registry.rs`: uses `CallbackConfig::new()` which now defaults to strict/explicit-only (progress-only config, unchanged intent).
- `send_trait_test.rs`: ambient `Default` test configs explicitly opt into `AllowAmbient`.
- No non-test code relied on the always-accept default.

## Non-goals (per issue)

Full CA pinning and custom trust-store management are follow-ons.

Refs #1429. Epic #1427.