### PR TITLE
fix(rpc): write full chunk on UDS send streams instead of truncating at 16 KiB

### DIFF
--- a/crates/hyprstream-rpc/src/transport/uds_session.rs
+++ b/crates/hyprstream-rpc/src/transport/uds_session.rs
@@ -147,6 +147,15 @@ impl web_transport_trait::SendStream for UdsSendStream {
         wh.write(buf).await.map_err(UdsError::io)
     }
 
+    async fn write_chunk(&mut self, chunk: Bytes) -> Result<(), Self::Error> {
+        // The trait's default `write_chunk` issues a single `write` and silently
+        // discards any unwritten tail. yamux caps each write at its split-send
+        // size (16 KiB), so a larger chunk — e.g. a signed envelope carrying a
+        // hybrid ML-DSA JWT — would be truncated and then FIN'd by the caller.
+        // Loop until the whole chunk is on the stream.
+        self.write_all(&chunk).await
+    }
+
     fn set_priority(&mut self, _order: u8) {
         // yamux has no per-stream priority; no-op.
     }
@@ -587,6 +596,36 @@ mod tests {
         }
         assert_eq!(&got, b"hello");
         srv.await.unwrap();
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn write_chunk_larger_than_yamux_split_size_is_not_truncated() {
+        // yamux caps a single poll_write at its split-send size (16 KiB). A
+        // chunk larger than that must still arrive whole: a partial write that
+        // gets FIN'd truncates the message (e.g. a >16 KiB signed envelope
+        // arriving with its capnp length header claiming more words than the
+        // peer received).
+        let (client, server) = session_pair().await;
+
+        let payload: Vec<u8> = (0..20_000u32).map(|i| (i % 251) as u8).collect();
+        let expected = payload.clone();
+
+        let srv = tokio::spawn(async move {
+            let (_send, mut recv) = server.accept_bi().await.unwrap();
+            recv.read_all().await.unwrap()
+        });
+
+        let (mut send, _recv) = client.open_bi().await.unwrap();
+        send.write_chunk(Bytes::from(payload)).await.unwrap();
+        send.finish().unwrap();
+
+        let got = tokio::time::timeout(Duration::from_secs(5), srv)
+            .await
+            .expect("server read timed out")
+            .unwrap();
+        assert_eq!(got.len(), expected.len(), "chunk was truncated in flight");
+        assert_eq!(&got[..], &expected[..]);
+        drop(client);
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]


### PR DESCRIPTION
Fixes #1497

## Root cause

`web-transport-trait` 0.3.6's default `SendStream::write_chunk` issues a single `write()` and silently discards the unwritten tail. `UdsSendStream` inherited that default, and yamux caps each `poll_write` at its split-send size (16 KiB) — so any RPC envelope over 16 KiB sent via `write_chunk` (both the client path in `SessionRpcTransport::send` and the server response write in `rpc_session.rs`) was truncated at 16,384 bytes and then FIN'd. The receiver's `read_to_cap` correctly reads to FIN; the tail simply was never written.

Hybrid ML-DSA-65+Ed25519 service JWTs push `registerServiceKey` envelopes past 16 KiB, surfacing this as identity-plane startup failures:

- `policy envelope verification failed: Message ends prematurely. Header claimed 2213 words, but message only has 2046 words`
- `registerServiceKey RPC failed for 'discovery': response request id 0 does not match pending request 2` (fallout: the stub error envelope carries request_id 0)

## Fix

Override `write_chunk` on `UdsSendStream` to loop (`write_all`) until the whole chunk is on the stream. quinn/iroh already override it upstream; the WASM adapter's `write` writes the full buffer, so UDS was the only affected impl.

## Validation

- New regression test `write_chunk_larger_than_yamux_split_size_is_not_truncated`: 20,000-byte chunk through a `UdsSession` pair — failed before the fix (16,384 of 20,000 bytes arrived), passes after.
- `cargo test -p hyprstream-rpc --lib`: 996 passed, 0 failed.
- `cargo check -p hyprstream`: clean.
- Live repro (`hyprstream service start --foreground --services event,policy,discovery,registry,oauth`): both truncation symptoms are gone — the >16 KiB envelope now verifies on the policy side and the reply correlates to the pending request id. Startup then proceeds to a **distinct, pre-existing** blocker: the mandatory RPC-dispatch MAC PEP denies `registerServiceKey` with `UnlabeledObject` (genesis labels `/srv/{name}` nodes but the dispatch PEP resolves bare service domains). That gap was masked by the truncation (the parent of #1494's merge hits the same truncation) and is filed separately as #1499 — it needs a design decision, not a transport patch.