### PR TITLE
feat(git2db): untrusted-repo clone guards (submodule/filter/scoped-token)

### DIFF
--- a/crates/git2db/src/clone_options.rs
+++ b/crates/git2db/src/clone_options.rs
@@ -23,8 +23,84 @@
 //!     .build();
 //! ```
 
-use crate::callback_config::CallbackConfig;
+use crate::callback_config::{AuthMode, CallbackConfig};
 use git2::{FetchOptions, RemoteCallbacks, build::CheckoutBuilder};
+
+/// Trust posture for a clone/fetch operation.
+///
+/// `Untrusted` is the mode required for any repository whose remote or
+/// contents are not first-party-controlled — concretely, a PR head fetched by
+/// a merge gate. Selecting it clamps three independently-dangerous properties
+/// together (issue #1430), rather than requiring the caller to remember all
+/// three every time:
+///
+/// - [`SubmoduleMode`] is forced to [`SubmoduleMode::Disabled`] regardless of
+///   what the caller configured — `.gitmodules` is attacker-controlled
+///   content, and initializing a declared submodule means fetching from an
+///   arbitrary attacker-chosen remote URL.
+/// - [`FilterMode`] is forced to [`FilterMode::Passthrough`] regardless of
+///   what the caller configured — a `.gitattributes`-declared content filter
+///   (XET/LFS smudge) would resolve attacker-controlled pointer content
+///   against a real endpoint during checkout.
+/// - Auth is required to be [`AuthMode::ExplicitOnly`] (already the
+///   `CallbackConfig`/`AuthManager` default per B2/#1429) with no unscoped
+///   (`host: None`) [`crate::auth::AuthStrategy::Token`] present — see
+///   [`CloneOptions::validate_trust`].
+///
+/// This is deliberately the *only* notion of "untrusted" in `git2db` — it
+/// composes the ambient-vs-explicit auth split B2 already established rather
+/// than introducing a second, parallel trust concept.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum CloneTrust {
+    /// First-party, operator-controlled repository. The caller-selected
+    /// [`SubmoduleMode`], [`FilterMode`], and auth configuration are honored
+    /// as configured — this is the default, matching today's behavior.
+    #[default]
+    Trusted,
+    /// Arbitrary or attacker-influenced repository (PR heads, forge-facing
+    /// fetches, anything the merge gate builds). See [`CloneTrust`] docs for
+    /// exactly what this clamps.
+    Untrusted,
+}
+
+/// Controls whether `.gitmodules`-declared submodules are initialized and
+/// updated after a clone.
+///
+/// Replaces the previous plain `update_submodules: bool` field — folding
+/// submodule handling into a named mode makes the untrusted clamp in
+/// [`CloneTrust::Untrusted`] a single, unambiguous source of truth instead of
+/// a bool the caller could independently flip back on.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum SubmoduleMode {
+    /// Never initialize or update submodules, even if the repository
+    /// declares them via `.gitmodules`. Secure default — matches the
+    /// pre-#1430 behavior, where submodule initialization was never wired
+    /// into [`crate::manager::GitManager::clone_repository`] at all.
+    #[default]
+    Disabled,
+    /// Initialize and update submodules after clone (equivalent to
+    /// `git clone --recurse-submodules`). Only appropriate for trusted,
+    /// first-party repositories, since a submodule's remote URL is taken
+    /// verbatim from the repository's own `.gitmodules` content.
+    Enabled,
+}
+
+/// Controls whether libgit2 content filters (XET/LFS smudge, and libgit2's
+/// own built-in `ident`/`crlf` filters) are applied during checkout.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum FilterMode {
+    /// Apply registered content filters normally during checkout — the
+    /// default, matching today's behavior.
+    #[default]
+    Enabled,
+    /// Disable all content filters during checkout
+    /// (`git2::build::CheckoutBuilder::disable_filters(true)`), so no
+    /// registered filter — XET/LFS smudge included — resolves checked-out
+    /// file content against an external endpoint. Required for untrusted
+    /// checkouts, where the `.gitattributes` filter declaration and the
+    /// pointer content it would smudge are both attacker-controlled.
+    Passthrough,
+}
 
 /// Send-safe options for cloning a repository
 #[derive(Default, Clone)]
@@ -44,8 +120,16 @@ pub struct CloneOptions {
     /// Custom refspecs
     pub refspecs: Vec<String>,
 
-    /// Whether to update submodules
-    pub update_submodules: bool,
+    /// Trust posture for this clone. See [`CloneTrust`].
+    pub trust: CloneTrust,
+
+    /// Submodule handling, subject to the [`CloneTrust::Untrusted`] clamp —
+    /// see [`CloneOptions::effective_submodule_mode`].
+    pub submodule_mode: SubmoduleMode,
+
+    /// Content filter handling, subject to the [`CloneTrust::Untrusted`]
+    /// clamp — see [`CloneOptions::effective_filter_mode`].
+    pub filter_mode: FilterMode,
 
     /// Network proxy URL
     pub proxy_url: Option<String>,
@@ -77,6 +161,77 @@ impl CloneOptions {
         }
     }
 
