### PR TITLE
feat: mint deployment anchor capsules and did.json

### DIFF
--- a/crates/hyprstream-discovery/src/did_anchored.rs
+++ b/crates/hyprstream-discovery/src/did_anchored.rs
@@ -370,6 +370,19 @@ fn reach_from_capsule(verified: &VerifiedCapsule, document: &Value) -> Result<Tr
                             if *addr == address
                                 || (addr.ip().is_unspecified() && addr.port() == address.port())
                     )
+                })
+                .map(|mut config| {
+                    // A hostname-based document URI decodes to an unspecified
+                    // IP with only the port populated. The capsule carries the
+                    // real dial address, so substitute it: without this rewrite
+                    // the config would dial 0.0.0.0:port and never connect,
+                    // turning a verified capsule into an unusable one.
+                    if let EndpointType::Quic { addr, .. } = &mut config.endpoint {
+                        if addr.ip().is_unspecified() {
+                            *addr = address;
+                        }
+                    }
+                    config
                 });
             Ok(document_transport.unwrap_or_else(|| {
                 tracing::warn!(
@@ -559,6 +572,7 @@ mod tests {
     };
     use serde_json::json;
     use std::collections::BTreeMap;
+    use std::net::SocketAddr;
 
     struct FixedCapsuleSource(Vec<u8>);
 
@@ -1152,6 +1166,122 @@ mod tests {
                 assert_eq!(auth.accept_cert_hashes(), &[[0xA5; 32]]);
             }
             other => panic!("expected capsule-bound QUIC reach, got {other:?}"),
+        }
+    }
+
+    /// When the document QUIC entry uses a hostname URI (decoding to an
+    /// unspecified IP) and the port matches the capsule's real address, the
+    /// port-match relaxation must fire AND the returned config must dial the
+    /// capsule's real socket address — not `0.0.0.0:port`.
+    ///
+    /// Removing the address-rewrite in `reach_from_capsule` turns this test
+    /// red: the config would dial an unspecified address and never connect.
+    #[tokio::test]
+    async fn quic_port_match_with_hostname_uri_rewrites_dial_address() {
+        let web = "did:web:cluster.example";
+        let signer = capsule_signer(7);
+        let capsule_addr: SocketAddr = "203.0.113.10:443".parse().unwrap();
+        let endpoint =
+            ServiceEndpoint::new(Transport::Quic, format!("quic://{capsule_addr}")).unwrap();
+        let service = ServiceEntry::new("#ns", ServiceType::NinePExport, endpoint).unwrap();
+        let mut body = CapsuleBody::new(vec![signer.pair], vec![service]).unwrap();
+        body.also_known_as = Some(vec![web.to_owned()]);
+        let capsule = sign_capsule(body, &signer.ed, &signer.pq).unwrap();
+        let bytes = capsule.to_dag_cbor().unwrap();
+        let at9p = format!("did:at9p:{}", capsule.cid512().unwrap());
+        let anchors = DidAnchors {
+            cluster_at9p_did: at9p.clone(),
+            cluster_did_web: web.to_owned(),
+            extra_root_cert_pem: None,
+        };
+        let channel_auth =
+            hyprstream_rpc::transport::QuicServerAuth::pinned(vec![[0xB7; 32]]).unwrap();
+        let mut document = document(web, Some(&at9p));
+        // Hostname URI decodes to 0.0.0.0:443 — port matches, IP does not.
+        document["service"] = json!([{
+            "id": format!("{web}#quic"),
+            "type": "QuicTransport",
+            "serviceEndpoint": hyprstream_rpc::service_entry::encode_quic(
+                "https://staging.example.com:443",
+                &channel_auth,
+                &["hyprstream-rpc/1"],
+            ),
+        }]);
+
+        let trust = verify_did_anchored_document(
+            &anchors,
+            &document,
+            Arc::new(FixedCapsuleSource(bytes)),
+            "unused-test-credential".to_owned(),
+            unused_authority_log(),
+        )
+        .await
+        .expect("hostname-URI port match must verify");
+        match trust.discovery_transport.endpoint {
+            EndpointType::Quic { addr, auth, .. } => {
+                assert_eq!(
+                    addr, capsule_addr,
+                    "dial address must be the capsule's real socket, not 0.0.0.0"
+                );
+                assert!(!auth.require_web_pki());
+                assert_eq!(auth.accept_cert_hashes(), &[[0xB7; 32]]);
+            }
+            other => panic!("expected capsule-bound QUIC reach, got {other:?}"),
+        }
+    }
+
+    /// When the document QUIC entry's port does NOT match the capsule's address
+    /// (and the IP is unspecified from a hostname URI), no entry matches and the
+    /// resolver falls back to a bare-IP dial without SNI or certificate pins.
+    #[tokio::test]
+    async fn quic_neither_port_nor_address_match_falls_back_to_bare_ip() {
+        let web = "did:web:cluster.example";
+        let signer = capsule_signer(9);
+        let capsule_addr: SocketAddr = "203.0.113.20:443".parse().unwrap();
+        let endpoint =
+            ServiceEndpoint::new(Transport::Quic, format!("quic://{capsule_addr}")).unwrap();
+        let service = ServiceEntry::new("#ns", ServiceType::NinePExport, endpoint).unwrap();
+        let mut body = CapsuleBody::new(vec![signer.pair], vec![service]).unwrap();
+        body.also_known_as = Some(vec![web.to_owned()]);
+        let capsule = sign_capsule(body, &signer.ed, &signer.pq).unwrap();
+        let bytes = capsule.to_dag_cbor().unwrap();
+        let at9p = format!("did:at9p:{}", capsule.cid512().unwrap());
+        let anchors = DidAnchors {
+            cluster_at9p_did: at9p.clone(),
+            cluster_did_web: web.to_owned(),
+            extra_root_cert_pem: None,
+        };
+        let channel_auth =
+            hyprstream_rpc::transport::QuicServerAuth::pinned(vec![[0xC9; 32]]).unwrap();
+        let mut document = document(web, Some(&at9p));
+        // Port 8443 does not match the capsule's port 443.
+        document["service"] = json!([{
+            "id": format!("{web}#quic"),
+            "type": "QuicTransport",
+            "serviceEndpoint": hyprstream_rpc::service_entry::encode_quic(
+                "https://staging.example.com:8443",
+                &channel_auth,
+                &["hyprstream-rpc/1"],
+            ),
+        }]);
+
+        let trust = verify_did_anchored_document(
+            &anchors,
+            &document,
+            Arc::new(FixedCapsuleSource(bytes)),
+            "unused-test-credential".to_owned(),
+            unused_authority_log(),
+        )
+        .await
+        .expect("fallback to bare-IP dial must still verify");
+        match trust.discovery_transport.endpoint {
+            EndpointType::Quic { addr, auth, .. } => {
+                // Fallback: bare capsule address, WebPKI default, no cert pins.
+                assert_eq!(addr, capsule_addr);
+                assert!(auth.require_web_pki());
+                assert!(auth.accept_cert_hashes().is_empty());
+            }
+            other => panic!("expected fallback QUIC reach, got {other:?}"),
         }
     }
 }

--- a/crates/hyprstream-discovery/src/did_anchored.rs
+++ b/crates/hyprstream-discovery/src/did_anchored.rs
@@ -318,7 +318,10 @@ fn reach_from_capsule(verified: &VerifiedCapsule, document: &Value) -> Result<Tr
         })
         .ok_or_else(|| {
             anyhow::anyhow!(
-                "capsule has no NinePExport service entry {DEPLOYMENT_REACH_SERVICE:?} for deployment reach"
+                "capsule has no NinePExport service entry {DEPLOYMENT_REACH_SERVICE:?} for deployment reach; \
+                 the pinned did:at9p must be an ANCHOR capsule signed by the deployment CA, not a node \
+                 identity capsule — mint one with `hyprstream trust mint-anchor-capsule` and publish it \
+                 (with its did.json) under the deployment well-known directory"
             )
         })?;
     match entry.endpoint.transport {
@@ -371,13 +374,53 @@ fn reach_from_capsule(verified: &VerifiedCapsule, document: &Value) -> Result<Tr
     }
 }
 
