### PR TITLE
fix(runtime): offset causal mask by cached KV length in multi-token forwards

### DIFF
--- a/crates/hyprstream/src/runtime/architectures/llama.rs
+++ b/crates/hyprstream/src/runtime/architectures/llama.rs
@@ -1074,7 +1074,11 @@ impl LlamaAttention {
             } else if q_len > 1 {
                 // Causal mask only when processing multiple query tokens (prompt
                 // phase); for q_len == 1 (decode) all past positions are valid.
-                let mask = Tensor::ones([q_len, k_len], (tch::Kind::Float, device)).tril(0);
+                // Offset by the cached history length: query row i sits at
+                // absolute position (k_len - q_len) + i, so it may attend keys
+                // 0..=(k_len - q_len + i). tril(0) would mask out all history
+                // whenever start_pos > 0 (e.g. partial prefill on a prefix hit).
+                let mask = Tensor::ones([q_len, k_len], (tch::Kind::Float, device)).tril(k_len - q_len);
                 let mask = mask.unsqueeze(0).unsqueeze(0).expand_as(&scores);
                 scores = scores.masked_fill(&mask.eq(0.0), -10000.0f64);
             }
@@ -1088,8 +1092,9 @@ impl LlamaAttention {
 
             scores.softmax(-1, tch::Kind::Float).matmul(&v)
         } else {
-            // Chunk over the query axis. Per-chunk causal mask `tril(start)` is the
-            // exact restriction of the full `tril(0)` mask to rows [start, start+cur),
+            // Chunk over the query axis. Per-chunk causal mask
+            // `tril(k_len - q_len + start)` is the exact restriction of the full
+            // causal mask (history offset + row index) to rows [start, start+cur),
             // so masking is identical to the single-shot path.
             let mut outputs: Vec<Tensor> = Vec::new();
             let mut start = 0i64;
@@ -1097,7 +1102,7 @@ impl LlamaAttention {
                 let cur = (q_len - start).min(CHUNK);
                 let q_chunk = q.narrow(2, start, cur); // [batch, heads, cur, dim]
                 let mut scores = q_chunk.matmul(&k_t) * (scale as f64); // [batch, heads, cur, k_len]
-                let mask = Tensor::ones([cur, k_len], (tch::Kind::Float, device)).tril(start);
+                let mask = Tensor::ones([cur, k_len], (tch::Kind::Float, device)).tril(k_len - q_len + start);
                 let mask = mask.unsqueeze(0).unsqueeze(0).expand_as(&scores);
                 scores = scores.masked_fill(&mask.eq(0.0), -10000.0f64);
                 outputs.push(scores.softmax(-1, tch::Kind::Float).matmul(&v)); // [batch, heads, cur, dim]
@@ -3729,6 +3734,54 @@ mod pipeline_tests {
             r_c.allclose(&b_c, 1e-4, 1e-4, false),
             "single-row batched decode diverged from serial (max_diff={max_diff})"
         );
+    }
+
+    /// Regression guard for the causal-mask offset in cached multi-token
+    /// forwards: with `q_len > 1` and `start_pos > 0` the mask must be
+    /// `tril(k_len - q_len)`, not `tril(0)` — otherwise every cached row attends
+    /// only to the first `i+1` keys and all prompt history is masked out. This
+    /// is exactly the serial partial-prefill shape taken on a session
+    /// prefix-cache hit with a >=2-token suffix. Compares LOGITS (not just
+    /// argmax) at fp tolerance.
+    #[test]
+    fn cached_two_token_forward_matches_serial_decode_steps() {
+        let prompt: [i64; 4] = [1, 5, 9, 2];
+
+        // Serial reference: prefill, then two one-token decode steps.
+        let serial = whole_model();
+        let prompt_t = Tensor::from_slice(&prompt).reshape([1, 4]);
+        let _ = serial.forward_with_cache(&prompt_t, 0).unwrap();
+        let ref1 = serial
+            .forward_with_cache(&Tensor::from_slice(&[11i64]).reshape([1, 1]), 4)
+            .unwrap();
+        let ref2 = serial
+            .forward_with_cache(&Tensor::from_slice(&[13i64]).reshape([1, 1]), 5)
+            .unwrap();
+
+        // Cached two-token forward at start_pos=4 (partial-prefill shape).
+        let cached = whole_model();
+        let _ = cached.forward_with_cache(&prompt_t, 0).unwrap();
+        let logits2 = cached
+            .forward_with_cache(&Tensor::from_slice(&[11i64, 13]).reshape([1, 2]), 4)
+            .unwrap();
+
+        let orig = serial.config.original_vocab_size as i64;
+        for (row, ref_l) in [(0i64, &ref1), (1, &ref2)] {
+            let got = logits2.select(1, row).select(0, 0).narrow(0, 0, orig);
+            let want = ref_l.select(0, 0).select(0, 0).narrow(0, 0, orig);
+            let max_diff = (&got - &want).abs().max().double_value(&[]);
+            assert!(
+                got.allclose(&want, 1e-4, 1e-4, false),
+                "cached 2-token forward row {row} diverged from the serial decode step \
+                 (max_diff={max_diff}); the causal mask must keep k_len - q_len history, \
+                 not tril(0)"
+            );
+            assert_eq!(
+                got.argmax(-1, false).int64_value(&[]),
+                want.argmax(-1, false).int64_value(&[]),
+                "row {row} argmax differs",
+            );
+        }
     }
 
     /// `forward_layers_train` must reject ranges outside the stage's owned window

--- a/crates/hyprstream/src/runtime/architectures/qwen3_5.rs
+++ b/crates/hyprstream/src/runtime/architectures/qwen3_5.rs
@@ -1020,15 +1020,21 @@ impl Qwen3_5FullAttention {
         let ctx = if q_len <= ATTN_CHUNK {
             let mut scores = q_p.matmul(&k_p) * scale; // [batch, heads, q_seq, kv_seq]
             if q_len > 1 {
-                let mask = Tensor::ones([q_len, kv_len], (Kind::Float, device)).tril(0);
+                // Causal mask for a possibly-cached forward: query row i sits at
+                // absolute position (kv_len - q_len) + i, so it may attend keys
+                // 0..=(kv_len - q_len + i). tril(0) would mask out all history
+                // whenever start_pos > 0 (e.g. partial prefill on a prefix hit).
+                let mask = Tensor::ones([q_len, kv_len], (Kind::Float, device)).tril(kv_len - q_len);
                 let mask = mask.unsqueeze(0).unsqueeze(0).expand_as(&scores);
                 scores = scores.masked_fill(&mask.eq(0.0), -10000.0f64);
             }
             let attn = scores.softmax(-1, Kind::Float).to_kind(dtype);
             attn.matmul(&v_p.to_kind(dtype)) // [batch, heads, q_seq, head_dim]
         } else {
-            // Chunk over the query axis. Per-chunk causal mask `tril(start)` is the
-            // exact restriction of the full `tril(0)` mask to rows [start, start+cur).
+            // Chunk over the query axis. Per-chunk causal mask
+            // `tril(kv_len - q_len + start)` is the exact restriction of the
+            // full causal mask (history offset + row index) to rows
+            // [start, start+cur).
             let v_d = v_p.to_kind(dtype);
             let mut outs: Vec<Tensor> = Vec::new();
             let mut start = 0i64;
@@ -1036,7 +1042,7 @@ impl Qwen3_5FullAttention {
                 let cur = (q_len - start).min(ATTN_CHUNK);
                 let q_chunk = q_p.narrow(2, start, cur); // [batch, heads, cur, head_dim]
                 let mut scores = q_chunk.matmul(&k_p) * scale; // [batch, heads, cur, kv_seq]
-                let mask = Tensor::ones([cur, kv_len], (Kind::Float, device)).tril(start);
+                let mask = Tensor::ones([cur, kv_len], (Kind::Float, device)).tril(kv_len - q_len + start);
                 let mask = mask.unsqueeze(0).unsqueeze(0).expand_as(&scores);
                 scores = scores.masked_fill(&mask.eq(0.0), -10000.0f64);
                 let attn = scores.softmax(-1, Kind::Float).to_kind(dtype);
@@ -2900,5 +2906,101 @@ mod pipeline_tests {
         let emb = Tensor::randn([1, 3, HIDDEN], (Kind::Float, Device::Cpu));
         assert!(stage.forward_layers_train(&emb, 0..2, None).is_err(), "range below window");
         assert!(stage.forward_layers_train(&emb, 2..LAYERS, None).is_ok(), "owned range ok");
+    }
+
+    /// Regression guard for the causal-mask offset in cached multi-token
+    /// forwards: with `q_len > 1` and `start_pos > 0` the mask must be
+    /// `tril(kv_len - q_len)`, not `tril(0)` — otherwise every cached row
+    /// attends only to the first `i+1` keys and all prompt history is masked
+    /// out. This is exactly the serial partial-prefill shape taken on a session
+    /// prefix-cache hit with a >=2-token suffix. Compares LOGITS (not just
+    /// argmax) at fp tolerance.
+    ///
+    /// Uses an all-full-attention variant of the tiny model so the only
+    /// divergence source is attention itself (the hybrid GDN stack adds ~1e-3
+    /// chunked-vs-recurrent kernel noise, too loose for this guard).
+    #[test]
+    fn cached_two_token_forward_matches_serial_decode_steps() {
+        let allattn_config = || {
+            let mut cfg = tiny_config();
+            cfg.layer_types = (0..cfg.num_hidden_layers)
+                .map(|_| "full_attention".to_owned())
+                .collect();
+            cfg
+        };
+        let build = || {
+            let mut w = tiny_weights();
+            let cfg = allattn_config();
+            // Replace GDN mixers with full-attention ones (deterministic pattern,
+            // same style as tiny_weights).
+            let opt = (Kind::Float, Device::Cpu);
+            let mut seed: i64 = 20_000;
+            let mut pat = |dims: &[i64]| -> Tensor {
+                let n: i64 = dims.iter().product();
+                seed += 7;
+                (Tensor::arange(n, opt) * 0.017 + seed as f64 * 0.013)
+                    .sin()
+                    .reshape(dims)
+                    * 0.05
+            };
+            for i in 0..cfg.num_hidden_layers as usize {
+                if (i + 1) % 4 == 0 {
+                    continue; // already full-attention in tiny_weights
+                }
+                let p = format!("model.layers.{i}");
+                w.retain(|k, _| !k.starts_with(&format!("{p}.linear_attn.")));
+                let ap = format!("{p}.self_attn");
+                w.insert(format!("{ap}.q_proj.weight"), pat(&[HEADS * HEAD_DIM * 2, HIDDEN]));
+                w.insert(format!("{ap}.k_proj.weight"), pat(&[KV_HEADS * HEAD_DIM, HIDDEN]));
+                w.insert(format!("{ap}.v_proj.weight"), pat(&[KV_HEADS * HEAD_DIM, HIDDEN]));
+                w.insert(format!("{ap}.o_proj.weight"), pat(&[HIDDEN, HEADS * HEAD_DIM]));
+                w.insert(format!("{ap}.q_norm.weight"), pat(&[HEAD_DIM]));
+                w.insert(format!("{ap}.k_norm.weight"), pat(&[HEAD_DIM]));
+            }
+            Qwen3_5Model::from_weights(
+                &mut w, allattn_config(), None, &Device::Cpu, Kind::Float, KVQuantType::None,
+            )
+            .unwrap()
+        };
+
+        let prompt: [i64; 6] = [1, 5, 9, 2, 7, 3];
+        let prompt_t = Tensor::from_slice(&prompt).reshape([1, prompt.len() as i64]);
+        let pos = prompt.len();
+
+        // Serial reference: prefill, then two one-token decode steps.
+        let serial = build();
+        let _ = serial.forward_with_cache(&prompt_t, 0).unwrap();
+        let step1 = Tensor::from_slice(&[11i64]).reshape([1, 1]);
+        let ref1 = serial.forward_with_cache(&step1, pos).unwrap(); // [1, 1, V]
+        let step2 = Tensor::from_slice(&[13i64]).reshape([1, 1]);
+        let ref2 = serial.forward_with_cache(&step2, pos + 1).unwrap();
+
+        // Cached two-token forward at start_pos=pos (partial-prefill shape).
+        // forward_with_cache returns last-row logits only (#201), so go through
+        // the forward_layers orchestration to get BOTH rows.
+        let cached = build();
+        let _ = cached.forward_with_cache(&prompt_t, 0).unwrap();
+        let pair = Tensor::from_slice(&[11i64, 13]).reshape([1, 2]);
+        let emb = cached.embed_tokens(&pair).unwrap();
+        let h = cached.forward_layers(&emb, 0..cached.num_layers(), pos, None).unwrap();
+        let h = cached.apply_final_norm(&h).unwrap();
+        let logits2 = cached.lm_head(&h).unwrap(); // [1, 2, V]
+
+        for (row, ref_l) in [(0i64, &ref1), (1, &ref2)] {
+            let got = logits2.select(1, row).reshape([-1i64]);
+            let want = ref_l.reshape([-1i64]);
+            let max_diff = (&got - &want).abs().max().double_value(&[]);
+            assert!(
+                got.allclose(&want, 1e-4, 1e-4, false),
+                "cached 2-token forward row {row} diverged from the serial decode step \
+                 (max_diff={max_diff}); the causal mask must keep kv_len - q_len history, \
+                 not tril(0)"
+            );
+            assert_eq!(
+                got.argmax(-1, false).int64_value(&[]),
+                want.argmax(-1, false).int64_value(&[]),
+                "row {row} argmax differs",
+            );
+        }
     }
 }


### PR DESCRIPTION
Found while reviewing speculative-decoding work: llama.rs and qwen3_5.rs built the causal mask as `tril(0)` on `[q_len, kv_len]`, correct only when `kv_len == q_len`. For a cached multi-token forward (`kv_len = start_pos + q_len`), query row i kept only keys `j <= i` — **the entire prompt history is masked out**.

Production impact: every partial prefill on a session prefix-cache hit with a ≥2-token suffix computes the suffix (and the first sampled token after the hit) with prompt history absent from attention. Verified empirically: a cached 2-token forward diverges from two serial 1-token decode steps at 5.5e-4 (llama) / 1.1e-2 (qwen3_5) max logit diff pre-fix, and matches at fp floor post-fix.

Fix: offset by `kv_len - q_len` (single-shot) / `kv_len - q_len + start` (chunked). No-op at `start_pos == 0`; full prefill, training, and the explicit-mask batched path are untouched. qwen.rs/janus.rs delegate to LlamaModel and are covered.

## Regression tests
`cached_two_token_forward_matches_serial_decode_steps` for llama and qwen3_5 (tiny CPU models, per-row logits allclose 1e-4 + argmax equality; the qwen3_5 probe uses an all-full-attention variant to stay under the GDN kernel noise floor).

## Validation (BuildQ helper, rocm71, CPU)
- `cargo test -p hyprstream --lib --tests --no-fail-fast` — 1640 passed / 0 failed (auth::pglite_store skipped: known pre-existing parallel-harness crash, passes with --test-threads=1)
- `cargo clippy -p hyprstream --all-targets -- -D warnings` — clean

Note: PR #1520 (MTP speculative decoding) carries the identical qwen3_5 hunk; merges cleanly either order.

Sweep notes for follow-up issues (not fixed here): `apply_sliding_window_mask` (llama.rs, Gemma3 local layers) has the same flaw class — loud shape error on cached multi-token forwards and a no-op window at decode; the `get_attention_mask` trait impls are currently dead code (gemma's returns an all-ones stub).