+    /// The submodule mode actually in effect, after applying the
+    /// [`CloneTrust::Untrusted`] clamp. Under `Untrusted` this is always
+    /// [`SubmoduleMode::Disabled`], regardless of `self.submodule_mode` —
+    /// this is the single source of truth callers and tests should read,
+    /// rather than the raw field.
+    pub fn effective_submodule_mode(&self) -> SubmoduleMode {
+        match self.trust {
+            CloneTrust::Untrusted => SubmoduleMode::Disabled,
+            CloneTrust::Trusted => self.submodule_mode,
+        }
+    }
+
+    /// The filter mode actually in effect, after applying the
+    /// [`CloneTrust::Untrusted`] clamp. Under `Untrusted` this is always
+    /// [`FilterMode::Passthrough`], regardless of `self.filter_mode`.
+    pub fn effective_filter_mode(&self) -> FilterMode {
+        match self.trust {
+            CloneTrust::Untrusted => FilterMode::Passthrough,
+            CloneTrust::Trusted => self.filter_mode,
+        }
+    }
+
+    /// Validate that an [`CloneTrust::Untrusted`] clone cannot silently widen
+    /// its own credential surface — checked independently of the submodule/
+    /// filter clamps above, which cannot be bypassed by construction, but
+    /// auth is a `Vec<AuthStrategy>` the caller assembles separately.
+    ///
+    /// Refuses:
+    /// - [`AuthMode::AllowAmbient`] — untrusted fetches must stay
+    ///   [`AuthMode::ExplicitOnly`] (credential helper / `~/.gitconfig` / SSH
+    ///   agent must never be consulted for an attacker-influenced remote).
+    /// - An unscoped [`crate::auth::AuthStrategy::Token`] (`host: None`) —
+    ///   such a token is offered to *any* remote that challenges for it
+    ///   (see `auth.rs`), which for an untrusted, caller-selected remote is a
+    ///   credential-exfiltration vector. Untrusted clones must use either no
+    ///   token or one bound to an exact origin authority.
+    ///
+    /// `Trusted` options always validate successfully — this check exists
+    /// only to keep `Untrusted` honest.
+    pub fn validate_trust(&self) -> Result<(), crate::errors::Git2DBError> {
+        if self.trust != CloneTrust::Untrusted {
+            return Ok(());
+        }
+
+        let Some(config) = self.callback_config.as_ref() else {
+            return Ok(());
+        };
+
+        if config.auth_mode == AuthMode::AllowAmbient {
+            return Err(crate::errors::Git2DBError::configuration(
+                "CloneTrust::Untrusted requires AuthMode::ExplicitOnly; \
+                 AllowAmbient would permit ambient credential discovery \
+                 (credential helper, ~/.gitconfig, SSH agent) against an \
+                 untrusted remote",
+            ));
+        }
+
+        for strategy in &config.auth {
+            if let crate::auth::AuthStrategy::Token { host: None, .. } = strategy {
+                return Err(crate::errors::Git2DBError::configuration(
+                    "CloneTrust::Untrusted refuses an unscoped Token (host: \
+                     None): it would be offered to any remote, including an \
+                     untrusted caller-selected one — bind it to an exact \
+                     origin authority or omit it",
+                ));
+            }
+        }
+
+        Ok(())
+    }
+
     /// Convert to legacy git2 options for use within spawn_blocking
     /// This is called inside spawn_blocking where lifetime constraints are satisfied
     pub(crate) fn to_git2_options(&self) -> LegacyCloneOptions<'_> {
@@ -85,7 +240,8 @@ impl CloneOptions {
             depth: self.depth,
             branch: self.branch.clone(),
             _refspecs: self.refspecs.clone(),
-            _update_submodules: self.update_submodules,
+            submodule_mode: self.effective_submodule_mode(),
+            filter_mode: self.effective_filter_mode(),
             proxy_url: self.proxy_url.clone(),
             _timeout_seconds: self.timeout_seconds,
             ..Default::default()
@@ -111,7 +267,11 @@ pub(crate) struct LegacyCloneOptions<'cb> {
     pub depth: Option<i32>,
     pub branch: Option<String>,
     pub _refspecs: Vec<String>,
-    pub _update_submodules: bool,
+    /// Already resolved via [`CloneOptions::effective_submodule_mode`] — the
+    /// [`CloneTrust`] clamp has already been applied by the time this is set.
+    pub submodule_mode: SubmoduleMode,
+    /// Already resolved via [`CloneOptions::effective_filter_mode`].
+    pub filter_mode: FilterMode,
     pub proxy_url: Option<String>,
     pub _timeout_seconds: Option<u32>,
     /// Off-site redirect policy (default: None — no off-site redirects).
@@ -150,9 +310,18 @@ impl<'cb> LegacyCloneOptions<'cb> {
         Ok(fetch_opts)
     }
 
-    /// Create CheckoutBuilder for this clone
+    /// Create CheckoutBuilder for this clone.
+    ///
+    /// Under [`FilterMode::Passthrough`] this disables libgit2 content
+    /// filters entirely (`GIT_CHECKOUT_DISABLE_FILTERS`) so no
+    /// `.gitattributes`-registered filter — XET/LFS smudge included — runs
+    /// during checkout. See issue #1430.
     pub fn create_checkout_builder(&self) -> CheckoutBuilder<'static> {
-        CheckoutBuilder::new()
+        let mut builder = CheckoutBuilder::new();
+        if matches!(self.filter_mode, FilterMode::Passthrough) {
+            builder.disable_filters(true);
+        }
+        builder
     }
 }
 
