### PR TITLE
fix(ci): mount merge gate cache in builder jobs

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -86,7 +86,9 @@ jobs:
       run: |
         podman run --rm \
           -v "$PWD":/build:Z -w /build \
-          -v /mnt/hypr-ci-cache:/mnt/hypr-ci-cache:Z \
+          # The EBS cache filesystem rejects SELinux relabel xattrs; leave this shared
+          # ephemeral runner cache unlabeled and retain :Z only on the checked-out source.
+          -v /mnt/hypr-ci-cache:/mnt/hypr-ci-cache \
           -e RUSTC_WRAPPER=sccache -e SCCACHE_BUCKET -e SCCACHE_REGION \
           -e AWS_ACCESS_KEY_ID -e AWS_SECRET_ACCESS_KEY -e AWS_SESSION_TOKEN \
           -e AWS_REGION -e AWS_DEFAULT_REGION \
@@ -194,7 +196,9 @@ jobs:
       run: |
         podman run --rm \
           -v "$PWD":/build:Z -w /build \
-          -v /mnt/hypr-ci-cache:/mnt/hypr-ci-cache:Z \
+          # The EBS cache filesystem rejects SELinux relabel xattrs; leave this shared
+          # ephemeral runner cache unlabeled and retain :Z only on the checked-out source.
+          -v /mnt/hypr-ci-cache:/mnt/hypr-ci-cache \
           -e RUSTC_WRAPPER=sccache -e SCCACHE_BUCKET -e SCCACHE_REGION \
           -e AWS_ACCESS_KEY_ID -e AWS_SECRET_ACCESS_KEY -e AWS_SESSION_TOKEN \
           -e AWS_REGION -e AWS_DEFAULT_REGION \
@@ -271,7 +275,9 @@ jobs:
       run: |
         podman run --rm \
           -v "$PWD":/build:Z -w /build \
-          -v /mnt/hypr-ci-cache:/mnt/hypr-ci-cache:Z \
+          # The EBS cache filesystem rejects SELinux relabel xattrs; leave this shared
+          # ephemeral runner cache unlabeled and retain :Z only on the checked-out source.
+          -v /mnt/hypr-ci-cache:/mnt/hypr-ci-cache \
           -e RUSTC_WRAPPER=sccache -e SCCACHE_BUCKET -e SCCACHE_REGION \
           -e SCCACHE_IDLE_TIMEOUT=0 \
           -e AWS_ACCESS_KEY_ID -e AWS_SECRET_ACCESS_KEY -e AWS_SESSION_TOKEN \

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -86,7 +86,7 @@ jobs:
       run: |
         # The EBS cache filesystem rejects SELinux relabel xattrs; leave this shared
         # ephemeral runner cache unlabeled and retain :Z only on the checked-out source.
-        podman run --rm \
+        podman run --rm --security-opt label=disable \
           -v "$PWD":/build:Z -w /build \
           -v /mnt/hypr-ci-cache:/mnt/hypr-ci-cache \
           -e RUSTC_WRAPPER=sccache -e SCCACHE_BUCKET -e SCCACHE_REGION \
@@ -196,7 +196,7 @@ jobs:
       run: |
         # The EBS cache filesystem rejects SELinux relabel xattrs; leave this shared
         # ephemeral runner cache unlabeled and retain :Z only on the checked-out source.
-        podman run --rm \
+        podman run --rm --security-opt label=disable \
           -v "$PWD":/build:Z -w /build \
           -v /mnt/hypr-ci-cache:/mnt/hypr-ci-cache \
           -e RUSTC_WRAPPER=sccache -e SCCACHE_BUCKET -e SCCACHE_REGION \
@@ -275,7 +275,7 @@ jobs:
       run: |
         # The EBS cache filesystem rejects SELinux relabel xattrs; leave this shared
         # ephemeral runner cache unlabeled and retain :Z only on the checked-out source.
-        podman run --rm \
+        podman run --rm --security-opt label=disable \
           -v "$PWD":/build:Z -w /build \
           -v /mnt/hypr-ci-cache:/mnt/hypr-ci-cache \
           -e RUSTC_WRAPPER=sccache -e SCCACHE_BUCKET -e SCCACHE_REGION \

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -84,10 +84,10 @@ jobs:
 
     - name: Run Clippy (in rust-builder container)
       run: |
