### PR TITLE
test: eliminate deployment credential clock race

### DIFF
--- a/crates/hyprstream-discovery/src/service.rs
+++ b/crates/hyprstream-discovery/src/service.rs
@@ -4131,12 +4131,12 @@ mod resolver_tests {
             (
                 "future nbf",
                 "nbf",
-                serde_json::json!(checked_test_time(now, 61)),
+                serde_json::json!(checked_test_time(now, 3600)),
             ),
             (
                 "future iat",
                 "iat",
-                serde_json::json!(checked_test_time(now, 61)),
+                serde_json::json!(checked_test_time(now, 3600)),
             ),
             (
                 "nbf after iat",


### PR DESCRIPTION
Closes #1465.

The end-to-end deployment credential rejection test sampled its own wall clock and placed future nbf/iat only 61 seconds ahead. The validator samples time independently and permits 60 seconds of skew, leaving a one-second scheduling margin.

Move the two end-to-end future claims to one hour ahead. The deterministic numeric-date table continues to cover the exact 60/61-second skew boundary, so this removes timing dependence without losing boundary coverage.

Reproduction before the fix:
- Focused test failed on repetition 18/40 with: invalid deployment credential accepted: future iat

Validation after the fix:
- Focused end-to-end test: 40/40 passes
- Deterministic numeric-date boundary test: pass
- cargo test -p hyprstream-discovery --lib --no-fail-fast: 120 passed
- cargo clippy -p hyprstream-discovery --all-targets -- -D warnings: pass
- Repository pre-commit release Clippy hook: pass

All Cargo commands and hooks ran through the shared BuildQ lease.