### PR TITLE
feat(auth): hybrid Ed25519+ML-DSA-65 bootstrap-pubkeys entries

### DIFF
--- a/crates/hyprstream/src/auth/identity_store.rs
+++ b/crates/hyprstream/src/auth/identity_store.rs
@@ -414,57 +414,234 @@ pub fn write_service_jwt(
 ///
 /// Wire format (see `docs/bootstrap-pubkeys-format.md`): a flat JSON object
 /// `{ "<service>": "<base64>" }`, base64 using the URL-safe-no-pad alphabet
-/// (RFC 4648 §5, no `+`/`/`/`=`), decoding to exactly 32 raw Ed25519 bytes.
+/// (RFC 4648 §5, no `+`/`/`/`=`). Each value decodes either to 32 raw Ed25519
+/// bytes (classical entry) or to 1984 bytes — 32 Ed25519 followed by 1952
+/// ML-DSA-65 — for a hybrid entry, the same concatenation the deployment CA
+/// root uses.
+///
+/// This projection returns only the Ed25519 anchor of each entry, so callers
+/// that predate hybrid entries keep working unchanged. Callers that need the
+/// bound post-quantum key use [`load_bootstrap_pubkeys_hybrid`].
 pub fn load_bootstrap_pubkeys(
     credentials_dir: &std::path::Path,
 ) -> Result<std::collections::HashMap<String, VerifyingKey>> {
-    const NAME: &str = "bootstrap-pubkeys";
-    match read_secret(credentials_dir, NAME) {
-        Ok(Some(bytes)) => {
-            let json: std::collections::HashMap<String, String> = serde_json::from_slice(&bytes)
-                .context(
-                    "bootstrap-pubkeys is not valid JSON: expected a flat object \
-                     `{ \"<service>\": \"<base64>\" }` (see docs/bootstrap-pubkeys-format.md)",
-                )?;
-            let mut map = std::collections::HashMap::new();
-            for (name, b64) in json {
-                let pubkey_bytes: Vec<u8> = URL_SAFE_NO_PAD.decode(&b64).with_context(|| {
-                    format!(
-                        "invalid base64 in bootstrap-pubkeys for '{name}': expected \
-                         URL-safe-no-pad alphabet (RFC 4648 §5, no '+'/'/'/'='), got {b64:?}"
-                    )
-                })?;
-                let arr: [u8; 32] = pubkey_bytes.try_into().map_err(|v: Vec<u8>| {
-                    anyhow!(
-                        "bootstrap-pubkey for '{name}' must decode to exactly 32 bytes \
-                         (raw Ed25519 verifying key); got {} bytes",
-                        v.len()
-                    )
-                })?;
-                let vk = VerifyingKey::from_bytes(&arr)
-                    .map_err(|e| anyhow!("invalid bootstrap-pubkey for '{name}': {e}"))?;
-                map.insert(name, vk);
-            }
-            Ok(map)
-        }
-        Ok(None) => Ok(std::collections::HashMap::new()),
-        Err(e) => Err(e),
-    }
+    Ok(load_bootstrap_pubkeys_hybrid(credentials_dir)?
+        .into_iter()
+        .map(|(name, entry)| (name, entry.ed25519))
+        .collect())
 }
 
 /// Write bootstrap pubkeys to the credentials directory.
+///
+/// Every entry is written in the classical 32-byte form. Use
+/// [`write_bootstrap_pubkeys_hybrid`] to persist entries that carry a bound
+/// ML-DSA-65 key.
 pub fn write_bootstrap_pubkeys(
     credentials_dir: &std::path::Path,
     pubkeys: &std::collections::HashMap<String, VerifyingKey>,
 ) -> Result<()> {
-    use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine as _};
+    let hybrid: std::collections::HashMap<String, BootstrapPubkey> = pubkeys
+        .iter()
+        .map(|(name, vk)| (name.clone(), BootstrapPubkey::classical(*vk)))
+        .collect();
+    write_bootstrap_pubkeys_hybrid(credentials_dir, &hybrid)
+}
+
+// ─── Hybrid bootstrap entries ────────────────────────────────────────────────
+
+/// Length of a raw Ed25519 verifying key.
+const BOOTSTRAP_ED25519_BYTES: usize = 32;
+/// Length of a raw ML-DSA-65 verifying key.
+const BOOTSTRAP_ML_DSA_65_BYTES: usize = 1952;
+/// Length of the concatenated hybrid form (Ed25519 ‖ ML-DSA-65).
+const BOOTSTRAP_HYBRID_BYTES: usize = BOOTSTRAP_ED25519_BYTES + BOOTSTRAP_ML_DSA_65_BYTES;
+
+/// The on-disk file name of the bootstrap pubkeys seed.
+const BOOTSTRAP_PUBKEYS_NAME: &str = "bootstrap-pubkeys";
+
+/// One `bootstrap-pubkeys` entry: the Ed25519 anchor plus an optional bound
+/// ML-DSA-65 verifying key.
+///
+/// The Ed25519 key is always the identity of the entry — the post-quantum key
+/// is bound *to* it, mirroring the user identity and deployment-CA layouts.
+/// Verification is per-identity: an entry that carries no PQ key verifies
+/// classically, an entry that carries one requires both signatures.
+#[derive(Clone, Debug)]
+pub struct BootstrapPubkey {
+    pub ed25519: VerifyingKey,
+    pub ml_dsa_65: Option<hyprstream_rpc::crypto::pq::MlDsaVerifyingKey>,
+}
+
+impl BootstrapPubkey {
+    /// A classical (Ed25519-only) entry.
+    pub fn classical(ed25519: VerifyingKey) -> Self {
+        Self { ed25519, ml_dsa_65: None }
+    }
+
+    /// A hybrid entry binding an ML-DSA-65 key to an Ed25519 anchor.
+    pub fn hybrid(
+        ed25519: VerifyingKey,
+        ml_dsa_65: hyprstream_rpc::crypto::pq::MlDsaVerifyingKey,
+    ) -> Self {
+        Self { ed25519, ml_dsa_65: Some(ml_dsa_65) }
+    }
+
+    /// Whether this entry carries a bound post-quantum key.
+    pub fn is_hybrid(&self) -> bool {
+        self.ml_dsa_65.is_some()
+    }
+
+    /// The canonical byte encoding: the 32 raw Ed25519 bytes, followed by the
+    /// 1952 raw ML-DSA-65 bytes when the entry is hybrid.
+    pub fn to_key_bytes(&self) -> Vec<u8> {
+        let mut out = Vec::with_capacity(if self.is_hybrid() {
+            BOOTSTRAP_HYBRID_BYTES
+        } else {
+            BOOTSTRAP_ED25519_BYTES
+        });
+        out.extend_from_slice(self.ed25519.as_bytes());
+        if let Some(pq) = &self.ml_dsa_65 {
+            out.extend_from_slice(&hyprstream_rpc::crypto::pq::ml_dsa_vk_bytes(pq));
+        }
+        out
+    }
+
+    /// Decode the canonical byte encoding, discriminating on length.
+    ///
+    /// `service` names the entry only so the error text is actionable.
+    pub fn from_key_bytes(service: &str, bytes: &[u8]) -> Result<Self> {
+        let (ed_bytes, pq_bytes) = match bytes.len() {
+            BOOTSTRAP_ED25519_BYTES => (bytes, None),
+            BOOTSTRAP_HYBRID_BYTES => {
+                let (ed, pq) = bytes.split_at(BOOTSTRAP_ED25519_BYTES);
+                (ed, Some(pq))
+            }
+            other => {
+                return Err(anyhow!(
+                    "bootstrap-pubkey for '{service}' must decode to either \
+                     {BOOTSTRAP_ED25519_BYTES} bytes (raw Ed25519 verifying key) or \
+                     {BOOTSTRAP_HYBRID_BYTES} bytes (32-byte Ed25519 followed by \
+                     {BOOTSTRAP_ML_DSA_65_BYTES}-byte ML-DSA-65 verifying key); \
+                     got {other} bytes"
+                ))
+            }
+        };
+
+        let arr: [u8; BOOTSTRAP_ED25519_BYTES] = ed_bytes
+            .try_into()
+            .map_err(|_| anyhow!("bootstrap-pubkey for '{service}' has a malformed Ed25519 part"))?;
+        let ed25519 = VerifyingKey::from_bytes(&arr)
+            .map_err(|e| anyhow!("invalid bootstrap-pubkey for '{service}': {e}"))?;
+
+        let ml_dsa_65 = match pq_bytes {
+            Some(pq) => Some(
+                hyprstream_rpc::crypto::pq::ml_dsa_vk_from_bytes(pq).map_err(|e| {
+                    anyhow!("bootstrap-pubkey for '{service}' has a malformed ML-DSA-65 part: {e}")
+                })?,
+            ),
+            None => None,
+        };
+
+        Ok(Self { ed25519, ml_dsa_65 })
+    }
+
+    /// Verify a signature over `message` under this entry's per-identity policy.
+    ///
+    /// - Classical entry: the Ed25519 signature must verify. A post-quantum
+    ///   signature cannot be checked against an entry with no bound PQ key, so
+    ///   supplying one is an error rather than a silently ignored input.
+    /// - Hybrid entry: **both** the Ed25519 and the ML-DSA-65 signature must be
+    ///   present and verify.
+    ///
+    /// Post-quantum verification is never demanded of an entry that does not
+    /// carry a post-quantum key — a classical entry keeps its classical floor.
+    pub fn verify(
+        &self,
+        message: &[u8],
+        ed25519_sig: &ed25519_dalek::Signature,
+        ml_dsa_65_sig: Option<&[u8]>,
+    ) -> Result<()> {
+        use ed25519_dalek::Verifier;
+
+        self.ed25519
+            .verify(message, ed25519_sig)
+            .map_err(|e| anyhow!("Ed25519 signature verification failed: {e}"))?;
+
+        match (&self.ml_dsa_65, ml_dsa_65_sig) {
+            (Some(pq_key), Some(sig)) => hyprstream_rpc::crypto::pq::ml_dsa_verify(pq_key, message, sig),
+            (Some(_), None) => Err(anyhow!(
+                "this bootstrap key is hybrid (Ed25519 + ML-DSA-65) but no ML-DSA-65 \
+                 signature was supplied; both signatures are required"
+            )),
+            (None, Some(_)) => Err(anyhow!(
+                "an ML-DSA-65 signature was supplied but this bootstrap key is \
+                 Ed25519-only, so the signature cannot be verified; re-provision the \
+                 entry in its 1984-byte hybrid form to enable post-quantum verification"
+            )),
+            (None, None) => Ok(()),
+        }
+    }
+}
+
+/// Load bootstrap pubkeys, preserving any bound post-quantum key material.
+///
+/// Accepts both the classical (32-byte value) and the hybrid (1984-byte value)
+/// form in the same file; the two are distinguished by decoded length. Files
+/// written before hybrid entries existed load unchanged.
+pub fn load_bootstrap_pubkeys_hybrid(
+    credentials_dir: &std::path::Path,
+) -> Result<std::collections::HashMap<String, BootstrapPubkey>> {
+    let Some(bytes) = read_secret(credentials_dir, BOOTSTRAP_PUBKEYS_NAME)? else {
+        return Ok(std::collections::HashMap::new());
+    };
+
+    let json: std::collections::HashMap<String, String> = serde_json::from_slice(&bytes).context(
+        "bootstrap-pubkeys is not valid JSON: expected a flat object \
+         `{ \"<service>\": \"<base64>\" }` (see docs/bootstrap-pubkeys-format.md)",
+    )?;
+
+    let mut map = std::collections::HashMap::new();
+    let mut classical_only = Vec::new();
+    for (name, b64) in json {
+        let key_bytes: Vec<u8> = URL_SAFE_NO_PAD.decode(&b64).with_context(|| {
+            format!(
+                "invalid base64 in bootstrap-pubkeys for '{name}': expected \
+                 URL-safe-no-pad alphabet (RFC 4648 §5, no '+'/'/'/'='), got {b64:?}"
+            )
+        })?;
+        let entry = BootstrapPubkey::from_key_bytes(&name, &key_bytes)?;
+        if !entry.is_hybrid() {
+            classical_only.push(name.clone());
+        }
+        map.insert(name, entry);
+    }
+
+    if !classical_only.is_empty() {
+        classical_only.sort();
+        tracing::debug!(
+            services = %classical_only.join(", "),
+            "bootstrap-pubkeys entries are Ed25519-only; they verify classically \
+             until re-provisioned with a bound ML-DSA-65 key"
+        );
+    }
+
+    Ok(map)
+}
+
+/// Write bootstrap pubkeys, encoding hybrid entries in their concatenated form.
+///
+/// Classical entries are written exactly as the pre-hybrid writer wrote them, so
+/// a file round-trips byte-for-byte when no entry carries a PQ key.
+pub fn write_bootstrap_pubkeys_hybrid(
+    credentials_dir: &std::path::Path,
+    pubkeys: &std::collections::HashMap<String, BootstrapPubkey>,
+) -> Result<()> {
     let json: std::collections::HashMap<String, String> = pubkeys
         .iter()
-        .map(|(name, vk)| (name.clone(), URL_SAFE_NO_PAD.encode(vk.as_bytes())))
+        .map(|(name, entry)| (name.clone(), URL_SAFE_NO_PAD.encode(entry.to_key_bytes())))
         .collect();
-    let data = serde_json::to_vec(&json)
-        .context("failed to serialize bootstrap-pubkeys")?;
-    write_secret(credentials_dir, "bootstrap-pubkeys", &data)
+    let data = serde_json::to_vec(&json).context("failed to serialize bootstrap-pubkeys")?;
+    write_secret(credentials_dir, BOOTSTRAP_PUBKEYS_NAME, &data)
 }
 
 // ─── Node-level key loaders ──────────────────────────────────────────────────
