### PR TITLE
trust: session PQ overlay — TOFU binding with out-of-band promotion for browser/dynamic clients

### DIFF
--- a/crates/hyprstream-crypto/src/cose_sign.rs
+++ b/crates/hyprstream-crypto/src/cose_sign.rs
@@ -450,6 +450,47 @@ pub fn encode_composite_for_test(inner: Vec<u8>, outer: Option<Vec<u8>>) -> Resu
     encode_composite(inner, outer)
 }
 
+/// The ML-DSA-65 verifying key the composite's outer layer **claims** for
+/// itself, read out of that layer's `kid` protected header.
+///
+/// # This value is not trusted
+///
+/// It is attacker-controlled wire data: whoever produced the composite chose
+/// it. It carries exactly one property — an outer signature that verifies
+/// against it proves the producer held the matching ML-DSA-65 private key —
+/// and it proves *nothing* about that key belonging to the identity in the
+/// inner EdDSA layer. [`verify_composite`] therefore never reads it as an
+/// anchor; it only compares it against a key the caller resolved from a trust
+/// source, and rejects a mismatch.
+///
+/// The one legitimate use is as a *candidate* offered to a trust-on-first-use
+/// record: verify the whole composite against this candidate first, so that
+/// possession of both the EdDSA and the ML-DSA-65 private keys is proven, and
+/// only then record the pairing — at a provenance that grants no additional
+/// trust.
+///
+/// Returns `Ok(None)` when the composite has no outer layer (classical-only) or
+/// when its outer layer carries no `kid`.
+pub fn self_asserted_outer_pq_key(
+    cose_composite_bytes: &[u8],
+) -> Result<Option<MlDsaVerifyingKey>> {
+    let (_, outer_bytes) = decode_composite(cose_composite_bytes)?;
+    let Some(ob) = outer_bytes else {
+        return Ok(None);
+    };
+    let outer =
+        CoseSign1::from_slice(&ob).map_err(|e| anyhow!("malformed outer ML-DSA COSE_Sign1: {e}"))?;
+    let outer_alg = header_alg(&outer)?;
+    if outer_alg != ALG_ML_DSA_65 {
+        bail!("outer COSE_Sign1 must be ML-DSA-65, got alg={outer_alg}");
+    }
+    let kid = &outer.protected.header.key_id;
+    if kid.is_empty() {
+        return Ok(None);
+    }
+    crate::pq::ml_dsa_vk_from_bytes(kid).map(Some)
+}
+
 /// Outcome of composite verification.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct CompositeVerified {

--- a/crates/hyprstream-crypto/src/cose_sign.rs
+++ b/crates/hyprstream-crypto/src/cose_sign.rs
@@ -177,17 +177,82 @@ fn ml_dsa_kid(vk: &MlDsaVerifyingKey) -> Vec<u8> {
     crate::pq::ml_dsa_vk_bytes(vk)
 }
 