+        # The EBS cache filesystem rejects SELinux relabel xattrs; leave this shared
+        # ephemeral runner cache unlabeled and retain :Z only on the checked-out source.
         podman run --rm \
           -v "$PWD":/build:Z -w /build \
-          # The EBS cache filesystem rejects SELinux relabel xattrs; leave this shared
-          # ephemeral runner cache unlabeled and retain :Z only on the checked-out source.
           -v /mnt/hypr-ci-cache:/mnt/hypr-ci-cache \
           -e RUSTC_WRAPPER=sccache -e SCCACHE_BUCKET -e SCCACHE_REGION \
           -e AWS_ACCESS_KEY_ID -e AWS_SECRET_ACCESS_KEY -e AWS_SESSION_TOKEN \
@@ -194,10 +194,10 @@ jobs:
     # merge-group build, preventing the two gates from drifting apart.
     - name: Check wasm32 browser build (in rust-builder container)
       run: |
+        # The EBS cache filesystem rejects SELinux relabel xattrs; leave this shared
+        # ephemeral runner cache unlabeled and retain :Z only on the checked-out source.
         podman run --rm \
           -v "$PWD":/build:Z -w /build \
-          # The EBS cache filesystem rejects SELinux relabel xattrs; leave this shared
-          # ephemeral runner cache unlabeled and retain :Z only on the checked-out source.
           -v /mnt/hypr-ci-cache:/mnt/hypr-ci-cache \
           -e RUSTC_WRAPPER=sccache -e SCCACHE_BUCKET -e SCCACHE_REGION \
           -e AWS_ACCESS_KEY_ID -e AWS_SECRET_ACCESS_KEY -e AWS_SESSION_TOKEN \
@@ -273,10 +273,10 @@ jobs:
     # in-image sccache reaches the same-region S3 bucket.
     - name: WASM preflight + build + test (in rust-builder container)
       run: |
+        # The EBS cache filesystem rejects SELinux relabel xattrs; leave this shared
+        # ephemeral runner cache unlabeled and retain :Z only on the checked-out source.
         podman run --rm \
           -v "$PWD":/build:Z -w /build \
-          # The EBS cache filesystem rejects SELinux relabel xattrs; leave this shared
-          # ephemeral runner cache unlabeled and retain :Z only on the checked-out source.
           -v /mnt/hypr-ci-cache:/mnt/hypr-ci-cache \
           -e RUSTC_WRAPPER=sccache -e SCCACHE_BUCKET -e SCCACHE_REGION \
           -e SCCACHE_IDLE_TIMEOUT=0 \

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -86,11 +86,13 @@ jobs:
       run: |
         podman run --rm \
           -v "$PWD":/build:Z -w /build \
+          -v /mnt/hypr-ci-cache:/mnt/hypr-ci-cache:Z \
           -e RUSTC_WRAPPER=sccache -e SCCACHE_BUCKET -e SCCACHE_REGION \
           -e AWS_ACCESS_KEY_ID -e AWS_SECRET_ACCESS_KEY -e AWS_SESSION_TOKEN \
           -e AWS_REGION -e AWS_DEFAULT_REGION \
           -e LIBTORCH=/opt/libtorch -e LD_LIBRARY_PATH=/opt/libtorch/lib \
           -e LIBTORCH_BYPASS_VERSION_CHECK=1 -e OPENSSL_NO_VENDOR=1 \
+          -e CARGO_TARGET_DIR=/mnt/hypr-ci-cache/target/hyprstream \
           -e CARGO_INCREMENTAL=0 -e CARGO_TERM_COLOR=always \
           "$BUILDER_IMAGE" \
           bash -euo pipefail -c '
@@ -192,9 +194,11 @@ jobs:
       run: |
         podman run --rm \
           -v "$PWD":/build:Z -w /build \
