### PR TITLE
deps: bump iroh/web-transport-iroh off the RC to clear the noq GSO abort

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3133,12 +3133,12 @@ dependencies = [
 
 [[package]]
 name = "curve25519-dalek"
-version = "5.0.0-pre.6"
+version = "5.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "335f1947f241137a14106b6f5acc5918a5ede29c9d71d3f2cb1678d5075d9fc3"
+checksum = "b5eed333089e2e1c1ac8c6c0398e5e2497b4c9926ca6d0365ed1e099afa5bc23"
 dependencies = [
  "cfg-if 1.0.3",
- "cpufeatures 0.2.17",
+ "cpufeatures 0.3.0",
  "curve25519-dalek-derive",
  "digest 0.11.3",
  "fiat-crypto 0.3.0",
@@ -4774,11 +4774,11 @@ dependencies = [
 
 [[package]]
 name = "ed25519-dalek"
-version = "3.0.0-pre.7"
+version = "3.0.0-rc.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20449acd54b660981ae5caa2bcb56d1fe7f25f2e37a38ec507400fab034d4bb6"
+checksum = "b011170fe4f04665565b4110afef66774fe9ffff278f3eb5b81cc73d26e27d60"
 dependencies = [
- "curve25519-dalek 5.0.0-pre.6",
+ "curve25519-dalek 5.0.0",
  "ed25519 3.0.0",
  "rand_core 0.10.1",
  "serde",
@@ -8105,9 +8105,9 @@ dependencies = [
 
 [[package]]
 name = "iroh"
-version = "1.0.0-rc.0"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b98e206e3d3f2642f5c08c413755fc0ac19b54ae1a656af88be03454ce3ed2e6"
+checksum = "5fca9b4b462c343ff88fc0af4096c186f939b602a0bc08723536ef2c31c93971"
 dependencies = [
  "backon",
  "blake3",
@@ -8116,7 +8116,7 @@ dependencies = [
  "ctutils",
  "data-encoding",
  "derive_more",
- "ed25519-dalek 3.0.0-pre.7",
+ "ed25519-dalek 3.0.0-rc.0",
  "futures-util",
  "getrandom 0.4.2",
  "hickory-resolver",
@@ -8141,7 +8141,6 @@ dependencies = [
  "rustc-hash",
  "rustls 0.23.40",
  "rustls-pki-types",
- "rustls-webpki 0.103.13",
  "serde",
  "smallvec",
  "strum 0.28.0",
@@ -8152,36 +8151,32 @@ dependencies = [
  "tracing",
  "url",
  "wasm-bindgen-futures",
- "webpki-roots 1.0.7",
 ]
 
 [[package]]
 name = "iroh-base"
-version = "1.0.0-rc.0"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2160a45265eba3bd290ce698f584c9b088bee47e518e9ec4460d5e5888ef660e"
+checksum = "6be73e16ee21c923aca9b3121aaa0db936f7c7ecc156ff47b8dac944c68d59a8"
 dependencies = [
- "curve25519-dalek 5.0.0-pre.6",
+ "curve25519-dalek 5.0.0",
  "data-encoding",
  "data-encoding-macro",
  "derive_more",
- "digest 0.11.3",
- "ed25519-dalek 3.0.0-pre.7",
+ "ed25519-dalek 3.0.0-rc.0",
  "getrandom 0.4.2",
  "n0-error",
  "rand 0.10.1",
  "serde",
- "sha2 0.11.0",
  "url",
  "zeroize",
- "zeroize_derive",
 ]
 
 [[package]]
 name = "iroh-blobs"
-version = "0.101.0"
+version = "0.103.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6e351f5c1db08dcfb456e6299bda0881e1ba95a360f0913a5e57344c1538fb2"
+checksum = "5be50b0e2d0a9ba65cee4e0dfb708b3704e02ad12bd4c14c6307e94245943126"
 dependencies = [
  "arrayvec",
  "bao-tree",
@@ -8219,9 +8214,9 @@ dependencies = [
 
 [[package]]
 name = "iroh-dns"
-version = "1.0.0-rc.0"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8b6d2946350d398c9d2d795bb99b04f22e8414c8a8ad9c5c3c0c5b7899af9a4"
+checksum = "516e4eedc38e33ab69a6bd325520332dc3d67b25454e2d590ebb84a25240dd9a"
 dependencies = [
  "arc-swap",
  "cfg_aliases",
@@ -8231,8 +8226,8 @@ dependencies = [
  "n0-error",
  "n0-future",
  "ndk-context",
+ "portable-atomic",
  "rand 0.10.1",
- "reqwest 0.13.4",
  "rustls 0.23.40",
  "simple-dns",
  "strum 0.28.0",
@@ -8256,9 +8251,9 @@ dependencies = [
 
 [[package]]
 name = "iroh-metrics"
-version = "1.0.0-rc.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d102597d0ee523f17fdb672c532395e634dbe945429284c811430d63bacc0d8a"
+checksum = "291065721ad7c477b972e581bbc528df031dc8eb5e39fe1ff3300ae5dfb157ef"
 dependencies = [
  "iroh-metrics-derive",
  "itoa",
@@ -8271,9 +8266,9 @@ dependencies = [
 
 [[package]]
 name = "iroh-metrics-derive"
-version = "1.0.0-rc.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91c8e0c97f1dc787107f388433c349397c565572fe6406d600ff7bb7b7fe3b30"
+checksum = "1ae5f0c4405d1fbc9fb16ff422ca40620e93dc36c30ecaba0c2aee3992b7bd48"
 dependencies = [
  "heck 0.5.0",
  "proc-macro2",
@@ -8283,9 +8278,9 @@ dependencies = [
 
 [[package]]
 name = "iroh-relay"
-version = "1.0.0-rc.0"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54f490405e42dd2ecf16be18a3587d2665401e94a498094f12322eaa6d5ebb2b"
+checksum = "8149bb6a57126225a07d6928846d82dcedfd24ea0f863ef7b2eb475e1d726354"
 dependencies = [
  "blake3",
  "bytes",
@@ -8329,9 +8324,9 @@ dependencies = [
 
 [[package]]
 name = "iroh-tickets"
-version = "1.0.0-rc.0"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a4b7fbfa10582f6b4f6b013eef1d21987d3df5fd42c0f7707d5de6abd34f8e9"
+checksum = "da53233419ca36bf521ed45683b7748366f9b233032891eefc2d70567a84ac54"
 dependencies = [
  "data-encoding",
  "derive_more",
@@ -8343,9 +8338,9 @@ dependencies = [
 
 [[package]]
 name = "iroh-util"
-version = "0.4.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7705450a124b2b05f7caad505620ab5ac3bf4eb6b85018e6b9bca36329fd031"
+checksum = "20e41eb982f15230c55f0a70a74a514360e1f565b07861924fd0e8db172b3d00"
 dependencies = [
  "derive_more",
  "iroh",
@@ -8357,9 +8352,9 @@ dependencies = [
 
 [[package]]
 name = "irpc"
-version = "0.15.0"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d38567eed2ed120e1040386930eb3b9ce6ca8a94b13c20a1b3b6535f253b00c"
+checksum = "3623d6ff582b415904b29bbe6ebcb4a4f9a262ccdee05a45fdd003ef0950c386"
 dependencies = [
  "futures-util",
  "irpc-derive",
@@ -8375,9 +8370,9 @@ dependencies = [
 
 [[package]]
 name = "irpc-derive"
-version = "0.15.0"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d8030c02dce4c9a8aecfb6e0870ee13ba3060096d88f6c1309919af8f197793"
+checksum = "35c254013736de16472140d26904e6ac98e8f3887284dcf4af40f88c77411b56"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -9501,7 +9496,7 @@ dependencies = [
  "crc",
  "document-features",
  "dyn-clone",
- "ed25519-dalek 3.0.0-pre.7",
+ "ed25519-dalek 3.0.0-rc.0",
  "flume",
  "futures-lite 2.6.1",
  "getrandom 0.4.2",
@@ -9967,9 +9962,9 @@ dependencies = [
 
 [[package]]
 name = "n0-error"
-version = "1.0.0-rc.0"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "223e946a84aa91644507a6b7865cfebbb9a231ace499041c747ab0fd30408212"
+checksum = "c37e81176a83a77d2514528b91bdafc70ef88aab428f0e1b91aebb8d99888895"
 dependencies = [
  "n0-error-macros",
  "spez",
@@ -9977,9 +9972,9 @@ dependencies = [
 
 [[package]]
 name = "n0-error-macros"
-version = "1.0.0-rc.0"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "565305a21e6b3bf26640ad98f05a0fda12d3ab4315394566b52a7bddb8b34828"
+checksum = "e2acd8b070213b0299282f884b4beba4e7b52d624fdcd504a3ad3665390c11e1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -10009,9 +10004,9 @@ dependencies = [
 
 [[package]]
 name = "n0-watcher"
-version = "1.0.0-rc.0"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "928d8039a66cce5efcfd35e88b32d3defc8eba630b3ac451522997f563956a52"
+checksum = "bbc618745ad0b7414b149d0517ad8b5573b2fb4d4e2717add3d2446ce1fdd826"
 dependencies = [
  "derive_more",
  "n0-error",
@@ -10070,19 +10065,22 @@ dependencies = [
 
 [[package]]
 name = "netdev"
-version = "0.43.0"
+version = "0.45.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57bacaf873ee4eab5646f99b381b271ec75e716902a67cf962c0f328c5eb5bfb"
+checksum = "569dfbdd2efd771b24ec9bb57f956e04d4fbfc72f62b2f11961723f9b3f4b020"
 dependencies = [
  "block2",
  "dispatch2",
  "dlopen2",
  "ipnet",
+ "jni 0.21.1",
  "libc",
  "mac-addr",
+ "ndk-context",
  "netlink-packet-core",
- "netlink-packet-route 0.29.0",
+ "netlink-packet-route",
  "netlink-sys",
+ "objc2",
  "objc2-core-foundation",
  "objc2-core-wlan",
  "objc2-foundation",
@@ -10103,21 +10101,9 @@ dependencies = [
 
 [[package]]
 name = "netlink-packet-route"
-version = "0.29.0"
+version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df9854ea6ad14e3f4698a7f03b65bce0833dd2d81d594a0e4a984170537146b6"
-dependencies = [
- "bitflags 2.11.0",
- "libc",
- "log",
- "netlink-packet-core",
-]
-
-[[package]]
-name = "netlink-packet-route"
-version = "0.30.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be8919612f6028ab4eacbbfe1234a9a43e3722c6e0915e7ff519066991905092"
+checksum = "e2288fcb784eb3defd5fb16f4c4160d5f477de192eac730f43e1d11c24d9a007"
 dependencies = [
  "bitflags 2.11.0",
  "libc",
@@ -10154,14 +10140,15 @@ dependencies = [
 
 [[package]]
 name = "netwatch"
-version = "0.17.0"
+version = "0.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5bfbba77b994ce69f1d40fc66fd8abbd23df62ce4aea61fbb34d638106a2549"
+checksum = "4d9cbe01741347ef750d743d6690603f5eed8341e679fb51c8e629337aa11976"
 dependencies = [
  "atomic-waker",
  "bytes",
  "cfg_aliases",
  "derive_more",
+ "ipnet",
  "js-sys",
  "libc",
  "n0-error",
@@ -10169,7 +10156,7 @@ dependencies = [
  "n0-watcher",
  "netdev",
  "netlink-packet-core",
- "netlink-packet-route 0.30.0",
+ "netlink-packet-route",
  "netlink-proto",
  "netlink-sys",
  "noq-udp",
@@ -10309,9 +10296,9 @@ dependencies = [
 
 [[package]]
 name = "noq"
-version = "1.0.0-rc.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22739e0831e40f5ab7d6ac5317ed80bfe5fb3f44be57d23fa2eea8bff83fb303"
+checksum = "4bf95190af1bd4a00a10e8255ca0c8ddd9e9a9f5e79151d7a7eb6d56aff5dc89"
 dependencies = [
  "bytes",
  "cfg_aliases",
@@ -10331,9 +10318,9 @@ dependencies = [
 
 [[package]]
 name = "noq-proto"
-version = "1.0.0-rc.0"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7cee32450cf726b223ac4154003c93cb52fbde159ab1240990e88945bf3ae35e"
+checksum = "baa7b5ccd819a9c68a0d955e67a881032d09b1a17219b1f90b0997a0888e1a15"
 dependencies = [
  "aes-gcm",
  "aws-lc-rs",
@@ -10359,9 +10346,9 @@ dependencies = [
 
 [[package]]
 name = "noq-udp"
-version = "1.0.0-rc.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78633d1fe1bde91d12bcabb230ac9edb890857414c6d44f3212e0d309525b5ff"
+checksum = "3137a52df66c20090a889828d1c655f21f52294cba64e5c4fbb04fc83eee7c8e"
 dependencies = [
  "cfg_aliases",
  "libc",
@@ -18322,9 +18309,9 @@ dependencies = [
 
 [[package]]
 name = "web-transport-iroh"
-version = "0.5.1"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f4ebffba98c30a0ac3560c4d7c595e61a5ad040049d65ff5c91304e5ee5f5ee"
+checksum = "d34a91cf241951b8fe02ff216fdf16fc0a52b910568053652d546ded52399f77"
 dependencies = [
  "bytes",
  "http 1.3.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -159,10 +159,12 @@ http = "1"
 
 # Iroh + Media-over-QUIC (Epic #131 — Phase 1 substrate)
 # iroh re-exported via web-transport-iroh — match its major to avoid duplicate copies.
-# Note: web-transport-iroh 0.5.x pins iroh =1.0.0-rc.0 exactly; co-bump these together.
-iroh = { version = "=1.0.0-rc.0", default-features = false, features = ["tls-ring"] }
+# Note: web-transport-iroh 0.6.x requires iroh ^1 (0.5.x pinned =1.0.0-rc.0 exactly);
+# co-bump these together. Staying on the RC held noq/noq-proto at 1.0.0-rc.0, which
+# predates the n0-computer/noq#690 GSO-batch alignment fix (#1456).
+iroh = { version = "^1", default-features = false, features = ["tls-ring"] }
 moq-net = "0.1"
-web-transport-iroh = { version = "0.5.1", default-features = false, features = ["ring"] }
+web-transport-iroh = { version = "0.6.0", default-features = false, features = ["ring"] }
 web-transport-quinn = { version = "0.11.9", default-features = false, features = ["ring"] }
 web-transport-trait = "0.3"
 # Stream multiplexer for the UDS transport (`web_transport_trait::Session` over a

--- a/crates/hyprstream-p2p/Cargo.toml
+++ b/crates/hyprstream-p2p/Cargo.toml
@@ -74,9 +74,9 @@ blake3 = { workspace = true }
 
 # iroh-blobs content-addressed byte transport (F1, #899). This is now the
 # sole object plane behind `put_object`/`get_object` (F3 retired libp2p).
-# 0.101.0 pins iroh =1.0.0-rc.0 - the exact version the workspace pins via
-# web-transport-iroh 0.5.x; co-bump all three together (see workspace Cargo.toml).
-iroh-blobs = { version = "=0.101.0", default-features = false, features = ["fs-store"] }
+# 0.103.0 is the first release to take iroh ^1.0.0 (0.101.0/0.102.0 pinned the
+# rc's exactly); co-bump all three together (see workspace Cargo.toml).
+iroh-blobs = { version = "=0.103.0", default-features = false, features = ["fs-store"] }
 multihash = "0.19"
 sha2 = "0.10"
 

--- a/crates/hyprstream-rpc/Cargo.toml
+++ b/crates/hyprstream-rpc/Cargo.toml
@@ -104,7 +104,7 @@ url = { workspace = true }
 # n0-error's `AnyError`. iroh_peer.rs needs the `StackError` trait to walk the
 # source chain and downcast a pkarr 404 to `Ok(None)` (#475). Pinned to iroh's
 # transitive version so the `PkarrError` downcast resolves the same type.
-n0-error = "=1.0.0-rc.0"
+n0-error = "^1"
 # NOTE: moq-net is NOT added here. moq-net 0.1.8 has Session+Sync bounds that
 # conflict with browser WebTransport types (!Sync on wasm32). This requires an
 # upstream fix in moq-net before it can compile for wasm32-unknown-unknown.
@@ -179,7 +179,7 @@ tracing-subscriber = { workspace = true }
 # (the #1425 r2 P2 browser fetch test) does not try to compile a native UDP/mio
 # stack for the browser target).
 [target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
-noq = { version = "=1.0.0-rc.0", default-features = false, features = ["rustls-aws-lc-rs"] }
+noq = { version = "^1", default-features = false, features = ["rustls-aws-lc-rs"] }
 # Quinn hides the negotiated NamedGroup behind this upstream diagnostic feature.
 # Enabling it only for tests lets live zmtp assertions use handshake_data without
 # packet parsing or changing production wire behavior.


### PR DESCRIPTION
Closes the root cause behind #1456.

## Why

A `noq-proto` debug assertion — `datagrams in a GSO batch must be aligned to the segment size` — panics during QUIC teardown. `noq`'s mutex wrapper then unwraps the poisoned lock inside a `Drop` impl, a non-unwinding panic, so the **entire test process aborts with SIGABRT**. One teardown destroys a 4,000+ test merge-gate run.

**This dequeued four PRs from the merge queue in a single day** — a documentation-only change, a cfg-gated one-file change, a test-only change, and a CI-scripts-only change. None could have touched QUIC datagram batching; each required an independent causal-innocence investigation before it was safe to re-enqueue.

**Upstream will not fix the amplifier.** n0-computer/noq#723 was closed 2026-07-31 as working-as-intended ("we unwrap poisoned locks on purpose"), so removing the *root panic* is the only available lever — patch-forking the mutex would mean permanently diverging from a deliberate upstream decision.

**The root panic is already fixed upstream and we were pinned behind it.** n0-computer/noq#690 — the identical assertion — was fixed 2026-06-11. Its cause is directly ours: a large ClientHello from a **post-quantum key share** splits the handshake across packets and hits the unfixed GSO path. We run PQ key exchange, so this was deterministic exposure, not bad luck. We were on `1.0.0-rc.0`, a release candidate predating `1.0.0`.

The fix is present in what we move to — `noq-proto` 1.1.1's `connection/mod.rs` adds `pad_datagram` and guards initial-packet construction with `segment_size() >= MIN_INITIAL_SIZE`. (`transmit_buf.rs` is byte-identical between the two versions: the assertion was never the bug, it is the invariant check, and the fix makes the invariant hold.)

## What moved

| crate | before | after |
|---|---|---|
| `iroh` | `=1.0.0-rc.0` | 1.0.2 (`^1`) |
| `web-transport-iroh` | 0.5.1 | 0.6.0 |
| `iroh-blobs` | `=0.101.0` | `=0.103.0` |
| `noq` | 1.0.0-rc.0 | 1.0.1 |
| **`noq-proto`** | **1.0.0-rc.0** | **1.1.1** |
| `noq-udp` | 1.0.0-rc.0 | 1.0.1 |

23 packages re-locked. **Zero source changes** — the RC→stable boundary required no code adaptation; `cargo build --workspace` compiled first try.

## The five manifest edits, and why each was required

`Cargo.toml:162-165` is the prescribed change — its own comment already said *"web-transport-iroh 0.5.x pins iroh =1.0.0-rc.0 exactly; co-bump these together"*, and 0.6.0 relaxing to `iroh ^1` is what lifted the blocker. The comment is rewritten to describe the new reality rather than the retired pin.

Three further pins had to move or the bump would have been silently useless:

- **`crates/hyprstream-rpc/Cargo.toml:182`** — the direct `noq` **dev-dependency** was pinned `=1.0.0-rc.0`. Left alone, it would have pulled the *unfixed* crate back into the graph **for test binaries** — precisely the binaries that abort. This one mattered most.
- **`crates/hyprstream-rpc/Cargo.toml:107`** — `n0-error` `=1.0.0-rc.0` → `^1`; `web-transport-iroh 0.6.0` needs `n0-error ^1` and the exact pin made the graph unsatisfiable. The pin's stated intent (track iroh's transitive version so the `PkarrError` downcast resolves the same type) is preserved.
- **`crates/hyprstream-p2p/Cargo.toml:79`** — `iroh-blobs` `=0.101.0` → `=0.103.0`; 0.103.0 is the first release taking `iroh ^1.0.0` / `noq ^1.0.0`. Exact-pin style kept, matching the file's convention.

## Validation (hypr1, in-checkout rustc 1.97.0 = CI's compiler, via BuildQ)

- `cargo build --workspace` — exit 0 (19m14s)
- `cargo clippy --workspace --all-targets -- -D warnings` — exit 0
- `cargo clippy --release --workspace --all-targets -- -D warnings` — exit 0 (10m35s)
- `python3 scripts/check_license_boundary.py` — exit 0 (run because this edits manifests)
- `cargo test --workspace` — one failure, **unrelated and proven so** (below)

### The one test failure is a pre-existing race, not this bump

`hyprstream-service::service::factory::tests::public_context_cannot_select_production_authority` fails intermittently on `HYPRSTREAM_INSTANCE must contain only ASCII letters…`.

A sibling test (`manager/units.rs::config_dir_rejects_instance_path_traversal`) calls `std::env::set_var("HYPRSTREAM_INSTANCE", …)` with deliberately invalid values, guarded only by a lock private to *its own module*. The failing test re-execs the test binary as a **subprocess**, which inherits whatever the variable happens to be at fork time. Evidence: `--test-threads=1` passes 5/5; running the two in parallel gives 5 pass / 1 fail; `HYPRSTREAM_INSTANCE` is unset in the lane's environment. No connection to QUIC, iroh, or noq. Not fixed here — that is a behavioral change in an unrelated crate — and filed separately.

## What is deliberately not claimed

**The abort was not observed locally, before or after, so this does not claim the flake is fixed.** What is established: the crate carrying the assertion moved from a release predating the fix to one containing it, and the workspace builds and tests clean. The abort is intermittent and load-dependent — **the merge queue is the real test.**