### PR TITLE
fix(auth): gate Postgres-only column glue on the postgres feature

### DIFF
--- a/crates/hyprstream/src/auth/cipher_glue.rs
+++ b/crates/hyprstream/src/auth/cipher_glue.rs
@@ -1,16 +1,27 @@
 //! Shared glue between relational [`UserStore`] backends and the
-//! backend-neutral [`ColumnCipher`] (#1401).
+//! backend-neutral `ColumnCipher`.
 //!
-//! The four seal/open free functions and the `USERSTORE_SCHEMA` DDL live here
-//! so that [`PgliteUserStore`](super::pglite_store::PgliteUserStore) and
-//! [`PostgresUserStore`](super::postgres_store::PostgresUserStore) share one
-//! source of truth for value-column encryption and schema. Neither this module
-//! nor [`encrypted_columns`] has any backend-specific (pglite / tokio-postgres)
-//! dependency — the cipher is pure AES-GCM-SIV + HKDF + age CLI, and the DDL
-//! is standard PostgreSQL.
+//! `USERSTORE_SCHEMA` is the one source of truth for the relational DDL and is
+//! consumed by every relational backend, so it is compiled whenever any of them
+//! is enabled.
+//!
+//! The four seal/open free functions below serve the server-Postgres backend
+//! specifically: they take the cipher and root key as `Option`s, because that
+//! backend can run with value-column encryption absent. `PgliteUserStore` holds
+//! a non-optional `ColumnCipher` — encryption is unconditional there — so it
+//! seals the same columns through the inherent `ColumnCipher::seal_*`/`open_*`
+//! methods instead, and never calls these. They are therefore compiled only
+//! with the `postgres` backend, matching their callers.
+//!
+//! Neither this module nor [`encrypted_columns`] has any backend-specific
+//! (pglite / tokio-postgres) dependency — the cipher is pure AES-GCM-SIV +
+//! HKDF + age CLI, and the DDL is standard PostgreSQL.
 
+#[cfg(feature = "postgres")]
 use super::encrypted_columns::{ColumnCipher, EncryptedColumn, ROOT_DEK_BYTES};
+#[cfg(feature = "postgres")]
 use anyhow::{bail, Result};
+#[cfg(feature = "postgres")]
 use zeroize::Zeroizing;
 
 /// PostgreSQL-compatible schema shared by embedded PGlite and server Postgres.