@@ -199,9 +368,25 @@ impl CloneOptionsBuilder {
         self
     }
 
-    /// Set whether to update submodules
-    pub fn update_submodules(mut self, update: bool) -> Self {
-        self.options.update_submodules = update;
+    /// Set the trust posture for this clone. See [`CloneTrust`] — selecting
+    /// [`CloneTrust::Untrusted`] clamps submodule and filter handling
+    /// regardless of what is configured below.
+    pub fn trust(mut self, trust: CloneTrust) -> Self {
+        self.options.trust = trust;
+        self
+    }
+
+    /// Set the submodule handling mode. Subject to the [`CloneTrust`] clamp
+    /// — see [`CloneOptions::effective_submodule_mode`].
+    pub fn submodule_mode(mut self, mode: SubmoduleMode) -> Self {
+        self.options.submodule_mode = mode;
+        self
+    }
+
+    /// Set the content filter handling mode. Subject to the [`CloneTrust`]
+    /// clamp — see [`CloneOptions::effective_filter_mode`].
+    pub fn filter_mode(mut self, mode: FilterMode) -> Self {
+        self.options.filter_mode = mode;
         self
     }
 
@@ -262,4 +447,150 @@ mod tests {
         fn assert_send<T: Send>() {}
         assert_send::<CloneOptions>();
     }
+
+    // ---- CloneTrust clamp ----
+
+    /// Defaults are `Trusted` + `SubmoduleMode::Disabled` +
+    /// `FilterMode::Enabled` — matches pre-#1430 behavior (submodules were
+    /// never wired up at all, filters ran normally).
+    #[test]
+    fn defaults_are_trusted_and_match_legacy_behavior() {
+        let options = CloneOptions::default();
+        assert_eq!(options.trust, CloneTrust::Trusted);
+        assert_eq!(options.effective_submodule_mode(), SubmoduleMode::Disabled);
+        assert_eq!(options.effective_filter_mode(), FilterMode::Enabled);
+    }
+
+    /// A `Trusted` clone honors whatever `SubmoduleMode`/`FilterMode` the
+    /// caller explicitly configured.
+    #[test]
+    fn trusted_honors_configured_modes() {
+        let options = CloneOptions::builder()
+            .trust(CloneTrust::Trusted)
+            .submodule_mode(SubmoduleMode::Enabled)
+            .filter_mode(FilterMode::Passthrough)
+            .build();
+        assert_eq!(options.effective_submodule_mode(), SubmoduleMode::Enabled);
+        assert_eq!(options.effective_filter_mode(), FilterMode::Passthrough);
+    }
+
+    /// `Untrusted` clamps submodule and filter mode to the safe values EVEN
+    /// WHEN the caller explicitly (mis)configured the opposite — this is the
+    /// property that makes `Untrusted` a single source of truth rather than
+    /// a bool that can be independently flipped back on.
+    #[test]
+    fn untrusted_clamps_submodule_and_filter_mode_despite_caller_override() {
+        let options = CloneOptions::builder()
+            .trust(CloneTrust::Untrusted)
+            .submodule_mode(SubmoduleMode::Enabled) // attempted override
+            .filter_mode(FilterMode::Enabled) // attempted override
+            .build();
+
+        assert_eq!(
+            options.effective_submodule_mode(),
+            SubmoduleMode::Disabled,
+            "Untrusted must clamp submodule_mode to Disabled regardless of the raw field"
+        );
+        assert_eq!(
+            options.effective_filter_mode(),
+            FilterMode::Passthrough,
+            "Untrusted must clamp filter_mode to Passthrough regardless of the raw field"
+        );
+    }
+
+    // ---- validate_trust() ----
+
+    #[test]
+    fn trusted_options_always_validate() {
+        use crate::auth::AuthStrategy;
+        use crate::callback_config::{AuthMode, CallbackConfigBuilder};
+
+        let options = CloneOptions::builder()
+            .trust(CloneTrust::Trusted)
+            .callback_config(
+                CallbackConfigBuilder::new()
+                    .auth(AuthStrategy::Token {
+                        token: "t".into(),
+                        host: None,
+                    })
+                    .auth_mode(AuthMode::AllowAmbient)
+                    .build(),
+            )
+            .build();
+        assert!(options.validate_trust().is_ok());
+    }
+
+    #[test]
+    fn untrusted_rejects_allow_ambient_auth_mode() {
+        use crate::callback_config::{AuthMode, CallbackConfigBuilder};
+
+        let options = CloneOptions::builder()
+            .trust(CloneTrust::Untrusted)
+            .callback_config(
+                CallbackConfigBuilder::new()
+                    .auth_mode(AuthMode::AllowAmbient)
+                    .build(),
+            )
+            .build();
+        assert!(
+            options.validate_trust().is_err(),
+            "Untrusted + AllowAmbient must be refused at validation time"
+        );
+    }
+
+    #[test]
+    fn untrusted_rejects_unscoped_token() {
+        use crate::auth::AuthStrategy;
+        use crate::callback_config::CallbackConfigBuilder;
+
+        let options = CloneOptions::builder()
+            .trust(CloneTrust::Untrusted)
+            .callback_config(
+                CallbackConfigBuilder::new()
+                    .auth(AuthStrategy::Token {
+                        token: "unscoped".into(),
+                        host: None,
+                    })
+                    .build(),
+            )
+            .build();
+        assert!(
+            options.validate_trust().is_err(),
+            "Untrusted + an unscoped Token (host: None) must be refused"
+        );
+    }
+
+    #[test]
+    fn untrusted_accepts_host_scoped_token() {
+        use crate::auth::AuthStrategy;
+        use crate::callback_config::CallbackConfigBuilder;
+
+        let options = CloneOptions::builder()
+            .trust(CloneTrust::Untrusted)
+            .callback_config(
+                CallbackConfigBuilder::new()
+                    .auth(AuthStrategy::Token {
+                        token: "scoped".into(),
+                        host: Some("github.com".into()),
+                    })
+                    .build(),
+            )
+            .build();
+        assert!(
+            options.validate_trust().is_ok(),
+            "Untrusted + a host-scoped Token must validate — this is the intended scoped-token path"
+        );
+    }
+
+    #[test]
+    fn untrusted_with_no_callback_config_validates() {
+        let options = CloneOptions::builder().trust(CloneTrust::Untrusted).build();
+        assert!(options.validate_trust().is_ok());
+    }
+
+    // FilterMode's effect on the actual checkout (disable_filters wiring) is
+    // proved end-to-end in manager.rs's ident-filter adversarial test — a
+    // git2::build::CheckoutBuilder has no getter to unit-test the flag in
+    // isolation, and a fake assertion here would prove nothing about the
+    // real libgit2 behavior.
 }