+          -v /mnt/hypr-ci-cache:/mnt/hypr-ci-cache:Z \
           -e RUSTC_WRAPPER=sccache -e SCCACHE_BUCKET -e SCCACHE_REGION \
           -e AWS_ACCESS_KEY_ID -e AWS_SECRET_ACCESS_KEY -e AWS_SESSION_TOKEN \
           -e AWS_REGION -e AWS_DEFAULT_REGION \
+          -e CARGO_TARGET_DIR=/mnt/hypr-ci-cache/target/hyprstream \
           -e CARGO_INCREMENTAL=0 -e CARGO_TERM_COLOR=always \
           "$BUILDER_IMAGE" \
           bash -euo pipefail -c '
@@ -267,12 +271,14 @@ jobs:
       run: |
         podman run --rm \
           -v "$PWD":/build:Z -w /build \
+          -v /mnt/hypr-ci-cache:/mnt/hypr-ci-cache:Z \
           -e RUSTC_WRAPPER=sccache -e SCCACHE_BUCKET -e SCCACHE_REGION \
           -e SCCACHE_IDLE_TIMEOUT=0 \
           -e AWS_ACCESS_KEY_ID -e AWS_SECRET_ACCESS_KEY -e AWS_SESSION_TOKEN \
           -e AWS_REGION -e AWS_DEFAULT_REGION \
           -e LIBTORCH=/opt/libtorch -e LD_LIBRARY_PATH=/opt/libtorch/lib \
           -e LIBTORCH_BYPASS_VERSION_CHECK=1 -e OPENSSL_NO_VENDOR=1 \
+          -e CARGO_TARGET_DIR=/mnt/hypr-ci-cache/target/hyprstream \
           -e CARGO_INCREMENTAL=0 -e CARGO_TERM_COLOR=always \
           "$BUILDER_IMAGE" \
           bash -euo pipefail -c '

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -84,9 +84,9 @@ jobs:
 
     - name: Run Clippy (in rust-builder container)
       run: |
-        # The EBS cache filesystem rejects SELinux relabel xattrs; leave this shared
-        # ephemeral runner cache unlabeled and retain :Z only on the checked-out source.
-        podman run --rm --security-opt label=disable \
+        # Runner boot labels this target subtree container_file_t; leave the
+        # container confined and retain :Z only on the checked-out source.
+        podman run --rm \
           -v "$PWD":/build:Z -w /build \
           -v /mnt/hypr-ci-cache:/mnt/hypr-ci-cache \
           -e RUSTC_WRAPPER=sccache -e SCCACHE_BUCKET -e SCCACHE_REGION \
@@ -194,9 +194,9 @@ jobs:
     # merge-group build, preventing the two gates from drifting apart.
     - name: Check wasm32 browser build (in rust-builder container)
       run: |
-        # The EBS cache filesystem rejects SELinux relabel xattrs; leave this shared
-        # ephemeral runner cache unlabeled and retain :Z only on the checked-out source.
-        podman run --rm --security-opt label=disable \
+        # Runner boot labels this target subtree container_file_t; leave the
+        # container confined and retain :Z only on the checked-out source.
+        podman run --rm \
           -v "$PWD":/build:Z -w /build \
           -v /mnt/hypr-ci-cache:/mnt/hypr-ci-cache \
           -e RUSTC_WRAPPER=sccache -e SCCACHE_BUCKET -e SCCACHE_REGION \
@@ -273,9 +273,9 @@ jobs:
     # in-image sccache reaches the same-region S3 bucket.
     - name: WASM preflight + build + test (in rust-builder container)
       run: |
-        # The EBS cache filesystem rejects SELinux relabel xattrs; leave this shared
-        # ephemeral runner cache unlabeled and retain :Z only on the checked-out source.
-        podman run --rm --security-opt label=disable \
+        # Runner boot labels this target subtree container_file_t; leave the
+        # container confined and retain :Z only on the checked-out source.
+        podman run --rm \
           -v "$PWD":/build:Z -w /build \
           -v /mnt/hypr-ci-cache:/mnt/hypr-ci-cache \
           -e RUSTC_WRAPPER=sccache -e SCCACHE_BUCKET -e SCCACHE_REGION \

