### PR TITLE
feat(auth): make hybrid service identities mandatory on the install path

### DIFF
--- a/crates/hyprstream-rpc/src/envelope.rs
+++ b/crates/hyprstream-rpc/src/envelope.rs
@@ -1775,6 +1775,17 @@ impl SignedEnvelope {
         // peers — anchoring a peer is what turns PQ on for that peer. An
         // identity with no anchor falls back to the global policy, so a
         // deployment holding no hybrid material behaves exactly as before.
+        //
+        // The unanchored branch is DELIBERATE INTEROP POLICY, not laxity, and
+        // must not be tightened here. It is the only place a signer this node
+        // does not itself provision — an external client, or a federated peer
+        // whose key comes from its own published document — can be admitted on
+        // terms other than our own. This node's own service identities are
+        // always provisioned hybrid and therefore always anchored, so making
+        // them mandatorily hybrid is achieved entirely by what gets anchored,
+        // and needs no change on this line. Deciding what the unanchored
+        // branch may admit is a separate, interop-facing question; do not
+        // settle it as a side effect of an internal-identity change.
         let anchored_pq = pq_store.and_then(|store| store.ml_dsa_key_for(&self.cnf));
         if anchored_pq.is_none() && verify_policy.uses_pq() {
             return Err(EnvelopeError::PqSignatureInvalid(
@@ -4793,6 +4804,54 @@ mod tests {
         // Unanchored service in the SAME store keeps the classical floor.
         let legacy = SignedEnvelope::new_signed(RequestEnvelope::anonymous(vec![7]), &legacy_sk);
         legacy.verify_with(&legacy_vk, &cache, Some(&store), CryptoPolicy::Classical)?;
+        Ok(())
+    }
+
+    /// The interop guarantee, in the shape a real deployment has it.
+    ///
+    /// Every internal service identity is provisioned hybrid and is therefore
+    /// anchored, so the store is non-empty and PQ is enforced for all of them.
+    /// An external classical client — an identity this node does not provision
+    /// and never anchors — must keep verifying on its Ed25519 signature alone
+    /// in that same process, against that same store. Making internal service
+    /// identities mandatorily hybrid must not reach this path.
+    #[test]
+    fn unanchored_interop_client_still_verifies_classically() -> crate::EnvelopeResult<()> {
+        let cache = TestNonceCache::new();
+
+        // Two internal services, both hybrid and both anchored.
+        let (svc_a_sk, svc_a_vk) = generate_signing_keypair();
+        let (svc_b_sk, svc_b_vk) = generate_signing_keypair();
+        let (svc_a_pq_sk, svc_a_pq_vk) = crate::crypto::pq::ml_dsa_generate_keypair();
+        let (svc_b_pq_sk, svc_b_pq_vk) = crate::crypto::pq::ml_dsa_generate_keypair();
+        let mut store = KeyedPqTrustStore::new();
+        store.bind(svc_a_vk.to_bytes(), &svc_a_pq_vk);
+        store.bind(svc_b_vk.to_bytes(), &svc_b_pq_vk);
+
+        // Both services verify hybrid, and neither can fall back to classical.
+        for (sk, vk, pq_sk, tag) in [
+            (&svc_a_sk, &svc_a_vk, &svc_a_pq_sk, 10u8),
+            (&svc_b_sk, &svc_b_vk, &svc_b_pq_sk, 11u8),
+        ] {
+            SignedEnvelope::new_signed_hybrid(RequestEnvelope::anonymous(vec![tag]), sk, pq_sk)
+                .verify_with(vk, &cache, Some(&store), CryptoPolicy::Classical)?;
+            assert!(
+                SignedEnvelope::new_signed(RequestEnvelope::anonymous(vec![tag + 100]), sk)
+                    .verify_with(vk, &cache, Some(&store), CryptoPolicy::Classical)
+                    .is_err(),
+                "an anchored service identity must not verify classically"
+            );
+        }
+
+        // The interop client: not a service, never anchored, classical only.
+        let (client_sk, client_vk) = generate_signing_keypair();
+        assert!(
+            !store.is_anchored(&client_vk.to_bytes()),
+            "the interop client must not be anchored — that is what this test is about"
+        );
+        SignedEnvelope::new_signed(RequestEnvelope::anonymous(vec![12]), &client_sk)
+            .verify_with(&client_vk, &cache, Some(&store), CryptoPolicy::Classical)?;
+
         Ok(())
     }
 

--- a/crates/hyprstream/src/auth/identity_store.rs
+++ b/crates/hyprstream/src/auth/identity_store.rs
@@ -1923,6 +1923,10 @@ mod tests {
             "error must not implicate the hybrid service: {err}"
         );
         assert!(err.contains("wizard"), "error names the working recovery: {err}");
+        assert!(
+            !err.contains("service repair"),
+            "error must not name the dead-end 'service repair' command: {err}"
+        );
         assert!(err.contains("ML-DSA-65"), "error names what is missing: {err}");
     }
 

--- a/crates/hyprstream/src/auth/identity_store.rs
+++ b/crates/hyprstream/src/auth/identity_store.rs
@@ -486,6 +486,26 @@ impl BootstrapPubkey {
         Self { ed25519, ml_dsa_65: Some(ml_dsa_65) }
     }
 
+    /// The hybrid entry for a service that signs with `service_key`.
+    ///
+    /// The ML-DSA-65 half is DERIVED from the service's Ed25519 key with
+    /// [`hyprstream_rpc::node_identity::derive_mesh_mldsa_key`] rather than
+    /// generated independently. That is not merely convenient — it is required
+    /// for the entry to be usable: every signer in the tree (the local signer,
+    /// the service dispatch default, the published `#mesh-pq` verification
+    /// method) produces its post-quantum signature from exactly that
+    /// derivation, so an independently generated key would anchor a public key
+    /// nothing ever signs with. It also keeps the service's secret material a
+    /// single Ed25519 seed — nothing new to persist, protect, back up or
+    /// rotate.
+    pub fn for_service_key(service_key: &SigningKey) -> Result<Self> {
+        let pq_sk = hyprstream_rpc::node_identity::derive_mesh_mldsa_key(service_key);
+        let pq_vk_bytes = hyprstream_rpc::crypto::pq::ml_dsa_sk_to_vk_bytes(&pq_sk);
+        let pq_vk = hyprstream_rpc::crypto::pq::ml_dsa_vk_from_bytes(&pq_vk_bytes)
+            .context("derived mesh ML-DSA-65 verifying key is malformed")?;
+        Ok(Self::hybrid(service_key.verifying_key(), pq_vk))
+    }
+
     /// Whether this entry carries a bound post-quantum key.
     pub fn is_hybrid(&self) -> bool {
         self.ml_dsa_65.is_some()
@@ -626,6 +646,43 @@ pub fn load_bootstrap_pubkeys_hybrid(
     }
 
     Ok(map)
+}
+
+/// Reject a `bootstrap-pubkeys` map that still carries Ed25519-only service
+/// entries.
+///
+/// Every service this node provisions gets a bound ML-DSA-65 key: there is no
+/// classical-only install path, so a classical entry here is stale material
+/// from a pre-hybrid provisioning run, not a supported configuration. Left
+/// alone it does not degrade gracefully — the service is simply never anchored
+/// in the post-quantum trust store, and its RPC is later refused with an
+/// opaque "no anchored ML-DSA-65 signer key" at verification time. Failing
+/// here converts that into an actionable provisioning error.
+///
+/// Deliberately NOT enforced inside [`load_bootstrap_pubkeys_hybrid`]: the
+/// low-level loader must stay able to read a legacy file so tooling — and this
+/// error itself — can report precisely which entries are stale.
+pub fn ensure_bootstrap_pubkeys_hybrid(
+    entries: &std::collections::HashMap<String, BootstrapPubkey>,
+) -> Result<()> {
+    let mut classical: Vec<&str> = entries
+        .iter()
+        .filter(|(_, entry)| !entry.is_hybrid())
+        .map(|(name, _)| name.as_str())
+        .collect();
+    if classical.is_empty() {
+        return Ok(());
+    }
+    classical.sort_unstable();
+    Err(anyhow!(
+        "bootstrap-pubkeys has Ed25519-only entries for service(s): {}. Service \
+         identities must be hybrid (Ed25519 + ML-DSA-65); these were written by a \
+         pre-hybrid provisioning run and cannot be anchored for post-quantum \
+         verification. Re-provision this node — run 'hyprstream wizard', or \
+         'hyprstream service repair' — to rewrite {BOOTSTRAP_PUBKEYS_NAME} with \
+         the bound ML-DSA-65 key for every service.",
+        classical.join(", ")
+    ))
 }
 
 /// Write bootstrap pubkeys, encoding hybrid entries in their concatenated form.
@@ -1834,6 +1891,91 @@ mod tests {
     fn write_raw_bootstrap_pubkeys(dir: &std::path::Path, entries: &[(&str, &str)]) {
         let json: std::collections::BTreeMap<&str, &str> = entries.iter().copied().collect();
         write_secret(dir, "bootstrap-pubkeys", &serde_json::to_vec(&json).unwrap()).unwrap();
+    }
+
+    // ── mandatory hybrid service entries ─────────────────────────────────────
+
+    /// A classical service entry is a hard, actionable error — never a silent
+    /// downgrade to the classical floor.
+    #[test]
+    fn classical_service_entry_is_a_hard_actionable_error() {
+        let dir = TempDir::new().unwrap();
+        let mut map = std::collections::HashMap::new();
+        map.insert(
+            "discovery".to_owned(),
+            BootstrapPubkey::classical(bootstrap_ed_key(11).verifying_key()),
+        );
+        map.insert(
+            "policy".to_owned(),
+            BootstrapPubkey::for_service_key(&bootstrap_ed_key(12)).unwrap(),
+        );
+        write_bootstrap_pubkeys_hybrid(dir.path(), &map).unwrap();
+
+        // The low-level loader still reads the file, so the error can name the
+        // offending entries precisely.
+        let loaded = load_bootstrap_pubkeys_hybrid(dir.path()).unwrap();
+        assert_eq!(loaded.len(), 2);
+
+        let err = format!("{:#}", ensure_bootstrap_pubkeys_hybrid(&loaded).unwrap_err());
+        assert!(err.contains("discovery"), "error names the classical service: {err}");
+        assert!(
+            !err.contains("policy"),
+            "error must not implicate the hybrid service: {err}"
+        );
+        assert!(err.contains("wizard") || err.contains("repair"), "error names the fix: {err}");
+        assert!(err.contains("ML-DSA-65"), "error names what is missing: {err}");
+    }
+
+    /// An all-hybrid file passes, and an unprovisioned (empty) node is not an
+    /// error — there are no service identities to be wrong about yet.
+    #[test]
+    fn hybrid_service_entries_and_empty_file_both_pass() {
+        let mut map = std::collections::HashMap::new();
+        for (name, seed) in [("policy", 21u8), ("discovery", 22), ("inference", 23)] {
+            map.insert(
+                name.to_owned(),
+                BootstrapPubkey::for_service_key(&bootstrap_ed_key(seed)).unwrap(),
+            );
+        }
+        ensure_bootstrap_pubkeys_hybrid(&map).unwrap();
+        ensure_bootstrap_pubkeys_hybrid(&std::collections::HashMap::new()).unwrap();
+    }
+
+    /// A provisioned service entry round-trips through the file and then
+    /// verifies a real hybrid signature made with the keys the service actually
+    /// signs with — the Ed25519 key plus the ML-DSA-65 key derived from it.
+    #[test]
+    fn provisioned_service_entry_verifies_a_hybrid_signature_end_to_end() {
+        use ed25519_dalek::Signer;
+
+        let dir = TempDir::new().unwrap();
+        let service_key = bootstrap_ed_key(31);
+
+        let mut map = std::collections::HashMap::new();
+        map.insert(
+            "discovery".to_owned(),
+            BootstrapPubkey::for_service_key(&service_key).unwrap(),
+        );
+        write_bootstrap_pubkeys_hybrid(dir.path(), &map).unwrap();
+
+        let loaded = load_bootstrap_pubkeys_hybrid(dir.path()).unwrap();
+        let entry = &loaded["discovery"];
+        assert!(entry.is_hybrid());
+        ensure_bootstrap_pubkeys_hybrid(&loaded).unwrap();
+
+        // Sign exactly as the service's own signer does.
+        let msg = b"service response payload";
+        let ed_sig = service_key.sign(msg);
+        let pq_sk = hyprstream_rpc::node_identity::derive_mesh_mldsa_key(&service_key);
+        let pq_sig = hyprstream_rpc::crypto::pq::ml_dsa_sign(&pq_sk, msg);
+
+        entry.verify(msg, &ed_sig, Some(&pq_sig)).unwrap();
+
+        // And the Ed25519 signature alone is not enough for a provisioned service.
+        assert!(
+            entry.verify(msg, &ed_sig, None).is_err(),
+            "a provisioned service entry must require both signatures"
+        );
     }
 
     #[test]

--- a/crates/hyprstream/src/auth/identity_store.rs
+++ b/crates/hyprstream/src/auth/identity_store.rs
@@ -678,9 +678,9 @@ pub fn ensure_bootstrap_pubkeys_hybrid(
         "bootstrap-pubkeys has Ed25519-only entries for service(s): {}. Service \
          identities must be hybrid (Ed25519 + ML-DSA-65); these were written by a \
          pre-hybrid provisioning run and cannot be anchored for post-quantum \
-         verification. Re-provision this node — run 'hyprstream wizard', or \
-         'hyprstream service repair' — to rewrite {BOOTSTRAP_PUBKEYS_NAME} with \
-         the bound ML-DSA-65 key for every service.",
+         verification. Re-provision this node by running 'hyprstream wizard' — \
+         it re-provisions in place, preserving existing keys while binding the \
+         ML-DSA-65 half for every service — to rewrite {BOOTSTRAP_PUBKEYS_NAME}.",
         classical.join(", ")
     ))
 }
@@ -1922,7 +1922,7 @@ mod tests {
             !err.contains("policy"),
             "error must not implicate the hybrid service: {err}"
         );
-        assert!(err.contains("wizard") || err.contains("repair"), "error names the fix: {err}");
+        assert!(err.contains("wizard"), "error names the working recovery: {err}");
         assert!(err.contains("ML-DSA-65"), "error names what is missing: {err}");
     }
 

--- a/crates/hyprstream/src/bin/main.rs
+++ b/crates/hyprstream/src/bin/main.rs
@@ -2091,6 +2091,30 @@ fn main() -> Result<()> {
         }
     }
 