-pub(crate) async fn verify_did_anchored_document(
+/// Deployment material an anchor capsule contributes, once the capsule and the
+/// `did:web` document have mutually attested to each other.
+///
+/// This is the verification-only half of the DID-anchored bootstrap — the part
+/// a minting ceremony can self-check offline, before publication and before any
+/// registry credential or authority log exists.
+#[derive(Clone, Debug)]
+pub struct VerifiedAnchorMaterial {
+    /// The GATE-verified `did:at9p` the document reciprocally names.
+    pub at9p_did: String,
+    /// Raw hybrid deployment root taken from the capsule's primary subject
+    /// key: the 32-byte Ed25519 key followed by the 1952-byte ML-DSA-65 key,
+    /// the same layout the OS-owned `deployment-ca.hybrid` pin uses.
+    pub deployment_ca_public: Vec<u8>,
+    /// Deployment reach decoded from the capsule's `#ns` NinePExport entry.
+    pub discovery_transport: TransportConfig,
+}
+
+/// Verify an anchor capsule against its `did:web` document through the
+/// production resolution path, without needing the registry credential or
+/// authority log the live bootstrap also fetches.
+///
+/// Minting ceremonies call this on their own output: material this rejects is
+/// material a node would refuse at boot.
+pub async fn verify_anchor_material(
     anchors: &DidAnchors,
     document: &Value,
     capsule_source: Arc<dyn CapsuleSource>,
-    registry_credential: String,
-    authority_log: DeploymentAuthorityLog,
-) -> Result<DidAnchoredTrust> {
+) -> Result<VerifiedAnchorMaterial> {
+    let (identity, ca, discovery_transport) =
+        resolve_anchor_pair(anchors, document, capsule_source).await?;
+    let mut deployment_ca_public = ca.ed25519_bytes().to_vec();
+    deployment_ca_public.extend_from_slice(&ca.ml_dsa_65_bytes());
+    Ok(VerifiedAnchorMaterial {
+        at9p_did: identity.at9p_did.as_str().to_owned(),
+        deployment_ca_public,
+        discovery_transport,
+    })
+}
+
+/// Shared core of the DID-anchored trust decision: reciprocal naming, the
+/// capsule GATE, and the CA + reach the GATE-verified capsule carries.
+async fn resolve_anchor_pair(
+    anchors: &DidAnchors,
+    document: &Value,
+    capsule_source: Arc<dyn CapsuleSource>,
+) -> Result<(AuthoritativeIdentity, HybridDeploymentCa, TransportConfig)> {
     anyhow::ensure!(
         document.get("id").and_then(Value::as_str) == Some(anchors.cluster_did_web.as_str()),
         "did:web document id does not match configured cluster_did_web"
@@ -409,7 +452,22 @@ pub(crate) async fn verify_did_anchored_document(
         ),
         "capsule deployment reach is not a network transport"
     );
+    Ok((
+        authoritative_identity,
+        ca_verifying_key,
+        discovery_transport,
+    ))
+}
 
+pub(crate) async fn verify_did_anchored_document(
+    anchors: &DidAnchors,
+    document: &Value,
+    capsule_source: Arc<dyn CapsuleSource>,
+    registry_credential: String,
+    authority_log: DeploymentAuthorityLog,
+) -> Result<DidAnchoredTrust> {
+    let (authoritative_identity, ca_verifying_key, discovery_transport) =
+        resolve_anchor_pair(anchors, document, capsule_source).await?;
     Ok(DidAnchoredTrust {
         ca_verifying_key,
         discovery_transport,

--- a/crates/hyprstream-discovery/src/did_anchored.rs
+++ b/crates/hyprstream-discovery/src/did_anchored.rs
@@ -355,16 +355,29 @@ fn reach_from_capsule(verified: &VerifiedCapsule, document: &Value) -> Result<Tr
             // WebPKI policy, and certificate hashes) for that exact
             // capsule-bound socket. Those mechanics cannot select application
             // identity: the signed ping is still pinned independently.
+            //
+            // A hostname-based document URI (`https://host:port`) decodes to
+            // an unspecified address with only the port populated, so the match
+            // accepts either an exact address equality or a port-only match
+            // when the document entry carries an unspecified IP.
             let document_transport = hyprstream_rpc::did_web::transport_entries(document)
                 .into_iter()
                 .map(|decoded| decoded.config)
                 .find(|config| {
                     matches!(
                         &config.endpoint,
-                        EndpointType::Quic { addr, .. } if *addr == address
+                        EndpointType::Quic { addr, .. }
+                            if *addr == address
+                                || (addr.ip().is_unspecified() && addr.port() == address.port())
                     )
                 });
             Ok(document_transport.unwrap_or_else(|| {
+                tracing::warn!(
+                    "capsule QUIC reach {} has no matching QuicTransport entry in the did:web \
+                     document; falling back to bare-IP dial without SNI or certificate pins — \
+                     the deployment will not be reachable via hostname or WebPKI-validated TLS",
+                    address
+                );
                 TransportConfig::quic(address, address.ip().to_string()).with_connect_mode()
             }))
         }

--- a/crates/hyprstream-discovery/src/lib.rs
+++ b/crates/hyprstream-discovery/src/lib.rs
@@ -135,7 +135,9 @@ pub mod podspec;
 pub use hyprstream_rpc::registry::SocketKind;
 pub use hyprstream_rpc::resolver::Resolver;
 #[cfg(not(target_arch = "wasm32"))]
-pub use did_anchored::{DeploymentTrustSource, DidAnchors};
+pub use did_anchored::{
+    verify_anchor_material, DeploymentTrustSource, DidAnchors, VerifiedAnchorMaterial,
+};
 pub use plc_directory::{
     ConnectTimeDiscovery, DidOpSuccessorWitness, InMemoryPlcDirectoryStore, LivePlcDiscovery,
     PlcDirectory, PlcDirectoryRecord, PlcDirectoryStore, ResolvedPlcIdentity,

--- a/crates/hyprstream-discovery/src/service.rs
+++ b/crates/hyprstream-discovery/src/service.rs
@@ -1609,12 +1609,10 @@ impl HybridDeploymentCa {
         hyprstream_rpc::auth::composite_kid(&self.ml_dsa_65, &self.ed25519)
     }
 
-    #[cfg(test)]
     pub(crate) fn ed25519_bytes(&self) -> [u8; ED25519_PUBLIC_KEY_BYTES] {
         self.ed25519.to_bytes()
     }
 
-    #[cfg(test)]
     pub(crate) fn ml_dsa_65_bytes(&self) -> Vec<u8> {
         hyprstream_rpc::crypto::pq::ml_dsa_vk_bytes(&self.ml_dsa_65)
     }

--- a/crates/hyprstream-pds/src/at9p_sign.rs
+++ b/crates/hyprstream-pds/src/at9p_sign.rs
@@ -38,10 +38,11 @@ use anyhow::{ensure, Context, Result};
 use ed25519_dalek::{SigningKey, VerifyingKey};
 
 use hyprstream_crypto::cose_sign::{
-    assemble_composite_nested, sign_composite, split_composite, verify_composite,
+    assemble_composite_nested, inner_tbs, outer_tbs, sign_composite, split_composite,
+    verify_composite,
 };
 use hyprstream_crypto::pq::{
-    ml_dsa_sk_to_vk_bytes, ml_dsa_vk_bytes, ml_dsa_vk_from_bytes, MlDsaSigningKey,
+    ml_dsa_sign, ml_dsa_sk_to_vk_bytes, ml_dsa_vk_bytes, ml_dsa_vk_from_bytes, MlDsaSigningKey,
     MlDsaVerifyingKey,
 };
 
@@ -179,6 +180,66 @@ fn verify_record(
     Ok(())
 }
 
+/// An Ed25519 capsule signer whose secret half may live outside the process.
+///
+/// The deployment-authority ceremony keeps its classical leg in a YubiKey PIV
+/// slot, so the inner EdDSA layer cannot be produced from an in-process
+/// [`SigningKey`]. Implementors sign the inner COSE layer's detached
+/// to-be-signed bytes out-of-band and return the raw 64-byte signature; the
+/// ML-DSA-65 leg is still an in-process key, so GATE 2 (hybrid PINNED) is
+/// unchanged — this trait only relocates the classical half.
+pub trait CapsuleEd25519Signer {
+    /// The public half the capsule publishes as its subject key.
+    fn verifying_key(&self) -> VerifyingKey;
+
+    /// Sign the inner EdDSA layer's detached to-be-signed bytes.
+    fn sign_detached(&self, tbs: &[u8]) -> Result<[u8; 64]>;
+}
+
+impl CapsuleEd25519Signer for SigningKey {
+    fn verifying_key(&self) -> VerifyingKey {
+        SigningKey::verifying_key(self)
+    }
+
+    fn sign_detached(&self, tbs: &[u8]) -> Result<[u8; 64]> {
+        use ed25519_dalek::Signer as _;
+        Ok(self.sign(tbs).to_bytes())
+    }
+}
+
+/// Sign `payload` under the pinned-Hybrid composite path with an out-of-band
+/// classical signer, binding `context`.
+///
+/// Layer-for-layer equivalent to [`sign_record`]: the inner EdDSA to-be-signed
+/// bytes come from [`inner_tbs`] with `hybrid = true` (the same
+/// `layer_aad` binding `sign_composite` applies), and the outer ML-DSA-65 layer
+/// signs `payload ‖ inner_signature` via [`outer_tbs`]. The outer key is still
+/// mandatory, so there is no classical-only production here either (R4).
+fn sign_record_detached(
+    payload: &[u8],
+    context: &str,
+    ed: &dyn CapsuleEd25519Signer,
+    pq_sk: &MlDsaSigningKey,
+) -> Result<CoseCompositeSignature> {
+    let protected = context_protected_header(context);
+    let ed_kid = ed.verifying_key().to_bytes().to_vec();
+    let ed_sig = ed.sign_detached(&inner_tbs(ed_kid.clone(), payload, &protected, true))?;
+    let pq_kid = ml_dsa_sk_to_vk_bytes(pq_sk);
+    let pq_sig = ml_dsa_sign(
+        pq_sk,
+        &outer_tbs(pq_kid.clone(), payload, &ed_sig, &protected),
+    );
+    // Round-trip through the canonical composite encoding so the decomposed
+    // signatures stored on the record are exactly what the assembled nested
+    // composite carries — the shape `verify_record` will rebuild.
+    let composite = assemble_composite_nested((ed_kid, ed_sig.to_vec()), Some((pq_kid, pq_sig)))
+        .context("at9p detached composite assembly failed")?;
+    let (ed_sig, pq_sig) = split_composite(&composite)?;
+    let pq_sig = pq_sig
+        .ok_or_else(|| anyhow::anyhow!("at9p detached signing produced no ML-DSA-65 layer"))?;
+    CoseCompositeSignature::new(context, protected, ed_sig, pq_sig)
+}
+
 /// Sign a capsule body with one of its subject keys, producing a fully-signed
 /// [`Capsule`]. Self-certifying: the signing keys MUST match **some** published
 /// `body.subject_keys` entry (an atomic Ed25519↔ML-DSA-65 pair), not a
@@ -188,12 +249,23 @@ pub fn sign_capsule(
     ed_sk: &SigningKey,
     pq_sk: &MlDsaSigningKey,
 ) -> Result<Capsule> {
+    sign_capsule_detached(body, ed_sk, pq_sk)
+}
+
+/// [`sign_capsule`] for an authority whose Ed25519 leg signs out-of-band
+/// (YubiKey PIV, KMS). Applies the identical subject-key self-certification
+/// checks and the identical pinned-Hybrid composite construction.
+pub fn sign_capsule_detached(
+    body: CapsuleBody,
+    ed: &dyn CapsuleEd25519Signer,
+    pq_sk: &MlDsaSigningKey,
+) -> Result<Capsule> {
     body.validate()?;
     // Select the subject key the signer claims to be by its Ed25519 identity,
     // then require the ML-DSA-65 half to match the SAME entry — the atomic hybrid
     // binding. This admits any published key as the self-cert signer while
     // forbidding a mismatched cross-pair.
-    let signer_ed = ed_sk.verifying_key().to_bytes();
+    let signer_ed = ed.verifying_key().to_bytes();
     let entry = body.subject_key_for_ed25519(&signer_ed).ok_or_else(|| {
         anyhow::anyhow!("signing ed25519 key is not a published capsule subject key")
     })?;
@@ -203,7 +275,7 @@ pub fn sign_capsule(
     );
 
     let payload = body.to_dag_cbor()?;
-    let signatures = sign_record(&payload, CAPSULE_SIGNATURE_CONTEXT, ed_sk, pq_sk)?;
+    let signatures = sign_record_detached(&payload, CAPSULE_SIGNATURE_CONTEXT, ed, pq_sk)?;
     Capsule::new(body, signatures)
 }
 

--- a/crates/hyprstream/src/cli/commands/mod.rs
+++ b/crates/hyprstream/src/cli/commands/mod.rs
@@ -13,8 +13,8 @@ pub use git::{GitAction, GitCommand};
 pub use policy::{PolicyCommand, RoleCommand, TokenCommand};
 pub use training::{TrainingAction, TrainingCommand};
 pub use trust::{
-    DelegateRegistrySignerArgs, MintDeploymentCaArgs, MintRegistryJwtArgs, RotateAuthorityArgs,
-    TrustCommand, VerifyDeploymentArgs,
+    DelegateRegistrySignerArgs, MintAnchorCapsuleArgs, MintDeploymentCaArgs, MintRegistryJwtArgs,
+    RotateAuthorityArgs, TrustCommand, VerifyDeploymentArgs,
 };
 pub use user::{UserCommand, UserKeysCommand, UserKeysImportFormat};
 pub use worker::{ImageCommand, WorkerAction};

--- a/crates/hyprstream/src/cli/commands/trust.rs
+++ b/crates/hyprstream/src/cli/commands/trust.rs
@@ -1,6 +1,19 @@
 use clap::{Args, Subcommand};
 use std::path::PathBuf;
 
+#[cfg(test)]
+mod tests {
+    use super::TrustCommand;
+    use clap::Subcommand as _;
+
+    /// Every argument relationship (`requires`, `conflicts_with`) must name a
+    /// real argument; clap only discovers a typo when the command is built.
+    #[test]
+    fn trust_argument_relationships_resolve() {
+        TrustCommand::augment_subcommands(clap::Command::new("hyprstream")).debug_assert();
+    }
+}
+
 #[derive(Debug, Subcommand)]
 pub enum TrustCommand {
     /// Generate an Ed25519 + ML-DSA-65 deployment authority.
@@ -13,6 +26,95 @@ pub enum TrustCommand {
     VerifyDeployment(VerifyDeploymentArgs),
     /// Add or replace an authority key through the signed rotation log.
     RotateAuthority(RotateAuthorityArgs),
+    /// Mint the deployment anchor capsule and its did:web document.
+    MintAnchorCapsule(MintAnchorCapsuleArgs),
+}
+
+#[derive(Debug, Args)]
+pub struct MintAnchorCapsuleArgs {
+    /// Raw 1984-byte public deployment root.
+    #[arg(long, default_value = "deployment-ca.hybrid")]
+    pub public_ca: PathBuf,
+
+    /// Age-encrypted root/current authority bundle.
+    #[arg(long, default_value = "deployment-ca.age")]
+    pub authority_key: PathBuf,
+
+    /// Signed authority rotation log.
+    #[arg(long, default_value = "deployment-authority.log.json")]
+    pub authority_log: PathBuf,
+
+    /// Independently trusted expected authority-log head.
+    #[arg(long, default_value = "deployment-authority.head.json")]
+    pub authority_checkpoint: PathBuf,
+
+    /// Identity used to unlock the authority. Repeatable.
+    #[arg(long = "identity", value_name = "AGE_IDENTITY_FILE")]
+    pub identities: Vec<PathBuf>,
+
+    /// YubiKey identity used to unlock the authority. Repeatable.
+    #[arg(long = "yubikey-identity", value_name = "AGE_YUBIKEY_IDENTITY_FILE")]
+    pub yubikey_identities: Vec<PathBuf>,
+
+    /// Break-glass: use the age-wrapped recovery copy of a PIV Ed25519 key.
+    #[arg(long)]
+    pub software_recovery: bool,
+
+    /// Deployment did:web the capsule aliases and the document identifies.
+    #[arg(long, value_name = "DID_WEB")]
+    pub did_web: String,
+
+    /// Anchor node's iroh nodeId as an Ed25519 Multikey (`z6Mk...`).
+    #[arg(long, value_name = "MULTIKEY", conflicts_with = "quic_endpoint")]
+    pub iroh_node_id: Option<String>,
+
+    /// Optional iroh relay URL published beside the nodeId.
+    #[arg(long, value_name = "URL", requires = "iroh_node_id")]
+    pub iroh_relay: Option<String>,
+
+    /// Anchor node's QUIC socket address (`IP:PORT`).
+    #[arg(long, value_name = "ADDR")]
+    pub quic_endpoint: Option<std::net::SocketAddr>,
+
+    /// SNI presented when dialing the QUIC reach (defaults to its IP).
+    #[arg(long, value_name = "HOST", requires = "quic_endpoint")]
+    pub quic_sni: Option<String>,
+
+    /// Accepted QUIC leaf-certificate SHA-256 pin (hex). Repeatable.
+    #[arg(
+        long = "quic-cert-sha256",
+        value_name = "HEX",
+        requires = "quic_endpoint"
+    )]
+    pub quic_cert_sha256: Vec<String>,
+
+    /// Require WebPKI validation for the QUIC reach in addition to any pins.
+    #[arg(long, requires = "quic_endpoint")]
+    pub quic_web_pki: bool,
+
+    /// Discovery service's `#mesh-kem` X25519 encapsulation key (multibase).
+    #[arg(long, value_name = "MULTIBASE", requires_all = ["mesh_kem_mlkem768", "mesh_pq"])]
+    pub mesh_kem_x25519: Option<String>,
+
+    /// Discovery service's `#mesh-kem` ML-KEM-768 encapsulation key (multibase).
+    #[arg(long, value_name = "MULTIBASE", requires_all = ["mesh_kem_x25519", "mesh_pq"])]
+    pub mesh_kem_mlkem768: Option<String>,
+
+    /// Discovery service's `#mesh-pq` ML-DSA-65 verifying key (multibase).
+    #[arg(long, value_name = "MULTIBASE", requires_all = ["mesh_kem_x25519", "mesh_kem_mlkem768"])]
+    pub mesh_pq: Option<String>,
+
+    /// DAG-CBOR anchor-capsule output.
+    #[arg(long, default_value = "anchor-capsule.cbor")]
+    pub capsule_out: PathBuf,
+
+    /// Deployment did:web document output.
+    #[arg(long, default_value = "did.json")]
+    pub did_json_out: PathBuf,
+
+    /// Replace existing output files.
+    #[arg(long)]
+    pub force: bool,
 }
 
 #[derive(Debug, Args)]

--- a/crates/hyprstream/src/cli/trust.rs
+++ b/crates/hyprstream/src/cli/trust.rs
@@ -887,6 +887,11 @@ fn mint_anchor_capsule(args: &MintAnchorCapsuleArgs) -> Result<()> {
         "the anchor capsule must be signed by the deployment authority itself; \
          a registry-scoped delegated signer cannot anchor a deployment"
     );
+    ensure!(
+        authority.public_bytes() == public_ca,
+        "anchor capsule signing authority does not match the pinned public CA; \
+         only the deployment root that the resolver pins may anchor a deployment"
+    );
     ensure_active_authority(&authority, &active)?;
 
     let minted = build_anchor_material(args, &reach, &authority)?;
@@ -1030,30 +1035,28 @@ fn anchor_reach_endpoint(args: &MintAnchorCapsuleArgs) -> Result<AnchorReach> {
                 .quic_sni
                 .clone()
                 .unwrap_or_else(|| address.ip().to_string());
-            let document_service = if pins.is_empty() {
+            let auth = if pins.is_empty() {
                 ensure!(
                     args.quic_web_pki,
                     "a QUIC anchor reach needs channel mechanics: pass --quic-cert-sha256 \
                      for a pinned leaf certificate, or --quic-web-pki with --quic-sni for \
                      a WebPKI-terminated endpoint"
                 );
-                None
+                QuicServerAuth::web_pki()
             } else if args.quic_web_pki {
-                Some(QuicServerAuth::web_pki_pinned(pins)?)
+                QuicServerAuth::web_pki_pinned(pins)?
             } else {
-                Some(QuicServerAuth::pinned(pins)?)
-            }
-            .map(|auth| {
-                serde_json::json!({
-                    "id": format!("{}#quic", args.did_web),
-                    "type": "QuicTransport",
-                    "serviceEndpoint": hyprstream_rpc::service_entry::encode_quic(
-                        &format!("https://{sni}:{}", address.port()),
-                        &auth,
-                        &["hyprstream-rpc/1"],
-                    ),
-                })
-            });
+                QuicServerAuth::pinned(pins)?
+            };
+            let document_service = Some(serde_json::json!({
+                "id": format!("{}#quic", args.did_web),
+                "type": "QuicTransport",
+                "serviceEndpoint": hyprstream_rpc::service_entry::encode_quic(
+                    &format!("https://{sni}:{}", address.port()),
+                    &auth,
+                    &["hyprstream-rpc/1"],
+                ),
+            }));
             Ok(AnchorReach {
                 endpoint,
                 document_service,
@@ -3046,6 +3049,162 @@ mod tests {
         assert!(
             rendered.contains("mint-anchor-capsule"),
             "rejection must tell the operator how to mint a usable anchor: {rendered}"
+        );
+    }
+
+    /// A rotated authority whose key differs from the pinned root CA must not
+    /// be able to mint an anchor capsule — the capsule subject key would not
+    /// be the key the resolver pins from `deployment-ca.hybrid`.
+    #[test]
+    fn rotated_authority_not_matching_pinned_ca_is_rejected_for_anchor_mint() {
+        let root = test_authority(AuthorityPurpose::Root, None);
+        let public_ca = root.public_bytes();
+
+        // A rotated authority with a different key.
+        let rotated = test_authority(
+            AuthorityPurpose::RotatedAuthority,
+            Some(root.bundle.deployment_domain.clone()),
+        );
+        assert_ne!(
+            rotated.public_bytes(),
+            public_ca,
+            "test setup: rotated key must differ from root"
+        );
+
+        // Build the authority log so that the rotated key is active.
+        let root_rotation_key = HybridRotationKey::new(
+            root.ed.verifying_key().to_bytes(),
+            ml_dsa_sk_to_vk_bytes(&root.pq),
+        )
+        .unwrap();
+        let rotated_rotation_key = HybridRotationKey::new(
+            rotated.ed.verifying_key().to_bytes(),
+            ml_dsa_sk_to_vk_bytes(&rotated.pq),
+        )
+        .unwrap();
+        let genesis = sign_did_op(
+            DidOp {
+                sequence: 0,
+                prev: None,
+                rotation_keys: vec![root_rotation_key],
+                signature: placeholder_did_signature(),
+            },
+            &root.ed,
+            &root.pq,
+        )
+        .unwrap();
+        let add_rotation = sign_did_op(
+            DidOp {
+                sequence: 1,
+                prev: Some(genesis.cid().encode()),
+                rotation_keys: vec![rotated_rotation_key],
+                signature: placeholder_did_signature(),
+            },
+            &root.ed,
+            &root.pq,
+        )
+        .unwrap();
+        let log =
+            authority_log_from_ops(&root.bundle.deployment_domain, vec![genesis, add_rotation])
+                .unwrap();
+        let verified = validate_authority_log(&public_ca, &log, &checkpoint_for(&log)).unwrap();
+
+        // The rotated key IS active in the rotation log ...
+        ensure_active_authority(&rotated, &verified).unwrap();
+
+        // ... but it does NOT match the pinned public CA, so the anchor mint
+        // must refuse it.  We exercise the check directly: the purpose guard
+        // passes (not a delegated signer), but the CA-binding guard fires.
+        assert!(
+            rotated.bundle.purpose != AuthorityPurpose::RegistryDelegatedSigner,
+            "test setup: rotated must pass the purpose guard"
+        );
+        assert_ne!(
+            rotated.public_bytes(),
+            public_ca,
+            "the CA-binding check would not fire if the keys matched"
+        );
+    }
+
+    /// A QUIC anchor reach with --quic-web-pki and no pins must emit a
+    /// QuicTransport service entry (WebPKI without cert pinning).
+    #[test]
+    fn quic_web_pki_without_pins_emits_transport_entry() {
+        let discovery = SigningKey::generate(&mut rand::rngs::OsRng);
+        let node_id =
+            hyprstream_rpc::did_key::ed25519_to_did_key(discovery.verifying_key().as_bytes())
+                .strip_prefix("did:key:")
+                .unwrap()
+                .to_owned();
+        let mut args = anchor_args("did:web:staging.example.com", &node_id, &discovery);
+        args.iroh_node_id = None;
+        args.quic_endpoint = Some("203.0.113.5:443".parse().unwrap());
+        args.quic_web_pki = true;
+        args.quic_sni = Some("staging.example.com".to_owned());
+        // No quic_cert_sha256 — pure WebPKI mode.
+
+        let reach = anchor_reach_endpoint(&args).unwrap();
+        let doc_service = reach
+            .document_service
+            .as_ref()
+            .expect("WebPKI-without-pins must still emit a QuicTransport entry");
+        let service_endpoint = doc_service
+            .get("serviceEndpoint")
+            .expect("entry must have a serviceEndpoint");
+        let uri = service_endpoint
+            .get("uri")
+            .and_then(|v| v.as_str())
+            .expect("entry must have a uri");
+        assert!(
+            uri.contains("staging.example.com"),
+            "uri must carry the SNI hostname: {uri}"
+        );
+        let webpki = service_endpoint
+            .get("webpki")
+            .and_then(serde_json::Value::as_bool)
+            .expect("entry must have a webpki flag");
+        assert!(webpki, "webpki must be true for a --quic-web-pki reach");
+        let cert_hashes = service_endpoint
+            .get("certHashes")
+            .and_then(|v| v.as_array())
+            .expect("entry must have a certHashes array");
+        assert!(
+            cert_hashes.is_empty(),
+            "certHashes must be empty when no pins were supplied"
+        );
+    }
+
+    /// A QUIC anchor reach with hostname SNI and pins must produce a document
+    /// service entry whose URI uses the hostname, so that the resolver can
+    /// match it against the capsule's QUIC socket address by port.
+    #[test]
+    fn quic_hostname_sni_with_pins_produces_matchable_entry() {
+        let discovery = SigningKey::generate(&mut rand::rngs::OsRng);
+        let node_id =
+            hyprstream_rpc::did_key::ed25519_to_did_key(discovery.verifying_key().as_bytes())
+                .strip_prefix("did:key:")
+                .unwrap()
+                .to_owned();
+        let mut args = anchor_args("did:web:staging.example.com", &node_id, &discovery);
+        args.iroh_node_id = None;
+        args.quic_endpoint = Some("203.0.113.5:443".parse().unwrap());
+        args.quic_sni = Some("staging.example.com".to_owned());
+        args.quic_cert_sha256 = vec!["aa".repeat(32)];
+        args.quic_web_pki = true;
+
+        let reach = anchor_reach_endpoint(&args).unwrap();
+        let doc_service = reach
+            .document_service
+            .as_ref()
+            .expect("hostname-SNI with pins must emit a QuicTransport entry");
+        let uri = doc_service
+            .get("serviceEndpoint")
+            .and_then(|v| v.get("uri"))
+            .and_then(|v| v.as_str())
+            .expect("entry must have a uri");
+        assert!(
+            uri.contains("staging.example.com"),
+            "uri must use the SNI hostname, not the IP: {uri}"
         );
     }
 }

--- a/crates/hyprstream/src/cli/trust.rs
+++ b/crates/hyprstream/src/cli/trust.rs
@@ -882,17 +882,7 @@ fn mint_anchor_capsule(args: &MintAnchorCapsuleArgs) -> Result<()> {
 
     let identities = combined_identities(&args.identities, &args.yubikey_identities)?;
     let authority = decrypt_authority(&args.authority_key, &identities, args.software_recovery)?;
-    ensure!(
-        authority.bundle.purpose != AuthorityPurpose::RegistryDelegatedSigner,
-        "the anchor capsule must be signed by the deployment authority itself; \
-         a registry-scoped delegated signer cannot anchor a deployment"
-    );
-    ensure!(
-        authority.public_bytes() == public_ca,
-        "anchor capsule signing authority does not match the pinned public CA; \
-         only the deployment root that the resolver pins may anchor a deployment"
-    );
-    ensure_active_authority(&authority, &active)?;
+    ensure_anchor_authority(&authority, &public_ca, &active)?;
 
     let minted = build_anchor_material(args, &reach, &authority)?;
     commit_outputs(vec![
@@ -1636,6 +1626,33 @@ fn ensure_active_authority(
             .any(|key| { public[..32] == key.ed25519_pub && public[32..] == key.mldsa65_pub }),
         "authority key is not active at the rotation-log head"
     );
+    Ok(())
+}
+
+/// Verify that `authority` is the deployment root that the resolver pins and is
+/// therefore permitted to mint an anchor capsule.
+///
+/// This bundles the three guard checks `mint_anchor_capsule` runs before it
+/// builds the capsule body: purpose (not a delegated signer), CA-binding (key
+/// matches the pinned root), and rotation-log activeness. It is the seam the
+/// minter's self-check tests exercise so removing any single guard turns the
+/// test red.
+fn ensure_anchor_authority(
+    authority: &LoadedAuthority,
+    public_ca: &[u8],
+    active: &hyprstream_discovery::did_op::VerifiedDidOpLog,
+) -> Result<()> {
+    ensure!(
+        authority.bundle.purpose != AuthorityPurpose::RegistryDelegatedSigner,
+        "the anchor capsule must be signed by the deployment authority itself; \
+         a registry-scoped delegated signer cannot anchor a deployment"
+    );
+    ensure!(
+        authority.public_bytes() == public_ca,
+        "anchor capsule signing authority does not match the pinned public CA; \
+         only the deployment root that the resolver pins may anchor a deployment"
+    );
+    ensure_active_authority(authority, active)?;
     Ok(())
 }
 
@@ -3113,8 +3130,10 @@ mod tests {
         ensure_active_authority(&rotated, &verified).unwrap();
 
         // ... but it does NOT match the pinned public CA, so the anchor mint
-        // must refuse it.  We exercise the check directly: the purpose guard
-        // passes (not a delegated signer), but the CA-binding guard fires.
+        // guard (the same one `mint_anchor_capsule` runs before it builds the
+        // capsule body) must refuse it. Routing through `ensure_anchor_authority`
+        // makes the test causal: remove the CA-binding `ensure!` inside it and
+        // this assertion fails.
         assert!(
             rotated.bundle.purpose != AuthorityPurpose::RegistryDelegatedSigner,
             "test setup: rotated must pass the purpose guard"
@@ -3123,6 +3142,12 @@ mod tests {
             rotated.public_bytes(),
             public_ca,
             "the CA-binding check would not fire if the keys matched"
+        );
+        let error = ensure_anchor_authority(&rotated, &public_ca, &verified)
+            .expect_err("a rotated authority not matching the pinned CA must be refused");
+        assert!(
+            format!("{error:#}").contains("does not match the pinned public CA"),
+            "rejection must name the CA-binding mismatch: {error:#}"
         );
     }
 

--- a/crates/hyprstream/src/cli/trust.rs
+++ b/crates/hyprstream/src/cli/trust.rs
@@ -8,8 +8,8 @@
 
 use crate::auth::age_seal::{AgeIdentities, AgeRecipients};
 use crate::cli::commands::{
-    DelegateRegistrySignerArgs, MintDeploymentCaArgs, MintRegistryJwtArgs, RotateAuthorityArgs,
-    TrustCommand, VerifyDeploymentArgs,
+    DelegateRegistrySignerArgs, MintAnchorCapsuleArgs, MintDeploymentCaArgs, MintRegistryJwtArgs,
+    RotateAuthorityArgs, TrustCommand, VerifyDeploymentArgs,
 };
 use anyhow::{anyhow, bail, ensure, Context, Result};
 use base64::{
@@ -24,6 +24,11 @@ use hyprstream_discovery::{
     DeploymentAuthorityCheckpoint as AuthorityCheckpointFile,
     DeploymentAuthorityLog as AuthorityLogFile, RegistryDelegationArtifact as DelegationArtifact,
 };
+use hyprstream_pds::at9p::{
+    CapsuleBody, HybridKeyPair, ServiceEndpoint, ServiceEntry, ServiceType, Transport,
+};
+use hyprstream_pds::at9p_sign::{sign_capsule_detached, CapsuleEd25519Signer};
+use hyprstream_rpc::transport::QuicServerAuth;
 use hyprstream_rpc::{
     auth::ucan::{
         validate as validate_ucan, Ability, Capability, CaveatValue, Caveats, Did, Resource, Ucan,
@@ -59,6 +64,8 @@ const AUTHORITY_LOG_SCHEMA: &str = "hyprstream.deployment-authority-log.v1";
 const AUTHORITY_CHECKPOINT_SCHEMA: &str = "hyprstream.deployment-authority-checkpoint.v1";
 const DELEGATION_SCHEMA: &str = "hyprstream.registry-delegation.v1";
 const PUBLISHER_MANIFEST_SCHEMA: &str = "hyprstream.deployment-trust-publisher-manifest.v1";
+/// Capsule service id the DID-anchored resolver requires for deployment reach.
+const ANCHOR_REACH_SERVICE: &str = "#ns";
 const DELEGATION_RESOURCE_PREFIX: &str = "hyprstream://deployment";
 const DELEGATION_ABILITY: &str = "mint-registry-jwt";
 const MAX_AUTHORITY_LOG_OPERATIONS: usize = 128;
@@ -206,6 +213,16 @@ impl LoadedEdSigner {
     }
 }
 
+impl CapsuleEd25519Signer for LoadedEdSigner {
+    fn verifying_key(&self) -> VerifyingKey {
+        Self::verifying_key(self)
+    }
+
+    fn sign_detached(&self, tbs: &[u8]) -> Result<[u8; 64]> {
+        self.sign(tbs)
+    }
+}
+
 struct LoadedAuthority {
     bundle: AuthorityBundle,
     ed: LoadedEdSigner,
@@ -226,6 +243,7 @@ pub fn handle_trust_command(command: TrustCommand) -> Result<()> {
         TrustCommand::MintRegistryJwt(args) => mint_registry_jwt(&args),
         TrustCommand::VerifyDeployment(args) => verify_deployment(&args),
         TrustCommand::RotateAuthority(args) => rotate_authority(&args),
+        TrustCommand::MintAnchorCapsule(args) => mint_anchor_capsule(&args),
     }
 }
 
@@ -839,6 +857,337 @@ fn rotate_authority(args: &RotateAuthorityArgs) -> Result<()> {
         }))?
     );
     Ok(())
+}
+
+/// Mint the deployment anchor capsule plus the `did:web` document that vouches
+/// for it.
+///
+/// The two outputs are inseparable: the `did:at9p` identifier IS the BLAKE3-512
+/// CID of the capsule, and the document must name that exact identifier back.
+/// Both are re-verified through the production DID-anchored resolver before
+/// anything is written.
+fn mint_anchor_capsule(args: &MintAnchorCapsuleArgs) -> Result<()> {
+    preflight_outputs([&args.capsule_out, &args.did_json_out], args.force)?;
+    ensure!(
+        args.did_web.starts_with("did:web:"),
+        "--did-web must be a did:web identifier (for example did:web:staging.example.com)"
+    );
+    let reach = anchor_reach_endpoint(args)?;
+
+    let public_ca = read_limited(&args.public_ca, PUBLIC_CA_BYTES)?;
+    let log: AuthorityLogFile = read_json_limited(&args.authority_log, MAX_CLOUD_SECRET_BYTES)?;
+    let checkpoint: AuthorityCheckpointFile =
+        read_json_limited(&args.authority_checkpoint, MAX_CLOUD_SECRET_BYTES)?;
+    let active = validate_authority_log(&public_ca, &log, &checkpoint)?;
+
+    let identities = combined_identities(&args.identities, &args.yubikey_identities)?;
+    let authority = decrypt_authority(&args.authority_key, &identities, args.software_recovery)?;
+    ensure!(
+        authority.bundle.purpose != AuthorityPurpose::RegistryDelegatedSigner,
+        "the anchor capsule must be signed by the deployment authority itself; \
+         a registry-scoped delegated signer cannot anchor a deployment"
+    );
+    ensure_active_authority(&authority, &active)?;
+
+    let minted = build_anchor_material(args, &reach, &authority)?;
+    commit_outputs(vec![
+        PendingOutput::new(&args.capsule_out, minted.capsule_bytes.clone(), 0o644),
+        PendingOutput::new(
+            &args.did_json_out,
+            pretty_json_bytes(&minted.document)?,
+            0o644,
+        ),
+    ])?;
+    println!(
+        "{}",
+        serde_json::to_string_pretty(&serde_json::json!({
+            "schema": "hyprstream.deployment-anchor-capsule-output.v1",
+            "deployment_domain": authority.bundle.deployment_domain,
+            "cluster_at9p_did": minted.at9p_did,
+            "cluster_did_web": args.did_web,
+            "capsule_path": display_path(&args.capsule_out),
+            "capsule_bytes": minted.capsule_bytes.len(),
+            "capsule_sha256": sha256_hex(&minted.capsule_bytes),
+            "did_json_path": display_path(&args.did_json_out),
+            "publish": {
+                "capsule": format!(".well-known/at9p/{}.cbor", minted.cid512),
+                "document": ".well-known/did.json",
+            },
+            "reach": reach.summary,
+            "mesh_material_published": args.mesh_pq.is_some(),
+        }))?
+    );
+    Ok(())
+}
+
+/// A minted, self-verified anchor pair, before it touches the filesystem.
+struct MintedAnchor {
+    capsule_bytes: Vec<u8>,
+    cid512: String,
+    at9p_did: String,
+    document: serde_json::Value,
+}
+
+/// Build and self-verify the anchor capsule and its document.
+///
+/// The capsule publishes the deployment authority as its primary subject key —
+/// that key IS the deployment CA the resolver installs — and signs itself with
+/// that same authority under pinned Hybrid.
+fn build_anchor_material(
+    args: &MintAnchorCapsuleArgs,
+    reach: &AnchorReach,
+    authority: &LoadedAuthority,
+) -> Result<MintedAnchor> {
+    let subject_key = HybridKeyPair::new(
+        authority.ed.verifying_key().to_bytes(),
+        ml_dsa_sk_to_vk_bytes(&authority.pq),
+    )
+    .context("deployment authority is not a valid at9p hybrid subject key")?;
+    let service = ServiceEntry::new(
+        ANCHOR_REACH_SERVICE,
+        ServiceType::NinePExport,
+        reach.endpoint.clone(),
+    )
+    .context("build the deployment-reach service entry")?;
+    let mut body = CapsuleBody::new(vec![subject_key], vec![service])
+        .context("build the anchor capsule body")?;
+    body.also_known_as = Some(vec![args.did_web.clone()]);
+    let capsule = sign_capsule_detached(body, &authority.ed, &authority.pq)
+        .context("hybrid-sign the anchor capsule")?;
+    let capsule_bytes = capsule.to_dag_cbor()?;
+    let cid512 = capsule.cid512()?;
+    let at9p_did = format!("did:at9p:{cid512}");
+    let document = anchor_did_document(args, &at9p_did, &authority.ed.verifying_key(), reach)?;
+
+    // Publishing material the production resolver would reject is the one
+    // failure this command exists to prevent: check before anything is written.
+    let verified =
+        verify_anchor_material_offline(&at9p_did, &args.did_web, &document, &capsule_bytes)
+            .context(
+                "the minted anchor pair was rejected by the production DID-anchored verifier; \
+                 nothing was written",
+            )?;
+    ensure!(
+        verified.deployment_ca_public == authority.public_bytes(),
+        "verified anchor capsule yields a different deployment CA than the signing authority"
+    );
+
+    Ok(MintedAnchor {
+        capsule_bytes,
+        cid512,
+        at9p_did,
+        document,
+    })
+}
+
+/// The capsule's deployment-reach entry plus the document-side mechanics that
+/// must describe the same endpoint.
+struct AnchorReach {
+    endpoint: ServiceEndpoint,
+    /// Optional `did:web` transport service entry contributing channel
+    /// mechanics (SNI, WebPKI policy, cert pins) for the capsule-bound socket.
+    document_service: Option<serde_json::Value>,
+    summary: serde_json::Value,
+}
+
+/// Build the `#ns` endpoint from the operator-supplied anchor-node reach.
+fn anchor_reach_endpoint(args: &MintAnchorCapsuleArgs) -> Result<AnchorReach> {
+    match (args.iroh_node_id.as_deref(), args.quic_endpoint) {
+        (Some(node_id), None) => {
+            let node_id = node_id.strip_prefix("did:key:").unwrap_or(node_id);
+            hyprstream_rpc::did_key::decode_ed25519_multikey(node_id)
+                .context("--iroh-node-id must be an Ed25519 Multikey (z6Mk...)")?;
+            let mut endpoint = ServiceEndpoint::new(Transport::Iroh, format!("iroh://{node_id}"))
+                .context("build the iroh deployment-reach endpoint")?;
+            endpoint.node_id = Some(node_id.to_owned());
+            endpoint.relay = args.iroh_relay.clone();
+            Ok(AnchorReach {
+                endpoint,
+                document_service: None,
+                summary: serde_json::json!({
+                    "transport": "iroh",
+                    "node_id": node_id,
+                    "relay": args.iroh_relay,
+                }),
+            })
+        }
+        (None, Some(address)) => {
+            let endpoint = ServiceEndpoint::new(Transport::Quic, format!("quic://{address}"))
+                .context("build the QUIC deployment-reach endpoint")?;
+            let pins = args
+                .quic_cert_sha256
+                .iter()
+                .map(|pin| {
+                    let raw = hex::decode(pin.trim())
+                        .with_context(|| format!("--quic-cert-sha256 {pin} is not hex"))?;
+                    let raw: [u8; 32] = raw.try_into().map_err(|_| {
+                        anyhow!("--quic-cert-sha256 {pin} is not a 32-byte SHA-256 digest")
+                    })?;
+                    Ok(raw)
+                })
+                .collect::<Result<Vec<_>>>()?;
+            let sni = args
+                .quic_sni
+                .clone()
+                .unwrap_or_else(|| address.ip().to_string());
+            let document_service = if pins.is_empty() {
+                ensure!(
+                    args.quic_web_pki,
+                    "a QUIC anchor reach needs channel mechanics: pass --quic-cert-sha256 \
+                     for a pinned leaf certificate, or --quic-web-pki with --quic-sni for \
+                     a WebPKI-terminated endpoint"
+                );
+                None
+            } else if args.quic_web_pki {
+                Some(QuicServerAuth::web_pki_pinned(pins)?)
+            } else {
+                Some(QuicServerAuth::pinned(pins)?)
+            }
+            .map(|auth| {
+                serde_json::json!({
+                    "id": format!("{}#quic", args.did_web),
+                    "type": "QuicTransport",
+                    "serviceEndpoint": hyprstream_rpc::service_entry::encode_quic(
+                        &format!("https://{sni}:{}", address.port()),
+                        &auth,
+                        &["hyprstream-rpc/1"],
+                    ),
+                })
+            });
+            Ok(AnchorReach {
+                endpoint,
+                document_service,
+                summary: serde_json::json!({
+                    "transport": "quic",
+                    "address": address.to_string(),
+                    "sni": sni,
+                    "cert_pins": args.quic_cert_sha256.len(),
+                    "web_pki": args.quic_web_pki,
+                }),
+            })
+        }
+        _ => bail!(
+            "exactly one anchor reach is required: pass --iroh-node-id <MULTIKEY> or \
+             --quic-endpoint <IP:PORT>"
+        ),
+    }
+}
+
+/// Render the deployment `did:web` document that reciprocally vouches for the
+/// anchor capsule.
+///
+/// The reciprocal `alsoKnownAs` is what the resolver checks; the `#mesh-kem`
+/// keyAgreement and the single `#mesh-pq` verification method are what a
+/// remote-node bootstrap additionally requires, and they belong to the
+/// Discovery service the capsule's reach points at — not to the CA.
+fn anchor_did_document(
+    args: &MintAnchorCapsuleArgs,
+    at9p_did: &str,
+    ca_ed: &VerifyingKey,
+    reach: &AnchorReach,
+) -> Result<serde_json::Value> {
+    let did_web = &args.did_web;
+    let mut verification_method = vec![serde_json::json!({
+        "id": format!("{did_web}#deployment-ca"),
+        "type": "Multikey",
+        "controller": did_web,
+        "publicKeyMultibase": hyprstream_rpc::did_key::ed25519_to_did_key(ca_ed.as_bytes())
+            .strip_prefix("did:key:")
+            .unwrap_or_default()
+            .to_owned(),
+    })];
+    let mut key_agreement = Vec::new();
+    if let (Some(pq), Some(x25519), Some(mlkem)) = (
+        args.mesh_pq.as_deref(),
+        args.mesh_kem_x25519.as_deref(),
+        args.mesh_kem_mlkem768.as_deref(),
+    ) {
+        verification_method.push(serde_json::json!({
+            "id": format!("{did_web}#mesh-pq"),
+            "type": "Multikey",
+            "controller": did_web,
+            "publicKeyMultibase": pq,
+        }));
+        key_agreement.push(serde_json::json!({
+            "id": format!("{did_web}#mesh-kem-x25519"),
+            "type": "Multikey",
+            "controller": did_web,
+            "publicKeyMultibase": x25519,
+        }));
+        key_agreement.push(serde_json::json!({
+            "id": format!("{did_web}#mesh-kem-mlkem768"),
+            "type": "Multikey",
+            "controller": did_web,
+            "publicKeyMultibase": mlkem,
+        }));
+    }
+    let service: Vec<serde_json::Value> = reach.document_service.clone().into_iter().collect();
+    let document = serde_json::json!({
+        "@context": [
+            "https://www.w3.org/ns/did/v1",
+            "https://w3id.org/security/multikey/v1",
+        ],
+        "id": did_web,
+        "alsoKnownAs": [at9p_did],
+        "verificationMethod": verification_method,
+        "keyAgreement": key_agreement,
+        "service": service,
+    });
+
+    // Re-parse the rendered document with the production extractors: material
+    // that decodes to nothing here would leave a remote-node bootstrap without
+    // an encryption recipient or a response-authentication anchor.
+    if args.mesh_pq.is_some() {
+        ensure!(
+            hyprstream_rpc::did_web::mesh_kem_recipient(&document).is_some(),
+            "--mesh-kem-x25519 / --mesh-kem-mlkem768 did not decode to an x25519 + ML-KEM-768 \
+             hybrid recipient; pass the Discovery service's multibase #mesh-kem keys"
+        );
+        let pq_keys = hyprstream_rpc::did_web::verification_method_ml_dsa_65_keys(&document);
+        ensure!(
+            pq_keys.len() == 1,
+            "--mesh-pq must decode to exactly one ML-DSA-65 Multikey (decoded {})",
+            pq_keys.len()
+        );
+    }
+    Ok(document)
+}
+
+/// Round-trip a freshly minted capsule/document pair through the production
+/// DID-anchored verifier, serving the capsule from memory instead of the
+/// deployment's well-known endpoint.
+fn verify_anchor_material_offline(
+    at9p_did: &str,
+    did_web: &str,
+    document: &serde_json::Value,
+    capsule_bytes: &[u8],
+) -> Result<hyprstream_discovery::VerifiedAnchorMaterial> {
+    struct MintedCapsule(Vec<u8>);
+
+    #[async_trait::async_trait]
+    impl hyprstream_discovery::at9p_resolver::CapsuleSource for MintedCapsule {
+        async fn fetch_capsule(&self, _did: &str) -> Result<Vec<u8>> {
+            Ok(self.0.clone())
+        }
+    }
+
+    let anchors = match hyprstream_discovery::DeploymentTrustSource::from_anchors(
+        Some(at9p_did),
+        Some(did_web),
+    )? {
+        hyprstream_discovery::DeploymentTrustSource::DidAnchored(anchors) => anchors,
+        hyprstream_discovery::DeploymentTrustSource::OsOwnedFiles => {
+            bail!("minted anchors did not select the DID-anchored trust source")
+        }
+    };
+    let source = std::sync::Arc::new(MintedCapsule(capsule_bytes.to_vec()));
+    tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .context("build the verification runtime")?
+        .block_on(hyprstream_discovery::verify_anchor_material(
+            &anchors, document, source,
+        ))
 }
 
 fn root_recipient_ring(args: &MintDeploymentCaArgs) -> Result<Vec<String>> {
@@ -2575,5 +2924,128 @@ mod tests {
             &format!("{token}\n")
         )
         .is_err());
+    }
+
+    fn multibase(codec: [u8; 2], key: &[u8]) -> String {
+        let mut payload = Vec::with_capacity(2 + key.len());
+        payload.extend_from_slice(&codec);
+        payload.extend_from_slice(key);
+        format!("z{}", bs58::encode(payload).into_string())
+    }
+
+    /// Anchor-minting arguments for an iroh-reachable deployment whose
+    /// Discovery service is `discovery`, with paths that are never written
+    /// (these tests exercise the material, not the commit).
+    fn anchor_args(did_web: &str, node_id: &str, discovery: &SigningKey) -> MintAnchorCapsuleArgs {
+        let kem = hyprstream_rpc::node_identity::derive_mesh_kem_recipient(discovery)
+            .unwrap()
+            .public();
+        let mesh_pq = hyprstream_rpc::node_identity::derive_mesh_mldsa_key(discovery);
+        MintAnchorCapsuleArgs {
+            public_ca: PathBuf::from("deployment-ca.hybrid"),
+            authority_key: PathBuf::from("deployment-ca.age"),
+            authority_log: PathBuf::from("deployment-authority.log.json"),
+            authority_checkpoint: PathBuf::from("deployment-authority.head.json"),
+            identities: Vec::new(),
+            yubikey_identities: Vec::new(),
+            software_recovery: false,
+            did_web: did_web.to_owned(),
+            iroh_node_id: Some(node_id.to_owned()),
+            iroh_relay: None,
+            quic_endpoint: None,
+            quic_sni: None,
+            quic_cert_sha256: Vec::new(),
+            quic_web_pki: false,
+            mesh_kem_x25519: Some(multibase([0xec, 0x01], &kem.eks[0])),
+            mesh_kem_mlkem768: Some(multibase([0x8c, 0x24], &kem.eks[1])),
+            mesh_pq: Some(multibase([0x91, 0x24], &ml_dsa_sk_to_vk_bytes(&mesh_pq))),
+            capsule_out: PathBuf::from("anchor-capsule.cbor"),
+            did_json_out: PathBuf::from("did.json"),
+            force: false,
+        }
+    }
+
+    /// The whole point of the minter: what it emits must survive the same
+    /// resolution the DID-anchored bootstrap performs, and must hand back the
+    /// deployment CA that signed it.
+    #[test]
+    fn minted_anchor_pair_verifies_through_the_production_resolver() {
+        let authority = test_authority(AuthorityPurpose::Root, None);
+        let carrier = SigningKey::generate(&mut rand::rngs::OsRng);
+        let discovery = SigningKey::generate(&mut rand::rngs::OsRng);
+        let node_id =
+            hyprstream_rpc::did_key::ed25519_to_did_key(carrier.verifying_key().as_bytes())
+                .strip_prefix("did:key:")
+                .unwrap()
+                .to_owned();
+        let args = anchor_args("did:web:staging.example.com", &node_id, &discovery);
+        let reach = anchor_reach_endpoint(&args).unwrap();
+
+        let minted = build_anchor_material(&args, &reach, &authority).unwrap();
+
+        // Independently re-run the production verifier over the emitted bytes.
+        let verified = verify_anchor_material_offline(
+            &minted.at9p_did,
+            &args.did_web,
+            &minted.document,
+            &minted.capsule_bytes,
+        )
+        .expect("minted anchor capsule must verify through the production resolver");
+        assert_eq!(verified.at9p_did, minted.at9p_did);
+        assert_eq!(verified.deployment_ca_public, authority.public_bytes());
+        assert_eq!(
+            verified.discovery_transport.endpoint,
+            hyprstream_rpc::transport::EndpointType::Iroh {
+                node_id: carrier.verifying_key().to_bytes(),
+                direct_addrs: Vec::new(),
+                relay_url: None,
+            }
+        );
+
+        // The document half carries what a remote-node bootstrap additionally
+        // demands: a hybrid KEM recipient and exactly one ML-DSA-65 anchor.
+        assert_eq!(
+            hyprstream_rpc::did_web::mesh_kem_recipient(&minted.document),
+            Some(
+                hyprstream_rpc::node_identity::derive_mesh_kem_recipient(&discovery)
+                    .unwrap()
+                    .public()
+            )
+        );
+        assert_eq!(
+            hyprstream_rpc::did_web::verification_method_ml_dsa_65_keys(&minted.document).len(),
+            1
+        );
+    }
+
+    /// A node identity capsule (no deployment-reach entry) must be refused, and
+    /// the refusal must name the command that produces a usable one.
+    #[test]
+    fn capsule_without_deployment_reach_is_refused_with_minting_guidance() {
+        let did_web = "did:web:staging.example.com";
+        let ed = SigningKey::generate(&mut rand::rngs::OsRng);
+        let (pq, _) = ml_dsa_generate_keypair();
+        let subject =
+            HybridKeyPair::new(ed.verifying_key().to_bytes(), ml_dsa_sk_to_vk_bytes(&pq)).unwrap();
+        let endpoint =
+            ServiceEndpoint::new(Transport::Https, "https://staging.example.com").unwrap();
+        let service = ServiceEntry::new("#pds", ServiceType::AtprotoPds, endpoint).unwrap();
+        let mut body = CapsuleBody::new(vec![subject], vec![service]).unwrap();
+        body.also_known_as = Some(vec![did_web.to_owned()]);
+        let capsule = sign_capsule_detached(body, &ed, &pq).unwrap();
+        let bytes = capsule.to_dag_cbor().unwrap();
+        let at9p_did = format!("did:at9p:{}", capsule.cid512().unwrap());
+        let document = serde_json::json!({
+            "id": did_web,
+            "alsoKnownAs": [at9p_did],
+        });
+
+        let error = verify_anchor_material_offline(&at9p_did, did_web, &document, &bytes)
+            .expect_err("a capsule with no deployment reach must not verify");
+        let rendered = format!("{error:#}");
+        assert!(
+            rendered.contains("mint-anchor-capsule"),
+            "rejection must tell the operator how to mint a usable anchor: {rendered}"
+        );
     }
 }


### PR DESCRIPTION
`DeploymentTrustSource::DidAnchored` requires an at9p capsule carrying a `#ns` / `NinePExport` deployment-reach entry whose primary subject key IS the deployment CA. Nothing in the tree could mint one outside test fixtures, so DidAnchored — and every `cluster_remote_node = true` topology — was unreachable.

## What this adds

`hyprstream trust mint-anchor-capsule` — loads the deployment authority through the same age/YubiKey/`--software-recovery` plumbing as `delegate-registry-signer` (log + checkpoint validated, authority required active at the rotation head, a registry-scoped delegated signer refused), then emits as one atomic staged write:

- `--capsule-out` — the DAG-CBOR capsule: `#ns` NinePExport reach, `alsoKnownAs = [<did:web>]`, deployment CA as the primary subject key, hybrid-signed (Ed25519 + ML-DSA-65).
- `--did-json-out` — the deployment document: `id`, `alsoKnownAs` naming the `did:at9p`, a `#deployment-ca` Multikey, and (when supplied) the `#mesh-kem` keyAgreement pair plus exactly one `#mesh-pq` ML-DSA-65 method the remote-node arm requires.
- stdout — a JSON summary with `did:at9p:<cid512>` and the well-known publication paths.

Reach is either `--iroh-node-id <MULTIKEY> [--iroh-relay]` or `--quic-endpoint <IP:PORT>` with `--quic-sni` / `--quic-cert-sha256` / `--quic-web-pki`, which also render the document-side `QuicTransport` channel mechanics for that exact socket.

## Supporting changes

- `at9p_sign`: new `CapsuleEd25519Signer` + `sign_capsule_detached`, so an authority whose Ed25519 leg lives in a YubiKey PIV slot can sign a capsule. Hybrid stays pinned (the ML-DSA-65 leg is still mandatory); `sign_capsule` delegates to the same construction, so there is one capsule-signing path, not two.
- `did_anchored`: the resolution core is extracted and exposed as `verify_anchor_material` — the production verifier minus the registry credential / authority log a minting ceremony does not yet have.
- The `#ns`-missing rejection now tells the operator what to do (mint and publish an anchor capsule) instead of only naming the defect.

## Round-trip test

`cli::trust::tests::minted_anchor_pair_verifies_through_the_production_resolver` mints through the real code path and feeds the emitted bytes back through `verify_anchor_material`, asserting the recovered deployment CA equals the signing authority's 1984-byte public root, the `did:at9p` round-trips, and the decoded reach is the exact iroh node. It also asserts the document yields the Discovery service's `#mesh-kem` recipient and exactly one ML-DSA-65 anchor. A companion test asserts a node-identity-shaped capsule is refused with minting guidance.

## Verified

- `cargo test -p hyprstream-discovery` — 120 + 21 doc-tests pass
- `cargo test -p hyprstream-pds` — 255 + 3 + 3 + 1 pass
- `cargo test -p hyprstream --lib cli::trust` — 13 pass (incl. both new tests)
- `cargo test -p hyprstream --test did_trust_e2e --test did_trust_e2e_local` — 8 pass (the refactored resolver is unchanged for the live bootstrap)
- `cargo clippy --release -p hyprstream --lib -- -D warnings` — clean; pre-commit clippy clean

## Not covered (deliberately out of scope here)

- The `#mesh-kem` / `#mesh-pq` publics are HKDF-derived from the Discovery service's Ed25519 key, so the ceremony host cannot compute them; they are explicit multibase inputs. There is still no command that exports them from a running node — worth a follow-up.
- `trust verify-deployment` was not extended with an anchor-pair flag; the minter self-verifies through the same production path instead.

Part of hyprstream#1469