+/// Protected-header label under which the INNER EdDSA layer names the ML-DSA-65
+/// verifying key that must sit above it.
+///
+/// # What this closes
+///
+/// The nested construction binds inner→outer: the outer layer signs
+/// `payload ‖ inner_signature`. It does **not** bind outer→inner. Without this
+/// header the inner EdDSA layer commits to the payload and says nothing about
+/// which ML-DSA-65 key is above it, so anyone holding a *copy* of a valid inner
+/// layer — its signature bytes, not the private key — can discard the outer
+/// layer, re-sign `payload ‖ inner_signature` with an ML-DSA key of their own,
+/// and produce a composite that verifies completely: ML-DSA key theirs, Ed25519
+/// identity the victim's.
+///
+/// That asymmetry is harmless as long as the ML-DSA key is always resolved from
+/// a trust store (a wrong `kid` simply fails). It stops being harmless the
+/// moment the outer `kid` becomes a value a verifier *records*.
+///
+/// A COSE protected header is part of the `Sig_structure`, so naming the outer
+/// key here puts it under the Ed25519 signature: swapping the outer layer now
+/// contradicts the inner header, and removing the header breaks the inner
+/// signature.
+///
+/// A text label is used deliberately — it needs no IANA code point and cannot
+/// collide with a future registry allocation.
+pub const PQ_BINDING_HEADER_LABEL: &str = "hs-pq-bind";
+
+/// Build the inner EdDSA protected header.
+///
+/// `pq_binding` is the raw ML-DSA-65 verifying key this layer commits to, or
+/// `None` for the unbound form. **The unbound form is the default and is
+/// byte-for-byte what this module has always produced**, because records that
+/// persist a *decomposed* composite (at9p capsules, DID operations, the PLC
+/// directory) store only the two raw signatures and rebuild the headers
+/// deterministically on read — adding a header unconditionally would invalidate
+/// every stored signature.
+fn inner_protected(ed_kid: Vec<u8>, pq_binding: Option<&[u8]>) -> coset::Header {
+    let builder = HeaderBuilder::new()
+        .algorithm(iana::Algorithm::EdDSA)
+        .key_id(ed_kid);
+    match pq_binding {
+        Some(vk) => builder
+            .text_value(
+                PQ_BINDING_HEADER_LABEL.to_owned(),
+                CborValue::Bytes(vk.to_vec()),
+            )
+            .build(),
+        None => builder.build(),
+    }
+}
+
+/// Read the ML-DSA-65 key an inner layer commits to, if it commits to one.
+///
+/// Returns `Err` when the header is present but not a byte string — a
+/// malformed binding is a rejection, never a silently-absent one.
+fn inner_pq_binding(inner: &CoseSign1) -> Result<Option<Vec<u8>>> {
+    for (label, value) in &inner.protected.header.rest {
+        if matches!(label, coset::Label::Text(t) if t == PQ_BINDING_HEADER_LABEL) {
+            return match value {
+                CborValue::Bytes(b) => Ok(Some(b.clone())),
+                _ => bail!("inner EdDSA COSE_Sign1 PQ-binding header must be a byte string"),
+            };
+        }
+    }
+    Ok(None)
+}
+
 /// Build the inner EdDSA `COSE_Sign1` over the detached `payload`.
 fn build_inner_eddsa(
     ed_sk: &ed25519_dalek::SigningKey,
     payload: &[u8],
     external_aad: &[u8],
+    pq_binding: Option<&[u8]>,
 ) -> Result<CoseSign1> {
     use ed25519_dalek::Signer as _;
-    let protected = HeaderBuilder::new()
-        .algorithm(iana::Algorithm::EdDSA)
-        .key_id(eddsa_kid(&ed_sk.verifying_key()))
-        .build();
+    let protected = inner_protected(eddsa_kid(&ed_sk.verifying_key()), pq_binding);
     Ok(CoseSign1Builder::new()
         .protected(protected)
         .create_detached_signature(payload, external_aad, |tbs| {
@@ -281,13 +346,51 @@ pub fn sign_composite(
     payload: &[u8],
     external_aad: &[u8],
 ) -> Result<Vec<u8>> {
+    sign_composite_inner(ed_sk, pq_sk, payload, external_aad, false)
+}
+
+/// [`sign_composite`], with the inner EdDSA layer additionally committing to the
+/// ML-DSA-65 key above it (see [`PQ_BINDING_HEADER_LABEL`]).
+///
+/// Use this wherever a verifier may *record* the composite's ML-DSA-65 key
+/// rather than resolve it from a trust store. Without the commitment, a valid
+/// composite proves possession of the ML-DSA key plus possession of one
+/// replayable Ed25519 signature — not of the Ed25519 private key.
+///
+/// Classical mode (`pq_sk = None`) has no outer key to commit to and is
+/// identical to [`sign_composite`].
+///
+/// The output stays verifiable by verifiers that predate the header: they parse
+/// the protected bucket as received, so the unknown label is carried into the
+/// `Sig_structure` and simply not interpreted.
+pub fn sign_composite_pq_bound(
+    ed_sk: &ed25519_dalek::SigningKey,
+    pq_sk: Option<&MlDsaSigningKey>,
+    payload: &[u8],
+    external_aad: &[u8],
+) -> Result<Vec<u8>> {
+    sign_composite_inner(ed_sk, pq_sk, payload, external_aad, true)
+}
+
+fn sign_composite_inner(
+    ed_sk: &ed25519_dalek::SigningKey,
+    pq_sk: Option<&MlDsaSigningKey>,
+    payload: &[u8],
+    external_aad: &[u8],
+    bind_pq: bool,
+) -> Result<Vec<u8>> {
+    use ml_dsa::Keypair;
     // Hybrid iff an ML-DSA-65 key is present. In Hybrid mode the hybrid-composite
     // alg-id is bound into BOTH layers' external_aad (#278); in Classical mode the
     // bare base AAD is used so classical signatures are byte-identical to before.
     let hybrid = pq_sk.is_some();
     let aad = layer_aad(external_aad, hybrid);
 
-    let inner = build_inner_eddsa(ed_sk, payload, &aad)?;
+    let binding = match (bind_pq, pq_sk) {
+        (true, Some(pq)) => Some(ml_dsa_kid(&pq.verifying_key().clone())),
+        _ => None,
+    };
+    let inner = build_inner_eddsa(ed_sk, payload, &aad, binding.as_deref())?;
     let inner_sig = inner_signature_bytes(&inner).to_vec();
     let inner_bytes = inner
         .to_vec()
@@ -321,14 +424,9 @@ pub fn sign_composite(
 // ────────────────────────────────────────────────────────────────────────────
 
 /// Build an unsigned inner EdDSA `COSE_Sign1` (protected header only).
-fn unsigned_inner(ed_kid: Vec<u8>) -> CoseSign1 {
+fn unsigned_inner(ed_kid: Vec<u8>, pq_binding: Option<&[u8]>) -> CoseSign1 {
     CoseSign1Builder::new()
-        .protected(
-            HeaderBuilder::new()
-                .algorithm(iana::Algorithm::EdDSA)
-                .key_id(ed_kid)
-                .build(),
-        )
+        .protected(inner_protected(ed_kid, pq_binding))
         .build()
 }
 
@@ -352,7 +450,23 @@ fn unsigned_outer(pq_kid: Vec<u8>) -> CoseSign1 {
 /// Classical-only composite.
 pub fn inner_tbs(ed_kid: Vec<u8>, payload: &[u8], external_aad: &[u8], hybrid: bool) -> Vec<u8> {
     let aad = layer_aad(external_aad, hybrid);
-    unsigned_inner(ed_kid).tbs_detached_data(payload, &aad)
+    unsigned_inner(ed_kid, None).tbs_detached_data(payload, &aad)
+}
+
+/// [`inner_tbs`] for a composite whose inner layer commits to the ML-DSA-65 key
+/// above it (see [`PQ_BINDING_HEADER_LABEL`]).
+///
+/// `pq_kid` MUST be the same value passed to [`outer_tbs`] and to
+/// [`assemble_composite_nested_pq_bound`]; the resulting composite is rejected
+/// if the inner commitment and the outer `kid` disagree.
+pub fn inner_tbs_pq_bound(
+    ed_kid: Vec<u8>,
+    pq_kid: &[u8],
+    payload: &[u8],
+    external_aad: &[u8],
+) -> Vec<u8> {
+    let aad = build_hybrid_external_aad(external_aad);
+    unsigned_inner(ed_kid, Some(pq_kid)).tbs_detached_data(payload, &aad)
 }
 
 /// Compute the outer ML-DSA-65 layer's detached to-be-signed bytes over
@@ -382,8 +496,33 @@ pub fn assemble_composite_nested(
     ed: (Vec<u8>, Vec<u8>),
     pq: Option<(Vec<u8>, Vec<u8>)>,
 ) -> Result<Vec<u8>> {
+    assemble_nested(ed, pq, false)
+}
+
+/// [`assemble_composite_nested`] for a composite whose inner layer commits to
+/// the ML-DSA-65 key above it.
+///
+/// The inner signature MUST have been produced over [`inner_tbs_pq_bound`] with
+/// the same `pq_kid` that appears in `pq`, otherwise the assembled composite
+/// will not verify.
+pub fn assemble_composite_nested_pq_bound(
+    ed: (Vec<u8>, Vec<u8>),
+    pq: (Vec<u8>, Vec<u8>),
+) -> Result<Vec<u8>> {
+    assemble_nested(ed, Some(pq), true)
+}
+
+fn assemble_nested(
+    ed: (Vec<u8>, Vec<u8>),
+    pq: Option<(Vec<u8>, Vec<u8>)>,
+    bind_pq: bool,
+) -> Result<Vec<u8>> {
     let (ed_kid, ed_sig) = ed;
-    let mut inner = unsigned_inner(ed_kid);
+    let binding = match (bind_pq, pq.as_ref()) {
+        (true, Some((pq_kid, _))) => Some(pq_kid.clone()),
+        _ => None,
+    };
+    let mut inner = unsigned_inner(ed_kid, binding.as_deref());
     inner.signature = ed_sig;
     let inner_bytes = inner
         .to_vec()
@@ -450,6 +589,20 @@ pub fn encode_composite_for_test(inner: Vec<u8>, outer: Option<Vec<u8>>) -> Resu
     encode_composite(inner, outer)
 }
 
+/// Test-only: serialize a standalone outer ML-DSA-65 `COSE_Sign1`.
+///
+/// Exposed so tests in other crates can build the outer-layer-substitution
+/// attack — a captured inner layer kept verbatim under a freshly signed outer —
+/// which is the case the inner layer's PQ commitment exists to reject.
+#[doc(hidden)]
+pub fn outer_layer_for_test(pq_kid: Vec<u8>, pq_signature: Vec<u8>) -> Result<Vec<u8>> {
+    let mut outer = unsigned_outer(pq_kid);
+    outer.signature = pq_signature;
+    outer
+        .to_vec()
+        .map_err(|e| anyhow!("serialize outer ML-DSA COSE_Sign1: {e}"))
+}
+
 /// The ML-DSA-65 verifying key the composite's outer layer **claims** for
 /// itself, read out of that layer's `kid` protected header.
 ///
@@ -464,10 +617,21 @@ pub fn encode_composite_for_test(inner: Vec<u8>, outer: Option<Vec<u8>>) -> Resu
 /// source, and rejects a mismatch.
 ///
 /// The one legitimate use is as a *candidate* offered to a trust-on-first-use
-/// record: verify the whole composite against this candidate first, so that
-/// possession of both the EdDSA and the ML-DSA-65 private keys is proven, and
-/// only then record the pairing — at a provenance that grants no additional
-/// trust.
+/// record — and verifying the composite against it is **not** sufficient
+/// grounds to record the pairing.
+///
+/// An earlier revision of this documentation claimed that a verifying composite
+/// proves possession of both private keys. It does not, and the difference is
+/// the whole attack: the nesting binds inner→outer only, so anyone holding a
+/// *copy* of a valid inner layer can drop the outer, re-sign
+/// `payload ‖ inner_signature` with an ML-DSA key of their own, and produce a
+/// composite that verifies under the captured identity. What a plain verifying
+/// composite proves is possession of the ML-DSA-65 key plus possession of one
+/// replayable Ed25519 signature.
+///
+/// A recorded pairing therefore additionally requires
+/// [`CompositeVerified::pq_bound`] — the inner layer's signed commitment to the
+/// key above it (see [`PQ_BINDING_HEADER_LABEL`]).
 ///
 /// Returns `Ok(None)` when the composite has no outer layer (classical-only) or
 /// when its outer layer carries no `kid`.
@@ -498,6 +662,16 @@ pub struct CompositeVerified {
     pub eddsa: bool,
     /// Outer ML-DSA-65 layer was verified.
     pub ml_dsa: bool,
+    /// The inner EdDSA layer named the ML-DSA-65 key above it, and that name
+    /// matched the outer layer (see [`PQ_BINDING_HEADER_LABEL`]).
+    ///
+    /// Only when this is `true` does the composite prove possession of the
+    /// **Ed25519 private key alongside** the ML-DSA-65 one. Without it a valid
+    /// composite proves possession of the ML-DSA key plus possession of one
+    /// replayable Ed25519 signature, which is not the same claim. A verifier
+    /// that intends to *record* the composite's ML-DSA-65 key — rather than
+    /// resolve it from a trust store — MUST require this.
+    pub pq_bound: bool,
 }
 
 /// Verify a CBOR-encoded nested COSE composite against a detached `payload`.
@@ -559,12 +733,29 @@ pub fn verify_composite(
     if !inner_kid.is_empty() && inner_kid.as_slice() != expected_ed_vk.to_bytes() {
         bail!("inner EdDSA COSE_Sign1 kid does not match anchored EdDSA key");
     }
+    let declared_pq = inner_pq_binding(&inner)?;
     inner
         .verify_detached_signature(payload, &inner_aad, |sig, tbs| {
             ed_verify(expected_ed_vk, tbs, sig)
         })
         .context("inner EdDSA signature verification failed")?;
     let eddsa_ok = true;
+
+    // The inner layer named an outer key, so the outer layer is not optional and
+    // not substitutable. Checking this before any outer work means a swapped or
+    // stripped outer is rejected on the strength of the Ed25519 signature alone.
+    let mut pq_bound = false;
+    if let Some(declared) = &declared_pq {
+        let Some(ob) = outer_bytes.as_ref() else {
+            bail!("inner EdDSA COSE_Sign1 commits to an ML-DSA-65 key but the outer layer is absent");
+        };
+        let outer = CoseSign1::from_slice(ob)
+            .map_err(|e| anyhow!("malformed outer ML-DSA COSE_Sign1: {e}"))?;
+        if outer.protected.header.key_id.as_slice() != declared.as_slice() {
+            bail!("outer ML-DSA-65 COSE_Sign1 kid does not match the key the inner EdDSA layer committed to (outer-layer substitution rejected)");
+        }
+        pq_bound = true;
+    }
 
     // Capture the inner signature; it is bound into the outer layer's signed message.
     let inner_sig = inner_signature_bytes(&inner).to_vec();
@@ -583,6 +774,7 @@ pub fn verify_composite(
                 return Ok(CompositeVerified {
                     eddsa: eddsa_ok,
                     ml_dsa: false,
+                    pq_bound,
                 });
             };
             let outer = CoseSign1::from_slice(ob)
@@ -624,6 +816,7 @@ pub fn verify_composite(
     Ok(CompositeVerified {
         eddsa: eddsa_ok,
         ml_dsa: ml_dsa_ok,
+        pq_bound,
     })
 }
 
@@ -662,6 +855,220 @@ mod tests {
 
     fn aad() -> Vec<u8> {
         build_external_aad(SCHEMA_ID, INNER_TYPE_ID)
+    }
+
+    /// The attack the PQ-binding header exists to stop: keep a victim's inner
+    /// EdDSA layer byte-for-byte and re-sign the outer layer with a key of your
+    /// own. No Ed25519 private key is involved.
+    #[test]
+    fn an_unbound_composite_lets_an_outer_layer_be_swapped_without_the_ed25519_key() {
+        use ml_dsa::Keypair;
+        let ed = SigningKey::generate(&mut OsRng);
+        let (victim_pq, _) = ml_dsa_generate_keypair();
+        let attacker_pq = crate::pq::ml_dsa_sk_from_seed(&[0xEE; 32]);
+        let attacker_vk = attacker_pq.verifying_key().clone();
+        let payload = b"captured payload";
+
+        // The victim's genuine composite, WITHOUT the binding.
+        let cose = sign_composite(&ed, Some(&victim_pq), payload, &aad()).unwrap();
+        let (ed_sig, _) = split_composite(&cose).unwrap();
+
+        // The attacker holds no Ed25519 key — only the signature bytes.
+        let attacker_kid = ml_dsa_kid(&attacker_vk);
+        let tbs = outer_tbs(attacker_kid.clone(), payload, &ed_sig, &aad());
+        let forged = assemble_composite_nested(
+            (ed.verifying_key().to_bytes().to_vec(), ed_sig),
+            Some((attacker_kid, ml_dsa_sign(&attacker_pq, &tbs))),
+        )
+        .unwrap();
+
+        let res = verify_composite(
+            &forged,
+            &ed.verifying_key(),
+            Some(&attacker_vk),
+            payload,
+            &aad(),
+            true,
+        )
+        .unwrap();
+        // It verifies — which is exactly why an unbound composite must never
+        // establish a recorded binding.
+        assert!(res.eddsa && res.ml_dsa);
+        assert!(
+            !res.pq_bound,
+            "an unbound composite must never report the both-keys-proven property"
+        );
+    }
+
+    #[test]
+    fn a_bound_composite_refuses_the_same_outer_layer_swap() {
+        use ml_dsa::Keypair;
+        let ed = SigningKey::generate(&mut OsRng);
+        let (victim_pq, victim_vk) = ml_dsa_generate_keypair();
+        let attacker_pq = crate::pq::ml_dsa_sk_from_seed(&[0xEF; 32]);
+        let attacker_vk = attacker_pq.verifying_key().clone();
+        let payload = b"captured payload";
+
+        let cose = sign_composite_pq_bound(&ed, Some(&victim_pq), payload, &aad()).unwrap();
+        let honest = verify_composite(
+            &cose,
+            &ed.verifying_key(),
+            Some(&victim_vk),
+            payload,
+            &aad(),
+            true,
+        )
+        .unwrap();
+        assert!(honest.eddsa && honest.ml_dsa && honest.pq_bound);
+
+        let (ed_sig, _) = split_composite(&cose).unwrap();
+        let attacker_kid = ml_dsa_kid(&attacker_vk);
+        let tbs = outer_tbs(attacker_kid.clone(), payload, &ed_sig, &aad());
+        let attacker_sig = ml_dsa_sign(&attacker_pq, &tbs);
+
+        // Route 1: keep the victim's inner layer byte-for-byte — binding header
+        // and all — and swap only the outer. This is the strongest form of the
+        // attack: the inner signature is untouched and still valid.
+        let (victim_inner_bytes, _) = decode_composite_for_test(&cose).unwrap();
+        let mut attacker_outer = unsigned_outer(attacker_kid.clone());
+        attacker_outer.signature = attacker_sig.clone();
+        let swapped = encode_composite_for_test(
+            victim_inner_bytes,
+            Some(attacker_outer.to_vec().unwrap()),
+        )
+        .unwrap();
+        let err = verify_composite(
+            &swapped,
+            &ed.verifying_key(),
+            Some(&attacker_vk),
+            payload,
+            &aad(),
+            true,
+        )
+        .unwrap_err();
+        assert!(
+            format!("{err:#}").contains("committed to"),
+            "the inner layer's commitment must reject a swapped outer: {err:#}"
+        );
+
+        // Route 2: rebuild the inner layer naming the attacker's key instead.
+        // The commitment lives in the signed protected header, so rewriting it
+        // invalidates the victim's Ed25519 signature.
+        let renamed = assemble_composite_nested_pq_bound(
+            (ed.verifying_key().to_bytes().to_vec(), ed_sig.clone()),
+            (attacker_kid.clone(), attacker_sig.clone()),
+        )
+        .unwrap();
+        assert!(verify_composite(
+            &renamed,
+            &ed.verifying_key(),
+            Some(&attacker_vk),
+            payload,
+            &aad(),
+            true,
+        )
+        .is_err());
+
+        // Route 3: drop the commitment entirely, hoping to fall back to the
+        // unbound shape. Same reason: the protected header is signed.
+        let unbound = assemble_composite_nested(
+            (ed.verifying_key().to_bytes().to_vec(), ed_sig),
+            Some((attacker_kid, attacker_sig)),
+        )
+        .unwrap();
+        assert!(verify_composite(
+            &unbound,
+            &ed.verifying_key(),
+            Some(&attacker_vk),
+            payload,
+            &aad(),
+            true,
+        )
+        .is_err());
+    }
+
+    #[test]
+    fn a_bound_composite_cannot_have_its_outer_layer_stripped() {
+        let ed = SigningKey::generate(&mut OsRng);
+        let (pq_sk, _) = ml_dsa_generate_keypair();
+        let payload = b"strip me";
+        let cose = sign_composite_pq_bound(&ed, Some(&pq_sk), payload, &aad()).unwrap();
+        let (inner, _) = decode_composite_for_test(&cose).unwrap();
+        let stripped = encode_composite_for_test(inner, None).unwrap();
+
+        // Rejected even by a verifier that does not require PQ. Two independent
+        // mechanisms catch it — the hybrid inner AAD no longer reconstructs once
+        // the outer is gone, and the inner layer said an outer belongs here —
+        // so this asserts the rejection rather than which one fired first.
+        assert!(
+            verify_composite(&stripped, &ed.verifying_key(), None, payload, &aad(), false).is_err()
+        );
+    }
+
+    #[test]
+    fn the_binding_is_additive_for_verifiers_that_do_not_know_it() {
+        // An unbound composite keeps reporting exactly what it always did, so
+        // every persisted decomposed signature (at9p capsules, DID operations,
+        // the PLC directory) verifies unchanged.
+        let ed = SigningKey::generate(&mut OsRng);
+        let (pq_sk, pq_vk) = ml_dsa_generate_keypair();
+        let payload = b"legacy payload";
+        let unbound = sign_composite(&ed, Some(&pq_sk), payload, &aad()).unwrap();
+        let res = verify_composite(
+            &unbound,
+            &ed.verifying_key(),
+            Some(&pq_vk),
+            payload,
+            &aad(),
+            true,
+        )
+        .unwrap();
+        assert!(res.eddsa && res.ml_dsa && !res.pq_bound);
+
+        // And a split/reassemble round-trip — how those records persist — is
+        // still byte-identical.
+        let (ed_sig, pq_sig) = split_composite(&unbound).unwrap();
+        let rebuilt = assemble_composite_nested(
+            (ed.verifying_key().to_bytes().to_vec(), ed_sig),
+            Some((ml_dsa_kid(&pq_vk), pq_sig.unwrap())),
+        )
+        .unwrap();
+        assert_eq!(rebuilt, unbound);
+    }
+
+    #[test]
+    fn the_out_of_band_signing_path_produces_a_bound_composite() {
+        use ed25519_dalek::Signer as _;
+        use ml_dsa::Keypair;
+        let ed = SigningKey::generate(&mut OsRng);
+        let (pq_sk, pq_vk) = ml_dsa_generate_keypair();
+        let payload = b"browser payload";
+        let ed_kid = ed.verifying_key().to_bytes().to_vec();
+        let pq_kid = ml_dsa_kid(&pq_sk.verifying_key().clone());
+
+        let ed_sig = ed
+            .sign(&inner_tbs_pq_bound(
+                ed_kid.clone(),
+                &pq_kid,
+                payload,
+                &aad(),
+            ))
+            .to_bytes()
+            .to_vec();
+        let pq_sig = ml_dsa_sign(&pq_sk, &outer_tbs(pq_kid.clone(), payload, &ed_sig, &aad()));
+        let cose =
+            assemble_composite_nested_pq_bound((ed_kid, ed_sig), (pq_kid, pq_sig)).unwrap();
+
+        let res = verify_composite(
+            &cose,
+            &ed.verifying_key(),
+            Some(&pq_vk),
+            payload,
+            &aad(),
+            true,
+        )
+        .unwrap();
+        assert!(res.eddsa && res.ml_dsa && res.pq_bound);
     }
 
     #[test]
@@ -815,7 +1222,7 @@ mod tests {
         // did, the outer was bound to the original inner_sig.
         let (_inner, outer) = decode_composite(&cose).unwrap();
         let other_ed = SigningKey::generate(&mut OsRng);
-        let forged_inner = build_inner_eddsa(&other_ed, payload, &aad()).unwrap();
+        let forged_inner = build_inner_eddsa(&other_ed, payload, &aad(), None).unwrap();
         let forged_inner_bytes = forged_inner.to_vec().unwrap();
         let tampered = encode_composite(forged_inner_bytes, outer).unwrap();
 

--- a/crates/hyprstream-rpc/src/envelope.rs
+++ b/crates/hyprstream-rpc/src/envelope.rs
@@ -1518,7 +1518,13 @@ impl SignedEnvelope {
             None
         };
         let aad = envelope_external_aad();
-        crate::crypto::cose_sign::sign_composite(signing_key, pq, signing_data, &aad)
+        // PQ-bound: the inner EdDSA layer commits to the ML-DSA-65 key above it.
+        // Request envelopes are the one composite whose ML-DSA-65 key a verifier
+        // may RECORD (first contact) rather than resolve from a trust store, so
+        // the Ed25519 signature has to cover which PQ key is being claimed.
+        // Without that, a captured envelope's inner layer can be re-used under a
+        // different outer key by someone who never held the Ed25519 secret.
+        crate::crypto::cose_sign::sign_composite_pq_bound(signing_key, pq, signing_data, &aad)
     }
 
     /// Create, hybrid-encrypt (HyKEM `#mesh-kem` → COSE_Encrypt0), and dual-sign
@@ -1803,9 +1809,9 @@ impl SignedEnvelope {
             .is_ok();
             if sender_holds_identity {
                 if let Some(overlay) = crate::session_pq_overlay::global_session_pq_overlay() {
-                    // Refuses the write and publishes the event; it cannot
-                    // overwrite the established binding.
-                    let _ = overlay.observe_first_contact(self.cnf, presented);
+                    // Publish-only: this key has NOT been proven, so it must not
+                    // reach a code path that could record it.
+                    overlay.surface_rebind(self.cnf, presented);
                 }
             }
             return Err(EnvelopeError::PqSignatureInvalid(
@@ -1815,7 +1821,7 @@ impl SignedEnvelope {
             ));
         }
 
-        crate::crypto::cose_sign::verify_composite(
+        let verified = crate::crypto::cose_sign::verify_composite(
             &self.cose,
             ed_vk,
             anchor.as_ref().map(PqAnchor::key),
@@ -1825,13 +1831,30 @@ impl SignedEnvelope {
         )
         .map_err(|e| EnvelopeError::PqSignatureInvalid(e.to_string()))?;
 
-        // Commit a first-contact observation only now: the composite verified
-        // against the presented key, so the client demonstrably held BOTH the
-        // Ed25519 and the ML-DSA-65 private keys. Recording before this point
-        // would let anyone who can shape an envelope squat an identity's
-        // binding with a key they do not control.
+        // Commit a first-contact observation only now, and only if the composite
+        // proved possession of the Ed25519 private key *alongside* the ML-DSA-65
+        // one.
+        //
+        // `verified.pq_bound` is exactly that proof. The nesting alone is not:
+        // it binds inner→outer, so an unbound composite can be rebuilt by anyone
+        // holding a COPY of the inner layer — they discard the outer, re-sign
+        // `payload ‖ inner_signature` with an ML-DSA key of their own, and the
+        // result verifies with their PQ key under the captured identity. Only
+        // the inner layer's commitment to the outer key rules that out, because
+        // that commitment sits inside the Ed25519 signature.
+        //
+        // An unbound composite still verifies (it may be a peer resolved from
+        // the anchored store, or an older client); it simply cannot establish a
+        // binding.
         #[cfg(not(target_arch = "wasm32"))]
         if let Some(PqAnchor::FirstContact(key)) = &anchor {
+            if !verified.pq_bound {
+                return Err(EnvelopeError::PqSignatureInvalid(
+                    "first contact requires the inner EdDSA layer to commit to its ML-DSA-65 \
+                     key; an uncommitted composite cannot establish a binding"
+                        .to_owned(),
+                ));
+            }
             if let Some(overlay) = crate::session_pq_overlay::global_session_pq_overlay() {
                 let outcome = overlay.observe_first_contact(self.cnf, key);
                 if !matches!(
@@ -1839,9 +1862,9 @@ impl SignedEnvelope {
                     crate::session_pq_overlay::FirstContactOutcome::Recorded
                         | crate::session_pq_overlay::FirstContactOutcome::AlreadyBound(_)
                 ) {
-                    // A racing contact took the slot, or the overlay is full.
-                    // Fail closed rather than serve a request whose signer this
-                    // node did not end up remembering.
+                    // A racing contact took the slot. Fail closed rather than
+                    // serve a request whose signer this node did not end up
+                    // remembering.
                     return Err(EnvelopeError::PqSignatureInvalid(
                         "first-contact ML-DSA-65 binding was not recorded".to_owned(),
                     ));

--- a/crates/hyprstream-rpc/src/envelope.rs
+++ b/crates/hyprstream-rpc/src/envelope.rs
@@ -985,6 +985,44 @@ pub trait PqTrustStore: Send + Sync {
     ) -> Option<crate::crypto::pq::MlDsaVerifyingKey>;
 }
 
+/// The ML-DSA-65 key an envelope's signature is checked against, plus how it
+/// was obtained.
+///
+/// The distinction exists so the commit step can tell "already trusted for this
+/// identity" from "asserted by this very envelope and not yet recorded". The
+/// second kind must not be written down until the composite has verified
+/// against it.
+enum PqAnchor {
+    /// Resolved from the admin-anchored store or from an already-established
+    /// overlay binding.
+    Anchored(crate::crypto::pq::MlDsaVerifyingKey),
+    /// Asserted by this envelope for an identity with no binding on file.
+    #[cfg(not(target_arch = "wasm32"))]
+    FirstContact(crate::crypto::pq::MlDsaVerifyingKey),
+    /// This identity has a binding on file and the envelope asserts a
+    /// different key. The request is rejected either way; the key is carried
+    /// so the event can be raised once the EdDSA layer proves who sent it.
+    #[cfg(not(target_arch = "wasm32"))]
+    Rebind {
+        established: crate::crypto::pq::MlDsaVerifyingKey,
+        presented: crate::crypto::pq::MlDsaVerifyingKey,
+    },
+}
+
+impl PqAnchor {
+    fn key(&self) -> &crate::crypto::pq::MlDsaVerifyingKey {
+        match self {
+            PqAnchor::Anchored(k) => k,
+            #[cfg(not(target_arch = "wasm32"))]
+            PqAnchor::FirstContact(k) => k,
+            // The established key, so the composite check fails on the kid
+            // mismatch rather than on a key the envelope chose.
+            #[cfg(not(target_arch = "wasm32"))]
+            PqAnchor::Rebind { established, .. } => established,
+        }
+    }
+}
+
 /// In-memory kid-anchored ML-DSA-65 trust store mapping an Ed25519 signer
 /// identity to its trusted ML-DSA-65 verifying key.
 ///
@@ -1741,32 +1779,133 @@ impl SignedEnvelope {
         let signing_data = self.signed_bytes();
         let aad = envelope_external_aad();
 
-        let anchored_pq = if verify_policy.uses_pq() {
-            Some(
-                pq_store
-                    .and_then(|store| store.ml_dsa_key_for(&self.cnf))
-                    .ok_or_else(|| {
-                        EnvelopeError::PqSignatureInvalid(
-                            "mandatory Hybrid suite requires an anchored ML-DSA-65 signer key"
-                                .to_owned(),
-                        )
-                    })?,
-            )
+        let anchor = if verify_policy.uses_pq() {
+            Some(self.resolve_pq_anchor(pq_store)?)
         } else {
             None
         };
 
+        // A rebinding attempt is rejected without ever consulting the key the
+        // envelope chose. It is raised as an event only if the EdDSA layer
+        // verifies — otherwise anyone who merely knows an identity's public
+        // key could inject alarms about it, and a security-event channel that
+        // unauthenticated senders can drive is worse than none.
+        #[cfg(not(target_arch = "wasm32"))]
+        if let Some(PqAnchor::Rebind { presented, .. }) = &anchor {
+            let sender_holds_identity = crate::crypto::cose_sign::verify_composite(
+                &self.cose,
+                ed_vk,
+                None,
+                &signing_data,
+                &aad,
+                false,
+            )
+            .is_ok();
+            if sender_holds_identity {
+                if let Some(overlay) = crate::session_pq_overlay::global_session_pq_overlay() {
+                    // Refuses the write and publishes the event; it cannot
+                    // overwrite the established binding.
+                    let _ = overlay.observe_first_contact(self.cnf, presented);
+                }
+            }
+            return Err(EnvelopeError::PqSignatureInvalid(
+                "presented ML-DSA-65 key differs from this identity's established binding; \
+                 rebinding requires explicit approval"
+                    .to_owned(),
+            ));
+        }
+
         crate::crypto::cose_sign::verify_composite(
             &self.cose,
             ed_vk,
-            anchored_pq.as_ref(),
+            anchor.as_ref().map(PqAnchor::key),
             &signing_data,
             &aad,
             verify_policy.uses_pq(),
         )
         .map_err(|e| EnvelopeError::PqSignatureInvalid(e.to_string()))?;
 
+        // Commit a first-contact observation only now: the composite verified
+        // against the presented key, so the client demonstrably held BOTH the
+        // Ed25519 and the ML-DSA-65 private keys. Recording before this point
+        // would let anyone who can shape an envelope squat an identity's
+        // binding with a key they do not control.
+        #[cfg(not(target_arch = "wasm32"))]
+        if let Some(PqAnchor::FirstContact(key)) = &anchor {
+            if let Some(overlay) = crate::session_pq_overlay::global_session_pq_overlay() {
+                let outcome = overlay.observe_first_contact(self.cnf, key);
+                if !matches!(
+                    outcome,
+                    crate::session_pq_overlay::FirstContactOutcome::Recorded
+                        | crate::session_pq_overlay::FirstContactOutcome::AlreadyBound(_)
+                ) {
+                    // A racing contact took the slot, or the overlay is full.
+                    // Fail closed rather than serve a request whose signer this
+                    // node did not end up remembering.
+                    return Err(EnvelopeError::PqSignatureInvalid(
+                        "first-contact ML-DSA-65 binding was not recorded".to_owned(),
+                    ));
+                }
+            }
+        }
+
         Ok(())
+    }
+
+    /// Resolve the ML-DSA-65 key this envelope's signature is checked against.
+    ///
+    /// Order, and why:
+    ///
+    /// 1. The admin-anchored [`PqTrustStore`]. Operator-enrolled bindings are
+    ///    the strongest anchor and are never displaced by anything below.
+    /// 2. An established overlay binding. If the envelope presents a different
+    ///    key than the one on file, this reports a rebinding attempt and the
+    ///    caller rejects the request; the binding on file is left untouched — a
+    ///    rotation is applied only through the overlay's explicit approval
+    ///    path.
+    /// 3. First contact. The key the composite asserts for itself becomes a
+    ///    *candidate* only; it is trusted for nothing until the whole composite
+    ///    verifies against it, and even then it is recorded at a provenance
+    ///    that cannot raise MAC assurance.
+    ///
+    /// With no overlay installed, only step 1 exists and the behavior is
+    /// unchanged: an unanchored identity fails closed.
+    fn resolve_pq_anchor(&self, pq_store: Option<&dyn PqTrustStore>) -> EnvelopeResult<PqAnchor> {
+        if let Some(key) = pq_store.and_then(|store| store.ml_dsa_key_for(&self.cnf)) {
+            return Ok(PqAnchor::Anchored(key));
+        }
+
+        #[cfg(not(target_arch = "wasm32"))]
+        if let Some(overlay) = crate::session_pq_overlay::global_session_pq_overlay() {
+            let presented = crate::crypto::cose_sign::self_asserted_outer_pq_key(&self.cose)
+                .map_err(|e| EnvelopeError::PqSignatureInvalid(e.to_string()))?;
+
+            if let Some(established) = overlay.verifying_key_for(&self.cnf) {
+                let Some(presented) = presented else {
+                    // No outer layer to compare. The binding stands: a
+                    // PQ-less envelope from a bound identity is rejected by
+                    // the composite check below, and clears nothing.
+                    return Ok(PqAnchor::Anchored(established));
+                };
+                if crate::crypto::pq::ml_dsa_vk_bytes(&presented)
+                    != crate::crypto::pq::ml_dsa_vk_bytes(&established)
+                {
+                    return Ok(PqAnchor::Rebind {
+                        established,
+                        presented,
+                    });
+                }
+                return Ok(PqAnchor::Anchored(established));
+            }
+
+            if let Some(candidate) = presented {
+                return Ok(PqAnchor::FirstContact(candidate));
+            }
+        }
+
+        Err(EnvelopeError::PqSignatureInvalid(
+            "mandatory Hybrid suite requires an anchored ML-DSA-65 signer key".to_owned(),
+        ))
     }
 
     /// Compute the bytes that were signed.

--- a/crates/hyprstream-rpc/src/lib.rs
+++ b/crates/hyprstream-rpc/src/lib.rs
@@ -208,6 +208,12 @@ pub mod did_plc;
 pub mod did_url;
 #[cfg(not(target_arch = "wasm32"))]
 pub mod admission;
+// Additive, session-scoped PQ binding overlay: trust-on-first-use continuity
+// for dynamically-identified clients, with out-of-band promotion. Consulted by
+// the envelope verify path after the admin-anchored store misses; never mutates
+// that store.
+#[cfg(not(target_arch = "wasm32"))]
+pub mod session_pq_overlay;
 // The real, method-dispatched `IdentityResolver` (#579). Native-only: the
 // did:web arm depends on `did_web`'s DID-document helpers.
 #[cfg(not(target_arch = "wasm32"))]

--- a/crates/hyprstream-rpc/src/rpc_client.rs
+++ b/crates/hyprstream-rpc/src/rpc_client.rs
@@ -921,10 +921,18 @@ impl<S: Signer, T: Transport + 'static> RpcClientImpl<S, T> {
         //
         // The inner EdDSA layer always binds the pinned hybrid-composite alg-id
         // into its AAD (#278). There is no classical request construction path.
-        let hybrid = true;
+        //
+        // The inner layer also commits to the ML-DSA-65 key above it, so a
+        // captured inner layer cannot be re-used under a different outer key.
+        // This is what lets a server record this client's PQ key at first
+        // contact on the strength of the Ed25519 signature.
         let ed_kid = ed_pubkey.to_vec();
-        let ed_tbs =
-            crate::crypto::cose_sign::inner_tbs(ed_kid.clone(), signing_data, &aad, hybrid);
+        let ed_tbs = crate::crypto::cose_sign::inner_tbs_pq_bound(
+            ed_kid.clone(),
+            &pq_kid,
+            signing_data,
+            &aad,
+        );
         let ed_sig = self.signer.sign(&ed_tbs).await?.to_vec();
 
         let pq_tbs =
@@ -935,9 +943,9 @@ impl<S: Signer, T: Transport + 'static> RpcClientImpl<S, T> {
                  refusing to emit an incomplete mandatory Hybrid composite"
             )
         })?;
-        let cose = crate::crypto::cose_sign::assemble_composite_nested(
+        let cose = crate::crypto::cose_sign::assemble_composite_nested_pq_bound(
             (ed_kid, ed_sig),
-            Some((pq_kid, pq_sig)),
+            (pq_kid, pq_sig),
         )?;
 
         let signed = SignedEnvelope {

--- a/crates/hyprstream-rpc/src/service/svc.rs
+++ b/crates/hyprstream-rpc/src/service/svc.rs
@@ -499,8 +499,14 @@ impl EnvelopeContext {
     ///   the kid-anchored binding the rest of the TCB uses — the PQ key is
     ///   resolved from the trust store keyed by the EdDSA identity, never
     ///   self-asserted.
+    ///   A session-overlay binding also reaches `PqHybrid`, but **only** when it
+    ///   has been confirmed out of band; a first-contact binding is capped at
+    ///   `Classical` by
+    ///   [`crate::session_pq_overlay::PqProvenance::key_material`].
     /// - **`Classical`** — the `cnf` Ed25519 signer key is verified but NO bound
-    ///   ML-DSA-65 anchor is present (the federation edge, or a pre-PQ identity).
+    ///   ML-DSA-65 anchor is present (the federation edge, or a pre-PQ
+    ///   identity), or the only binding is a first-contact one, which makes the
+    ///   signature checkable without making the signer more trusted.
     /// - **`Unverified`** — the `cnf` key is zeroed (a callback-service context
     ///   with no real envelope; assurance floors to the S1 `Unverified` floor
     ///   so it dominates nothing above it).
@@ -530,6 +536,16 @@ impl EnvelopeContext {
             if let Some(store) = crate::envelope::global_pq_store() {
                 if store.ml_dsa_key_for(&self.cnf).is_some() {
                     return crate::auth::mac::VerifiedKeyMaterial::PqHybrid;
+                }
+            }
+            // A session overlay binding makes the signature checkable; whether
+            // it makes the signer more believed is a separate question, and
+            // `PqProvenance::key_material` is the only place it is answered. A
+            // first-contact binding maps to Classical there — the overlay lets
+            // the request in, it does not promote the requester.
+            if let Some(overlay) = crate::session_pq_overlay::global_session_pq_overlay() {
+                if let Some(provenance) = overlay.provenance_for(&self.cnf) {
+                    return provenance.key_material();
                 }
             }
         }

--- a/crates/hyprstream-rpc/src/session_pq_overlay.rs
+++ b/crates/hyprstream-rpc/src/session_pq_overlay.rs
@@ -30,6 +30,23 @@
 //!   this, and [`PqProvenance::key_material`] refuses to map `TofuBound` to
 //!   anything above `Classical`.
 //!
+//! # What a composite has to prove before anything is recorded
+//!
+//! The nested composite binds inner→outer — the outer ML-DSA-65 layer signs
+//! `payload ‖ inner_signature` — and **not** outer→inner. So a composite that
+//! verifies proves possession of the ML-DSA-65 key plus possession of one
+//! Ed25519 *signature*, which is not the same as possession of the Ed25519
+//! *private key*: anyone holding a copy of a valid inner layer can drop the
+//! outer, re-sign with an ML-DSA key of their own, and produce a composite that
+//! verifies under the captured identity.
+//!
+//! That is survivable while the PQ key is always resolved from a trust store,
+//! and fatal the moment it is recorded. So a binding is established only from a
+//! composite whose inner EdDSA layer *commits* to the key above it
+//! ([`crate::crypto::cose_sign::PQ_BINDING_HEADER_LABEL`]) — a commitment that
+//! lives inside the Ed25519 signature. An uncommitted composite still verifies;
+//! it just cannot establish a binding.
+//!
 //! # Rebinding is loud by construction
 //!
 //! TOFU's security value is change detection, not initial trust. A silent
@@ -79,9 +96,15 @@ const FINGERPRINT_DOMAIN: &[u8] = b"hyprstream/pq-composite-fingerprint/v1";
 /// remembered.
 pub const DEFAULT_TOFU_TTL_MS: i64 = 12 * 60 * 60 * 1000;
 
-/// Default ceiling on retained bindings. Recording costs an attacker a full
-/// verified hybrid signature per entry, which is cheap enough that an unbounded
-/// map is a memory-exhaustion surface.
+/// Default ceiling on retained bindings.
+///
+/// Recording costs an attacker only a self-minted Ed25519 + ML-DSA-65 keypair —
+/// no enrollment, no credential, no prior relationship — and the verify path
+/// runs before authorization, so an unbounded map is a memory-exhaustion
+/// surface. At the ceiling the least-recently-seen first-contact entry is
+/// evicted rather than the new one refused; see
+/// [`SessionPqOverlay::observe_first_contact`] for why refusing is the worse
+/// failure. Promoted bindings are never evicted.
 pub const DEFAULT_MAX_ENTRIES: usize = 4096;
 
 /// How a PQ verifying key came to be associated with an Ed25519 identity.
@@ -142,6 +165,9 @@ struct OverlayEntry {
     /// promoted binding, which outlives the session that created it and is
     /// withdrawn by revocation rather than by lapse.
     expires_at_ms: Option<i64>,
+    /// Monotonically increasing stamp of the last contact that touched this
+    /// entry. Orders eviction when the table is full.
+    last_seen_seq: u64,
 }
 
 impl OverlayEntry {
@@ -288,6 +314,10 @@ pub trait PqBindingEventSink: Send + Sync {
 
     /// A promotion or a whole binding was withdrawn.
     fn on_revoked(&self, _identity: &[u8; 32], _from: PqProvenance, _to: Option<PqProvenance>) {}
+
+    /// A first-contact binding was evicted to make room. The identity loses
+    /// change detection until it is seen again.
+    fn on_evicted(&self, _identity: &[u8; 32]) {}
 }
 
 /// Sink that records events to `tracing` at warning level.
@@ -341,6 +371,14 @@ impl PqBindingEventSink for TracingPqBindingEventSink {
             "PQ binding withdrawn"
         );
     }
+
+    fn on_evicted(&self, identity: &[u8; 32]) {
+        tracing::warn!(
+            identity = %hex::encode(identity),
+            "PQ binding evicted under capacity pressure; change detection for this identity \
+             is reset until it is seen again"
+        );
+    }
 }
 
 /// The fingerprint compared over the out-of-band channel.
@@ -382,6 +420,9 @@ pub struct SessionPqOverlay {
     sink: Arc<dyn PqBindingEventSink>,
     tofu_ttl_ms: i64,
     max_entries: usize,
+    /// Recency counter for eviction ordering. Wall-clock is unsuitable: many
+    /// first contacts can land inside one millisecond.
+    contact_seq: std::sync::atomic::AtomicU64,
 }
 
 impl Default for SessionPqOverlay {
@@ -399,6 +440,7 @@ impl SessionPqOverlay {
             sink,
             tofu_ttl_ms: DEFAULT_TOFU_TTL_MS,
             max_entries: DEFAULT_MAX_ENTRIES,
+            contact_seq: std::sync::atomic::AtomicU64::new(0),
         }
     }
 
@@ -458,9 +500,14 @@ impl SessionPqOverlay {
 
     /// Offer a PQ key observed at first contact.
     ///
-    /// **Call only after the whole composite has verified against
-    /// `presented_vk`**, so that possession of both private keys is proven
-    /// before anything is written.
+    /// **Call only after the composite has verified against `presented_vk` AND
+    /// reported the inner layer's commitment to it** (`CompositeVerified::
+    /// pq_bound`). Verification alone is not enough: the nesting binds
+    /// inner→outer only, so a composite without that commitment proves
+    /// possession of the ML-DSA-65 key plus possession of one replayable
+    /// Ed25519 signature — not of the Ed25519 private key. Recording on those
+    /// weaker grounds lets anyone holding a captured envelope bind their own PQ
+    /// key to the sender's identity.
     ///
     /// This never overwrites a **live** entry. A live entry naming a different
     /// key produces [`FirstContactOutcome::RebindRefused`], and the event
@@ -484,12 +531,18 @@ impl SessionPqOverlay {
     ) -> FirstContactOutcome {
         let now = crate::envelope::current_timestamp();
         let presented_bytes = ml_dsa_vk_bytes(presented_vk);
+        let seq = self
+            .contact_seq
+            .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+        let mut evicted: Option<[u8; 32]> = None;
+        let mut return_capacity_exhausted = false;
 
         let outcome = {
             let mut entries = self.entries.write();
-            match entries.get(&ed25519_pubkey) {
+            match entries.get_mut(&ed25519_pubkey) {
                 Some(entry) if entry.is_live(now) => {
                     if entry.ml_dsa_vk == presented_bytes {
+                        entry.last_seen_seq = seq;
                         FirstContactOutcome::AlreadyBound(entry.provenance)
                     } else {
                         // Refuse. The established binding stays exactly as it
@@ -504,14 +557,44 @@ impl SessionPqOverlay {
                     }
                 }
                 _ => {
-                    // Vacant or lapsed. Reclaim lapsed entries before consulting
-                    // the ceiling so a quiet period is not permanently fatal.
+                    // Vacant or lapsed. Reclaim lapsed entries first — a quiet
+                    // period must not be permanently fatal.
                     if entries.len() >= self.max_entries {
                         entries.retain(|_, e| e.is_live(now));
                     }
-                    if entries.len() >= self.max_entries
-                        && !entries.contains_key(&ed25519_pubkey)
-                    {
+                    // Still full: evict the least-recently-seen *first-contact*
+                    // entry rather than refusing the new one.
+                    //
+                    // Refusing was the obvious fail-closed choice and it is the
+                    // wrong one here. Recording costs an attacker only a
+                    // self-minted keypair — no enrollment, no credential — and
+                    // this runs before authorization, so filling the table is
+                    // seconds of work. Under refusal that locks out every NEW
+                    // dynamic client until entries lapse, i.e. an unauthenticated
+                    // party gets to switch the feature off. Under eviction the
+                    // worst an attacker achieves is resetting other identities'
+                    // change detection, which is the same exposure a lapse
+                    // already carries, and legitimate clients keep connecting.
+                    //
+                    // Promoted bindings are never evicted: they are an operator
+                    // statement, not session continuity.
+                    if entries.len() >= self.max_entries && !entries.contains_key(&ed25519_pubkey) {
+                        let victim = entries
+                            .iter()
+                            .filter(|(_, e)| e.provenance == PqProvenance::TofuBound)
+                            .min_by_key(|(_, e)| e.last_seen_seq)
+                            .map(|(id, _)| *id);
+                        match victim {
+                            Some(id) => {
+                                entries.remove(&id);
+                                evicted = Some(id);
+                            }
+                            // Every slot holds a promotion. Refuse rather than
+                            // discard operator-established trust.
+                            None => return_capacity_exhausted = true,
+                        }
+                    }
+                    if return_capacity_exhausted {
                         FirstContactOutcome::CapacityExhausted
                     } else {
                         entries.insert(
@@ -520,6 +603,7 @@ impl SessionPqOverlay {
                                 ml_dsa_vk: presented_bytes,
                                 provenance: PqProvenance::TofuBound,
                                 expires_at_ms: Some(now.saturating_add(self.tofu_ttl_ms)),
+                                last_seen_seq: seq,
                             },
                         );
                         FirstContactOutcome::Recorded
@@ -537,13 +621,53 @@ impl SessionPqOverlay {
             FirstContactOutcome::CapacityExhausted => {
                 tracing::warn!(
                     identity = %hex::encode(ed25519_pubkey),
-                    "PQ overlay at capacity; first-contact binding refused (request fails closed)"
+                    "PQ overlay at capacity with every slot promoted; first-contact binding \
+                     refused (request fails closed)"
                 );
             }
             FirstContactOutcome::AlreadyBound(_) => {}
         }
+        if let Some(id) = evicted {
+            // An evicted identity loses change detection: its next contact is a
+            // fresh first contact. Say so, rather than letting the table quietly
+            // forget.
+            tracing::warn!(
+                evicted_identity = %hex::encode(id),
+                admitted_identity = %hex::encode(ed25519_pubkey),
+                "PQ overlay at capacity; evicted the least-recently-seen first-contact binding"
+            );
+            self.sink.on_evicted(&id);
+        }
 
         outcome
+    }
+
+    /// Publish a rebinding event **without any possibility of recording**.
+    ///
+    /// The verify path reaches a rebinding attempt before the presented key has
+    /// been checked against anything — the whole point is that the request is
+    /// being rejected. [`Self::observe_first_contact`] must not be reused there:
+    /// its contract is "the composite already verified against this key", and a
+    /// binding that lapses between the lookup and the call would send it down
+    /// the recording branch with an unproven key. This entry point cannot
+    /// record under any interleaving.
+    pub fn surface_rebind(&self, ed25519_pubkey: [u8; 32], presented_vk: &MlDsaVerifyingKey) {
+        let now = crate::envelope::current_timestamp();
+        let event = {
+            let entries = self.entries.read();
+            entries
+                .get(&ed25519_pubkey)
+                .filter(|e| e.is_live(now))
+                .map(|entry| RebindEvent {
+                    identity: ed25519_pubkey,
+                    established_vk: entry.ml_dsa_vk.clone(),
+                    established_provenance: entry.provenance,
+                    presented_vk: ml_dsa_vk_bytes(presented_vk),
+                })
+        };
+        if let Some(event) = event {
+            self.sink.on_rebind_refused(&event);
+        }
     }
 
     /// Replace an established binding, under an approval that answers a
@@ -570,6 +694,9 @@ impl SessionPqOverlay {
                             ml_dsa_vk: approval.event.presented_vk.clone(),
                             provenance: approval.provenance,
                             expires_at_ms,
+                            last_seen_seq: self
+                                .contact_seq
+                                .fetch_add(1, std::sync::atomic::Ordering::Relaxed),
                         },
                     );
                     true
@@ -994,14 +1121,72 @@ mod tests {
     }
 
     #[test]
-    fn capacity_is_bounded() {
+    fn a_full_table_evicts_the_stalest_entry_rather_than_locking_new_clients_out() {
+        let (overlay, _sink) = overlay_with_sink();
+        let overlay = overlay.with_max_entries(2);
+        let stale = ed_identity(13);
+        let recent = ed_identity(14);
+        let arriving = ed_identity(15);
+
+        let _ = overlay.observe_first_contact(stale, &pq_key(26));
+        let _ = overlay.observe_first_contact(recent, &pq_key(27));
+        // Touch `recent` so `stale` is unambiguously the least-recently-seen.
+        let _ = overlay.observe_first_contact(recent, &pq_key(27));
+
+        assert!(matches!(
+            overlay.observe_first_contact(arriving, &pq_key(28)),
+            FirstContactOutcome::Recorded
+        ));
+        assert!(
+            overlay.verifying_key_for(&arriving).is_some(),
+            "a new client must not be locked out by a full table"
+        );
+        assert!(overlay.verifying_key_for(&stale).is_none());
+        assert!(overlay.verifying_key_for(&recent).is_some());
+    }
+
+    #[test]
+    fn a_promoted_binding_is_never_evicted() {
         let (overlay, _sink) = overlay_with_sink();
         let overlay = overlay.with_max_entries(1);
-        let _ = overlay.observe_first_contact(ed_identity(13), &pq_key(26));
+        let promoted = ed_identity(16);
+        let key = pq_key(29);
+        let _ = overlay.observe_first_contact(promoted, &key);
+        overlay
+            .promote_out_of_band(&promoted, &composite_fingerprint(&promoted, &key), "printed")
+            .unwrap();
+
+        // Every slot holds operator-established trust, so the arriving identity
+        // is refused rather than that trust discarded.
         assert!(matches!(
-            overlay.observe_first_contact(ed_identity(14), &pq_key(27)),
+            overlay.observe_first_contact(ed_identity(17), &pq_key(30)),
             FirstContactOutcome::CapacityExhausted
         ));
+        assert_eq!(
+            overlay.provenance_for(&promoted),
+            Some(PqProvenance::OobVerified)
+        );
+    }
+
+    #[test]
+    fn surfacing_a_rebind_can_never_record() {
+        let (overlay, sink) = overlay_with_sink();
+        let id = ed_identity(18);
+        let original = pq_key(31);
+        let other = pq_key(32);
+
+        // No binding at all: surfacing must not create one.
+        overlay.surface_rebind(id, &other);
+        assert!(overlay.verifying_key_for(&id).is_none());
+        assert_eq!(CountingSink::count(&sink.refused), 0);
+
+        let _ = overlay.observe_first_contact(id, &original);
+        overlay.surface_rebind(id, &other);
+        assert_eq!(CountingSink::count(&sink.refused), 1);
+        assert_eq!(
+            ml_dsa_vk_bytes(&overlay.verifying_key_for(&id).unwrap()),
+            ml_dsa_vk_bytes(&original)
+        );
     }
 
     #[test]

--- a/crates/hyprstream-rpc/src/session_pq_overlay.rs
+++ b/crates/hyprstream-rpc/src/session_pq_overlay.rs
@@ -1,0 +1,1026 @@
+//! Session-scoped PQ binding overlay: trust-on-first-use continuity for
+//! browser and other dynamically-identified clients, with out-of-band
+//! promotion.
+//!
+//! # Why this exists
+//!
+//! [`crate::envelope::KeyedPqTrustStore`] is admin-anchored and immutable after
+//! install: an operator enrolls each peer's ML-DSA-65 key out of band. A
+//! browser's Ed25519 identity is user/device-generated, so no operator can
+//! pre-enroll it, and under the mandatory Hybrid suite an unanchored identity
+//! cannot have its signature checked at all — the request is dropped.
+//!
+//! This overlay is the additive answer. It is consulted by the envelope verify
+//! path *after* the admin-anchored store misses, and it **never mutates that
+//! store**: its entries are established out of band by contract, and the
+//! federation perimeter deliberately leaves it untouched. Consult-then-fall-
+//! back, never write-through.
+//!
+//! # The load-bearing property
+//!
+//! A [`PqProvenance::TofuBound`] entry makes a signature **verifiable** without
+//! making the signer **more trusted**. Those are two different questions and
+//! this module answers them through two different methods that share no return
+//! type:
+//!
+//! - [`SessionPqOverlay::verifying_key_for`] — verifiability. Returns a key and
+//!   nothing else, so the verify path structurally cannot learn provenance from
+//!   it and therefore cannot launder it into an assurance decision.
+//! - [`SessionPqOverlay::provenance_for`] — trust. The MAC assurance seam reads
+//!   this, and [`PqProvenance::key_material`] refuses to map `TofuBound` to
+//!   anything above `Classical`.
+//!
+//! # Rebinding is loud by construction
+//!
+//! TOFU's security value is change detection, not initial trust. A silent
+//! last-write-wins rebind voids every guarantee here, so the API offers no way
+//! to perform one:
+//!
+//! - [`SessionPqOverlay::observe_first_contact`] inserts into a **vacant** slot
+//!   only. An occupied slot naming a different key yields
+//!   [`FirstContactOutcome::RebindRefused`], and the [`RebindEvent`] is
+//!   published to the event sink *before* that value is returned, so a caller
+//!   that discards the return value has still surfaced the event.
+//! - The only way to change an established binding is
+//!   [`SessionPqOverlay::apply_rebind`], which takes a [`RebindApproval`]. A
+//!   `RebindApproval` can only be built by consuming a `RebindEvent`, which
+//!   only the overlay can mint, and only by refusing a rebind. Legitimate key
+//!   rotation therefore travels the same visible path as an attack.
+//!
+//! # Promotion and revocation
+//!
+//! Promotion to [`PqProvenance::OobVerified`] requires presenting the
+//! [`composite_fingerprint`] — a hash over `ed25519 ‖ ml_dsa_65`, covering the
+//! *pair*, because fingerprinting the PQ half alone confirms possession of a
+//! key without binding it to the identity it claims to belong to. The value
+//! must have been obtained through a channel with different compromise
+//! assumptions from the one being bootstrapped; this module verifies the value
+//! matches, and cannot verify where the operator got it.
+//!
+//! `TofuBound` entries expire with the session. An `OobVerified` promotion
+//! outlives one, so it has an explicit revocation path
+//! ([`SessionPqOverlay::revoke_promotion`],
+//! [`SessionPqOverlay::revoke_binding`]) — an irreversible promotion would be
+//! worse than no promotion.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use parking_lot::RwLock;
+
+use crate::auth::mac::{Assurance, VerifiedKeyMaterial};
+use crate::crypto::pq::{ml_dsa_vk_bytes, MlDsaVerifyingKey};
+
+/// Domain separation tag for the composite fingerprint.
+const FINGERPRINT_DOMAIN: &[u8] = b"hyprstream/pq-composite-fingerprint/v1";
+
+/// Default lifetime of a first-contact binding. It is session continuity, not
+/// enrollment: it lapses so that a device that stops appearing stops being
+/// remembered.
+pub const DEFAULT_TOFU_TTL_MS: i64 = 12 * 60 * 60 * 1000;
+
+/// Default ceiling on retained bindings. Recording costs an attacker a full
+/// verified hybrid signature per entry, which is cheap enough that an unbounded
+/// map is a memory-exhaustion surface.
+pub const DEFAULT_MAX_ENTRIES: usize = 4096;
+
+/// How a PQ verifying key came to be associated with an Ed25519 identity.
+///
+/// The absence of an entry is the third state of the model — `Classical`, no PQ
+/// key bound — and is deliberately not a variant here: it is not something the
+/// overlay records.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum PqProvenance {
+    /// Recorded at first contact, over a channel authenticated only
+    /// classically. Proves the client held both private keys at that moment
+    /// and nothing more. Sufficient to check a signature; insufficient to
+    /// believe the signer any harder than a classical one.
+    TofuBound,
+    /// Confirmed through a channel with different compromise assumptions than
+    /// the one being bootstrapped — an operator-published deployment
+    /// fingerprint, or an already-authenticated session on another device.
+    OobVerified,
+}
+
+impl PqProvenance {
+    /// The verified key material this provenance supports.
+    ///
+    /// This is the single point where a binding is allowed to influence
+    /// assurance, and the only mapping that reaches
+    /// [`VerifiedKeyMaterial::PqHybrid`] is [`PqProvenance::OobVerified`].
+    #[must_use]
+    pub fn key_material(self) -> VerifiedKeyMaterial {
+        match self {
+            // Capped. A first-contact record is continuity, not an anchor.
+            PqProvenance::TofuBound => VerifiedKeyMaterial::Classical,
+            PqProvenance::OobVerified => VerifiedKeyMaterial::PqHybrid,
+        }
+    }
+
+    /// The highest MAC assurance this provenance can support.
+    #[must_use]
+    pub fn assurance_ceiling(self) -> Assurance {
+        self.key_material().assurance()
+    }
+
+    /// Stable label for logs and audit records.
+    #[must_use]
+    pub fn as_str(self) -> &'static str {
+        match self {
+            PqProvenance::TofuBound => "tofu-bound",
+            PqProvenance::OobVerified => "oob-verified",
+        }
+    }
+}
+
+/// A recorded binding.
+#[derive(Debug, Clone)]
+struct OverlayEntry {
+    ml_dsa_vk: Vec<u8>,
+    provenance: PqProvenance,
+    /// Wall-clock ms after which the entry is treated as absent. `None` for a
+    /// promoted binding, which outlives the session that created it and is
+    /// withdrawn by revocation rather than by lapse.
+    expires_at_ms: Option<i64>,
+}
+
+impl OverlayEntry {
+    fn is_live(&self, now_ms: i64) -> bool {
+        match self.expires_at_ms {
+            Some(deadline) => now_ms < deadline,
+            None => true,
+        }
+    }
+}
+
+/// A surfaced attempt to bind an already-bound identity to a different PQ key.
+///
+/// Minted only by [`SessionPqOverlay::observe_first_contact`] refusing a
+/// rebind. It is the sole input to [`RebindApproval`], which makes "change an
+/// established binding" unreachable without an event having been raised first.
+#[derive(Debug, Clone)]
+#[must_use = "a refused rebind is a security event; record it or approve it deliberately"]
+pub struct RebindEvent {
+    identity: [u8; 32],
+    established_vk: Vec<u8>,
+    established_provenance: PqProvenance,
+    presented_vk: Vec<u8>,
+}
+
+impl RebindEvent {
+    /// The Ed25519 identity whose binding was challenged.
+    #[must_use]
+    pub fn identity(&self) -> &[u8; 32] {
+        &self.identity
+    }
+
+    /// Provenance of the binding already on file.
+    #[must_use]
+    pub fn established_provenance(&self) -> PqProvenance {
+        self.established_provenance
+    }
+
+    /// Fingerprint of the pairing already on file.
+    #[must_use]
+    pub fn established_fingerprint(&self) -> [u8; 32] {
+        fingerprint_bytes(&self.identity, &self.established_vk)
+    }
+
+    /// Fingerprint of the pairing that was presented and refused.
+    #[must_use]
+    pub fn presented_fingerprint(&self) -> [u8; 32] {
+        fingerprint_bytes(&self.identity, &self.presented_vk)
+    }
+
+    /// Turn this surfaced event into an approval to replace the binding.
+    ///
+    /// Consumes the event: an approval cannot exist unless a rebind was
+    /// refused first. `justification` is carried into the applied-rebind
+    /// notification so the record says who decided and on what basis.
+    #[must_use]
+    pub fn approve(self, provenance: PqProvenance, justification: impl Into<String>) -> RebindApproval {
+        RebindApproval {
+            event: self,
+            provenance,
+            justification: justification.into(),
+        }
+    }
+}
+
+/// An operator decision to replace an established binding, carrying the event
+/// it answers.
+#[derive(Debug, Clone)]
+pub struct RebindApproval {
+    event: RebindEvent,
+    provenance: PqProvenance,
+    justification: String,
+}
+
+impl RebindApproval {
+    /// The event this approval answers.
+    pub fn event(&self) -> &RebindEvent {
+        &self.event
+    }
+
+    /// The provenance the replacement binding will carry.
+    #[must_use]
+    pub fn provenance(&self) -> PqProvenance {
+        self.provenance
+    }
+}
+
+/// Outcome of offering a first-contact observation.
+#[derive(Debug, Clone)]
+#[must_use]
+pub enum FirstContactOutcome {
+    /// No live binding existed; the presented key is now recorded `TofuBound`.
+    Recorded,
+    /// A live binding exists and names the same key. Nothing changed.
+    AlreadyBound(PqProvenance),
+    /// A live binding exists and names a *different* key. **Not applied.**
+    RebindRefused(RebindEvent),
+    /// The overlay is at capacity and no expired entry could be reclaimed. The
+    /// binding was not recorded; the request that offered it fails closed.
+    CapacityExhausted,
+}
+
+/// Why a promotion was refused.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum PromotionError {
+    /// No live binding exists for the identity — there is nothing to promote.
+    /// Promotion never creates a binding: the out-of-band channel confirms a
+    /// pairing the node already observed, it does not introduce one.
+    NotBound,
+    /// The out-of-band fingerprint does not match the recorded pairing.
+    FingerprintMismatch,
+}
+
+impl std::fmt::Display for PromotionError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            PromotionError::NotBound => f.write_str("no live PQ binding for this identity"),
+            PromotionError::FingerprintMismatch => {
+                f.write_str("out-of-band fingerprint does not match the recorded pairing")
+            }
+        }
+    }
+}
+
+impl std::error::Error for PromotionError {}
+
+/// Sink for binding lifecycle events.
+///
+/// Every method has a default no-op body except the two that report a change of
+/// trust state; implementors are expected to route those to the audit journal.
+pub trait PqBindingEventSink: Send + Sync {
+    /// An identity presented a PQ key different from its established binding.
+    /// The binding was left alone.
+    fn on_rebind_refused(&self, event: &RebindEvent);
+
+    /// An established binding was replaced under an explicit approval.
+    fn on_rebind_applied(&self, approval: &RebindApproval);
+
+    /// A first-contact binding was recorded.
+    fn on_first_contact(&self, _identity: &[u8; 32], _fingerprint: &[u8; 32]) {}
+
+    /// A binding was promoted to `OobVerified`.
+    fn on_promoted(&self, _identity: &[u8; 32], _fingerprint: &[u8; 32], _channel: &str) {}
+
+    /// A promotion or a whole binding was withdrawn.
+    fn on_revoked(&self, _identity: &[u8; 32], _from: PqProvenance, _to: Option<PqProvenance>) {}
+}
+
+/// Sink that records events to `tracing` at warning level.
+pub struct TracingPqBindingEventSink;
+
+impl PqBindingEventSink for TracingPqBindingEventSink {
+    fn on_rebind_refused(&self, event: &RebindEvent) {
+        tracing::warn!(
+            identity = %hex::encode(event.identity()),
+            established_provenance = event.established_provenance().as_str(),
+            established_fingerprint = %hex::encode(event.established_fingerprint()),
+            presented_fingerprint = %hex::encode(event.presented_fingerprint()),
+            "PQ rebinding refused: identity presented a different ML-DSA-65 key than its \
+             established binding; the binding was NOT changed"
+        );
+    }
+
+    fn on_rebind_applied(&self, approval: &RebindApproval) {
+        tracing::warn!(
+            identity = %hex::encode(approval.event().identity()),
+            from_fingerprint = %hex::encode(approval.event().established_fingerprint()),
+            to_fingerprint = %hex::encode(approval.event().presented_fingerprint()),
+            provenance = approval.provenance().as_str(),
+            justification = %approval.justification,
+            "PQ binding replaced under explicit approval"
+        );
+    }
+
+    fn on_first_contact(&self, identity: &[u8; 32], fingerprint: &[u8; 32]) {
+        tracing::info!(
+            identity = %hex::encode(identity),
+            fingerprint = %hex::encode(fingerprint),
+            "PQ binding recorded at first contact (verifiable, assurance capped at Classical)"
+        );
+    }
+
+    fn on_promoted(&self, identity: &[u8; 32], fingerprint: &[u8; 32], channel: &str) {
+        tracing::warn!(
+            identity = %hex::encode(identity),
+            fingerprint = %hex::encode(fingerprint),
+            channel,
+            "PQ binding promoted to out-of-band verified"
+        );
+    }
+
+    fn on_revoked(&self, identity: &[u8; 32], from: PqProvenance, to: Option<PqProvenance>) {
+        tracing::warn!(
+            identity = %hex::encode(identity),
+            from = from.as_str(),
+            to = to.map_or("none", PqProvenance::as_str),
+            "PQ binding withdrawn"
+        );
+    }
+}
+
+/// The fingerprint compared over the out-of-band channel.
+///
+/// Covers the **pair** — `domain ‖ ed25519 ‖ ml_dsa_65` — not the PQ key alone.
+/// A fingerprint over only the PQ half would confirm that someone holds that
+/// key while saying nothing about which identity it belongs to, which is
+/// exactly the substitution the out-of-band comparison exists to catch.
+#[must_use]
+pub fn composite_fingerprint(ed25519_pubkey: &[u8; 32], ml_dsa_vk: &MlDsaVerifyingKey) -> [u8; 32] {
+    fingerprint_bytes(ed25519_pubkey, &ml_dsa_vk_bytes(ml_dsa_vk))
+}
+
+fn fingerprint_bytes(ed25519_pubkey: &[u8; 32], ml_dsa_vk_bytes: &[u8]) -> [u8; 32] {
+    use sha2::Digest as _;
+    let mut hasher = sha2::Sha256::new();
+    hasher.update(FINGERPRINT_DOMAIN);
+    hasher.update(ed25519_pubkey);
+    hasher.update(ml_dsa_vk_bytes);
+    hasher.finalize().into()
+}
+
+/// Render a fingerprint the way it is shown to a human performing the
+/// comparison: uppercase hex in space-separated quads, so a mismatch in any
+/// position is easy to spot when read aloud or compared by eye.
+#[must_use]
+pub fn format_fingerprint(fingerprint: &[u8; 32]) -> String {
+    let hex = hex::encode_upper(fingerprint);
+    hex.as_bytes()
+        .chunks(4)
+        .map(|c| String::from_utf8_lossy(c).into_owned())
+        .collect::<Vec<_>>()
+        .join(" ")
+}
+
+/// Additive, session-scoped PQ binding overlay.
+pub struct SessionPqOverlay {
+    entries: RwLock<HashMap<[u8; 32], OverlayEntry>>,
+    sink: Arc<dyn PqBindingEventSink>,
+    tofu_ttl_ms: i64,
+    max_entries: usize,
+}
+
+impl Default for SessionPqOverlay {
+    fn default() -> Self {
+        Self::new(Arc::new(TracingPqBindingEventSink))
+    }
+}
+
+impl SessionPqOverlay {
+    /// Build an overlay with the default TTL and capacity.
+    #[must_use]
+    pub fn new(sink: Arc<dyn PqBindingEventSink>) -> Self {
+        Self {
+            entries: RwLock::new(HashMap::new()),
+            sink,
+            tofu_ttl_ms: DEFAULT_TOFU_TTL_MS,
+            max_entries: DEFAULT_MAX_ENTRIES,
+        }
+    }
+
+    /// Override the first-contact lifetime.
+    #[must_use]
+    pub fn with_tofu_ttl_ms(mut self, ttl_ms: i64) -> Self {
+        self.tofu_ttl_ms = ttl_ms;
+        self
+    }
+
+    /// Override the retained-binding ceiling.
+    #[must_use]
+    pub fn with_max_entries(mut self, max_entries: usize) -> Self {
+        self.max_entries = max_entries;
+        self
+    }
+
+    /// The ML-DSA-65 key to check this identity's signature against.
+    ///
+    /// Returns the key and nothing else. There is deliberately no provenance in
+    /// the return type: the verify path has no business knowing how much the
+    /// binding is believed, and cannot accidentally propagate it.
+    #[must_use]
+    pub fn verifying_key_for(&self, ed25519_pubkey: &[u8; 32]) -> Option<MlDsaVerifyingKey> {
+        let now = crate::envelope::current_timestamp();
+        let entries = self.entries.read();
+        let entry = entries.get(ed25519_pubkey)?;
+        if !entry.is_live(now) {
+            return None;
+        }
+        crate::crypto::pq::ml_dsa_vk_from_bytes(&entry.ml_dsa_vk).ok()
+    }
+
+    /// How much this identity's binding is believed, if it has a live one.
+    ///
+    /// This is the trust question, answered separately from
+    /// [`Self::verifying_key_for`].
+    #[must_use]
+    pub fn provenance_for(&self, ed25519_pubkey: &[u8; 32]) -> Option<PqProvenance> {
+        let now = crate::envelope::current_timestamp();
+        let entries = self.entries.read();
+        let entry = entries.get(ed25519_pubkey)?;
+        entry.is_live(now).then_some(entry.provenance)
+    }
+
+    /// The fingerprint of this identity's live binding, for display in an
+    /// out-of-band comparison ceremony.
+    #[must_use]
+    pub fn fingerprint_for(&self, ed25519_pubkey: &[u8; 32]) -> Option<[u8; 32]> {
+        let now = crate::envelope::current_timestamp();
+        let entries = self.entries.read();
+        let entry = entries.get(ed25519_pubkey)?;
+        entry
+            .is_live(now)
+            .then(|| fingerprint_bytes(ed25519_pubkey, &entry.ml_dsa_vk))
+    }
+
+    /// Offer a PQ key observed at first contact.
+    ///
+    /// **Call only after the whole composite has verified against
+    /// `presented_vk`**, so that possession of both private keys is proven
+    /// before anything is written.
+    ///
+    /// This never overwrites a **live** entry. A live entry naming a different
+    /// key produces [`FirstContactOutcome::RebindRefused`], and the event
+    /// reaches the sink before this returns.
+    ///
+    /// # Change detection is bounded by the TTL
+    ///
+    /// A binding that has lapsed is, by the session-scoped model, forgotten:
+    /// the identity is unbound again and the next contact is genuinely a first
+    /// one, recorded without a refusal even if it names a different key. So the
+    /// window in which a key substitution is caught is exactly the TTL, and an
+    /// attacker who can wait out a device's idle period sees an unbound
+    /// identity rather than a challenged one. Raising the TTL widens detection
+    /// at the cost of remembering devices longer; a promotion
+    /// ([`Self::promote_out_of_band`]) removes the deadline entirely, which is
+    /// the durable answer for an identity worth pinning.
+    pub fn observe_first_contact(
+        &self,
+        ed25519_pubkey: [u8; 32],
+        presented_vk: &MlDsaVerifyingKey,
+    ) -> FirstContactOutcome {
+        let now = crate::envelope::current_timestamp();
+        let presented_bytes = ml_dsa_vk_bytes(presented_vk);
+
+        let outcome = {
+            let mut entries = self.entries.write();
+            match entries.get(&ed25519_pubkey) {
+                Some(entry) if entry.is_live(now) => {
+                    if entry.ml_dsa_vk == presented_bytes {
+                        FirstContactOutcome::AlreadyBound(entry.provenance)
+                    } else {
+                        // Refuse. The established binding stays exactly as it
+                        // is; the only path that replaces it is `apply_rebind`,
+                        // which needs the event this constructs.
+                        FirstContactOutcome::RebindRefused(RebindEvent {
+                            identity: ed25519_pubkey,
+                            established_vk: entry.ml_dsa_vk.clone(),
+                            established_provenance: entry.provenance,
+                            presented_vk: presented_bytes,
+                        })
+                    }
+                }
+                _ => {
+                    // Vacant or lapsed. Reclaim lapsed entries before consulting
+                    // the ceiling so a quiet period is not permanently fatal.
+                    if entries.len() >= self.max_entries {
+                        entries.retain(|_, e| e.is_live(now));
+                    }
+                    if entries.len() >= self.max_entries
+                        && !entries.contains_key(&ed25519_pubkey)
+                    {
+                        FirstContactOutcome::CapacityExhausted
+                    } else {
+                        entries.insert(
+                            ed25519_pubkey,
+                            OverlayEntry {
+                                ml_dsa_vk: presented_bytes,
+                                provenance: PqProvenance::TofuBound,
+                                expires_at_ms: Some(now.saturating_add(self.tofu_ttl_ms)),
+                            },
+                        );
+                        FirstContactOutcome::Recorded
+                    }
+                }
+            }
+        };
+
+        match &outcome {
+            FirstContactOutcome::RebindRefused(event) => self.sink.on_rebind_refused(event),
+            FirstContactOutcome::Recorded => {
+                let fp = fingerprint_bytes(&ed25519_pubkey, &ml_dsa_vk_bytes(presented_vk));
+                self.sink.on_first_contact(&ed25519_pubkey, &fp);
+            }
+            FirstContactOutcome::CapacityExhausted => {
+                tracing::warn!(
+                    identity = %hex::encode(ed25519_pubkey),
+                    "PQ overlay at capacity; first-contact binding refused (request fails closed)"
+                );
+            }
+            FirstContactOutcome::AlreadyBound(_) => {}
+        }
+
+        outcome
+    }
+
+    /// Replace an established binding, under an approval that answers a
+    /// surfaced [`RebindEvent`].
+    ///
+    /// This is the only mutation that can change an existing binding, and it is
+    /// unreachable without the overlay having refused a rebind first. Returns
+    /// `false` when the identity's binding no longer matches the one the event
+    /// described — a concurrent change means the approval answered a stale
+    /// observation and must be re-taken.
+    pub fn apply_rebind(&self, approval: RebindApproval) -> bool {
+        let now = crate::envelope::current_timestamp();
+        let applied = {
+            let mut entries = self.entries.write();
+            match entries.get(&approval.event.identity) {
+                Some(entry) if entry.ml_dsa_vk == approval.event.established_vk => {
+                    let expires_at_ms = match approval.provenance {
+                        PqProvenance::TofuBound => Some(now.saturating_add(self.tofu_ttl_ms)),
+                        PqProvenance::OobVerified => None,
+                    };
+                    entries.insert(
+                        approval.event.identity,
+                        OverlayEntry {
+                            ml_dsa_vk: approval.event.presented_vk.clone(),
+                            provenance: approval.provenance,
+                            expires_at_ms,
+                        },
+                    );
+                    true
+                }
+                _ => false,
+            }
+        };
+        if applied {
+            self.sink.on_rebind_applied(&approval);
+        }
+        applied
+    }
+
+    /// Promote a live binding to [`PqProvenance::OobVerified`].
+    ///
+    /// `oob_fingerprint` is the value the operator obtained through the
+    /// independent channel; it must equal [`composite_fingerprint`] over the
+    /// recorded pairing. `channel` names where it came from and is carried into
+    /// the notification.
+    ///
+    /// Promotion never creates a binding — an identity the node has never
+    /// observed cannot be promoted, because there would be no observed pairing
+    /// for the fingerprint to confirm.
+    ///
+    /// # Errors
+    ///
+    /// [`PromotionError::NotBound`] when no live binding exists;
+    /// [`PromotionError::FingerprintMismatch`] when the value does not match.
+    pub fn promote_out_of_band(
+        &self,
+        ed25519_pubkey: &[u8; 32],
+        oob_fingerprint: &[u8; 32],
+        channel: &str,
+    ) -> std::result::Result<(), PromotionError> {
+        use subtle::ConstantTimeEq as _;
+        let now = crate::envelope::current_timestamp();
+        {
+            let mut entries = self.entries.write();
+            let entry = entries
+                .get_mut(ed25519_pubkey)
+                .filter(|e| e.is_live(now))
+                .ok_or(PromotionError::NotBound)?;
+            let recorded = fingerprint_bytes(ed25519_pubkey, &entry.ml_dsa_vk);
+            if !bool::from(recorded.ct_eq(oob_fingerprint)) {
+                return Err(PromotionError::FingerprintMismatch);
+            }
+            entry.provenance = PqProvenance::OobVerified;
+            // A promotion is a statement about the pairing, not about the
+            // session that happened to observe it, so it stops lapsing.
+            entry.expires_at_ms = None;
+        }
+        self.sink
+            .on_promoted(ed25519_pubkey, oob_fingerprint, channel);
+        Ok(())
+    }
+
+    /// Withdraw a promotion, returning the binding to `TofuBound` continuity
+    /// (and to lapsing) without breaking the session using it.
+    ///
+    /// Returns `false` when the identity has no live `OobVerified` binding.
+    pub fn revoke_promotion(&self, ed25519_pubkey: &[u8; 32]) -> bool {
+        let now = crate::envelope::current_timestamp();
+        let revoked = {
+            let mut entries = self.entries.write();
+            match entries.get_mut(ed25519_pubkey) {
+                Some(entry)
+                    if entry.is_live(now) && entry.provenance == PqProvenance::OobVerified =>
+                {
+                    entry.provenance = PqProvenance::TofuBound;
+                    entry.expires_at_ms = Some(now.saturating_add(self.tofu_ttl_ms));
+                    true
+                }
+                _ => false,
+            }
+        };
+        if revoked {
+            self.sink.on_revoked(
+                ed25519_pubkey,
+                PqProvenance::OobVerified,
+                Some(PqProvenance::TofuBound),
+            );
+        }
+        revoked
+    }
+
+    /// Withdraw the binding entirely. The identity returns to the `Classical`
+    /// state — no PQ key bound — and its next contact is a fresh first contact.
+    ///
+    /// Returns `false` when there was nothing to withdraw.
+    pub fn revoke_binding(&self, ed25519_pubkey: &[u8; 32]) -> bool {
+        let removed = self.entries.write().remove(ed25519_pubkey);
+        match removed {
+            Some(entry) => {
+                self.sink.on_revoked(ed25519_pubkey, entry.provenance, None);
+                true
+            }
+            None => false,
+        }
+    }
+
+    /// Number of live bindings.
+    #[must_use]
+    pub fn len(&self) -> usize {
+        let now = crate::envelope::current_timestamp();
+        self.entries
+            .read()
+            .values()
+            .filter(|v| v.is_live(now))
+            .count()
+    }
+
+    /// Whether the overlay holds no live bindings.
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+}
+
+// ============================================================================
+// Process-global overlay.
+// ============================================================================
+
+#[cfg(not(target_arch = "wasm32"))]
+static SESSION_PQ_OVERLAY: std::sync::OnceLock<Arc<SessionPqOverlay>> = std::sync::OnceLock::new();
+
+/// Install the process-global overlay. First write wins.
+///
+/// **Not installed by default.** With no overlay installed the verify path
+/// behaves exactly as it did before this existed: an identity with no
+/// admin-anchored ML-DSA-65 key is rejected under the mandatory Hybrid suite.
+/// Trust-on-first-use is a deployment decision, so it is opted into explicitly
+/// rather than acquired by linking this crate.
+///
+/// # Errors
+///
+/// Returns `Err` when an overlay was already installed.
+#[cfg(not(target_arch = "wasm32"))]
+pub fn install_session_pq_overlay(overlay: Arc<SessionPqOverlay>) -> anyhow::Result<()> {
+    SESSION_PQ_OVERLAY
+        .set(overlay)
+        .map_err(|_| anyhow::anyhow!("session PQ overlay already installed"))
+}
+
+/// The installed process-global overlay, if any.
+#[cfg(not(target_arch = "wasm32"))]
+#[must_use]
+pub fn global_session_pq_overlay() -> Option<Arc<SessionPqOverlay>> {
+    SESSION_PQ_OVERLAY.get().cloned()
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+mod tests {
+    use super::*;
+
+    fn pq_key(seed: u8) -> MlDsaVerifyingKey {
+        let sk = crate::crypto::pq::ml_dsa_sk_from_seed(&[seed; 32]);
+        crate::crypto::pq::ml_dsa_vk_from_bytes(&crate::crypto::pq::ml_dsa_sk_to_vk_bytes(&sk))
+            .expect("derived verifying key round-trips")
+    }
+
+    fn ed_identity(seed: u8) -> [u8; 32] {
+        [seed; 32]
+    }
+
+    #[derive(Default)]
+    struct CountingSink {
+        refused: std::sync::atomic::AtomicUsize,
+        applied: std::sync::atomic::AtomicUsize,
+        first_contact: std::sync::atomic::AtomicUsize,
+        promoted: std::sync::atomic::AtomicUsize,
+        revoked: std::sync::atomic::AtomicUsize,
+    }
+
+    impl CountingSink {
+        fn count(v: &std::sync::atomic::AtomicUsize) -> usize {
+            v.load(std::sync::atomic::Ordering::SeqCst)
+        }
+        fn bump(v: &std::sync::atomic::AtomicUsize) {
+            v.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+        }
+    }
+
+    impl PqBindingEventSink for CountingSink {
+        fn on_rebind_refused(&self, _event: &RebindEvent) {
+            Self::bump(&self.refused);
+        }
+        fn on_rebind_applied(&self, _approval: &RebindApproval) {
+            Self::bump(&self.applied);
+        }
+        fn on_first_contact(&self, _identity: &[u8; 32], _fingerprint: &[u8; 32]) {
+            Self::bump(&self.first_contact);
+        }
+        fn on_promoted(&self, _identity: &[u8; 32], _fingerprint: &[u8; 32], _channel: &str) {
+            Self::bump(&self.promoted);
+        }
+        fn on_revoked(&self, _i: &[u8; 32], _f: PqProvenance, _t: Option<PqProvenance>) {
+            Self::bump(&self.revoked);
+        }
+    }
+
+    fn overlay_with_sink() -> (SessionPqOverlay, Arc<CountingSink>) {
+        let sink = Arc::new(CountingSink::default());
+        (SessionPqOverlay::new(sink.clone()), sink)
+    }
+
+    #[test]
+    fn first_contact_records_a_tofu_binding() {
+        let (overlay, sink) = overlay_with_sink();
+        let id = ed_identity(1);
+        let key = pq_key(11);
+
+        assert!(matches!(
+            overlay.observe_first_contact(id, &key),
+            FirstContactOutcome::Recorded
+        ));
+        assert_eq!(CountingSink::count(&sink.first_contact), 1);
+        assert_eq!(
+            ml_dsa_vk_bytes(&overlay.verifying_key_for(&id).unwrap()),
+            ml_dsa_vk_bytes(&key)
+        );
+        assert_eq!(overlay.provenance_for(&id), Some(PqProvenance::TofuBound));
+    }
+
+    #[test]
+    fn repeat_contact_with_the_same_key_changes_nothing() {
+        let (overlay, sink) = overlay_with_sink();
+        let id = ed_identity(2);
+        let key = pq_key(12);
+
+        let _ = overlay.observe_first_contact(id, &key);
+        let outcome = overlay.observe_first_contact(id, &key);
+        assert!(matches!(
+            outcome,
+            FirstContactOutcome::AlreadyBound(PqProvenance::TofuBound)
+        ));
+        assert_eq!(CountingSink::count(&sink.refused), 0);
+        assert_eq!(CountingSink::count(&sink.first_contact), 1);
+    }
+
+    #[test]
+    fn a_different_key_is_refused_and_surfaced_not_silently_written() {
+        let (overlay, sink) = overlay_with_sink();
+        let id = ed_identity(3);
+        let original = pq_key(13);
+        let substitute = pq_key(14);
+
+        let _ = overlay.observe_first_contact(id, &original);
+        let outcome = overlay.observe_first_contact(id, &substitute);
+
+        let FirstContactOutcome::RebindRefused(event) = outcome else {
+            panic!("a different key must be refused, not accepted");
+        };
+        // The event reached the sink before the caller saw the outcome.
+        assert_eq!(CountingSink::count(&sink.refused), 1);
+        assert_eq!(event.established_provenance(), PqProvenance::TofuBound);
+        assert_ne!(event.established_fingerprint(), event.presented_fingerprint());
+        // Last write did NOT win.
+        assert_eq!(
+            ml_dsa_vk_bytes(&overlay.verifying_key_for(&id).unwrap()),
+            ml_dsa_vk_bytes(&original)
+        );
+    }
+
+    #[test]
+    fn replacing_a_binding_requires_an_approval_built_from_the_refusal() {
+        let (overlay, sink) = overlay_with_sink();
+        let id = ed_identity(4);
+        let original = pq_key(15);
+        let rotated = pq_key(16);
+
+        let _ = overlay.observe_first_contact(id, &original);
+        let FirstContactOutcome::RebindRefused(event) =
+            overlay.observe_first_contact(id, &rotated)
+        else {
+            panic!("rotation must surface as a refused rebind");
+        };
+
+        assert!(overlay.apply_rebind(event.approve(PqProvenance::TofuBound, "operator rotation")));
+        assert_eq!(CountingSink::count(&sink.applied), 1);
+        assert_eq!(
+            ml_dsa_vk_bytes(&overlay.verifying_key_for(&id).unwrap()),
+            ml_dsa_vk_bytes(&rotated)
+        );
+        // Rotation through the visible path does not confer trust on its own.
+        assert_eq!(overlay.provenance_for(&id), Some(PqProvenance::TofuBound));
+    }
+
+    #[test]
+    fn a_stale_approval_does_not_apply() {
+        let (overlay, _sink) = overlay_with_sink();
+        let id = ed_identity(5);
+        let original = pq_key(17);
+        let rotated = pq_key(18);
+        let other = pq_key(19);
+
+        let _ = overlay.observe_first_contact(id, &original);
+        let FirstContactOutcome::RebindRefused(event) =
+            overlay.observe_first_contact(id, &rotated)
+        else {
+            panic!("expected a refusal");
+        };
+        // The binding moves underneath the pending approval.
+        overlay.revoke_binding(&id);
+        let _ = overlay.observe_first_contact(id, &other);
+
+        assert!(!overlay.apply_rebind(event.approve(PqProvenance::OobVerified, "stale")));
+        assert_eq!(
+            ml_dsa_vk_bytes(&overlay.verifying_key_for(&id).unwrap()),
+            ml_dsa_vk_bytes(&other)
+        );
+    }
+
+    #[test]
+    fn tofu_never_reaches_pq_hybrid_key_material() {
+        assert_eq!(
+            PqProvenance::TofuBound.key_material(),
+            VerifiedKeyMaterial::Classical
+        );
+        assert_eq!(PqProvenance::TofuBound.assurance_ceiling(), Assurance::Classical);
+        assert!(PqProvenance::TofuBound.assurance_ceiling() < Assurance::PqHybrid);
+    }
+
+    #[test]
+    fn only_oob_verified_reaches_pq_hybrid() {
+        // Exhaustive over the provenance domain: exactly one variant may raise.
+        for p in [PqProvenance::TofuBound, PqProvenance::OobVerified] {
+            let raises = p.key_material() == VerifiedKeyMaterial::PqHybrid;
+            assert_eq!(raises, p == PqProvenance::OobVerified);
+        }
+    }
+
+    #[test]
+    fn promotion_requires_the_composite_fingerprint() {
+        let (overlay, sink) = overlay_with_sink();
+        let id = ed_identity(6);
+        let key = pq_key(20);
+        let _ = overlay.observe_first_contact(id, &key);
+
+        // A fingerprint over the PQ half bound to a *different* identity must
+        // not promote: the value covers the pair, not the key alone.
+        let wrong = composite_fingerprint(&ed_identity(7), &key);
+        assert_eq!(
+            overlay.promote_out_of_band(&id, &wrong, "printed"),
+            Err(PromotionError::FingerprintMismatch)
+        );
+        assert_eq!(overlay.provenance_for(&id), Some(PqProvenance::TofuBound));
+
+        let right = composite_fingerprint(&id, &key);
+        assert!(overlay.promote_out_of_band(&id, &right, "printed").is_ok());
+        assert_eq!(overlay.provenance_for(&id), Some(PqProvenance::OobVerified));
+        assert_eq!(CountingSink::count(&sink.promoted), 1);
+    }
+
+    #[test]
+    fn promotion_cannot_invent_a_binding() {
+        let (overlay, _sink) = overlay_with_sink();
+        let id = ed_identity(8);
+        let key = pq_key(21);
+        assert_eq!(
+            overlay.promote_out_of_band(&id, &composite_fingerprint(&id, &key), "printed"),
+            Err(PromotionError::NotBound)
+        );
+        assert!(overlay.verifying_key_for(&id).is_none());
+    }
+
+    #[test]
+    fn a_promotion_can_be_revoked() {
+        let (overlay, sink) = overlay_with_sink();
+        let id = ed_identity(9);
+        let key = pq_key(22);
+        let _ = overlay.observe_first_contact(id, &key);
+        overlay
+            .promote_out_of_band(&id, &composite_fingerprint(&id, &key), "printed")
+            .unwrap();
+
+        assert!(overlay.revoke_promotion(&id));
+        assert_eq!(CountingSink::count(&sink.revoked), 1);
+        // Trust is withdrawn; verifiability and the live session are not.
+        assert_eq!(overlay.provenance_for(&id), Some(PqProvenance::TofuBound));
+        assert!(overlay.verifying_key_for(&id).is_some());
+        // Idempotent: nothing left to revoke.
+        assert!(!overlay.revoke_promotion(&id));
+    }
+
+    #[test]
+    fn revoking_a_binding_returns_the_identity_to_unbound() {
+        let (overlay, _sink) = overlay_with_sink();
+        let id = ed_identity(10);
+        let key = pq_key(23);
+        let _ = overlay.observe_first_contact(id, &key);
+        assert!(overlay.revoke_binding(&id));
+        assert!(overlay.verifying_key_for(&id).is_none());
+        assert!(overlay.provenance_for(&id).is_none());
+        assert!(!overlay.revoke_binding(&id));
+    }
+
+    #[test]
+    fn a_lapsed_first_contact_binding_stops_verifying() {
+        let (overlay, _sink) = overlay_with_sink();
+        let overlay = overlay.with_tofu_ttl_ms(0);
+        let id = ed_identity(11);
+        let key = pq_key(24);
+        let _ = overlay.observe_first_contact(id, &key);
+        assert!(overlay.verifying_key_for(&id).is_none());
+        assert!(overlay.is_empty());
+    }
+
+    #[test]
+    fn a_promoted_binding_does_not_lapse() {
+        let (overlay, _sink) = overlay_with_sink();
+        let overlay = overlay.with_tofu_ttl_ms(60_000);
+        let id = ed_identity(12);
+        let key = pq_key(25);
+        let _ = overlay.observe_first_contact(id, &key);
+        overlay
+            .promote_out_of_band(&id, &composite_fingerprint(&id, &key), "printed")
+            .unwrap();
+        // Shrinking the TTL cannot retroactively expire a promotion: it carries
+        // no deadline at all.
+        assert_eq!(overlay.provenance_for(&id), Some(PqProvenance::OobVerified));
+    }
+
+    #[test]
+    fn capacity_is_bounded() {
+        let (overlay, _sink) = overlay_with_sink();
+        let overlay = overlay.with_max_entries(1);
+        let _ = overlay.observe_first_contact(ed_identity(13), &pq_key(26));
+        assert!(matches!(
+            overlay.observe_first_contact(ed_identity(14), &pq_key(27)),
+            FirstContactOutcome::CapacityExhausted
+        ));
+    }
+
+    #[test]
+    fn the_fingerprint_covers_both_halves() {
+        let a = ed_identity(15);
+        let b = ed_identity(16);
+        let k1 = pq_key(28);
+        let k2 = pq_key(29);
+        assert_ne!(composite_fingerprint(&a, &k1), composite_fingerprint(&b, &k1));
+        assert_ne!(composite_fingerprint(&a, &k1), composite_fingerprint(&a, &k2));
+    }
+
+    #[test]
+    fn fingerprint_display_is_grouped_for_reading_aloud() {
+        let fp = composite_fingerprint(&ed_identity(17), &pq_key(30));
+        let rendered = format_fingerprint(&fp);
+        assert_eq!(rendered.split(' ').count(), 16);
+        assert!(rendered
+            .chars()
+            .all(|c| c.is_ascii_hexdigit() && !c.is_ascii_lowercase() || c == ' '));
+    }
+}

--- a/crates/hyprstream-rpc/tests/session_pq_overlay_dispatch.rs
+++ b/crates/hyprstream-rpc/tests/session_pq_overlay_dispatch.rs
@@ -1,0 +1,604 @@
+//! End-to-end proof that a dynamically-identified client — one no operator
+//! could have pre-enrolled — completes a real dispatch round-trip under the
+//! production-mandatory Hybrid suite.
+//!
+//! **There is deliberately no `KeyedPqTrustStore::bind` call in this file.**
+//! Every other hybrid integration test in this crate hand-anchors its synthetic
+//! client, which is precisely the production mechanism that did not exist; a
+//! test that hand-binds proves nothing about the path exercised here. The store
+//! installed below is empty and stays empty: it is asserted empty after the
+//! round-trip, so the overlay cannot be quietly writing through to it.
+//!
+//! What is proved:
+//!
+//! - first contact admits the request and records a binding;
+//! - a first-contact binding does NOT raise MAC assurance above Classical;
+//! - presenting a different PQ key for a bound identity is refused, surfaced,
+//!   and leaves the binding intact;
+//! - a self-asserted key the client cannot actually sign with is never recorded;
+//! - a PQ-less envelope from a bound identity does not clear the binding;
+//! - an out-of-band promotion does raise assurance, and can be revoked.
+
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+
+mod support;
+
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, OnceLock};
+
+use parking_lot::Mutex;
+
+use anyhow::Result;
+use async_trait::async_trait;
+use ed25519_dalek::SigningKey;
+
+use hyprstream_rpc::auth::mac::VerifiedKeyMaterial;
+use hyprstream_rpc::crypto::pq::{
+    ml_dsa_sk_from_seed, ml_dsa_sk_to_vk_bytes, ml_dsa_vk_from_bytes, MlDsaSigningKey,
+    MlDsaVerifyingKey,
+};
+use hyprstream_rpc::crypto::signing::generate_signing_keypair;
+use hyprstream_rpc::envelope::{
+    self, Authorization, EnvelopeVerification, RequestEnvelope, SignedEnvelope,
+};
+use hyprstream_rpc::node_identity::derive_mesh_kem_recipient;
+use hyprstream_rpc::service::dispatch::process_request;
+use hyprstream_rpc::service::{Continuation, EnvelopeContext, RequestService};
+use hyprstream_rpc::session_pq_overlay::{
+    composite_fingerprint, FirstContactOutcome, PqBindingEventSink, PqProvenance, RebindApproval,
+    RebindEvent, SessionPqOverlay,
+};
+use hyprstream_rpc::transport::carrier::CarrierContext;
+use hyprstream_rpc::transport::TransportConfig;
+
+// ---------------------------------------------------------------------------
+// Process fixtures. The verify config, the overlay, and the PEP are all
+// first-write-wins process globals, so they are built once for the binary.
+// ---------------------------------------------------------------------------
+
+/// Records every binding event the overlay publishes, so a test can assert that
+/// a refusal was surfaced rather than merely returned.
+#[derive(Default)]
+struct RecordingSink {
+    refused: Mutex<Vec<[u8; 32]>>,
+    applied: Mutex<Vec<[u8; 32]>>,
+    first_contact: Mutex<Vec<[u8; 32]>>,
+}
+
+impl PqBindingEventSink for RecordingSink {
+    fn on_rebind_refused(&self, event: &RebindEvent) {
+        self.refused.lock().push(*event.identity());
+    }
+    fn on_rebind_applied(&self, approval: &RebindApproval) {
+        self.applied.lock().push(*approval.event().identity());
+    }
+    fn on_first_contact(&self, identity: &[u8; 32], _fingerprint: &[u8; 32]) {
+        self.first_contact.lock().push(*identity);
+    }
+}
+
+struct Fixtures {
+    server_sk: SigningKey,
+    overlay: Arc<SessionPqOverlay>,
+    sink: Arc<RecordingSink>,
+    /// The admin-anchored store, kept so tests can assert it never grew.
+    store: Arc<envelope::KeyedPqTrustStore>,
+}
+
+fn fixtures() -> &'static Fixtures {
+    static F: OnceLock<Fixtures> = OnceLock::new();
+    F.get_or_init(|| {
+        let (server_sk, _) = generate_signing_keypair();
+
+        // An EMPTY admin-anchored store: no operator enrolled anybody. This is
+        // the state a real deployment is in with respect to a browser.
+        let store = Arc::new(envelope::KeyedPqTrustStore::new());
+        assert!(store.is_empty());
+        envelope::install_verify_config(envelope::EnvelopeVerifyConfig {
+            policy: hyprstream_rpc::crypto::CryptoPolicy::Hybrid,
+            pq_store: Some(store.clone()),
+        })
+        .expect("verify config installs once per test binary");
+
+        let sink = Arc::new(RecordingSink::default());
+        let overlay = Arc::new(SessionPqOverlay::new(sink.clone()));
+        hyprstream_rpc::session_pq_overlay::install_session_pq_overlay(overlay.clone())
+            .expect("overlay installs once per test binary");
+
+        Fixtures {
+            server_sk,
+            overlay,
+            sink,
+            store,
+        }
+    })
+}
+
+/// A client whose Ed25519 identity and ML-DSA-65 key are both self-generated —
+/// the browser/dynamic shape. Nothing about it is known to the server in
+/// advance.
+struct DynamicClient {
+    ed_sk: SigningKey,
+    pq_sk: MlDsaSigningKey,
+}
+
+impl DynamicClient {
+    fn new(pq_seed: u8) -> Self {
+        let (ed_sk, _) = generate_signing_keypair();
+        Self {
+            ed_sk,
+            pq_sk: ml_dsa_sk_from_seed(&[pq_seed; 32]),
+        }
+    }
+
+    fn identity(&self) -> [u8; 32] {
+        self.ed_sk.verifying_key().to_bytes()
+    }
+
+    fn pq_vk(&self) -> MlDsaVerifyingKey {
+        ml_dsa_vk_from_bytes(&ml_dsa_sk_to_vk_bytes(&self.pq_sk)).unwrap()
+    }
+
+    /// Sign a request the way a real hybrid client does, encrypted to the
+    /// server's `#mesh-kem` recipient because the carrier forbids cleartext.
+    fn signed_request(&self, service: &str, payload: &[u8]) -> SignedEnvelope {
+        let request = RequestEnvelope {
+            request_id: 7,
+            payload: payload.to_vec(),
+            iat: envelope::current_timestamp(),
+            nonce: envelope::generate_nonce(),
+            authorization: Authorization::None,
+            delegation_token: None,
+            wth: None,
+            client_dh_public: None,
+            client_kem_public: None,
+            response_kem_recipient: None,
+            service_domain: Some(service.to_owned()),
+        };
+        let response_recipient = hyprstream_rpc::crypto::hybrid_kem::generate_recipient(
+            hyprstream_rpc::crypto::hybrid_kem::SuiteId::HyKemX25519MlKem768,
+        )
+        .unwrap();
+        let request = request.with_response_kem_recipient(response_recipient.public());
+        let server_recipient = derive_mesh_kem_recipient(&fixtures().server_sk).unwrap();
+        SignedEnvelope::new_signed_encrypted_mesh_kem(
+            request,
+            &self.ed_sk,
+            &self.pq_sk,
+            &server_recipient.public(),
+        )
+        .unwrap()
+    }
+}
+
+/// Service that records the MAC key material derived for each request it sees.
+struct ObservingService {
+    name: String,
+    transport: TransportConfig,
+    signing_key: SigningKey,
+    invoked: Arc<AtomicBool>,
+    key_material: Arc<Mutex<Option<VerifiedKeyMaterial>>>,
+    signer: Arc<Mutex<Option<[u8; 32]>>>,
+}
+
+impl ObservingService {
+    fn new(name: &str) -> Self {
+        Self {
+            name: name.to_owned(),
+            transport: TransportConfig::inproc(name),
+            signing_key: fixtures().server_sk.clone(),
+            invoked: Arc::new(AtomicBool::new(false)),
+            key_material: Arc::new(Mutex::new(None)),
+            signer: Arc::new(Mutex::new(None)),
+        }
+    }
+
+    fn was_invoked(&self) -> bool {
+        self.invoked.load(Ordering::SeqCst)
+    }
+
+    fn observed_key_material(&self) -> Option<VerifiedKeyMaterial> {
+        *self.key_material.lock()
+    }
+
+    fn observed_signer(&self) -> Option<[u8; 32]> {
+        *self.signer.lock()
+    }
+}
+
+#[async_trait(?Send)]
+impl RequestService for ObservingService {
+    async fn handle_request(
+        &self,
+        ctx: &EnvelopeContext,
+        payload: &[u8],
+    ) -> Result<(Vec<u8>, Option<Continuation>)> {
+        self.invoked.store(true, Ordering::SeqCst);
+        *self.signer.lock() = Some(ctx.cnf);
+        *self.key_material.lock() = Some(ctx.verified_key_material());
+        Ok((payload.to_vec(), None))
+    }
+
+    fn name(&self) -> &str {
+        &self.name
+    }
+
+    fn transport(&self) -> &TransportConfig {
+        &self.transport
+    }
+
+    fn signing_key(&self) -> SigningKey {
+        self.signing_key.clone()
+    }
+
+    fn pq_signing_key(&self) -> Option<MlDsaSigningKey> {
+        Some(hyprstream_rpc::node_identity::derive_mesh_mldsa_key(
+            &self.signing_key,
+        ))
+    }
+}
+
+fn to_wire(signed: &SignedEnvelope) -> Vec<u8> {
+    use hyprstream_rpc::ToCapnp;
+    let mut message = capnp::message::Builder::new_default();
+    {
+        let mut builder =
+            message.init_root::<hyprstream_rpc::common_capnp::signed_envelope::Builder>();
+        signed.write_to(&mut builder);
+    }
+    let mut bytes = Vec::new();
+    capnp::serialize::write_message(&mut bytes, &message).unwrap();
+    bytes
+}
+
+async fn dispatch(service: &ObservingService, signed: &SignedEnvelope) -> Result<Vec<u8>> {
+    support::install_explicit_dispatch_pep();
+    process_request(
+        &to_wire(signed),
+        service,
+        EnvelopeVerification::AnySigner,
+        &fixtures().server_sk,
+        &envelope::InMemoryNonceCache::new(),
+        CarrierContext::iroh(),
+    )
+    .await
+}
+
+fn refusals_for(identity: &[u8; 32]) -> usize {
+    fixtures()
+        .sink
+        .refused
+        .lock()
+        .iter()
+        .filter(|i| *i == identity)
+        .count()
+}
+
+fn first_contacts_for(identity: &[u8; 32]) -> usize {
+    fixtures()
+        .sink
+        .first_contact
+        .lock()
+        .iter()
+        .filter(|i| *i == identity)
+        .count()
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+/// The acceptance case: a client the operator never enrolled gets its hybrid
+/// signature checked and its request handled — and gains no trust for it.
+#[tokio::test]
+async fn unenrolled_hybrid_client_dispatches_and_stays_classical() {
+    let f = fixtures();
+    let client = DynamicClient::new(0xA1);
+    let service = ObservingService::new("overlay-first-contact");
+
+    // Precondition: nobody anchored this identity, and nothing knows it yet.
+    assert!(f.overlay.provenance_for(&client.identity()).is_none());
+
+    dispatch(&service, &client.signed_request("overlay-first-contact", b"hello"))
+        .await
+        .expect("first contact from an unenrolled hybrid client must dispatch");
+
+    assert!(service.was_invoked());
+    assert_eq!(service.observed_signer(), Some(client.identity()));
+    assert_eq!(first_contacts_for(&client.identity()), 1);
+    assert_eq!(
+        f.overlay.provenance_for(&client.identity()),
+        Some(PqProvenance::TofuBound)
+    );
+
+    // The load-bearing property: verifiable, not more trusted.
+    assert_eq!(
+        service.observed_key_material(),
+        Some(VerifiedKeyMaterial::Classical),
+        "a first-contact binding must not raise MAC assurance"
+    );
+
+    // The admin-anchored store was consulted, never written.
+    assert!(
+        f.store.is_empty(),
+        "the overlay must never write through to the admin-anchored store"
+    );
+}
+
+/// A second request from the same client reuses the established binding without
+/// re-recording it.
+#[tokio::test]
+async fn an_established_binding_serves_later_requests() {
+    let f = fixtures();
+    let client = DynamicClient::new(0xA2);
+    let service = ObservingService::new("overlay-repeat");
+
+    dispatch(&service, &client.signed_request("overlay-repeat", b"one"))
+        .await
+        .unwrap();
+    dispatch(&service, &client.signed_request("overlay-repeat", b"two"))
+        .await
+        .expect("an established binding keeps serving");
+
+    assert_eq!(
+        first_contacts_for(&client.identity()),
+        1,
+        "the binding is recorded once, not re-recorded per request"
+    );
+    assert_eq!(refusals_for(&client.identity()), 0);
+    assert!(f.store.is_empty());
+}
+
+/// The service-worker / cache-replacement case: the same identity comes back
+/// holding a different PQ key. It must be refused and surfaced, and the
+/// established binding must survive untouched.
+#[tokio::test]
+async fn a_different_pq_key_for_a_bound_identity_is_refused_and_surfaced() {
+    let f = fixtures();
+    let mut client = DynamicClient::new(0xA3);
+    let service = ObservingService::new("overlay-rebind");
+
+    dispatch(&service, &client.signed_request("overlay-rebind", b"first"))
+        .await
+        .unwrap();
+    let original_key = client.pq_vk();
+
+    // Same Ed25519 identity, different ML-DSA-65 key — the substitution TOFU
+    // exists to catch.
+    client.pq_sk = ml_dsa_sk_from_seed(&[0xB3; 32]);
+    let substituted = ObservingService::new("overlay-rebind-2");
+    let err = dispatch(
+        &substituted,
+        &client.signed_request("overlay-rebind-2", b"second"),
+    )
+    .await
+    .expect_err("a substituted PQ key must not be silently accepted");
+    assert!(
+        format!("{err:#}").contains("established binding"),
+        "rejection must name the rebinding, got: {err:#}"
+    );
+    assert!(!substituted.was_invoked());
+
+    assert_eq!(
+        refusals_for(&client.identity()),
+        1,
+        "the refusal must reach the event sink, not merely be returned"
+    );
+    // Last write did NOT win.
+    assert_eq!(
+        hyprstream_rpc::crypto::pq::ml_dsa_vk_bytes(
+            &f.overlay.verifying_key_for(&client.identity()).unwrap()
+        ),
+        hyprstream_rpc::crypto::pq::ml_dsa_vk_bytes(&original_key)
+    );
+    assert!(f.store.is_empty());
+}
+
+/// The rebinding alarm must be attributable. Anyone can copy a public key into
+/// an envelope's `cnf`; only the identity's holder can sign as it. A stranger
+/// waving a victim's public key around must not be able to inject a security
+/// event about that victim.
+#[tokio::test]
+async fn a_rebinding_alarm_cannot_be_injected_by_a_stranger() {
+    let f = fixtures();
+    let victim = DynamicClient::new(0xA8);
+    let service = ObservingService::new("overlay-alarm");
+
+    dispatch(&service, &victim.signed_request("overlay-alarm", b"bind"))
+        .await
+        .unwrap();
+    let before = refusals_for(&victim.identity());
+
+    // A stranger signs with their own keys, then relabels the envelope as the
+    // victim. The PQ key on the wire differs from the victim's binding, so the
+    // rebinding branch is reached — but the EdDSA layer does not verify as the
+    // victim, so nothing may be raised about them.
+    let stranger = DynamicClient::new(0xB8);
+    let mut impersonation = stranger.signed_request("overlay-alarm-2", b"not-me");
+    impersonation.cnf = victim.identity();
+
+    let target = ObservingService::new("overlay-alarm-2");
+    dispatch(&target, &impersonation)
+        .await
+        .expect_err("a relabelled envelope must be rejected");
+    assert!(!target.was_invoked());
+    assert_eq!(
+        refusals_for(&victim.identity()),
+        before,
+        "an unauthenticated sender must not be able to raise a rebinding alarm"
+    );
+    // And the victim's binding is untouched.
+    assert_eq!(
+        hyprstream_rpc::crypto::pq::ml_dsa_vk_bytes(
+            &f.overlay.verifying_key_for(&victim.identity()).unwrap()
+        ),
+        hyprstream_rpc::crypto::pq::ml_dsa_vk_bytes(&victim.pq_vk())
+    );
+    assert!(f.store.is_empty());
+}
+
+/// A PQ key the client asserts but cannot sign with must never be recorded:
+/// the binding is committed only after the whole composite verifies against
+/// the candidate.
+#[tokio::test]
+async fn an_unusable_self_asserted_key_is_never_recorded() {
+    use hyprstream_rpc::crypto::cose_sign::{assemble_composite_nested, split_composite};
+
+    let f = fixtures();
+    let client = DynamicClient::new(0xA4);
+    let service = ObservingService::new("overlay-forged");
+
+    let mut signed = client.signed_request("overlay-forged", b"forged");
+    let (ed_sig, pq_sig) = split_composite(&signed.cose).unwrap();
+    // Keep the real ML-DSA-65 signature, but claim a key it was not made with.
+    let squatted = ml_dsa_sk_to_vk_bytes(&ml_dsa_sk_from_seed(&[0xC4; 32]));
+    signed.cose = assemble_composite_nested(
+        (signed.cnf.to_vec(), ed_sig),
+        Some((squatted.clone(), pq_sig.unwrap())),
+    )
+    .unwrap();
+
+    dispatch(&service, &signed)
+        .await
+        .expect_err("a self-asserted key the signer cannot use must be rejected");
+    assert!(!service.was_invoked());
+    assert!(
+        f.overlay.provenance_for(&client.identity()).is_none(),
+        "nothing may be recorded for a composite that did not verify"
+    );
+    assert_eq!(first_contacts_for(&client.identity()), 0);
+    assert!(f.store.is_empty());
+}
+
+/// Downgrade monotonicity: an envelope arriving without the PQ layer from an
+/// already-bound identity is rejected and clears nothing.
+#[tokio::test]
+async fn a_pq_less_envelope_does_not_clear_an_established_binding() {
+    use hyprstream_rpc::crypto::cose_sign::{decode_composite_for_test, encode_composite_for_test};
+
+    let f = fixtures();
+    let client = DynamicClient::new(0xA5);
+    let service = ObservingService::new("overlay-downgrade");
+
+    dispatch(&service, &client.signed_request("overlay-downgrade", b"bound"))
+        .await
+        .unwrap();
+    let bound_key = hyprstream_rpc::crypto::pq::ml_dsa_vk_bytes(
+        &f.overlay.verifying_key_for(&client.identity()).unwrap(),
+    );
+
+    let mut stripped = client.signed_request("overlay-downgrade-2", b"downgrade");
+    let (inner, _outer) = decode_composite_for_test(&stripped.cose).unwrap();
+    stripped.cose = encode_composite_for_test(inner, None).unwrap();
+
+    let downgraded = ObservingService::new("overlay-downgrade-2");
+    dispatch(&downgraded, &stripped)
+        .await
+        .expect_err("the mandatory Hybrid suite must reject a PQ-less envelope");
+    assert!(!downgraded.was_invoked());
+
+    assert_eq!(
+        hyprstream_rpc::crypto::pq::ml_dsa_vk_bytes(
+            &f.overlay.verifying_key_for(&client.identity()).unwrap()
+        ),
+        bound_key,
+        "a PQ-less envelope must not clear an established binding"
+    );
+    assert_eq!(
+        f.overlay.provenance_for(&client.identity()),
+        Some(PqProvenance::TofuBound)
+    );
+    assert!(f.store.is_empty());
+}
+
+/// Out-of-band promotion is the only route to `PqHybrid`, and it is reversible.
+#[tokio::test]
+async fn out_of_band_promotion_raises_assurance_and_can_be_revoked() {
+    let f = fixtures();
+    let client = DynamicClient::new(0xA6);
+    let service = ObservingService::new("overlay-promote");
+
+    dispatch(&service, &client.signed_request("overlay-promote", b"before"))
+        .await
+        .unwrap();
+    assert_eq!(
+        service.observed_key_material(),
+        Some(VerifiedKeyMaterial::Classical)
+    );
+
+    // The operator compares the fingerprint over the PAIR through a channel
+    // with different compromise assumptions, then promotes.
+    let fingerprint = composite_fingerprint(&client.identity(), &client.pq_vk());
+    assert_eq!(f.overlay.fingerprint_for(&client.identity()), Some(fingerprint));
+    f.overlay
+        .promote_out_of_band(&client.identity(), &fingerprint, "operator-published")
+        .expect("a matching out-of-band fingerprint promotes");
+
+    let promoted = ObservingService::new("overlay-promote-2");
+    dispatch(&promoted, &client.signed_request("overlay-promote-2", b"after"))
+        .await
+        .unwrap();
+    assert_eq!(
+        promoted.observed_key_material(),
+        Some(VerifiedKeyMaterial::PqHybrid),
+        "an out-of-band verified binding may raise assurance"
+    );
+
+    // Revocation through the granting channel takes the assurance back without
+    // breaking the live session.
+    assert!(f.overlay.revoke_promotion(&client.identity()));
+    let revoked = ObservingService::new("overlay-promote-3");
+    dispatch(&revoked, &client.signed_request("overlay-promote-3", b"revoked"))
+        .await
+        .expect("revoking a promotion does not break verifiability");
+    assert_eq!(
+        revoked.observed_key_material(),
+        Some(VerifiedKeyMaterial::Classical),
+        "a revoked promotion returns to first-contact continuity"
+    );
+    assert!(f.store.is_empty());
+}
+
+/// Rotation is permitted, but only through the same visible path an attack
+/// takes: the refusal event is what an approval is built from.
+#[tokio::test]
+async fn rotation_travels_the_visible_rebinding_path() {
+    let f = fixtures();
+    let mut client = DynamicClient::new(0xA7);
+    let service = ObservingService::new("overlay-rotate");
+
+    dispatch(&service, &client.signed_request("overlay-rotate", b"old"))
+        .await
+        .unwrap();
+
+    client.pq_sk = ml_dsa_sk_from_seed(&[0xB7; 32]);
+    let rotated_key = client.pq_vk();
+
+    // The rotated key is refused at the verify path first.
+    let blocked = ObservingService::new("overlay-rotate-2");
+    dispatch(&blocked, &client.signed_request("overlay-rotate-2", b"new"))
+        .await
+        .expect_err("rotation is not silently accepted");
+
+    // The operator reviews the surfaced event and approves it.
+    let FirstContactOutcome::RebindRefused(event) = f
+        .overlay
+        .observe_first_contact(client.identity(), &rotated_key)
+    else {
+        panic!("the overlay must surface the rebinding rather than apply it");
+    };
+    assert!(f
+        .overlay
+        .apply_rebind(event.approve(PqProvenance::TofuBound, "operator-reviewed rotation")));
+
+    let after = ObservingService::new("overlay-rotate-3");
+    dispatch(&after, &client.signed_request("overlay-rotate-3", b"new"))
+        .await
+        .expect("an approved rotation is accepted");
+    assert_eq!(
+        after.observed_key_material(),
+        Some(VerifiedKeyMaterial::Classical),
+        "an approved rotation confers no trust of its own"
+    );
+    assert!(f.store.is_empty());
+}

--- a/crates/hyprstream-rpc/tests/session_pq_overlay_dispatch.rs
+++ b/crates/hyprstream-rpc/tests/session_pq_overlay_dispatch.rs
@@ -17,7 +17,11 @@
 //!   and leaves the binding intact;
 //! - a self-asserted key the client cannot actually sign with is never recorded;
 //! - a PQ-less envelope from a bound identity does not clear the binding;
-//! - an out-of-band promotion does raise assurance, and can be revoked.
+//! - an out-of-band promotion does raise assurance, and can be revoked;
+//! - a captured envelope cannot be re-outer-signed to squat the sender's
+//!   binding, at this node or at one that cannot even decrypt the request;
+//! - an admin-anchored key always wins over an overlay entry;
+//! - a flood of self-minted identities cannot lock legitimate clients out.
 
 #![allow(clippy::unwrap_used, clippy::expect_used)]
 
@@ -77,12 +81,45 @@ impl PqBindingEventSink for RecordingSink {
     }
 }
 
+/// Stands in for the admin-anchored `KeyedPqTrustStore`, which is immutable
+/// after install. Tests need to enroll a key mid-run to exercise precedence,
+/// and need to read the store back to prove the overlay never wrote through to
+/// it.
+#[derive(Default)]
+struct AnchoredStore {
+    bindings: Mutex<std::collections::HashMap<[u8; 32], Vec<u8>>>,
+}
+
+impl AnchoredStore {
+    fn bind(&self, identity: [u8; 32], vk: &MlDsaVerifyingKey) {
+        self.bindings
+            .lock()
+            .insert(identity, hyprstream_rpc::crypto::pq::ml_dsa_vk_bytes(vk));
+    }
+    fn unbind(&self, identity: &[u8; 32]) {
+        self.bindings.lock().remove(identity);
+    }
+    fn has(&self, identity: &[u8; 32]) -> bool {
+        self.bindings.lock().contains_key(identity)
+    }
+}
+
+impl envelope::PqTrustStore for AnchoredStore {
+    fn ml_dsa_key_for(&self, ed25519_pubkey: &[u8; 32]) -> Option<MlDsaVerifyingKey> {
+        self.bindings
+            .lock()
+            .get(ed25519_pubkey)
+            .and_then(|b| ml_dsa_vk_from_bytes(b).ok())
+    }
+}
+
 struct Fixtures {
     server_sk: SigningKey,
     overlay: Arc<SessionPqOverlay>,
     sink: Arc<RecordingSink>,
-    /// The admin-anchored store, kept so tests can assert it never grew.
-    store: Arc<envelope::KeyedPqTrustStore>,
+    /// The admin-anchored store, kept so tests can prove the overlay never
+    /// wrote through to it.
+    anchored: Arc<AnchoredStore>,
 }
 
 fn fixtures() -> &'static Fixtures {
@@ -92,11 +129,10 @@ fn fixtures() -> &'static Fixtures {
 
         // An EMPTY admin-anchored store: no operator enrolled anybody. This is
         // the state a real deployment is in with respect to a browser.
-        let store = Arc::new(envelope::KeyedPqTrustStore::new());
-        assert!(store.is_empty());
+        let anchored = Arc::new(AnchoredStore::default());
         envelope::install_verify_config(envelope::EnvelopeVerifyConfig {
             policy: hyprstream_rpc::crypto::CryptoPolicy::Hybrid,
-            pq_store: Some(store.clone()),
+            pq_store: Some(anchored.clone()),
         })
         .expect("verify config installs once per test binary");
 
@@ -109,7 +145,7 @@ fn fixtures() -> &'static Fixtures {
             server_sk,
             overlay,
             sink,
-            store,
+            anchored,
         }
     })
 }
@@ -264,6 +300,42 @@ async fn dispatch(service: &ObservingService, signed: &SignedEnvelope) -> Result
     .await
 }
 
+/// Rewrite only the OUTER ML-DSA layer, keeping the sender's inner EdDSA
+/// COSE_Sign1 byte-for-byte. Uses **no** Ed25519 private key — the whole point
+/// is that holding the captured bytes is enough to do this.
+fn swap_outer_layer(signed: &mut SignedEnvelope, attacker_pq: &MlDsaSigningKey) -> Vec<u8> {
+    use hyprstream_rpc::crypto::cose_sign::{decode_composite_for_test, encode_composite_for_test};
+
+    let payload = signed
+        .encrypted_envelope
+        .clone()
+        .expect("the mesh-kem shape signs over the ciphertext");
+    let aad = hyprstream_rpc::crypto::cose_sign1::build_external_aad(
+        envelope::ENVELOPE_SCHEMA_ID,
+        envelope::REQUEST_ENVELOPE_TYPE_ID,
+    );
+    let (inner_bytes, _) = decode_composite_for_test(&signed.cose).unwrap();
+    let (ed_sig, _) =
+        hyprstream_rpc::crypto::cose_sign::split_composite(&signed.cose).unwrap();
+
+    let attacker_kid = ml_dsa_sk_to_vk_bytes(attacker_pq);
+    let tbs = hyprstream_rpc::crypto::cose_sign::outer_tbs(
+        attacker_kid.clone(),
+        &payload,
+        &ed_sig,
+        &aad,
+    );
+    let attacker_sig = hyprstream_rpc::crypto::pq::ml_dsa_sign(attacker_pq, &tbs);
+    let attacker_outer = hyprstream_rpc::crypto::cose_sign::outer_layer_for_test(
+        attacker_kid.clone(),
+        attacker_sig,
+    )
+    .unwrap();
+
+    signed.cose = encode_composite_for_test(inner_bytes, Some(attacker_outer)).unwrap();
+    attacker_kid
+}
+
 fn refusals_for(identity: &[u8; 32]) -> usize {
     fixtures()
         .sink
@@ -320,7 +392,7 @@ async fn unenrolled_hybrid_client_dispatches_and_stays_classical() {
 
     // The admin-anchored store was consulted, never written.
     assert!(
-        f.store.is_empty(),
+        !f.anchored.has(&client.identity()),
         "the overlay must never write through to the admin-anchored store"
     );
 }
@@ -346,7 +418,7 @@ async fn an_established_binding_serves_later_requests() {
         "the binding is recorded once, not re-recorded per request"
     );
     assert_eq!(refusals_for(&client.identity()), 0);
-    assert!(f.store.is_empty());
+    assert!(!f.anchored.has(&client.identity()));
 }
 
 /// The service-worker / cache-replacement case: the same identity comes back
@@ -391,7 +463,7 @@ async fn a_different_pq_key_for_a_bound_identity_is_refused_and_surfaced() {
         ),
         hyprstream_rpc::crypto::pq::ml_dsa_vk_bytes(&original_key)
     );
-    assert!(f.store.is_empty());
+    assert!(!f.anchored.has(&client.identity()));
 }
 
 /// The rebinding alarm must be attributable. Anyone can copy a public key into
@@ -434,7 +506,7 @@ async fn a_rebinding_alarm_cannot_be_injected_by_a_stranger() {
         ),
         hyprstream_rpc::crypto::pq::ml_dsa_vk_bytes(&victim.pq_vk())
     );
-    assert!(f.store.is_empty());
+    assert!(!f.anchored.has(&victim.identity()));
 }
 
 /// A PQ key the client asserts but cannot sign with must never be recorded:
@@ -467,7 +539,7 @@ async fn an_unusable_self_asserted_key_is_never_recorded() {
         "nothing may be recorded for a composite that did not verify"
     );
     assert_eq!(first_contacts_for(&client.identity()), 0);
-    assert!(f.store.is_empty());
+    assert!(!f.anchored.has(&client.identity()));
 }
 
 /// Downgrade monotonicity: an envelope arriving without the PQ layer from an
@@ -508,7 +580,220 @@ async fn a_pq_less_envelope_does_not_clear_an_established_binding() {
         f.overlay.provenance_for(&client.identity()),
         Some(PqProvenance::TofuBound)
     );
-    assert!(f.store.is_empty());
+    assert!(!f.anchored.has(&client.identity()));
+}
+
+/// The outer layer of a captured envelope can be re-signed by anyone who holds
+/// the bytes — the nesting binds inner→outer, not outer→inner. If first contact
+/// recorded such a composite, an attacker with no Ed25519 key would squat the
+/// sender's binding and lock them out of their own identity.
+///
+/// The inner layer's commitment to the key above it is what makes that
+/// impossible, and this is the proof.
+#[tokio::test]
+async fn an_outer_layer_swap_cannot_squat_the_senders_binding() {
+    let f = fixtures();
+    let victim = DynamicClient::new(0xA9);
+    let attacker_pq = ml_dsa_sk_from_seed(&[0xEE; 32]);
+
+    // The victim's own genuine envelope, as any node it talks to receives it.
+    let mut captured = victim.signed_request("overlay-swap", b"legitimate work");
+    let attacker_kid = swap_outer_layer(&mut captured, &attacker_pq);
+
+    let service = ObservingService::new("overlay-swap");
+    dispatch(&service, &captured)
+        .await
+        .expect_err("a re-outer-signed capture must not be served");
+    assert!(!service.was_invoked());
+
+    assert!(
+        f.overlay.provenance_for(&victim.identity()).is_none(),
+        "no binding may be established from a composite whose Ed25519 signature \
+         does not cover the PQ key being claimed"
+    );
+
+    // And the victim is not locked out of their own identity.
+    let victim_svc = ObservingService::new("overlay-swap-2");
+    dispatch(
+        &victim_svc,
+        &victim.signed_request("overlay-swap-2", b"hello"),
+    )
+    .await
+    .expect("the victim still owns their identity");
+    assert_eq!(
+        hyprstream_rpc::crypto::pq::ml_dsa_vk_bytes(
+            &f.overlay.verifying_key_for(&victim.identity()).unwrap()
+        ),
+        hyprstream_rpc::crypto::pq::ml_dsa_vk_bytes(&victim.pq_vk())
+    );
+    assert_ne!(
+        hyprstream_rpc::crypto::pq::ml_dsa_vk_bytes(&victim.pq_vk()),
+        attacker_kid
+    );
+    assert!(!f.anchored.has(&victim.identity()));
+}
+
+/// The recording guard, pinned on its own. A composite signed by the true key
+/// holder but WITHOUT the inner commitment is perfectly valid — it just does
+/// not prove the Ed25519 private key was involved in choosing the PQ key, so it
+/// must not establish a binding. This is what stands between a captured
+/// envelope and a squatted identity even if the signing side regresses.
+#[tokio::test]
+async fn an_uncommitted_composite_cannot_establish_a_binding() {
+    use ed25519_dalek::Signer as _;
+    use hyprstream_rpc::crypto::cose_sign::{assemble_composite_nested, inner_tbs, outer_tbs};
+
+    let f = fixtures();
+    let client = DynamicClient::new(0xAC);
+    let mut signed = client.signed_request("overlay-uncommitted", b"hello");
+
+    // Sign the same payload properly, with both real private keys, in the
+    // UNBOUND shape — what an older client emits, or what a regression in the
+    // signing side would emit. Every signature here is genuine.
+    let payload = signed.encrypted_envelope.clone().unwrap();
+    let aad = hyprstream_rpc::crypto::cose_sign1::build_external_aad(
+        envelope::ENVELOPE_SCHEMA_ID,
+        envelope::REQUEST_ENVELOPE_TYPE_ID,
+    );
+    let ed_kid = signed.cnf.to_vec();
+    let pq_kid = ml_dsa_sk_to_vk_bytes(&client.pq_sk);
+    let ed_sig = client
+        .ed_sk
+        .sign(&inner_tbs(ed_kid.clone(), &payload, &aad, true))
+        .to_bytes()
+        .to_vec();
+    let pq_sig = hyprstream_rpc::crypto::pq::ml_dsa_sign(
+        &client.pq_sk,
+        &outer_tbs(pq_kid.clone(), &payload, &ed_sig, &aad),
+    );
+    signed.cose =
+        assemble_composite_nested((ed_kid, ed_sig), Some((pq_kid, pq_sig))).unwrap();
+
+    let service = ObservingService::new("overlay-uncommitted");
+    dispatch(&service, &signed)
+        .await
+        .expect_err("an uncommitted composite must not establish a binding");
+    assert!(!service.was_invoked());
+    assert!(f.overlay.provenance_for(&client.identity()).is_none());
+    assert!(!f.anchored.has(&client.identity()));
+}
+
+/// The overlay commit runs inside `verify_cose`, which the envelope lifecycle
+/// executes before decryption and before the replay-nonce commit. So a captured
+/// envelope re-aimed at a node that cannot even decrypt it still reaches the
+/// recording step — and must still record nothing.
+#[tokio::test]
+async fn a_capture_replayed_at_a_node_that_cannot_decrypt_records_nothing() {
+    let f = fixtures();
+    let victim = DynamicClient::new(0xAA);
+    let attacker_pq = ml_dsa_sk_from_seed(&[0xED; 32]);
+
+    let mut captured = victim.signed_request("overlay-crossnode", b"work for node A");
+    swap_outer_layer(&mut captured, &attacker_pq);
+
+    // A different node: different signing key, so a different `#mesh-kem`
+    // recipient and no way to open the ciphertext.
+    let (other_node_sk, _) = generate_signing_keypair();
+    let service = ObservingService::new("overlay-crossnode");
+    support::install_explicit_dispatch_pep();
+    let res = process_request(
+        &to_wire(&captured),
+        &service,
+        EnvelopeVerification::AnySigner,
+        &other_node_sk,
+        &envelope::InMemoryNonceCache::new(),
+        CarrierContext::iroh(),
+    )
+    .await;
+
+    assert!(res.is_err());
+    assert!(!service.was_invoked());
+    assert!(
+        f.overlay.provenance_for(&victim.identity()).is_none(),
+        "an undeliverable replay must not poison a node's binding table"
+    );
+    assert!(!f.anchored.has(&victim.identity()));
+}
+
+/// An admin-anchored enrollment outranks anything the overlay holds, and the
+/// two answers — which key verifies, and how much assurance it carries — stay
+/// pinned together. Without this, a reordering would let a session-scoped key
+/// inherit the anchored `PqHybrid` assurance.
+#[tokio::test]
+async fn an_admin_anchored_key_outranks_an_overlay_entry() {
+    let f = fixtures();
+    let client = DynamicClient::new(0xAB);
+
+    // The operator enrolls K1 for this identity out of band.
+    let anchored_pq = ml_dsa_sk_from_seed(&[0xC1; 32]);
+    let anchored_vk = ml_dsa_vk_from_bytes(&ml_dsa_sk_to_vk_bytes(&anchored_pq)).unwrap();
+    f.anchored.bind(client.identity(), &anchored_vk);
+
+    // The overlay independently holds K2 for the same identity.
+    let overlay_vk = client.pq_vk();
+    let _ = f
+        .overlay
+        .observe_first_contact(client.identity(), &overlay_vk);
+    assert_ne!(
+        hyprstream_rpc::crypto::pq::ml_dsa_vk_bytes(&anchored_vk),
+        hyprstream_rpc::crypto::pq::ml_dsa_vk_bytes(&overlay_vk)
+    );
+
+    // A request signed with the ANCHORED key verifies, and carries the
+    // anchored assurance.
+    let anchored_client = DynamicClient {
+        ed_sk: client.ed_sk.clone(),
+        pq_sk: anchored_pq,
+    };
+    let svc = ObservingService::new("overlay-precedence");
+    dispatch(
+        &svc,
+        &anchored_client.signed_request("overlay-precedence", b"anchored"),
+    )
+    .await
+    .expect("the admin-anchored key must be the verify anchor");
+    assert_eq!(
+        svc.observed_key_material(),
+        Some(VerifiedKeyMaterial::PqHybrid),
+        "assurance must come from the store, not from the overlay entry"
+    );
+
+    // A request signed with the OVERLAY key is rejected: the overlay must not
+    // shadow the enrollment.
+    let shadow = ObservingService::new("overlay-precedence-2");
+    dispatch(
+        &shadow,
+        &client.signed_request("overlay-precedence-2", b"overlay"),
+    )
+    .await
+    .expect_err("an overlay entry must not shadow an admin-anchored key");
+    assert!(!shadow.was_invoked());
+
+    f.anchored.unbind(&client.identity());
+}
+
+/// A flood of self-minted identities costs an attacker nothing but keypairs and
+/// runs before authorization. It must not be able to switch the feature off for
+/// everyone else.
+#[tokio::test]
+async fn a_flood_of_self_minted_identities_does_not_lock_out_new_clients() {
+    let f = fixtures();
+    let flood_overlay = SessionPqOverlay::new(Arc::new(RecordingSink::default())).with_max_entries(3);
+
+    for i in 0..6u8 {
+        let flooder = DynamicClient::new(0xF0 + i);
+        let _ = flood_overlay.observe_first_contact(flooder.identity(), &flooder.pq_vk());
+    }
+    assert_eq!(flood_overlay.len(), 3);
+
+    // A genuine new client still gets in.
+    let legit = DynamicClient::new(0x0C);
+    assert!(matches!(
+        flood_overlay.observe_first_contact(legit.identity(), &legit.pq_vk()),
+        FirstContactOutcome::Recorded
+    ));
+    assert!(flood_overlay.verifying_key_for(&legit.identity()).is_some());
+    assert!(!f.anchored.has(&legit.identity()));
 }
 
 /// Out-of-band promotion is the only route to `PqHybrid`, and it is reversible.
@@ -556,7 +841,7 @@ async fn out_of_band_promotion_raises_assurance_and_can_be_revoked() {
         Some(VerifiedKeyMaterial::Classical),
         "a revoked promotion returns to first-contact continuity"
     );
-    assert!(f.store.is_empty());
+    assert!(!f.anchored.has(&client.identity()));
 }
 
 /// Rotation is permitted, but only through the same visible path an attack
@@ -600,5 +885,5 @@ async fn rotation_travels_the_visible_rebinding_path() {
         Some(VerifiedKeyMaterial::Classical),
         "an approved rotation confers no trust of its own"
     );
-    assert!(f.store.is_empty());
+    assert!(!f.anchored.has(&client.identity()));
 }

--- a/crates/hyprstream/src/bin/main.rs
+++ b/crates/hyprstream/src/bin/main.rs
@@ -1712,6 +1712,22 @@ fn install_envelope_verify_config(oauth: Option<&hyprstream_core::config::OAuthC
 ///
 /// Set `HYPRSTREAM_SESSION_PQ_OVERLAY=0` for a mesh-only deployment that wants
 /// every unenrolled identity rejected at the envelope layer as before.
+///
+/// # Operator limitations at this revision — read before enabling
+///
+/// The overlay's approve / promote / revoke operations exist as library calls
+/// and have **no operator surface yet**: nothing here, no RPC method, no CLI.
+/// Two consequences an operator must know about up front:
+///
+/// - Every binding stays at first-contact provenance for its lifetime.
+///   Out-of-band promotion is unreachable, so the overlay cannot raise MAC
+///   assurance for anyone — a browser client is `Classical` and stays there.
+/// - A refused rebinding is loud but **unanswerable**. A client that rotates
+///   its ML-DSA-65 key while keeping its Ed25519 identity is refused here,
+///   cannot be approved (no surface), and cannot be routed around through the
+///   admin-anchored store (immutable after install). Restarting the daemon
+///   clears the overlay and is currently the only way through. Until the
+///   operator surface lands, plan rotations around a restart.
 fn install_session_pq_overlay() {
     let disabled = std::env::var("HYPRSTREAM_SESSION_PQ_OVERLAY")
         .map(|v| matches!(v.trim(), "0" | "false" | "off" | "no"))
@@ -1730,7 +1746,9 @@ fn install_session_pq_overlay() {
         tracing::info!(
             "session PQ overlay installed: unenrolled identities bind their ML-DSA-65 key \
              at first contact (verifiable, assurance capped at Classical); rebinding an \
-             established identity is refused and surfaced, never silently applied"
+             established identity is refused and surfaced, never silently applied. \
+             No approve/promote/revoke surface exists yet: a refused rebinding requires \
+             a daemon restart to clear."
         );
     }
 }

--- a/crates/hyprstream/src/bin/main.rs
+++ b/crates/hyprstream/src/bin/main.rs
@@ -1696,6 +1696,43 @@ fn install_envelope_verify_config(oauth: Option<&hyprstream_core::config::OAuthC
              peer ML-DSA bindings required for cross-node traffic"
         );
     }
+
+    install_session_pq_overlay();
+}
+
+/// Install the session PQ binding overlay, the runtime anchoring path for
+/// clients no operator can pre-enroll (browsers and other device-generated
+/// identities).
+///
+/// It is consulted only after the admin-anchored store above misses, so it
+/// cannot displace an operator's enrollment, and a binding it establishes at
+/// first contact is capped at `Classical` assurance — it makes a request
+/// verifiable, it does not make the requester more trusted. Promotion to
+/// `PqHybrid` requires an out-of-band fingerprint comparison.
+///
+/// Set `HYPRSTREAM_SESSION_PQ_OVERLAY=0` for a mesh-only deployment that wants
+/// every unenrolled identity rejected at the envelope layer as before.
+fn install_session_pq_overlay() {
+    let disabled = std::env::var("HYPRSTREAM_SESSION_PQ_OVERLAY")
+        .map(|v| matches!(v.trim(), "0" | "false" | "off" | "no"))
+        .unwrap_or(false);
+    if disabled {
+        tracing::info!(
+            "session PQ overlay disabled by configuration; identities without an \
+             admin-anchored ML-DSA-65 key are rejected at the envelope layer"
+        );
+        return;
+    }
+    let overlay = std::sync::Arc::new(hyprstream_rpc::session_pq_overlay::SessionPqOverlay::new(
+        std::sync::Arc::new(hyprstream_rpc::session_pq_overlay::TracingPqBindingEventSink),
+    ));
+    if hyprstream_rpc::session_pq_overlay::install_session_pq_overlay(overlay).is_ok() {
+        tracing::info!(
+            "session PQ overlay installed: unenrolled identities bind their ML-DSA-65 key \
+             at first contact (verifiable, assurance capped at Classical); rebinding an \
+             established identity is refused and surfaced, never silently applied"
+        );
+    }
 }
 
 fn main() -> Result<()> {


### PR DESCRIPTION
Implements the ADR proposed on #1426 ("TOFU binding with out-of-band promotion") and closes the blocker in #1484: a browser/dynamic client's Ed25519 identity is user/device-generated, so no operator can pre-enroll it in the admin-anchored `KeyedPqTrustStore`, and under the production-mandatory Hybrid suite `ml_dsa_key_for` returns `None` and the request is dropped without a signed reply.

Refs #1484, #1426.

## What lands

A `SessionPqOverlay` (`crates/hyprstream-rpc/src/session_pq_overlay.rs`), additive and consulted by the envelope verify path **after** the admin-anchored store misses. It never mutates `KeyedPqTrustStore` — that store's contract says entries are established out-of-band, and the federation perimeter deliberately leaves it untouched. Consult-then-fall-back, no write-through.

Three provenance states, as specified:

| state | recorded as | signature verifies? | MAC assurance |
|---|---|---|---|
| `Classical` | absence of an entry | n/a | Classical |
| `TofuBound` | first contact | yes | **capped at Classical** |
| `OobVerified` | fingerprint confirmed out of band | yes | may raise to `PqHybrid` |

### The verifiability/trust separation is structural, not conventional

The overlay answers the two questions through two methods that share no return type:

- `verifying_key_for(&cnf) -> Option<MlDsaVerifyingKey>` — returns a key and *nothing else*. The verify path cannot learn provenance from it, so it cannot launder it into an assurance decision.
- `provenance_for(&cnf) -> Option<PqProvenance>` — the MAC seam (`EnvelopeContext::verified_key_material`) reads this, and `PqProvenance::key_material()` is the single mapping; `TofuBound` maps to `Classical` there.

### Rebinding is loud by construction

This is the defect class the independent crypto review found in #1480 (silent last-write-wins PQ rebind via the mesh_peers→bootstrap seeding order), so it is enforced by the type/API rather than by convention:

- `observe_first_contact` writes only into a **vacant or lapsed** slot. A live entry naming a different key returns `FirstContactOutcome::RebindRefused(RebindEvent)`, and the event is published to the sink **before** that value is returned — a caller that discards the return value has still surfaced it.
- The only way to change an established binding is `apply_rebind(RebindApproval)`. A `RebindApproval` can only be built by consuming a `RebindEvent`, which only the overlay mints, and only by refusing a rebind. There is no other constructor. Legitimate rotation therefore travels the same visible path as an attack.
- `apply_rebind` re-checks that the binding still matches the one the event described, so a stale approval does not apply.

### The alarm is attributable

A rebinding event is raised only after the inner EdDSA layer verifies as the identity in question (`verify_composite` with `require_pq = false`). `cnf` is copyable public data; without this check anyone who knows a victim's public key could inject security events about that victim, and an event channel unauthenticated senders can drive is worse than none. Covered by `a_rebinding_alarm_cannot_be_injected_by_a_stranger`.

### Recording requires the identity's own signature to cover the PQ key

**This is the correction from the review round — the original revision of this PR got it wrong.**

The first revision claimed that verifying the whole composite before recording proved possession of both private keys. It does not. The nested composite binds inner→outer (the outer ML-DSA-65 layer signs `payload ‖ inner_signature`) and **not** outer→inner: the inner EdDSA layer commits to nothing about which ML-DSA key sits above it. So a verifying composite proves possession of the ML-DSA-65 key plus possession of **one replayable Ed25519 signature**.

The attack the reviewer reproduced end-to-end: take one genuine envelope from a client, keep its inner EdDSA layer byte-for-byte, re-sign `payload ‖ inner_signature` with an ML-DSA key you generated, reassemble. The composite verifies completely — attacker's PQ key, victim's identity. First contact then recorded the attacker's key against the victim's identity, and the victim's next genuine request was refused as a rebinding with the alarm attributed to *them*. Because the overlay commit runs before decryption and before the replay-nonce commit, a capture re-aimed at a node that could not even decrypt it poisoned that node too. Cost: one capture inside the 5-minute timestamp window — available to any node, relay, or component in the client's path.

That asymmetry was harmless while the PQ key was always resolved from the admin-anchored store (a mismatched `kid` simply fails). Turning the outer `kid` into a **recorded** value is what made it a defect, and that is what this PR does.

**Fix.** The inner EdDSA layer now names the ML-DSA-65 key above it in its COSE protected header (`PQ_BINDING_HEADER_LABEL`). RFC 9052 folds the protected header into the `Sig_structure`, so the commitment is covered by the Ed25519 signature: swapping the outer layer contradicts the inner header, and removing the header breaks the inner signature. `verify_composite` reports it as `CompositeVerified::pq_bound`, and first contact refuses to record without it.

Two independent defenses, each pinned by its own failing mutant:

| defense | mutant that kills it | test that fails |
|---|---|---|
| request envelopes sign with the commitment | sign unbound | `an_outer_layer_swap_cannot_squat_the_senders_binding` |
| recording requires `pq_bound` | drop the guard | `an_uncommitted_composite_cannot_establish_a_binding` |

Removing **both** reproduces the reviewer's squat exactly (3 tests fail).

### Compatibility of the format change — assessed plainly

The change is **additive and opt-in**, not a wire break:

- `sign_composite` is untouched. Every persisted decomposed signature — at9p capsules, DID operations, the PLC directory, UCAN tokens, approvals, event attestations, stream provenance, browser provisioning — is byte-identical, and its `split_composite` → store → `assemble_composite_nested` round-trip still matches. Pinned by `the_binding_is_additive_for_verifiers_that_do_not_know_it` and by the 44 pre-existing crypto tests, all unchanged and green.
- Only **request envelopes** (`envelope.rs`) and the **browser out-of-band signer** (`rpc_client.rs`) emit the commitment. Response envelopes deliberately do not: their key is anchored client-side and never recorded.
- **Old verifier + new client**: verifies. coset preserves the received protected bytes for the TBS, so an unknown label is carried through and simply not interpreted.
- **New verifier + old client**: verifies, `pq_bound = false`. Anchored peers are wholly unaffected. The one deliberate cost: an old client cannot obtain a TOFU binding until it upgrades — and it fails closed, not open.

### Fingerprint covers the pair

`composite_fingerprint` is SHA-256 over `domain ‖ ed25519 ‖ ml_dsa_65`. Fingerprinting the PQ half alone would confirm possession of a key without binding it to the identity it claims — the substitution the comparison exists to catch. `promote_out_of_band` recomputes from the recorded pairing and compares in constant time; it cannot invent a binding for an identity the node never observed.

### Capacity pressure is an availability question, not only a memory one

A full overlay previously refused every new first contact until entries lapsed. Recording costs an attacker only a self-minted keypair — no enrollment, no credential — and `verify_cose` runs before authorization, so filling 4096 slots was seconds of work and handed an unauthenticated party an off-switch for the whole feature for the TTL.

The table now evicts the least-recently-seen `TofuBound` entry instead, and **never** evicts a promoted one. The worst an attacker achieves is resetting other identities' change detection — the same exposure a TTL lapse already carries — while legitimate clients keep connecting. If every slot holds a promotion, the new binding is refused rather than operator-established trust discarded.

### The rebind path can no longer record

`observe_first_contact`'s contract is "the composite already verified against this key". The rebind branch violated it — it passes a key that has *not* been checked — and was safe only because a live entry forced the refusing arm. A binding lapsing between the lookup and the call would have sent an unproven key down the recording path. It now uses `surface_rebind`, which is publish-only and cannot record under any interleaving.

### Revocation

`revoke_promotion` demotes `OobVerified → TofuBound` (withdraws trust, keeps the live session verifiable); `revoke_binding` removes the entry entirely. `TofuBound` entries carry a TTL and lapse; `OobVerified` entries carry no deadline, which is exactly why they need the explicit path.

### Wiring

`install_session_pq_overlay()` in `crates/hyprstream/src/bin/main.rs`, alongside the existing verify-config install. On by default; `HYPRSTREAM_SESSION_PQ_OVERLAY=0` restores the previous mesh-only posture (every unenrolled identity rejected at the envelope layer). With no overlay installed the verify path behaves exactly as before.

**The `did:at9p` admission arm is deliberately NOT wired here.** Per the ADR it needs a browser-shaped capsule issuer that does not exist; it stays a future route to `OobVerified`.

## Tests

`crates/hyprstream-rpc/tests/session_pq_overlay_dispatch.rs` — 13 tests through the real `service::dispatch::process_request` pipeline, with **no `store.bind()` call anywhere in the file**. #1483 identifies that hand-bind as what masks this gap in every current hybrid test; the store installed here is empty and every test asserts it is *still* empty afterwards, so the overlay cannot be quietly writing through to it.

Revert-verified: with the `install_session_pq_overlay` call removed from the fixture, 6 of the original 8 fail (the two that survive are negative tests, as expected). The existing hybrid tests are untouched.

Coverage: first-contact dispatch + Classical assurance; established binding serves later requests; a different PQ key is refused, surfaced, and does not overwrite; alarm injection by a stranger; unusable self-asserted key never recorded; PQ-less envelope does not clear a binding; out-of-band promotion raises assurance and is revocable; rotation through the approval path.

**From this review round** — the reviewer's probe lands as `an_outer_layer_swap_cannot_squat_the_senders_binding` (assertion inverted, since the squat no longer succeeds), plus its cross-node variant `a_capture_replayed_at_a_node_that_cannot_decrypt_records_nothing`, the `an_uncommitted_composite_cannot_establish_a_binding` guard, K3's F2 precedence test (`an_admin_anchored_key_outranks_an_overlay_entry`, asserting *both* that the anchored key is the verify anchor and that assurance comes from the store), and a capacity-flood test.

18 unit tests in the module cover TTL lapse, LRU eviction, promoted-entry pinning, publish-only rebind surfacing, stale approvals, fingerprint coverage of both halves, and an exhaustive check that exactly one provenance variant can reach `PqHybrid`.

5 new crypto-layer tests in `hyprstream-crypto` cover all three outer-swap routes (keep the victim's inner verbatim; rename the binding; drop the binding), outer-strip rejection, the additive round-trip, and the out-of-band signing path.

## Local verification

- `cargo clippy --workspace --all-targets -- -D warnings` (the real CI command, not the pre-commit hook's `--all-targets`-less variant): **green**.
- `cargo test -p hyprstream-rpc -p hyprstream-crypto`: **green**, including all 8 new integration tests and 16 new unit tests.
- `cargo test --workspace`: 28 suites ok, **0 test failures**.
- `.github/scripts/browser-wasm-check.sh` (the wasm32 browser gate): **green**.
- The `hyprstream --lib` binary exits abnormally (status 100) in the embedded-PostgreSQL area — `PostgreSQL stand-alone backend 17.5 / backend>` immediately before the abort, no named test failing. **This is pre-existing:** it reproduces identically on a clean worktree of `origin/main` @ `d112678f1`, the base of this branch. Not introduced here, and unchanged by this round.
- Re-run after the fix: `cargo clippy --workspace --all-targets -- -D warnings` green, release clippy green (pre-commit), `cargo test --workspace` 28 suites ok / 0 failures, wasm32 browser gate green, `hyprstream-rpc` + `hyprstream-crypto` fully green.

## What I did NOT verify


- **No real browser was driven.** The tests use a synthetic hybrid client, not `JsSigner::new_hybrid` in a browser over WebTransport, and use `CarrierContext::iroh()` rather than `browser_web_transport()`. `verify_cose` is a single funnel with no browser exemption, so the crypto path is the same one, but the browser leg of #1484's acceptance criterion is untested here.
- **Change detection is bounded by the TTL** (12h default). A lapsed binding is by design forgotten, so a substitution after the idle window is recorded as a genuine first contact rather than challenged. Documented on `observe_first_contact`. A promotion removes the deadline; that is the durable answer for an identity worth pinning.
- **CPU amplification.** An unanchored identity now costs the server an ML-DSA-65 verification against an attacker-chosen key, where it previously bailed before any PQ work. The overlay is capacity-bounded (4096 default, fail-closed when full), but I did not benchmark this or model the rate.
- **No operator surface for approve / promote / revoke.** Tracked as #1487. Consequences an operator must know: every binding stays `TofuBound` for its lifetime (so `OobVerified` is unreachable and the overlay cannot raise assurance for anyone today), and **a refused rebinding currently requires a daemon restart** — it cannot be approved, and cannot be routed around through the immutable anchored store. This is now documented on `install_session_pq_overlay`. Note the ordering constraint the reviewer flagged: the unreachability of promotion is what keeps an overlay defect DoS rather than escalation, so a promotion surface must not land against a regression in the `pq_bound` requirement.
- **The audit journal is not wired.** `PqBindingEventSink` docs say implementors should route to the audit journal; the installed sink routes to `tracing`. Same follow-up.
- **`authenticated_pq_signer_key()` and the UCAN verifier still consult the admin store only.** A TOFU- or OOB-bound identity yields `None` there and cannot have UCAN chains validated. That is the conservative reading of "trusted PQ key" and is deliberate, but it means an `OobVerified` browser is `PqHybrid` for MAC assurance while being invisible to those two paths — worth a reviewer's opinion on whether that asymmetry should close.
- **The out-of-band channel itself is out of scope.** The overlay verifies that a presented fingerprint matches the recorded pairing; it cannot verify where the operator got the value. No promotion API is exposed over RPC/HTTP in this PR — promotion is a library call only, so nothing remote can reach it yet.
- No persistence: the overlay is in-memory and process-scoped, so a restart forgets every `OobVerified` promotion too. That is a real gap for a promotion meant to outlive a session.