+    // ── `service repair` early dispatch ──────────────────────────────────────
+    // `service repair` must run on a partially-broken install — including one
+    // whose bootstrap-pubkeys is stale (classical-only) and trips the hybrid
+    // gate below. Dispatch it before the gate so the operator always has an
+    // in-product diagnostic, and let run_repair_checks flag the stale file.
+    if let Some(("service", sub_m)) = matches.subcommand() {
+        if let Some(("repair", _)) = sub_m.subcommand() {
+            let verbose = sub_m
+                .subcommand_matches("repair")
+                .map(|m| m.get_flag("verbose"))
+                .unwrap_or(false);
+            let models_dir = config.models_dir().clone();
+            return with_runtime(
+                RuntimeConfig {
+                    device: DeviceConfig::request_cpu(),
+                    multi_threaded: true,
+                },
+                || async move {
+                    hyprstream_core::cli::service_handlers::run_repair_checks(&models_dir, verbose).await
+                },
+            );
+        }
+    }
+
     // Start registry service ONCE at CLI level
     let _registry_runtime = tokio::runtime::Builder::new_multi_thread()
         .enable_all()

--- a/crates/hyprstream/src/bin/main.rs
+++ b/crates/hyprstream/src/bin/main.rs
@@ -1506,23 +1506,42 @@ fn resolve_service_vk(service_name: &str) -> Option<VerifyingKey> {
     let Ok(secrets_dir) = HyprConfig::resolve_secrets_dir() else {
         return None;
     };
-    // Only the Ed25519 half is needed here: the ML-DSA-65 half of these same
-    // entries is anchored into the process-global PQ trust store when the
-    // envelope verify config is installed (that store is immutable afterwards,
-    // so it is seeded once at construction rather than lazily here).
-    if let Ok(pubkeys) = hyprstream_core::auth::identity_store::load_bootstrap_pubkeys(&secrets_dir) {
-        for (name, vk) in &pubkeys {
-            trust.insert(
-                *vk,
-                hyprstream_service::Attestation {
-                    scopes: std::iter::once(name.clone()).collect(),
-                    subject: None,
-                    jwt: None,
-                    expires_at: 0,
-                    attested_by: None,
-                },
-            );
-        }
+    // Load the full entries so the hybrid requirement can be enforced before
+    // anything is trusted. Only the Ed25519 half is inserted here: the
+    // ML-DSA-65 half of these same entries is anchored into the process-global
+    // PQ trust store when the envelope verify config is installed (that store
+    // is immutable afterwards, so it is seeded once at construction rather
+    // than lazily here).
+    let entries =
+        match hyprstream_core::auth::identity_store::load_bootstrap_pubkeys_hybrid(&secrets_dir) {
+            Ok(entries) => entries,
+            Err(e) => {
+                tracing::error!("bootstrap-pubkeys could not be read: {e:#}");
+                return None;
+            }
+        };
+    // A classical-only service entry is refused rather than seeded. Seeding it
+    // would not fail safe by half-measures: the service would be trusted
+    // classically here and then denied at envelope verification for having no
+    // anchored post-quantum key, with an error that names neither the file nor
+    // the fix. Refusing here reports the actual provisioning fault.
+    if let Err(e) =
+        hyprstream_core::auth::identity_store::ensure_bootstrap_pubkeys_hybrid(&entries)
+    {
+        tracing::error!("{e:#}");
+        return None;
+    }
+    for (name, entry) in &entries {
+        trust.insert(
+            entry.ed25519,
+            hyprstream_service::Attestation {
+                scopes: std::iter::once(name.clone()).collect(),
+                subject: None,
+                jwt: None,
+                expires_at: 0,
+                attested_by: None,
+            },
+        );
     }
     trust.resolve_one(service_name)
 }
@@ -1535,6 +1554,21 @@ async fn install_process_production_resolver(
     signing_key: &SigningKey,
     config: &HyprConfig,
 ) -> Result<bool> {
+    // Every service identity this node provisions is hybrid, so a classical
+    // service entry means the node was provisioned by a pre-hybrid wizard and
+    // its services can never be anchored for post-quantum verification. Fail
+    // startup here, where the fix can be named, instead of letting each RPC
+    // fail later with an opaque "no anchored ML-DSA-65 signer key". An
+    // unprovisioned node has no entries and is unaffected.
+    //
+    // Scoped to this node's OWN service identities. External classical clients
+    // and federated peers do not appear in this file and are not affected.
+    if let Ok(secrets_dir) = HyprConfig::resolve_secrets_dir() {
+        let entries =
+            hyprstream_core::auth::identity_store::load_bootstrap_pubkeys_hybrid(&secrets_dir)?;
+        hyprstream_core::auth::identity_store::ensure_bootstrap_pubkeys_hybrid(&entries)?;
+    }
+
     // The bootstrap pins the discovery service key from the process trust
     // store; in CLI/service-start mode nothing has seeded it yet. Seed from
     // the node's own bootstrap-pubkeys (the same source resolve_service_vk
@@ -2279,8 +2313,13 @@ fn main() -> Result<()> {
                                         )?,
                                     );
 
-                                    // Load bootstrap pubkeys (all service pubkeys) into trust store
-                                    if let Ok(pubkeys) = hyprstream_core::auth::identity_store::load_bootstrap_pubkeys(&secrets_dir) {
+                                    // Load bootstrap pubkeys (all service pubkeys) into trust store.
+                                    // Service identities are hybrid by construction; a classical
+                                    // entry is stale provisioning and is refused, not trusted.
+                                    if let Ok(entries) = hyprstream_core::auth::identity_store::load_bootstrap_pubkeys_hybrid(&secrets_dir) {
+                                        hyprstream_core::auth::identity_store::ensure_bootstrap_pubkeys_hybrid(&entries)?;
+                                        let pubkeys: std::collections::HashMap<String, VerifyingKey> =
+                                            entries.into_iter().map(|(n, e)| (n, e.ed25519)).collect();
                                         for (svc_name, vk) in &pubkeys {
                                             hyprstream_service::global_trust_store().insert(
                                                 *vk,
@@ -2351,12 +2390,17 @@ fn main() -> Result<()> {
                                         )?,
                                     );
 
-                                    // Load bootstrap pubkeys (all service pubkeys) into trust store
-                                    let pubkeys = hyprstream_core::auth::identity_store::load_bootstrap_pubkeys(&secrets_dir)
+                                    // Load bootstrap pubkeys (all service pubkeys) into trust store.
+                                    // Service identities are hybrid by construction; a classical
+                                    // entry is stale provisioning and is refused, not trusted.
+                                    let entries = hyprstream_core::auth::identity_store::load_bootstrap_pubkeys_hybrid(&secrets_dir)
                                         .context("Bootstrap pubkeys not found — run 'hyprstream wizard' first")?;
-                                    if pubkeys.is_empty() {
+                                    if entries.is_empty() {
                                         anyhow::bail!("Bootstrap pubkeys file is empty — run 'hyprstream wizard' first");
                                     }
+                                    hyprstream_core::auth::identity_store::ensure_bootstrap_pubkeys_hybrid(&entries)?;
+                                    let pubkeys: std::collections::HashMap<String, VerifyingKey> =
+                                        entries.into_iter().map(|(n, e)| (n, e.ed25519)).collect();
                                     for (svc_name, vk) in &pubkeys {
                                         hyprstream_service::global_trust_store().insert(
                                             *vk,

--- a/crates/hyprstream/src/bin/main.rs
+++ b/crates/hyprstream/src/bin/main.rs
@@ -2920,6 +2920,10 @@ fn main() -> Result<()> {
                 }
 
                 ServiceAction::Repair { verbose } => {
+                    // Normally handled by the early dispatch above (before
+                    // the hybrid gate). This arm is a defense-in-depth fallback
+                    // that runs the same diagnostic checks if the early
+                    // dispatch is ever bypassed.
                     let models_dir = config_for_service.models_dir().clone();
                     with_runtime(
                         RuntimeConfig {
@@ -2927,7 +2931,7 @@ fn main() -> Result<()> {
                             multi_threaded: true,
                         },
                         || async move {
-                            handle_service_install(&models_dir, &services, None, false, false, hyprstream_service::ServiceTarget::User, verbose).await
+                            hyprstream_core::cli::service_handlers::run_repair_checks(&models_dir, verbose).await
                         },
                     )?;
                 }

--- a/crates/hyprstream/src/cli/bootstrap_manager.rs
+++ b/crates/hyprstream/src/cli/bootstrap_manager.rs
@@ -719,46 +719,15 @@ async fn do_bootstrap(
         // Generate independent keypairs for each registered service
         use hyprstream_service::list_factories;
 
-        let mut bootstrap_pubkeys = std::collections::HashMap::new();
-        let now = chrono::Utc::now().timestamp();
-
-        for factory in list_factories() {
-            let service_name = factory.name;
-
-            // PolicyService's identity IS the root/CA key: unlike every other
-            // service it has no independent per-service keypair, so it resolves
-            // to `root_key` rather than `load_or_generate_service_signing_key`
-            // (which would read/generate a divergent `policy/signing-key`).
-            //
-            // But it is NOT skipped: we still mint a CA-signed `service:policy`
-            // JWT — self-signed in the sense that the CA JWT key signs it, with
-            // `cnf` binding the root verifying key — and persist it to
-            // `policy/service-jwt`. That makes PolicyService symmetric with
-            // every other service and keeps the trust store (which records
-            // `root_key.verifying_key()` for "policy") in lockstep with the
-            // on-disk JWT, so a later `service repair`/reinstall can no longer
-            // leave a stale `policy` key/JWT pair that disagrees with the
-            // current CA key (#448). It also enables future per-service
-            // rotation of the policy credential.
-            let service_key = if service_name == "policy" {
-                root_key.clone()
-            } else {
-                identity_store::load_or_generate_service_signing_key(
-                    &credentials_dir, service_name,
-                )?
-            };
-            let service_vk = service_key.verifying_key();
-
-            let jwt = crate::auth::service_jwt::issue_or_load_service_jwt(
-                &credentials_dir, service_name, &ca_jwt_key, &service_vk, &local_issuer_url, now,
-            )?;
-            identity_store::write_service_jwt(&credentials_dir, service_name, &jwt)?;
-
-            bootstrap_pubkeys.insert(service_name.to_owned(), service_vk);
-        }
-
-        // Write bootstrap pubkeys for all services
-        identity_store::write_bootstrap_pubkeys(&credentials_dir, &bootstrap_pubkeys)?;
+        let service_names: Vec<&str> = list_factories().map(|f| f.name).collect();
+        let bootstrap_pubkeys = provision_service_identities(
+            &credentials_dir,
+            &root_key,
+            &ca_jwt_key,
+            &local_issuer_url,
+            &service_names,
+            chrono::Utc::now().timestamp(),
+        )?;
 
         tracing::info!(
             "Generated service keypairs + JWTs for {} services",
@@ -775,12 +744,140 @@ async fn do_bootstrap(
     Ok(())
 }
 
+/// Provision one identity per named service: an Ed25519 signing key, a CA-signed
+/// service JWT, and the `bootstrap-pubkeys` entry that publishes the key.
+///
+/// Every entry written here is hybrid (Ed25519 + a derived ML-DSA-65 key). There
+/// is no classical provisioning mode and no flag to request one: the derived
+/// post-quantum key is what the service's own signer signs with, so publishing
+/// it is what makes the service verifiable at all. Re-running is idempotent —
+/// existing per-service keys and JWTs are loaded rather than replaced, so the
+/// entries it rewrites describe the same identities.
+fn provision_service_identities(
+    credentials_dir: &std::path::Path,
+    root_key: &ed25519_dalek::SigningKey,
+    ca_jwt_key: &ed25519_dalek::SigningKey,
+    local_issuer_url: &str,
+    service_names: &[&str],
+    now: i64,
+) -> anyhow::Result<std::collections::HashMap<String, identity_store::BootstrapPubkey>> {
+    let mut bootstrap_pubkeys = std::collections::HashMap::new();
+
+    for service_name in service_names {
+        let service_name = *service_name;
+
+        // PolicyService's identity IS the root/CA key: unlike every other
+        // service it has no independent per-service keypair, so it resolves
+        // to `root_key` rather than `load_or_generate_service_signing_key`
+        // (which would read/generate a divergent `policy/signing-key`).
+        //
+        // But it is NOT skipped: we still mint a CA-signed `service:policy`
+        // JWT — self-signed in the sense that the CA JWT key signs it, with
+        // `cnf` binding the root verifying key — and persist it to
+        // `policy/service-jwt`. That makes PolicyService symmetric with
+        // every other service and keeps the trust store (which records
+        // `root_key.verifying_key()` for "policy") in lockstep with the
+        // on-disk JWT, so a later `service repair`/reinstall can no longer
+        // leave a stale `policy` key/JWT pair that disagrees with the
+        // current CA key (#448). It also enables future per-service
+        // rotation of the policy credential.
+        let service_key = if service_name == "policy" {
+            root_key.clone()
+        } else {
+            identity_store::load_or_generate_service_signing_key(credentials_dir, service_name)?
+        };
+        let service_vk = service_key.verifying_key();
+
+        let jwt = crate::auth::service_jwt::issue_or_load_service_jwt(
+            credentials_dir, service_name, ca_jwt_key, &service_vk, local_issuer_url, now,
+        )?;
+        identity_store::write_service_jwt(credentials_dir, service_name, &jwt)?;
+
+        // The hybrid entry: the Ed25519 identity plus the ML-DSA-65 key derived
+        // from it. This is what `seed_bootstrap_pq_bindings` later anchors, and
+        // what turns post-quantum enforcement on for this service.
+        bootstrap_pubkeys.insert(
+            service_name.to_owned(),
+            identity_store::BootstrapPubkey::for_service_key(&service_key)?,
+        );
+    }
+
+    identity_store::write_bootstrap_pubkeys_hybrid(credentials_dir, &bootstrap_pubkeys)?;
+
+    Ok(bootstrap_pubkeys)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
     use crate::auth::{RocksDbUserStore, UserStore};
     use crate::cli::enroll::bind_user_signing_key;
     use tempfile::TempDir;
+
+    /// A fresh provisioning run writes a hybrid entry for EVERY service, and
+    /// those entries anchor into the post-quantum trust store.
+    ///
+    /// There is no classical provisioning mode to compare against — this is the
+    /// only path, so the assertion is that it has no classical output at all.
+    #[test]
+    fn provisioning_writes_hybrid_entries_that_anchor_for_every_service() -> anyhow::Result<()> {
+        use ed25519_dalek::SigningKey;
+        use hyprstream_rpc::envelope::{KeyedPqTrustStore, PqTrustStore};
+
+        let creds = TempDir::new()?;
+        let root_key = SigningKey::generate(&mut rand::rngs::OsRng);
+        let ca_jwt_key =
+            hyprstream_rpc::node_identity::derive_purpose_key(&root_key, "hyprstream-jwt-v1");
+        let services = ["policy", "discovery", "inference", "storage"];
+
+        let provisioned = provision_service_identities(
+            creds.path(),
+            &root_key,
+            &ca_jwt_key,
+            "https://node.invalid",
+            &services,
+            1_700_000_000,
+        )?;
+
+        assert_eq!(provisioned.len(), services.len());
+        for name in services {
+            let entry = provisioned
+                .get(name)
+                .unwrap_or_else(|| panic!("no bootstrap entry provisioned for '{name}'"));
+            assert!(entry.is_hybrid(), "service '{name}' was provisioned classical");
+        }
+
+        // What landed on disk is hybrid too, and passes the strict check.
+        let on_disk = identity_store::load_bootstrap_pubkeys_hybrid(creds.path())?;
+        assert_eq!(on_disk.len(), services.len());
+        identity_store::ensure_bootstrap_pubkeys_hybrid(&on_disk)?;
+
+        // Every provisioned service anchors into the PQ trust store.
+        let mut store = KeyedPqTrustStore::new();
+        let anchored =
+            crate::auth::mesh_trust::seed_bootstrap_pq_bindings(&mut store, creds.path());
+        assert_eq!(anchored, services.len(), "every service must anchor");
+        for name in services {
+            let entry = &on_disk[name];
+            assert!(
+                store.ml_dsa_key_for(&entry.ed25519.to_bytes()).is_some(),
+                "service '{name}' is not anchored in the PQ trust store"
+            );
+        }
+
+        // The anchored ML-DSA key is the one the service's signer signs with.
+        let policy_pq = store
+            .ml_dsa_key_for(&root_key.verifying_key().to_bytes())
+            .ok_or_else(|| anyhow::anyhow!("policy identity not anchored"))?;
+        let msg = b"anchored-key round trip";
+        let sig = hyprstream_rpc::crypto::pq::ml_dsa_sign(
+            &hyprstream_rpc::node_identity::derive_mesh_mldsa_key(&root_key),
+            msg,
+        );
+        hyprstream_rpc::crypto::pq::ml_dsa_verify(&policy_pq, msg, &sig)?;
+
+        Ok(())
+    }
 
     /// Replicates the register + bind sequence performed by
     /// `register_local_identity` against a temp store/secrets dir, then asserts

--- a/crates/hyprstream/src/cli/commands/mod.rs
+++ b/crates/hyprstream/src/cli/commands/mod.rs
@@ -271,10 +271,12 @@ pub enum ServiceAction {
         verbose: bool,
     },
 
-    /// Diagnose, initialize, and repair hyprstream installation
+    /// Diagnose the hyprstream installation
     ///
-    /// Alias for `service install --verbose`. Runs all setup checks and fixes
-    /// without starting services.
+    /// Runs all setup checks (directories, registry, policy, signing keys,
+    /// TLS, bootstrap-pubkeys hybrid posture) and reports status without
+    /// starting services. Dispatches before the hybrid gate so it works on
+    /// a partially-broken install.
     Repair {
         /// Show verbose output for each check
         #[arg(long, short = 'v')]

--- a/crates/hyprstream/src/cli/service_handlers.rs
+++ b/crates/hyprstream/src/cli/service_handlers.rs
@@ -782,7 +782,11 @@ pub async fn run_repair_checks(
         println!("    Some checks failed. Review output above.");
     }
 
-    Ok(())
+    if all_passed {
+        Ok(())
+    } else {
+        Err(anyhow::anyhow!("one or more repair checks failed; review output above"))
+    }
 }
 
 #[allow(dead_code)]

--- a/crates/hyprstream/src/cli/service_handlers.rs
+++ b/crates/hyprstream/src/cli/service_handlers.rs
@@ -430,7 +430,7 @@ pub async fn handle_service_status(
 ///
 /// Extracted from the old `handle_service_repair` so it can be called as part
 /// of `handle_service_install` without the surrounding summary chrome.
-pub(crate) async fn run_repair_checks(
+pub async fn run_repair_checks(
     models_dir: &Path,
     verbose: bool,
 ) -> Result<()> {
@@ -714,6 +714,53 @@ pub(crate) async fn run_repair_checks(
         } else {
             print_check(label, CheckStatus::Warn, "policy.csv not found");
             warnings.push("Run 'hyprstream service install' again after fixing policy files".to_owned());
+        }
+    }
+
+    // 8. Bootstrap-pubkeys hybrid posture
+    //
+    // A stale Ed25519-only file (from a pre-hybrid provisioning run) blocks
+    // startup: service identities can never be anchored for post-quantum
+    // verification. Detect it here and name the recovery, rather than letting
+    // the operator discover it from a startup refusal.
+    {
+        let label = "Hybrid bootstrap";
+        match crate::config::HyprConfig::resolve_secrets_dir() {
+            Ok(secrets_dir) => {
+                match crate::auth::identity_store::load_bootstrap_pubkeys_hybrid(&secrets_dir) {
+                    Ok(entries) if entries.is_empty() => {
+                        print_check(label, CheckStatus::Ok, "unprovisioned (clean)");
+                    }
+                    Ok(entries) => {
+                        match crate::auth::identity_store::ensure_bootstrap_pubkeys_hybrid(&entries) {
+                            Ok(()) => {
+                                let n = entries.len();
+                                let noun = if n == 1 { "entry" } else { "entries" };
+                                print_check(label, CheckStatus::Ok,
+                                    &format!("{n} hybrid {noun} bound"));
+                            }
+                            Err(e) => {
+                                print_check(label, CheckStatus::Fail, &format!("{e}"));
+                                all_passed = false;
+                                warnings.push(
+                                    "Re-provision with 'hyprstream wizard' to bind \
+                                     ML-DSA-65 keys for every service".to_owned()
+                                );
+                            }
+                        }
+                    }
+                    Err(e) => {
+                        print_check(label, CheckStatus::Fail, &format!("parse error: {e}"));
+                        all_passed = false;
+                        warnings.push(
+                            "Fix the file or re-provision with 'hyprstream wizard'".to_owned()
+                        );
+                    }
+                }
+            }
+            Err(e) => {
+                print_check(label, CheckStatus::Warn, &format!("secrets dir: {e}"));
+            }
         }
     }
 

--- a/docs/bootstrap-pubkeys-format.md
+++ b/docs/bootstrap-pubkeys-format.md
@@ -112,10 +112,9 @@ Consequently a classical **service** entry is not a supported configuration; it
 is stale material from a pre-hybrid provisioning run. The runtime refuses it
 with an actionable error when it resolves service keys, rather than trusting it
 classically and then failing each RPC later with an opaque "no anchored
-ML-DSA-65 signer key". The fix is to re-provision: `hyprstream wizard`, or
-`hyprstream service repair`. Per-service keys and JWTs are preserved across a
-re-run, so the identities do not change — only the published entries gain their
-post-quantum half.
+ML-DSA-65 signer key". The fix is to re-provision with `hyprstream wizard`.
+Per-service keys and JWTs are preserved across a re-run, so the identities do
+not change — only the published entries gain their post-quantum half.
 
 The low-level loader still reads classical entries so tooling, and that error
 itself, can report precisely which services are stale. This rule is scoped to

--- a/docs/bootstrap-pubkeys-format.md
+++ b/docs/bootstrap-pubkeys-format.md
@@ -94,6 +94,34 @@ Upgrading a service is therefore a per-entry operation: rewrite one value in
 the 1984-byte form, leave the rest alone. Nothing else in the file, and no
 other node, has to change at the same time.
 
+## Hybrid is mandatory for this node's own services
+
+The two forms above describe what the *parser* accepts. What this node's
+provisioning *writes* is narrower: **every service entry is hybrid**. There is
+no classical provisioning mode and no flag to request one.
+
+The ML-DSA-65 half of each entry is derived from that service's Ed25519 key
+(HKDF, `hyprstream-mesh-mldsa-v1`) rather than generated independently. That is
+required, not merely convenient: every signer in the tree derives its
+post-quantum key the same way, so an independently generated key would publish
+a public key that nothing ever signs with. It also means a service's secret
+material stays a single Ed25519 seed — there is no second private key to
+persist, protect, back up or rotate.
+
+Consequently a classical **service** entry is not a supported configuration; it
+is stale material from a pre-hybrid provisioning run. The runtime refuses it
+with an actionable error when it resolves service keys, rather than trusting it
+classically and then failing each RPC later with an opaque "no anchored
+ML-DSA-65 signer key". The fix is to re-provision: `hyprstream wizard`, or
+`hyprstream service repair`. Per-service keys and JWTs are preserved across a
+re-run, so the identities do not change — only the published entries gain their
+post-quantum half.
+
+The low-level loader still reads classical entries so tooling, and that error
+itself, can report precisely which services are stale. This rule is scoped to
+the node's own services: external classical clients and federated peers do not
+appear in this file and are unaffected by it.
+
 ## Which service names matter
 
 The wizard mints a keypair for every registered factory, but the runtime only


### PR DESCRIPTION
Stacked on `feat/1478-pq-trust-anchoring`. Consumes both the hybrid `bootstrap-pubkeys` writer and the PQ anchoring that branch adds.

## Directive

> we should always be hybrid. there should be no non-hybrid install path. We will still support classical-only clients and federated atproto peers at interop surfaces accordingly.

## The gap this closes

The hybrid `bootstrap-pubkeys` format and the PQ anchoring that consumes it both already existed — but **nothing ever produced hybrid material**. The provisioning wizard called the classical writer (`bootstrap_manager.rs:761`), so every installed node published Ed25519-only service entries, anchored nothing into the `KeyedPqTrustStore`, and got no post-quantum enforcement for its own services. Hybrid was implemented end to end and switched off by default at the one place that mattered.

## What changed

**1. Provisioning always writes hybrid.** Every service entry now carries a bound ML-DSA-65 key. There is no flag to disable it and no classical provisioning mode.

**2. Derive, not generate.** The ML-DSA-65 half is derived from the service's Ed25519 key via `node_identity::derive_mesh_mldsa_key` (HKDF, `hyprstream-mesh-mldsa-v1`). This is *required for correctness*, not just convenient: `LocalSigner::new` (`signer.rs:54`), the service dispatch default (`svc.rs:744`), and the published `#mesh-pq` verification method all produce their PQ signature from exactly that derivation. An independently generated key would anchor a public key nothing ever signs with, and every hybrid verification would fail. It also means **no new secret is introduced** — a service's private material stays a single Ed25519 seed, with nothing extra to persist, protect, back up or rotate.

**3. Classical service entries are a hard, actionable error** where the runtime resolves service keys. Previously such an entry was trusted classically and then denied at envelope verification with an opaque `mandatory Hybrid suite requires an anchored ML-DSA-65 signer key` — naming neither the file nor the fix. The check is deliberately **not** in `load_bootstrap_pubkeys`: the low-level loader must stay able to read legacy files so tooling and this error can report precisely which services are stale.

**4. Interop untouched.** No change to the ATProto perimeter, browser/WNS paths, or DID-document identity resolution. The per-identity fallback for unanchored signers in `verify_cose` is byte-for-byte unchanged and now carries a comment recording that it is deliberate interop policy.

## Open question, answered: does interop share `verify_cose`?

**Split, and not the convenient split.**

- **Browser / WASM external clients: YES, same path.** `dispatch::process_request` is a single funnel for browser WebTransport, QUIC, iroh, UDS and inproc alike; `AnySigner` vs `FixedSigner` changes who is accepted, not the policy or the PQ requirement.
- **Federated ATProto peers: NO, separate surface** — axum HTTP routes with DID-document / JWT / DPoP checks (`services/oauth/xrpc.rs`, `hyprstream-pds-service/src/federation_intake.rs`). They never reach `verify_cose` today. Note that `build_federation_admission_gate` has zero production callers but is *designed* to consume a `verify_cose`-verified signer, so wiring it would move federated peers onto the shared path.

**The belt-and-braces flip is moot: `CryptoPolicy` is already `Hybrid`-mandatory.** `CryptoPolicy::Classical` is `#[cfg(any(test, feature = "test-classical-policy"))]` and does not exist in a production build; `Hybrid` is the `#[default]`, the value `mandatory_envelope_policy()` returns, and the fail-closed default when no config is installed. There is no flip left to make, and none is made here.

A consequence worth flagging separately from this PR: under the pinned Hybrid policy, the real admission control is *which identities are anchored*, and the `KeyedPqTrustStore` is populated only from `mesh_peers` config plus `bootstrap-pubkeys` at startup and is immutable thereafter. A browser client using classical `JsSigner::new` rather than `new_hybrid` has no runtime path to become anchored. Whether any deployment does that is worth confirming; it is pre-existing behavior on this base branch, not introduced here.

## Migration — breaking

Every existing deployment has a classical `bootstrap-pubkeys` and **will fail to start** until re-provisioned.

**Operator action:** run `hyprstream wizard`, or `hyprstream service repair`, before starting the upgraded binary. Per-service Ed25519 keys and service JWTs are loaded rather than replaced, so **service identities do not change** — only the published entries gain their post-quantum half. No coordination between nodes is needed and no other file changes.

The error names the offending services and the fix.

**No transition escape hatch is included**, per the directive's explicit rejection of a non-hybrid path. If one is later wanted, the narrowest sound form would be a time-boxed env var that downgrades the strict check to a `tracing::warn!` — but note it would buy little, because those services would still be unanchored and their RPC still refused by the already-Hybrid envelope policy. Re-provisioning is the actual fix, and it is cheap and non-destructive.

## Tests

- `provisioning_writes_hybrid_entries_that_anchor_for_every_service` — a fresh provisioning run produces hybrid entries for every service, they anchor into the PQ store, and the anchored ML-DSA key is the one the service's signer signs with.
- `classical_service_entry_is_a_hard_actionable_error` — the error names the classical service, does not implicate hybrid ones, and names the fix.
- `provisioned_service_entry_verifies_a_hybrid_signature_end_to_end` — round trip through the file, then verify a real hybrid signature; the Ed25519 signature alone is rejected.
- `unanchored_interop_client_still_verifies_classically` — **the interop guarantee**, in deployment shape: two anchored hybrid services enforced in the same process and the same store, while an unanchored external client still verifies on Ed25519 alone.
- `hybrid_service_entries_and_empty_file_both_pass` — an unprovisioned node is not an error.

Refs #1478
