### PR TITLE
docs(trust): document the deployment trust ceremony

### DIFF
--- a/docs/deployment-trust-ceremony.md
+++ b/docs/deployment-trust-ceremony.md
@@ -1,0 +1,244 @@
+# Deployment trust: the root ceremony and the autonomous path
+
+**Who this is for:** whoever holds the hardware tokens, and whoever has to reason about what an
+automated deployment is allowed to do without them.
+
+This document covers the **operational** half of deployment trust — which keys are minted by a human
+at a ceremony, which are minted by automation, and what each one can do. The cryptographic design is
+in [`cryptography-architecture.md`](cryptography-architecture.md); the wire contracts are in
+[`deployment-registry-trust.md`](deployment-registry-trust.md). Neither of those says who holds what,
+which is the gap this fills.
+
+The ceremony procedure was exercised against a real YubiKey 5C NFC. The command and credential
+contracts in this document are normative only where they agree with
+[`deployment-trust-contract.md`](deployment-trust-contract.md) and
+[`deployment-registry-trust.md`](deployment-registry-trust.md); those contracts win on disagreement.
+
+---
+
+## The property we are buying
+
+> **The root of trust is offline and physically gated. Everything the fleet does day to day runs on
+> short-lived, narrowly-scoped credentials that the root authorized once.**
+
+Concretely: an automated deploy can mint the credential a registry needs, all day, unattended. It
+**cannot** mint a new authority, rotate the root, or widen its own scope — those require a human
+holding a token. Compromising the whole automation fleet does not compromise the deployment root.
+
+## Three layers
+
+| Layer | Command | Who runs it | Hardware needed |
+|---|---|---|---|
+| **Root** — the deployment authority | `trust mint-deployment-ca`, `trust rotate-authority` | human, at a ceremony | no token to *create*; token/backup identity to *use* |
+| **Delegation** — a scoped online signer | `trust delegate-registry-signer` | human, at a ceremony | **token: PIN + touch** |
+| **Autonomous** — the actual credential | `trust mint-registry-jwt --via-delegated-signer` | automation | **none** |
+
+The asymmetry is the design: **creating** the root needs no token (it only *encrypts to* public
+recipients), while **using** the root costs a human a PIN and a physical touch, because using it means
+decrypting the authority bundle.
+
+```
+   ceremony (rare, human, touch-gated)          autonomous (constant, unattended)
+   ─────────────────────────────────────        ────────────────────────────────
+   mint-deployment-ca   ── authority ──►  delegate-registry-signer
+                                                  │  emits scoped signer + delegation
+                                                  ▼
+                                          mint-registry-jwt --via-delegated-signer
+                                                  │  ≤1 hour, registry-only
+                                                  ▼
+                                            deployed service
+```
+
+## Rules the tooling enforces
+
+**A sole token is refused.** The root demands at least two distinct age recipients:
+
+```
+Error: root authority requires at least two distinct age recipients
+       (primary + backup/break-glass); a sole YubiKey is forbidden
+```
+
+This is not bureaucratic. A single token is a single point of *loss* — lose it and the deployment
+root is unrecoverable. The intended topology is **hardware primary + break-glass backup**.
+
+**The delegation is scoped and expiring.** `delegate-registry-signer` emits, verified:
+
+```json
+"scope": { "aud": "urn:hyprstream:service:registry",
+           "sub": "service:registry",
+           "profile": "hyprstream.registry-deployment.v1",
+           "max_ttl_seconds": 3600 }
+```
+
+The online signer cannot mint outside `service:registry`, and nothing it mints outlives an hour —
+regardless of the 30-day (max 1-year) delegation lifetime.
+
+**The authority bundle is kept offline.** The mint output records
+`"authority_key_export_allowed": false`; publisher manifests additionally assert
+`"private_authority_exported": false`. Those assertions do not make the local encrypted bundle
+magically non-copyable: operators must keep it out of deployed hosts, repositories, IaC state, and
+publisher manifests.
+
+## ⚠️ The break-glass recipient must be encrypted
+
+**This is the rule most easily gotten wrong, and the tooling cannot enforce it.**
+
+The CLI verifies you supplied *two distinct recipients*. It has no way to check that the second one
+is actually protected — a recipient string looks identical whether its private half lives on a
+hardware token or in a world-readable file.
+
+`age-keygen -o backup.key` writes an **unencrypted** identity. If you hand that recipient to
+`mint-deployment-ca`, the deployment root is decryptable by anyone who can read that file, and the
+hardware token guarding the primary path becomes irrelevant. **A root is exactly as strong as its
+weakest recipient.**
+
+The break-glass **MUST** be one of:
+
+1. **A second hardware token** — best; the same properties as the primary.
+2. **A passphrase-encrypted identity** — `age-keygen | age -p > backup.key.age`, passphrase held
+   separately from the file.
+3. **Split offline media** — Shamir-split or sealed and stored apart.
+
+An unencrypted identity file is acceptable **only** for a throwaway validation root that protects
+nothing and is destroyed immediately afterward.
+
+## Hardware: what your token actually protects
+
+There are two distinct YubiKey roles, and conflating them overstates what you have.
+
+| Flag | What it does | Firmware |
+|---|---|---|
+| `--yubikey age1yubikey1…` | Token acts as an **age recipient**: it decrypts the authority bundle. The bundle's private key is briefly **in host memory** during a ceremony. | any PIV-capable (verified on **5.4.3**) |
+| `--piv-slot <SLOT>` | The **Ed25519 leg lives in the token** and never reaches host memory. | **≥ 5.7.4** — Ed25519-in-PIV. **Not verified here** (test token was 5.4.3) |
+
+Both are legitimate. Only the second is "the key never leaves the hardware." Say which one you are
+running; do not let "we use YubiKeys" imply the stronger claim.
+
+`--kms-plugin` accepts a cloud/PQ-HSM age-plugin recipient for organizations preferring an HSM.
+
+### Token preparation
+
+After a PIV reset, verify the PIV PIN, PUK, and management-key posture before generating an age
+identity. A PIV reset returns those PIV values to factory defaults; it does not reset FIDO2,
+OpenPGP, OATH, or the whole device. Do not automate this interactive step or capture it through a
+pipe.
+
+**Override the plugin's PIN-policy default.** It defaults to `once`, which caches the PIN for a
+session so one entry can authorize several root operations. For a deployment root:
+
+```bash
+age-plugin-yubikey --generate --name "<deployment> root" \
+  --pin-policy always --touch-policy always
+```
+
+`always` means every decryption costs a PIN **and** a touch.
+
+## The ceremony (verified end to end)
+
+Run in a clean directory. **All paths must be absolute** — see Gotchas.
+
+### 1. Prepare the token
+
+```bash
+age-plugin-yubikey --generate --name "hyprstream deployment root" \
+  --pin-policy always --touch-policy always
+age-plugin-yubikey --identity > "$CEREMONY/yubikey-identity.txt"
+```
+Record the printed `age1yubikey1…` **recipient** (public — safe to store anywhere).
+
+### 2. Prepare the break-glass — encrypted (see the rule above)
+
+Second token preferred. If using software, passphrase-encrypt it and store the passphrase separately.
+
+### 3. Mint the root — no touch required
+
+```bash
+hyprstream trust mint-deployment-ca \
+  --yubikey    "age1yubikey1…" \
+  --recipient  "<encrypted break-glass recipient>" \
+  --public-ca            "$CEREMONY/deployment-ca.hybrid" \
+  --authority-key        "$CEREMONY/deployment-ca.age" \
+  --authority-log        "$CEREMONY/deployment-authority.log.json" \
+  --authority-checkpoint "$CEREMONY/deployment-authority.head.json"
+```
+
+Produces a **1984-byte** hybrid public root (32-byte Ed25519 ‖ 1952-byte ML-DSA-65), the
+age-encrypted authority bundle, a signed rotation log, and an anti-rollback checkpoint. Record
+`public_ca_sha256` out of band — it is what downstream verification pins.
+
+The public artifacts install to `/etc/hyprstream/trust/`. **`deployment-ca.age` does not** — it stays
+operator-held and never reaches a deployed host.
+
+### 4. Delegate an online signer — **PIN + touch**
+
+```bash
+hyprstream trust delegate-registry-signer \
+  --public-ca "$CEREMONY/deployment-ca.hybrid" \
+  --authority-key "$CEREMONY/deployment-ca.age" \
+  --authority-log "$CEREMONY/deployment-authority.log.json" \
+  --authority-checkpoint "$CEREMONY/deployment-authority.head.json" \
+  --yubikey-identity "$CEREMONY/yubikey-identity.txt" \
+  --signer-recipient "<recipient automation can decrypt>" \
+  --delegated-key "$CEREMONY/registry-delegated-signer.age" \
+  --delegation    "$CEREMONY/registry-signer.delegation.json"
+```
+
+The token will prompt for a PIN and require a physical touch. **This is the ceremony.** If it ever
+completes without one, stop and investigate — the root is not gated.
+
+For the ordinary age-recipient design, break-glass decrypts `deployment-ca.age` with the separately
+held encrypted recovery identity passed via `--identity`; it does not require `--software-recovery`.
+`--software-recovery` is only for the distinct PIV-backed-authority mode, where it authorizes use of
+the age-wrapped recovery copy of that PIV Ed25519 key.
+
+### 5. Autonomous minting — no token, no root
+
+```bash
+hyprstream trust mint-registry-jwt \
+  --registry-public-key "<raw 32-byte Ed25519 service public key>" \
+  --public-ca … --authority-log … --authority-checkpoint … \
+  --via-delegated-signer "$DEPLOY/registry-delegated-signer.age" \
+  --delegation           "$DEPLOY/registry-signer.delegation.json" \
+  --identity             "$DEPLOY/online-signer.key" \
+  --jwt      "$DEPLOY/registry-service.jwt" \
+  --contract "$DEPLOY/deployment-trust.contract.json"
+```
+
+Verified: succeeds with **no root bundle and no hardware token**. The credential is the required
+`ML-DSA-65-Ed25519` composite, `typ: wit+jwt`, bound to
+`urn:hyprstream:service:registry`, and capped at one hour. This is what a deploy runs.
+
+Verify anything with `hyprstream trust verify-deployment`, which uses the production verifier.
+
+### 6. After the ceremony
+
+- `deployment-ca.age` → offline storage with the token. Never onto a deployed host.
+- Public artifacts (`deployment-ca.hybrid`, authority log, checkpoint) → `/etc/hyprstream/trust/`.
+- Delegated signer + delegation → the deployment environment.
+- **Destroy the ceremony working directory** (`shred` key material, then remove it).
+
+## Gotchas (each cost real time)
+
+**Relative paths fail.** Every default is a bare filename, and using them dies with
+`Error: inspect output parent / No such file or directory`. Pass absolute paths for every input and
+output.
+
+**`age-plugin-yubikey --generate` cannot be piped.** Through `| tee` it fails with
+`Failed to get input from user: IO error: not a terminal`. It needs a real TTY — correct for a
+ceremony tool, but it means the ceremony cannot be captured by naive output redirection, and an
+automated wrapper will not work.
+
+**A build-queue slot is not durable storage.** If you build the binary through a shared/pooled
+`CARGO_TARGET_DIR`, copy it out before using it — pooled slots are reclaimed and your binary will
+vanish mid-ceremony.
+
+## Local development
+
+`dev/local-e2e/` mints a **throwaway** deployment authority, standing in for the offline ceremony so
+a rootless local stack can run without hardware. That is correct for local dev and **must never be
+used for anything real** — throwaway material, software recipients, no hardware gating.
+
+The registry *service* signing key is an **online autonomous key**, not ceremony material: it is
+generated locally and then authorized by a root-signed delegation. Do not confuse it with the
+deployment authority. If you find yourself about to make an automated path generate something at the
+*root* layer, stop — that is the property this whole design exists to protect.


