### PR TITLE
build(oci): run on Hummingbird core-runtime as an unprivileged user

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,18 @@ ARG LIBTORCH_CUDA130_URL=https://download.pytorch.org/libtorch/cu130/libtorch-sh
 ARG LIBTORCH_ROCM_URL=https://download.pytorch.org/libtorch/rocm7.1/libtorch-shared-with-deps-${LIBTORCH_VERSION}%2Brocm7.1.zip
 ARG LIBTORCH_CPU_URL=https://download.pytorch.org/libtorch/cpu/libtorch-shared-with-deps-${LIBTORCH_VERSION}%2Bcpu.zip
 
+# Runtime base for every variant, pinned by multi-arch index digest so amd64 and
+# arm64 resolve from one immutable reference. This image ships no package
+# manager, runs as an unprivileged user, and provides glibc, libstdc++, libgcc,
+# libz, and a shell; only OpenSSL has to be carried over from the builder (see
+# the runtime stages). Bump by replacing the digest, never by moving to a tag.
+ARG RUNTIME_BASE=registry.access.redhat.com/hi/core-runtime@sha256:80bd4bd4e74c8ab4e372cf355b335dbd30d91e9e5669822283299e65c64788e2
+
+# Unprivileged runtime account provided by the runtime base. Declared here so
+# the USER instruction and any future ownership rules share one source.
+ARG RUNTIME_UID=65532
+ARG RUNTIME_GID=65532
+
 #############################################
 # Base Builder - Common for all variants
 #############################################
@@ -320,20 +332,34 @@ RUN --mount=type=cache,target=/root/.cargo/registry \
     && cp /build/target/release/hyprstream /out/hyprstream
 
 #############################################
-# Runtime Stage Selection (Distroless)
+# Runtime Stage Selection
 #############################################
+#
+# The runtime base is a package-manager-free image whose default account is
+# unprivileged. Its library search path is /usr/lib64, NOT the Debian multiarch
+# directories the builder uses, so every system-library COPY lands in /usr/lib64
+# regardless of the builder's source path. The builder stays Debian-based: the
+# binary it produces requires no glibc/libstdc++ symbol newer than the runtime
+# base provides, and its ELF interpreter resolves through the base's /lib
+# symlink.
+#
+# Only OpenSSL genuinely has to be carried over — the runtime base supplies
+# libc, libm, libdl, libpthread, librt, libstdc++, libgcc_s, and libz. libgomp
+# and libz are copied anyway so the runtime keeps the exact implementations the
+# LibTorch build was validated against rather than silently adopting the base
+# image's; LD_LIBRARY_PATH puts LibTorch's own bundled copies first in any case.
 
 #############################################
 # CUDA 12.8 Runtime
 #############################################
 
-FROM gcr.io/distroless/cc-debian13 AS runtime-cuda128
+FROM ${RUNTIME_BASE} AS runtime-cuda128
 
 # Copy required system libraries
-COPY --from=builder /usr/lib/x86_64-linux-gnu/libgomp.so.1 /usr/lib/x86_64-linux-gnu/
-COPY --from=builder /usr/lib/x86_64-linux-gnu/libz.so.1 /usr/lib/x86_64-linux-gnu/
-COPY --from=builder /usr/lib/x86_64-linux-gnu/libssl.so* /usr/lib/x86_64-linux-gnu/
-COPY --from=builder /usr/lib/x86_64-linux-gnu/libcrypto.so* /usr/lib/x86_64-linux-gnu/
+COPY --from=builder /usr/lib/x86_64-linux-gnu/libgomp.so.1 /usr/lib64/
+COPY --from=builder /usr/lib/x86_64-linux-gnu/libz.so.1 /usr/lib64/
+COPY --from=builder /usr/lib/x86_64-linux-gnu/libssl.so* /usr/lib64/
+COPY --from=builder /usr/lib/x86_64-linux-gnu/libcrypto.so* /usr/lib64/
 
 # Copy CUDA runtime libraries from builder (toolkit includes runtime)
 COPY --from=builder /usr/local/cuda-12.8/lib64/libcudart.so* /usr/local/cuda/lib64/
@@ -347,13 +373,13 @@ COPY --from=builder /opt/libtorch/lib/ /opt/libtorch/lib/
 # CUDA 13.0 Runtime
 #############################################
 
