### PR TITLE
feat(wizard): opt-in deployment-trust ceremony with YubiKey detection

### DIFF
--- a/crates/hyprstream/src/bin/main.rs
+++ b/crates/hyprstream/src/bin/main.rs
@@ -243,6 +243,47 @@ fn build_cli() -> ClapCommand {
                     .value_name("ROLE")
                     .default_value("admin")
                     .help("Role to assign the local user under --non-interactive (admin|operator|trainer|viewer). Default is admin; use operator/viewer in tests for least-privilege."),
+            )
+            .arg(
+                Arg::new("deployment_trust")
+                    .long("deployment-trust")
+                    .action(clap::ArgAction::SetTrue)
+                    .help("Run the deployment-trust ceremony after node bootstrap — detects an attached YubiKey and mints the deployment root, delegated signer, and registry credential. Opt-in: node bootstrap alone is unchanged without it."),
+            )
+            .arg(
+                Arg::new("deployment_trust_dir")
+                    .long("deployment-trust-dir")
+                    .value_name("DIR")
+                    .requires("deployment_trust")
+                    .help("Absolute ceremony working directory (default: <models-dir>/deployment-ceremony). Destroy it once the artifacts are distributed."),
+            )
+            .arg(
+                Arg::new("deployment_trust_software")
+                    .long("deployment-trust-software")
+                    .action(clap::ArgAction::SetTrue)
+                    .requires("deployment_trust")
+                    .help("Mint a DEV-GRADE software deployment root even if a hardware token is attached. Never selected on your behalf."),
+            )
+            .arg(
+                Arg::new("deployment_trust_serial")
+                    .long("deployment-trust-serial")
+                    .value_name("SERIAL")
+                    .requires("deployment_trust")
+                    .help("Bind the deployment root to the token with this serial when several are attached."),
+            )
+            .arg(
+                Arg::new("deployment_trust_piv_slot")
+                    .long("deployment-trust-piv-slot")
+                    .value_name("SLOT")
+                    .requires("deployment_trust")
+                    .help("PIV slot holding the Ed25519 leg on firmware 5.7.4+ (default: 9c)."),
+            )
+            .arg(
+                Arg::new("deployment_trust_allow_plaintext_break_glass")
+                    .long("deployment-trust-allow-plaintext-break-glass")
+                    .action(clap::ArgAction::SetTrue)
+                    .requires("deployment_trust")
+                    .help("Accept an unencrypted break-glass identity. Only for a throwaway root you destroy immediately afterwards."),
             ),
     );
 