@@ -1644,5 +1821,194 @@ mod tests {
             resolve_service_signing_key(dir.path(), "model", SecretsProfile::SharedDirectory)
                 .unwrap();
         assert_eq!(model_1.to_bytes(), model_2.to_bytes());
+    }
+
+    // ── bootstrap-pubkeys wire format ────────────────────────────────────────
+
+    fn bootstrap_ed_key(seed: u8) -> SigningKey {
+        SigningKey::from_bytes(&[seed; 32])
+    }
+
+    /// Write a `bootstrap-pubkeys` file verbatim, as an external provisioner
+    /// (or an older release of this code) would have left it on disk.
+    fn write_raw_bootstrap_pubkeys(dir: &std::path::Path, entries: &[(&str, &str)]) {
+        let json: std::collections::BTreeMap<&str, &str> = entries.iter().copied().collect();
+        write_secret(dir, "bootstrap-pubkeys", &serde_json::to_vec(&json).unwrap()).unwrap();
+    }
+
+    #[test]
+    fn bootstrap_pubkeys_classical_round_trip() {
+        let dir = TempDir::new().unwrap();
+        let vk = bootstrap_ed_key(7).verifying_key();
+
+        let mut map = std::collections::HashMap::new();
+        map.insert("discovery".to_owned(), vk);
+        write_bootstrap_pubkeys(dir.path(), &map).unwrap();
+
+        let loaded = load_bootstrap_pubkeys(dir.path()).unwrap();
+        assert_eq!(loaded.get("discovery"), Some(&vk));
+
+        let hybrid = load_bootstrap_pubkeys_hybrid(dir.path()).unwrap();
+        let entry = &hybrid["discovery"];
+        assert!(!entry.is_hybrid(), "an entry written from a bare Ed25519 key is classical");
+        assert_eq!(entry.to_key_bytes().len(), 32);
+    }
+
+    #[test]
+    fn bootstrap_pubkeys_hybrid_round_trip() {
+        let dir = TempDir::new().unwrap();
+        let ed = bootstrap_ed_key(9).verifying_key();
+        let (_pq_sk, pq_vk) = hyprstream_rpc::crypto::pq::ml_dsa_generate_keypair();
+
+        let mut map = std::collections::HashMap::new();
+        map.insert("discovery".to_owned(), BootstrapPubkey::hybrid(ed, pq_vk.clone()));
+        write_bootstrap_pubkeys_hybrid(dir.path(), &map).unwrap();
+
+        let loaded = load_bootstrap_pubkeys_hybrid(dir.path()).unwrap();
+        let entry = &loaded["discovery"];
+        assert!(entry.is_hybrid());
+        assert_eq!(entry.ed25519, ed);
+        assert_eq!(
+            hyprstream_rpc::crypto::pq::ml_dsa_vk_bytes(entry.ml_dsa_65.as_ref().unwrap()),
+            hyprstream_rpc::crypto::pq::ml_dsa_vk_bytes(&pq_vk)
+        );
+        assert_eq!(entry.to_key_bytes().len(), 1984);
+
+        // The Ed25519-only projection still sees the anchor, so callers that
+        // predate hybrid entries keep resolving the same key.
+        assert_eq!(load_bootstrap_pubkeys(dir.path()).unwrap().get("discovery"), Some(&ed));
+    }
+
+    #[test]
+    fn bootstrap_pubkeys_legacy_file_loads_unchanged() {
+        let dir = TempDir::new().unwrap();
+        let discovery = bootstrap_ed_key(0x11).verifying_key();
+        let policy = bootstrap_ed_key(0x22).verifying_key();
+
+        // Exactly the shape deployed nodes and external provisioning emit:
+        // a flat map of URL-safe-no-pad base64 over 32 raw Ed25519 bytes.
+        write_raw_bootstrap_pubkeys(
+            dir.path(),
+            &[
+                ("discovery", &URL_SAFE_NO_PAD.encode(discovery.as_bytes())),
+                ("policy", &URL_SAFE_NO_PAD.encode(policy.as_bytes())),
+            ],
+        );
+
+        let loaded = load_bootstrap_pubkeys(dir.path()).unwrap();
+        assert_eq!(loaded.len(), 2);
+        assert_eq!(loaded.get("discovery"), Some(&discovery));
+        assert_eq!(loaded.get("policy"), Some(&policy));
+
+        let hybrid = load_bootstrap_pubkeys_hybrid(dir.path()).unwrap();
+        assert!(hybrid.values().all(|e| !e.is_hybrid()));
+    }
+
+    #[test]
+    fn bootstrap_pubkeys_mixed_file_verifies_per_identity() {
+        let dir = TempDir::new().unwrap();
+        let legacy_sk = bootstrap_ed_key(0x33);
+        let hybrid_ed_sk = bootstrap_ed_key(0x44);
+        let (pq_sk, pq_vk) = hyprstream_rpc::crypto::pq::ml_dsa_generate_keypair();
+
+        let hybrid_entry = BootstrapPubkey::hybrid(hybrid_ed_sk.verifying_key(), pq_vk);
+        write_raw_bootstrap_pubkeys(
+            dir.path(),
+            &[
+                ("policy", &URL_SAFE_NO_PAD.encode(legacy_sk.verifying_key().as_bytes())),
+                ("discovery", &URL_SAFE_NO_PAD.encode(hybrid_entry.to_key_bytes())),
+            ],
+        );
+
+        let loaded = load_bootstrap_pubkeys_hybrid(dir.path()).unwrap();
+        assert_eq!(loaded.len(), 2);
+
+        let msg = b"bootstrap trust seed";
+
+        // Classical entry: an Ed25519 signature alone is sufficient, and no
+        // post-quantum material is demanded of it.
+        let legacy = &loaded["policy"];
+        assert!(!legacy.is_hybrid());
+        let legacy_sig = {
+            use ed25519_dalek::Signer;
+            legacy_sk.sign(msg)
+        };
+        legacy.verify(msg, &legacy_sig, None).unwrap();
+
+        // Hybrid entry: both signatures are required, and the classical half
+        // alone is rejected.
+        let hybrid = &loaded["discovery"];
+        assert!(hybrid.is_hybrid());
+        let hybrid_ed_sig = {
+            use ed25519_dalek::Signer;
+            hybrid_ed_sk.sign(msg)
+        };
+        let pq_sig = hyprstream_rpc::crypto::pq::ml_dsa_sign(&pq_sk, msg);
+        hybrid.verify(msg, &hybrid_ed_sig, Some(&pq_sig)).unwrap();
+        assert!(
+            hybrid.verify(msg, &hybrid_ed_sig, None).is_err(),
+            "a hybrid entry must not verify on the Ed25519 signature alone"
+        );
+
+        // A post-quantum signature has nothing to check against on a classical
+        // entry, so it is rejected rather than silently ignored.
+        assert!(legacy.verify(msg, &legacy_sig, Some(&pq_sig)).is_err());
+    }
+
+    #[test]
+    fn bootstrap_pubkeys_reject_wrong_length_values() {
+        let dir = TempDir::new().unwrap();
+        // 33 bytes: neither the classical nor the hybrid length.
+        write_raw_bootstrap_pubkeys(dir.path(), &[("discovery", &URL_SAFE_NO_PAD.encode([0u8; 33]))]);
+
+        let err = load_bootstrap_pubkeys(dir.path()).unwrap_err().to_string();
+        assert!(err.contains("'discovery'"), "error names the offending service: {err}");
+        assert!(err.contains("32 bytes"), "error states the classical shape: {err}");
+        assert!(err.contains("1984 bytes"), "error states the hybrid shape: {err}");
+        assert!(err.contains("got 33 bytes"), "error states what was found: {err}");
+    }
+
+    #[test]
+    fn bootstrap_pubkeys_reject_standard_alphabet_base64() {
+        let dir = TempDir::new().unwrap();
+        // Standard-alphabet base64 with padding is not the documented alphabet.
+        write_raw_bootstrap_pubkeys(dir.path(), &[("discovery", "AAECAwQFBgcICQoLDA0ODxAREhMUFRYXGBkaGxwdHh8=")]);
+
+        let err = format!("{:#}", load_bootstrap_pubkeys(dir.path()).unwrap_err());
+        assert!(err.contains("URL-safe-no-pad"), "error states the expected alphabet: {err}");
+    }
+
+    #[test]
+    fn bootstrap_pubkeys_reject_malformed_pq_length() {
+        let dir = TempDir::new().unwrap();
+        // Correct Ed25519 prefix, truncated ML-DSA-65 tail.
+        let mut bytes = bootstrap_ed_key(0x55).verifying_key().as_bytes().to_vec();
+        bytes.extend_from_slice(&[0u8; 1951]);
+        write_raw_bootstrap_pubkeys(dir.path(), &[("discovery", &URL_SAFE_NO_PAD.encode(&bytes))]);
+
+        let err = load_bootstrap_pubkeys_hybrid(dir.path()).unwrap_err().to_string();
+        assert!(err.contains("1984 bytes"), "error states the hybrid shape: {err}");
+    }
+
+    /// The hybrid `discovery` value published as the worked example in
+    /// `docs/bootstrap-pubkeys-format.md`. Kept verbatim so the documented
+    /// example cannot drift away from what the parser actually accepts.
+    const DOC_EXAMPLE_HYBRID_VALUE: &str = "JIrL26-eBQGW3nBL6i1odw5RkVDRA7WH2uLZytU92TAXHtJkdXNEM19SNj1GPxnt-7mImdVPdRRENw5lnPLIVkDc3BiWsqDvmLI2x9roidQrSRArrQ-itYpEyQaLf-y6ckpa1NdkeN9ibwNu393M3E8PD2N3Vh9vx_sD2mbn532l0QXGV3i-9lQppfKcFwzinBkQN7eLLWRrInMfbE3IY_7FnC9Q0scH7bUMBvNY7k5jEDNtz1ZpEWgR-1u2M-iF221WgzT9AnQX5X88dd9gYs0SsIHLjx5o8-nnHk0XRxPq1JtegEupUKLf5a7e3IEm62VSXRJhH_V2IA9PAJMlSL8rJGYHdMwjscP1DyKCpCquSgYIH8zJDQCPqVUFBujtdq3x-eMFd0CxpVssPuLeoNb_4YZbtSwdk6iMMPupiDYIKOgknxymsnYGxR1PiA_7b1lZVaD62pCZHSCi9nJEDVoWuQ0_cSMB589zaDSTcI7r5Ks6l0MUPtVsa_yWQ4jwS8GnDMikXXmLvKegE5V6rZpG6AXx707kEvpxyESIzwnMU9UO2h4MGI1uWp36SXzHxF5RSZrY3Wr1ei1MwnJj7kgve4w1skjtZ32EE4A8r7R8mIl8L6LkXsD6n4FXFWQWocLdBerVvVBSDTDca8mQ3Lqr-3Q8wasUx-Ifqk6AAOZTmPseQ50uoiZnr0MCzxVkbAmvB5o_I5J_BqxKqQUimv0xiq69n9Vr__7FS8HTd9139LUPBkBDduZeH4qqJyIkDshEPJeXqOwBQZDIupnjc-PvDNKRM6o8Kg1OtaBjYwWWL6pVFRXYw3NeGb52N77-T9dEOCR659RHFrI-741xIaJ_gTJb6G43C7Go-EMI0aMkzakh-LSyTrv4C2s-KYksgVap-EsREaKmX1FAinmWsn0222V-tzJ-9dvPKKwCnTyTXpYRK3ltR-3LnP-onbg4ysP_tpVMg8K7jAeCzYsEEZCIjoJr5qpTkwGncfytwVvT6sHsoD988S10in7Dz9TNcNnFmb_foYqELht6jhAv_X6nf8IJEZgaLNaz9eV-_L87TdgQDF4iKrgHcuUZjPlfi-az1B6uV1Z7pqUsqJBT5XQkCqr3j4chZ2gNEw8SpconZVuXsT1tEtSWyo9GmvNntsiCvGM30faWGj-_cIsrCveMeMfLLsfNP3X7jG7Jgb7uYbj50Mwf7b-VqrdAmIJ0CMmCSygBaWV7YDx_qTEEuE7oL-R6_fXkhmXeZYyhFPF-As70CrVW-KwAJVp0mYasmPwu9YZ-Mlerg-QgHiAXnNpVjXE-wvnqP6JKbrbgaUZiLC4gXn0VTnB70y4e97Efl8ztGqE7AazPxwRMDyfher5oGpVm2lh9StBZYqaoAO7XQTUKvczld7imzqDugagVpWRW7ffE5qKp0ezq5PUwws4GB7UfTrmBm2gQ2HmT8aouV15b5zJaI1x9sOsNUjFrL1yL3V-Fi8adOXfRc5MR1JzdsaAki5YZhyjjYEHzdZfD8mwvN8jxN5U03tq495bR87ER_tHZNNd875gYZNYQ-pkD8zBlLWq54mDj5AKCwdTce3gOVTx9CtNYm3LFxsaB9VL_B93X81IR_Czaf_cHNQPsTpd8wWCWTZbc9zBhHUYtlrTrxhzXV68yBDcjnVF3LkbOcqapBCsUTrQ6XgloOp-fkUYd1LWTQN7ofcCXvR7x30BXXsM_qZnlUR4zminj2lWlJacV90Uqf7SL4HAEefqH8btyoVepUG_5JYQ7bp7NsUWUlw-Jc0hkumvNcaNX5uNFCLIIVTGgA9dG8ELuC3g-bhVjokIr4wSHVCyjFJs2qo93VdHy-abKdwpjeRwo6r66uaideZKEBxKUlZ_XHiZmT_FksJZIOHrq-8gQVPyjwo0oyI9Dq8xF-5aVN8NpHaJU7x4VcsndfHqsY5CGQUV0ZfuDpA94Srx-vvnvAJeM8ql63Ng2-0dNDra6fr8fgdEZeyJaIhdVBU8wBlshyeX32N2dbiJR7qWY5VqLbaKjePvqLa1LnnMtWdS2PqMX2UE_Q44Oa_FUdOB2sFdvKpxEbHDS74w5sd6C5AZzYPNUL1ICrV1F-c0Mxm9Z2j8PFEuYDz6fpR4Z1iDzLH9QKFUwus9fPzCU7b-ptTU3T3vnFTN4NLgxR6Ih78B-Mp3QrrCOxW3NtBNpnImuqHgRYBBPkg_dM659hgNtgCMYefiQuWJlpS22GG3kwPVuHoG8eqa-NDtxgMgFOPy30IKJcLh9ooG-QD9reZht_TBkLWbDW1JfeINAeJ86oZ5g3qtTdVAftVHaRCHLQN0ClLXPquM-v1GJm2F_tIXFJF-utsp0SgCDKo2VUymmMSgXQL3iP29lHQcp6Jzgisk6ZAEs6MqzrGV-T0cl0sQ4pKECzGHUL-8B8CKmMtshHZLCX4hvc3ALGd8ls72e6sh2JkFcU84I_8GLPgJu66dN5eZtOPR9CkmTKa2Ph1MgXqBGwmcYcvlg5GVZvzZC-UlhTrF7WAbObzDrGQbIGHBKG09dobSuSXpiSmZljJUh-88qsTXEVW12C4ZoWyDQ4OzH09JofMByTzb-k5Hn8cKIawcJBqCaAXElF5Z6MLrxxwagcL9XuMMdKG3UtEWY9HrsGY6qsA";
+
+    #[test]
+    fn documented_hybrid_example_loads_as_a_hybrid_entry() {
+        let dir = TempDir::new().unwrap();
+        write_raw_bootstrap_pubkeys(dir.path(), &[("discovery", DOC_EXAMPLE_HYBRID_VALUE)]);
+
+        let loaded = load_bootstrap_pubkeys_hybrid(dir.path()).unwrap();
+        let entry = &loaded["discovery"];
+        assert!(entry.is_hybrid(), "the documented example must be a hybrid entry");
+        assert_eq!(entry.to_key_bytes().len(), 1984);
+        // The documented Ed25519 anchor is the leading 43 base64 characters.
+        assert!(
+            DOC_EXAMPLE_HYBRID_VALUE
+                .starts_with(&URL_SAFE_NO_PAD.encode(entry.ed25519.as_bytes())),
+            "the documented anchor prefix must be the entry's Ed25519 key"
+        );
     }
 }