-FROM gcr.io/distroless/cc-debian13 AS runtime-cuda130
+FROM ${RUNTIME_BASE} AS runtime-cuda130
 
 # Copy required system libraries
-COPY --from=builder /usr/lib/x86_64-linux-gnu/libgomp.so.1 /usr/lib/x86_64-linux-gnu/
-COPY --from=builder /usr/lib/x86_64-linux-gnu/libz.so.1 /usr/lib/x86_64-linux-gnu/
-COPY --from=builder /usr/lib/x86_64-linux-gnu/libssl.so* /usr/lib/x86_64-linux-gnu/
-COPY --from=builder /usr/lib/x86_64-linux-gnu/libcrypto.so* /usr/lib/x86_64-linux-gnu/
+COPY --from=builder /usr/lib/x86_64-linux-gnu/libgomp.so.1 /usr/lib64/
+COPY --from=builder /usr/lib/x86_64-linux-gnu/libz.so.1 /usr/lib64/
+COPY --from=builder /usr/lib/x86_64-linux-gnu/libssl.so* /usr/lib64/
+COPY --from=builder /usr/lib/x86_64-linux-gnu/libcrypto.so* /usr/lib64/
 
 # Copy CUDA runtime libraries from builder (toolkit includes runtime)
 COPY --from=builder /usr/local/cuda-13.0/lib64/libcudart.so* /usr/local/cuda/lib64/
@@ -367,13 +393,13 @@ COPY --from=builder /opt/libtorch/lib/ /opt/libtorch/lib/
 # ROCm 7.1 Runtime
 #############################################
 
-FROM gcr.io/distroless/cc-debian13 AS runtime-rocm71
+FROM ${RUNTIME_BASE} AS runtime-rocm71
 
 # Copy required system libraries
-COPY --from=builder /usr/lib/x86_64-linux-gnu/libgomp.so.1 /usr/lib/x86_64-linux-gnu/
-COPY --from=builder /usr/lib/x86_64-linux-gnu/libz.so.1 /usr/lib/x86_64-linux-gnu/
-COPY --from=builder /usr/lib/x86_64-linux-gnu/libssl.so* /usr/lib/x86_64-linux-gnu/
-COPY --from=builder /usr/lib/x86_64-linux-gnu/libcrypto.so* /usr/lib/x86_64-linux-gnu/
+COPY --from=builder /usr/lib/x86_64-linux-gnu/libgomp.so.1 /usr/lib64/
+COPY --from=builder /usr/lib/x86_64-linux-gnu/libz.so.1 /usr/lib64/
+COPY --from=builder /usr/lib/x86_64-linux-gnu/libssl.so* /usr/lib64/
+COPY --from=builder /usr/lib/x86_64-linux-gnu/libcrypto.so* /usr/lib64/
 
 # Copy entire LibTorch lib directory (includes Tensile libraries for ROCm)
 COPY --from=builder /opt/libtorch/lib/ /opt/libtorch/lib/
@@ -382,13 +408,13 @@ COPY --from=builder /opt/libtorch/lib/ /opt/libtorch/lib/
 # CPU Runtime
 #############################################
 
-FROM gcr.io/distroless/cc-debian13 AS runtime-cpu
+FROM ${RUNTIME_BASE} AS runtime-cpu
 
 # Copy required system libraries
-COPY --from=builder /usr/lib/x86_64-linux-gnu/libgomp.so.1 /usr/lib/x86_64-linux-gnu/
-COPY --from=builder /usr/lib/x86_64-linux-gnu/libz.so.1 /usr/lib/x86_64-linux-gnu/
-COPY --from=builder /usr/lib/x86_64-linux-gnu/libssl.so* /usr/lib/x86_64-linux-gnu/
-COPY --from=builder /usr/lib/x86_64-linux-gnu/libcrypto.so* /usr/lib/x86_64-linux-gnu/
+COPY --from=builder /usr/lib/x86_64-linux-gnu/libgomp.so.1 /usr/lib64/
+COPY --from=builder /usr/lib/x86_64-linux-gnu/libz.so.1 /usr/lib64/
+COPY --from=builder /usr/lib/x86_64-linux-gnu/libssl.so* /usr/lib64/
+COPY --from=builder /usr/lib/x86_64-linux-gnu/libcrypto.so* /usr/lib64/
 
 # Copy entire LibTorch lib directory
 COPY --from=builder /opt/libtorch/lib/ /opt/libtorch/lib/