@@ -100,13 +111,17 @@ CREATE TABLE IF NOT EXISTS user_encryption_keys (
 
 // ── Field-level seal/open free functions ─────────────────────────────
 //
-// These are the shared glue between the backend-neutral [`ColumnCipher`] and
-// each store's read/write paths. They are parameterized by
-// `(cipher, root, username, column, value)` — no `self`, no backend type.
+// These bridge the backend-neutral `ColumnCipher` and the server-Postgres
+// store's read/write paths. They are parameterized by
+// `(cipher, root, username, column, value)` — no `self`, no backend type —
+// and are `Option`-taking because that backend may run without value-column
+// encryption configured. Backends whose cipher is unconditional call the
+// inherent `ColumnCipher` methods directly rather than these.
 
 /// Seal an optional text field for storage. Returns `None` for `None`
 /// input. When encryption is disabled (`cipher` and `root` both `None`),
 /// returns plaintext bytes.
+#[cfg(feature = "postgres")]
 pub(crate) fn seal_text(
     cipher: Option<&ColumnCipher>,
     root: Option<&Zeroizing<[u8; ROOT_DEK_BYTES]>>,
@@ -129,6 +144,7 @@ pub(crate) fn seal_text(
 
 /// Open an optional text field from stored bytes. When encryption is
 /// disabled, interprets bytes as UTF-8 directly.
+#[cfg(feature = "postgres")]
 pub(crate) fn open_text(
     cipher: Option<&ColumnCipher>,
     root: Option<&Zeroizing<[u8; ROOT_DEK_BYTES]>>,
@@ -148,6 +164,7 @@ pub(crate) fn open_text(
 }
 
 /// Seal raw bytes (e.g. pubkey material) for storage.
+#[cfg(feature = "postgres")]
 pub(crate) fn seal_raw(
     cipher: Option<&ColumnCipher>,
     root: Option<&Zeroizing<[u8; ROOT_DEK_BYTES]>>,
@@ -163,6 +180,7 @@ pub(crate) fn seal_raw(
 }
 
 /// Open raw bytes from storage.
+#[cfg(feature = "postgres")]
 pub(crate) fn open_raw(
     cipher: Option<&ColumnCipher>,
     root: Option<&Zeroizing<[u8; ROOT_DEK_BYTES]>>,


### PR DESCRIPTION
## What

`#1414` added `credential-pds` (→ `pglite`) to `hyprstream`'s default features. That
turns on `auth::cipher_glue`, which is gated `any(feature = "pglite", feature =
"postgres")` — but four of its functions are only ever called from
`postgres_store.rs`, behind `#[cfg(feature = "postgres")]`. With `pglite` on and
`postgres` off they compile with no callers, so under `-D warnings` every
default-feature build raises four never-used denials:

```
crates/hyprstream/src/auth/cipher_glue.rs:110  seal_text
crates/hyprstream/src/auth/cipher_glue.rs:132  open_text
crates/hyprstream/src/auth/cipher_glue.rs:151  seal_raw
crates/hyprstream/src/auth/cipher_glue.rs:166  open_raw
```

This fails every PR's merge-ref Clippy and the local pre-commit hook.

The repair makes the gate causal: the four functions, and the imports only they
need, move to the `postgres` cfg that matches their real callers.
`USERSTORE_SCHEMA` stays shared and compiled whenever any relational backend is
enabled. No `allow(dead_code)`, no gate weakening, no lint downgrade.

## Why this is safe — PGlite is not losing encryption

Established before editing:

- `PgliteUserStore` holds a **non-optional** `ColumnCipher` (`pglite_store.rs:61`,
  constructed `:73`) and seals the **same** columns — profile name, email,
  external id, pubkey, label, pq pubkey — through the inherent
  `ColumnCipher::{seal_text,open_text,seal_raw,open_raw}`
  (`encrypted_columns.rs:313/332/349/360`), which call `encrypt`/`decrypt`
  unconditionally. 19 call sites.
- The `cipher_glue` free functions differ only by taking `Option<&ColumnCipher>` /
  `Option<root>` — the shape for a backend that *may* run without value-column
  encryption. All 19 of their call sites are in `postgres_store.rs`.
- PGlite is therefore strictly *more* mandatory than Postgres here; it cannot even
  construct without a cipher, and the shared DDL's `HSC1`-magic + length CHECK
  constraints would reject an unsealed write.

`pglite_store.rs` consumes only `cipher_glue::USERSTORE_SCHEMA`, which is why the
module stays compiled for it.

This is a compile-gating change only. No store's encryption behavior moves.

## Validation

Canonical BuildQ wrapper, output tee'd to `.fleet-coord/`.

| run | features | exit | denials |
|---|---|---|---|
| baseline (pristine `2241c8d1c`) | default | 101 | exactly the 4 `cipher_glue` denials |
| this branch | default | **0** | none |
| baseline (pristine `2241c8d1c`) | `postgres` | 101 | 14 in `postgres_store.rs`, 0 `cipher_glue` |
| this branch | `postgres` | 101 | **byte-identical** 14, 0 `cipher_glue` |

Revert-verified: stashing this diff reproduces the four denials at the exact
reported lines; restoring it clears them.

The pre-commit gate — `cargo clippy --workspace --all-targets --release -- -D
warnings` — **passes** on this commit.

### Pre-existing, not addressed here

`--features postgres` is already red on `main` for reasons unrelated to this
change: dead constructors and pool helpers in `postgres_store.rs`
(`connect`/`new`/`migrate`, `build_pool_config`, `load_ca_roots`, `PoolAssembly`,
`assemble_pool`, `build_pool`, `percent_decode`), three `redundant_closure`, one
`match_same_arms`, one `print_stderr`. The error set is identical with and
without this diff. `postgres` is a non-default feature, so CI does not build it
and it rotted unnoticed. Repairing it is out of scope for this lane and wants its
own ticket. What the `postgres` run establishes for *this* change — that the four
functions remain live and used there — holds: zero `cipher_glue` denials.

## Unblocks

Hosted exact-head Clippy on merge refs for #1383, #1448, #1449, #1450; makes
option 2 of the `merge-group-clippy` CI decision available so its hook-bypass
request can be withdrawn.

Refs #1414.
