### PR TITLE
ci: classify hyprstream-pay + baseline the ledger dev DSN (repair red main)

### DIFF
--- a/.github/license-boundary.toml
+++ b/.github/license-boundary.toml
@@ -3,6 +3,7 @@
 [license_gate]
 mit_packages = [
   "bitsandbytes-sys",
+  "hyprstream-pay",
   "cas-serve",
   "git-xet-filter",
 ]
@@ -60,6 +61,7 @@ standalone_manifests = [
 # guarantee: none may reach a local AGPL package through any dependency source.
 permissive_roots = [
   "bitsandbytes-sys",
+  "hyprstream-pay",
   "cas-serve",
   "chat-core",
   "git-xet-filter",

--- a/scripts/loopback-baseline.txt
+++ b/scripts/loopback-baseline.txt
@@ -10,6 +10,7 @@
 1	crates/hyprstream-flight/src/cli/handlers.rs
 2	crates/hyprstream-flight/src/client.rs
 1	crates/hyprstream-flight/src/lib.rs
+1	crates/hyprstream-ledger/src/postgres.rs
 2	crates/hyprstream-metrics/src/storage/cached.rs
 1	crates/hyprstream-p2p/src/bin/gittorrentd.rs
 1	crates/hyprstream-p2p/src/service.rs


### PR DESCRIPTION
Mechanical repair of main-branch CI fallout from the PAY ledger merge: the new `hyprstream-pay` crate was never classified in `.github/license-boundary.toml` (guard fails closed on new packages) and the ledger's default `postgres://localhost/...` DSN added a loopback literal to the burn-down count. Neither check gates in the merge queue, so every PR branched after that merge fails both checks regardless of content (first hit: #1494).

- `hyprstream-pay` → MIT (matches its manifest) + `permissive_roots` (it is the externally-linkable protocol seam; the boundary check proves it reaches no AGPL package).
- Ledger DSN → justified into the burn-down baseline: dev-default for an opt-in backend that refuses non-durable stores in production mode.

Both checks green locally: `license boundary OK: 33 reusable MIT/Apache roots …`, `burn-down: current 83 … baseline 83`. Consider adding these two checks to the merge-queue check set so main can't silently go red again.