### PR TITLE
test(service): stop the authority subprocess inheriting an instance namespace

### DIFF
--- a/crates/hyprstream-service/src/service/factory.rs
+++ b/crates/hyprstream-service/src/service/factory.rs
@@ -1145,6 +1145,10 @@ mod tests {
             .arg("--nocapture")
             .env(CHILD, "1")
             .env(EXPECTED, &expected)
+            // The child resolves deployment paths, so it must not inherit an
+            // instance namespace that another test in this binary may have set
+            // in the shared process environment while this fork happens.
+            .env_remove("HYPRSTREAM_INSTANCE")
             .env("XDG_DATA_HOME", deployment.path())
             .env("HYPRSTREAM__PDS__STORE_PATH", caller_store.path())
             .env(


### PR DESCRIPTION
Fixes #1461.

## The race

`service::factory::tests::public_context_cannot_select_production_authority` re-execs the test binary as a subprocess to assert a public context cannot select the production authority. The child resolves deployment paths, so it validates whatever `HYPRSTREAM_INSTANCE` it inherits **at fork time**.

`service::manager::units::tests::config_dir_rejects_instance_path_traversal` sets that variable to deliberately invalid values (`"../other"`, `"nested/name"`, `"name..suffix"`) while exercising path-traversal rejection. It serializes its own mutations behind an `INSTANCE_ENV_LOCK` — but `set_var` mutates the **whole process**, and that lock is private to its module, so nothing else in the binary respects it. A fork landing inside that window inherits an invalid instance name, and the child aborts in `validate_instance_name` rather than on the property under test:

```
called `Result::unwrap()` on an `Err` value: HYPRSTREAM_INSTANCE must contain
only ASCII letters, digits, '.', '_', or '-' and must not be '.' or '..'
```

## The fix

`.env_remove("HYPRSTREAM_INSTANCE")` on the child `Command`, making the subprocess hermetic with respect to that variable.

Chosen over widening the lock deliberately: a binary-global lock only holds while every present **and future** mutator remembers to take it, whereas not inheriting ambient state removes the dependence on test scheduling entirely. It also keeps working if another test later mutates the same variable.

Four added lines, test-only, no production path touched.

## Evidence

Reproduced and validated on hypr1 with the two implicated tests run together under `--test-threads=2` against a BuildQ-built binary:

| | result |
|---|---|
| before the fix | **5 failures / 20 runs** (~25% per run) |
| after the fix | **0 failures / 30 runs** |

30 consecutive clean runs against a ~25% per-run failure rate is roughly 0.9998 confidence the race is closed.

Independently on fedora at this head: the targeted pair under `--test-threads=2` passes **15/15**, and `cargo test -p hyprstream-service --lib` passes 12/12.

**Stated plainly:** the race does **not** reproduce on fedora — the unfixed baseline also passed there — so the fedora runs confirm no regression rather than proving the fix. The before/after evidence above is the hypr1 reproduction.

## Why it is worth fixing rather than tolerating

Same **"one bad test kills the run"** shape as #1456: an intermittent failure unrelated to whatever change is being gated, costing a merge-gate run and a fresh causal-innocence investigation every time it fires.