--- a/docs/bootstrap-pubkeys-format.md
+++ b/docs/bootstrap-pubkeys-format.md
@@ -10,7 +10,8 @@ CA-verified credential.
 ## Wire format
 
 The file is a flat JSON object mapping service name to a base64-encoded
-32-byte Ed25519 verifying key:
+verifying key. The classical form — a 32-byte Ed25519 key — is shown first;
+the hybrid form is described under [Hybrid entries](#hybrid-entries):
 
 ```json
 {
@@ -27,8 +28,10 @@ value is any 43-character URL-safe-no-pad base64 string that decodes to the
   `{service, key_type, public_key}` objects.
 - **Base64 alphabet**: `URL_SAFE_NO_PAD` (RFC 4648 §5, no `+`, `/`, or `=`).
   Standard-alphabet base64 (with `+`/`/`/`=`) will fail to decode.
-- **Key type**: Ed25519 only, exactly 32 raw bytes after decoding. No other
-  curve or encoding is accepted. In particular, do **not** encode a DER/SPKI
+- **Key type**: an entry is either **classical** — exactly 32 raw Ed25519
+  bytes after decoding — or **hybrid**, exactly 1984 bytes (see
+  [Hybrid entries](#hybrid-entries) below). Any other decoded length is
+  rejected. In particular, do **not** encode a DER/SPKI
   (`SubjectPublicKeyInfo`) blob — that decodes to 44 bytes and is rejected.
   If you have a PEM/DER key (e.g. from `openssl genpkey -algorithm ed25519`),
   extract the raw key first: the raw 32 bytes are the *last* 32 bytes of the
@@ -40,8 +43,56 @@ value is any 43-character URL-safe-no-pad base64 string that decodes to the
   (wizard / bootstrap manager). Consumers look up the exact names
   `discovery` and `policy`, so anything else parses but is ignored.
 
-Produced by `write_bootstrap_pubkeys` and consumed by `load_bootstrap_pubkeys`
-in `crates/hyprstream/src/auth/identity_store.rs`.
+Produced by `write_bootstrap_pubkeys` / `write_bootstrap_pubkeys_hybrid` and
+consumed by `load_bootstrap_pubkeys` / `load_bootstrap_pubkeys_hybrid` in
+`crates/hyprstream/src/auth/identity_store.rs`.
+
+## Hybrid entries
+
+A value may also carry a post-quantum key bound to the Ed25519 anchor. The
+hybrid encoding is the **concatenation** `Ed25519 (32 B) ‖ ML-DSA-65 (1952 B)`
+= 1984 bytes, base64'd with the same URL-safe-no-pad alphabet — byte-for-byte
+the same layout the deployment CA root uses for its 1984-byte public pair.
+
+The two forms are distinguished by **decoded length only**: 32 bytes is
+classical, 1984 bytes is hybrid, anything else is an error. The file stays a
+flat `{ "<service>": "<base64>" }` map, so a file may freely mix classical and
+hybrid entries, and a file written before hybrid entries existed loads
+unchanged.
+
+```json
+{
+  "policy": "AAECAwQFBgcICQoLDA0ODxAREhMUFRYXGBkaGxwdHh8",
+  "discovery": "JIrL26-eBQGW3nBL6i1odw5RkVDRA7WH2uLZytU92TAXHtJkdXNEM19SNj1GPxnt-7mImdVPdRRENw5lnPLIVkDc3BiWsqDvmLI2x9roidQrSRArrQ-itYpEyQaLf-y6ckpa1NdkeN9ibwNu393M3E8PD2N3Vh9vx_sD2mbn532l0QXGV3i-9lQppfKcFwzinBkQN7eLLWRrInMfbE3IY_7FnC9Q0scH7bUMBvNY7k5jEDNtz1ZpEWgR-1u2M-iF221WgzT9AnQX5X88dd9gYs0SsIHLjx5o8-nnHk0XRxPq1JtegEupUKLf5a7e3IEm62VSXRJhH_V2IA9PAJMlSL8rJGYHdMwjscP1DyKCpCquSgYIH8zJDQCPqVUFBujtdq3x-eMFd0CxpVssPuLeoNb_4YZbtSwdk6iMMPupiDYIKOgknxymsnYGxR1PiA_7b1lZVaD62pCZHSCi9nJEDVoWuQ0_cSMB589zaDSTcI7r5Ks6l0MUPtVsa_yWQ4jwS8GnDMikXXmLvKegE5V6rZpG6AXx707kEvpxyESIzwnMU9UO2h4MGI1uWp36SXzHxF5RSZrY3Wr1ei1MwnJj7kgve4w1skjtZ32EE4A8r7R8mIl8L6LkXsD6n4FXFWQWocLdBerVvVBSDTDca8mQ3Lqr-3Q8wasUx-Ifqk6AAOZTmPseQ50uoiZnr0MCzxVkbAmvB5o_I5J_BqxKqQUimv0xiq69n9Vr__7FS8HTd9139LUPBkBDduZeH4qqJyIkDshEPJeXqOwBQZDIupnjc-PvDNKRM6o8Kg1OtaBjYwWWL6pVFRXYw3NeGb52N77-T9dEOCR659RHFrI-741xIaJ_gTJb6G43C7Go-EMI0aMkzakh-LSyTrv4C2s-KYksgVap-EsREaKmX1FAinmWsn0222V-tzJ-9dvPKKwCnTyTXpYRK3ltR-3LnP-onbg4ysP_tpVMg8K7jAeCzYsEEZCIjoJr5qpTkwGncfytwVvT6sHsoD988S10in7Dz9TNcNnFmb_foYqELht6jhAv_X6nf8IJEZgaLNaz9eV-_L87TdgQDF4iKrgHcuUZjPlfi-az1B6uV1Z7pqUsqJBT5XQkCqr3j4chZ2gNEw8SpconZVuXsT1tEtSWyo9GmvNntsiCvGM30faWGj-_cIsrCveMeMfLLsfNP3X7jG7Jgb7uYbj50Mwf7b-VqrdAmIJ0CMmCSygBaWV7YDx_qTEEuE7oL-R6_fXkhmXeZYyhFPF-As70CrVW-KwAJVp0mYasmPwu9YZ-Mlerg-QgHiAXnNpVjXE-wvnqP6JKbrbgaUZiLC4gXn0VTnB70y4e97Efl8ztGqE7AazPxwRMDyfher5oGpVm2lh9StBZYqaoAO7XQTUKvczld7imzqDugagVpWRW7ffE5qKp0ezq5PUwws4GB7UfTrmBm2gQ2HmT8aouV15b5zJaI1x9sOsNUjFrL1yL3V-Fi8adOXfRc5MR1JzdsaAki5YZhyjjYEHzdZfD8mwvN8jxN5U03tq495bR87ER_tHZNNd875gYZNYQ-pkD8zBlLWq54mDj5AKCwdTce3gOVTx9CtNYm3LFxsaB9VL_B93X81IR_Czaf_cHNQPsTpd8wWCWTZbc9zBhHUYtlrTrxhzXV68yBDcjnVF3LkbOcqapBCsUTrQ6XgloOp-fkUYd1LWTQN7ofcCXvR7x30BXXsM_qZnlUR4zminj2lWlJacV90Uqf7SL4HAEefqH8btyoVepUG_5JYQ7bp7NsUWUlw-Jc0hkumvNcaNX5uNFCLIIVTGgA9dG8ELuC3g-bhVjokIr4wSHVCyjFJs2qo93VdHy-abKdwpjeRwo6r66uaideZKEBxKUlZ_XHiZmT_FksJZIOHrq-8gQVPyjwo0oyI9Dq8xF-5aVN8NpHaJU7x4VcsndfHqsY5CGQUV0ZfuDpA94Srx-vvnvAJeM8ql63Ng2-0dNDra6fr8fgdEZeyJaIhdVBU8wBlshyeX32N2dbiJR7qWY5VqLbaKjePvqLa1LnnMtWdS2PqMX2UE_Q44Oa_FUdOB2sFdvKpxEbHDS74w5sd6C5AZzYPNUL1ICrV1F-c0Mxm9Z2j8PFEuYDz6fpR4Z1iDzLH9QKFUwus9fPzCU7b-ptTU3T3vnFTN4NLgxR6Ih78B-Mp3QrrCOxW3NtBNpnImuqHgRYBBPkg_dM659hgNtgCMYefiQuWJlpS22GG3kwPVuHoG8eqa-NDtxgMgFOPy30IKJcLh9ooG-QD9reZht_TBkLWbDW1JfeINAeJ86oZ5g3qtTdVAftVHaRCHLQN0ClLXPquM-v1GJm2F_tIXFJF-utsp0SgCDKo2VUymmMSgXQL3iP29lHQcp6Jzgisk6ZAEs6MqzrGV-T0cl0sQ4pKECzGHUL-8B8CKmMtshHZLCX4hvc3ALGd8ls72e6sh2JkFcU84I_8GLPgJu66dN5eZtOPR9CkmTKa2Ph1MgXqBGwmcYcvlg5GVZvzZC-UlhTrF7WAbObzDrGQbIGHBKG09dobSuSXpiSmZljJUh-88qsTXEVW12C4ZoWyDQ4OzH09JofMByTzb-k5Hn8cKIawcJBqCaAXElF5Z6MLrxxwagcL9XuMMdKG3UtEWY9HrsGY6qsA"
+}
+```
+
+That `discovery` value is a real 2646-character encoding of a real key pair: it
+decodes to 1984 bytes whose first 43 base64 characters
+(`JIrL26-eBQGW3nBL6i1odw5RkVDRA7WH2uLZytU92TA`) are the Ed25519 anchor and whose
+remaining bytes are the bound ML-DSA-65 verifying key. A test in
+`identity_store.rs` decodes this exact string and asserts it loads as a hybrid
+entry, so the example cannot drift from the parser. The `policy` value beside it
+is a classical entry — mixing the two forms in one file is supported.
+
+## Verification policy
+
+Verification is **per identity**, matching the hybrid posture used elsewhere in
+the system. There is no global "post-quantum required" switch:
+
+- A service whose entry is classical (32 bytes) verifies **classically**. It is
+  never asked for a post-quantum signature; that is the classical floor for
+  identities that carry no PQ key.
+- A service whose entry is hybrid (1984 bytes) requires **both** signatures —
+  the Ed25519 signature *and* the ML-DSA-65 signature must be present and
+  verify. A hybrid entry never verifies on its classical half alone.
+- Offering a post-quantum signature against a classical entry is an error, not
+  a silently ignored input: there is no bound key to check it with, and
+  accepting it would let a caller believe a downgrade was a hybrid verification.
+
+Upgrading a service is therefore a per-entry operation: rewrite one value in
+the 1984-byte form, leave the rest alone. Nothing else in the file, and no
+other node, has to change at the same time.
 
 ## Which service names matter
 


### PR DESCRIPTION
Stacked on `docs/1470-bootstrap-pubkeys-wire-contract` (the part-1 docs branch), because it extends the doc that branch introduced.

## What changes

A `bootstrap-pubkeys` value may now decode to either:

- **32 bytes** — raw Ed25519 verifying key (the form every deployed node and the staging Terraform stack already emits), or
- **1984 bytes** — 32-byte Ed25519 followed by 1952-byte ML-DSA-65, the same concatenation the deployment CA root uses for its 1984-byte public pair.

The file stays a flat `{ "<service>": "<base64>" }` map with the URL-safe-no-pad alphabet, so the two forms mix freely in one file and a service can be upgraded one entry at a time.

### Why length discrimination rather than a versioned envelope

- It reuses the deployment CA's existing hybrid byte layout instead of inventing a second hybrid encoding.
- 32 and 1984 are unambiguous, so a strict consumer never has to guess, and the existing flat-map shape is preserved exactly — no envelope means no "old file has no version field" migration and no risk of stranding deployed nodes.
- It is not a dead end: values are currently always JSON strings, so a tagged object value (`{"ed25519": ..., "mlDsa65": ...}`) can be added later as a distinguishable JSON type without breaking either existing form.

### Verification policy

Per identity, matching the project's established hybrid posture — no global "PQ required" switch:

- Classical entry → verifies classically, and is never asked for a post-quantum signature.
- Hybrid entry → **both** the Ed25519 and the ML-DSA-65 signature must be present and verify; the classical half alone is rejected.
- A PQ signature offered against a classical entry is an error, not a silently ignored input (there is no bound key to check it with, and accepting it would let a caller mistake a downgrade for a hybrid verification).

### Compatibility

`load_bootstrap_pubkeys` keeps its `HashMap<String, VerifyingKey>` signature by projecting the Ed25519 anchor of each entry, so every existing consumer (`resolve_service_vk`, `install_process_production_resolver`, the worker-startup `policy` path) is untouched. Callers that need the bound PQ key use the new `load_bootstrap_pubkeys_hybrid`. `write_bootstrap_pubkeys` emits the classical form exactly as before.

## Tests

`cargo test -p hyprstream --lib auth::identity_store` — 39 passed, including:

- `bootstrap_pubkeys_legacy_file_loads_unchanged` — the backward-compat guarantee, against a file written verbatim in the deployed shape
- `bootstrap_pubkeys_classical_round_trip` / `bootstrap_pubkeys_hybrid_round_trip`
- `bootstrap_pubkeys_mixed_file_verifies_per_identity` — one legacy + one hybrid service, each verified under its own policy
- `bootstrap_pubkeys_reject_wrong_length_values`, `..._reject_standard_alphabet_base64`, `..._reject_malformed_pq_length` — the documented actionable errors
- `documented_hybrid_example_loads_as_a_hybrid_entry` — the worked example in the doc is the literal string the parser is fed, so it cannot drift

`cargo clippy --release -p hyprstream --lib -- -D warnings` is clean; the pre-commit hook's `--tests` clippy also passes.

## Not in scope

The process trust store is keyed by `VerifyingKey` and has no PQ field, so hybrid entries are parsed and exposed but not yet bound into `Attestation`. Wiring PQ material through the trust store is a follow-on.

Part of hyprstream#1470