### PR TITLE
fix(ci): isolate license boundary metadata from sccache

### DIFF
--- a/scripts/check_license_boundary.py
+++ b/scripts/check_license_boundary.py
@@ -45,12 +45,19 @@ def cargo_workspace_manifest_paths(root: Path) -> set[Path]:
         command.insert(len(cargo) + 4, "--locked")
     else:
         command.remove("--no-deps")
+    # The license-boundary checker is metadata-only.  Its fixture subprocesses
+    # must not inherit a workflow-level compiler wrapper: the hosted deny job
+    # deliberately does not install sccache, and Cargo still consults
+    # RUSTC_WRAPPER while probing rustc for `cargo metadata`.
+    environment = os.environ.copy()
+    environment.pop("RUSTC_WRAPPER", None)
     result = subprocess.run(
         command,
         cwd=root,
         text=True,
         capture_output=True,
         check=False,
+        env=environment,
     )
     if result.returncode:
         fail(f"cargo metadata failed: {result.stderr.strip()}")

--- a/scripts/tests/test_check_license_boundary.py
+++ b/scripts/tests/test_check_license_boundary.py
@@ -3,6 +3,7 @@
 
 from __future__ import annotations
 
+import os
 import subprocess
 import sys
 import tempfile
@@ -146,6 +147,20 @@ class LicenseBoundaryFixtures(unittest.TestCase):
         result = self.run_fixture(
             apache_manifest='[dependencies]\nmiddle = { path = "../middle" }\n'
         )
+        self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+
+    def test_fixture_ignores_missing_parent_rustc_wrapper(self) -> None:
+        original = os.environ.get("RUSTC_WRAPPER")
+        os.environ["RUSTC_WRAPPER"] = "missing-ci-sccache"
+        try:
+            result = self.run_fixture(
+                apache_manifest='[dependencies]\nmiddle = { path = "../middle" }\n'
+            )
+        finally:
+            if original is None:
+                os.environ.pop("RUSTC_WRAPPER", None)
+            else:
+                os.environ["RUSTC_WRAPPER"] = original
         self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
 
     def test_direct_apache_root_dependency_fails(self) -> None:


### PR DESCRIPTION
## Root cause
The hosted `cargo-deny` job exports `RUSTC_WRAPPER=sccache` globally but does not install `sccache`. Its prior `unset` only applied to the preceding shell. The license-boundary fixture suite invokes `cargo metadata`, which therefore tried to execute a nonexistent wrapper and made every fixture fail.

## Fix
- remove `RUSTC_WRAPPER` only from the checker’s metadata subprocess environment
- add a causal fixture proving the checker succeeds with a missing parent wrapper

## Validation
- `RUSTC_WRAPPER=missing-ci-sccache python3 -m unittest discover -s scripts/tests -p test_check_license_boundary.py` — 32 passed
- `RUSTC_WRAPPER=missing-ci-sccache python3 scripts/check_license_boundary.py` — passed
- workflow-matrix and browser-WASM static checks — passed
- `git diff --check` — passed

No Rust source or license-policy semantics changed. Full clippy pre-commit was not run; this is a Python metadata-environment hotfix and CI is the authoritative full gate.