### PR TITLE
fix(ci): derive the npm manifest license from the crate manifest

### DIFF
--- a/.github/scripts/package-rpc-std-wasm.sh
+++ b/.github/scripts/package-rpc-std-wasm.sh
@@ -32,6 +32,24 @@ print(tomllib.loads(pathlib.Path(sys.argv[1]).read_text())["package"]["version"]
 PY
 })"
 
+# The npm manifest's license must be the crate's own, not a value copied in by
+# hand — a hand-copied value silently goes stale when the crate's declared
+# license changes (as happened: this script once hardcoded MIT after the
+# crate's Cargo.toml had already moved to Apache-2.0). Derive it here, fail
+# closed if the crate declares none.
+crate_license="$({
+  python3 - "$CRATE_DIR/Cargo.toml" <<'PY'
+import pathlib
+import sys
+import tomllib
+print(tomllib.loads(pathlib.Path(sys.argv[1]).read_text())["package"].get("license", ""))
+PY
+})"
+if [[ -z "$crate_license" ]]; then
+  echo "crate manifest declares no license; refusing to package with an unverified license" >&2
+  exit 1
+fi
+
 case "$CHANNEL" in
   production)
     expected_ref="refs/tags/${RELEASE_TAG_PREFIX}-v${crate_version}"
@@ -86,16 +104,16 @@ wasm-pack build \
 
 # wasm-pack derives its name from the Rust package. Validate that generated
 # identity before rewriting it to the explicitly authorized public npm scope.
-node - "$PKG_DIR/package.json" "$package_version" "$WASM_PACK_PACKAGE_NAME" "$PACKAGE_NAME" "$REGISTRY" <<'NODE'
+node - "$PKG_DIR/package.json" "$package_version" "$WASM_PACK_PACKAGE_NAME" "$PACKAGE_NAME" "$REGISTRY" "$crate_license" <<'NODE'
 const fs = require('node:fs');
-const [manifestPath, version, wasmPackName, packageName, registry] = process.argv.slice(2);
+const [manifestPath, version, wasmPackName, packageName, registry, crateLicense] = process.argv.slice(2);
 const manifest = JSON.parse(fs.readFileSync(manifestPath, 'utf8'));
 if (manifest.name !== wasmPackName) {
   throw new Error(`wasm-pack package name ${manifest.name} != ${wasmPackName}`);
 }
 manifest.name = packageName;
 manifest.version = version;