@@ -398,18 +424,19 @@ COPY --from=builder /opt/libtorch/lib/ /opt/libtorch/lib/
 #############################################
 #
 # Variant of runtime-cpu for the builder-cpu-arm64 toolchain (PyTorch aarch64
-# pip wheel's libtorch). Debian multilib lives under /usr/lib/aarch64-linux-gnu
-# on arm64, so the system-library COPYs cannot share the x86_64 runtime stage.
-# Selected via `FROM runtime-${VARIANT}` when VARIANT=cpu-arm64. gcr.io/distroless
-# cc-debian13 is multi-arch, so the base resolves to its arm64 variant natively.
+# pip wheel's libtorch). The Debian builder keeps its multiarch libraries under
+# /usr/lib/aarch64-linux-gnu, so the COPY SOURCE paths differ from the x86_64
+# stage and the two cannot be merged; the destination is /usr/lib64 on both.
+# Selected via `FROM runtime-${VARIANT}` when VARIANT=cpu-arm64. The runtime base
+# is a multi-arch index, so it resolves to its arm64 variant natively.
 
-FROM gcr.io/distroless/cc-debian13 AS runtime-cpu-arm64
+FROM ${RUNTIME_BASE} AS runtime-cpu-arm64
 
-# Copy required system libraries (arm64 multilib path)
-COPY --from=builder /usr/lib/aarch64-linux-gnu/libgomp.so.1 /usr/lib/aarch64-linux-gnu/
-COPY --from=builder /usr/lib/aarch64-linux-gnu/libz.so.1 /usr/lib/aarch64-linux-gnu/
-COPY --from=builder /usr/lib/aarch64-linux-gnu/libssl.so* /usr/lib/aarch64-linux-gnu/
-COPY --from=builder /usr/lib/aarch64-linux-gnu/libcrypto.so* /usr/lib/aarch64-linux-gnu/
+# Copy required system libraries (arm64 multiarch source path)
+COPY --from=builder /usr/lib/aarch64-linux-gnu/libgomp.so.1 /usr/lib64/
+COPY --from=builder /usr/lib/aarch64-linux-gnu/libz.so.1 /usr/lib64/
+COPY --from=builder /usr/lib/aarch64-linux-gnu/libssl.so* /usr/lib64/
+COPY --from=builder /usr/lib/aarch64-linux-gnu/libcrypto.so* /usr/lib64/
 
 # Copy entire LibTorch lib directory
 COPY --from=builder /opt/libtorch/lib/ /opt/libtorch/lib/
@@ -428,8 +455,20 @@ COPY --from=builder /out/hyprstream /hyprstream
 # Set library paths
 ENV LD_LIBRARY_PATH=/opt/libtorch/lib:/usr/local/cuda/lib64
 
-# Expose default ports
+# Expose default ports. Both are above 1024, so the unprivileged runtime account
+# can bind them without any capability grant.
 EXPOSE 8080 50051
 
-# Run hyprstream (distroless uses absolute paths)
+# Run unprivileged. The runtime base already defaults to this account, but state
+# it explicitly so the image never silently reverts to root if the base changes,
+# and so `podman inspect` reports the account this image is supported on. The
+# binary and its libraries are root-owned and world-readable/executable, which
+# is what an immutable runtime wants: the service can execute them and cannot
+# rewrite them.
+ARG RUNTIME_UID
+ARG RUNTIME_GID
+USER ${RUNTIME_UID}:${RUNTIME_GID}
+
+# Run hyprstream (the runtime base has no working directory conventions of its
+# own, so use an absolute path)
 ENTRYPOINT ["/hyprstream"]


### PR DESCRIPTION
## What

Every published `hyprstream/hyprstream` image currently runs as **uid 0**. This moves all five runtime stages from `gcr.io/distroless/cc-debian13` to Project Hummingbird's `core-runtime`, pinned by multi-arch index digest, and declares `USER 65532:65532` explicitly.