--- a/scripts/check_rust_workflow_matrix.py
+++ b/scripts/check_rust_workflow_matrix.py
@@ -272,7 +272,7 @@ def check_rust_text(text: str) -> None:
     # otherwise a full link writes into the 80 GiB runner root and can exhaust
     # it despite the 200 GiB cache volume being available.
     required_cache_args = (
-        "-v /mnt/hypr-ci-cache:/mnt/hypr-ci-cache:Z",
+        "-v /mnt/hypr-ci-cache:/mnt/hypr-ci-cache",
         "-e CARGO_TARGET_DIR=/mnt/hypr-ci-cache/target/hyprstream",
     )
     job_blocks = _job_blocks(text)
@@ -283,6 +283,10 @@ def check_rust_text(text: str) -> None:
                 argument in block,
                 f"rust.yml: job {name!r} must pass {argument!r} to Podman",
             )
+        _assert(
+            "-v /mnt/hypr-ci-cache:/mnt/hypr-ci-cache:Z" not in block,
+            f"rust.yml: job {name!r} must not SELinux-relabel the cache EBS mount",
+        )
 
 
 def check_appimage_text(text: str) -> None:
@@ -400,7 +404,7 @@ def _rust_mutations(rust_text: str) -> list[tuple[str, str]]:
         (
             "drop merge-gate cache mount",
             rust_text.replace(
-                "          -v /mnt/hypr-ci-cache:/mnt/hypr-ci-cache:Z \\\n",
+                "          -v /mnt/hypr-ci-cache:/mnt/hypr-ci-cache \\\n",
                 "",
                 1,
             ),
@@ -410,6 +414,14 @@ def _rust_mutations(rust_text: str) -> list[tuple[str, str]]:
             rust_text.replace(
                 "          -e CARGO_TARGET_DIR=/mnt/hypr-ci-cache/target/hyprstream \\\n",
                 "",
+                1,
+            ),
+        ),
+        (
+            "SELinux-relabel cache mount (the EBS cache rejects xattrs)",
+            rust_text.replace(
+                "          -v /mnt/hypr-ci-cache:/mnt/hypr-ci-cache \\\n",
+                "          -v /mnt/hypr-ci-cache:/mnt/hypr-ci-cache:Z \\\n",
                 1,
             ),
         ),

--- a/scripts/check_rust_workflow_matrix.py
+++ b/scripts/check_rust_workflow_matrix.py
@@ -272,6 +272,7 @@ def check_rust_text(text: str) -> None:
     # otherwise a full link writes into the 80 GiB runner root and can exhaust
     # it despite the 200 GiB cache volume being available.
     required_cache_args = (
+        "--security-opt label=disable",
         "-v /mnt/hypr-ci-cache:/mnt/hypr-ci-cache",
         "-e CARGO_TARGET_DIR=/mnt/hypr-ci-cache/target/hyprstream",
     )
@@ -286,6 +287,10 @@ def check_rust_text(text: str) -> None:
         _assert(
             "-v /mnt/hypr-ci-cache:/mnt/hypr-ci-cache:Z" not in block,
             f"rust.yml: job {name!r} must not SELinux-relabel the cache EBS mount",
+        )
+        _assert(
+            re.search(r"\\\n[ \t]*#", block) is None,
+            f"rust.yml: job {name!r} must not put comments inside continued shell commands",
         )
 
 
@@ -422,6 +427,18 @@ def _rust_mutations(rust_text: str) -> list[tuple[str, str]]:
             rust_text.replace(
                 "          -v /mnt/hypr-ci-cache:/mnt/hypr-ci-cache \\\n",
                 "          -v /mnt/hypr-ci-cache:/mnt/hypr-ci-cache:Z \\\n",
+                1,
+            ),
+        ),
+        (
+            "disable cache label bypass",
+            rust_text.replace("--security-opt label=disable ", "", 1),
+        ),
+        (
+            "comment inside continued Podman command",
+            rust_text.replace(
+                "          -v /mnt/hypr-ci-cache:/mnt/hypr-ci-cache \\\n",
+                "          # unsafe inline comment \\\n          -v /mnt/hypr-ci-cache:/mnt/hypr-ci-cache \\\n",
                 1,
             ),
         ),