--- a/crates/git2db/src/manager.rs
+++ b/crates/git2db/src/manager.rs
@@ -34,7 +34,7 @@ fn ensure_libgit2_initialized() {
     });
 }
 
-use crate::clone_options::CloneOptions;
+use crate::clone_options::{CloneOptions, SubmoduleMode};
 use crate::config::Git2DBConfig;
 use crate::errors::{Git2DBError, Git2DBResult};
 use crate::repository::{CacheStats, RepositoryCache};
@@ -513,6 +513,11 @@ impl GitManager {
         let target_path = target_path.to_path_buf();
         let mut options = options.unwrap_or_else(|| self.default_clone_options());
 
+        // Refuse to even start the network operation if an `Untrusted` clone
+        // is misconfigured with ambient auth or an unscoped token — see
+        // `CloneOptions::validate_trust` (issue #1430).
+        options.validate_trust()?;
+
         // libgit2's local transport rejects shallow fetch over `file://` —
         // disable it here so callers that default to prefer_shallow (the
         // global config default) don't get an opaque failure when cloning a
@@ -592,6 +597,25 @@ impl GitManager {
             })?;
 
             info!("Successfully cloned repository to {:?}", validated_path);
+
+            // Submodule handling. `submodule_mode` here is the value already
+            // resolved by `CloneOptions::effective_submodule_mode` — the
+            // `CloneTrust::Untrusted` clamp has already forced it to
+            // `Disabled` for an untrusted clone by the time it reaches here,
+            // so this is the ONLY place a fresh clone's submodules are
+            // touched. A `.gitmodules` submodule URL is taken verbatim from
+            // the just-cloned repository's own content, so initializing it
+            // under `Disabled` would fetch from an attacker-chosen remote for
+            // an untrusted repo (issue #1430).
+            if git2_options.submodule_mode == SubmoduleMode::Enabled {
+                init_submodules(&repo)?;
+            } else {
+                debug!(
+                    "Skipping submodule initialization for {:?} (SubmoduleMode::Disabled)",
+                    validated_path
+                );
+            }
+
             Ok(repo)
         })
         .await
@@ -761,6 +785,48 @@ impl GitManager {
     pub fn driver_registry(&self) -> &Arc<DriverRegistry> {
         &self.driver_registry
     }
+}
+
+/// Initialize and update every submodule declared by `repo`'s `.gitmodules`.
+///
+/// Equivalent to `git submodule init && git submodule update`. Mirrors
+/// `Git2DB::init_submodules` (registry.rs), which performs the same operation
+/// for the registry's own tracked-repos-as-submodules; this free function is
+/// the equivalent for an arbitrary freshly-cloned repository.
+///
+/// Callers MUST gate this behind [`crate::clone_options::SubmoduleMode`] —
+/// a submodule's URL is taken verbatim from the repository's own
+/// `.gitmodules` content, so calling this against an untrusted repository
+/// means fetching from an attacker-chosen remote. See issue #1430.
+fn init_submodules(repo: &Repository) -> Git2DBResult<()> {
+    let submodules = repo
+        .submodules()
+        .map_err(|e| Git2DBError::submodule("*", format!("Failed to list submodules: {e}")))?;
+
+    if submodules.is_empty() {
+        debug!("No submodules found in cloned repository");
+        return Ok(());
+    }
+
+    info!("Initializing {} submodule(s)", submodules.len());
+
+    for mut submodule in submodules {
+        let name = submodule.name().unwrap_or("unknown").to_owned();
+
+        debug!("Initializing submodule: {}", name);
+        submodule
+            .init(false)
+            .map_err(|e| Git2DBError::submodule(&name, format!("Failed to init: {e}")))?;
+
+        let mut update_opts = git2::SubmoduleUpdateOptions::new();
+        submodule
+            .update(true, Some(&mut update_opts))
+            .map_err(|e| Git2DBError::submodule(&name, format!("Failed to update: {e}")))?;
+
+        info!("Initialized submodule: {}", name);
+    }
+
+    Ok(())
 }
 
 #[cfg(test)]