The builder is unchanged — still Debian. Only the runtime stages move.

## Why this base

`registry.access.redhat.com/hi/core-runtime` — index digest `sha256:80bd4bd4e74c…`, version 2.43, arm64 + amd64. No package manager (`dnf`/`microdnf`/`rpm`/`yum`/`apt`/`apk` all absent), unprivileged by default, 37 MB on arm64.

## Verification

Checked against the **published arm64 artifact**, not inferred from the Dockerfile:

**ELF interpreter** — the binary requires `/lib/ld-linux-aarch64.so.1`; the base ships `usr/lib/ld-linux-aarch64.so.1` plus a `/lib -> usr/lib` symlink, so it resolves.

**Symbol versions** — highest required vs. provided:

| | required | provided by base |
|---|---|---|
| binary GLIBC | 2.34 | **2.43** |
| binary GLIBCXX | 3.4.30 | **3.4.35** |
| LibTorch GLIBC | 2.28 | **2.43** |
| LibTorch GLIBCXX | 3.4.22 | **3.4.35** |
| LibTorch CXXABI | 1.3.11 | **1.3.17** |
| LibTorch GCC | 4.5.0 | **16.0** |

**Library closure** — the binary's `NEEDED` set is `libstdc++`, `libtorch{,_cpu}`, `libc10`, `libssl.so.3`, `libcrypto.so.3`, `libgcc_s`, `libm`, `libc`. Union of `NEEDED` across all LibTorch `.so`s adds `libdl`, `libpthread`, `librt`, `libz`, and its own bundled `libgomp`, `libgfortran`, `libopenblas`, `libarm_compute*`. The base provides everything except **OpenSSL**, which is therefore the only library that genuinely has to be carried from the builder. Confirmed present in the base: `libc.so.6`, `libm.so.6`, `libdl.so.2`, `libpthread.so.0`, `librt.so.1`, `libstdc++.so.6`, `libgcc_s.so.1`, `libz.so.1`.

**`ARG`-in-`FROM` + `USER`** — built the stage skeleton against the pinned digest on `linux/arm64`; result is `User=65532:65532`, `Entrypoint=[/hyprstream]`, `Arch=arm64`.

## The one behavioural trap

System-library `COPY` **destinations** move from the Debian multiarch directories to `/usr/lib64`, which is where this base's loader searches. Copying to `/usr/lib/{x86_64,aarch64}-linux-gnu/` on this base would put them somewhere `ld.so` never looks and the image would fail at exec. Source paths are unchanged, so the x86_64 and arm64 stages still can't be merged.

## Deliberately not in this PR

`libgomp` and `libz` are still copied even though the base ships `libz` and LibTorch bundles its own `libgomp`. Keeping them preserves the exact implementations LibTorch was validated against. Dropping them is a follow-up once a real build confirms the image.

**No `HEALTHCHECK`.** This base ships bash 5.3, so a real probe becomes cheap — and the deployment readiness contract wants one, since a container with no health status is treated as never-ready. But `/health`'s default listener and port aren't confirmed yet, and a wrong probe marks every container unhealthy, which is worse than none. Separate change.

## ⚠ No CI job validates this change before merge

Worth stating plainly, because it changes how this should be reviewed. **Nothing builds a runtime image on `pull_request`:**

| workflow | trigger | builds runtime image? |
|---|---|---|
| `docker-build.yml` | push to `main`, tags | yes — **only after merge** |
| `build-image.yml` | push to `main`, `workflow_dispatch`, weekly cron | yes — not on PRs |
| `graviton-build-validate.yml` | `workflow_dispatch`, push to one smoke-test branch | no — builds the **builder** stage only |

So a merge here is the first time any runtime image gets built, and a mistake surfaces as a broken publish on `main` rather than a red PR check. The pre-merge options are:

1. `workflow_dispatch` `build-image.yml` against this branch — cleanest, consumes a self-hosted Graviton runner;
2. an out-of-band `podman build --target runtime-cpu-arm64` on an arm64 host;
3. accept the risk and merge, relying on the static verification above.

I'd take (1). This stays **draft** until a real image has been built, started, and confirmed serving. The CUDA/ROCm variants additionally need GPU-host validation before they're trusted — the static analysis above only covers the CPU arm64 path end to end.
