### PR TITLE
trust: anchor hybrid bootstrap-pubkeys into PqTrustStore and enforce PQ per identity

### DIFF
--- a/crates/hyprstream-rpc/src/envelope.rs
+++ b/crates/hyprstream-rpc/src/envelope.rs
@@ -1018,6 +1018,34 @@ impl KeyedPqTrustStore {
         );
     }
 
+    /// Register an identity that may or may not carry a bound ML-DSA-65 key.
+    ///
+    /// Anchoring is **monotonic**: a `None` key never clears or replaces an
+    /// anchor already established for that identity. Re-registering a
+    /// previously hybrid identity from a classical-only source (a legacy
+    /// bootstrap file, a re-enrollment that omitted the PQ half) therefore
+    /// cannot silently downgrade the peer back to classical.
+    ///
+    /// Returns whether the identity is anchored after the call.
+    pub fn register(
+        &mut self,
+        ed25519_pubkey: [u8; 32],
+        ml_dsa_vk: Option<&crate::crypto::pq::MlDsaVerifyingKey>,
+    ) -> bool {
+        match ml_dsa_vk {
+            Some(vk) => {
+                self.bind(ed25519_pubkey, vk);
+                true
+            }
+            None => self.bindings.contains_key(&ed25519_pubkey),
+        }
+    }
+
+    /// Whether this identity has an anchored ML-DSA-65 key.
+    pub fn is_anchored(&self, ed25519_pubkey: &[u8; 32]) -> bool {
+        self.bindings.contains_key(ed25519_pubkey)
+    }
+
     /// Number of bindings.
     pub fn len(&self) -> usize {
         self.bindings.len()
@@ -1741,20 +1769,19 @@ impl SignedEnvelope {
         let signing_data = self.signed_bytes();
         let aad = envelope_external_aad();
 
-        let anchored_pq = if verify_policy.uses_pq() {
-            Some(
-                pq_store
-                    .and_then(|store| store.ml_dsa_key_for(&self.cnf))
-                    .ok_or_else(|| {
-                        EnvelopeError::PqSignatureInvalid(
-                            "mandatory Hybrid suite requires an anchored ML-DSA-65 signer key"
-                                .to_owned(),
-                        )
-                    })?,
-            )
-        } else {
-            None
-        };
+        // The PQ requirement is derived PER IDENTITY, not deployment-wide.
+        // An identity with an anchored ML-DSA-65 key MUST present a verifying
+        // outer PQ layer even where the global policy still admits classical
+        // peers — anchoring a peer is what turns PQ on for that peer. An
+        // identity with no anchor falls back to the global policy, so a
+        // deployment holding no hybrid material behaves exactly as before.
+        let anchored_pq = pq_store.and_then(|store| store.ml_dsa_key_for(&self.cnf));
+        if anchored_pq.is_none() && verify_policy.uses_pq() {
+            return Err(EnvelopeError::PqSignatureInvalid(
+                "mandatory Hybrid suite requires an anchored ML-DSA-65 signer key".to_owned(),
+            ));
+        }
+        let require_pq = anchored_pq.is_some();
 
         crate::crypto::cose_sign::verify_composite(
             &self.cose,
@@ -1762,7 +1789,7 @@ impl SignedEnvelope {
             anchored_pq.as_ref(),
             &signing_data,
             &aad,
-            verify_policy.uses_pq(),
+            require_pq,
         )
         .map_err(|e| EnvelopeError::PqSignatureInvalid(e.to_string()))?;
 
@@ -2500,19 +2527,16 @@ impl ResponseEnvelope {
         };
         let aad = response_envelope_external_aad();
 
-        let anchored_pq = if verify_policy.uses_pq() {
-            Some(
-                pq_store
-                    .and_then(|store| store.ml_dsa_key_for(&self.cnf))
-                    .ok_or_else(|| {
-                        anyhow!(
-                            "mandatory Hybrid suite requires an anchored ML-DSA-65 response key"
-                        )
-                    })?,
-            )
-        } else {
-            None
-        };
+        // Per-identity PQ requirement, mirroring the request side: an anchored
+        // responder MUST present a verifying outer PQ layer regardless of the
+        // global policy; an unanchored responder falls back to that policy.
+        let anchored_pq = pq_store.and_then(|store| store.ml_dsa_key_for(&self.cnf));
+        if anchored_pq.is_none() && verify_policy.uses_pq() {
+            return Err(anyhow!(
+                "mandatory Hybrid suite requires an anchored ML-DSA-65 response key"
+            ));
+        }
+        let require_pq = anchored_pq.is_some();
 
         crate::crypto::cose_sign::verify_composite(
             &self.cose,
@@ -2520,7 +2544,7 @@ impl ResponseEnvelope {
             anchored_pq.as_ref(),
             &signing_data,
             &aad,
-            verify_policy.uses_pq(),
+            require_pq,
         )
         .map_err(|e| anyhow::anyhow!("Response signature verification failed: {e}"))?;
 
@@ -4681,5 +4705,159 @@ mod tests {
             .get_root::<crate::common_capnp::response_envelope::Reader>()
             .unwrap();
         assert!(ResponseEnvelope::read_from(response_reader).is_err());
+    }
+
+    // =========================================================================
+    // Per-identity PQ enforcement: anchoring an identity turns PQ on for THAT
+    // identity, without a deployment-wide flag day for everyone else.
+    // =========================================================================
+
+    /// An anchored identity must present the outer ML-DSA-65 layer even where
+    /// the deployment's global policy still admits classical peers.
+    #[test]
+    fn anchored_identity_rejects_classical_under_classical_policy() {
+        let (sk, vk) = generate_signing_keypair();
+        let (_pq_sk, pq_vk) = crate::crypto::pq::ml_dsa_generate_keypair();
+        let cache = TestNonceCache::new();
+        let signed = SignedEnvelope::new_signed(RequestEnvelope::anonymous(vec![1]), &sk);
+        let store = pq_store_for(vk.to_bytes(), &pq_vk);
+        let res = signed.verify_with(&vk, &cache, Some(&store), CryptoPolicy::Classical);
+        assert!(
+            res.is_err(),
+            "an anchored identity must not be admitted with a classical-only signature"
+        );
+    }
+
+    /// The same anchored identity is admitted when it signs hybrid.
+    #[test]
+    fn anchored_identity_accepts_hybrid_under_classical_policy() -> crate::EnvelopeResult<()> {
+        let (sk, vk) = generate_signing_keypair();
+        let (pq_sk, pq_vk) = crate::crypto::pq::ml_dsa_generate_keypair();
+        let cache = TestNonceCache::new();
+        let signed =
+            SignedEnvelope::new_signed_hybrid(RequestEnvelope::anonymous(vec![2]), &sk, &pq_sk);
+        let store = pq_store_for(vk.to_bytes(), &pq_vk);
+        signed.verify_with(&vk, &cache, Some(&store), CryptoPolicy::Classical)?;
+        Ok(())
+    }
+
+    /// No flag day: an identity with no anchored PQ key keeps behaving exactly
+    /// as before under a classical-permissive policy, even when a PQ store is
+    /// consulted and holds bindings for other identities.
+    #[test]
+    fn unanchored_identity_unchanged_under_classical_policy() -> crate::EnvelopeResult<()> {
+        let (sk, vk) = generate_signing_keypair();
+        let (other_sk, other_vk) = generate_signing_keypair();
+        let (_pq_sk, pq_vk) = crate::crypto::pq::ml_dsa_generate_keypair();
+        let cache = TestNonceCache::new();
+
+        // A store that anchors somebody else entirely.
+        let store = pq_store_for(other_vk.to_bytes(), &pq_vk);
+        let signed = SignedEnvelope::new_signed(RequestEnvelope::anonymous(vec![3]), &sk);
+        signed.verify_with(&vk, &cache, Some(&store), CryptoPolicy::Classical)?;
+
+        // An entirely empty store is likewise unchanged.
+        let empty = KeyedPqTrustStore::new();
+        let signed2 = SignedEnvelope::new_signed(RequestEnvelope::anonymous(vec![4]), &other_sk);
+        signed2.verify_with(&other_vk, &cache, Some(&empty), CryptoPolicy::Classical)?;
+        Ok(())
+    }
+
+    /// One process, one store, two services: the anchored one is enforced and
+    /// the unanchored one is not.
+    #[test]
+    fn mixed_anchored_and_unanchored_services_in_one_store() -> crate::EnvelopeResult<()> {
+        let (anchored_sk, anchored_vk) = generate_signing_keypair();
+        let (legacy_sk, legacy_vk) = generate_signing_keypair();
+        let (pq_sk, pq_vk) = crate::crypto::pq::ml_dsa_generate_keypair();
+        let cache = TestNonceCache::new();
+
+        let mut store = KeyedPqTrustStore::new();
+        store.bind(anchored_vk.to_bytes(), &pq_vk);
+
+        // Anchored service: classical rejected, hybrid accepted.
+        let classical = SignedEnvelope::new_signed(RequestEnvelope::anonymous(vec![5]), &anchored_sk);
+        assert!(
+            classical
+                .verify_with(&anchored_vk, &cache, Some(&store), CryptoPolicy::Classical)
+                .is_err(),
+            "anchored service must be held to the hybrid signature"
+        );
+        let hybrid = SignedEnvelope::new_signed_hybrid(
+            RequestEnvelope::anonymous(vec![6]),
+            &anchored_sk,
+            &pq_sk,
+        );
+        hybrid.verify_with(&anchored_vk, &cache, Some(&store), CryptoPolicy::Classical)?;
+
+        // Unanchored service in the SAME store keeps the classical floor.
+        let legacy = SignedEnvelope::new_signed(RequestEnvelope::anonymous(vec![7]), &legacy_sk);
+        legacy.verify_with(&legacy_vk, &cache, Some(&store), CryptoPolicy::Classical)?;
+        Ok(())
+    }
+
+    /// Anchoring is monotonic: re-registering an anchored identity from a
+    /// classical-only source must not drop the binding, or enforcement could be
+    /// switched back off by replaying a legacy enrollment.
+    #[test]
+    fn anchored_identity_cannot_be_downgraded_to_unanchored() {
+        let (sk, vk) = generate_signing_keypair();
+        let (_pq_sk, pq_vk) = crate::crypto::pq::ml_dsa_generate_keypair();
+        let cache = TestNonceCache::new();
+
+        let mut store = KeyedPqTrustStore::new();
+        assert!(store.register(vk.to_bytes(), Some(&pq_vk)));
+        assert!(store.register(vk.to_bytes(), None), "classical re-registration must not clear the anchor");
+        assert!(store.is_anchored(&vk.to_bytes()));
+        assert_eq!(store.len(), 1);
+
+        // And the surviving anchor still enforces the PQ leg.
+        let classical = SignedEnvelope::new_signed(RequestEnvelope::anonymous(vec![8]), &sk);
+        assert!(
+            classical
+                .verify_with(&vk, &cache, Some(&store), CryptoPolicy::Classical)
+                .is_err(),
+            "the surviving anchor must still require the hybrid signature"
+        );
+    }
+
+    /// Registering an unanchored identity leaves it unanchored (a classical
+    /// entry never fabricates a binding).
+    #[test]
+    fn classical_registration_anchors_nothing() {
+        let (_sk, vk) = generate_signing_keypair();
+        let mut store = KeyedPqTrustStore::new();
+        assert!(!store.register(vk.to_bytes(), None));
+        assert!(store.is_empty());
+    }
+
+    /// The response side enforces the same per-identity rule.
+    #[test]
+    fn anchored_responder_rejects_classical_response() -> anyhow::Result<()> {
+        let (sk, vk) = generate_signing_keypair();
+        let (pq_sk, pq_vk) = crate::crypto::pq::ml_dsa_generate_keypair();
+        let store = pq_store_for(vk.to_bytes(), &pq_vk);
+
+        let classical = ResponseEnvelope::new_signed(21, vec![1, 2], &sk);
+        assert!(
+            classical
+                .verify_with(Some(&vk), Some(&store), CryptoPolicy::Classical)
+                .is_err(),
+            "an anchored responder must not be admitted with a classical-only signature"
+        );
+
+        let hybrid = ResponseEnvelope::new_signed_hybrid(22, vec![3, 4], &sk, &pq_sk);
+        hybrid.verify_with(Some(&vk), Some(&store), CryptoPolicy::Classical)?;
+        Ok(())
+    }
+
+    /// No flag day on the response side either.
+    #[test]
+    fn unanchored_responder_unchanged_under_classical_policy() -> anyhow::Result<()> {
+        let (sk, vk) = generate_signing_keypair();
+        let empty = KeyedPqTrustStore::new();
+        let classical = ResponseEnvelope::new_signed(23, vec![5, 6], &sk);
+        classical.verify_with(Some(&vk), Some(&empty), CryptoPolicy::Classical)?;
+        Ok(())
     }
 }

--- a/crates/hyprstream-rpc/src/envelope.rs
+++ b/crates/hyprstream-rpc/src/envelope.rs
@@ -1024,6 +1024,7 @@ impl KeyedPqTrustStore {
             if existing == &new_bytes {
                 return; // idempotent re-registration of the same key
             }
+            #[cfg(not(target_arch = "wasm32"))]
             tracing::error!(
                 ed25519 = %hex::encode(ed25519_pubkey),
                 "PQ anchor conflict: identity is already bound to a different \

--- a/crates/hyprstream-rpc/src/envelope.rs
+++ b/crates/hyprstream-rpc/src/envelope.rs
@@ -1007,15 +1007,32 @@ impl KeyedPqTrustStore {
 
     /// Bind an Ed25519 signer identity to its trusted ML-DSA-65 verifying key
     /// (stored as raw vk bytes; re-decoded on lookup).
+    ///
+    /// Anchoring is **monotonic and conflict-resistant**: once an identity is
+    /// bound to a specific ML-DSA-65 key, a subsequent attempt to bind it to a
+    /// *different* key is refused (not silently overwritten). The same key
+    /// re-registered is an idempotent no-op. This prevents a stale or hostile
+    /// seeding source from silently substituting a different PQ identity for an
+    /// already-anchored peer — the last writer does not win.
     pub fn bind(
         &mut self,
         ed25519_pubkey: [u8; 32],
         ml_dsa_vk: &crate::crypto::pq::MlDsaVerifyingKey,
     ) {
-        self.bindings.insert(
-            ed25519_pubkey,
-            crate::crypto::pq::ml_dsa_vk_bytes(ml_dsa_vk),
-        );
+        let new_bytes = crate::crypto::pq::ml_dsa_vk_bytes(ml_dsa_vk);
+        if let Some(existing) = self.bindings.get(&ed25519_pubkey) {
+            if existing == &new_bytes {
+                return; // idempotent re-registration of the same key
+            }
+            tracing::error!(
+                ed25519 = %hex::encode(ed25519_pubkey),
+                "PQ anchor conflict: identity is already bound to a different \
+                 ML-DSA-65 key; refusing to rebind. The existing anchor is \
+                 retained — investigate if this is unexpected."
+            );
+            return;
+        }
+        self.bindings.insert(ed25519_pubkey, new_bytes);
     }
 
     /// Register an identity that may or may not carry a bound ML-DSA-65 key.
@@ -1025,6 +1042,9 @@ impl KeyedPqTrustStore {
     /// previously hybrid identity from a classical-only source (a legacy
     /// bootstrap file, a re-enrollment that omitted the PQ half) therefore
     /// cannot silently downgrade the peer back to classical.
+    ///
+    /// Equally, a `Some` registration with a *different* PQ key than the one
+    /// already anchored is refused (see [`bind`]) — a rebind is not silent.
     ///
     /// Returns whether the identity is anchored after the call.
     pub fn register(
@@ -4829,6 +4849,37 @@ mod tests {
         let mut store = KeyedPqTrustStore::new();
         assert!(!store.register(vk.to_bytes(), None));
         assert!(store.is_empty());
+    }
+
+    /// A differing PQ key for an already-anchored identity is refused — the
+    /// existing anchor is retained and the rebind is not silent. This prevents
+    /// a stale bootstrap entry (or hostile seeding source) from substituting a
+    /// different PQ identity for an operator-anchored peer.
+    #[test]
+    fn differing_pq_rebind_is_refused_not_silent() {
+        let (_sk1, vk) = generate_signing_keypair();
+        let (_pq_sk_a, pq_vk_a) = crate::crypto::pq::ml_dsa_generate_keypair();
+        let (_pq_sk_b, pq_vk_b) = crate::crypto::pq::ml_dsa_generate_keypair();
+
+        let mut store = KeyedPqTrustStore::new();
+        store.bind(vk.to_bytes(), &pq_vk_a);
+
+        // Attempt to rebind to a different PQ key — must be refused.
+        store.bind(vk.to_bytes(), &pq_vk_b);
+
+        // The original anchor survives.
+        let anchored_vk = store.ml_dsa_key_for(&vk.to_bytes()).expect("anchor survived");
+        let original_bytes = crate::crypto::pq::ml_dsa_vk_bytes(&pq_vk_a);
+        let survived_bytes = crate::crypto::pq::ml_dsa_vk_bytes(&anchored_vk);
+        assert_eq!(
+            original_bytes, survived_bytes,
+            "the original PQ key must be retained, not the attempted rebind"
+        );
+        assert_eq!(store.len(), 1, "no duplicate entry created");
+
+        // Re-registering the SAME key via register() is idempotent.
+        store.register(vk.to_bytes(), Some(&pq_vk_a));
+        assert_eq!(store.len(), 1);
     }
 
     /// The response side enforces the same per-identity rule.

--- a/crates/hyprstream/src/auth/mesh_trust.rs
+++ b/crates/hyprstream/src/auth/mesh_trust.rs
@@ -71,6 +71,47 @@ pub fn build_mesh_pq_trust_store(oauth: &OAuthConfig) -> KeyedPqTrustStore {
     store
 }
 
+/// Anchor the ML-DSA-65 keys carried by the node's own `bootstrap-pubkeys`
+/// entries into `store`, keyed by the Ed25519 signer identity each entry
+/// already anchors in the classical trust store.
+///
+/// The bootstrap file is OS-owned, written out-of-band by the provisioning
+/// wizard, so it satisfies the [`KeyedPqTrustStore`] contract exactly as
+/// `mesh_peers` does. Classical-only entries contribute nothing and clear
+/// nothing: anchoring is monotonic, so a legacy file left in place after a
+/// hybrid enrollment cannot downgrade an already-anchored service.
+///
+/// A missing or unreadable file yields zero bindings — the pre-hybrid
+/// behavior, unchanged.
+///
+/// Returns the number of identities anchored from the file.
+pub fn seed_bootstrap_pq_bindings(
+    store: &mut KeyedPqTrustStore,
+    credentials_dir: &std::path::Path,
+) -> usize {
+    let entries = match crate::auth::identity_store::load_bootstrap_pubkeys_hybrid(credentials_dir)
+    {
+        Ok(entries) => entries,
+        Err(e) => {
+            tracing::error!(
+                "bootstrap-pubkeys could not be read for PQ anchoring, no bindings seeded \
+                 (re-run the provisioning wizard if hybrid services are expected): {e}"
+            );
+            return 0;
+        }
+    };
+
+    let mut anchored = 0usize;
+    for (name, entry) in &entries {
+        let ed_pubkey = entry.ed25519.to_bytes();
+        if store.register(ed_pubkey, entry.ml_dsa_65.as_ref()) && entry.is_hybrid() {
+            anchored += 1;
+            tracing::info!("bootstrap service '{name}': anchored ML-DSA-65 key for its Ed25519 signer identity");
+        }
+    }
+    anchored
+}
+
 /// Build the per-host mesh identity roster from the admin-configured
 /// `mesh_peers` (#328): each peer's Ed25519 signer pubkey → its per-host
 /// authorization subject (`service:inference:host-<label>`).
@@ -253,5 +294,91 @@ mod tests {
         // Round-trips with the correct codec.
         let raw = decode_multikey(&ed_mb, &MULTICODEC_ED25519_PUB).unwrap();
         assert_eq!(raw, [7u8; 32]);
+    }
+
+    // ─── bootstrap-pubkeys PQ seeding ────────────────────────────────────────
+
+    fn write_entries(
+        dir: &std::path::Path,
+        entries: Vec<(&str, crate::auth::identity_store::BootstrapPubkey)>,
+    ) {
+        let map: std::collections::HashMap<String, _> =
+            entries.into_iter().map(|(k, v)| (k.to_owned(), v)).collect();
+        crate::auth::identity_store::write_bootstrap_pubkeys_hybrid(dir, &map)
+            .expect("write bootstrap-pubkeys");
+    }
+
+    #[test]
+    fn hybrid_bootstrap_file_anchors_its_services() {
+        use crate::auth::identity_store::BootstrapPubkey;
+        use hyprstream_rpc::envelope::PqTrustStore;
+
+        let dir = tempfile::TempDir::new().unwrap();
+        let ed = SigningKey::generate(&mut OsRng);
+        let (_pq_sk, pq_vk) = pq::ml_dsa_generate_keypair();
+        write_entries(
+            dir.path(),
+            vec![("policy", BootstrapPubkey::hybrid(ed.verifying_key(), pq_vk))],
+        );
+
+        let mut store = KeyedPqTrustStore::new();
+        let anchored = seed_bootstrap_pq_bindings(&mut store, dir.path());
+        assert_eq!(anchored, 1, "the hybrid entry must be anchored");
+        assert!(store
+            .ml_dsa_key_for(&ed.verifying_key().to_bytes())
+            .is_some());
+    }
+
+    #[test]
+    fn classical_bootstrap_file_anchors_nothing() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let ed = SigningKey::generate(&mut OsRng);
+        write_entries(
+            dir.path(),
+            vec![(
+                "policy",
+                crate::auth::identity_store::BootstrapPubkey::classical(ed.verifying_key()),
+            )],
+        );
+
+        let mut store = KeyedPqTrustStore::new();
+        let anchored = seed_bootstrap_pq_bindings(&mut store, dir.path());
+        assert_eq!(anchored, 0, "a classical-only file must anchor nothing");
+        assert!(store.is_empty(), "a classical-only file must change nothing");
+    }
+
+    #[test]
+    fn absent_bootstrap_file_anchors_nothing() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let mut store = KeyedPqTrustStore::new();
+        assert_eq!(seed_bootstrap_pq_bindings(&mut store, dir.path()), 0);
+        assert!(store.is_empty());
+    }
+
+    #[test]
+    fn a_later_classical_file_cannot_unanchor_a_service() {
+        use crate::auth::identity_store::BootstrapPubkey;
+
+        let dir = tempfile::TempDir::new().unwrap();
+        let ed = SigningKey::generate(&mut OsRng);
+        let (_pq_sk, pq_vk) = pq::ml_dsa_generate_keypair();
+
+        let mut store = KeyedPqTrustStore::new();
+        write_entries(
+            dir.path(),
+            vec![("policy", BootstrapPubkey::hybrid(ed.verifying_key(), pq_vk))],
+        );
+        assert_eq!(seed_bootstrap_pq_bindings(&mut store, dir.path()), 1);
+
+        // Re-seeding from a file that lost its PQ half must leave the anchor.
+        write_entries(
+            dir.path(),
+            vec![("policy", BootstrapPubkey::classical(ed.verifying_key()))],
+        );
+        seed_bootstrap_pq_bindings(&mut store, dir.path());
+        assert!(
+            store.is_anchored(&ed.verifying_key().to_bytes()),
+            "a classical re-registration must not clear an established anchor"
+        );
     }
 }

--- a/crates/hyprstream/src/bin/main.rs
+++ b/crates/hyprstream/src/bin/main.rs
@@ -1657,6 +1657,11 @@ fn install_envelope_verify_config(oauth: Option<&hyprstream_core::config::OAuthC
             &secrets_dir,
         );
         tracing::info!("bootstrap PQ trust store seeded with {anchored} service binding(s)");
+    } else {
+        tracing::warn!(
+            "secrets directory unresolvable; bootstrap PQ bindings not seeded. \
+             Under Hybrid envelope policy local services may be unverifiable."
+        );
     }
 
     tracing::info!("mesh PQ trust store installed with {} peer binding(s)", keyed_store.len());

--- a/crates/hyprstream/src/bin/main.rs
+++ b/crates/hyprstream/src/bin/main.rs
@@ -1506,6 +1506,10 @@ fn resolve_service_vk(service_name: &str) -> Option<VerifyingKey> {
     let Ok(secrets_dir) = HyprConfig::resolve_secrets_dir() else {
         return None;
     };
+    // Only the Ed25519 half is needed here: the ML-DSA-65 half of these same
+    // entries is anchored into the process-global PQ trust store when the
+    // envelope verify config is installed (that store is immutable afterwards,
+    // so it is seeded once at construction rather than lazily here).
     if let Ok(pubkeys) = hyprstream_core::auth::identity_store::load_bootstrap_pubkeys(&secrets_dir) {
         for (name, vk) in &pubkeys {
             trust.insert(
@@ -1636,10 +1640,25 @@ fn install_envelope_verify_config(oauth: Option<&hyprstream_core::config::OAuthC
     // Mesh kid-anchored PQ trust store (#157, Option A): populated eagerly from
     // admin-configured `mesh_peers`, immutable after install. An empty store
     // under Hybrid fails closed for unknown peers (correct, by design).
-    let keyed_store = match oauth {
+    let mut keyed_store = match oauth {
         Some(oauth) => hyprstream_core::auth::mesh_trust::build_mesh_pq_trust_store(oauth),
         None => KeyedPqTrustStore::new(),
     };
+
+    // The node's own OS-owned bootstrap-pubkeys anchor the local services'
+    // Ed25519 identities; hybrid entries additionally carry the ML-DSA-65 key
+    // bound to that identity. Anchor those here, into the SAME store the
+    // envelope verify path consults, so supplying hybrid material actually
+    // turns PQ enforcement on for those services. A classical-only file
+    // anchors nothing and changes nothing.
+    if let Ok(secrets_dir) = HyprConfig::resolve_secrets_dir() {
+        let anchored = hyprstream_core::auth::mesh_trust::seed_bootstrap_pq_bindings(
+            &mut keyed_store,
+            &secrets_dir,
+        );
+        tracing::info!("bootstrap PQ trust store seeded with {anchored} service binding(s)");
+    }
+
     tracing::info!("mesh PQ trust store installed with {} peer binding(s)", keyed_store.len());
 
     // Per-host mesh identity roster (#328): bind each enrolled peer's Ed25519


### PR DESCRIPTION
Stacked on #1477 (`feat/1470-hybrid-bootstrap-pubkeys`).

Supplying hybrid Ed25519 + ML-DSA-65 material in `bootstrap-pubkeys` now changes what the running system enforces. No schema, codegen, or WASM change.

## 1. Population

`mesh_trust::seed_bootstrap_pq_bindings()` anchors the ML-DSA-65 half of each hybrid bootstrap entry, keyed by the same Ed25519 pubkey the classical trust store uses. It is called from `install_envelope_verify_config()` in `bin/main.rs`, into the same `KeyedPqTrustStore` that already backs both the request-side and response-side process-global verify configs — no parallel global. The store is immutable after install, so seeding happens at construction rather than lazily at the CLI `resolve_service_vk()` site (which reads the same file, and now says so).

## 2. Per-identity enforcement

`SignedEnvelope::verify_cose` and `ResponseEnvelope::verify_cose` no longer derive `require_pq` from the global `CryptoPolicy::uses_pq()`:

- anchored ML-DSA-65 key present for this signer → PQ required for that peer, regardless of the global policy;
- no anchor → previous global-policy behavior, unchanged (Hybrid still fails closed; classical-permissive deployments keep working).

No flag day: a deployment with no hybrid material anywhere behaves exactly as it does today. Explicitly tested.

## Monotonic anchoring

`KeyedPqTrustStore::register()` never lets a classical-only re-registration clear an established binding, so replaying a legacy enrollment cannot switch enforcement back off. Tested at the store level and end to end through verification.

## Note on `verify_composite(..., require_pq = false)`

Investigated per the issue. With `require_pq = false` **and no anchored key**, a present outer ML-DSA layer is deliberately ignored (`cose_sign.rs` "skip-unknown" arm). With `require_pq = false` but an anchored key supplied, the outer layer **is** verified.

This is not a signature-stripping gap: the inner EdDSA layer's AAD is derived from whether an outer layer is present, so stripping the outer layer off a hybrid composite makes the inner signature fail. The residual is outer-layer malleability for unanchored peers (an on-path attacker can garble/replace the ignored outer layer without detection); it grants no forgery, since the inner EdDSA leg still authenticates the message. Filed separately rather than expanded into this PR.

## Tests

`hyprstream-rpc --lib`: 973 passed. `hyprstream --lib auth::mesh_trust`: 11 passed, `auth::identity_store`: 39 passed. Clippy clean on `-p hyprstream-rpc --lib --tests`, `-p hyprstream --lib --tests`, and `-p hyprstream --bin hyprstream`, all with `-D warnings`.

Closes #1478