### PR DESCRIPTION
Adds `docs/deployment-trust-ceremony.md`: who holds which key across the deployment trust hierarchy, which operations require a hardware touch, and how break-glass recovery works. `cryptography-architecture.md` covers the primitives and `deployment-registry-trust.md` the wire contract; neither says who holds what, which is the gap this fills.

Claims are reconciled against the authoritative deployment trust and registry-trust contracts, which are declared to win on disagreement:

- Root authority **creation needs no token** — a token is required only to *use* it. The earlier draft said otherwise.
- Registry credentials are the **`ML-DSA-65-Ed25519` composite** with `typ: wit+jwt`, not plain `alg: ML-DSA-65`.
- Ordinary age-recipient **break-glass decrypts `deployment-ca.age` via `--identity`**. The distinct `--software-recovery` path applies only to PIV-backed authority mode — pointing operators at it for the ordinary case would send them down the wrong recovery procedure.
- The **non-export assertions record intent**, not a guarantee: `"authority_key_export_allowed": false` does not make the local encrypted bundle uncopyable. Operators must keep it off deployed hosts, repositories, IaC state, and publisher manifests.
- **PIV reset scope and hardware-verification claims narrowed** to what was actually exercised — a PIV reset restores PIV defaults only; it does not reset FIDO2, OpenPGP, OATH, or the device.

Documentation only; no source, test, or CI change.

Reviewed and exercised locally prior to submission; merging without a further review pass under direct maintainer direction.