--- a/crates/git2db/src/security_tests.rs
+++ b/crates/git2db/src/security_tests.rs
@@ -3,7 +3,7 @@
 //! This module contains security-focused tests to verify that all
 //! critical security fixes are working correctly.
 
-#![allow(clippy::unwrap_used)]
+#![allow(clippy::unwrap_used, clippy::expect_used)]
 
 use crate::config::Git2DBConfig;
 use crate::errors::Git2DBError;
@@ -374,5 +374,422 @@ mod regression_tests {
         // Should have successful registrations
         let success_count = results.iter().filter(|r| r.is_ok()).count();
         assert!(success_count > 0, "At least some registrations should succeed");
+    }
+}
+
+/// Adversarial tests for the untrusted-repo clone guards (issue #1430):
+/// submodule auto-init, content-filter smudge (XET/LFS), and credential
+/// scoping must all be refused for a [`crate::clone_options::CloneTrust::Untrusted`]
+/// clone. Each guard is proven load-bearing by a matching positive control —
+/// the identical fixture cloned WITHOUT the guard in effect, showing the
+/// unguarded behavior (submodule fetched / filter expanded) actually occurs.
+/// Per the task, each guard was manually verified to fail (assertion fails,
+/// not "doesn't compile") when its corresponding clamp in
+/// `CloneOptions::effective_submodule_mode` / `effective_filter_mode` /
+/// `validate_trust` was temporarily removed — see the PR description /
+/// RESULT report for the exact removal-and-rerun transcript.
+mod untrusted_repo_guards {
+    use crate::callback_config::CallbackConfigBuilder;
+    use crate::clone_options::{CloneOptions, CloneTrust, FilterMode, SubmoduleMode};
+    use crate::config::Git2DBConfig;
+    use crate::errors::Git2DBError;
+    use crate::manager::GitManager;
+    use git2::{Repository, Signature};
+    use std::path::Path;
+    use tempfile::tempdir;
+
+    fn test_manager() -> GitManager {
+        let mut config = Git2DBConfig::default();
+        config.performance.auto_cleanup = false; // avoid background task spawning in tests
+        GitManager::new(config)
+    }
+
+    fn file_url(path: &Path) -> String {
+        format!("file://{}", path.display())
+    }
+
+    /// Commit whatever is currently staged in `repo`'s index, against
+    /// whatever parent HEAD currently resolves to (none for the first
+    /// commit).
+    fn commit_index(repo: &Repository, message: &str) -> git2::Oid {
+        let sig = Signature::now("git2db-test", "test@git2db.invalid").unwrap();
+        let mut index = repo.index().unwrap();
+        let tree_id = index.write_tree().unwrap();
+        let tree = repo.find_tree(tree_id).unwrap();
+        let parent = repo.head().ok().and_then(|h| h.peel_to_commit().ok());
+        let parents: Vec<&git2::Commit<'_>> = parent.iter().collect();
+        repo.commit(Some("HEAD"), &sig, &sig, message, &tree, &parents)
+            .unwrap()
+    }
+
+    /// A small "target" repository with one committed file — stands in for
+    /// the dependency a submodule would pull in.
+    fn init_target_repo(path: &Path, filename: &str, content: &str) {
+        let repo = Repository::init(path).unwrap();
+        std::fs::write(path.join(filename), content).unwrap();
+        repo.index()
+            .unwrap()
+            .add_path(Path::new(filename))
+            .unwrap();
+        repo.index().unwrap().write().unwrap();
+        commit_index(&repo, "initial");
+    }
+
+    /// An "outer" repository — standing in for an untrusted PR head — that
+    /// declares a real libgit2 submodule (proper `.gitmodules` + gitlink tree
+    /// entry, via `git_submodule_add_setup`/`clone`/`add_finalize`, exactly
+    /// as a real `git submodule add` would) pointing at `target_url`.
+    fn init_outer_repo_with_submodule(path: &Path, target_url: &str, submodule_path: &str) {
+        let repo = Repository::init(path).unwrap();
+        std::fs::write(path.join("outer.txt"), "outer repo content\n").unwrap();
+        repo.index()
+            .unwrap()
+            .add_path(Path::new("outer.txt"))
+            .unwrap();
+        repo.index().unwrap().write().unwrap();
+        commit_index(&repo, "outer initial");
+
+        let mut submodule = repo
+            .submodule(target_url, Path::new(submodule_path), true)
+            .expect("submodule add_setup");
+        submodule.clone(None).expect("submodule clone step");
+        submodule.add_finalize().expect("submodule add_finalize");
+        commit_index(&repo, "add submodule");
+    }
+
+    /// A repository with a file bearing the `ident` gitattribute — this
+    /// exercises libgit2's own built-in `ident` content filter, which is
+    /// registered and invoked through the *identical* `git_filter_register` +
+    /// `.gitattributes`-driven mechanism that `git-xet-filter` uses for the
+    /// real XET/LFS smudge filter (see `crates/git-xet-filter/src/filter.rs`:
+    /// same filter API, same `attributes` string match, same libgit2 checkout
+    /// pipeline). We use `ident` instead of the real XET filter because
+    /// invoking real XET smudge requires a live CAS endpoint / `XETHUB_TOKEN`
+    /// — out of scope for a hermetic unit test. `disable_filters(true)`
+    /// suppresses `ident` and XET/LFS identically, because both run through
+    /// the same libgit2 filter-application code path during checkout.
+    fn init_repo_with_ident_file(path: &Path) {
+        let repo = Repository::init(path).unwrap();
+        std::fs::write(path.join(".gitattributes"), "id.txt ident\n").unwrap();
+        std::fs::write(path.join("id.txt"), "$Id$\n").unwrap();
+        {
+            let mut index = repo.index().unwrap();
+            index.add_path(Path::new(".gitattributes")).unwrap();
+            index.add_path(Path::new("id.txt")).unwrap();
+            index.write().unwrap();
+        }
+        commit_index(&repo, "add ident file");
+    }
+
+    // ---- Guard 1: SubmoduleMode ----
+
+    /// Adversarial: a repo with `.gitmodules` (a real, properly-registered
+    /// libgit2 submodule) cloned as `CloneTrust::Untrusted` must NOT have its
+    /// submodule initialized — even though the caller explicitly (and
+    /// wrongly) requested `SubmoduleMode::Enabled`. This is the exact
+    /// acceptance scenario named in issue #1430.
+    #[tokio::test]
+    async fn untrusted_clone_does_not_initialize_submodule() {
+        let manager = test_manager();
+
+        let target_dir = tempdir().unwrap();
+        init_target_repo(target_dir.path(), "secret.txt", "attacker-controlled payload\n");
+
+        let outer_dir = tempdir().unwrap();
+        init_outer_repo_with_submodule(
+            outer_dir.path(),
+            &file_url(target_dir.path()),
+            "vendor/target",
+        );
+
+        let dest_dir = tempdir().unwrap();
+        let dest_path = dest_dir.path().join("clone");
+
+        let options = CloneOptions::builder()
+            .trust(CloneTrust::Untrusted)
+            // Attempted override — Untrusted must clamp this regardless.
+            .submodule_mode(SubmoduleMode::Enabled)
+            .build();
+
+        let repo = manager
+            .clone_repository(&file_url(outer_dir.path()), &dest_path, Some(options))
+            .await
+            .expect("untrusted clone of the outer repo itself must still succeed");
+
+        let submodule = repo
+            .find_submodule("vendor/target")
+            .expect(".gitmodules entry must still be visible (only init/update are refused)");
+        assert!(
+            submodule.open().is_err(),
+            "submodule must NOT be checked out under CloneTrust::Untrusted, even though the \
+             caller requested SubmoduleMode::Enabled"
+        );
+        assert!(
+            !dest_path.join("vendor/target/secret.txt").exists(),
+            "submodule content must not have been fetched from the (attacker-controlled) \
+             submodule URL"
+        );
+    }
+
+    /// Positive control for the test above: the identical fixture, but
+    /// `CloneTrust::Trusted` + `SubmoduleMode::Enabled` DOES fetch and check
+    /// out the submodule. This proves the guard above is load-bearing — a
+    /// test that passed regardless of the guard would prove nothing.
+    #[tokio::test]
+    async fn trusted_clone_with_submodule_enabled_does_initialize_submodule() {
+        let manager = test_manager();
+
+        let target_dir = tempdir().unwrap();
+        init_target_repo(target_dir.path(), "secret.txt", "attacker-controlled payload\n");
+
+        let outer_dir = tempdir().unwrap();
+        init_outer_repo_with_submodule(
+            outer_dir.path(),
+            &file_url(target_dir.path()),
+            "vendor/target",
+        );
+
+        let dest_dir = tempdir().unwrap();
+        let dest_path = dest_dir.path().join("clone");
+
+        let options = CloneOptions::builder()
+            .trust(CloneTrust::Trusted)
+            .submodule_mode(SubmoduleMode::Enabled)
+            .build();
+
+        let repo = manager
+            .clone_repository(&file_url(outer_dir.path()), &dest_path, Some(options))
+            .await
+            .expect("trusted clone should succeed");
+
+        let submodule = repo.find_submodule("vendor/target").unwrap();
+        assert!(
+            submodule.open().is_ok(),
+            "submodule SHOULD be checked out when trusted + explicitly enabled"
+        );
+        let content = std::fs::read_to_string(dest_path.join("vendor/target/secret.txt"))
+            .expect("submodule content should have been fetched to disk");
+        assert_eq!(content, "attacker-controlled payload\n");
+    }
+
+    /// The secure DEFAULT (no explicit trust/mode at all) also leaves the
+    /// submodule uninitialized — matches pre-#1430 behavior, where submodule
+    /// initialization was never wired into `clone_repository` in the first
+    /// place. Guards against a future default flip being unnoticed.
+    #[tokio::test]
+    async fn default_clone_options_do_not_initialize_submodule() {
+        let manager = test_manager();
+
+        let target_dir = tempdir().unwrap();
+        init_target_repo(target_dir.path(), "secret.txt", "payload\n");
+        let outer_dir = tempdir().unwrap();
+        init_outer_repo_with_submodule(
+            outer_dir.path(),
+            &file_url(target_dir.path()),
+            "vendor/target",
+        );
+
+        let dest_dir = tempdir().unwrap();
+        let dest_path = dest_dir.path().join("clone");
+
+        let repo = manager
+            .clone_repository(
+                &file_url(outer_dir.path()),
+                &dest_path,
+                Some(CloneOptions::default()),
+            )
+            .await
+            .unwrap();
+
+        assert!(repo.find_submodule("vendor/target").unwrap().open().is_err());
+    }
+
+    // ---- Guard 2: FilterMode ----
+
+    /// Adversarial: cloning as `CloneTrust::Untrusted` must not run ANY
+    /// libgit2 content filter during checkout — proven here via the built-in
+    /// `ident` filter (see `init_repo_with_ident_file` doc comment for why
+    /// this proxies XET/LFS). The caller even (wrongly) requests
+    /// `FilterMode::Enabled`; `Untrusted` must clamp it to `Passthrough`
+    /// regardless.
+    #[tokio::test]
+    async fn untrusted_clone_does_not_expand_ident_filter() {
+        let manager = test_manager();
+
+        let src_dir = tempdir().unwrap();
+        init_repo_with_ident_file(src_dir.path());
+
+        let dest_dir = tempdir().unwrap();
+        let dest_path = dest_dir.path().join("clone");
+
+        let options = CloneOptions::builder()
+            .trust(CloneTrust::Untrusted)
+            // Attempted override — Untrusted must clamp this regardless.
+            .filter_mode(FilterMode::Enabled)
+            .build();
+
+        manager
+            .clone_repository(&file_url(src_dir.path()), &dest_path, Some(options))
+            .await
+            .expect("untrusted clone should still succeed");
+
+        let content = std::fs::read_to_string(dest_path.join("id.txt")).unwrap();
+        assert_eq!(
+            content, "$Id$\n",
+            "content filters (ident, standing in for XET/LFS smudge) must NOT run under \
+             CloneTrust::Untrusted"
+        );
+    }
+
+    /// Positive control: the identical fixture, `CloneTrust::Trusted` +
+    /// `FilterMode::Enabled` (the default), DOES expand the ident filter —
+    /// proving `disable_filters` above is what suppressed it, not some
+    /// unrelated reason the file happened to stay unexpanded.
+    #[tokio::test]
+    async fn trusted_clone_with_filters_enabled_does_expand_ident_filter() {
+        let manager = test_manager();
+
+        let src_dir = tempdir().unwrap();
+        init_repo_with_ident_file(src_dir.path());
+
+        let dest_dir = tempdir().unwrap();
+        let dest_path = dest_dir.path().join("clone");
+
+        let options = CloneOptions::builder()
+            .trust(CloneTrust::Trusted)
+            .filter_mode(FilterMode::Enabled)
+            .build();
+
+        manager
+            .clone_repository(&file_url(src_dir.path()), &dest_path, Some(options))
+            .await
+            .unwrap();
+
+        let content = std::fs::read_to_string(dest_path.join("id.txt")).unwrap();
+        assert!(
+            content.starts_with("$Id: "),
+            "the ident filter SHOULD expand $Id$ when filters are enabled and trusted, got: \
+             {content:?}"
+        );
+    }
+
+    // ---- Guard 3: scoped-token-only / no ambient fallback ----
+
+    /// Adversarial: an untrusted clone request carrying an unscoped
+    /// (`host: None`) token must be refused BEFORE any network operation is
+    /// attempted — proven by pointing the clone at an unresolvable
+    /// `.invalid` host and asserting the failure is `Git2DBError::Configuration`
+    /// (from `validate_trust`), not a network/DNS error that would indicate
+    /// the guard let the request through to the transport layer.
+    #[tokio::test]
+    async fn untrusted_clone_rejects_unscoped_token_before_network() {
+        use crate::auth::AuthStrategy;
+
+        let manager = test_manager();
+        let options = CloneOptions::builder()
+            .trust(CloneTrust::Untrusted)
+            .callback_config(
+                CallbackConfigBuilder::new()
+                    .auth(AuthStrategy::Token {
+                        token: "should-never-be-sent".to_owned(),
+                        host: None,
+                    })
+                    .build(),
+            )
+            .build();
+
+        let dest_dir = tempdir().unwrap();
+        let result = manager
+            .clone_repository(
+                "https://untrusted-guard-test.invalid/should-never-be-fetched.git",
+                &dest_dir.path().join("clone"),
+                Some(options),
+            )
+            .await
+            .map(|_repo| ());
+
+        match result {
+            Err(Git2DBError::Configuration { message }) => {
+                assert!(
+                    message.contains("unscoped"),
+                    "expected the unscoped-token refusal message, got: {message}"
+                );
+            }
+            other => panic!(
+                "expected Git2DBError::Configuration from validate_trust (refused before any \
+                 network attempt), got: {other:?}"
+            ),
+        }
+    }
+
+    /// Same shape, but for `AuthMode::AllowAmbient` under `Untrusted`.
+    #[tokio::test]
+    async fn untrusted_clone_rejects_allow_ambient_before_network() {
+        use crate::callback_config::AuthMode;
+
+        let manager = test_manager();
+        let options = CloneOptions::builder()
+            .trust(CloneTrust::Untrusted)
+            .callback_config(
+                CallbackConfigBuilder::new()
+                    .auth_mode(AuthMode::AllowAmbient)
+                    .build(),
+            )
+            .build();
+
+        let dest_dir = tempdir().unwrap();
+        let result = manager
+            .clone_repository(
+                "https://untrusted-guard-test.invalid/should-never-be-fetched.git",
+                &dest_dir.path().join("clone"),
+                Some(options),
+            )
+            .await
+            .map(|_repo| ());
+
+        assert!(
+            matches!(result, Err(Git2DBError::Configuration { .. })),
+            "expected Git2DBError::Configuration from validate_trust, got: {result:?}"
+        );
+    }
+
+    /// A host-scoped token IS accepted under `Untrusted` and the clone
+    /// proceeds normally — the scoped-token-only path this whole mode exists
+    /// to allow (e.g. a merge gate's scoped GitHub App installation token).
+    #[tokio::test]
+    async fn untrusted_clone_accepts_host_scoped_token() {
+        use crate::auth::AuthStrategy;
+
+        let manager = test_manager();
+        let src_dir = tempdir().unwrap();
+        init_target_repo(src_dir.path(), "readme.txt", "hello\n");
+
+        // The token is scoped to a host the fixture's file:// URL does not
+        // match, but that's fine here: we're only proving validate_trust
+        // lets a host-scoped token past construction-time validation (it is
+        // simply never offered for a `file://` URL, which the credential
+        // callback never even gets invoked for on a local transport).
+        let options = CloneOptions::builder()
+            .trust(CloneTrust::Untrusted)
+            .callback_config(
+                CallbackConfigBuilder::new()
+                    .auth(AuthStrategy::Token {
+                        token: "scoped".to_owned(),
+                        host: Some("github.com".to_owned()),
+                    })
+                    .build(),
+            )
+            .build();
+
+        let dest_dir = tempdir().unwrap();
+        let result = manager
+            .clone_repository(&file_url(src_dir.path()), &dest_dir.path().join("clone"), Some(options))
+            .await
+            .map(|_repo| ());
+
+        assert!(
+            result.is_ok(),
+            "a host-scoped token must be accepted under Untrusted, got: {result:?}"
+        );
     }
 }