@@ -1954,7 +1995,31 @@ fn main() -> Result<()> {
                     .get_one::<String>("initial_user_role")
                     .cloned()
                     .unwrap_or_else(|| "admin".to_owned());
-                let use_tui = tui_mode || (pds_url.is_none() && !non_interactive && !bootstrap_only && supports_tui());
+                let deployment_trust = hyprstream_core::cli::wizard_handlers::DeploymentTrustOptions {
+                    enabled: sub_m.get_flag("deployment_trust"),
+                    dir: sub_m.get_one::<String>("deployment_trust_dir").map(std::path::PathBuf::from),
+                    force_software: sub_m.get_flag("deployment_trust_software"),
+                    serial: sub_m.get_one::<String>("deployment_trust_serial").cloned(),
+                    piv_slot: sub_m.get_one::<String>("deployment_trust_piv_slot").cloned(),
+                    allow_plaintext_break_glass: sub_m
+                        .get_flag("deployment_trust_allow_plaintext_break_glass"),
+                };
+                let wizard_options = hyprstream_core::cli::WizardOptions {
+                    non_interactive,
+                    start_services,
+                    bootstrap_only,
+                    enable_federation,
+                    initial_user_role,
+                    deployment_trust,
+                };
+                // The TUI wizard has no ceremony flow yet, so an explicit
+                // --deployment-trust keeps the text wizard.
+                let use_tui = tui_mode
+                    || (pds_url.is_none()
+                        && !non_interactive
+                        && !bootstrap_only
+                        && !wizard_options.deployment_trust.enabled
+                        && supports_tui());
                 let config = config.clone();
                 return with_runtime(
                     RuntimeConfig { device: DeviceConfig::request_cpu(), multi_threaded: true },
@@ -1963,8 +2028,7 @@ fn main() -> Result<()> {
                             hyprstream_core::cli::handle_wizard_tui(&models_dir, &services).await
                         } else {
                             hyprstream_core::cli::handle_wizard(
-                                &models_dir, &services, non_interactive, start_services,
-                                bootstrap_only, enable_federation, &initial_user_role,
+                                &models_dir, &services, wizard_options,
                             ).await?;
                             if let Some(pds_url) = pds_url {
                                 hyprstream_core::cli::pds_handlers::handle_pds_join(
@@ -1986,7 +2050,9 @@ fn main() -> Result<()> {
                         // First-run fallback (no `wizard` subcommand) defaults
                         // federation to off — explicit opt-in only.
                         hyprstream_core::cli::handle_wizard(
-                            &models_dir, &services, false, false, false, false, "admin",
+                            &models_dir,
+                            &services,
+                            hyprstream_core::cli::WizardOptions::first_run(),
                         ).await
                     }
                 },
@@ -3070,7 +3136,9 @@ fn main() -> Result<()> {
                         } else {
                             // First-run auto-wizard defaults federation to off.
                             hyprstream_core::cli::handle_wizard(
-                                &models_dir, &services, false, false, false, false, "admin",
+                                &models_dir,
+                            &services,
+                            hyprstream_core::cli::WizardOptions::first_run(),
                             ).await
                         }
                     },

--- a/crates/hyprstream/src/cli/mod.rs
+++ b/crates/hyprstream/src/cli/mod.rs
@@ -25,6 +25,7 @@ pub mod sign_challenge;
 pub mod systemd_setup;
 pub mod training_handlers;
 pub mod trust;
+pub mod trust_ceremony;
 pub mod tui_handlers;
 pub mod update_handlers;
 pub mod user_handlers;
@@ -75,7 +76,7 @@ pub use service_handlers::{
     handle_service_uninstall, handle_service_start, handle_service_stop, handle_service_status,
 };
 pub use sign_challenge::handle_sign_challenge;
-pub use wizard_handlers::{handle_wizard, handle_wizard_tui};
+pub use wizard_handlers::{handle_wizard, handle_wizard_tui, WizardOptions};
 
 /// Device preference strategy
 #[derive(Debug, Clone, Copy)]

--- a/crates/hyprstream/src/cli/trust.rs
+++ b/crates/hyprstream/src/cli/trust.rs
@@ -1788,23 +1788,120 @@ fn validate_delegation_artifact(
     )
 }
 
+/// Inputs collected from probing a PIV slot before a destructive import.
+///
+/// Kept as a plain data struct so the safety decision in
+/// [`slot_occupied_from_probe`] can be unit-tested without launching
+/// external processes or relying on a real YubiKey being attached.
+#[derive(Clone, Copy, Debug)]
+struct SlotProbeInputs {
+    /// `yubico-piv-tool -a read-certificate` exited successfully, i.e. the
+    /// slot holds a certificate object.
+    cert_present: bool,
+    /// A separate key-presence probe (`ykman piv keys list`) indicated a
+    /// key occupies the slot. A slot with a key but no certificate is
+    /// exactly the state [`piv_import_ed25519`] leaves behind: it imports
+    /// a key without minting a certificate object. Probing certificate
+    /// alone misses that state, which is why this field exists.
+    key_present: bool,
+    /// Any probe failed to produce a definitive answer (PCSC failure,
+    /// token removed, binary not found, unexpected non-zero exit).
+    /// Treated as occupied: the safe default is to refuse the destructive
+    /// import rather than silently permit it.
+    probe_indeterminate: bool,
+}
+
+/// Decide whether a PIV slot must be treated as occupied.
+///
+/// Pure wrapper over [`SlotProbeInputs`] so the safety logic can be tested
+/// without a YubiKey. The decision is:
+/// - If any probe was indeterminate, treat as occupied (fail closed).
+/// - Otherwise, occupied iff the slot has a certificate OR a key object.
+fn slot_occupied_from_probe(inputs: SlotProbeInputs) -> bool {
+    if inputs.probe_indeterminate {
+        return true;
+    }
+    inputs.cert_present || inputs.key_present
+}
+
 /// Check whether a PIV slot already holds a key or certificate.
 ///
 /// `ykman piv keys import` silently overwrites slot contents; this check
 /// gives the caller a chance to warn or refuse before the import runs.
+///
+/// Probes BOTH the certificate object (via `yubico-piv-tool -a
+/// read-certificate`) AND the key object (via `ykman piv keys list`).
+/// Probing certificate alone misses the exact state left behind by
+/// [`piv_import_ed25519`]: a key imported without minting a certificate
+/// object, which reads as empty to a certificate-only probe. Any probe
+/// error (PCSC failure, token removed, binary missing) is treated as
+/// "occupied" — the safe default that refuses a destructive overwrite
+/// rather than silently permitting it.
 fn piv_slot_occupied(slot: &str) -> Result<bool> {
     let slot = validate_piv_slot(slot)?;
-    // Try reading the slot's certificate object. A slot with no object
-    // returns a non-zero exit; a slot with any data returns zero.
-    let status = Command::new("yubico-piv-tool")
+    Ok(slot_occupied_from_probe(probe_piv_slot(&slot)?))
+}
+
+/// Probe a PIV slot for certificate and key presence. See
+/// [`slot_occupied_from_probe`] for the decision rule applied to the
+/// returned inputs.
+fn probe_piv_slot(slot: &str) -> Result<SlotProbeInputs> {
+    // Certificate probe: a slot with no certificate object returns a
+    // non-zero exit; a slot with any certificate object returns zero.
+    let cert_present = match Command::new("yubico-piv-tool")
         .args(["-a", "read-certificate", "-s"])
-        .arg(&slot)
+        .arg(slot)
         .stdin(Stdio::null())
         .stdout(Stdio::null())
         .stderr(Stdio::null())
         .status()
-        .context("launch yubico-piv-tool to read slot status")?;
-    Ok(status.success())
+    {
+        Ok(status) => status.success(),
+        Err(_) => {
+            return Ok(SlotProbeInputs {
+                cert_present: false,
+                key_present: false,
+                probe_indeterminate: true,
+            });
+        }
+    };
+
+    // Key-presence probe: `ykman piv keys list` enumerates keys in all PIV
+    // slots regardless of whether a certificate object has been minted.
+    // This is what catches the key-but-no-certificate state produced by
+    // `piv_import_ed25519`, which the certificate probe above cannot see.
+    let key_present = match Command::new("ykman")
+        .args(["piv", "keys", "list"])
+        .stdin(Stdio::null())
+        .stderr(Stdio::null())
+        .output()
+    {
+        Ok(output) if output.status.success() => {
+            let stdout = String::from_utf8_lossy(&output.stdout);
+            // ykman prints one row per occupied slot with the slot id as
+            // the leading whitespace-delimited token (e.g. "9a    ED25519
+            // ..."). Match only the first token so "9a" does not match
+            // inside another row's fingerprint or policy string.
+            stdout
+                .lines()
+                .any(|line| line.split_whitespace().next() == Some(slot))
+        }
+        _ => {
+            // ykman unavailable or returned non-zero: indeterminate. Fail
+            // closed rather than silently allowing an overwrite.
+            return Ok(SlotProbeInputs {
+                cert_present,
+                key_present: false,
+                probe_indeterminate: true,
+            });
+        }
+    };
+
+    Ok(SlotProbeInputs {
+        cert_present,
+        key_present,
+        probe_indeterminate: false,
+    })
 }
 
 fn piv_import_ed25519(slot: &str, key: &SigningKey) -> Result<(String, VerifyingKey)> {
@@ -3261,6 +3358,82 @@ mod tests {
         assert!(
             uri.contains("staging.example.com"),
             "uri must use the SNI hostname, not the IP: {uri}"
+        );
+    }
+
+    // ---- PIV slot occupancy guard ------------------------------------
+
+    /// Helper: build probe inputs without spelling every field each call.
+    fn probe(cert: bool, key: bool, indeterminate: bool) -> SlotProbeInputs {
+        SlotProbeInputs {
+            cert_present: cert,
+            key_present: key,
+            probe_indeterminate: indeterminate,
+        }
+    }
+
+    /// The primary scenario the guard exists for: an operator re-runs
+    /// import against a slot they already provisioned. `piv_import_ed25519`
+    /// imports a key but does not mint a certificate object, so a
+    /// certificate-only probe reads this state as EMPTY. The key-presence
+    /// probe must catch it.
+    #[test]
+    fn piv_slot_with_key_but_no_certificate_is_occupied() {
+        assert!(slot_occupied_from_probe(probe(false, true, false)));
+    }
+
+    /// A slot with a certificate is occupied regardless of key state.
+    #[test]
+    fn piv_slot_with_certificate_is_occupied() {
+        assert!(slot_occupied_from_probe(probe(true, false, false)));
+        assert!(slot_occupied_from_probe(probe(true, true, false)));
+    }
+
+    /// A definitively empty slot (no cert, no key, all probes ran clean)
+    /// is the only state that reads as not occupied.
+    #[test]
+    fn piv_slot_definitively_empty_is_not_occupied() {
+        assert!(!slot_occupied_from_probe(probe(false, false, false)));
+    }
+
+    /// Any probe that cannot produce a definitive answer (PCSC failure,
+    /// token removed, binary missing) must be treated as occupied — never
+    /// as empty. This is the fail-closed rule.
+    #[test]
+    fn piv_slot_probe_indeterminate_fails_closed() {
+        assert!(slot_occupied_from_probe(probe(false, false, true)));
+    }
+
+    /// Indeterminate dominates: even when a partial probe suggested the
+    /// slot was empty, an indeterminate result on the other probe must
+    /// not downgrade the slot to "safe to overwrite".
+    #[test]
+    fn piv_slot_indeterminate_dominates_empty_signals() {
+        assert!(slot_occupied_from_probe(probe(true, false, true)));
+    }
+
+    /// The slot string passed to `ykman piv keys list` matching must be
+    /// matched only as the leading token of a row, never as a substring
+    /// of a fingerprint or policy string. A slot id like "9a" must not
+    /// match a row for "9c" whose fingerprint happens to contain "9a".
+    /// This is enforced at the call site via `split_whitespace().next()`;
+    /// this test pins the matching primitive itself.
+    #[test]
+    fn ykman_row_match_is_first_token_only() {
+        let slot = "9a";
+        let rows = "9c    ED25519     PIN_ONCE   ALWAYS   9a01deadbeef\n";
+        assert!(
+            !rows
+                .lines()
+                .any(|line| line.split_whitespace().next() == Some(slot)),
+            "slot 9a must not match a row whose first token is 9c"
+        );
+        let rows_with_9a = "9a    ED25519     PIN_ONCE   ALWAYS   ---\n9c    X25519\n";
+        assert!(
+            rows_with_9a
+                .lines()
+                .any(|line| line.split_whitespace().next() == Some(slot)),
+            "slot 9a must match a row whose first token is 9a"
         );
     }
 }

--- a/crates/hyprstream/src/cli/trust.rs
+++ b/crates/hyprstream/src/cli/trust.rs
@@ -273,6 +273,12 @@ fn mint_deployment_ca(args: &MintDeploymentCaArgs) -> Result<()> {
                      confirm the overwrite."
                 );
             }
+            if args.force {
+                println!(
+                    "  WARNING: --force bypasses the PIV slot occupancy check. \
+                     Any existing key in slot {slot} will be IRREVERSIBLY destroyed."
+                );
+            }
             let recovery_key = SigningKey::generate(&mut rand::rngs::OsRng);
             let (slot, public) = piv_import_ed25519(slot, &recovery_key)?;
             (
@@ -1788,40 +1794,73 @@ fn validate_delegation_artifact(
     )
 }
 
-/// Inputs collected from probing a PIV slot before a destructive import.
+/// `ykman` argv (after the program name) that asks whether a PIV slot holds
+/// a private key, plus the stderr marker it prints when the slot has none.
 ///
-/// Kept as a plain data struct so the safety decision in
-/// [`slot_occupied_from_probe`] can be unit-tested without launching
-/// external processes or relying on a real YubiKey being attached.
+/// `{slot}` is substituted with the validated slot id.
+const PIV_KEY_PROBE: PivProbe = PivProbe {
+    argv: &["piv", "keys", "info", "{slot}"],
+    absent_marker: "No key stored in slot",
+};
+
+/// `ykman` argv that asks whether a PIV slot holds a certificate object,
+/// plus the stderr marker it prints when the slot has none. `-` sends any
+/// certificate found to stdout, which the probe discards.
+const PIV_CERT_PROBE: PivProbe = PivProbe {
+    argv: &["piv", "certificates", "export", "{slot}", "-"],
+    absent_marker: "No certificate found",
+};
+
+/// A single `ykman` presence probe: what to run, and how to recognise a
+/// definitive "nothing is here" answer.
 #[derive(Clone, Copy, Debug)]
-struct SlotProbeInputs {
-    /// `yubico-piv-tool -a read-certificate` exited successfully, i.e. the
-    /// slot holds a certificate object.
-    cert_present: bool,
-    /// A separate key-presence probe (`ykman piv keys list`) indicated a
-    /// key occupies the slot. A slot with a key but no certificate is
-    /// exactly the state [`piv_import_ed25519`] leaves behind: it imports
-    /// a key without minting a certificate object. Probing certificate
-    /// alone misses that state, which is why this field exists.
-    key_present: bool,
-    /// Any probe failed to produce a definitive answer (PCSC failure,
-    /// token removed, binary not found, unexpected non-zero exit).
-    /// Treated as occupied: the safe default is to refuse the destructive
-    /// import rather than silently permit it.
-    probe_indeterminate: bool,
+struct PivProbe {
+    argv: &'static [&'static str],
+    absent_marker: &'static str,
 }
 
-/// Decide whether a PIV slot must be treated as occupied.
+/// Decide whether a probe definitively reported an empty slot.
 ///
-/// Pure wrapper over [`SlotProbeInputs`] so the safety logic can be tested
-/// without a YubiKey. The decision is:
-/// - If any probe was indeterminate, treat as occupied (fail closed).
-/// - Otherwise, occupied iff the slot has a certificate OR a key object.
-fn slot_occupied_from_probe(inputs: SlotProbeInputs) -> bool {
-    if inputs.probe_indeterminate {
-        return true;
+/// `ykman` signals absence as exit 1 with a specific message on stderr.
+/// Every other outcome is indeterminate and must NOT read as absent:
+/// exit 0 (the object exists), a different exit-1 message (PCSC failure,
+/// no token present, locked slot), exit 2 (argument or subcommand error —
+/// including a subcommand that does not exist), or no exit code at all
+/// (killed by signal). Refusing a destructive import on an indeterminate
+/// answer is recoverable; permitting one is not.
+fn probe_reports_absent(probe: PivProbe, exit_code: Option<i32>, stderr: &str) -> bool {
+    exit_code == Some(1) && stderr.contains(probe.absent_marker)
+}
+
+/// Combine both probe results into the occupancy decision.
+///
+/// The slot is occupied unless BOTH probes definitively reported absence.
+/// Split out from [`piv_slot_occupied`] so the decision — including the
+/// fail-closed handling of every indeterminate outcome — is unit-testable
+/// against the exact exit codes and stderr text the real binary emits.
+fn slot_occupied_from_probes(key: (Option<i32>, &str), cert: (Option<i32>, &str)) -> bool {
+    !probe_reports_absent(PIV_KEY_PROBE, key.0, key.1)
+        || !probe_reports_absent(PIV_CERT_PROBE, cert.0, cert.1)
+}
+
+/// Run one `ykman` presence probe and return its exit code and stderr.
+///
+/// A failure to launch `ykman` at all is returned as an error rather than
+/// as a probe result: the caller propagates it, which aborts the mint
+/// before anything destructive runs.
+fn run_piv_probe(probe: PivProbe, slot: &str) -> Result<(Option<i32>, String)> {
+    let mut command = Command::new("ykman");
+    for arg in probe.argv {
+        command.arg(if *arg == "{slot}" { slot } else { arg });
     }
-    inputs.cert_present || inputs.key_present
+    let output = command
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::piped())
+        .output()
+        .with_context(|| format!("launch ykman {}", probe.argv.join(" ")))?;
+    let stderr = String::from_utf8_lossy(&output.stderr).into_owned();
+    Ok((output.status.code(), stderr))
 }
 
 /// Check whether a PIV slot already holds a key or certificate.
@@ -1829,79 +1868,31 @@ fn slot_occupied_from_probe(inputs: SlotProbeInputs) -> bool {
 /// `ykman piv keys import` silently overwrites slot contents; this check
 /// gives the caller a chance to warn or refuse before the import runs.
 ///
-/// Probes BOTH the certificate object (via `yubico-piv-tool -a
-/// read-certificate`) AND the key object (via `ykman piv keys list`).
-/// Probing certificate alone misses the exact state left behind by
-/// [`piv_import_ed25519`]: a key imported without minting a certificate
-/// object, which reads as empty to a certificate-only probe. Any probe
-/// error (PCSC failure, token removed, binary missing) is treated as
-/// "occupied" — the safe default that refuses a destructive overwrite
-/// rather than silently permitting it.
+/// Probes BOTH objects, because either alone misses a real state:
+/// - `ykman piv keys info <slot>` reports key metadata regardless of
+///   certificate state, which is what catches the key-but-no-certificate
+///   slot [`piv_import_ed25519`] leaves behind.
+/// - `ykman piv certificates export <slot> -` catches a slot holding a
+///   certificate whose private key lives elsewhere or has been deleted.
+///
+/// Any outcome that is not a definitive "absent" — PCSC failure, token
+/// removed, locked slot, unexpected exit status — reads as occupied. If
+/// `ykman` cannot be launched at all this returns an error, which also
+/// stops the import.
 fn piv_slot_occupied(slot: &str) -> Result<bool> {
     let slot = validate_piv_slot(slot)?;
-    Ok(slot_occupied_from_probe(probe_piv_slot(&slot)?))
-}
-
-/// Probe a PIV slot for certificate and key presence. See
-/// [`slot_occupied_from_probe`] for the decision rule applied to the
-/// returned inputs.
-fn probe_piv_slot(slot: &str) -> Result<SlotProbeInputs> {
-    // Certificate probe: a slot with no certificate object returns a
-    // non-zero exit; a slot with any certificate object returns zero.
-    let cert_present = match Command::new("yubico-piv-tool")
-        .args(["-a", "read-certificate", "-s"])
-        .arg(slot)
-        .stdin(Stdio::null())
-        .stdout(Stdio::null())
-        .stderr(Stdio::null())
-        .status()
-    {
-        Ok(status) => status.success(),
-        Err(_) => {
-            return Ok(SlotProbeInputs {
-                cert_present: false,
-                key_present: false,
-                probe_indeterminate: true,
-            });
-        }
-    };
-
-    // Key-presence probe: `ykman piv keys list` enumerates keys in all PIV
-    // slots regardless of whether a certificate object has been minted.
-    // This is what catches the key-but-no-certificate state produced by
-    // `piv_import_ed25519`, which the certificate probe above cannot see.
-    let key_present = match Command::new("ykman")
-        .args(["piv", "keys", "list"])
-        .stdin(Stdio::null())
-        .stderr(Stdio::null())
-        .output()
-    {
-        Ok(output) if output.status.success() => {
-            let stdout = String::from_utf8_lossy(&output.stdout);
-            // ykman prints one row per occupied slot with the slot id as
-            // the leading whitespace-delimited token (e.g. "9a    ED25519
-            // ..."). Match only the first token so "9a" does not match
-            // inside another row's fingerprint or policy string.
-            stdout
-                .lines()
-                .any(|line| line.split_whitespace().next() == Some(slot))
-        }
-        _ => {
-            // ykman unavailable or returned non-zero: indeterminate. Fail
-            // closed rather than silently allowing an overwrite.
-            return Ok(SlotProbeInputs {
-                cert_present,
-                key_present: false,
-                probe_indeterminate: true,
-            });
-        }
-    };
-
-    Ok(SlotProbeInputs {
-        cert_present,
-        key_present,
-        probe_indeterminate: false,
-    })
+    let key = run_piv_probe(PIV_KEY_PROBE, &slot)?;
+    // Short-circuit: a key is the object the guard exists to protect, so
+    // there is no reason to touch the card a second time once one is
+    // known (or suspected) to be present.
+    if !probe_reports_absent(PIV_KEY_PROBE, key.0, &key.1) {
+        return Ok(true);
+    }
+    let cert = run_piv_probe(PIV_CERT_PROBE, &slot)?;
+    Ok(slot_occupied_from_probes(
+        (key.0, &key.1),
+        (cert.0, &cert.1),
+    ))
 }
 
 fn piv_import_ed25519(slot: &str, key: &SigningKey) -> Result<(String, VerifyingKey)> {
@@ -2510,7 +2501,9 @@ fn now_unix_u64() -> Result<u64> {
 }
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used, clippy::expect_used)]
+// `print_stderr` is exempted alongside unwrap/expect so a test that has to
+// skip (external binary absent) can say so instead of passing silently.
+#[allow(clippy::unwrap_used, clippy::expect_used, clippy::print_stderr)]
 mod tests {
     use super::*;
 
@@ -3363,77 +3356,135 @@ mod tests {
 
     // ---- PIV slot occupancy guard ------------------------------------
 
-    /// Helper: build probe inputs without spelling every field each call.
-    fn probe(cert: bool, key: bool, indeterminate: bool) -> SlotProbeInputs {
-        SlotProbeInputs {
-            cert_present: cert,
-            key_present: key,
-            probe_indeterminate: indeterminate,
-        }
+    /// Verbatim stderr from `ykman piv keys info 9c` against a YubiKey
+    /// whose slot holds no key.
+    const YKMAN_NO_KEY: &str = "ERROR: No key stored in slot 9C (SIGNATURE).\n";
+    /// Verbatim stderr from `ykman piv certificates export 9c -` against a
+    /// YubiKey whose slot holds no certificate.
+    const YKMAN_NO_CERT: &str = "ERROR: No certificate found.\n";
+
+    /// The only state that permits a destructive import: both objects
+    /// definitively reported absent.
+    #[test]
+    fn piv_slot_empty_only_when_both_probes_report_absent() {
+        assert!(!slot_occupied_from_probes(
+            (Some(1), YKMAN_NO_KEY),
+            (Some(1), YKMAN_NO_CERT),
+        ));
     }
 
-    /// The primary scenario the guard exists for: an operator re-runs
-    /// import against a slot they already provisioned. `piv_import_ed25519`
-    /// imports a key but does not mint a certificate object, so a
-    /// certificate-only probe reads this state as EMPTY. The key-presence
-    /// probe must catch it.
+    /// The primary scenario the guard exists for: `piv_import_ed25519`
+    /// imports a key without minting a certificate, so a certificate-only
+    /// probe reads that slot as empty. The key probe must catch it.
     #[test]
     fn piv_slot_with_key_but_no_certificate_is_occupied() {
-        assert!(slot_occupied_from_probe(probe(false, true, false)));
+        assert!(slot_occupied_from_probes(
+            (Some(0), ""),
+            (Some(1), YKMAN_NO_CERT),
+        ));
     }
 
-    /// A slot with a certificate is occupied regardless of key state.
+    /// The mirror case: a certificate whose private key lives elsewhere.
     #[test]
-    fn piv_slot_with_certificate_is_occupied() {
-        assert!(slot_occupied_from_probe(probe(true, false, false)));
-        assert!(slot_occupied_from_probe(probe(true, true, false)));
+    fn piv_slot_with_certificate_but_no_key_is_occupied() {
+        assert!(slot_occupied_from_probes(
+            (Some(1), YKMAN_NO_KEY),
+            (Some(0), "")
+        ));
     }
 
-    /// A definitively empty slot (no cert, no key, all probes ran clean)
-    /// is the only state that reads as not occupied.
+    /// Exit 1 carrying a message OTHER than the absence marker is a
+    /// transient failure, not an empty slot. Either probe failing this
+    /// way must refuse the import.
     #[test]
-    fn piv_slot_definitively_empty_is_not_occupied() {
-        assert!(!slot_occupied_from_probe(probe(false, false, false)));
+    fn piv_slot_transient_failure_is_not_absence() {
+        let transient = "ERROR: Failed to connect to YubiKey.\n";
+        assert!(slot_occupied_from_probes(
+            (Some(1), transient),
+            (Some(1), YKMAN_NO_CERT),
+        ));
+        assert!(slot_occupied_from_probes(
+            (Some(1), YKMAN_NO_KEY),
+            (Some(1), transient),
+        ));
     }
 
-    /// Any probe that cannot produce a definitive answer (PCSC failure,
-    /// token removed, binary missing) must be treated as occupied — never
-    /// as empty. This is the fail-closed rule.
+    /// Exit 2 is how `ykman` reports a subcommand or argument it does not
+    /// recognise. It must never read as "slot is empty" — that inversion
+    /// is exactly how a wrong command name turns the guard into a
+    /// rubber stamp.
     #[test]
-    fn piv_slot_probe_indeterminate_fails_closed() {
-        assert!(slot_occupied_from_probe(probe(false, false, true)));
+    fn piv_slot_argument_error_is_not_absence() {
+        assert!(slot_occupied_from_probes(
+            (Some(2), "Error: No such command 'list'.\n"),
+            (Some(1), YKMAN_NO_CERT),
+        ));
     }
 
-    /// Indeterminate dominates: even when a partial probe suggested the
-    /// slot was empty, an indeterminate result on the other probe must
-    /// not downgrade the slot to "safe to overwrite".
+    /// Absence requires BOTH the exit code and the marker. Matching the
+    /// marker alone would let any failure that happens to quote the
+    /// message — a usage error echoing it, a wrapper relaying it —
+    /// clear the guard.
     #[test]
-    fn piv_slot_indeterminate_dominates_empty_signals() {
-        assert!(slot_occupied_from_probe(probe(true, false, true)));
+    fn piv_slot_absence_marker_alone_is_not_absence() {
+        assert!(slot_occupied_from_probes(
+            (Some(2), "Usage error near: No key stored in slot 9C\n"),
+            (Some(1), YKMAN_NO_CERT),
+        ));
+        assert!(slot_occupied_from_probes(
+            (Some(1), YKMAN_NO_KEY),
+            (Some(2), "Usage error near: No certificate found\n"),
+        ));
     }
 
-    /// The slot string passed to `ykman piv keys list` matching must be
-    /// matched only as the leading token of a row, never as a substring
-    /// of a fingerprint or policy string. A slot id like "9a" must not
-    /// match a row for "9c" whose fingerprint happens to contain "9a".
-    /// This is enforced at the call site via `split_whitespace().next()`;
-    /// this test pins the matching primitive itself.
+    /// A probe killed by a signal reports no exit code at all.
     #[test]
-    fn ykman_row_match_is_first_token_only() {
-        let slot = "9a";
-        let rows = "9c    ED25519     PIN_ONCE   ALWAYS   9a01deadbeef\n";
-        assert!(
-            !rows
-                .lines()
-                .any(|line| line.split_whitespace().next() == Some(slot)),
-            "slot 9a must not match a row whose first token is 9c"
-        );
-        let rows_with_9a = "9a    ED25519     PIN_ONCE   ALWAYS   ---\n9c    X25519\n";
-        assert!(
-            rows_with_9a
-                .lines()
-                .any(|line| line.split_whitespace().next() == Some(slot)),
-            "slot 9a must match a row whose first token is 9a"
-        );
+    fn piv_slot_signal_kill_is_not_absence() {
+        assert!(slot_occupied_from_probes(
+            (None, ""),
+            (Some(1), YKMAN_NO_CERT)
+        ));
+    }
+
+    /// The classification tests above all feed the probes synthetic
+    /// output, so none of them can catch the failure that actually
+    /// shipped: an argv naming a subcommand `ykman` does not have. This
+    /// test runs the real binary and asserts each probe's subcommand is
+    /// recognised — `ykman` exits 0 on `--help` for a command it has and
+    /// 2 for one it does not, without touching a YubiKey.
+    ///
+    /// Skipped when `ykman` is not installed, so the suite stays
+    /// hermetic; on any host that has it, a renamed or invented
+    /// subcommand fails here instead of silently inverting the guard.
+    #[test]
+    fn ykman_probe_subcommands_exist_in_the_real_binary() {
+        for probe in [PIV_KEY_PROBE, PIV_CERT_PROBE] {
+            // Everything up to the slot placeholder is the subcommand path.
+            let subcommand: Vec<&str> = probe
+                .argv
+                .iter()
+                .copied()
+                .take_while(|arg| *arg != "{slot}")
+                .collect();
+            let mut command = Command::new("ykman");
+            let status = command
+                .args(&subcommand)
+                .arg("--help")
+                .stdin(Stdio::null())
+                .stdout(Stdio::null())
+                .stderr(Stdio::null())
+                .status();
+            let Ok(status) = status else {
+                eprintln!("ykman not installed; skipping subcommand existence check");
+                return;
+            };
+            assert_eq!(
+                status.code(),
+                Some(0),
+                "ykman does not recognise the subcommand `{}` used by the PIV \
+                 slot probe",
+                subcommand.join(" ")
+            );
+        }
     }
 }

--- a/crates/hyprstream/src/cli/trust.rs
+++ b/crates/hyprstream/src/cli/trust.rs
@@ -261,6 +261,18 @@ fn mint_deployment_ca(args: &MintDeploymentCaArgs) -> Result<()> {
 
     let (ed_secret, ed_signer) = match args.piv_slot.as_deref() {
         Some(slot) => {
+            // Destructive overwrite guard: ykman piv keys import silently
+            // replaces whatever is in the slot. Check first and refuse unless
+            // --force was given, so a daily-driver YubiKey's existing key
+            // (SSH, PIV cert, age identity) is not destroyed behind a
+            // routine-looking touch prompt.
+            if !args.force && piv_slot_occupied(slot)? {
+                anyhow::bail!(
+                    "PIV slot {slot} already contains a key or certificate. \
+                     Re-running will IRREVERSIBLY overwrite it. Pass --force to \
+                     confirm the overwrite."
+                );
+            }
             let recovery_key = SigningKey::generate(&mut rand::rngs::OsRng);
             let (slot, public) = piv_import_ed25519(slot, &recovery_key)?;
             (
@@ -1774,6 +1786,25 @@ fn validate_delegation_artifact(
         &active.rotation_keys,
         now,
     )
+}
+
+/// Check whether a PIV slot already holds a key or certificate.
+///
+/// `ykman piv keys import` silently overwrites slot contents; this check
+/// gives the caller a chance to warn or refuse before the import runs.
+fn piv_slot_occupied(slot: &str) -> Result<bool> {
+    let slot = validate_piv_slot(slot)?;
+    // Try reading the slot's certificate object. A slot with no object
+    // returns a non-zero exit; a slot with any data returns zero.
+    let status = Command::new("yubico-piv-tool")
+        .args(["-a", "read-certificate", "-s"])
+        .arg(&slot)
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .status()
+        .context("launch yubico-piv-tool to read slot status")?;
+    Ok(status.success())
 }
 
 fn piv_import_ed25519(slot: &str, key: &SigningKey) -> Result<(String, VerifyingKey)> {

--- a/crates/hyprstream/src/cli/trust_ceremony.rs
+++ b/crates/hyprstream/src/cli/trust_ceremony.rs
@@ -46,8 +46,12 @@ pub const CEREMONY_MODE_SCHEMA: &str = "hyprstream.deployment-trust-ceremony-mod
 /// Human-visible grade of a software root. Deliberately shouty.
 pub const DEV_GRADE_LABEL: &str = "DEV-GRADE — software root, no hardware gating, not for production";
 
-/// Grade of a token-gated root.
-const HARDWARE_GRADE_LABEL: &str = "hardware-gated deployment root";
+/// Grade of a token-gated root. The convenience signing path requires the
+/// token (PIN + touch), but the root seed is generated in host memory and
+/// stored in the age-encrypted authority bundle — it is recoverable by any
+/// bundle recipient, so "hardware-confined" would be materially false.
+const TOKEN_GATED_GRADE_LABEL: &str =
+    "token-gated deployment root (seed recoverable from bundle)";
 
 /// The delegation lifetime the ceremony requests (30 days).
 const DELEGATION_TTL_SECONDS: u64 = 2_592_000;
@@ -173,7 +177,9 @@ pub trait AgeYubikeyPlugin {
 /// How the deployment root will be protected.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum CeremonyMode {
-    /// Ed25519 leg is generated into a PIV slot and never enters host memory.
+    /// Ed25519 root is generated in host memory, imported into a PIV slot for
+    /// token-gated signing (PIN + touch). The recovery seed is stored in the
+    /// age-encrypted authority bundle — the key is NOT hardware-confined.
     HardwarePiv { token: DetectedToken, slot: String },
     /// Token decrypts the authority bundle; the bundle is briefly in memory.
     HardwareAgeRecipient { token: DetectedToken },
@@ -202,13 +208,26 @@ impl CeremonyMode {
         if self.is_dev_grade() {
             DEV_GRADE_LABEL
         } else {
-            HARDWARE_GRADE_LABEL
+            TOKEN_GATED_GRADE_LABEL
         }
     }
 
-    /// True only when the classical leg is confined to the token.
+    /// Whether the Ed25519 root key is **truly** confined to the hardware token
+    /// and cannot be extracted. In the current ceremony the key is generated in
+    /// host memory, imported into the PIV slot, and its seed is stored in the
+    /// age-encrypted authority bundle — so any bundle recipient can reconstruct
+    /// the software signer. This method returns `false` to reflect that reality
+    /// honestly in the audit record.
     #[must_use]
     pub fn ed25519_confined_to_hardware(&self) -> bool {
+        false
+    }
+
+    /// True when the convenience signing path is token-gated (requires PIN +
+    /// touch on the hardware token). This is what the PIV mode actually
+    /// provides; it does not imply the seed is confined.
+    #[must_use]
+    pub fn token_gated_signing(&self) -> bool {
         matches!(self, Self::HardwarePiv { .. })
     }
 
@@ -402,7 +421,9 @@ pub fn select_mode_for_token(request: &CeremonyRequest, token: &DetectedToken) -
             },
             rationale: format!(
                 "{} runs firmware {} (>= {PIV_ED25519_MIN_FIRMWARE}), so the Ed25519 leg is \
-                 generated into PIV slot {} and never enters host memory",
+                 imported into PIV slot {} for token-gated signing (PIN + touch). The seed \
+                 is stored in the age-encrypted authority bundle and is recoverable by any \
+                 bundle recipient — signing convenience is token-gated, not hardware-confined.",
                 token.label(),
                 token.firmware,
                 request.piv_slot
@@ -790,6 +811,14 @@ pub struct CeremonyModeRecord {
     pub grade: String,
     pub dev_grade: bool,
     pub ed25519_confined_to_hardware: bool,
+    /// Whether the root seed is recoverable from the authority bundle by any
+    /// bundle recipient (always true in the current ceremony — the seed is
+    /// stored as `recovery_seed_b64` inside the age-encrypted bundle).
+    pub seed_recoverable_from_bundle: bool,
+    /// Whether the convenience signing path is gated by the hardware token
+    /// (requires PIN + touch). True for PIV mode; does NOT imply the seed is
+    /// hardware-confined.
+    pub token_gated_signing: bool,
     pub token_model: Option<String>,
     pub token_serial: Option<String>,
     pub token_firmware: Option<String>,
@@ -809,6 +838,8 @@ pub fn mode_record(mode: &CeremonyMode, break_glass: &BreakGlass, rationale: &st
         grade: mode.grade_label().to_owned(),
         dev_grade: mode.is_dev_grade(),
         ed25519_confined_to_hardware: mode.ed25519_confined_to_hardware(),
+        seed_recoverable_from_bundle: true,
+        token_gated_signing: mode.token_gated_signing(),
         token_model: token.map(|token| token.model.clone()),
         token_serial: token.map(|token| token.serial.clone()),
         token_firmware: token.map(|token| token.firmware.to_string()),
@@ -1235,8 +1266,9 @@ mod tests {
                 slot: DEFAULT_PIV_SLOT.to_owned(),
             }
         );
-        assert!(mode.ed25519_confined_to_hardware());
-        assert!(rationale.contains("never enters host memory"));
+        assert!(!mode.ed25519_confined_to_hardware());
+        assert!(mode.token_gated_signing());
+        assert!(rationale.contains("token-gated signing"));
     }
 
     #[test]
@@ -1437,7 +1469,8 @@ mod tests {
         else {
             panic!("expected a hardware mode");
         };
-        assert!(mode.ed25519_confined_to_hardware());
+        assert!(!mode.ed25519_confined_to_hardware());
+        assert!(mode.token_gated_signing());
         let CeremonyPlan::Proceed { mode, .. } = select_mode_for_token(&request, &old_token())
         else {
             panic!("expected a hardware mode");
@@ -1728,6 +1761,8 @@ mod tests {
         assert!(record.dev_grade);
         assert_eq!(record.grade, DEV_GRADE_LABEL);
         assert!(!record.ed25519_confined_to_hardware);
+        assert!(!record.token_gated_signing);
+        assert!(record.seed_recoverable_from_bundle);
         assert_eq!(record.token_serial, None);
         assert_eq!(record.piv_slot, None);
         assert!(!record.break_glass_protected);
@@ -1746,7 +1781,9 @@ mod tests {
             "firmware 5.7.4",
         );
         assert!(!record.dev_grade);
-        assert!(record.ed25519_confined_to_hardware);
+        assert!(!record.ed25519_confined_to_hardware);
+        assert!(record.token_gated_signing);
+        assert!(record.seed_recoverable_from_bundle);
         assert_eq!(record.token_firmware.as_deref(), Some("5.7.4"));
         assert_eq!(record.token_serial.as_deref(), Some("22222222"));
         assert_eq!(record.piv_slot.as_deref(), Some(DEFAULT_PIV_SLOT));

--- a/crates/hyprstream/src/cli/trust_ceremony.rs
+++ b/crates/hyprstream/src/cli/trust_ceremony.rs
@@ -1,0 +1,1848 @@
+//! Deployment-trust ceremony automation for the setup wizard.
+//!
+//! Node bootstrap (directories, node root key, per-service keypairs, CA-signed
+//! service JWTs) and deployment trust are separate concerns and stay separate:
+//! this module is opt-in and additive. Nothing here runs unless the operator
+//! asks for the ceremony.
+//!
+//! What it adds is the decision an operator would otherwise make by reading
+//! [`docs/deployment-trust-ceremony.md`]: is a hardware token attached, does its
+//! firmware confine an Ed25519 key to the token, and — when nothing is attached
+//! — is the operator willing to accept a software root that is only fit for
+//! development.
+//!
+//! Hardware access sits behind [`TokenDetector`] and [`AgeYubikeyPlugin`] so the
+//! decision logic can be exercised without a token. The decision logic itself is
+//! pure: [`plan_ceremony`], [`select_mode_for_token`], [`validate_break_glass`]
+//! and [`ceremony_commands`] take values and return values.
+
+use std::{
+    path::{Path, PathBuf},
+    process::{Command, Stdio},
+    time::{Duration, Instant},
+};
+
+use anyhow::{bail, Context, Result};
+use serde::{Deserialize, Serialize};
+
+use crate::cli::commands::{
+    DelegateRegistrySignerArgs, MintDeploymentCaArgs, MintRegistryJwtArgs, TrustCommand,
+    VerifyDeploymentArgs,
+};
+
+/// First firmware generation that can hold an Ed25519 key in a PIV slot.
+pub const PIV_ED25519_MIN_FIRMWARE: FirmwareVersion = FirmwareVersion {
+    major: 5,
+    minor: 7,
+    patch: 4,
+};
+
+/// PIV digital-signature slot: PIN is demanded for every signature.
+pub const DEFAULT_PIV_SLOT: &str = "9c";
+
+/// Schema of the mode record written beside the ceremony artifacts.
+pub const CEREMONY_MODE_SCHEMA: &str = "hyprstream.deployment-trust-ceremony-mode.v1";
+
+/// Human-visible grade of a software root. Deliberately shouty.
+pub const DEV_GRADE_LABEL: &str = "DEV-GRADE — software root, no hardware gating, not for production";
+
+/// Grade of a token-gated root.
+const HARDWARE_GRADE_LABEL: &str = "hardware-gated deployment root";
+
+/// The delegation lifetime the ceremony requests (30 days).
+const DELEGATION_TTL_SECONDS: u64 = 2_592_000;
+
+/// Registry credential lifetime; the profile caps it at one hour anyway.
+const REGISTRY_JWT_TTL_SECONDS: u32 = 3600;
+
+/// How long to wait for the token-enumeration tool before giving up.
+const DETECTION_TIMEOUT: Duration = Duration::from_secs(10);
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Token facts
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// A three-part YubiKey firmware version.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord)]
+pub struct FirmwareVersion {
+    pub major: u8,
+    pub minor: u8,
+    pub patch: u8,
+}
+
+impl FirmwareVersion {
+    #[must_use]
+    pub const fn new(major: u8, minor: u8, patch: u8) -> Self {
+        Self {
+            major,
+            minor,
+            patch,
+        }
+    }
+
+    /// Parse `5.7.4`. Anything else is rejected rather than guessed at.
+    #[must_use]
+    pub fn parse(text: &str) -> Option<Self> {
+        let mut parts = text.trim().split('.');
+        let major = parts.next()?.parse().ok()?;
+        let minor = parts.next()?.parse().ok()?;
+        let patch = parts.next()?.parse().ok()?;
+        if parts.next().is_some() {
+            return None;
+        }
+        Some(Self::new(major, minor, patch))
+    }
+
+    /// Ed25519-in-PIV, which is what keeps the classical leg off the host.
+    #[must_use]
+    pub fn supports_piv_ed25519(&self) -> bool {
+        *self >= PIV_ED25519_MIN_FIRMWARE
+    }
+}
+
+impl std::fmt::Display for FirmwareVersion {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}.{}.{}", self.major, self.minor, self.patch)
+    }
+}
+
+/// A token the detector reported as attached.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct DetectedToken {
+    pub model: String,
+    pub firmware: FirmwareVersion,
+    pub serial: String,
+}
+
+impl DetectedToken {
+    /// One-line label for prompts and summaries.
+    #[must_use]
+    pub fn label(&self) -> String {
+        format!(
+            "{} (firmware {}, serial {})",
+            self.model, self.firmware, self.serial
+        )
+    }
+}
+
+/// Why the wizard could not learn whether a token is attached.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum DetectionError {
+    /// The enumeration tool is not installed.
+    ToolMissing { tool: String },
+    /// The tool did not finish within the detection budget.
+    Timeout { tool: String, seconds: u64 },
+    /// The tool ran but failed, or produced output we will not guess at.
+    Failed { tool: String, detail: String },
+}
+
+impl std::fmt::Display for DetectionError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::ToolMissing { tool } => write!(f, "`{tool}` is not installed"),
+            Self::Timeout { tool, seconds } => {
+                write!(f, "`{tool}` did not answer within {seconds}s")
+            }
+            Self::Failed { tool, detail } => write!(f, "`{tool}` failed: {detail}"),
+        }
+    }
+}
+
+impl std::error::Error for DetectionError {}
+
+/// Enumerates attached hardware tokens.
+///
+/// The wizard depends on this trait, never on the tool directly, so the
+/// selection logic can be driven from fixed detection results.
+pub trait TokenDetector {
+    fn detect(&self) -> Result<Vec<DetectedToken>, DetectionError>;
+}
+
+/// Creates and exports the PIV-backed age identity on an attached token.
+pub trait AgeYubikeyPlugin {
+    /// Generate a PIN-always/touch-always identity, returning its recipient.
+    fn generate_identity(&self, name: &str) -> Result<String, DetectionError>;
+    /// Write the identity stub the trust commands consume.
+    fn export_identity_file(&self, out: &Path) -> Result<(), DetectionError>;
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Mode selection
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// How the deployment root will be protected.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum CeremonyMode {
+    /// Ed25519 leg is generated into a PIV slot and never enters host memory.
+    HardwarePiv { token: DetectedToken, slot: String },
+    /// Token decrypts the authority bundle; the bundle is briefly in memory.
+    HardwareAgeRecipient { token: DetectedToken },
+    /// Software recipients only. Fit for development, nothing else.
+    SoftwareDevGrade,
+}
+
+impl CeremonyMode {
+    #[must_use]
+    pub fn is_dev_grade(&self) -> bool {
+        matches!(self, Self::SoftwareDevGrade)
+    }
+
+    /// Stable identifier recorded in the emitted mode record.
+    #[must_use]
+    pub fn mode_id(&self) -> &'static str {
+        match self {
+            Self::HardwarePiv { .. } => "yubikey-piv",
+            Self::HardwareAgeRecipient { .. } => "yubikey-age-recipient",
+            Self::SoftwareDevGrade => "software-dev-grade",
+        }
+    }
+
+    #[must_use]
+    pub fn grade_label(&self) -> &'static str {
+        if self.is_dev_grade() {
+            DEV_GRADE_LABEL
+        } else {
+            HARDWARE_GRADE_LABEL
+        }
+    }
+
+    /// True only when the classical leg is confined to the token.
+    #[must_use]
+    pub fn ed25519_confined_to_hardware(&self) -> bool {
+        matches!(self, Self::HardwarePiv { .. })
+    }
+
+    #[must_use]
+    pub fn token(&self) -> Option<&DetectedToken> {
+        match self {
+            Self::HardwarePiv { token, .. } | Self::HardwareAgeRecipient { token } => Some(token),
+            Self::SoftwareDevGrade => None,
+        }
+    }
+}
+
+/// What the wizard decided to do about deployment trust.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum CeremonyPlan {
+    /// Not requested. Node bootstrap stands alone, exactly as before.
+    Skipped { reason: String },
+    /// A mode was chosen; `rationale` explains the choice in one sentence.
+    Proceed { mode: CeremonyMode, rationale: String },
+    /// Several tokens are attached and the operator must say which one.
+    ChooseToken {
+        tokens: Vec<DetectedToken>,
+        rationale: String,
+    },
+    /// The ceremony cannot run as invoked. Never a silent downgrade.
+    Blocked { reason: String, remedy: String },
+}
+
+/// Everything the plan depends on that does not come from the token itself.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct CeremonyRequest {
+    /// Operator asked for the ceremony. False means the wizard does nothing.
+    pub enabled: bool,
+    /// A human is present and can answer prompts, enter a PIN, and touch.
+    pub interactive: bool,
+    /// Mint a software root even if a token is attached.
+    pub force_software: bool,
+    /// Use the token with this serial when several are attached.
+    pub serial: Option<String>,
+    /// PIV slot for the Ed25519 leg when the firmware supports it.
+    pub piv_slot: String,
+}
+
+impl Default for CeremonyRequest {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            interactive: true,
+            force_software: false,
+            serial: None,
+            piv_slot: DEFAULT_PIV_SLOT.to_owned(),
+        }
+    }
+}
+
+/// Decide what to do, given a detection result.
+///
+/// A software root is only ever chosen when no token was found, or when the
+/// operator explicitly asked for one. A detection failure blocks rather than
+/// degrades: not knowing whether hardware is present is not the same as knowing
+/// it is absent.
+#[must_use]
+pub fn plan_ceremony(
+    request: &CeremonyRequest,
+    detection: &Result<Vec<DetectedToken>, DetectionError>,
+) -> CeremonyPlan {
+    if !request.enabled {
+        return CeremonyPlan::Skipped {
+            reason: "deployment trust not requested; the wizard set up node-local trust only"
+                .to_owned(),
+        };
+    }
+
+    let tokens = match detection {
+        Err(error) => {
+            if request.force_software {
+                return CeremonyPlan::Proceed {
+                    mode: CeremonyMode::SoftwareDevGrade,
+                    rationale: format!(
+                        "token detection failed ({error}) and a software root was explicitly \
+                         requested, so the root is {DEV_GRADE_LABEL}"
+                    ),
+                };
+            }
+            return CeremonyPlan::Blocked {
+                reason: format!("could not tell whether a hardware token is attached: {error}"),
+                remedy: "install `ykman` (yubikey-manager) and re-run, or pass \
+                         --deployment-trust-software to accept a dev-grade software root"
+                    .to_owned(),
+            };
+        }
+        Ok(tokens) => tokens,
+    };
+
+    if request.force_software {
+        let rationale = if tokens.is_empty() {
+            format!("a software root was explicitly requested; the root is {DEV_GRADE_LABEL}")
+        } else {
+            format!(
+                "{} hardware token(s) are attached but a software root was explicitly requested; \
+                 the root is {DEV_GRADE_LABEL}",
+                tokens.len()
+            )
+        };
+        return CeremonyPlan::Proceed {
+            mode: CeremonyMode::SoftwareDevGrade,
+            rationale,
+        };
+    }
+
+    if tokens.is_empty() {
+        return CeremonyPlan::Proceed {
+            mode: CeremonyMode::SoftwareDevGrade,
+            rationale: format!(
+                "no hardware token is attached, so the root falls back to software recipients: \
+                 {DEV_GRADE_LABEL}"
+            ),
+        };
+    }
+
+    let token = match request.serial.as_deref() {
+        Some(serial) => match tokens.iter().find(|token| token.serial == serial) {
+            Some(token) => token,
+            None => {
+                let attached = tokens
+                    .iter()
+                    .map(|token| token.serial.clone())
+                    .collect::<Vec<_>>()
+                    .join(", ");
+                return CeremonyPlan::Blocked {
+                    reason: format!("no attached token has serial {serial}"),
+                    remedy: format!("attached serials are: {attached}"),
+                };
+            }
+        },
+        None => match tokens.split_first() {
+            Some((token, [])) => token,
+            _ => {
+                if request.interactive {
+                    return CeremonyPlan::ChooseToken {
+                        tokens: tokens.clone(),
+                        rationale: format!(
+                            "{} hardware tokens are attached; the deployment root must be bound to \
+                             exactly one",
+                            tokens.len()
+                        ),
+                    };
+                }
+                let attached = tokens
+                    .iter()
+                    .map(|token| token.serial.clone())
+                    .collect::<Vec<_>>()
+                    .join(", ");
+                return CeremonyPlan::Blocked {
+                    reason: format!("{} hardware tokens are attached", tokens.len()),
+                    remedy: format!(
+                        "pass --deployment-trust-serial <SERIAL> to pick one (attached: {attached})"
+                    ),
+                };
+            }
+        },
+    };
+
+    select_mode_for_token(request, token)
+}
+
+/// Resolve a chosen token to a mode, or block when no human can drive it.
+///
+/// Split out so the multiple-token prompt can feed the operator's answer back
+/// through exactly the same firmware rule.
+#[must_use]
+pub fn select_mode_for_token(request: &CeremonyRequest, token: &DetectedToken) -> CeremonyPlan {
+    if !request.interactive {
+        return CeremonyPlan::Blocked {
+            reason: format!(
+                "{} is attached, and a hardware ceremony needs a PIN, a physical touch, and a \
+                 break-glass passphrase",
+                token.label()
+            ),
+            remedy: "re-run the wizard without --non-interactive, or pass \
+                     --deployment-trust-software to mint a dev-grade software root instead"
+                .to_owned(),
+        };
+    }
+
+    if token.firmware.supports_piv_ed25519() {
+        CeremonyPlan::Proceed {
+            mode: CeremonyMode::HardwarePiv {
+                token: token.clone(),
+                slot: request.piv_slot.clone(),
+            },
+            rationale: format!(
+                "{} runs firmware {} (>= {PIV_ED25519_MIN_FIRMWARE}), so the Ed25519 leg is \
+                 generated into PIV slot {} and never enters host memory",
+                token.label(),
+                token.firmware,
+                request.piv_slot
+            ),
+        }
+    } else {
+        CeremonyPlan::Proceed {
+            mode: CeremonyMode::HardwareAgeRecipient {
+                token: token.clone(),
+            },
+            rationale: format!(
+                "{} runs firmware {}, below the {PIV_ED25519_MIN_FIRMWARE} needed for \
+                 Ed25519-in-PIV, so the token acts as the age recipient instead: it gates \
+                 decryption of the authority bundle, which is briefly in host memory during the \
+                 ceremony",
+                token.label(),
+                token.firmware
+            ),
+        }
+    }
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Break-glass
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// The recovery half of the root recipient ring.
+///
+/// The trust CLI can only check that the two recipients differ; whether the
+/// second is protected is decided here.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum BreakGlass {
+    /// A second hardware token. Best: same properties as the primary.
+    SecondToken { recipient: String },
+    /// A passphrase-encrypted identity file, passphrase held separately.
+    PassphraseEncrypted {
+        identity_file: PathBuf,
+        recipient: String,
+    },
+    /// A bare identity file. Anyone who can read it holds the root.
+    PlaintextIdentity {
+        identity_file: PathBuf,
+        recipient: String,
+    },
+}
+
+impl BreakGlass {
+    #[must_use]
+    pub fn recipient(&self) -> &str {
+        match self {
+            Self::SecondToken { recipient }
+            | Self::PassphraseEncrypted { recipient, .. }
+            | Self::PlaintextIdentity { recipient, .. } => recipient,
+        }
+    }
+
+    #[must_use]
+    pub fn kind_id(&self) -> &'static str {
+        match self {
+            Self::SecondToken { .. } => "second-token",
+            Self::PassphraseEncrypted { .. } => "passphrase-encrypted-identity",
+            Self::PlaintextIdentity { .. } => "plaintext-identity",
+        }
+    }
+
+    #[must_use]
+    pub fn is_protected(&self) -> bool {
+        !matches!(self, Self::PlaintextIdentity { .. })
+    }
+}
+
+/// Whether an unprotected break-glass is tolerable for the root being minted.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum PlaintextPolicy {
+    /// Refuse. This is the default for any root worth protecting.
+    Refuse,
+    /// The operator explicitly overrode the refusal.
+    AllowedByOverride,
+    /// The root is already dev-grade, so a bare backup adds no exposure.
+    AllowedForDevGradeRoot,
+}
+
+/// Reject a recipient ring that would leave the root weaker than it looks.
+pub fn validate_break_glass(
+    break_glass: &BreakGlass,
+    primary_recipient: &str,
+    policy: PlaintextPolicy,
+) -> Result<(), String> {
+    let recipient = break_glass.recipient().trim();
+    if recipient.is_empty() {
+        return Err("break-glass recipient is empty; paste the `age1…` recipient the backup \
+                    identity prints"
+            .to_owned());
+    }
+    if !recipient.is_ascii() || recipient.contains(['\n', '\r', '\0']) {
+        return Err("break-glass recipient contains characters an age recipient cannot hold; \
+                    re-copy it without line breaks"
+            .to_owned());
+    }
+    if !recipient.starts_with("age1") {
+        return Err(format!(
+            "break-glass value {recipient} is not an age recipient; it must start with `age1`"
+        ));
+    }
+    if recipient == primary_recipient.trim() {
+        return Err("break-glass recipient is identical to the primary recipient; the root would \
+                    then have a single point of loss, which is exactly what the second recipient \
+                    exists to prevent"
+            .to_owned());
+    }
+    if let BreakGlass::SecondToken { .. } = break_glass {
+        if !recipient.starts_with("age1yubikey1") {
+            return Err(format!(
+                "{recipient} is not an age-plugin-yubikey recipient; a second-token break-glass \
+                 recipient starts with `age1yubikey1`"
+            ));
+        }
+    }
+    if !break_glass.is_protected() && policy == PlaintextPolicy::Refuse {
+        return Err("refusing an unencrypted break-glass identity: a root is exactly as strong as \
+                    its weakest recipient, and a bare `age-keygen` file hands the deployment root \
+                    to anyone who can read it. Use a second token, or a passphrase-encrypted \
+                    identity (`age-keygen | age -p`). Pass \
+                    --deployment-trust-allow-plaintext-break-glass only for a throwaway root you \
+                    destroy immediately afterwards."
+            .to_owned());
+    }
+    Ok(())
+}
+
+/// What a candidate break-glass identity file actually is.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum IdentityFileKind {
+    /// age file sealed with a scrypt (passphrase) stanza.
+    PassphraseEncrypted,
+    /// A bare `AGE-SECRET-KEY-1…` identity.
+    PlaintextAgeIdentity,
+    /// Encrypted, or unrecognised — protection cannot be confirmed from here.
+    Unconfirmed,
+}
+
+/// Classify a candidate break-glass file without decrypting it.
+///
+/// Armored ciphertext reports [`IdentityFileKind::Unconfirmed`] rather than
+/// claiming a passphrase we cannot see.
+#[must_use]
+pub fn classify_identity_file(contents: &str) -> IdentityFileKind {
+    if contents.contains("AGE-SECRET-KEY-1") {
+        return IdentityFileKind::PlaintextAgeIdentity;
+    }
+    let mut lines = contents.lines();
+    if lines.next().map(str::trim) == Some("age-encryption.org/v1")
+        && lines.any(|line| line.starts_with("-> scrypt "))
+    {
+        return IdentityFileKind::PassphraseEncrypted;
+    }
+    IdentityFileKind::Unconfirmed
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Ceremony artifacts and commands
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Absolute paths of every ceremony input and output.
+///
+/// The trust CLI's bare-filename defaults fail from an unexpected working
+/// directory, so the wizard always passes absolute paths.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct CeremonyPaths {
+    dir: PathBuf,
+}
+
+impl CeremonyPaths {
+    /// Reject a relative directory up front rather than mid-ceremony.
+    pub fn new(dir: impl Into<PathBuf>) -> Result<Self> {
+        let dir = dir.into();
+        if !dir.is_absolute() {
+            bail!(
+                "ceremony directory {} must be an absolute path; the trust commands resolve \
+                 bare filenames against the working directory and fail mid-ceremony",
+                dir.display()
+            );
+        }
+        Ok(Self { dir })
+    }
+
+    #[must_use]
+    pub fn dir(&self) -> &Path {
+        &self.dir
+    }
+
+    #[must_use]
+    pub fn public_ca(&self) -> PathBuf {
+        self.dir.join("deployment-ca.hybrid")
+    }
+
+    #[must_use]
+    pub fn authority_key(&self) -> PathBuf {
+        self.dir.join("deployment-ca.age")
+    }
+
+    #[must_use]
+    pub fn authority_log(&self) -> PathBuf {
+        self.dir.join("deployment-authority.log.json")
+    }
+
+    #[must_use]
+    pub fn authority_checkpoint(&self) -> PathBuf {
+        self.dir.join("deployment-authority.head.json")
+    }
+
+    #[must_use]
+    pub fn yubikey_identity(&self) -> PathBuf {
+        self.dir.join("yubikey-identity.txt")
+    }
+
+    #[must_use]
+    pub fn primary_identity(&self) -> PathBuf {
+        self.dir.join("root-primary.key")
+    }
+
+    #[must_use]
+    pub fn break_glass_identity(&self) -> PathBuf {
+        self.dir.join("break-glass.key.age")
+    }
+
+    #[must_use]
+    pub fn online_signer_identity(&self) -> PathBuf {
+        self.dir.join("online-signer.key")
+    }
+
+    #[must_use]
+    pub fn delegated_signer(&self) -> PathBuf {
+        self.dir.join("registry-delegated-signer.age")
+    }
+
+    #[must_use]
+    pub fn delegation(&self) -> PathBuf {
+        self.dir.join("registry-signer.delegation.json")
+    }
+
+    #[must_use]
+    pub fn registry_public_key(&self) -> PathBuf {
+        self.dir.join("registry-service.pub")
+    }
+
+    #[must_use]
+    pub fn registry_jwt(&self) -> PathBuf {
+        self.dir.join("registry-service.jwt")
+    }
+
+    #[must_use]
+    pub fn contract(&self) -> PathBuf {
+        self.dir.join("deployment-trust.contract.json")
+    }
+
+    #[must_use]
+    pub fn mode_record(&self) -> PathBuf {
+        self.dir.join("deployment-trust-mode.json")
+    }
+}
+
+/// The identity that unlocks the authority bundle during the delegation step.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum UnlockIdentity {
+    /// An age-plugin-yubikey identity stub: decryption costs a PIN and a touch.
+    Yubikey(PathBuf),
+    /// A native age identity file.
+    Age(PathBuf),
+}
+
+/// Every value the four trust invocations need.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct CeremonyInputs {
+    pub mode: CeremonyMode,
+    /// Primary root recipient (`age1yubikey1…` in hardware modes).
+    pub primary_recipient: String,
+    pub break_glass: BreakGlass,
+    pub unlock_identity: UnlockIdentity,
+    /// Recipient the unattended deploy can decrypt the online signer with.
+    pub signer_recipient: String,
+    pub paths: CeremonyPaths,
+}
+
+/// Build the ceremony as the exact sequence of trust commands it runs.
+///
+/// Returning commands rather than running them keeps the mode-to-flag mapping —
+/// the part that decides whether the classical leg ever touches host memory —
+/// inspectable without a token.
+pub fn ceremony_commands(inputs: &CeremonyInputs) -> Result<Vec<TrustCommand>> {
+    let policy = if inputs.mode.is_dev_grade() {
+        PlaintextPolicy::AllowedForDevGradeRoot
+    } else {
+        PlaintextPolicy::Refuse
+    };
+    if let Err(reason) =
+        validate_break_glass(&inputs.break_glass, &inputs.primary_recipient, policy)
+    {
+        bail!("{reason}");
+    }
+
+    let (mut recipients, mut yubikey_recipients) = (Vec::new(), Vec::new());
+    for recipient in [
+        inputs.primary_recipient.trim(),
+        inputs.break_glass.recipient().trim(),
+    ] {
+        if recipient.starts_with("age1yubikey1") {
+            yubikey_recipients.push(recipient.to_owned());
+        } else {
+            recipients.push(recipient.to_owned());
+        }
+    }
+
+    let piv_slot = match &inputs.mode {
+        CeremonyMode::HardwarePiv { slot, .. } => Some(slot.clone()),
+        CeremonyMode::HardwareAgeRecipient { .. } | CeremonyMode::SoftwareDevGrade => None,
+    };
+
+    let (identities, yubikey_identities) = match &inputs.unlock_identity {
+        UnlockIdentity::Yubikey(path) => (Vec::new(), vec![path.clone()]),
+        UnlockIdentity::Age(path) => (vec![path.clone()], Vec::new()),
+    };
+
+    Ok(vec![
+        TrustCommand::MintDeploymentCa(MintDeploymentCaArgs {
+            public_ca: inputs.paths.public_ca(),
+            authority_key: inputs.paths.authority_key(),
+            authority_log: inputs.paths.authority_log(),
+            authority_checkpoint: inputs.paths.authority_checkpoint(),
+            recipients,
+            yubikey_recipients,
+            kms_plugin_recipients: Vec::new(),
+            piv_slot,
+            force: false,
+        }),
+        TrustCommand::DelegateRegistrySigner(DelegateRegistrySignerArgs {
+            public_ca: inputs.paths.public_ca(),
+            authority_log: inputs.paths.authority_log(),
+            authority_checkpoint: inputs.paths.authority_checkpoint(),
+            authority_key: inputs.paths.authority_key(),
+            identities: identities.clone(),
+            yubikey_identities: yubikey_identities.clone(),
+            software_recovery: false,
+            signer_recipients: vec![inputs.signer_recipient.trim().to_owned()],
+            delegated_key: inputs.paths.delegated_signer(),
+            delegation: inputs.paths.delegation(),
+            delegation_ttl_seconds: DELEGATION_TTL_SECONDS,
+            force: false,
+        }),
+        TrustCommand::MintRegistryJwt(MintRegistryJwtArgs {
+            public_ca: inputs.paths.public_ca(),
+            authority_key: inputs.paths.authority_key(),
+            identities: vec![inputs.paths.online_signer_identity()],
+            yubikey_identities: Vec::new(),
+            software_recovery: false,
+            via_delegated_signer: Some(inputs.paths.delegated_signer()),
+            delegation: Some(inputs.paths.delegation()),
+            authority_log: inputs.paths.authority_log(),
+            authority_checkpoint: inputs.paths.authority_checkpoint(),
+            root: false,
+            registry_public_key: inputs.paths.registry_public_key(),
+            ttl_seconds: REGISTRY_JWT_TTL_SECONDS,
+            jwt: inputs.paths.registry_jwt(),
+            contract: inputs.paths.contract(),
+            force: false,
+        }),
+        TrustCommand::VerifyDeployment(VerifyDeploymentArgs {
+            public_ca: inputs.paths.public_ca(),
+            jwt: inputs.paths.registry_jwt(),
+            authority_log: inputs.paths.authority_log(),
+            authority_checkpoint: inputs.paths.authority_checkpoint(),
+            contract: Some(inputs.paths.contract()),
+        }),
+    ])
+}
+
+/// Machine-readable record of which mode ran, written beside the artifacts.
+///
+/// A software root is labelled here as well as on screen, so the grade survives
+/// after the operator has closed the terminal.
+#[derive(Clone, Debug, Deserialize, PartialEq, Eq, Serialize)]
+pub struct CeremonyModeRecord {
+    pub schema: String,
+    pub mode: String,
+    pub grade: String,
+    pub dev_grade: bool,
+    pub ed25519_confined_to_hardware: bool,
+    pub token_model: Option<String>,
+    pub token_serial: Option<String>,
+    pub token_firmware: Option<String>,
+    pub piv_slot: Option<String>,
+    pub break_glass: String,
+    pub break_glass_protected: bool,
+    pub rationale: String,
+}
+
+/// Summarise a completed selection for the emitted record.
+#[must_use]
+pub fn mode_record(mode: &CeremonyMode, break_glass: &BreakGlass, rationale: &str) -> CeremonyModeRecord {
+    let token = mode.token();
+    CeremonyModeRecord {
+        schema: CEREMONY_MODE_SCHEMA.to_owned(),
+        mode: mode.mode_id().to_owned(),
+        grade: mode.grade_label().to_owned(),
+        dev_grade: mode.is_dev_grade(),
+        ed25519_confined_to_hardware: mode.ed25519_confined_to_hardware(),
+        token_model: token.map(|token| token.model.clone()),
+        token_serial: token.map(|token| token.serial.clone()),
+        token_firmware: token.map(|token| token.firmware.to_string()),
+        piv_slot: match mode {
+            CeremonyMode::HardwarePiv { slot, .. } => Some(slot.clone()),
+            CeremonyMode::HardwareAgeRecipient { .. } | CeremonyMode::SoftwareDevGrade => None,
+        },
+        break_glass: break_glass.kind_id().to_owned(),
+        break_glass_protected: break_glass.is_protected(),
+        rationale: rationale.to_owned(),
+    }
+}
+
+/// External programs a mode needs on `PATH`.
+#[must_use]
+pub fn required_tools(mode: &CeremonyMode) -> &'static [&'static str] {
+    match mode {
+        CeremonyMode::HardwarePiv { .. } => &["ykman", "yubico-piv-tool", "age-plugin-yubikey"],
+        CeremonyMode::HardwareAgeRecipient { .. } => &["age-plugin-yubikey"],
+        CeremonyMode::SoftwareDevGrade => &["age-keygen", "age"],
+    }
+}
+
+/// Names from `required_tools` that `probe` reports as absent.
+///
+/// `probe` is a parameter so the check is exercised without touching `PATH`.
+#[must_use]
+pub fn missing_tools(tools: &[&str], probe: impl Fn(&str) -> bool) -> Vec<String> {
+    tools
+        .iter()
+        .filter(|tool| !probe(tool))
+        .map(|tool| (*tool).to_owned())
+        .collect()
+}
+
+/// True when `tool` resolves through `PATH`.
+#[must_use]
+pub fn tool_on_path(tool: &str) -> bool {
+    let Some(path) = std::env::var_os("PATH") else {
+        return false;
+    };
+    std::env::split_paths(&path).any(|dir| dir.join(tool).is_file())
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Output parsing (pure; the commands themselves need hardware)
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Parse `ykman list` output.
+///
+/// A line that names a token but whose firmware cannot be read is an error, not
+/// a token silently dropped from the ring: dropping it could turn "hardware is
+/// present" into "nothing attached", which selects a software root.
+pub fn parse_ykman_list(stdout: &str) -> Result<Vec<DetectedToken>, DetectionError> {
+    let mut tokens = Vec::new();
+    for line in stdout.lines() {
+        let line = line.trim();
+        if line.is_empty() {
+            continue;
+        }
+        let unreadable = || DetectionError::Failed {
+            tool: "ykman".to_owned(),
+            detail: format!("could not read model, firmware and serial from `{line}`"),
+        };
+        let (model, rest) = line.split_once(" (").ok_or_else(unreadable)?;
+        let (firmware, rest) = rest.split_once(')').ok_or_else(unreadable)?;
+        let firmware = FirmwareVersion::parse(firmware).ok_or_else(unreadable)?;
+        let (_, serial) = rest.split_once("Serial: ").ok_or_else(unreadable)?;
+        let serial = serial.trim();
+        if serial.is_empty() || !serial.chars().all(|c| c.is_ascii_digit()) {
+            return Err(unreadable());
+        }
+        tokens.push(DetectedToken {
+            model: model.trim().to_owned(),
+            firmware,
+            serial: serial.to_owned(),
+        });
+    }
+    Ok(tokens)
+}
+
+/// Pull the `age1yubikey1…` recipient out of `age-plugin-yubikey` output.
+#[must_use]
+pub fn parse_age_plugin_recipient(output: &str) -> Option<String> {
+    output
+        .split_whitespace()
+        .find(|word| word.starts_with("age1yubikey1"))
+        .map(str::to_owned)
+}
+
+/// Pull the public recipient out of `age-keygen` output.
+#[must_use]
+pub fn parse_age_keygen_recipient(output: &str) -> Option<String> {
+    output
+        .split_whitespace()
+        .find(|word| word.starts_with("age1") && !word.starts_with("age1yubikey1"))
+        .map(str::to_owned)
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Real hardware backend
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Enumerates tokens with `ykman list`.
+///
+/// The hardware half of this type cannot be exercised without a token; the
+/// parsing and decision it feeds are covered separately.
+#[derive(Clone, Copy, Debug, Default)]
+pub struct SystemTokenDetector;
+
+impl TokenDetector for SystemTokenDetector {
+    fn detect(&self) -> Result<Vec<DetectedToken>, DetectionError> {
+        if !tool_on_path("ykman") {
+            return Err(DetectionError::ToolMissing {
+                tool: "ykman".to_owned(),
+            });
+        }
+        let stdout = run_with_timeout("ykman", &["list"], DETECTION_TIMEOUT)?;
+        parse_ykman_list(&stdout)
+    }
+}
+
+/// Drives `age-plugin-yubikey`, which needs a real TTY for PIN entry.
+#[derive(Clone, Copy, Debug, Default)]
+pub struct SystemAgeYubikeyPlugin;
+
+impl AgeYubikeyPlugin for SystemAgeYubikeyPlugin {
+    fn generate_identity(&self, name: &str) -> Result<String, DetectionError> {
+        if !tool_on_path("age-plugin-yubikey") {
+            return Err(DetectionError::ToolMissing {
+                tool: "age-plugin-yubikey".to_owned(),
+            });
+        }
+        // Inherited stdio: the plugin refuses a pipe, and the operator has to
+        // see the PIN prompt. `always` costs a PIN and a touch per decryption.
+        let status = Command::new("age-plugin-yubikey")
+            .args(["--generate", "--name"])
+            .arg(name)
+            .args(["--pin-policy", "always", "--touch-policy", "always"])
+            .stdin(Stdio::inherit())
+            .stdout(Stdio::inherit())
+            .stderr(Stdio::inherit())
+            .status()
+            .map_err(|error| DetectionError::Failed {
+                tool: "age-plugin-yubikey".to_owned(),
+                detail: error.to_string(),
+            })?;
+        if !status.success() {
+            return Err(DetectionError::Failed {
+                tool: "age-plugin-yubikey".to_owned(),
+                detail: "identity generation did not complete".to_owned(),
+            });
+        }
+        let listed = run_with_timeout("age-plugin-yubikey", &["--list"], DETECTION_TIMEOUT)?;
+        parse_age_plugin_recipient(&listed).ok_or_else(|| DetectionError::Failed {
+            tool: "age-plugin-yubikey".to_owned(),
+            detail: "no `age1yubikey1…` recipient was listed after generation".to_owned(),
+        })
+    }
+
+    fn export_identity_file(&self, out: &Path) -> Result<(), DetectionError> {
+        let identity = run_with_timeout("age-plugin-yubikey", &["--identity"], DETECTION_TIMEOUT)?;
+        std::fs::write(out, identity).map_err(|error| DetectionError::Failed {
+            tool: "age-plugin-yubikey".to_owned(),
+            detail: format!("write identity to {}: {error}", out.display()),
+        })
+    }
+}
+
+/// Run a command, capturing stdout and killing it if it overruns `budget`.
+fn run_with_timeout(tool: &str, args: &[&str], budget: Duration) -> Result<String, DetectionError> {
+    let mut child = Command::new(tool)
+        .args(args)
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .map_err(|error| {
+            if error.kind() == std::io::ErrorKind::NotFound {
+                DetectionError::ToolMissing {
+                    tool: tool.to_owned(),
+                }
+            } else {
+                DetectionError::Failed {
+                    tool: tool.to_owned(),
+                    detail: error.to_string(),
+                }
+            }
+        })?;
+
+    let started = Instant::now();
+    loop {
+        match child.try_wait() {
+            Ok(Some(_)) => break,
+            Ok(None) => {
+                if started.elapsed() >= budget {
+                    let _ = child.kill();
+                    let _ = child.wait();
+                    return Err(DetectionError::Timeout {
+                        tool: tool.to_owned(),
+                        seconds: budget.as_secs(),
+                    });
+                }
+                std::thread::sleep(Duration::from_millis(50));
+            }
+            Err(error) => {
+                return Err(DetectionError::Failed {
+                    tool: tool.to_owned(),
+                    detail: error.to_string(),
+                })
+            }
+        }
+    }
+
+    let output = child
+        .wait_with_output()
+        .map_err(|error| DetectionError::Failed {
+            tool: tool.to_owned(),
+            detail: error.to_string(),
+        })?;
+    if !output.status.success() {
+        return Err(DetectionError::Failed {
+            tool: tool.to_owned(),
+            detail: String::from_utf8_lossy(&output.stderr).trim().to_owned(),
+        });
+    }
+    Ok(String::from_utf8_lossy(&output.stdout).into_owned())
+}
+
+/// Create the ceremony directory, owner-only.
+pub fn create_ceremony_dir(dir: &Path) -> Result<()> {
+    use std::os::unix::fs::PermissionsExt as _;
+    std::fs::create_dir_all(dir)
+        .with_context(|| format!("create ceremony directory {}", dir.display()))?;
+    std::fs::set_permissions(dir, std::fs::Permissions::from_mode(0o700))
+        .with_context(|| format!("restrict ceremony directory {} to its owner", dir.display()))
+}
+
+/// Generate a native age identity at `out`, returning its recipient.
+///
+/// Used for the online signer, and for the software root's own recipients.
+pub fn generate_software_identity(out: &Path) -> Result<String> {
+    use std::os::unix::fs::PermissionsExt as _;
+    let output = Command::new("age-keygen")
+        .arg("-o")
+        .arg(out)
+        .stdin(Stdio::null())
+        .output()
+        .context("launch age-keygen (install the `age` tools)")?;
+    if !output.status.success() {
+        bail!(
+            "age-keygen failed: {}",
+            String::from_utf8_lossy(&output.stderr).trim()
+        );
+    }
+    std::fs::set_permissions(out, std::fs::Permissions::from_mode(0o600))
+        .with_context(|| format!("restrict {} to its owner", out.display()))?;
+    let printed = format!(
+        "{}\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    parse_age_keygen_recipient(&printed)
+        .ok_or_else(|| anyhow::anyhow!("age-keygen printed no `age1…` recipient"))
+}
+
+/// Generate a passphrase-encrypted break-glass identity, returning its recipient.
+///
+/// The identity is piped straight into `age -p`, so the private half is never
+/// written unencrypted. `age` reads the passphrase from the terminal, which is
+/// why this is offered only on an interactive run.
+pub fn generate_passphrase_encrypted_identity(out: &Path) -> Result<String> {
+    use std::os::unix::fs::PermissionsExt as _;
+    let mut keygen = Command::new("age-keygen")
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .context("launch age-keygen (install the `age` tools)")?;
+    let keygen_stdout = keygen
+        .stdout
+        .take()
+        .ok_or_else(|| anyhow::anyhow!("age-keygen produced no identity stream"))?;
+    let seal = Command::new("age")
+        .args(["-p", "-o"])
+        .arg(out)
+        .stdin(Stdio::from(keygen_stdout))
+        .stdout(Stdio::inherit())
+        .stderr(Stdio::inherit())
+        .status()
+        .context("launch age (install the `age` tools)")?;
+    let keygen = keygen
+        .wait_with_output()
+        .context("wait for age-keygen to finish")?;
+    if !keygen.status.success() {
+        bail!(
+            "age-keygen failed: {}",
+            String::from_utf8_lossy(&keygen.stderr).trim()
+        );
+    }
+    if !seal.success() {
+        bail!("age -p did not encrypt the break-glass identity; nothing was written");
+    }
+    std::fs::set_permissions(out, std::fs::Permissions::from_mode(0o600))
+        .with_context(|| format!("restrict {} to its owner", out.display()))?;
+    parse_age_keygen_recipient(&String::from_utf8_lossy(&keygen.stderr))
+        .ok_or_else(|| anyhow::anyhow!("age-keygen printed no `age1…` recipient"))
+}
+
+/// Write the raw 32-byte registry-service public key the JWT mint binds to.
+pub fn write_registry_public_key(out: &Path, public_key: &[u8; 32]) -> Result<()> {
+    if let Some(parent) = out.parent() {
+        std::fs::create_dir_all(parent)
+            .with_context(|| format!("create ceremony directory {}", parent.display()))?;
+    }
+    std::fs::write(out, public_key)
+        .with_context(|| format!("write registry public key to {}", out.display()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn token(model: &str, firmware: (u8, u8, u8), serial: &str) -> DetectedToken {
+        DetectedToken {
+            model: model.to_owned(),
+            firmware: FirmwareVersion::new(firmware.0, firmware.1, firmware.2),
+            serial: serial.to_owned(),
+        }
+    }
+
+    fn old_token() -> DetectedToken {
+        token("YubiKey 5C NFC", (5, 4, 3), "11111111")
+    }
+
+    fn new_token() -> DetectedToken {
+        token("YubiKey 5C NFC", (5, 7, 4), "22222222")
+    }
+
+    fn enabled() -> CeremonyRequest {
+        CeremonyRequest {
+            enabled: true,
+            ..CeremonyRequest::default()
+        }
+    }
+
+    /// A detector whose answer is fixed by the test.
+    struct FakeDetector(Result<Vec<DetectedToken>, DetectionError>);
+
+    impl TokenDetector for FakeDetector {
+        fn detect(&self) -> Result<Vec<DetectedToken>, DetectionError> {
+            self.0.clone()
+        }
+    }
+
+    // ── Firmware ────────────────────────────────────────────────────────────
+
+    #[test]
+    fn firmware_parses_three_part_versions_only() {
+        assert_eq!(
+            FirmwareVersion::parse("5.7.4"),
+            Some(FirmwareVersion::new(5, 7, 4))
+        );
+        assert_eq!(FirmwareVersion::parse("5.7"), None);
+        assert_eq!(FirmwareVersion::parse("5.7.4.1"), None);
+        assert_eq!(FirmwareVersion::parse("five.seven.four"), None);
+    }
+
+    #[test]
+    fn piv_ed25519_support_starts_at_the_documented_firmware() {
+        assert!(!FirmwareVersion::new(5, 4, 3).supports_piv_ed25519());
+        assert!(!FirmwareVersion::new(5, 7, 3).supports_piv_ed25519());
+        assert!(FirmwareVersion::new(5, 7, 4).supports_piv_ed25519());
+        assert!(FirmwareVersion::new(5, 8, 0).supports_piv_ed25519());
+        assert!(FirmwareVersion::new(6, 0, 0).supports_piv_ed25519());
+        assert!(!FirmwareVersion::new(4, 9, 9).supports_piv_ed25519());
+    }
+
+    // ── Selection ───────────────────────────────────────────────────────────
+
+    #[test]
+    fn ceremony_is_skipped_unless_requested() {
+        let detection = Ok(vec![new_token()]);
+        let plan = plan_ceremony(&CeremonyRequest::default(), &detection);
+        assert!(matches!(plan, CeremonyPlan::Skipped { .. }));
+    }
+
+    #[test]
+    fn no_token_selects_the_dev_grade_software_root() {
+        let plan = plan_ceremony(&enabled(), &Ok(Vec::new()));
+        let CeremonyPlan::Proceed { mode, rationale } = plan else {
+            panic!("expected a software root, got {plan:?}");
+        };
+        assert_eq!(mode, CeremonyMode::SoftwareDevGrade);
+        assert!(mode.is_dev_grade());
+        assert!(!mode.ed25519_confined_to_hardware());
+        assert!(rationale.contains("no hardware token"));
+        assert!(rationale.contains(DEV_GRADE_LABEL));
+    }
+
+    #[test]
+    fn old_firmware_selects_the_age_recipient_mode() {
+        let plan = plan_ceremony(&enabled(), &Ok(vec![old_token()]));
+        let CeremonyPlan::Proceed { mode, rationale } = plan else {
+            panic!("expected a hardware mode, got {plan:?}");
+        };
+        assert_eq!(mode, CeremonyMode::HardwareAgeRecipient { token: old_token() });
+        assert!(!mode.ed25519_confined_to_hardware());
+        assert!(rationale.contains("5.4.3"));
+        assert!(rationale.contains("host memory"));
+    }
+
+    #[test]
+    fn current_firmware_selects_the_piv_slot_mode() {
+        let plan = plan_ceremony(&enabled(), &Ok(vec![new_token()]));
+        let CeremonyPlan::Proceed { mode, rationale } = plan else {
+            panic!("expected a hardware mode, got {plan:?}");
+        };
+        assert_eq!(
+            mode,
+            CeremonyMode::HardwarePiv {
+                token: new_token(),
+                slot: DEFAULT_PIV_SLOT.to_owned(),
+            }
+        );
+        assert!(mode.ed25519_confined_to_hardware());
+        assert!(rationale.contains("never enters host memory"));
+    }
+
+    #[test]
+    fn several_tokens_ask_the_operator_which_one() {
+        let plan = plan_ceremony(&enabled(), &Ok(vec![old_token(), new_token()]));
+        let CeremonyPlan::ChooseToken { tokens, .. } = plan else {
+            panic!("expected an operator choice, got {plan:?}");
+        };
+        assert_eq!(tokens, vec![old_token(), new_token()]);
+    }
+
+    #[test]
+    fn a_named_serial_picks_its_token_without_prompting() {
+        let request = CeremonyRequest {
+            serial: Some(new_token().serial),
+            ..enabled()
+        };
+        let plan = plan_ceremony(&request, &Ok(vec![old_token(), new_token()]));
+        let CeremonyPlan::Proceed { mode, .. } = plan else {
+            panic!("expected a hardware mode, got {plan:?}");
+        };
+        assert_eq!(mode.token(), Some(&new_token()));
+    }
+
+    #[test]
+    fn an_unattached_serial_blocks_and_lists_what_is_attached() {
+        let request = CeremonyRequest {
+            serial: Some("99999999".to_owned()),
+            ..enabled()
+        };
+        let plan = plan_ceremony(&request, &Ok(vec![old_token(), new_token()]));
+        let CeremonyPlan::Blocked { reason, remedy } = plan else {
+            panic!("expected a block, got {plan:?}");
+        };
+        assert!(reason.contains("99999999"));
+        assert!(remedy.contains("11111111") && remedy.contains("22222222"));
+    }
+
+    #[test]
+    fn detection_failure_blocks_rather_than_falling_back_to_software() {
+        for error in [
+            DetectionError::ToolMissing {
+                tool: "ykman".to_owned(),
+            },
+            DetectionError::Timeout {
+                tool: "ykman".to_owned(),
+                seconds: 10,
+            },
+            DetectionError::Failed {
+                tool: "ykman".to_owned(),
+                detail: "unreadable line".to_owned(),
+            },
+        ] {
+            let plan = plan_ceremony(&enabled(), &Err(error.clone()));
+            let CeremonyPlan::Blocked { reason, remedy } = plan else {
+                panic!("expected a block for {error:?}");
+            };
+            assert!(reason.contains("could not tell whether"));
+            assert!(remedy.contains("--deployment-trust-software"));
+        }
+    }
+
+    #[test]
+    fn detection_failure_may_be_overridden_into_an_explicit_software_root() {
+        let request = CeremonyRequest {
+            force_software: true,
+            ..enabled()
+        };
+        let plan = plan_ceremony(
+            &request,
+            &Err(DetectionError::ToolMissing {
+                tool: "ykman".to_owned(),
+            }),
+        );
+        let CeremonyPlan::Proceed { mode, rationale } = plan else {
+            panic!("expected an explicit software root, got {plan:?}");
+        };
+        assert_eq!(mode, CeremonyMode::SoftwareDevGrade);
+        assert!(rationale.contains("explicitly requested"));
+        assert!(rationale.contains(DEV_GRADE_LABEL));
+    }
+
+    #[test]
+    fn software_is_never_chosen_over_present_hardware_without_an_explicit_override() {
+        // Attached hardware always wins unless the operator overrides it.
+        for tokens in [vec![old_token()], vec![new_token()], vec![old_token(), new_token()]] {
+            let plan = plan_ceremony(&enabled(), &Ok(tokens.clone()));
+            assert!(
+                !matches!(
+                    plan,
+                    CeremonyPlan::Proceed {
+                        mode: CeremonyMode::SoftwareDevGrade,
+                        ..
+                    }
+                ),
+                "software root silently selected with {tokens:?} attached"
+            );
+        }
+    }
+
+    #[test]
+    fn an_explicit_override_says_it_overrode_attached_hardware() {
+        let request = CeremonyRequest {
+            force_software: true,
+            ..enabled()
+        };
+        let plan = plan_ceremony(&request, &Ok(vec![new_token()]));
+        let CeremonyPlan::Proceed { mode, rationale } = plan else {
+            panic!("expected a software root, got {plan:?}");
+        };
+        assert_eq!(mode, CeremonyMode::SoftwareDevGrade);
+        assert!(rationale.contains("hardware token(s) are attached"));
+    }
+
+    // ── Non-interactive safety ──────────────────────────────────────────────
+
+    #[test]
+    fn a_scripted_run_never_reaches_a_prompt() {
+        let scripted = CeremonyRequest {
+            interactive: false,
+            ..enabled()
+        };
+        for detection in [
+            Ok(Vec::new()),
+            Ok(vec![old_token()]),
+            Ok(vec![new_token()]),
+            Ok(vec![old_token(), new_token()]),
+            Err(DetectionError::ToolMissing {
+                tool: "ykman".to_owned(),
+            }),
+        ] {
+            let plan = plan_ceremony(&scripted, &detection);
+            assert!(
+                !matches!(plan, CeremonyPlan::ChooseToken { .. }),
+                "scripted run would have prompted for {detection:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn a_scripted_run_with_hardware_blocks_with_both_ways_forward() {
+        let scripted = CeremonyRequest {
+            interactive: false,
+            ..enabled()
+        };
+        let CeremonyPlan::Blocked { reason, remedy } =
+            plan_ceremony(&scripted, &Ok(vec![new_token()]))
+        else {
+            panic!("expected a block");
+        };
+        assert!(reason.contains("physical touch"));
+        assert!(remedy.contains("--non-interactive"));
+        assert!(remedy.contains("--deployment-trust-software"));
+    }
+
+    #[test]
+    fn a_scripted_run_with_several_tokens_asks_for_a_serial() {
+        let scripted = CeremonyRequest {
+            interactive: false,
+            ..enabled()
+        };
+        let CeremonyPlan::Blocked { remedy, .. } =
+            plan_ceremony(&scripted, &Ok(vec![old_token(), new_token()]))
+        else {
+            panic!("expected a block");
+        };
+        assert!(remedy.contains("--deployment-trust-serial"));
+    }
+
+    #[test]
+    fn a_scripted_run_without_hardware_still_completes() {
+        let scripted = CeremonyRequest {
+            interactive: false,
+            ..enabled()
+        };
+        let CeremonyPlan::Proceed { mode, .. } = plan_ceremony(&scripted, &Ok(Vec::new())) else {
+            panic!("expected a software root");
+        };
+        assert!(mode.is_dev_grade());
+    }
+
+    #[test]
+    fn a_scripted_run_that_did_not_ask_for_trust_is_skipped_even_with_hardware() {
+        let scripted = CeremonyRequest {
+            interactive: false,
+            ..CeremonyRequest::default()
+        };
+        assert!(matches!(
+            plan_ceremony(&scripted, &Ok(vec![new_token()])),
+            CeremonyPlan::Skipped { .. }
+        ));
+    }
+
+    #[test]
+    fn a_chosen_token_runs_through_the_same_firmware_rule() {
+        let request = enabled();
+        let CeremonyPlan::Proceed { mode, .. } = select_mode_for_token(&request, &new_token())
+        else {
+            panic!("expected a hardware mode");
+        };
+        assert!(mode.ed25519_confined_to_hardware());
+        let CeremonyPlan::Proceed { mode, .. } = select_mode_for_token(&request, &old_token())
+        else {
+            panic!("expected a hardware mode");
+        };
+        assert!(!mode.ed25519_confined_to_hardware());
+    }
+
+    #[test]
+    fn the_detector_seam_feeds_the_plan() {
+        let detector = FakeDetector(Ok(vec![new_token()]));
+        let plan = plan_ceremony(&enabled(), &detector.detect());
+        assert!(matches!(
+            plan,
+            CeremonyPlan::Proceed {
+                mode: CeremonyMode::HardwarePiv { .. },
+                ..
+            }
+        ));
+    }
+
+    // ── Break-glass ─────────────────────────────────────────────────────────
+
+    #[test]
+    fn a_plaintext_break_glass_is_refused_by_default() {
+        let break_glass = BreakGlass::PlaintextIdentity {
+            identity_file: PathBuf::from("/tmp/backup.key"),
+            recipient: "age1backup".to_owned(),
+        };
+        let error = validate_break_glass(&break_glass, "age1yubikey1primary", PlaintextPolicy::Refuse)
+            .expect_err("plaintext break-glass must be refused");
+        assert!(error.contains("weakest recipient"));
+        assert!(error.contains("--deployment-trust-allow-plaintext-break-glass"));
+    }
+
+    #[test]
+    fn a_plaintext_break_glass_is_allowed_only_by_override_or_for_a_dev_root() {
+        let break_glass = BreakGlass::PlaintextIdentity {
+            identity_file: PathBuf::from("/tmp/backup.key"),
+            recipient: "age1backup".to_owned(),
+        };
+        for policy in [
+            PlaintextPolicy::AllowedByOverride,
+            PlaintextPolicy::AllowedForDevGradeRoot,
+        ] {
+            assert!(validate_break_glass(&break_glass, "age1yubikey1primary", policy).is_ok());
+        }
+    }
+
+    #[test]
+    fn a_passphrase_encrypted_break_glass_is_accepted() {
+        let break_glass = BreakGlass::PassphraseEncrypted {
+            identity_file: PathBuf::from("/tmp/backup.key.age"),
+            recipient: "age1backup".to_owned(),
+        };
+        assert!(validate_break_glass(
+            &break_glass,
+            "age1yubikey1primary",
+            PlaintextPolicy::Refuse
+        )
+        .is_ok());
+    }
+
+    #[test]
+    fn a_duplicate_break_glass_recipient_is_refused() {
+        let break_glass = BreakGlass::SecondToken {
+            recipient: "age1yubikey1primary".to_owned(),
+        };
+        let error = validate_break_glass(
+            &break_glass,
+            "age1yubikey1primary",
+            PlaintextPolicy::AllowedByOverride,
+        )
+        .expect_err("a duplicated recipient must be refused");
+        assert!(error.contains("single point of loss"));
+    }
+
+    #[test]
+    fn a_second_token_break_glass_must_be_a_plugin_recipient() {
+        let break_glass = BreakGlass::SecondToken {
+            recipient: "age1software".to_owned(),
+        };
+        let error =
+            validate_break_glass(&break_glass, "age1yubikey1primary", PlaintextPolicy::Refuse)
+                .expect_err("a software recipient is not a second token");
+        assert!(error.contains("age1yubikey1"));
+    }
+
+    #[test]
+    fn malformed_break_glass_recipients_are_refused() {
+        for recipient in ["", "   ", "not-a-recipient", "age1good\nage1evil"] {
+            let break_glass = BreakGlass::PassphraseEncrypted {
+                identity_file: PathBuf::from("/tmp/backup.key.age"),
+                recipient: recipient.to_owned(),
+            };
+            assert!(
+                validate_break_glass(&break_glass, "age1yubikey1primary", PlaintextPolicy::Refuse)
+                    .is_err(),
+                "accepted malformed recipient {recipient:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn identity_files_are_classified_without_decryption() {
+        assert_eq!(
+            classify_identity_file(
+                "# created: 2026-01-01\n# public key: age1abc\nAGE-SECRET-KEY-1QQQQ\n"
+            ),
+            IdentityFileKind::PlaintextAgeIdentity
+        );
+        assert_eq!(
+            classify_identity_file("age-encryption.org/v1\n-> scrypt abcdef 18\nxxxx\n"),
+            IdentityFileKind::PassphraseEncrypted
+        );
+        assert_eq!(
+            classify_identity_file("age-encryption.org/v1\n-> X25519 abcdef\nxxxx\n"),
+            IdentityFileKind::Unconfirmed
+        );
+        assert_eq!(
+            classify_identity_file("-----BEGIN AGE ENCRYPTED FILE-----\nYWJj\n"),
+            IdentityFileKind::Unconfirmed
+        );
+    }
+
+    // ── Command construction ────────────────────────────────────────────────
+
+    fn paths() -> CeremonyPaths {
+        CeremonyPaths::new("/srv/ceremony").expect("absolute path")
+    }
+
+    fn inputs(mode: CeremonyMode, primary: &str, break_glass: BreakGlass) -> CeremonyInputs {
+        CeremonyInputs {
+            mode,
+            primary_recipient: primary.to_owned(),
+            break_glass,
+            unlock_identity: UnlockIdentity::Yubikey(paths().yubikey_identity()),
+            signer_recipient: "age1deploy".to_owned(),
+            paths: paths(),
+        }
+    }
+
+    #[test]
+    fn a_relative_ceremony_directory_is_refused() {
+        assert!(CeremonyPaths::new("ceremony").is_err());
+    }
+
+    #[test]
+    fn the_piv_mode_sets_the_slot_and_keeps_both_recipients() {
+        let commands = ceremony_commands(&inputs(
+            CeremonyMode::HardwarePiv {
+                token: new_token(),
+                slot: DEFAULT_PIV_SLOT.to_owned(),
+            },
+            "age1yubikey1primary",
+            BreakGlass::PassphraseEncrypted {
+                identity_file: PathBuf::from("/srv/ceremony/break-glass.key.age"),
+                recipient: "age1backup".to_owned(),
+            },
+        ))
+        .expect("commands");
+        let TrustCommand::MintDeploymentCa(args) = &commands[0] else {
+            panic!("expected the mint step first");
+        };
+        assert_eq!(args.piv_slot.as_deref(), Some(DEFAULT_PIV_SLOT));
+        assert_eq!(args.yubikey_recipients, vec!["age1yubikey1primary"]);
+        assert_eq!(args.recipients, vec!["age1backup"]);
+        assert!(args.public_ca.is_absolute());
+    }
+
+    #[test]
+    fn the_age_recipient_mode_leaves_the_piv_slot_unset() {
+        let commands = ceremony_commands(&inputs(
+            CeremonyMode::HardwareAgeRecipient { token: old_token() },
+            "age1yubikey1primary",
+            BreakGlass::SecondToken {
+                recipient: "age1yubikey1backup".to_owned(),
+            },
+        ))
+        .expect("commands");
+        let TrustCommand::MintDeploymentCa(args) = &commands[0] else {
+            panic!("expected the mint step first");
+        };
+        assert_eq!(args.piv_slot, None);
+        assert_eq!(
+            args.yubikey_recipients,
+            vec!["age1yubikey1primary", "age1yubikey1backup"]
+        );
+        assert!(args.recipients.is_empty());
+    }
+
+    #[test]
+    fn the_software_mode_uses_native_recipients_and_no_slot() {
+        let mut inputs = inputs(
+            CeremonyMode::SoftwareDevGrade,
+            "age1primary",
+            BreakGlass::PlaintextIdentity {
+                identity_file: PathBuf::from("/srv/ceremony/break-glass.key"),
+                recipient: "age1backup".to_owned(),
+            },
+        );
+        inputs.unlock_identity = UnlockIdentity::Age(paths().primary_identity());
+        let commands = ceremony_commands(&inputs).expect("commands");
+        let TrustCommand::MintDeploymentCa(args) = &commands[0] else {
+            panic!("expected the mint step first");
+        };
+        assert_eq!(args.piv_slot, None);
+        assert!(args.yubikey_recipients.is_empty());
+        assert_eq!(args.recipients, vec!["age1primary", "age1backup"]);
+
+        let TrustCommand::DelegateRegistrySigner(args) = &commands[1] else {
+            panic!("expected the delegation step second");
+        };
+        assert!(args.yubikey_identities.is_empty());
+        assert_eq!(args.identities, vec![paths().primary_identity()]);
+    }
+
+    #[test]
+    fn the_ceremony_runs_the_documented_four_steps_in_order() {
+        let commands = ceremony_commands(&inputs(
+            CeremonyMode::HardwareAgeRecipient { token: old_token() },
+            "age1yubikey1primary",
+            BreakGlass::SecondToken {
+                recipient: "age1yubikey1backup".to_owned(),
+            },
+        ))
+        .expect("commands");
+        assert_eq!(commands.len(), 4);
+        assert!(matches!(commands[0], TrustCommand::MintDeploymentCa(_)));
+        assert!(matches!(
+            commands[1],
+            TrustCommand::DelegateRegistrySigner(_)
+        ));
+        assert!(matches!(commands[2], TrustCommand::MintRegistryJwt(_)));
+        assert!(matches!(commands[3], TrustCommand::VerifyDeployment(_)));
+    }
+
+    #[test]
+    fn the_credential_is_minted_through_the_delegated_signer_not_the_root() {
+        let commands = ceremony_commands(&inputs(
+            CeremonyMode::HardwareAgeRecipient { token: old_token() },
+            "age1yubikey1primary",
+            BreakGlass::SecondToken {
+                recipient: "age1yubikey1backup".to_owned(),
+            },
+        ))
+        .expect("commands");
+        let TrustCommand::MintRegistryJwt(args) = &commands[2] else {
+            panic!("expected the credential step third");
+        };
+        assert!(!args.root);
+        assert_eq!(
+            args.via_delegated_signer.as_deref(),
+            Some(paths().delegated_signer().as_path())
+        );
+        assert!(args.yubikey_identities.is_empty());
+        assert_eq!(args.ttl_seconds, REGISTRY_JWT_TTL_SECONDS);
+    }
+
+    #[test]
+    fn a_hardware_ceremony_refuses_to_build_around_a_plaintext_break_glass() {
+        let error = ceremony_commands(&inputs(
+            CeremonyMode::HardwarePiv {
+                token: new_token(),
+                slot: DEFAULT_PIV_SLOT.to_owned(),
+            },
+            "age1yubikey1primary",
+            BreakGlass::PlaintextIdentity {
+                identity_file: PathBuf::from("/srv/ceremony/break-glass.key"),
+                recipient: "age1backup".to_owned(),
+            },
+        ))
+        .expect_err("a hardware root must not accept a bare backup identity");
+        assert!(error.to_string().contains("weakest recipient"));
+    }
+
+    // ── Emitted metadata ────────────────────────────────────────────────────
+
+    #[test]
+    fn the_mode_record_labels_a_software_root_as_dev_grade() {
+        let record = mode_record(
+            &CeremonyMode::SoftwareDevGrade,
+            &BreakGlass::PlaintextIdentity {
+                identity_file: PathBuf::from("/srv/ceremony/break-glass.key"),
+                recipient: "age1backup".to_owned(),
+            },
+            "no hardware token is attached",
+        );
+        assert!(record.dev_grade);
+        assert_eq!(record.grade, DEV_GRADE_LABEL);
+        assert!(!record.ed25519_confined_to_hardware);
+        assert_eq!(record.token_serial, None);
+        assert_eq!(record.piv_slot, None);
+        assert!(!record.break_glass_protected);
+    }
+
+    #[test]
+    fn the_mode_record_keeps_the_token_and_slot_for_a_hardware_root() {
+        let record = mode_record(
+            &CeremonyMode::HardwarePiv {
+                token: new_token(),
+                slot: DEFAULT_PIV_SLOT.to_owned(),
+            },
+            &BreakGlass::SecondToken {
+                recipient: "age1yubikey1backup".to_owned(),
+            },
+            "firmware 5.7.4",
+        );
+        assert!(!record.dev_grade);
+        assert!(record.ed25519_confined_to_hardware);
+        assert_eq!(record.token_firmware.as_deref(), Some("5.7.4"));
+        assert_eq!(record.token_serial.as_deref(), Some("22222222"));
+        assert_eq!(record.piv_slot.as_deref(), Some(DEFAULT_PIV_SLOT));
+        assert_eq!(record.schema, CEREMONY_MODE_SCHEMA);
+        assert!(record.break_glass_protected);
+    }
+
+    #[test]
+    fn the_mode_record_round_trips_as_json() {
+        let record = mode_record(
+            &CeremonyMode::HardwareAgeRecipient { token: old_token() },
+            &BreakGlass::SecondToken {
+                recipient: "age1yubikey1backup".to_owned(),
+            },
+            "firmware 5.4.3",
+        );
+        let json = serde_json::to_string(&record).expect("serialize");
+        let parsed: CeremonyModeRecord = serde_json::from_str(&json).expect("deserialize");
+        assert_eq!(parsed, record);
+    }
+
+    // ── Tooling ─────────────────────────────────────────────────────────────
+
+    #[test]
+    fn each_mode_declares_the_tools_it_needs() {
+        assert!(required_tools(&CeremonyMode::HardwarePiv {
+            token: new_token(),
+            slot: DEFAULT_PIV_SLOT.to_owned(),
+        })
+        .contains(&"yubico-piv-tool"));
+        assert_eq!(
+            required_tools(&CeremonyMode::HardwareAgeRecipient { token: old_token() }),
+            &["age-plugin-yubikey"]
+        );
+        assert!(required_tools(&CeremonyMode::SoftwareDevGrade).contains(&"age-keygen"));
+    }
+
+    #[test]
+    fn missing_tools_are_reported_through_the_probe_seam() {
+        let tools = required_tools(&CeremonyMode::HardwarePiv {
+            token: new_token(),
+            slot: DEFAULT_PIV_SLOT.to_owned(),
+        });
+        assert!(missing_tools(tools, |_| true).is_empty());
+        assert_eq!(missing_tools(tools, |_| false).len(), tools.len());
+        assert_eq!(
+            missing_tools(tools, |tool| tool != "yubico-piv-tool"),
+            vec!["yubico-piv-tool".to_owned()]
+        );
+    }
+
+    // ── Output parsing ──────────────────────────────────────────────────────
+
+    #[test]
+    fn ykman_output_parses_into_tokens() {
+        let listed = "YubiKey 5C NFC (5.4.3) [OTP+FIDO+CCID] Serial: 11111111\n\
+                      YubiKey 5 NFC (5.7.4) [OTP+FIDO+CCID] Serial: 22222222\n";
+        let tokens = parse_ykman_list(listed).expect("parse");
+        assert_eq!(tokens.len(), 2);
+        assert_eq!(tokens[0].model, "YubiKey 5C NFC");
+        assert_eq!(tokens[0].firmware, FirmwareVersion::new(5, 4, 3));
+        assert_eq!(tokens[1].serial, "22222222");
+        assert!(tokens[1].firmware.supports_piv_ed25519());
+    }
+
+    #[test]
+    fn empty_ykman_output_means_nothing_is_attached() {
+        assert!(parse_ykman_list("").expect("parse").is_empty());
+        assert!(parse_ykman_list("\n  \n").expect("parse").is_empty());
+    }
+
+    #[test]
+    fn an_unreadable_ykman_line_is_an_error_not_a_missing_token() {
+        for listed in [
+            "YubiKey 5C NFC [OTP+FIDO+CCID] Serial: 11111111",
+            "YubiKey 5C NFC (5.4) [OTP] Serial: 11111111",
+            "YubiKey 5C NFC (5.4.3) [OTP]",
+            "YubiKey 5C NFC (5.4.3) [OTP] Serial: none",
+        ] {
+            assert!(
+                parse_ykman_list(listed).is_err(),
+                "silently dropped token from {listed:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn plugin_and_keygen_recipients_are_told_apart() {
+        assert_eq!(
+            parse_age_plugin_recipient("Serial: 1, Slot: 1\n  age1yubikey1qabc\n").as_deref(),
+            Some("age1yubikey1qabc")
+        );
+        assert_eq!(parse_age_plugin_recipient("no recipients here"), None);
+        assert_eq!(
+            parse_age_keygen_recipient("Public key: age1qsoftware").as_deref(),
+            Some("age1qsoftware")
+        );
+        assert_eq!(parse_age_keygen_recipient("Public key: age1yubikey1q"), None);
+    }
+}

--- a/crates/hyprstream/src/cli/trust_ceremony.rs
+++ b/crates/hyprstream/src/cli/trust_ceremony.rs
@@ -1129,6 +1129,7 @@ pub fn write_registry_public_key(out: &Path, public_key: &[u8; 32]) -> Result<()
 }
 
 #[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {
     use super::*;
 

--- a/crates/hyprstream/src/cli/wizard_handlers.rs
+++ b/crates/hyprstream/src/cli/wizard_handlers.rs
@@ -56,6 +56,8 @@ struct TextWizardSummary {
     templates_applied: Vec<String>,
     users_created: Vec<(String, String)>,
     tokens_generated: Vec<(String, String, String)>,
+    /// Grade line for the deployment root, when a ceremony ran.
+    deployment_trust: Option<String>,
 }
 
 impl TextWizardSummary {
@@ -64,6 +66,7 @@ impl TextWizardSummary {
             templates_applied: Vec::new(),
             users_created: Vec::new(),
             tokens_generated: Vec::new(),
+            deployment_trust: None,
         }
     }
 }
@@ -87,6 +90,55 @@ pub async fn handle_wizard_tui(models_dir: &Path, config_services: &[String]) ->
     Ok(())
 }
 
+/// Opt-in deployment-trust ceremony settings.
+///
+/// Deployment trust is a separate layer from node bootstrap: none of this runs
+/// unless `enabled` is set, and the wizard's node-local behaviour is unchanged
+/// when it is not.
+#[derive(Clone, Debug, Default)]
+pub struct DeploymentTrustOptions {
+    /// Run the ceremony after node bootstrap.
+    pub enabled: bool,
+    /// Absolute ceremony working directory. Defaults under the models dir.
+    pub dir: Option<std::path::PathBuf>,
+    /// Mint a software root even if a token is attached.
+    pub force_software: bool,
+    /// Token serial to use when several are attached.
+    pub serial: Option<String>,
+    /// PIV slot for the Ed25519 leg on firmware that supports it.
+    pub piv_slot: Option<String>,
+    /// Accept an unencrypted break-glass identity. Throwaway roots only.
+    pub allow_plaintext_break_glass: bool,
+}
+
+/// Everything `hyprstream wizard` was invoked with.
+#[derive(Clone, Debug, Default)]
+pub struct WizardOptions {
+    /// Accept defaults without prompting.
+    pub non_interactive: bool,
+    /// Start services once setup finishes.
+    pub start_services: bool,
+    /// Run only phase 1 (node bootstrap).
+    pub bootstrap_only: bool,
+    /// Apply the federation-open policy template.
+    pub enable_federation: bool,
+    /// Role assigned to the local user under `--non-interactive`.
+    pub initial_user_role: String,
+    /// Deployment-trust ceremony settings.
+    pub deployment_trust: DeploymentTrustOptions,
+}
+
+impl WizardOptions {
+    /// Defaults for the first-run path: interactive, no federation, admin user.
+    #[must_use]
+    pub fn first_run() -> Self {
+        Self {
+            initial_user_role: "admin".to_owned(),
+            ..Self::default()
+        }
+    }
+}
+
 /// Handle `hyprstream wizard` — interactive setup wizard.
 ///
 /// When `bootstrap_only` is true, only phase 1 (trust-root setup) runs.
@@ -96,34 +148,21 @@ pub async fn handle_wizard_tui(models_dir: &Path, config_services: &[String]) ->
 pub async fn handle_wizard(
     models_dir: &Path,
     config_services: &[String],
-    non_interactive: bool,
-    start_services: bool,
-    bootstrap_only: bool,
-    enable_federation: bool,
-    initial_user_role: &str,
+    options: WizardOptions,
 ) -> Result<()> {
     // Install systemd units before entering spawn_blocking (async operation).
-    if !bootstrap_only && hyprstream_rpc::has_systemd() {
+    if !options.bootstrap_only && hyprstream_rpc::has_systemd() {
         handle_service_install(models_dir, config_services, None, false, false, hyprstream_service::ServiceTarget::User, false).await?;
     }
 
     let rt = tokio::runtime::Handle::current();
     let models_dir = models_dir.to_path_buf();
     let config_services = config_services.to_vec();
-    let initial_user_role = initial_user_role.to_owned();
 
     tokio::task::spawn_blocking(move || {
         let mut backend =
-            crate::cli::bootstrap_manager::BootstrapManager::new(rt, models_dir, config_services.clone());
-        run_text_wizard(
-            &mut backend,
-            non_interactive,
-            bootstrap_only,
-            start_services,
-            enable_federation,
-            &initial_user_role,
-            &config_services,
-        )
+            crate::cli::bootstrap_manager::BootstrapManager::new(rt, models_dir.clone(), config_services.clone());
+        run_text_wizard(&mut backend, &options, &models_dir, &config_services)
     })
     .await??;
 
@@ -136,13 +175,12 @@ pub async fn handle_wizard(
 
 fn run_text_wizard(
     backend: &mut impl WizardBackend,
-    non_interactive: bool,
-    bootstrap_only: bool,
-    start_services_flag: bool,
-    enable_federation: bool,
-    initial_user_role: &str,
+    options: &WizardOptions,
+    models_dir: &Path,
     config_services: &[String],
 ) -> Result<()> {
+    let non_interactive = options.non_interactive;
+
     println!();
     println!("  Hyprstream Setup Wizard");
     println!("  {}", "=".repeat(40));
@@ -153,7 +191,7 @@ fn run_text_wizard(
     // Phase 1: Environment bootstrap
     text_phase_bootstrap(backend)?;
 
-    if bootstrap_only {
+    if options.bootstrap_only {
         return Ok(());
     }
 
@@ -161,16 +199,19 @@ fn run_text_wizard(
     text_phase_binary_install(non_interactive)?;
 
     // Phase 3: Policy template selection
-    text_phase_templates(backend, non_interactive, enable_federation, &mut summary)?;
+    text_phase_templates(backend, non_interactive, options.enable_federation, &mut summary)?;
 
     // Phase 4: User/role creation
-    text_phase_users(backend, non_interactive, initial_user_role, &mut summary)?;
+    text_phase_users(backend, non_interactive, &options.initial_user_role, &mut summary)?;
 
     // Phase 5: Token generation
     text_phase_tokens(backend, non_interactive, &mut summary)?;
 
-    // Phase 6: Service startup
-    text_phase_services(backend, config_services, non_interactive, start_services_flag)?;
+    // Phase 6: Deployment trust (opt-in; separate from node-local trust)
+    text_phase_deployment_trust(options, models_dir, &mut summary)?;
+
+    // Phase 7: Service startup
+    text_phase_services(backend, config_services, non_interactive, options.start_services)?;
 
     // Summary
     print_summary(&summary);
@@ -633,7 +674,308 @@ fn token_preview(token: &str) -> String {
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
-// Phase 6: Services (via WizardBackend)
+// Phase 6: Deployment trust (opt-in ceremony)
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Run the deployment-trust ceremony, if the operator asked for it.
+///
+/// Node bootstrap sets up node-local trust and stops there; this phase is the
+/// separate, deliberately opt-in deployment layer. When it is not requested the
+/// wizard behaves exactly as it did before, including under `--non-interactive`,
+/// where the phase never reaches a prompt.
+fn text_phase_deployment_trust(
+    options: &WizardOptions,
+    models_dir: &Path,
+    summary: &mut TextWizardSummary,
+) -> Result<()> {
+    use crate::cli::trust_ceremony as ceremony;
+    use crate::cli::trust_ceremony::{AgeYubikeyPlugin as _, TokenDetector as _};
+
+    let settings = &options.deployment_trust;
+    let request = ceremony::CeremonyRequest {
+        enabled: settings.enabled,
+        interactive: !options.non_interactive,
+        force_software: settings.force_software,
+        serial: settings.serial.clone(),
+        piv_slot: settings
+            .piv_slot
+            .clone()
+            .unwrap_or_else(|| ceremony::DEFAULT_PIV_SLOT.to_owned()),
+    };
+
+    if !request.enabled {
+        return Ok(());
+    }
+
+    println!("  Phase 6: Deployment Trust");
+    println!("  {}", "-".repeat(40));
+    println!();
+
+    println!("    Looking for a hardware token...");
+    let detection = ceremony::SystemTokenDetector.detect();
+    let mut plan = ceremony::plan_ceremony(&request, &detection);
+
+    if let ceremony::CeremonyPlan::ChooseToken { tokens, rationale } = &plan {
+        println!("    {rationale}.");
+        let labels: Vec<String> = tokens.iter().map(ceremony::DetectedToken::label).collect();
+        let chosen = Select::new("  Which token should hold the deployment root?", labels.clone())
+            .prompt()
+            .map_err(|e| anyhow::anyhow!("no token was chosen: {e}"))?;
+        let index = labels
+            .iter()
+            .position(|label| *label == chosen)
+            .ok_or_else(|| anyhow::anyhow!("token selection did not match an attached token"))?;
+        let token = tokens
+            .get(index)
+            .ok_or_else(|| anyhow::anyhow!("token selection did not match an attached token"))?
+            .clone();
+        plan = ceremony::select_mode_for_token(&request, &token);
+    }
+
+    let (mode, rationale) = match plan {
+        ceremony::CeremonyPlan::Skipped { reason } => {
+            println!("    {reason}.");
+            println!();
+            return Ok(());
+        }
+        ceremony::CeremonyPlan::Blocked { reason, remedy } => {
+            print_check("Deployment trust", CheckStatus::Fail, &reason);
+            println!("    {remedy}.");
+            return Err(anyhow::anyhow!(
+                "deployment trust ceremony cannot run: {reason} — {remedy}"
+            ));
+        }
+        ceremony::CeremonyPlan::ChooseToken { .. } => {
+            return Err(anyhow::anyhow!(
+                "several tokens are attached and none was chosen; pass \
+                 --deployment-trust-serial <SERIAL>"
+            ));
+        }
+        ceremony::CeremonyPlan::Proceed { mode, rationale } => (mode, rationale),
+    };
+
+    println!("    {rationale}.");
+    if mode.is_dev_grade() {
+        println!();
+        println!("    !! {}", ceremony::DEV_GRADE_LABEL);
+        println!("    !! Anyone who can read the recipient files holds the deployment root.");
+        println!("    !! Upgrade to hardware later with `hyprstream trust rotate-authority`.");
+        println!();
+    }
+
+    let missing = ceremony::missing_tools(ceremony::required_tools(&mode), ceremony::tool_on_path);
+    if !missing.is_empty() {
+        return Err(anyhow::anyhow!(
+            "the {} ceremony needs {} on PATH; install {} and re-run",
+            mode.mode_id(),
+            missing.join(", "),
+            missing.join(" and ")
+        ));
+    }
+
+    let dir = match settings.dir.clone() {
+        Some(dir) => dir,
+        None => models_dir.join("deployment-ceremony"),
+    };
+    let dir = if dir.is_absolute() {
+        dir
+    } else {
+        std::env::current_dir()
+            .map_err(|e| anyhow::anyhow!("resolve the ceremony directory: {e}"))?
+            .join(dir)
+    };
+    let paths = ceremony::CeremonyPaths::new(dir)?;
+    ceremony::create_ceremony_dir(paths.dir())?;
+    println!("    Ceremony working directory: {}", paths.dir().display());
+
+    // Primary recipient: the token's own age identity, or a software key.
+    let (primary_recipient, unlock_identity) = match &mode {
+        ceremony::CeremonyMode::HardwarePiv { token, .. }
+        | ceremony::CeremonyMode::HardwareAgeRecipient { token } => {
+            println!();
+            println!("    Generating the token's age identity (PIN + touch required for every");
+            println!("    use). Follow the prompts on your terminal and the token.");
+            let plugin = ceremony::SystemAgeYubikeyPlugin;
+            let recipient = plugin
+                .generate_identity(&format!("hyprstream deployment root ({})", token.serial))
+                .map_err(|e| anyhow::anyhow!("generate the token's age identity: {e}"))?;
+            plugin
+                .export_identity_file(&paths.yubikey_identity())
+                .map_err(|e| anyhow::anyhow!("export the token's age identity: {e}"))?;
+            (
+                recipient,
+                ceremony::UnlockIdentity::Yubikey(paths.yubikey_identity()),
+            )
+        }
+        ceremony::CeremonyMode::SoftwareDevGrade => {
+            let recipient = ceremony::generate_software_identity(&paths.primary_identity())?;
+            (
+                recipient,
+                ceremony::UnlockIdentity::Age(paths.primary_identity()),
+            )
+        }
+    };
+
+    let break_glass = prompt_break_glass(&mode, &primary_recipient, &paths, options)?;
+    println!("    Break-glass: {}", break_glass.kind_id());
+
+    // The online signer is an autonomous key: no token, no root.
+    let signer_recipient = ceremony::generate_software_identity(&paths.online_signer_identity())?;
+
+    // The credential binds the registry service key node bootstrap just made.
+    let credentials_dir = crate::auth::identity_store::credentials_dir()?;
+    let pubkeys = crate::auth::identity_store::load_bootstrap_pubkeys(&credentials_dir)?;
+    let registry_key = pubkeys.get("registry").ok_or_else(|| {
+        anyhow::anyhow!(
+            "no registry service key in {}; run node bootstrap before the ceremony",
+            credentials_dir.display()
+        )
+    })?;
+    ceremony::write_registry_public_key(&paths.registry_public_key(), registry_key.as_bytes())?;
+
+    let inputs = ceremony::CeremonyInputs {
+        mode: mode.clone(),
+        primary_recipient,
+        break_glass: break_glass.clone(),
+        unlock_identity,
+        signer_recipient,
+        paths: paths.clone(),
+    };
+
+    println!();
+    for (step, command) in ceremony::ceremony_commands(&inputs)?.into_iter().enumerate() {
+        println!("    Ceremony step {}/4...", step + 1);
+        crate::cli::trust::handle_trust_command(command)?;
+    }
+
+    let record = ceremony::mode_record(&mode, &break_glass, &rationale);
+    std::fs::write(
+        paths.mode_record(),
+        serde_json::to_vec_pretty(&record)?,
+    )?;
+
+    print_check("Deployment trust", CheckStatus::Ok, mode.grade_label());
+    println!();
+    println!("    The public artifacts are NOT installed yet. Copy them to a deployed host:");
+    println!("      {}", paths.public_ca().display());
+    println!("      {}", paths.authority_log().display());
+    println!("      {}", paths.authority_checkpoint().display());
+    println!("    Keep {} offline — it never belongs on a deployed host.", paths.authority_key().display());
+    println!();
+
+    summary.deployment_trust = Some(format!("{} — {}", mode.mode_id(), mode.grade_label()));
+    Ok(())
+}
+
+/// Walk the operator through a break-glass recipient the tooling can trust.
+///
+/// The trust CLI can only see that two recipients differ; whether the second is
+/// protected is decided here, and an unprotected one is refused by default.
+fn prompt_break_glass(
+    mode: &crate::cli::trust_ceremony::CeremonyMode,
+    primary_recipient: &str,
+    paths: &crate::cli::trust_ceremony::CeremonyPaths,
+    options: &WizardOptions,
+) -> Result<crate::cli::trust_ceremony::BreakGlass> {
+    use crate::cli::trust_ceremony as ceremony;
+
+    const SECOND_TOKEN: &str = "A second hardware token (best — same protection as the primary)";
+    const PASSPHRASE: &str = "A passphrase-encrypted identity file (age-keygen | age -p)";
+    const PLAINTEXT: &str = "An unencrypted identity file (throwaway roots only)";
+
+    let policy = if options.deployment_trust.allow_plaintext_break_glass {
+        ceremony::PlaintextPolicy::AllowedByOverride
+    } else if mode.is_dev_grade() {
+        ceremony::PlaintextPolicy::AllowedForDevGradeRoot
+    } else {
+        ceremony::PlaintextPolicy::Refuse
+    };
+
+    // A scripted run cannot answer a prompt or type a passphrase. It only gets
+    // here for a dev-grade root, where an unencrypted backup adds no exposure.
+    let break_glass = if options.non_interactive {
+        let recipient = ceremony::generate_software_identity(&paths.break_glass_identity())?;
+        ceremony::BreakGlass::PlaintextIdentity {
+            identity_file: paths.break_glass_identity(),
+            recipient,
+        }
+    } else {
+        println!();
+        println!("    A deployment root needs a second recipient, or losing the primary loses");
+        println!("    the root. The root is exactly as strong as its weakest recipient.");
+        let choice = Select::new(
+            "  How should the break-glass recipient be protected?",
+            vec![SECOND_TOKEN, PASSPHRASE, PLAINTEXT],
+        )
+        .with_starting_cursor(if mode.is_dev_grade() { 1 } else { 0 })
+        .prompt()
+        .map_err(|e| anyhow::anyhow!("no break-glass recipient was chosen: {e}"))?;
+
+        match choice {
+            SECOND_TOKEN => {
+                println!("    Prepare the second token elsewhere with:");
+                println!(
+                    "      age-plugin-yubikey --generate --name \"hyprstream break-glass\" \\"
+                );
+                println!("        --pin-policy always --touch-policy always");
+                let recipient = Text::new("  Paste its age1yubikey1… recipient:")
+                    .prompt()
+                    .map_err(|e| anyhow::anyhow!("no break-glass recipient was entered: {e}"))?;
+                ceremony::BreakGlass::SecondToken {
+                    recipient: recipient.trim().to_owned(),
+                }
+            }
+            PASSPHRASE => {
+                let destination = Text::new("  Where should the encrypted backup identity go?")
+                    .with_default(&paths.break_glass_identity().display().to_string())
+                    .prompt()
+                    .map_err(|e| anyhow::anyhow!("no backup destination was entered: {e}"))?;
+                let destination = std::path::PathBuf::from(destination.trim());
+                println!("    Choose a passphrase and store it apart from the file itself.");
+                let recipient =
+                    ceremony::generate_passphrase_encrypted_identity(&destination)?;
+                match ceremony::classify_identity_file(
+                    &std::fs::read_to_string(&destination).unwrap_or_default(),
+                ) {
+                    ceremony::IdentityFileKind::PassphraseEncrypted => {}
+                    ceremony::IdentityFileKind::PlaintextAgeIdentity => {
+                        return Err(anyhow::anyhow!(
+                            "{} was written unencrypted; delete it and retry",
+                            destination.display()
+                        ));
+                    }
+                    ceremony::IdentityFileKind::Unconfirmed => {
+                        println!(
+                            "    Note: {} is encrypted, but its passphrase stanza could not be \
+                             confirmed from here.",
+                            destination.display()
+                        );
+                    }
+                }
+                ceremony::BreakGlass::PassphraseEncrypted {
+                    identity_file: destination,
+                    recipient,
+                }
+            }
+            _ => {
+                let recipient =
+                    ceremony::generate_software_identity(&paths.break_glass_identity())?;
+                ceremony::BreakGlass::PlaintextIdentity {
+                    identity_file: paths.break_glass_identity(),
+                    recipient,
+                }
+            }
+        }
+    };
+
+    if let Err(reason) = ceremony::validate_break_glass(&break_glass, primary_recipient, policy) {
+        return Err(anyhow::anyhow!("{reason}"));
+    }
+    Ok(break_glass)
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Phase 7: Services
 // ─────────────────────────────────────────────────────────────────────────────
 
 fn text_phase_services(
@@ -642,7 +984,7 @@ fn text_phase_services(
     non_interactive: bool,
     start_flag: bool,
 ) -> Result<()> {
-    println!("  Phase 6: Services");
+    println!("  Phase 7: Services");
     println!("  {}", "-".repeat(40));
     println!();
 
@@ -714,9 +1056,14 @@ fn print_summary(summary: &TextWizardSummary) {
         }
     }
 
+    if let Some(deployment_trust) = &summary.deployment_trust {
+        println!("  Deployment trust: {deployment_trust}");
+    }
+
     if summary.templates_applied.is_empty()
         && summary.users_created.is_empty()
         && summary.tokens_generated.is_empty()
+        && summary.deployment_trust.is_none()
     {
         println!("  Environment bootstrapped with default settings.");
     }

--- a/docs/deployment-trust-ceremony.md
+++ b/docs/deployment-trust-ceremony.md
@@ -109,10 +109,14 @@ There are two distinct YubiKey roles, and conflating them overstates what you ha
 | Flag | What it does | Firmware |
 |---|---|---|
 | `--yubikey age1yubikey1…` | Token acts as an **age recipient**: it decrypts the authority bundle. The bundle's private key is briefly **in host memory** during a ceremony. | any PIV-capable (verified on **5.4.3**) |
-| `--piv-slot <SLOT>` | The **Ed25519 leg lives in the token** and never reaches host memory. | **≥ 5.7.4** — Ed25519-in-PIV. **Not verified here** (test token was 5.4.3) |
+| `--piv-slot <SLOT>` | The Ed25519 root is generated in host memory, imported into the PIV slot, and its recovery seed is stored inside the age-encrypted authority bundle — so any bundle recipient can reconstruct the software signer. The token only **gates signing** behind PIN + touch; it does **not** confine the key. | **≥ 5.7.4** — Ed25519-in-PIV. **Not verified here** (test token was 5.4.3) |
 
-Both are legitimate. Only the second is "the key never leaves the hardware." Say which one you are
-running; do not let "we use YubiKeys" imply the stronger claim.
+Neither role confines the Ed25519 key to the hardware. Both the `--yubikey` age recipient and the
+`--piv-slot` import path place the bundle private key (or its recoverable seed) inside host memory
+and inside the age-encrypted authority bundle. The PIV path additionally gates signing behind a
+hardware touch prompt, but a bundle recipient can still sign without the token by reconstructing
+the software signer from the seed. Say which one you are running, and do not let "we use YubiKeys"
+imply hardware confinement that neither path actually provides.
 
 `--kms-plugin` accepts a cloud/PQ-HSM age-plugin recipient for organizations preferring an HSM.
 

--- a/docs/deployment-trust-ceremony.md
+++ b/docs/deployment-trust-ceremony.md
@@ -232,6 +232,36 @@ automated wrapper will not work.
 `CARGO_TARGET_DIR`, copy it out before using it — pooled slots are reclaimed and your binary will
 vanish mid-ceremony.
 
+## Running the ceremony from the wizard
+
+`hyprstream wizard --deployment-trust` runs the same four steps after node bootstrap. It is opt-in:
+without the flag the wizard sets up node-local trust only, exactly as before.
+
+The wizard enumerates attached tokens with `ykman list` and picks the mode from the firmware it
+reports, saying which one it chose and why:
+
+| What it finds | Mode |
+|---|---|
+| no token | software recipients, labelled **dev-grade** on screen, in the summary, and in `deployment-trust-mode.json` |
+| firmware < 5.7.4 | `--yubikey` age-recipient mode |
+| firmware >= 5.7.4 | `--piv-slot` mode (slot `9c` by default) |
+| several tokens | asks which one; `--deployment-trust-serial <SERIAL>` answers ahead of time |
+| detection failed | **refuses to continue** — not knowing whether hardware is attached is not the same as knowing it is absent |
+
+A software root is never selected while a token is attached unless `--deployment-trust-software` says
+so explicitly. The break-glass prompt defaults to `age-keygen | age -p` and refuses a bare identity
+file unless `--deployment-trust-allow-plaintext-break-glass` is passed.
+
+`--non-interactive` never reaches a prompt: without `--deployment-trust` the phase does not run at
+all, and with it, an attached token stops the run with both ways forward rather than hanging on a PIN
+that no one is there to type.
+
+The wizard leaves the public artifacts in the ceremony directory; installing them to
+`/etc/hyprstream/trust/` is still the operator's step (see *After the ceremony*).
+
+> The `--piv-slot` path remains **unverified on real 5.7.4 hardware**. The firmware rule that selects
+> it is tested; what `ykman piv keys import` and `yubico-piv-tool` do on a token is not.
+
 ## Local development
 
 `dev/local-e2e/` mints a **throwaway** deployment authority, standing in for the offline ceremony so


### PR DESCRIPTION
Stacked on `feat/1469-anchor-capsule-minter`. Part of hyprstream#1467.

## What this does

`hyprstream wizard --deployment-trust` now runs the deployment-trust ceremony after node bootstrap, instead of leaving it as a manual procedure in `docs/deployment-trust-ceremony.md`. It is **opt-in and additive**: without the flag the wizard's behaviour is byte-for-byte what it was, and node-local trust stays separate from deployment trust.

New module `crates/hyprstream/src/cli/trust_ceremony.rs`. Hardware access sits behind two traits (`TokenDetector`, `AgeYubikeyPlugin`); everything that decides anything is a pure function taking values.

## Detection / selection decision table

| Detection result | `--deployment-trust-software` | Interactive? | Outcome |
|---|---|---|---|
| flag absent | — | — | `Skipped` — no prompt, no work |
| no token | no | either | `SoftwareDevGrade`, loudly labelled |
| firmware < 5.7.4 | no | yes | `HardwareAgeRecipient` (`--yubikey`) |
| firmware >= 5.7.4 | no | yes | `HardwarePiv` (`--piv-slot`, default `9c`) |
| several tokens | no | yes | `ChooseToken` prompt → same firmware rule |
| several tokens | no | no | `Blocked` → "pass `--deployment-trust-serial <SERIAL>`" |
| serial given, no match | no | either | `Blocked`, lists attached serials |
| any token attached | no | no | `Blocked` — a PIN, a touch and a passphrase need a human |
| detection error (tool missing / timeout / unparsable) | no | either | `Blocked` — **never** silently degrades to software |
| detection error | yes | either | `SoftwareDevGrade`, rationale names the override |
| token attached | yes | either | `SoftwareDevGrade`, rationale says it overrode present hardware |

Two invariants are tested directly: a software root is never chosen while hardware is attached without an explicit override, and a scripted run never returns a plan that would prompt.

## Dev-grade labelling

A software root is labelled in the mode rationale, in a `!!` block on screen, in the wizard summary line, and in `deployment-trust-mode.json` written beside the artifacts (`dev_grade`, `grade`, `ed25519_confined_to_hardware`, `break_glass_protected`).

## Break-glass

The trust CLI can only check the two recipients differ. The wizard offers second token / passphrase-encrypted (`age-keygen | age -p`, private half never written in clear) / unencrypted, refuses the last without `--deployment-trust-allow-plaintext-break-glass`, and classifies the resulting file without decrypting it (armored ciphertext reports "unconfirmed" rather than claiming a passphrase it cannot see).

## Not in this PR

**Installing the public artifacts to `/etc/hyprstream/trust/`** (issue item 5) is deliberately left out. Today `cli/trust.rs` only *prints* those paths, and choosing who writes them interacts with the unresolved artifact-delivery question (privileged wizard write vs. a separate root-run install step vs. the publisher-manifest/cloud-secret path the contract already describes). The wizard prints the ceremony outputs and their destinations, which matches current CLI behaviour exactly. Options + a recommendation are in the task report rather than guessed at here.

## Untested on hardware — required manual verification

I have no YubiKey. These paths compile and are reached by the tested decision logic, but **nothing about them is verified**:

- `SystemTokenDetector::detect` against a real `ykman list` (the parser is tested against captured-format strings, not real output).
- `SystemAgeYubikeyPlugin::generate_identity` / `export_identity_file` — `age-plugin-yubikey --generate --pin-policy always --touch-policy always` on a TTY, and that the recipient parsed back from `--list` is the one just generated.
- The whole `--piv-slot` path end to end on firmware >= 5.7.4: `ykman piv keys import`, the import self-check, and `yubico-piv-tool` signing. This is the issue's acceptance item and it stays open.
- That the delegation step actually demands a PIN **and** a physical touch. If it ever completes without one, the root is not gated.
- `generate_passphrase_encrypted_identity` (needs the `age` tools present).

An operator with a token should run: a wizard ceremony on 5.4.3 hardware (age-recipient mode), a wizard ceremony on >= 5.7.4 hardware (PIV mode), and confirm PIN+touch is demanded at the delegation step in both.

## Verification run here

- `cargo test -p hyprstream --lib trust_ceremony` — 43 passed, 0 failed
- `cargo test -p hyprstream --lib cli::` — 82 passed, 0 failed
- `cargo clippy --release -p hyprstream --lib -- -D warnings` — clean
- `cargo clippy --release -p hyprstream --bins -- -D warnings` — clean
