### PR TITLE
fix(auth): mint hybrid service JWTs so fresh installs pass the Hybrid dispatch gate

### DIFF
--- a/crates/hyprstream-crypto/src/pq.rs
+++ b/crates/hyprstream-crypto/src/pq.rs
@@ -57,6 +57,14 @@ pub fn ml_dsa_sk_to_vk_bytes(key: &MlDsaSigningKey) -> Vec<u8> {
     ml_dsa_vk_bytes(&key.verifying_key())
 }
 
+/// Derive the ML-DSA-65 verifying key from a signing key.
+///
+/// Convenience for callers outside this crate that hold a signing key but do
+/// not depend on the `ml_dsa` crate's `Keypair` trait directly.
+pub fn ml_dsa_sk_to_vk(key: &MlDsaSigningKey) -> MlDsaVerifyingKey {
+    key.verifying_key().clone()
+}
+
 pub fn ml_dsa_vk_from_bytes(bytes: &[u8]) -> Result<MlDsaVerifyingKey> {
     let encoded = EncodedVerifyingKey::<MlDsa65>::try_from(bytes).map_err(|_| {
         anyhow::anyhow!("invalid ML-DSA-65 verifying key length (expected 1952 bytes)")

--- a/crates/hyprstream-discovery/src/service.rs
+++ b/crates/hyprstream-discovery/src/service.rs
@@ -6000,6 +6000,17 @@ impl DiscoveryHandler for DiscoveryService {
                     .ok_or_else(|| {
                         anyhow::anyhow!("Invalid service JWT in announce: unknown composite kid")
                     })?;
+                // Signing-domain separation: announcements assert a service
+                // identity, which is certified by the Policy/CA domain only —
+                // the ledger's Policy slot and the derived CA pair (registered
+                // under the Policy role). The OAuth-role pair signs browser
+                // and workload WITs and must not be able to certify a service
+                // announcement.
+                anyhow::ensure!(
+                    pair.role() == hyprstream_rpc::auth::CompositePairRole::Policy,
+                    "Invalid service JWT in announce: composite pair role is not authorized \
+                     for service certification"
+                );
                 hyprstream_rpc::auth::jwt::decode_composite(
                     &service_jwt,
                     pair.ml_dsa(),

--- a/crates/hyprstream-discovery/src/service.rs
+++ b/crates/hyprstream-discovery/src/service.rs
@@ -5978,15 +5978,50 @@ impl DiscoveryHandler for DiscoveryService {
         // R3: Verify service JWT signature + subject matches serviceName.
         // Full JWT verification (not decode_unverified) to prevent forged identities.
         if !service_jwt.is_empty() {
-            let verified = hyprstream_rpc::auth::jwt::decode_with_key(
-                &service_jwt,
-                &self.jwt_verifying_key,
-                self.expected_audience.as_deref(),
-            )
-            .map_err(|e| {
-                tracing::warn!("Service JWT verification failed in announce: {}", e);
-                anyhow::anyhow!("Invalid service JWT in announce: {}", e)
-            })?;
+            // Service JWTs are minted hybrid (ML-DSA-65-Ed25519); the composite
+            // kid resolves through the key source (ledger pairs + the CA
+            // composite pair). Classical EdDSA remains accepted here for
+            // tokens minted before the hybrid cutover.
+            let is_composite = hyprstream_rpc::auth::jwt::header_alg(&service_jwt)
+                .ok()
+                .flatten()
+                .is_some_and(|alg| alg == "ML-DSA-65-Ed25519");
+            let verified = if is_composite {
+                let dispatch =
+                    hyprstream_rpc::auth::jwt::parse_composite_dispatch(&service_jwt, &["wit+jwt"])
+                        .map_err(|e| {
+                            tracing::warn!("Service JWT dispatch failed in announce: {}", e);
+                            anyhow::anyhow!("Invalid service JWT in announce: {}", e)
+                        })?;
+                let pair = self
+                    .jwt_key_source
+                    .as_ref()
+                    .and_then(|ks| ks.composite_pair(dispatch.kid()))
+                    .ok_or_else(|| {
+                        anyhow::anyhow!("Invalid service JWT in announce: unknown composite kid")
+                    })?;
+                hyprstream_rpc::auth::jwt::decode_composite(
+                    &service_jwt,
+                    pair.ml_dsa(),
+                    pair.ed25519(),
+                    self.expected_audience.as_deref(),
+                    &dispatch,
+                )
+                .map_err(|e| {
+                    tracing::warn!("Service JWT verification failed in announce: {}", e);
+                    anyhow::anyhow!("Invalid service JWT in announce: {}", e)
+                })?
+            } else {
+                hyprstream_rpc::auth::jwt::decode_with_key(
+                    &service_jwt,
+                    &self.jwt_verifying_key,
+                    self.expected_audience.as_deref(),
+                )
+                .map_err(|e| {
+                    tracing::warn!("Service JWT verification failed in announce: {}", e);
+                    anyhow::anyhow!("Invalid service JWT in announce: {}", e)
+                })?
+            };
             // Check that sub matches "service:{serviceName}"
             let expected_sub = format!("service:{}", svc_name);
             if verified.sub != expected_sub {

--- a/crates/hyprstream-rpc/src/auth/composite.rs
+++ b/crates/hyprstream-rpc/src/auth/composite.rs
@@ -181,6 +181,14 @@ impl CompositeKeySet {
         self.snapshot.read().clone()
     }
 
+    /// Whether an on-disk composite signing authority has been configured for
+    /// this process. `false` means first bootstrap — no ledger exists yet —
+    /// which is distinct from a configured authority whose
+    /// [`CompositeKeySet::mint_snapshot`] fails (stale or pending cutover).
+    pub fn authority_configured(&self) -> bool {
+        self.authority.read().is_some()
+    }
+
     pub fn configure_authority(
         &self,
         ledger: PathBuf,

--- a/crates/hyprstream-rpc/src/auth/jwt.rs
+++ b/crates/hyprstream-rpc/src/auth/jwt.rs
@@ -326,6 +326,39 @@ pub fn encode_service_jwt(claims: &Claims, signing_key: &SigningKey) -> String {
     encode_with_header(&claims, signing_key, &header)
 }
 
+/// Encode a composite ML-DSA-65-Ed25519 service WIT (`typ: "wit+jwt"`).
+///
+/// Per draft-ietf-jose-pq-composite-sigs, the signature is
+/// `ml_dsa_sig (3309 bytes) ∥ ed25519_sig (64 bytes)` over
+/// `base64url(header).base64url(payload)`, and the `kid` is the
+/// [`composite_kid`] thumbprint binding the exact key pair — the shape
+/// [`parse_composite_dispatch`] and [`decode_composite`] verify.
+/// Automatically assigns a `jti` if the claims don't already have one.
+pub fn encode_service_jwt_hybrid(
+    claims: &Claims,
+    ed: &SigningKey,
+    ml_dsa: &crate::crypto::pq::MlDsaSigningKey,
+    ml_dsa_vk: &crate::crypto::pq::MlDsaVerifyingKey,
+) -> String {
+    let kid = composite_kid(ml_dsa_vk, &ed.verifying_key());
+    let header = format!(
+        r#"{{"alg":"ML-DSA-65-Ed25519","typ":"wit+jwt","kid":"{}"}}"#,
+        kid
+    );
+    let claims = ensure_jti(claims);
+    let header_b64 = URL_SAFE_NO_PAD.encode(&header);
+    let payload_json = serde_json::to_string(claims.as_ref()).unwrap_or_else(|_e| {
+        #[cfg(not(target_arch = "wasm32"))]
+        tracing::error!("JWT claims serialization failed: {}", _e);
+        "{}".to_owned()
+    });
+    let payload_b64 = URL_SAFE_NO_PAD.encode(&payload_json);
+    let signing_input = format!("{header_b64}.{payload_b64}");
+    let mut signature = crate::crypto::pq::ml_dsa_sign(ml_dsa, signing_input.as_bytes());
+    signature.extend_from_slice(&ed.sign(signing_input.as_bytes()).to_bytes());
+    format!("{signing_input}.{}", URL_SAFE_NO_PAD.encode(signature))
+}
+
 fn ensure_jti(claims: &Claims) -> std::borrow::Cow<'_, Claims> {
     if claims.jti.is_some() {
         std::borrow::Cow::Borrowed(claims)
@@ -768,6 +801,40 @@ mod tests {
         let separately_valid = composite_token_with_keys("wit+jwt", &pq_sk, &pq, &ed_sk);
         assert!(matches!(
             decode_composite(&separately_valid, &pq, &ed, None, &dispatch),
+            Err(JwtError::InvalidSignature)
+        ));
+    }
+
+    /// A freshly minted hybrid service WIT carries the composite alg/typ/kid
+    /// shape the dispatch path verifies, and round-trips through the real
+    /// composite verification (`parse_composite_dispatch` + `decode_composite`).
+    #[test]
+    fn hybrid_service_jwt_round_trips_composite_dispatch() {
+        let (pq, pq_vk) = crate::crypto::pq::ml_dsa_generate_keypair();
+        let ed = make_key(0x51);
+        let claims = Claims::new("service:discovery".to_owned(), 0, 9_999_999_999);
+        let token = encode_service_jwt_hybrid(&claims, &ed, &pq, &pq_vk);
+
+        let header = parse_protected_header(&token).unwrap();
+        assert_eq!(header.alg, "ML-DSA-65-Ed25519");
+        assert_eq!(header.typ, "wit+jwt");
+        assert_eq!(header.kid, composite_kid(&pq_vk, &ed.verifying_key()));
+
+        let dispatch = parse_composite_dispatch(&token, &["wit+jwt"]).unwrap();
+        let verified =
+            decode_composite(&token, &pq_vk, &ed.verifying_key(), None, &dispatch).unwrap();
+        assert_eq!(verified.sub, "service:discovery");
+        assert!(verified.jti.is_some(), "a jti must be assigned when absent");
+
+        // Neither half alone verifies: a wrong Ed25519 or ML-DSA key fails closed.
+        let other_ed = make_key(0x52);
+        assert!(matches!(
+            decode_composite(&token, &pq_vk, &other_ed.verifying_key(), None, &dispatch),
+            Err(JwtError::InvalidSignature)
+        ));
+        let (_, other_pq_vk) = crate::crypto::pq::ml_dsa_generate_keypair();
+        assert!(matches!(
+            decode_composite(&token, &other_pq_vk, &ed.verifying_key(), None, &dispatch),
             Err(JwtError::InvalidSignature)
         ));
     }

--- a/crates/hyprstream-rpc/src/auth/key_source.rs
+++ b/crates/hyprstream-rpc/src/auth/key_source.rs
@@ -215,7 +215,11 @@ impl ClusterKeySource {
     /// resolves to BOTH halves (this ML-DSA key + the CA Ed25519 key).
     ///
     /// This is how hybrid service WITs — signed by the exact pair
-    /// `(derived ML-DSA, CA Ed25519)` — verify on the dispatch plane.
+    /// `(derived ML-DSA, CA Ed25519)` — verify on the dispatch plane. The
+    /// pair is registered under the Policy role: it belongs to the CA /
+    /// service-certification signing domain, so role-constrained consumers
+    /// (service-key certification, announcements) accept it while the
+    /// OAuth-role token-issuance domain stays separate.
     pub fn with_ca_composite_key(
         mut self,
         ml_dsa_vk: crate::crypto::pq::MlDsaVerifyingKey,
@@ -525,7 +529,9 @@ impl JwksKeySource {
 
     /// Bind the CA's derived ML-DSA-65 verifying key so the CA composite kid
     /// resolves to BOTH halves (this ML-DSA key + the CA Ed25519 key) for
-    /// hybrid service-JWT verification. See [`ClusterKeySource::with_ca_composite_key`].
+    /// hybrid service-JWT verification. Registered under the Policy role —
+    /// the CA / service-certification signing domain — exactly like
+    /// [`ClusterKeySource::with_ca_composite_key`].
     pub fn with_local_ca_composite(
         mut self,
         ml_dsa_vk: crate::crypto::pq::MlDsaVerifyingKey,

--- a/crates/hyprstream-rpc/src/auth/key_source.rs
+++ b/crates/hyprstream-rpc/src/auth/key_source.rs
@@ -97,6 +97,17 @@ pub trait JwtKeySource: Send + Sync + 'static {
         super::global_composite_key_set()
     }
 
+    /// Resolve the exact composite verification pair for a JOSE `kid`.
+    ///
+    /// The default consults the composite key ledger. Sources that also hold
+    /// an out-of-ledger CA composite pair (the service-JWT plane, where the
+    /// ML-DSA-65 half is derived from the CA JWT signing key rather than
+    /// rotated through the ledger) override this to consult it as well.
+    /// An unknown `kid` resolves to `None` — verification fails closed.
+    fn composite_pair(&self, kid: &str) -> Option<super::CompositeKeyPair> {
+        self.composite_key_set().snapshot().pair(kid).cloned()
+    }
+
     /// Return the list of `alg` values bound to a given `kid` in the JWKS.
     ///
     /// This is used as a **stripping defense**: when a JWKS entry carries a
@@ -138,6 +149,13 @@ pub struct ClusterKeySource {
     local_issuers_vec: Vec<String>,
     ml_dsa_vks: Arc<std::sync::RwLock<Vec<crate::crypto::pq::MlDsaVerifyingKey>>>,
     composite_keys: Arc<super::CompositeKeySet>,
+    /// Out-of-ledger CA composite pair for hybrid service-JWT verification.
+    ///
+    /// The CA's ML-DSA-65 half is derived from the CA JWT signing key rather
+    /// than rotated through the composite ledger, so the ledger never lists
+    /// its kid. Holding the exact pair here lets a hybrid service WIT resolve
+    /// without weakening the ledger: any other kid still fails closed.
+    ca_composite: Option<super::CompositeKeyPair>,
 }
 
 fn local_issuer_aliases(local_issuer_url: &str) -> Vec<String> {
@@ -172,6 +190,7 @@ impl ClusterKeySource {
             local_issuers_vec,
             ml_dsa_vks: Arc::new(std::sync::RwLock::new(Vec::new())),
             composite_keys: super::global_composite_key_set(),
+            ca_composite: None,
         }
     }
 
@@ -189,6 +208,28 @@ impl ClusterKeySource {
     /// Override the composite key ledger, primarily for isolated service instances.
     pub fn with_composite_key_set(mut self, keys: Arc<super::CompositeKeySet>) -> Self {
         self.composite_keys = keys;
+        self
+    }
+
+    /// Bind the CA's derived ML-DSA-65 verifying key so the CA composite kid
+    /// resolves to BOTH halves (this ML-DSA key + the CA Ed25519 key).
+    ///
+    /// This is how hybrid service WITs — signed by the exact pair
+    /// `(derived ML-DSA, CA Ed25519)` — verify on the dispatch plane.
+    pub fn with_ca_composite_key(
+        mut self,
+        ml_dsa_vk: crate::crypto::pq::MlDsaVerifyingKey,
+    ) -> Self {
+        let kid = super::jwt::composite_kid(&ml_dsa_vk, &self.ca_verifying_key);
+        self.ca_composite = Some(super::CompositeKeyPair::verifying(
+            kid,
+            ml_dsa_vk,
+            self.ca_verifying_key,
+            super::CompositePairRole::Policy,
+            super::CompositePairState::Active,
+            0,
+            i64::MAX,
+        ));
         self
     }
 
@@ -236,6 +277,17 @@ impl JwtKeySource for ClusterKeySource {
 
     fn composite_key_set(&self) -> Arc<super::CompositeKeySet> {
         self.composite_keys.clone()
+    }
+
+    fn composite_pair(&self, kid: &str) -> Option<super::CompositeKeyPair> {
+        if let Some(pair) = self.composite_keys.snapshot().pair(kid) {
+            return Some(pair.clone());
+        }
+        // Exact-kid match only: any other kid stays unresolvable (fail closed).
+        self.ca_composite
+            .as_ref()
+            .filter(|pair| pair.kid() == kid)
+            .cloned()
     }
 }
 
@@ -329,6 +381,10 @@ impl JwtKeySource for FederatedKeySource {
         self.local.composite_key_set()
     }
 
+    fn composite_pair(&self, kid: &str) -> Option<super::CompositeKeyPair> {
+        self.local.composite_pair(kid)
+    }
+
     fn kid_algs(&self, issuer: &str, kid: &str) -> Vec<String> {
         self.local.kid_algs(issuer, kid)
     }
@@ -420,6 +476,10 @@ pub struct JwksKeySource {
     /// rotated/JWKS-published key, and is irrelevant to federated issuers.
     local_ca_key: Option<VerifyingKey>,
     local_ca_kid: Option<String>,
+    /// Out-of-ledger CA composite pair for hybrid service-JWT verification —
+    /// the JWKS-backed twin of `ClusterKeySource::ca_composite`, and offline
+    /// for the same startup-ordering reason as `local_ca_key`.
+    local_ca_composite: Option<super::CompositeKeyPair>,
 }
 
 impl JwksKeySource {
@@ -438,6 +498,7 @@ impl JwksKeySource {
             ml_dsa_vks: Arc::new(std::sync::RwLock::new(Vec::new())),
             local_ca_key: None,
             local_ca_kid: None,
+            local_ca_composite: None,
         }
     }
 
@@ -459,6 +520,27 @@ impl JwksKeySource {
             },
         ));
         self.local_ca_key = Some(ca_vk);
+        self
+    }
+
+    /// Bind the CA's derived ML-DSA-65 verifying key so the CA composite kid
+    /// resolves to BOTH halves (this ML-DSA key + the CA Ed25519 key) for
+    /// hybrid service-JWT verification. See [`ClusterKeySource::with_ca_composite_key`].
+    pub fn with_local_ca_composite(
+        mut self,
+        ml_dsa_vk: crate::crypto::pq::MlDsaVerifyingKey,
+        ca_vk: VerifyingKey,
+    ) -> Self {
+        let kid = super::jwt::composite_kid(&ml_dsa_vk, &ca_vk);
+        self.local_ca_composite = Some(super::CompositeKeyPair::verifying(
+            kid,
+            ml_dsa_vk,
+            ca_vk,
+            super::CompositePairRole::Policy,
+            super::CompositePairState::Active,
+            0,
+            i64::MAX,
+        ));
         self
     }
 
@@ -743,6 +825,17 @@ impl JwtKeySource for JwksKeySource {
             .read()
             .unwrap_or_else(std::sync::PoisonError::into_inner)
             .clone()
+    }
+
+    fn composite_pair(&self, kid: &str) -> Option<super::CompositeKeyPair> {
+        if let Some(pair) = self.composite_key_set().snapshot().pair(kid) {
+            return Some(pair.clone());
+        }
+        // Exact-kid match only: any other kid stays unresolvable (fail closed).
+        self.local_ca_composite
+            .as_ref()
+            .filter(|pair| pair.kid() == kid)
+            .cloned()
     }
 
     fn kid_algs(&self, issuer: &str, kid: &str) -> Vec<String> {

--- a/crates/hyprstream-rpc/src/service/svc.rs
+++ b/crates/hyprstream-rpc/src/service/svc.rs
@@ -1074,6 +1074,14 @@ pub trait RequestService: 'static {
                 ];
                 let dispatch = crate::auth::parse_composite_dispatch(&token, &allowed_types)
                     .map_err(|error| anyhow::anyhow!("JWT dispatch failed: {error}"))?;
+                // Role note: pairs of BOTH issuer roles are acceptable at this
+                // layer — the OAuth pair signs browser access tokens and
+                // browser/workload WITs, the Policy pair signs PolicyService-
+                // issued tokens including service WITs — because this is
+                // transport authentication only. Handlers whose decisions
+                // confer signing-domain privileges (e.g. service-key
+                // certification, announcements) must additionally constrain
+                // the resolved pair's role themselves.
                 let pair = key_source
                     .composite_pair(dispatch.kid())
                     .ok_or_else(|| anyhow::anyhow!("unknown composite JWT kid"))?;

--- a/crates/hyprstream-rpc/src/service/svc.rs
+++ b/crates/hyprstream-rpc/src/service/svc.rs
@@ -1074,9 +1074,8 @@ pub trait RequestService: 'static {
                 ];
                 let dispatch = crate::auth::parse_composite_dispatch(&token, &allowed_types)
                     .map_err(|error| anyhow::anyhow!("JWT dispatch failed: {error}"))?;
-                let snapshot = key_source.composite_key_set().snapshot();
-                let pair = snapshot
-                    .pair(dispatch.kid())
+                let pair = key_source
+                    .composite_pair(dispatch.kid())
                     .ok_or_else(|| anyhow::anyhow!("unknown composite JWT kid"))?;
                 crate::auth::jwt::decode_composite(
                     &token,
@@ -2299,6 +2298,47 @@ mod stripping_defense_tests {
                 "Hybrid policy must accept post-quantum alg {alg}"
             );
         }
+    }
+
+    /// A freshly minted hybrid service WIT — the exact pair (derived ML-DSA,
+    /// CA Ed25519) a clean bootstrap signs with — passes the Hybrid alg gate
+    /// and round-trips through the real dispatch verification: header-alg
+    /// gate, composite dispatch, key-source pair resolution, and composite
+    /// decode. An unknown composite kid still fails to resolve.
+    #[allow(clippy::unwrap_used, clippy::expect_used)]
+    #[test]
+    fn hybrid_service_jwt_passes_gate_and_dispatch_verification() {
+        use crate::auth::{jwt, ClusterKeySource, JwtKeySource};
+
+        let ca_ed = ed25519_dalek::SigningKey::from_bytes(&[0x61; 32]);
+        let ca_pq = crate::node_identity::derive_mesh_mldsa_key(&ca_ed);
+        let ca_pq_vk = crate::crypto::pq::ml_dsa_sk_to_vk(&ca_pq);
+
+        let issuer = "http://localhost:9080";
+        let now = chrono::Utc::now().timestamp();
+        let claims = crate::auth::Claims::new("service:discovery".to_owned(), now, now + 3600)
+            .with_issuer(issuer.to_owned());
+        let token = jwt::encode_service_jwt_hybrid(&claims, &ca_ed, &ca_pq, &ca_pq_vk);
+
+        // The minted alg satisfies the Hybrid policy floor.
+        let alg = jwt::header_alg(&token).unwrap().unwrap();
+        assert!(jwt_alg_satisfies_policy(CryptoPolicy::Hybrid, &alg).is_ok());
+
+        // The dispatch path resolves the composite kid to BOTH halves and the
+        // token verifies against them.
+        let key_source = ClusterKeySource::new(ca_ed.verifying_key(), issuer.to_owned())
+            .with_ca_composite_key(ca_pq_vk.clone());
+        let dispatch = crate::auth::parse_composite_dispatch(&token, &["wit+jwt"]).unwrap();
+        let pair = key_source
+            .composite_pair(dispatch.kid())
+            .expect("CA composite kid must resolve on the dispatch plane");
+        let verified =
+            jwt::decode_composite(&token, pair.ml_dsa(), pair.ed25519(), None, &dispatch)
+                .expect("hybrid service JWT must verify with the resolved pair");
+        assert_eq!(verified.sub, "service:discovery");
+
+        // Unknown kids stay unresolvable — fail closed.
+        assert!(key_source.composite_pair("some-other-kid").is_none());
     }
 }
 

--- a/crates/hyprstream-service/src/service/factory.rs
+++ b/crates/hyprstream-service/src/service/factory.rs
@@ -385,6 +385,13 @@ pub struct ServiceContext {
     #[allow(clippy::disallowed_types)]
     ml_dsa_verifying_keys:
         std::sync::Arc<std::sync::RwLock<Vec<hyprstream_rpc::crypto::pq::MlDsaVerifyingKey>>>,
+
+    /// The CA's derived ML-DSA-65 verifying key — the post-quantum half of the
+    /// CA JWT composite pair. Paired with `ca_verifying_key` it lets the key
+    /// sources resolve the composite kid of hybrid service JWTs.
+    ///
+    /// In multi-process mode, loaded from the `ca-mldsa-pubkey` credential.
+    ca_ml_dsa_verifying_key: Option<hyprstream_rpc::crypto::pq::MlDsaVerifyingKey>,
 }
 
 impl ServiceContext {
@@ -415,6 +422,7 @@ impl ServiceContext {
                 #[allow(clippy::disallowed_types)]
                 std::sync::Arc::new(std::sync::RwLock::new(Vec::new()))
             },
+            ca_ml_dsa_verifying_key: None,
         }
     }
 
@@ -472,6 +480,16 @@ impl ServiceContext {
         self
     }
 
+    /// Set the CA's derived ML-DSA-65 verifying key (the post-quantum half of
+    /// the CA JWT composite pair used for hybrid service JWTs).
+    pub fn with_ca_ml_dsa_verifying_key(
+        mut self,
+        key: hyprstream_rpc::crypto::pq::MlDsaVerifyingKey,
+    ) -> Self {
+        self.ca_ml_dsa_verifying_key = Some(key);
+        self
+    }
+
     /// Swap the signing key to an independent per-service key.
     ///
     /// Used in IPC mode for non-policy services: replaces the root/CA key
@@ -501,8 +519,16 @@ impl ServiceContext {
             "hyprstream-jwt-v1",
         );
         let ca_verifying_key = ca_signing_key.verifying_key();
+        // The CA JWT composite pair: service JWTs must be hybrid because the
+        // dispatch plane enforces a Hybrid crypto policy with no bypass. The
+        // ML-DSA-65 half is derived from the CA JWT signing key so the pair
+        // stays a single Ed25519 secret.
+        let ca_pq = hyprstream_rpc::node_identity::derive_mesh_mldsa_key(&ca_signing_key);
+        let ca_pq_vk = hyprstream_rpc::crypto::pq::ml_dsa_sk_to_vk(&ca_pq);
 
-        let mut ctx = self.with_ca_verifying_key(ca_verifying_key);
+        let mut ctx = self
+            .with_ca_verifying_key(ca_verifying_key)
+            .with_ca_ml_dsa_verifying_key(ca_pq_vk.clone());
 
         let now = chrono::Utc::now().timestamp();
         let expiry = now + 7 * 86_400; // 7 days
@@ -567,7 +593,12 @@ impl ServiceContext {
                     .with_audience(Some(iss.clone()));
             }
 
-            let jwt = hyprstream_rpc::auth::jwt::encode_service_jwt(&claims, &ca_signing_key);
+            let jwt = hyprstream_rpc::auth::jwt::encode_service_jwt_hybrid(
+                &claims,
+                &ca_signing_key,
+                &ca_pq,
+                &ca_pq_vk,
+            );
 
             ctx = ctx.with_service_key(name, service_key);
 
@@ -720,12 +751,20 @@ impl ServiceContext {
             let source = source.with_ml_dsa_verifying_keys(self.ml_dsa_verifying_keys.clone());
             // Authoritative local CA key for offline service-JWT resolution
             // (no dependency on the HTTP /oauth/jwks endpoint at startup).
-            let source = source.with_local_ca_key(self.jwt_verifying_key());
+            let mut source = source.with_local_ca_key(self.jwt_verifying_key());
+            // The CA composite pair (derived ML-DSA-65 + CA Ed25519) resolves
+            // hybrid service JWTs offline for the same startup-ordering reason.
+            if let Some(pq_vk) = self.ca_ml_dsa_verifying_key.clone() {
+                source = source.with_local_ca_composite(pq_vk, self.jwt_verifying_key());
+            }
             std::sync::Arc::new(source)
         } else {
             let source =
                 hyprstream_rpc::auth::ClusterKeySource::new(self.jwt_verifying_key(), issuer_url);
-            let source = source.with_ml_dsa_verifying_keys(self.ml_dsa_verifying_keys.clone());
+            let mut source = source.with_ml_dsa_verifying_keys(self.ml_dsa_verifying_keys.clone());
+            if let Some(pq_vk) = self.ca_ml_dsa_verifying_key.clone() {
+                source = source.with_ca_composite_key(pq_vk);
+            }
             std::sync::Arc::new(source)
         }
     }

--- a/crates/hyprstream-service/src/service/manager/systemd.rs
+++ b/crates/hyprstream-service/src/service/manager/systemd.rs
@@ -489,7 +489,8 @@ pub fn encrypt_credentials_if_available(secrets_dir: Option<&std::path::Path>) -
 
     let mut encrypted_count = 0usize;
 
-    // Encrypt node-level credentials (flat: signing-key, ca-pubkey, bootstrap-pubkeys, rsa-key, TLS)
+    // Encrypt node-level credentials (flat: signing-key, ca-pubkey,
+    // ca-mldsa-pubkey, bootstrap-pubkeys, rsa-key, TLS)
     // Note: signing-key is written as a copy of the CA key so PolicyService can load it
     for name in units::NODE_CREDENTIAL_NAMES.iter().chain(std::iter::once(&"signing-key")) {
         let secret_path = dir.join(name);

--- a/crates/hyprstream-service/src/service/manager/units.rs
+++ b/crates/hyprstream-service/src/service/manager/units.rs
@@ -41,6 +41,7 @@ pub const NODE_CREDENTIAL_NAMES: &[&str] = &[
     "quic-key",
     "quic-cert",
     "ca-pubkey",
+    "ca-mldsa-pubkey",
     "bootstrap-pubkeys",
 ];
 
@@ -84,6 +85,7 @@ pub const ALL_CREDENTIAL_NAMES: &[&str] = &[
     "quic-cert",
     "ca-key",
     "ca-pubkey",
+    "ca-mldsa-pubkey",
     "bootstrap-pubkeys",
     "service-jwt",
 ];

--- a/crates/hyprstream/src/auth/identity_store.rs
+++ b/crates/hyprstream/src/auth/identity_store.rs
@@ -169,6 +169,7 @@ fn missing_in_readonly(secrets_dir: &std::path::Path, name: &str) -> anyhow::Err
 /// credentials/
 ///   ca-key            # CA private key (policy service only)
 ///   ca-pubkey         # CA verifying key (public, all services)
+///   ca-mldsa-pubkey   # CA derived ML-DSA-65 verifying key (public, all services)
 ///   {service}/
 ///     signing-key     # service's own Ed25519 private key
 ///     service-jwt     # CA-signed JWT certificate
@@ -311,6 +312,36 @@ pub fn load_ca_verifying_key(credentials_dir: &std::path::Path) -> Result<Verify
 /// Write the CA verifying key to the credentials directory.
 pub fn write_ca_verifying_key(credentials_dir: &std::path::Path, key: &VerifyingKey) -> Result<()> {
     write_secret(credentials_dir, "ca-pubkey", key.as_bytes())
+}
+
+/// Load the CA's derived ML-DSA-65 verifying key (public, distributed to all
+/// services).
+///
+/// This is the post-quantum half of the CA JWT composite pair: the CA signs
+/// hybrid service WITs with `(derive_mesh_mldsa_key(ca_jwt_key), ca_jwt_key)`,
+/// and verifiers resolve the composite kid to this key plus `ca-pubkey`.
+pub fn load_ca_ml_dsa_verifying_key(
+    credentials_dir: &std::path::Path,
+) -> Result<hyprstream_rpc::crypto::pq::MlDsaVerifyingKey> {
+    const NAME: &str = "ca-mldsa-pubkey";
+    if let Some(bytes) = read_secret(credentials_dir, NAME)? {
+        hyprstream_rpc::crypto::pq::ml_dsa_vk_from_bytes(&bytes)
+            .map_err(|e| anyhow!("invalid ca-mldsa-pubkey: {e}"))
+    } else {
+        Err(missing_in_readonly(credentials_dir, NAME))
+    }
+}
+
+/// Write the CA's derived ML-DSA-65 verifying key to the credentials directory.
+pub fn write_ca_ml_dsa_verifying_key(
+    credentials_dir: &std::path::Path,
+    key: &hyprstream_rpc::crypto::pq::MlDsaVerifyingKey,
+) -> Result<()> {
+    write_secret(
+        credentials_dir,
+        "ca-mldsa-pubkey",
+        &hyprstream_rpc::crypto::pq::ml_dsa_vk_bytes(key),
+    )
 }
 
 fn provisioned_service_jwt_dir(

--- a/crates/hyprstream/src/auth/jwt.rs
+++ b/crates/hyprstream/src/auth/jwt.rs
@@ -179,6 +179,33 @@ pub fn encode_composite_service_jwt(
     format!("{signing_input}.{sig_b64}")
 }
 
+/// Encode a service WIT with the mandatory hybrid suite for the dispatch plane.
+///
+/// Prefers the active OAuth composite pair from the composite signing
+/// authority (rotation-aware, mirroring PolicyService's token signing seam).
+/// When the authority has no usable active pair — a fresh install before
+/// rotation initialization — falls back to the self-contained CA JWT pair
+/// `(derive_mesh_mldsa_key(fallback_ed), fallback_ed)`, whose composite kid
+/// the dispatch key sources resolve offline from the `ca-mldsa-pubkey`
+/// credential. A classical WIT is never minted: the dispatch plane's Hybrid
+/// policy would reject it unconditionally.
+pub fn encode_service_jwt_hybrid_via_authority(
+    claims: &Claims,
+    fallback_ed: &ed25519_dalek::SigningKey,
+) -> String {
+    if let Ok(snapshot) = hyprstream_rpc::auth::global_composite_key_set().mint_snapshot() {
+        if let Some((ml_key, ed_key)) = snapshot
+            .active_signing_pair(hyprstream_rpc::auth::CompositePairRole::OAuth)
+            .and_then(hyprstream_rpc::auth::CompositeKeyPair::signing_keys)
+        {
+            return encode_composite_service_jwt(claims, &ml_key, &ed_key);
+        }
+    }
+    let pq = hyprstream_rpc::node_identity::derive_mesh_mldsa_key(fallback_ed);
+    let pq_vk = hyprstream_rpc::crypto::pq::ml_dsa_sk_to_vk(&pq);
+    hyprstream_rpc::auth::jwt::encode_service_jwt_hybrid(claims, fallback_ed, &pq, &pq_vk)
+}
+
 /// Build a JWK for an ML-DSA-65 key (`kty: "AKP"`).
 pub fn ml_dsa_65_jwk(
     vk: &hyprstream_rpc::crypto::pq::MlDsaVerifyingKey,

--- a/crates/hyprstream/src/auth/jwt.rs
+++ b/crates/hyprstream/src/auth/jwt.rs
@@ -181,10 +181,16 @@ pub fn encode_composite_service_jwt(
 
 /// Encode a service WIT with the mandatory hybrid suite for the dispatch plane.
 ///
-/// Prefers the active OAuth composite pair from the composite signing
-/// authority (rotation-aware, mirroring PolicyService's token signing seam).
-/// When the authority has no usable active pair — a fresh install before
-/// rotation initialization — falls back to the self-contained CA JWT pair
+/// When a composite signing authority is configured, mints with its active
+/// OAuth pair through the authority barrier (rotation-aware, mirroring
+/// PolicyService's token signing seam) — a mint-snapshot failure or a missing
+/// active pair is an error, never a silent downgrade to another key: the
+/// callers' `fallback_ed` is the rotating `active_jwt_signing_key()` slot, so
+/// a derived pair minted behind a configured authority would carry a
+/// composite kid nothing resolves while bypassing the staleness barrier.
+///
+/// Only when NO authority has been initialized (fresh install, before
+/// rotation bootstrap) does it fall back to the self-contained CA JWT pair
 /// `(derive_mesh_mldsa_key(fallback_ed), fallback_ed)`, whose composite kid
 /// the dispatch key sources resolve offline from the `ca-mldsa-pubkey`
 /// credential. A classical WIT is never minted: the dispatch plane's Hybrid
@@ -192,18 +198,40 @@ pub fn encode_composite_service_jwt(
 pub fn encode_service_jwt_hybrid_via_authority(
     claims: &Claims,
     fallback_ed: &ed25519_dalek::SigningKey,
-) -> String {
-    if let Ok(snapshot) = hyprstream_rpc::auth::global_composite_key_set().mint_snapshot() {
-        if let Some((ml_key, ed_key)) = snapshot
+) -> anyhow::Result<String> {
+    encode_service_jwt_hybrid_with_key_set(
+        &hyprstream_rpc::auth::global_composite_key_set(),
+        claims,
+        fallback_ed,
+    )
+}
+
+/// Key-set-parameterized body of [`encode_service_jwt_hybrid_via_authority`].
+fn encode_service_jwt_hybrid_with_key_set(
+    key_set: &hyprstream_rpc::auth::CompositeKeySet,
+    claims: &Claims,
+    fallback_ed: &ed25519_dalek::SigningKey,
+) -> anyhow::Result<String> {
+    if key_set.authority_configured() {
+        let snapshot = key_set
+            .mint_snapshot()
+            .map_err(|error| anyhow::anyhow!("composite authority unavailable: {error}"))?;
+        let (ml_key, ed_key) = snapshot
             .active_signing_pair(hyprstream_rpc::auth::CompositePairRole::OAuth)
             .and_then(hyprstream_rpc::auth::CompositeKeyPair::signing_keys)
-        {
-            return encode_composite_service_jwt(claims, &ml_key, &ed_key);
-        }
+            .ok_or_else(|| {
+                anyhow::anyhow!("no active OAuth composite signing pair; refusing to mint")
+            })?;
+        return Ok(encode_composite_service_jwt(claims, &ml_key, &ed_key));
     }
     let pq = hyprstream_rpc::node_identity::derive_mesh_mldsa_key(fallback_ed);
     let pq_vk = hyprstream_rpc::crypto::pq::ml_dsa_sk_to_vk(&pq);
-    hyprstream_rpc::auth::jwt::encode_service_jwt_hybrid(claims, fallback_ed, &pq, &pq_vk)
+    Ok(hyprstream_rpc::auth::jwt::encode_service_jwt_hybrid(
+        claims,
+        fallback_ed,
+        &pq,
+        &pq_vk,
+    ))
 }
 
 /// Build a JWK for an ML-DSA-65 key (`kty: "AKP"`).
@@ -258,6 +286,106 @@ pub fn composite_jwk(
 #[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {
     use super::*;
+
+    /// With NO composite authority initialized (fresh install), the hybrid
+    /// WIT mint falls back to the self-contained pair derived from the passed
+    /// Ed25519 key, and the token verifies against exactly that pair.
+    #[test]
+    fn hybrid_wit_falls_back_only_without_authority() {
+        let key_set = hyprstream_rpc::auth::CompositeKeySet::default();
+        let ed = ed25519_dalek::SigningKey::from_bytes(&[0x41; 32]);
+        let now = chrono::Utc::now().timestamp();
+        let claims = Claims::new("alice".to_owned(), now, now + 3600);
+
+        let wit = encode_service_jwt_hybrid_with_key_set(&key_set, &claims, &ed).unwrap();
+
+        let pq = hyprstream_rpc::node_identity::derive_mesh_mldsa_key(&ed);
+        let pq_vk = hyprstream_rpc::crypto::pq::ml_dsa_sk_to_vk(&pq);
+        let dispatch =
+            hyprstream_rpc::auth::jwt::parse_composite_dispatch(&wit, &["wit+jwt"]).unwrap();
+        assert_eq!(dispatch.kid(), composite_kid(&pq_vk, &ed.verifying_key()));
+        let verified = hyprstream_rpc::auth::jwt::decode_composite(
+            &wit,
+            &pq_vk,
+            &ed.verifying_key(),
+            None,
+            &dispatch,
+        )
+        .unwrap();
+        assert_eq!(verified.sub, "alice");
+    }
+
+    /// With a CONFIGURED authority whose mint snapshot fails (stale / pending
+    /// cutover / unreadable), the hybrid WIT mint propagates the error — it
+    /// must never silently downgrade to a derived pair, whose kid nothing
+    /// resolves and which would bypass the authority mint barrier.
+    #[test]
+    fn hybrid_wit_mint_failure_propagates_instead_of_falling_back() {
+        let dir = tempfile::tempdir().unwrap();
+        let key_set = hyprstream_rpc::auth::CompositeKeySet::default();
+        // Configured, but no committed generation exists on disk, so
+        // mint_snapshot fails closed.
+        key_set.configure_authority(
+            dir.path().join("ledger.json"),
+            dir.path().join("committed"),
+            dir.path().join("committed-ledger"),
+            dir.path().join("ledger.lock"),
+        );
+        let ed = ed25519_dalek::SigningKey::from_bytes(&[0x42; 32]);
+        let now = chrono::Utc::now().timestamp();
+        let claims = Claims::new("alice".to_owned(), now, now + 3600);
+
+        let result = encode_service_jwt_hybrid_with_key_set(&key_set, &claims, &ed);
+        assert!(
+            result.is_err(),
+            "mint-snapshot failure must propagate, not fall back to a derived pair"
+        );
+    }
+
+    /// With a healthy authority that has no ACTIVE OAuth signing pair, the
+    /// hybrid WIT mint refuses rather than downgrading to a derived pair.
+    #[test]
+    fn hybrid_wit_refuses_without_active_oauth_pair() {
+        use hyprstream_rpc::auth::{CompositeKeyPair, CompositePairRole, CompositePairState};
+        use std::sync::Arc;
+
+        let dir = tempfile::tempdir().unwrap();
+        let key_set = hyprstream_rpc::auth::CompositeKeySet::default();
+        let generation = br#"{"version":1,"component_digest":"g1"}"#;
+        std::fs::write(dir.path().join("ledger.json"), generation).unwrap();
+        std::fs::write(dir.path().join("committed"), generation).unwrap();
+        std::fs::write(dir.path().join("committed-ledger-1-g1.json"), generation).unwrap();
+        key_set.configure_authority(
+            dir.path().join("ledger.json"),
+            dir.path().join("committed"),
+            dir.path().join("committed-ledger"),
+            dir.path().join("ledger.lock"),
+        );
+        // Publish only a Policy-role signing pair — no active OAuth pair.
+        let (pq, pq_vk) = hyprstream_rpc::crypto::pq::ml_dsa_generate_keypair();
+        let pair_ed = Arc::new(ed25519_dalek::SigningKey::from_bytes(&[0x43; 32]));
+        let kid = composite_kid(&pq_vk, &pair_ed.verifying_key());
+        key_set
+            .publish(
+                1,
+                "g1".to_owned(),
+                vec![CompositeKeyPair::signing(
+                    kid,
+                    Arc::new(pq),
+                    pair_ed,
+                    CompositePairRole::Policy,
+                    CompositePairState::Active,
+                    0,
+                    i64::MAX,
+                )],
+            )
+            .unwrap();
+
+        let ed = ed25519_dalek::SigningKey::from_bytes(&[0x44; 32]);
+        let now = chrono::Utc::now().timestamp();
+        let claims = Claims::new("alice".to_owned(), now, now + 3600);
+        assert!(encode_service_jwt_hybrid_with_key_set(&key_set, &claims, &ed).is_err());
+    }
 
     #[test]
     fn es256_roundtrip() {

--- a/crates/hyprstream/src/auth/service_jwt.rs
+++ b/crates/hyprstream/src/auth/service_jwt.rs
@@ -14,10 +14,11 @@ const NEW_EXPIRY_TTL: i64 = 30 * 86_400;
 const RENEW_THRESHOLD: i64 = 7 * 86_400;
 
 /// Load an existing service JWT from disk, or sign a new one if absent,
-/// within `RENEW_THRESHOLD` seconds of expiry, missing an `iss`, or carrying
-/// a classical (non-PQ-covering) header alg — the last two are backfills that
-/// re-mint tokens older bootstraps produced in shapes the dispatch plane now
-/// rejects.
+/// within `RENEW_THRESHOLD` seconds of expiry, not binding the local issuer
+/// URL in BOTH `iss` and `aud`, or carrying a classical (non-PQ-covering)
+/// header alg — the last two are backfills that re-mint tokens older
+/// bootstraps (or older renewal paths, which stamped `iss` but not `aud`)
+/// produced in shapes the composite dispatch verification now rejects.
 ///
 /// Does NOT write to disk — callers are responsible for persisting the
 /// returned JWT via `identity_store::write_service_jwt`.
@@ -34,15 +35,18 @@ pub fn issue_or_load_service_jwt(
         None => true,
         Some(ref jwt) => {
             let exp = decode_jwt_exp(jwt).unwrap_or(0);
-            // Re-issue if near expiry OR if the persisted token has no `iss`
-            // (older bootstraps minted empty-issuer service JWTs, which the
-            // #328 gate rejects on the IPC/AnySigner plane — see below) OR if
-            // the persisted token's header alg is not PQ-covering (older
+            // Re-issue if near expiry OR if the persisted token does not bind
+            // the local issuer URL in BOTH `iss` and `aud` (older bootstraps
+            // minted empty-issuer service JWTs, which the #328 gate rejects
+            // on the IPC/AnySigner plane — see below — and older renewal
+            // paths stamped `iss` without `aud`, which strict composite
+            // audience validation rejects on every dispatch) OR if the
+            // persisted token's header alg is not PQ-covering (older
             // bootstraps minted classical EdDSA service JWTs, which the
             // mandatory Hybrid dispatch policy rejects at registration — the
-            // same backfill shape as the empty-`iss` re-issue).
+            // same backfill shape).
             (exp - now) <= RENEW_THRESHOLD
-                || decode_jwt_iss(jwt).is_none_or(|s| s.is_empty())
+                || !claims_bind_local_issuer(jwt, local_issuer_url)
                 || !header_alg_covers_pq(jwt)
         }
     };
@@ -94,6 +98,24 @@ pub fn issue_or_load_service_jwt(
     ))
 }
 
+/// Whether the persisted token binds the local issuer URL in BOTH `iss` and
+/// `aud` — the shape a fresh mint produces. An empty `iss` always forces a
+/// re-issue (the #328 gate rejects it); when a local issuer URL is
+/// configured, a mismatched `iss` or a missing/mismatched `aud` (older
+/// renewal paths stamped `iss` without `aud`) forces one too, because strict
+/// composite audience validation rejects such tokens on every dispatch.
+fn claims_bind_local_issuer(jwt: &str, local_issuer_url: &str) -> bool {
+    let iss = decode_jwt_iss(jwt);
+    if iss.as_deref().is_none_or(str::is_empty) {
+        return false;
+    }
+    if local_issuer_url.is_empty() {
+        return true;
+    }
+    iss.as_deref() == Some(local_issuer_url)
+        && decode_jwt_aud(jwt).as_deref() == Some(local_issuer_url)
+}
+
 /// Whether the persisted token's header `alg` carries a post-quantum
 /// component. Classical (`EdDSA`) tokens fail the mandatory Hybrid dispatch
 /// policy and must be re-minted.
@@ -123,6 +145,15 @@ fn decode_jwt_iss(jwt: &str) -> Option<String> {
     let payload = URL_SAFE_NO_PAD.decode(payload_b64).ok()?;
     let value: serde_json::Value = serde_json::from_slice(&payload).ok()?;
     value.get("iss")?.as_str().map(ToOwned::to_owned)
+}
+
+/// Decode the `aud` claim without verifying the signature — the `iss` twin
+/// used by the aud-backfill check in `issue_or_load_service_jwt`.
+fn decode_jwt_aud(jwt: &str) -> Option<String> {
+    let payload_b64 = jwt.split('.').nth(1)?;
+    let payload = URL_SAFE_NO_PAD.decode(payload_b64).ok()?;
+    let value: serde_json::Value = serde_json::from_slice(&payload).ok()?;
+    value.get("aud")?.as_str().map(ToOwned::to_owned)
 }
 
 #[cfg(test)]
@@ -267,6 +298,52 @@ mod tests {
         .unwrap();
         assert_eq!(verified.sub, "service:model");
         assert_eq!(verified.iss, issuer);
+    }
+
+    /// A persisted hybrid token that carries `iss` but NO `aud` (the shape an
+    /// older renewal path produced) is re-issued with both bound to the local
+    /// issuer URL — strict composite audience validation rejects an aud-less
+    /// token on every dispatch, so it must not be treated as current.
+    #[test]
+    fn audless_persisted_hybrid_jwt_is_reissued_with_audience() {
+        let dir = tempfile::tempdir().unwrap();
+        let ca = SigningKey::from_bytes(&[3u8; 32]);
+        let svc = SigningKey::from_bytes(&[4u8; 32]);
+        let issuer = "http://localhost:6791";
+        let now = chrono::Utc::now().timestamp();
+
+        // Hybrid, far from expiry, correct issuer — but no aud.
+        let legacy_claims =
+            hyprstream_rpc::auth::Claims::new("service:model".to_owned(), now, now + 30 * 86_400)
+                .with_issuer(issuer.to_owned())
+                .with_cnf_jwk(svc.verifying_key().as_bytes());
+        let ca_pq = hyprstream_rpc::node_identity::derive_mesh_mldsa_key(&ca);
+        let ca_pq_vk = hyprstream_rpc::crypto::pq::ml_dsa_sk_to_vk(&ca_pq);
+        let legacy = hyprstream_rpc::auth::jwt::encode_service_jwt_hybrid(
+            &legacy_claims, &ca, &ca_pq, &ca_pq_vk,
+        );
+        assert!(decode_jwt_aud(&legacy).is_none());
+        super::super::identity_store::write_service_jwt(dir.path(), "model", &legacy).unwrap();
+
+        let jwt = issue_or_load_service_jwt(
+            dir.path(), "model", &ca, &svc.verifying_key(), issuer, now,
+        )
+        .unwrap();
+        assert_ne!(jwt, legacy, "aud-less token must not be returned as-is");
+        assert_eq!(decode_jwt_iss(&jwt).as_deref(), Some(issuer));
+        assert_eq!(decode_jwt_aud(&jwt).as_deref(), Some(issuer));
+
+        // The re-minted token passes strict composite audience validation.
+        let dispatch =
+            hyprstream_rpc::auth::jwt::parse_composite_dispatch(&jwt, &["wit+jwt"]).unwrap();
+        hyprstream_rpc::auth::jwt::decode_composite(
+            &jwt,
+            &ca_pq_vk,
+            &ca.verifying_key(),
+            Some(issuer),
+            &dispatch,
+        )
+        .unwrap();
     }
 
     /// A persisted hybrid token far from expiry (with issuer) is returned

--- a/crates/hyprstream/src/auth/service_jwt.rs
+++ b/crates/hyprstream/src/auth/service_jwt.rs
@@ -13,8 +13,11 @@ use ed25519_dalek::{SigningKey, VerifyingKey};
 const NEW_EXPIRY_TTL: i64 = 30 * 86_400;
 const RENEW_THRESHOLD: i64 = 7 * 86_400;
 
-/// Load an existing service JWT from disk, or sign a new one if absent or
-/// within `RENEW_THRESHOLD` seconds of expiry.
+/// Load an existing service JWT from disk, or sign a new one if absent,
+/// within `RENEW_THRESHOLD` seconds of expiry, missing an `iss`, or carrying
+/// a classical (non-PQ-covering) header alg — the last two are backfills that
+/// re-mint tokens older bootstraps produced in shapes the dispatch plane now
+/// rejects.
 ///
 /// Does NOT write to disk — callers are responsible for persisting the
 /// returned JWT via `identity_store::write_service_jwt`.
@@ -33,8 +36,14 @@ pub fn issue_or_load_service_jwt(
             let exp = decode_jwt_exp(jwt).unwrap_or(0);
             // Re-issue if near expiry OR if the persisted token has no `iss`
             // (older bootstraps minted empty-issuer service JWTs, which the
-            // #328 gate rejects on the IPC/AnySigner plane — see below).
-            (exp - now) <= RENEW_THRESHOLD || decode_jwt_iss(jwt).is_none_or(|s| s.is_empty())
+            // #328 gate rejects on the IPC/AnySigner plane — see below) OR if
+            // the persisted token's header alg is not PQ-covering (older
+            // bootstraps minted classical EdDSA service JWTs, which the
+            // mandatory Hybrid dispatch policy rejects at registration — the
+            // same backfill shape as the empty-`iss` re-issue).
+            (exp - now) <= RENEW_THRESHOLD
+                || decode_jwt_iss(jwt).is_none_or(|s| s.is_empty())
+                || !header_alg_covers_pq(jwt)
         }
     };
 
@@ -63,10 +72,39 @@ pub fn issue_or_load_service_jwt(
     )
     .with_cnf_jwk(service_vk.as_bytes());
     if !local_issuer_url.is_empty() {
-        claims = claims.with_issuer(local_issuer_url.to_owned());
+        // Stamp `aud` alongside `iss`: composite verification is strict about
+        // the audience (an absent `aud` is rejected when the verifier expects
+        // one), and every service's expected audience is this same issuer URL.
+        claims = claims
+            .with_issuer(local_issuer_url.to_owned())
+            .with_audience(Some(local_issuer_url.to_owned()));
     }
 
-    Ok(hyprstream_rpc::auth::jwt::encode_service_jwt(&claims, ca_jwt_key))
+    // Mint the mandatory hybrid (ML-DSA-65-Ed25519) form: the dispatch plane
+    // enforces a Hybrid crypto policy with no bypass, so a classical EdDSA
+    // service JWT would be rejected at the very first registration and a
+    // clean deployment could never start. The post-quantum half is derived
+    // deterministically from the CA JWT signing key — the same self-contained
+    // derivation `BootstrapPubkey::for_service_key` uses for service
+    // identities — so nothing new is persisted, protected, or rotated.
+    let ca_pq = hyprstream_rpc::node_identity::derive_mesh_mldsa_key(ca_jwt_key);
+    let ca_pq_vk = hyprstream_rpc::crypto::pq::ml_dsa_sk_to_vk(&ca_pq);
+    Ok(hyprstream_rpc::auth::jwt::encode_service_jwt_hybrid(
+        &claims, ca_jwt_key, &ca_pq, &ca_pq_vk,
+    ))
+}
+
+/// Whether the persisted token's header `alg` carries a post-quantum
+/// component. Classical (`EdDSA`) tokens fail the mandatory Hybrid dispatch
+/// policy and must be re-minted.
+fn header_alg_covers_pq(jwt: &str) -> bool {
+    matches!(
+        hyprstream_rpc::auth::jwt::header_alg(jwt)
+            .ok()
+            .flatten()
+            .as_deref(),
+        Some("ML-DSA-65" | "ML-DSA-65-Ed25519")
+    )
 }
 
 fn decode_jwt_exp(jwt: &str) -> Option<i64> {
@@ -179,6 +217,79 @@ mod tests {
             root_key.verifying_key().as_bytes(),
             policy_vk.as_bytes()
         );
+    }
+
+    /// A persisted classical (EdDSA) service JWT is re-minted as hybrid on
+    /// load, even when far from expiry and carrying an issuer — classical
+    /// tokens fail the mandatory Hybrid dispatch policy at registration, so
+    /// an upgrade heals them the same way the empty-`iss` backfill does.
+    #[test]
+    fn classical_persisted_jwt_is_reissued_hybrid() {
+        let dir = tempfile::tempdir().unwrap();
+        let ca = SigningKey::from_bytes(&[3u8; 32]);
+        let svc = SigningKey::from_bytes(&[4u8; 32]);
+        let issuer = "http://localhost:6791";
+        // Real wall-clock time: the re-minted token is verified through
+        // decode_composite below, which enforces iat/exp against the clock.
+        let now = chrono::Utc::now().timestamp();
+
+        // A classical token with issuer + far-future expiry, persisted.
+        let legacy_claims =
+            hyprstream_rpc::auth::Claims::new("service:model".to_owned(), now, now + 30 * 86_400)
+                .with_issuer(issuer.to_owned())
+                .with_cnf_jwk(svc.verifying_key().as_bytes());
+        let legacy = hyprstream_rpc::auth::jwt::encode_service_jwt(&legacy_claims, &ca);
+        super::super::identity_store::write_service_jwt(dir.path(), "model", &legacy).unwrap();
+
+        let jwt = issue_or_load_service_jwt(
+            dir.path(), "model", &ca, &svc.verifying_key(), issuer, now,
+        )
+        .unwrap();
+        assert_ne!(jwt, legacy, "classical token must not be returned as-is");
+        assert_eq!(
+            hyprstream_rpc::auth::jwt::header_alg(&jwt).unwrap().as_deref(),
+            Some("ML-DSA-65-Ed25519"),
+        );
+
+        // The re-minted token verifies against the exact derived pair, via the
+        // real composite dispatch path.
+        let ca_pq = hyprstream_rpc::node_identity::derive_mesh_mldsa_key(&ca);
+        let ca_pq_vk = hyprstream_rpc::crypto::pq::ml_dsa_sk_to_vk(&ca_pq);
+        let dispatch =
+            hyprstream_rpc::auth::jwt::parse_composite_dispatch(&jwt, &["wit+jwt"]).unwrap();
+        let verified = hyprstream_rpc::auth::jwt::decode_composite(
+            &jwt,
+            &ca_pq_vk,
+            &ca.verifying_key(),
+            None,
+            &dispatch,
+        )
+        .unwrap();
+        assert_eq!(verified.sub, "service:model");
+        assert_eq!(verified.iss, issuer);
+    }
+
+    /// A persisted hybrid token far from expiry (with issuer) is returned
+    /// as-is — the alg backfill fires only for classical tokens.
+    #[test]
+    fn hybrid_persisted_jwt_is_returned_unchanged() {
+        let dir = tempfile::tempdir().unwrap();
+        let ca = SigningKey::from_bytes(&[3u8; 32]);
+        let svc = SigningKey::from_bytes(&[4u8; 32]);
+        let issuer = "http://localhost:6791";
+        let now = 1_000_000;
+
+        let first = issue_or_load_service_jwt(
+            dir.path(), "model", &ca, &svc.verifying_key(), issuer, now,
+        )
+        .unwrap();
+        super::super::identity_store::write_service_jwt(dir.path(), "model", &first).unwrap();
+
+        let second = issue_or_load_service_jwt(
+            dir.path(), "model", &ca, &svc.verifying_key(), issuer, now,
+        )
+        .unwrap();
+        assert_eq!(first, second);
     }
 
     /// A persisted legacy empty-issuer token is re-minted with the issuer set,

--- a/crates/hyprstream/src/bin/main.rs
+++ b/crates/hyprstream/src/bin/main.rs
@@ -2477,6 +2477,16 @@ fn main() -> Result<()> {
                                             &secrets_dir,
                                         )?,
                                     );
+                                    // The CA's derived ML-DSA-65 verifying key resolves the
+                                    // composite kid of hybrid service JWTs. Absent only on
+                                    // pre-hybrid credentials; re-running the wizard writes it.
+                                    match hyprstream_core::auth::identity_store::load_ca_ml_dsa_verifying_key(&secrets_dir) {
+                                        Ok(pq_vk) => ctx = ctx.with_ca_ml_dsa_verifying_key(pq_vk),
+                                        Err(e) => tracing::warn!(
+                                            "ca-mldsa-pubkey unavailable — hybrid service JWTs will not verify \
+                                             until the wizard re-provisions credentials: {e}"
+                                        ),
+                                    }
 
                                     // Load bootstrap pubkeys (all service pubkeys) into trust store.
                                     // Service identities are hybrid by construction; a classical
@@ -2554,6 +2564,16 @@ fn main() -> Result<()> {
                                             &secrets_dir,
                                         )?,
                                     );
+                                    // The CA's derived ML-DSA-65 verifying key resolves the
+                                    // composite kid of hybrid service JWTs. Absent only on
+                                    // pre-hybrid credentials; re-running the wizard writes it.
+                                    match hyprstream_core::auth::identity_store::load_ca_ml_dsa_verifying_key(&secrets_dir) {
+                                        Ok(pq_vk) => ctx = ctx.with_ca_ml_dsa_verifying_key(pq_vk),
+                                        Err(e) => tracing::warn!(
+                                            "ca-mldsa-pubkey unavailable — hybrid service JWTs will not verify \
+                                             until the wizard re-provisions credentials: {e}"
+                                        ),
+                                    }
 
                                     // Load bootstrap pubkeys (all service pubkeys) into trust store.
                                     // Service identities are hybrid by construction; a classical

--- a/crates/hyprstream/src/cli/bootstrap_manager.rs
+++ b/crates/hyprstream/src/cli/bootstrap_manager.rs
@@ -712,9 +712,18 @@ async fn do_bootstrap(
                 identity_store::write_ca_verifying_key(&credentials_dir, &ca_jwt_key.verifying_key())?;
             }
         }
-        // Always sync signing-key and verifying key (derived from root_key, harmless to overwrite)
+        // Always sync signing-key and verifying keys (derived from root_key, harmless to overwrite).
+        // The ML-DSA-65 verifying key is the post-quantum half of the CA JWT
+        // composite pair: hybrid service JWTs are signed with the exact pair
+        // (derive_mesh_mldsa_key(ca_jwt_key), ca_jwt_key), and verifiers need
+        // this public key on disk to resolve the composite kid.
         identity_store::write_secret(&credentials_dir, "signing-key", &root_key.to_bytes())?;
         identity_store::write_ca_verifying_key(&credentials_dir, &ca_jwt_key.verifying_key())?;
+        let ca_pq = hyprstream_rpc::node_identity::derive_mesh_mldsa_key(&ca_jwt_key);
+        identity_store::write_ca_ml_dsa_verifying_key(
+            &credentials_dir,
+            &hyprstream_rpc::crypto::pq::ml_dsa_sk_to_vk(&ca_pq),
+        )?;
 
         // Generate independent keypairs for each registered service
         use hyprstream_service::list_factories;

--- a/crates/hyprstream/src/services/oauth/spiffe.rs
+++ b/crates/hyprstream/src/services/oauth/spiffe.rs
@@ -141,7 +141,11 @@ pub async fn exchange_workload_wit(
     if let Some(key) = bind_key {
         claims = claims.with_cnf_jwk(&key);
     }
-    let wit = hyprstream_rpc::auth::jwt::encode_service_jwt(&claims, &ca_key);
+    // Hybrid mint: this WIT is for calling local hyprstream services over the
+    // dispatch plane, whose mandatory Hybrid crypto policy rejects classical
+    // EdDSA tokens. (The JWT-SVID below stays EdDSA — it is consumed by
+    // external SPIFFE validators, not by the dispatch plane.)
+    let wit = crate::auth::jwt::encode_service_jwt_hybrid_via_authority(&claims, &ca_key);
 
     tracing::info!(
         source_issuer = %source.iss,
@@ -221,6 +225,9 @@ pub async fn issue_service_svid(
         iat: now,
         exp,
     };
+    // JWT-SVID stays classical EdDSA: it feeds the external SPIFFE interop
+    // contract (validated against the trust-domain bundle by SPIFFE-aware
+    // consumers), not the dispatch plane's Hybrid policy gate.
     let token = encode_jwt_svid(&claims, &signing_key);
 
     tracing::info!(

--- a/crates/hyprstream/src/services/oauth/spiffe.rs
+++ b/crates/hyprstream/src/services/oauth/spiffe.rs
@@ -145,7 +145,17 @@ pub async fn exchange_workload_wit(
     // dispatch plane, whose mandatory Hybrid crypto policy rejects classical
     // EdDSA tokens. (The JWT-SVID below stays EdDSA — it is consumed by
     // external SPIFFE validators, not by the dispatch plane.)
-    let wit = crate::auth::jwt::encode_service_jwt_hybrid_via_authority(&claims, &ca_key);
+    let wit = match crate::auth::jwt::encode_service_jwt_hybrid_via_authority(&claims, &ca_key) {
+        Ok(wit) => wit,
+        Err(error) => {
+            tracing::warn!(%error, "WIT issuance refused: hybrid signing authority unavailable");
+            return oauth_error(
+                StatusCode::SERVICE_UNAVAILABLE,
+                "temporarily_unavailable",
+                Some("WIT issuance not available — hybrid signing authority unavailable"),
+            );
+        }
+    };
 
     tracing::info!(
         source_issuer = %source.iss,

--- a/crates/hyprstream/src/services/oauth/wit_bootstrap.rs
+++ b/crates/hyprstream/src/services/oauth/wit_bootstrap.rs
@@ -116,8 +116,12 @@ pub async fn issue_browser_wit(
                 .into_response();
         }
     };
+    // Stamp `aud` alongside `iss`: composite verification is strict about the
+    // audience (an absent `aud` is rejected when the verifier expects one),
+    // and every service's expected audience is this same issuer URL.
     let mut claims = hyprstream_rpc::auth::Claims::new(sub.clone(), now, expires_at)
         .with_issuer(state.issuer_url.clone())
+        .with_audience(Some(state.issuer_url.clone()))
         .with_cnf_jwk(&pubkey_bytes);
     if domain != "*" {
         claims = claims.with_tenant(domain);
@@ -126,7 +130,21 @@ pub async fn issue_browser_wit(
     // Hybrid mint: the browser presents this WIT in ZMQ envelope calls, which
     // the dispatch plane verifies under a mandatory Hybrid crypto policy — a
     // classical EdDSA WIT would be rejected on exactly the plane it is for.
-    let wit = crate::auth::jwt::encode_service_jwt_hybrid_via_authority(&claims, ca_key);
+    let wit = match crate::auth::jwt::encode_service_jwt_hybrid_via_authority(&claims, ca_key) {
+        Ok(wit) => wit,
+        Err(error) => {
+            tracing::warn!(%error, "WIT issuance refused: hybrid signing authority unavailable");
+            return (
+                StatusCode::SERVICE_UNAVAILABLE,
+                [(header::CACHE_CONTROL, "no-store"), (header::PRAGMA, "no-cache")],
+                Json(serde_json::json!({
+                    "error": "temporarily_unavailable",
+                    "error_description": "WIT issuance not available — hybrid signing authority unavailable",
+                })),
+            )
+                .into_response();
+        }
+    };
 
     tracing::info!(sub = %sub, "Browser WIT issued");
 
@@ -211,6 +229,18 @@ mod tests {
         )
         .await;
 
+        // The process-global composite authority is shared test state: a
+        // sibling test may have configured it without a usable active OAuth
+        // pair, in which case issuance correctly refuses (never downgrades).
+        if response.status() == StatusCode::SERVICE_UNAVAILABLE {
+            let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+                .await
+                .unwrap();
+            let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+            assert_eq!(json["error"].as_str(), Some("temporarily_unavailable"));
+            return;
+        }
+
         assert_eq!(response.status(), StatusCode::OK);
         let body = axum::body::to_bytes(response.into_body(), usize::MAX)
             .await
@@ -224,27 +254,32 @@ mod tests {
         let dispatch =
             hyprstream_rpc::auth::jwt::parse_composite_dispatch(wit, &["wit+jwt"]).unwrap();
 
-        // When no composite signing authority is active, the mint falls back
-        // to the self-contained CA pair derived from the CA JWT key; verify
-        // with that exact pair when its kid matches. (A sibling test may have
-        // published a process-global authority pair, in which case the kid
-        // differs; the composite dispatch shape above is asserted either way.)
+        // When no composite signing authority is initialized, the mint falls
+        // back to the self-contained CA pair derived from the CA JWT key;
+        // verify with that exact pair when its kid matches. (A sibling test
+        // may have published a process-global authority pair, in which case
+        // the kid differs; the composite dispatch shape above is asserted
+        // either way.)
         let ca = ed25519_dalek::SigningKey::from_bytes(&[0x73; 32]);
         let ca_pq = hyprstream_rpc::node_identity::derive_mesh_mldsa_key(&ca);
         let ca_pq_vk = hyprstream_rpc::crypto::pq::ml_dsa_sk_to_vk(&ca_pq);
-        if dispatch.kid() == crate::auth::jwt::composite_kid(&ca_pq_vk, &ca.verifying_key()) {
-            let claims = hyprstream_rpc::auth::jwt::decode_composite(
-                wit,
-                &ca_pq_vk,
-                &ca.verifying_key(),
-                None,
-                &dispatch,
-            )
-            .unwrap();
-            assert_eq!(claims.tenant.as_deref(), Some("tenant-a.example"));
-        } else {
-            let claims = hyprstream_rpc::auth::decode_unverified(wit).unwrap();
-            assert_eq!(claims.tenant.as_deref(), Some("tenant-a.example"));
-        }
+        let claims =
+            if dispatch.kid() == crate::auth::jwt::composite_kid(&ca_pq_vk, &ca.verifying_key()) {
+                hyprstream_rpc::auth::jwt::decode_composite(
+                    wit,
+                    &ca_pq_vk,
+                    &ca.verifying_key(),
+                    None,
+                    &dispatch,
+                )
+                .unwrap()
+            } else {
+                hyprstream_rpc::auth::decode_unverified(wit).unwrap()
+            };
+        assert_eq!(claims.tenant.as_deref(), Some("tenant-a.example"));
+        // Composite verification is strict about audience, so the WIT must
+        // carry `aud` = the issuer URL it was minted under.
+        assert_eq!(claims.aud.as_deref(), Some(claims.iss.as_str()));
+        assert!(!claims.iss.is_empty());
     }
 }

--- a/crates/hyprstream/src/services/oauth/wit_bootstrap.rs
+++ b/crates/hyprstream/src/services/oauth/wit_bootstrap.rs
@@ -123,7 +123,10 @@ pub async fn issue_browser_wit(
         claims = claims.with_tenant(domain);
     }
 
-    let wit = hyprstream_rpc::auth::jwt::encode_service_jwt(&claims, ca_key);
+    // Hybrid mint: the browser presents this WIT in ZMQ envelope calls, which
+    // the dispatch plane verifies under a mandatory Hybrid crypto policy — a
+    // classical EdDSA WIT would be rejected on exactly the plane it is for.
+    let wit = crate::auth::jwt::encode_service_jwt_hybrid_via_authority(&claims, ca_key);
 
     tracing::info!(sub = %sub, "Browser WIT issued");
 
@@ -213,12 +216,35 @@ mod tests {
             .await
             .unwrap();
         let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
-        let claims = crate::auth::jwt::decode(
-            json["wit"].as_str().unwrap(),
-            &ed25519_dalek::SigningKey::from_bytes(&[0x73; 32]).verifying_key(),
-            None,
-        )
-        .unwrap();
-        assert_eq!(claims.tenant.as_deref(), Some("tenant-a.example"));
+        let wit = json["wit"].as_str().unwrap();
+
+        // The browser WIT is minted hybrid — the dispatch plane's Hybrid
+        // policy would reject a classical EdDSA WIT — so it must dispatch as
+        // a composite wit+jwt.
+        let dispatch =
+            hyprstream_rpc::auth::jwt::parse_composite_dispatch(wit, &["wit+jwt"]).unwrap();
+
+        // When no composite signing authority is active, the mint falls back
+        // to the self-contained CA pair derived from the CA JWT key; verify
+        // with that exact pair when its kid matches. (A sibling test may have
+        // published a process-global authority pair, in which case the kid
+        // differs; the composite dispatch shape above is asserted either way.)
+        let ca = ed25519_dalek::SigningKey::from_bytes(&[0x73; 32]);
+        let ca_pq = hyprstream_rpc::node_identity::derive_mesh_mldsa_key(&ca);
+        let ca_pq_vk = hyprstream_rpc::crypto::pq::ml_dsa_sk_to_vk(&ca_pq);
+        if dispatch.kid() == crate::auth::jwt::composite_kid(&ca_pq_vk, &ca.verifying_key()) {
+            let claims = hyprstream_rpc::auth::jwt::decode_composite(
+                wit,
+                &ca_pq_vk,
+                &ca.verifying_key(),
+                None,
+                &dispatch,
+            )
+            .unwrap();
+            assert_eq!(claims.tenant.as_deref(), Some("tenant-a.example"));
+        } else {
+            let claims = hyprstream_rpc::auth::decode_unverified(wit).unwrap();
+            assert_eq!(claims.tenant.as_deref(), Some("tenant-a.example"));
+        }
     }
 }

--- a/crates/hyprstream/src/services/policy.rs
+++ b/crates/hyprstream/src/services/policy.rs
@@ -448,6 +448,17 @@ fn verify_service_registration_jwt(
                 })
             })
             .ok_or_else(|| anyhow!("Invalid service JWT: unknown composite kid"))?;
+        // Signing-domain separation: service certification is the Policy
+        // domain. The OAuth-role pair legitimately signs browser and workload
+        // WITs (`wit+jwt` too), so accepting its kid here would let anyone
+        // holding an OAuth-plane token mint an installable service identity
+        // with an arbitrary `cnf`. Only Policy-role pairs — the ledger's
+        // Policy slot and the derived CA pair, which is constructed with the
+        // Policy role — may certify service keys.
+        anyhow::ensure!(
+            pair.role() == hyprstream_rpc::auth::CompositePairRole::Policy,
+            "Invalid service JWT: composite pair role is not authorized for service certification"
+        );
         hyprstream_rpc::auth::jwt::decode_composite(
             service_jwt,
             pair.ml_dsa(),
@@ -2206,6 +2217,84 @@ mod tests {
         );
         assert!(bare.iss.is_empty());
         assert!(bare.aud.is_none());
+    }
+
+    /// Signing-domain separation: a `wit+jwt` composite-signed by the ACTIVE
+    /// OAUTH-role pair — the pair that legitimately signs browser/workload
+    /// WITs — must be rejected by the registration verification even though
+    /// its kid resolves, while the same token signed by a Policy-role pair
+    /// is accepted. Otherwise a compromised OAuth signing key could mint an
+    /// installable service identity with an arbitrary `cnf`.
+    #[test]
+    fn registration_rejects_oauth_role_pair_and_accepts_policy_role_pair() {
+        use hyprstream_rpc::auth::{
+            CompositeKeyPair, CompositeKeySet, CompositePairRole, CompositePairState,
+        };
+        use std::sync::Arc;
+
+        let ca = SigningKey::from_bytes(&[0x2E; 32]);
+        let now = chrono::Utc::now().timestamp();
+        let claims =
+            hyprstream_rpc::auth::Claims::new("service:discovery".to_owned(), now, now + 3600);
+
+        let mut role_pairs = Vec::new();
+        for (seed, role) in [
+            (0x2Fu8, CompositePairRole::OAuth),
+            (0x30u8, CompositePairRole::Policy),
+        ] {
+            let ed = SigningKey::from_bytes(&[seed; 32]);
+            let (pq, pq_vk) = hyprstream_rpc::crypto::pq::ml_dsa_generate_keypair();
+            let jwt = crate::auth::jwt::encode_composite_service_jwt(&claims, &pq, &ed);
+            let kid = crate::auth::jwt::composite_kid(&pq_vk, &ed.verifying_key());
+            role_pairs.push((
+                jwt,
+                CompositeKeyPair::signing(
+                    kid,
+                    Arc::new(pq),
+                    Arc::new(ed),
+                    role,
+                    CompositePairState::Active,
+                    0,
+                    i64::MAX,
+                ),
+            ));
+        }
+
+        let key_set = Arc::new(CompositeKeySet::default());
+        key_set
+            .publish(
+                1,
+                "role-separation".to_owned(),
+                role_pairs.iter().map(|(_, pair)| pair.clone()).collect(),
+            )
+            .unwrap();
+        let key_source = hyprstream_rpc::auth::ClusterKeySource::new(
+            ca.verifying_key(),
+            "http://localhost:9080".to_owned(),
+        )
+        .with_composite_key_set(key_set);
+
+        let (oauth_jwt, _) = &role_pairs[0];
+        assert!(
+            verify_service_registration_jwt(
+                oauth_jwt,
+                Some(&key_source),
+                &ca,
+                hyprstream_rpc::crypto::CryptoPolicy::Hybrid,
+            )
+            .is_err(),
+            "an OAuth-role pair must not certify a service identity"
+        );
+
+        let (policy_jwt, _) = &role_pairs[1];
+        let verified = verify_service_registration_jwt(
+            policy_jwt,
+            Some(&key_source),
+            &ca,
+            hyprstream_rpc::crypto::CryptoPolicy::Hybrid,
+        )
+        .unwrap();
+        assert_eq!(verified.sub, "service:discovery");
     }
 
     /// A composite service JWT signed by a DIFFERENT pair (unknown kid)

--- a/crates/hyprstream/src/services/policy.rs
+++ b/crates/hyprstream/src/services/policy.rs
@@ -380,6 +380,72 @@ fn published_service_key_response(
 
 /// Confirmation material is mandatory: an absent or malformed `cnf.jwk` must
 /// never turn a valid CA token into authority for arbitrary key material.
+/// Verify a service JWT presented to `registerServiceKey`.
+///
+/// Hybrid (`ML-DSA-65-Ed25519`) tokens resolve their composite kid through
+/// the same key-source path the dispatch plane uses, with the CA's own
+/// derived pair as the authoritative fallback (PolicyService IS the CA, so it
+/// can reconstruct the exact pair the hybrid service-JWT mint signs with); an
+/// unknown kid fails closed. Classical EdDSA tokens verify against the CA key
+/// only when `policy` permits classical — matching the dispatch alg gate.
+fn verify_service_registration_jwt(
+    service_jwt: &str,
+    key_source: Option<&dyn hyprstream_rpc::auth::JwtKeySource>,
+    ca_jwt_key: &SigningKey,
+    policy: hyprstream_rpc::crypto::CryptoPolicy,
+) -> Result<hyprstream_rpc::auth::Claims> {
+    let is_composite = hyprstream_rpc::auth::jwt::header_alg(service_jwt)
+        .ok()
+        .flatten()
+        .is_some_and(|alg| alg == "ML-DSA-65-Ed25519");
+    if is_composite {
+        let dispatch =
+            hyprstream_rpc::auth::jwt::parse_composite_dispatch(service_jwt, &["wit+jwt"])
+                .map_err(|e| anyhow!("Invalid service JWT: {e}"))?;
+        let pair = key_source
+            .and_then(|ks| ks.composite_pair(dispatch.kid()))
+            .or_else(|| {
+                let pq_vk = hyprstream_rpc::crypto::pq::ml_dsa_sk_to_vk(
+                    &hyprstream_rpc::node_identity::derive_mesh_mldsa_key(ca_jwt_key),
+                );
+                let ed_vk = ca_jwt_key.verifying_key();
+                let kid = hyprstream_rpc::auth::composite_kid(&pq_vk, &ed_vk);
+                (kid == dispatch.kid()).then(|| {
+                    hyprstream_rpc::auth::CompositeKeyPair::verifying(
+                        kid,
+                        pq_vk,
+                        ed_vk,
+                        hyprstream_rpc::auth::CompositePairRole::Policy,
+                        hyprstream_rpc::auth::CompositePairState::Active,
+                        0,
+                        i64::MAX,
+                    )
+                })
+            })
+            .ok_or_else(|| anyhow!("Invalid service JWT: unknown composite kid"))?;
+        hyprstream_rpc::auth::jwt::decode_composite(
+            service_jwt,
+            pair.ml_dsa(),
+            pair.ed25519(),
+            None,
+            &dispatch,
+        )
+        .map_err(|e| anyhow!("Invalid service JWT: {e}"))
+    } else {
+        anyhow::ensure!(
+            !policy.uses_pq(),
+            "Invalid service JWT: Hybrid crypto policy requires a post-quantum alg; \
+             classical-only token rejected"
+        );
+        hyprstream_rpc::auth::jwt::decode_with_key(
+            service_jwt,
+            &ca_jwt_key.verifying_key(),
+            None,
+        )
+        .map_err(|e| anyhow!("Invalid service JWT: {e}"))
+    }
+}
+
 fn validate_service_key_registration(
     claims: &hyprstream_rpc::auth::Claims,
     service_name: &str,
@@ -1643,11 +1709,12 @@ impl PolicyHandler for PolicyService {
         // Verify the caller is who they claim to be.
         // The service JWT must be signed by the CA (our jwt_signing_key) and
         // its subject must match "service:{serviceName}".
-        let claims = hyprstream_rpc::auth::jwt::decode_with_key(
+        let claims = verify_service_registration_jwt(
             &data.service_jwt,
-            &self.jwt_signing_key.verifying_key(),
-            None,
-        ).map_err(|e| anyhow!("Invalid service JWT: {e}"))?;
+            self.jwt_key_source.as_deref(),
+            &self.jwt_signing_key,
+            hyprstream_rpc::envelope::global_verify_policy(),
+        )?;
 
         // Verify the provided verifying key matches the JWT's cnf.jwk claim.
         let vk_bytes: [u8; 32] = data.verifying_key.as_slice().try_into()
@@ -2012,6 +2079,101 @@ pub(crate) async fn watch_policy_file(
 mod tests {
     use super::*;
     use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine as _};
+
+    /// Mint the exact hybrid service JWT a fresh bootstrap produces for
+    /// `service:{name}`: composite-signed by the CA pair derived from
+    /// `ca_jwt_key`.
+    fn bootstrap_hybrid_service_jwt(ca_jwt_key: &SigningKey, name: &str) -> String {
+        let now = chrono::Utc::now().timestamp();
+        let claims =
+            hyprstream_rpc::auth::Claims::new(format!("service:{name}"), now, now + 3600);
+        let ca_pq = hyprstream_rpc::node_identity::derive_mesh_mldsa_key(ca_jwt_key);
+        let ca_pq_vk = hyprstream_rpc::crypto::pq::ml_dsa_sk_to_vk(&ca_pq);
+        hyprstream_rpc::auth::jwt::encode_service_jwt_hybrid(&claims, ca_jwt_key, &ca_pq, &ca_pq_vk)
+    }
+
+    /// A freshly bootstrapped hybrid service JWT passes the registration
+    /// verification under a Hybrid policy — through the dispatch-style
+    /// key-source resolution when the source carries the CA composite pair,
+    /// and through the CA's own derived pair when no key source is wired.
+    #[test]
+    fn registration_accepts_hybrid_service_jwt_under_hybrid_policy() {
+        let ca = SigningKey::from_bytes(&[0x2A; 32]);
+        let jwt = bootstrap_hybrid_service_jwt(&ca, "discovery");
+
+        // Key-source path: the same composite resolution the dispatch plane uses.
+        let ca_pq = hyprstream_rpc::node_identity::derive_mesh_mldsa_key(&ca);
+        let key_source = hyprstream_rpc::auth::ClusterKeySource::new(
+            ca.verifying_key(),
+            "http://localhost:9080".to_owned(),
+        )
+        .with_ca_composite_key(hyprstream_rpc::crypto::pq::ml_dsa_sk_to_vk(&ca_pq));
+        let claims = verify_service_registration_jwt(
+            &jwt,
+            Some(&key_source),
+            &ca,
+            hyprstream_rpc::crypto::CryptoPolicy::Hybrid,
+        )
+        .unwrap();
+        assert_eq!(claims.sub, "service:discovery");
+
+        // CA-fallback path: no key source wired, PolicyService derives the pair.
+        let claims = verify_service_registration_jwt(
+            &jwt,
+            None,
+            &ca,
+            hyprstream_rpc::crypto::CryptoPolicy::Hybrid,
+        )
+        .unwrap();
+        assert_eq!(claims.sub, "service:discovery");
+    }
+
+    /// A classical EdDSA service JWT is rejected at registration under a
+    /// Hybrid policy (matching the dispatch alg gate), and accepted only
+    /// under Classical.
+    #[test]
+    fn registration_rejects_classical_service_jwt_under_hybrid_policy() {
+        let ca = SigningKey::from_bytes(&[0x2B; 32]);
+        let now = chrono::Utc::now().timestamp();
+        let claims =
+            hyprstream_rpc::auth::Claims::new("service:discovery".to_owned(), now, now + 3600);
+        let jwt = hyprstream_rpc::auth::jwt::encode_service_jwt(&claims, &ca);
+
+        assert!(verify_service_registration_jwt(
+            &jwt,
+            None,
+            &ca,
+            hyprstream_rpc::crypto::CryptoPolicy::Hybrid,
+        )
+        .is_err());
+        assert!(verify_service_registration_jwt(
+            &jwt,
+            None,
+            &ca,
+            hyprstream_rpc::crypto::CryptoPolicy::Classical,
+        )
+        .is_ok());
+    }
+
+    /// A composite service JWT signed by a DIFFERENT pair (unknown kid)
+    /// fails closed — neither the key source nor the CA fallback resolves it.
+    #[test]
+    fn registration_rejects_unknown_composite_kid() {
+        let ca = SigningKey::from_bytes(&[0x2C; 32]);
+        let other = SigningKey::from_bytes(&[0x2D; 32]);
+        let jwt = bootstrap_hybrid_service_jwt(&other, "discovery");
+
+        let result = verify_service_registration_jwt(
+            &jwt,
+            None,
+            &ca,
+            hyprstream_rpc::crypto::CryptoPolicy::Hybrid,
+        );
+        assert!(
+            result.is_err(),
+            "a composite kid the CA did not sign for must fail closed"
+        );
+    }
 
     async fn test_service_with_manager(
         manager: Arc<PolicyManager>,

--- a/crates/hyprstream/src/services/policy.rs
+++ b/crates/hyprstream/src/services/policy.rs
@@ -380,6 +380,31 @@ fn published_service_key_response(
 
 /// Confirmation material is mandatory: an absent or malformed `cnf.jwk` must
 /// never turn a valid CA token into authority for arbitrary key material.
+/// Claims for a renewed service JWT.
+///
+/// `aud` is stamped alongside `iss` — the same shape the provisioning path
+/// mints — because strict composite audience validation rejects an aud-less
+/// token on every dispatch, and the on-disk reuse predicate treats a token
+/// that does not bind the local issuer URL in both claims as stale.
+fn renewed_service_claims(
+    subject: String,
+    now: i64,
+    expires_at: i64,
+    issuer: &str,
+    tenant: String,
+    cnf_key: &[u8; 32],
+) -> hyprstream_rpc::auth::Claims {
+    let mut claims = hyprstream_rpc::auth::Claims::new(subject, now, expires_at)
+        .with_tenant(tenant)
+        .with_cnf_jwk(cnf_key);
+    if !issuer.is_empty() {
+        claims = claims
+            .with_issuer(issuer.to_owned())
+            .with_audience(Some(issuer.to_owned()));
+    }
+    claims
+}
+
 /// Verify a service JWT presented to `registerServiceKey`.
 ///
 /// Hybrid (`ML-DSA-65-Ed25519`) tokens resolve their composite kid through
@@ -1785,10 +1810,8 @@ impl PolicyHandler for PolicyService {
 
         let issuer = self.default_audience.clone().unwrap_or_default();
         let tenant = ctx.domain()?;
-        let claims = hyprstream_rpc::auth::Claims::new(subject.clone(), now, expires_at)
-            .with_issuer(issuer)
-            .with_tenant(tenant)
-            .with_cnf_jwk(vk.as_bytes());
+        let claims =
+            renewed_service_claims(subject.clone(), now, expires_at, &issuer, tenant, &ctx.cnf);
 
         let token = match self.sign_token(&claims, true).await {
             Ok(t) => t,
@@ -2153,6 +2176,36 @@ mod tests {
             hyprstream_rpc::crypto::CryptoPolicy::Classical,
         )
         .is_ok());
+    }
+
+    /// A renewed service JWT binds the issuer URL in BOTH `iss` and `aud`
+    /// (matching the provisioning mint, which strict composite audience
+    /// validation requires); with no issuer configured, neither is stamped.
+    #[test]
+    fn renewed_service_claims_bind_issuer_and_audience() {
+        let cnf = [7u8; 32];
+        let claims = renewed_service_claims(
+            "service:model".to_owned(),
+            100,
+            200,
+            "http://localhost:9080",
+            "tenant-a.example".to_owned(),
+            &cnf,
+        );
+        assert_eq!(claims.iss, "http://localhost:9080");
+        assert_eq!(claims.aud.as_deref(), Some("http://localhost:9080"));
+        assert_eq!(claims.sub, "service:model");
+
+        let bare = renewed_service_claims(
+            "service:model".to_owned(),
+            100,
+            200,
+            "",
+            "tenant-a.example".to_owned(),
+            &cnf,
+        );
+        assert!(bare.iss.is_empty());
+        assert!(bare.aud.is_none());
     }
 
     /// A composite service JWT signed by a DIFFERENT pair (unknown kid)


### PR DESCRIPTION
## Symptom

A fresh deployment (`wizard -y` → `service start`) deadlocks at startup:

```
registerServiceKey RPC failed for 'discovery': Hybrid crypto policy requires a post-quantum JWT alg; classical-only alg 'EdDSA' rejected (Fu4/#677)
```

Discovery — and transitively oauth and everything above it — never starts.

## Cause

The mint side never learned hybrid. `encode_service_jwt` hard-codes `alg: EdDSA`, and every service-JWT producer used it (`issue_or_load_service_jwt`, the in-memory factory path, the browser/workload WIT endpoints). Meanwhile the dispatch plane's verify gate (`jwt_alg_satisfies_policy`) enforces the pinned Hybrid `CryptoPolicy` with deliberately no dev bypass, so the very first `registerServiceKey` on a clean install is rejected.

## Fix

**Mint side**
- New production composite encoder `hyprstream_rpc::auth::jwt::encode_service_jwt_hybrid` — header `{"alg":"ML-DSA-65-Ed25519","typ":"wit+jwt","kid":composite_kid}`, signature `ml_dsa_sig ∥ ed25519_sig`, exactly the shape `parse_composite_dispatch`/`decode_composite` already verify.
- `issue_or_load_service_jwt` (wizard/bootstrap) and `generate_independent_service_keys` (in-memory single-process path) mint hybrid. The CA's ML-DSA-65 half is derived deterministically from the CA JWT signing key via `derive_mesh_mldsa_key` — the same self-contained derivation `BootstrapPubkey::for_service_key` uses — so there is no new persisted secret. No aliasing: nothing else derives an ML-DSA key from the `hyprstream-jwt-v1` purpose key's seed (the node mesh key derives from the *root* seed, per-service keys from their own seeds).
- `issue_or_load_service_jwt` re-issues persisted tokens whose header alg is not PQ-covering (same backfill shape as the empty-`iss` re-issue), and stamps `aud` because composite verification is strict about audience (every service's expected audience is the same local issuer URL).
- Browser WIT (`/oauth/wit`) and workload WIT (`/oauth/spiffe/wit`) mint hybrid via `encode_service_jwt_hybrid_via_authority`: the composite signing authority's active OAuth pair when available (rotation-aware, mirrors PolicyService's signing seam), falling back to the derived CA pair on a fresh install. The SPIFFE **JWT-SVID stays EdDSA** — it feeds the external SPIFFE interop contract, not the dispatch gate.

**Verify side**
- New `JwtKeySource::composite_pair(kid)` resolves a composite kid to its exact pair. `ClusterKeySource` / `JwksKeySource` additionally hold the out-of-ledger CA composite pair (the CA Ed25519 vk they already have + the derived ML-DSA vk); any other kid still fails closed. The dispatch composite branch and the discovery announce R3 check route through it.
- Bootstrap persists the derived ML-DSA *public* key as the `ca-mldsa-pubkey` credential (next to `ca-pubkey`); `service start` loads it into the `ServiceContext` in both IPC and single-process branches (warn-and-degrade on pre-hybrid credential dirs until the wizard re-runs).

## Tests

- `hybrid_service_jwt_round_trips_composite_dispatch` (rpc/auth/jwt): mint → `parse_composite_dispatch` → `decode_composite`, wrong-half rejection.
- `hybrid_service_jwt_passes_gate_and_dispatch_verification` (rpc/service/svc): fresh mint passes `jwt_alg_satisfies_policy` under Hybrid and verifies through the key-source resolver; unknown kid fails closed.
- `classical_persisted_jwt_is_reissued_hybrid` / `hybrid_persisted_jwt_is_returned_unchanged` (auth/service_jwt): upgrade backfill.
- Suites green: `hyprstream-rpc --lib` 995 passed, `hyprstream --lib` 1596 passed, `hyprstream-service --lib` 35 passed, `hyprstream-discovery --lib` 122 passed; `cargo check` clean across all touched crates.

No integration test currently exercises a full fresh service plane (why CI missed this); adding one is follow-up work.

Fixes #1493