### PR DESCRIPTION
## Summary
- Add `CloneTrust` to `CloneOptions` (`Trusted`/`Untrusted`) that composes three guards for a PR-head/forge-facing clone, per #1430:
  - `SubmoduleMode::Disabled` clamp — `.gitmodules` auto-init is refused under `Untrusted`, regardless of caller-requested mode.
  - `FilterMode::Passthrough` clamp — `disable_filters(true)` on checkout, so no libgit2 content filter (XET/LFS smudge included) runs against attacker-controlled endpoint/pointer content.
  - `CloneOptions::validate_trust()` — refuses `AuthMode::AllowAmbient` and any unscoped (`host: None`) `Token`, checked before the network operation starts.
- `SubmoduleMode` replaces the previously-unwired `update_submodules: bool`. Submodule init/update is now actually implemented in `GitManager::clone_repository` (it never was before this PR).
- Builds directly on B2's (#1429) ambient-vs-explicit auth split rather than introducing a second trust concept.

## Adversarial evidence
Real local fixtures, no network/CAS dependency:
- A `.gitmodules`-declared submodule (proper libgit2 `add_setup`/`clone`/`add_finalize`) pointing at a `file://` target repo — cloned `Untrusted` (even with `SubmoduleMode::Enabled` requested) leaves the submodule uninitialized; the identical fixture cloned `Trusted` + `Enabled` fetches and checks it out (positive control).
- libgit2's built-in `ident` filter (`$Id$` keyword expansion) as a hermetic proxy for XET/LFS smudge — both run through the identical `git_filter_register` + `.gitattributes`-driven checkout pipeline (see `git-xet-filter/src/filter.rs`), so `disable_filters(true)` suppresses them identically. Exercising the real XET filter would require a live CAS endpoint / `XETHUB_TOKEN`, out of scope for a hermetic unit test.
- Unscoped-token and `AllowAmbient` requests under `Untrusted` are rejected via `Git2DBError::Configuration` before any network attempt (proven by pointing at an unresolvable `.invalid` host and asserting the failure is a config error, not a DNS/network error).

Each of the three guards was manually verified to fail with the guard temporarily removed (see RESULT report for the exact transcript), then restored.

## Test plan
- [x] `cargo test -p git2db` — 143 lib tests + doctests, all passing (new: `security_tests::untrusted_repo_guards::*`, `clone_options::tests::*`)
- [x] `cargo clippy -p git2db --all-targets -- -D warnings` — clean
- [x] Workspace release clippy via pre-commit hook — passed
- [x] Manually verified each adversarial test fails when its guard is removed

Refs #1430, epic #1427.