-manifest.license = 'MIT';
+manifest.license = crateLicense;
 manifest.repository = {
   type: 'git',
   url: 'git+https://github.com/hyprstream/hyprstream.git',

--- a/.github/scripts/verify-rpc-std-wasm-package.mjs
+++ b/.github/scripts/verify-rpc-std-wasm-package.mjs
@@ -66,6 +66,15 @@ if (manifest.name !== evidence.package || manifest.name !== PACKAGE_NAME) {
 if (manifest.version !== evidence.version) {
   throw new Error(`tarball manifest version ${manifest.version} != evidence version ${evidence.version}`);
 }
+// The published license must be the crate's own, read independently from the
+// checked-out source rather than trusted from the tarball or the packaging
+// step that produced it — a hardcoded/stale manifest license (e.g. shipped
+// after the crate's Cargo.toml moved to a different license) must be refused
+// here even if every hash matches.
+const crateLicense = readCrateLicense();
+if (manifest.license !== crateLicense) {
+  throw new Error(`tarball manifest license ${manifest.license} != authoritative crate license ${crateLicense}`);
+}
 // A publishable package must not declare scripts or runtime dependencies that
 // could run on install; the browser bundle is self-contained.
 if (manifest.scripts && Object.keys(manifest.scripts).length > 0) {
@@ -124,6 +133,28 @@ if (expectedSha256 !== undefined && expectedSha256 !== sha256) {
 }
 
 console.log(path.join(distDir, tarballs[0]));
+
+// --- Authoritative crate license ------------------------------------------
+// Dependency-free: this is one scalar field, not a reason to add a TOML
+// parser dependency to a script whose whole point is verifying without one.
+// Scoped to the `[package]` table specifically (not a bare whole-file regex)
+// so a `license` key belonging to some other table can never be picked up.
+function readCrateLicense() {
+  const cargoTomlPath = path.join('crates', 'hyprstream-rpc-std', 'Cargo.toml');
+  const lines = fs.readFileSync(cargoTomlPath, 'utf8').split(/\r?\n/);
+  let inPackageTable = false;
+  for (const line of lines) {
+    const tableHeader = line.match(/^\[([^\]]*)\]\s*$/);
+    if (tableHeader) {
+      inPackageTable = tableHeader[1] === 'package';
+      continue;
+    }
+    if (!inPackageTable) continue;
+    const licenseLine = line.match(/^license\s*=\s*"([^"]+)"/);
+    if (licenseLine) return licenseLine[1];
+  }
+  throw new Error(`no license field in [package] table of ${cargoTomlPath}`);
+}
 
 // --- Minimal dependency-free USTAR/tar reader ---------------------------------
 // Reads a gzip-compressed POSIX/USTAR tar and returns the bytes of a single

--- a/.github/scripts/verify-rpc-std-wasm-package.probe.mjs
+++ b/.github/scripts/verify-rpc-std-wasm-package.probe.mjs
@@ -26,6 +26,30 @@ const PACKAGE_NAME = '@hyprstream/rpc';
 const STAGING_VERSION = '0.1.0-dev.1.abc1234';
 const PRODUCTION_VERSION = '9.9.9';
 
+// Read the same authoritative source the verifier itself now checks against,
+// rather than hardcoding a license string here — a hardcoded value would
+// silently stop testing anything real the next time the crate's declared
+// license changes (the exact staleness class this whole check exists to
+// catch). A tarball manifest with any OTHER value is guaranteed wrong.
+function readCrateLicense() {
+  const cargoTomlPath = path.join(HERE, '..', '..', 'crates', 'hyprstream-rpc-std', 'Cargo.toml');
+  const lines = fs.readFileSync(cargoTomlPath, 'utf8').split(/\r?\n/);
+  let inPackageTable = false;
+  for (const line of lines) {
+    const tableHeader = line.match(/^\[([^\]]*)\]\s*$/);
+    if (tableHeader) {
+      inPackageTable = tableHeader[1] === 'package';
+      continue;
+    }
+    if (!inPackageTable) continue;
+    const licenseLine = line.match(/^license\s*=\s*"([^"]+)"/);
+    if (licenseLine) return licenseLine[1];
+  }
+  throw new Error(`no license field in [package] table of ${cargoTomlPath}`);
+}
+const CRATE_LICENSE = readCrateLicense();
+const WRONG_LICENSE = CRATE_LICENSE === 'MIT' ? 'Apache-2.0' : 'MIT';
+
 function tarHeader(name, size) {
   const buf = Buffer.alloc(512);
   buf.write(name, 0, 100, 'utf8');
@@ -46,11 +70,11 @@ function buildTarGz(entries) {
   return zlib.gzipSync(Buffer.concat([body, end]));
 }
 
-function manifestBuf(version) {
-  return Buffer.from(JSON.stringify({ name: PACKAGE_NAME, version }), 'utf8');
+function manifestBuf(version, license = CRATE_LICENSE) {
+  return Buffer.from(JSON.stringify({ name: PACKAGE_NAME, version, license }), 'utf8');
 }
 
-function writeCase(dir, entries, version) {
+function writeCase(dir, entries, version, manifestSize = manifestBuf(version).length) {
   fs.mkdirSync(dir, { recursive: true });
   const gz = buildTarGz(entries);
   const tarballName = `hyprstream-rpc-${version}.tgz`;
@@ -70,7 +94,7 @@ function writeCase(dir, entries, version) {
     npmShasum: crypto.createHash('sha1').update(gz).digest('hex'),
     source: { repository: 'https://github.com/hyprstream/hyprstream', commit: '0'.repeat(40), ref: 'refs/heads/main', workflow: null, crate: 'crates/hyprstream-rpc-std' },
     build: { target: 'web', profile: 'release', rustToolchain: '1.97.0', wasmPack: '0.13.1' },
-    files: [{ path: 'package.json', size: manifestBuf(version).length }],
+    files: [{ path: 'package.json', size: manifestSize }],
   };
   fs.writeFileSync(path.join(dir, 'integrity.json'), `${JSON.stringify(evidence, null, 2)}\n`);
   return tarballPath;
@@ -108,10 +132,27 @@ if (controlResult.status !== 0) {
   failures.push(`control case: verifier REJECTED a single-entry tarball that should have passed. stderr:\n${controlResult.stderr}`);
 }
 
+// --- Adversarial case: manifest license differs from the crate's own -----
+// Proves a package whose declared license diverges from the authoritative
+// crates/hyprstream-rpc-std/Cargo.toml license (e.g. a hardcoded/stale
+// value) is refused, even with an otherwise-valid single manifest entry and
+// matching hashes. This is the causal negative for the regression that
+// motivated the check: a manifest hardcoding one license while the crate's
+// Cargo.toml declares another.
+const licenseMismatchDir = path.join(root, 'license-mismatch');
+const wrongManifest = manifestBuf(STAGING_VERSION, WRONG_LICENSE);
+writeCase(licenseMismatchDir, [tarEntry('package/package.json', wrongManifest)], STAGING_VERSION, wrongManifest.length);
+const licenseMismatchResult = runVerifier(licenseMismatchDir);
+if (licenseMismatchResult.status === 0) {
+  failures.push(`license-mismatch case: verifier ACCEPTED a manifest declaring "${WRONG_LICENSE}" against a crate declaring "${CRATE_LICENSE}" (expected rejection)`);
+} else if (!/manifest license .* != authoritative crate license/i.test(licenseMismatchResult.stderr)) {
+  failures.push(`license-mismatch case: verifier rejected, but not for the expected license-mismatch reason. stderr:\n${licenseMismatchResult.stderr}`);
+}
+
 fs.rmSync(root, { recursive: true, force: true });
 
 if (failures.length > 0) {
   for (const f of failures) console.error(`FAIL: ${f}`);
   throw new Error(`verify-rpc-std-wasm-package.probe.mjs: ${failures.length} assertion(s) failed`);
 }
-console.log('PASS: verifier rejects duplicate package/package.json entries and still accepts the equivalent single-entry tarball');
+console.log('PASS: verifier rejects duplicate package/package.json entries, rejects a manifest license diverging from the crate\'s own, and still accepts a correct single-entry tarball');


### PR DESCRIPTION
## The defect

`.github/scripts/package-rpc-std-wasm.sh` hardcoded `manifest.license = 'MIT'` while `crates/hyprstream-rpc-std/Cargo.toml` declares `license = "Apache-2.0"`. A publish from main would have labelled `@hyprstream/rpc` with a license the crate does not use.

**Nothing has shipped.** `@hyprstream/rpc` is not on the npm registry (`Not found`), and the publish workflow cannot publish on a merge to main — staging publication requires an operator `workflow_dispatch` pre-stating the exact version and SHA-256, and production requires a tag plus a separate environment that is not configured. So this corrects the defect **before first publication**, which is materially cheaper than a post-publish version bump and deprecation.

## The fix

1. **Packaging derives, rather than asserts.** The license is read from the crate's own `[package] license` field. If the crate declares none, packaging **fails closed** rather than shipping an unverified license.
2. **The verifier checks independently.** `verify-rpc-std-wasm-package.mjs` re-reads the authoritative license from the checked-out source and refuses a tarball whose manifest disagrees — **even when every hash matches**. This is deliberately not a restatement of what packaging just did: it is a second, independent read, so a reintroduced hardcode cannot ship undetected.
3. **The probe suite covers the divergence adversarially.** A new case builds a tarball whose manifest license differs from the crate's and asserts the verifier rejects it. The mismatched value is derived dynamically (`CRATE_LICENSE === 'MIT' ? 'Apache-2.0' : 'MIT'`) rather than hardcoded, so the test cannot silently stop testing anything real the next time the declared license changes — the exact staleness class this check exists to catch.

Both TOML readers are scoped to the `[package]` table specifically rather than a whole-file regex, so a `license` key belonging to another table cannot be picked up. They stay dependency-free: this is one scalar field, not a reason to add a TOML parser to scripts whose purpose is verifying without one.

## Verification

```
$ node .github/scripts/verify-rpc-std-wasm-package.probe.mjs
PASS: verifier rejects duplicate package/package.json entries, rejects a
manifest license diverging from the crate's own, and still accepts a
correct single-entry tarball
$ echo $?
0
```

`node --check` clean on both `.mjs` files; `bash -n` clean on the packaging script. Committed through the canonical BuildQ wrapper, so the full workspace release Clippy hook passed.

CI scripts only — no crate source, no runtime behavior change, no publish performed or authorized by this PR.