--- a/scripts/check_rust_workflow_matrix.py
+++ b/scripts/check_rust_workflow_matrix.py
@@ -272,7 +272,6 @@ def check_rust_text(text: str) -> None:
     # otherwise a full link writes into the 80 GiB runner root and can exhaust
     # it despite the 200 GiB cache volume being available.
     required_cache_args = (
-        "--security-opt label=disable",
         "-v /mnt/hypr-ci-cache:/mnt/hypr-ci-cache",
         "-e CARGO_TARGET_DIR=/mnt/hypr-ci-cache/target/hyprstream",
     )
@@ -287,6 +286,10 @@ def check_rust_text(text: str) -> None:
         _assert(
             "-v /mnt/hypr-ci-cache:/mnt/hypr-ci-cache:Z" not in block,
             f"rust.yml: job {name!r} must not SELinux-relabel the cache EBS mount",
+        )
+        _assert(
+            "--security-opt label=disable" not in block,
+            f"rust.yml: job {name!r} must keep the builder container SELinux-confined",
         )
         _assert(
             re.search(r"\\\n[ \t]*#", block) is None,
@@ -431,8 +434,8 @@ def _rust_mutations(rust_text: str) -> list[tuple[str, str]]:
             ),
         ),
         (
-            "disable cache label bypass",
-            rust_text.replace("--security-opt label=disable ", "", 1),
+            "disable container SELinux confinement",
+            rust_text.replace("podman run --rm \\\n", "podman run --rm --security-opt label=disable \\\n", 1),
         ),
         (
             "comment inside continued Podman command",

--- a/scripts/check_rust_workflow_matrix.py
+++ b/scripts/check_rust_workflow_matrix.py
@@ -267,6 +267,23 @@ def check_rust_text(text: str) -> None:
         f"(if={build_if!r})",
     )
 
+    # The merge-gate runners provision a dedicated cache EBS volume at this
+    # path. Every Rust container must bind it and direct Cargo's target there;
+    # otherwise a full link writes into the 80 GiB runner root and can exhaust
+    # it despite the 200 GiB cache volume being available.
+    required_cache_args = (
+        "-v /mnt/hypr-ci-cache:/mnt/hypr-ci-cache:Z",
+        "-e CARGO_TARGET_DIR=/mnt/hypr-ci-cache/target/hyprstream",
+    )
+    job_blocks = _job_blocks(text)
+    for name in ("clippy", "wasm", "build"):
+        block = job_blocks[name]
+        for argument in required_cache_args:
+            _assert(
+                argument in block,
+                f"rust.yml: job {name!r} must pass {argument!r} to Podman",
+            )
+
 
 def check_appimage_text(text: str) -> None:
     """Pin AppImage to one nightly cron, v* tags, and manual dispatch only."""
@@ -379,6 +396,22 @@ def _rust_mutations(rust_text: str) -> list[tuple[str, str]]:
         (
             "rename build job (removing the required gate)",
             rust_text.replace("  build:\n", "  build_renamed:\n", 1),
+        ),
+        (
+            "drop merge-gate cache mount",
+            rust_text.replace(
+                "          -v /mnt/hypr-ci-cache:/mnt/hypr-ci-cache:Z \\\n",
+                "",
+                1,
+            ),
+        ),
+        (
+            "drop merge-gate target directory",
+            rust_text.replace(
+                "          -e CARGO_TARGET_DIR=/mnt/hypr-ci-cache/target/hyprstream \\\n",
+                "",
+                1,
+            ),
         ),
     ]
 


### PR DESCRIPTION
Draft pending its infrastructure prerequisite: ingest !107 labels the freshly mounted runner Cargo target subtree `container_file_t` at boot, while retaining enforcing host SELinux and `container_t` builder processes.\n\nThis PR then mounts that cache normally, sets `CARGO_TARGET_DIR`, keeps the source mount `:Z`, and explicitly rejects `--security-opt label=disable` and cache relabeling.\n\nDo not merge or requeue #1414 until !107 has been applied to new runners and this exact workflow head has fresh green runner evidence.