### PR TITLE
fix(discovery): trust non-root service-owned artifacts

### DIFF
--- a/crates/hyprstream-discovery/src/service.rs
+++ b/crates/hyprstream-discovery/src/service.rs
@@ -2419,16 +2419,9 @@ pub fn verify_deployment_artifacts_with_authority_log(
     })
 }
 
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-enum TrustFileOwner {
-    Root,
-    EffectiveUser,
-}
-
 #[derive(Clone, Debug, Eq, PartialEq)]
 struct TrustedArtifactPath {
     path: std::path::PathBuf,
-    owner: TrustFileOwner,
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -2463,52 +2456,38 @@ fn resolve_deployment_trust_paths_from(
     trust_directory: Option<std::ffi::OsString>,
     credentials_directory: Option<std::ffi::OsString>,
 ) -> Result<DeploymentTrustPaths> {
-    let (public_ca, authority_log, authority_checkpoint, trust_owner) = match trust_directory {
+    let (public_ca, authority_log, authority_checkpoint) = match trust_directory {
         Some(value) => {
             let directory = explicit_absolute_directory(DEPLOYMENT_TRUST_DIR_ENV, value)?;
             (
                 directory.join(DEPLOYMENT_CA_ROOT_FILE),
                 directory.join(DEPLOYMENT_AUTHORITY_LOG_FILE),
                 directory.join(DEPLOYMENT_AUTHORITY_CHECKPOINT_FILE),
-                TrustFileOwner::EffectiveUser,
             )
         }
         None => (
             std::path::PathBuf::from(DEPLOYMENT_CA_ROOT_PATH),
             std::path::PathBuf::from(DEPLOYMENT_AUTHORITY_LOG_PATH),
             std::path::PathBuf::from(DEPLOYMENT_AUTHORITY_CHECKPOINT_PATH),
-            TrustFileOwner::Root,
         ),
     };
-    let (registry_credential, credential_owner) = match credentials_directory {
+    let registry_credential = match credentials_directory {
         Some(value) => {
             let directory = explicit_absolute_directory(SYSTEMD_CREDENTIALS_DIRECTORY_ENV, value)?;
-            (
-                directory.join(REGISTRY_DEPLOYMENT_CREDENTIAL_FILE),
-                TrustFileOwner::EffectiveUser,
-            )
+            directory.join(REGISTRY_DEPLOYMENT_CREDENTIAL_FILE)
         }
-        None => (
-            std::path::PathBuf::from(REGISTRY_DEPLOYMENT_CREDENTIAL_PATH),
-            TrustFileOwner::Root,
-        ),
+        None => std::path::PathBuf::from(REGISTRY_DEPLOYMENT_CREDENTIAL_PATH),
     };
     Ok(DeploymentTrustPaths {
-        public_ca: TrustedArtifactPath {
-            path: public_ca,
-            owner: trust_owner,
-        },
+        public_ca: TrustedArtifactPath { path: public_ca },
         authority_log: TrustedArtifactPath {
             path: authority_log,
-            owner: trust_owner,
         },
         authority_checkpoint: TrustedArtifactPath {
             path: authority_checkpoint,
-            owner: trust_owner,
         },
         registry_credential: TrustedArtifactPath {
             path: registry_credential,
-            owner: credential_owner,
         },
     })
 }
@@ -2518,6 +2497,21 @@ fn resolve_deployment_trust_paths() -> Result<DeploymentTrustPaths> {
         std::env::var_os(DEPLOYMENT_TRUST_DIR_ENV),
         std::env::var_os(SYSTEMD_CREDENTIALS_DIRECTORY_ENV),
     )
+}
+
+#[cfg(unix)]
+fn validate_trusted_artifact_metadata(
+    owner_uid: u32,
+    mode: u32,
+    effective_uid: u32,
+    subject: &str,
+) -> Result<()> {
+    anyhow::ensure!(
+        owner_uid == 0 || owner_uid == effective_uid,
+        "{subject} has an untrusted owner"
+    );
+    anyhow::ensure!(mode & 0o022 == 0, "{subject} is group/world writable");
+    Ok(())
 }
 
 #[cfg(unix)]
@@ -2533,10 +2527,6 @@ fn read_trusted_artifact(artifact: &TrustedArtifactPath, description: &str) -> R
         // SAFETY: geteuid has no preconditions and returns process-local state.
         unsafe { libc::geteuid() }
     };
-    let owner_is_allowed = |uid| match artifact.owner {
-        TrustFileOwner::Root => uid == 0,
-        TrustFileOwner::EffectiveUser => uid == 0 || uid == effective_uid,
-    };
     for parent in artifact.path.ancestors().skip(1) {
         let parent_metadata = std::fs::symlink_metadata(parent).map_err(|error| {
             anyhow::anyhow!("{description} parent {parent:?} is unavailable: {error}")
@@ -2545,14 +2535,12 @@ fn read_trusted_artifact(artifact: &TrustedArtifactPath, description: &str) -> R
             parent_metadata.file_type().is_dir(),
             "{description} parent {parent:?} is not a real directory"
         );
-        anyhow::ensure!(
-            owner_is_allowed(parent_metadata.uid()),
-            "{description} parent {parent:?} has an untrusted owner"
-        );
-        anyhow::ensure!(
-            parent_metadata.mode() & 0o022 == 0,
-            "{description} parent {parent:?} is group/world writable"
-        );
+        validate_trusted_artifact_metadata(
+            parent_metadata.uid(),
+            parent_metadata.mode(),
+            effective_uid,
+            &format!("{description} parent {parent:?}"),
+        )?;
     }
     let mut file = std::fs::OpenOptions::new()
         .read(true)
@@ -2574,14 +2562,12 @@ fn read_trusted_artifact(artifact: &TrustedArtifactPath, description: &str) -> R
         metadata.file_type().is_file(),
         "{description} is not a regular file"
     );
-    anyhow::ensure!(
-        owner_is_allowed(metadata.uid()),
-        "{description} has an untrusted owner"
-    );
-    anyhow::ensure!(
-        metadata.mode() & 0o022 == 0,
-        "{description} is group/world writable"
-    );
+    validate_trusted_artifact_metadata(
+        metadata.uid(),
+        metadata.mode(),
+        effective_uid,
+        description,
+    )?;
     let mut bytes = Vec::new();
     file.read_to_end(&mut bytes).map_err(|error| {
         anyhow::anyhow!(
@@ -4986,8 +4972,6 @@ mod resolver_tests {
             fixed.registry_credential.path,
             std::path::Path::new(REGISTRY_DEPLOYMENT_CREDENTIAL_PATH)
         );
-        assert_eq!(fixed.public_ca.owner, TrustFileOwner::Root);
-        assert_eq!(fixed.registry_credential.owner, TrustFileOwner::Root);
 
         let trust_dir = std::path::Path::new("/run/user/1000/hyprstream/trust");
         let credentials_dir =
@@ -5013,11 +4997,6 @@ mod resolver_tests {
             overridden.registry_credential.path,
             credentials_dir.join(REGISTRY_DEPLOYMENT_CREDENTIAL_FILE)
         );
-        assert_eq!(overridden.public_ca.owner, TrustFileOwner::EffectiveUser);
-        assert_eq!(
-            overridden.registry_credential.owner,
-            TrustFileOwner::EffectiveUser
-        );
 
         let trust_only =
             resolve_deployment_trust_paths_from(Some(trust_dir.as_os_str().to_owned()), None)
@@ -5030,7 +5009,6 @@ mod resolver_tests {
             trust_only.registry_credential.path,
             std::path::Path::new(REGISTRY_DEPLOYMENT_CREDENTIAL_PATH)
         );
-        assert_eq!(trust_only.registry_credential.owner, TrustFileOwner::Root);
 
         let credentials_only =
             resolve_deployment_trust_paths_from(None, Some(credentials_dir.as_os_str().to_owned()))
@@ -5043,7 +5021,6 @@ mod resolver_tests {
             credentials_only.registry_credential.path,
             credentials_dir.join(REGISTRY_DEPLOYMENT_CREDENTIAL_FILE)
         );
-        assert_eq!(credentials_only.public_ca.owner, TrustFileOwner::Root);
     }
 
     #[test]
@@ -5087,6 +5064,54 @@ mod resolver_tests {
                 "error did not identify {name}: {error}"
             );
         }
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn trusted_artifact_accepts_effective_uid_owned_file_without_path_override_policy() {
+        use std::os::unix::fs::PermissionsExt as _;
+
+        let fixture = tempfile::Builder::new()
+            .prefix(".trust-owner-test-")
+            .tempdir_in(env!("CARGO_MANIFEST_DIR"))
+            .expect("secure fixture directory");
+        let path = fixture.path().join("fixed-path-policy-artifact");
+        std::fs::write(&path, b"service-owned trust").expect("trust artifact");
+        std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o644))
+            .expect("read-only trust artifact");
+
+        let bytes = read_trusted_artifact(
+            &TrustedArtifactPath { path },
+            "service-owned trust artifact",
+        )
+        .expect("effective-uid-owned 0644 artifact must be trusted");
+        assert_eq!(bytes, b"service-owned trust");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn trusted_artifact_metadata_accepts_root_and_nonroot_service_but_rejects_other_uid() {
+        const NONROOT_SERVICE_UID: u32 = 1_000;
+        const OTHER_UID: u32 = 1_001;
+
+        validate_trusted_artifact_metadata(0, 0o100644, NONROOT_SERVICE_UID, "root artifact")
+            .expect("root-owned 0644 artifact must remain trusted");
+        validate_trusted_artifact_metadata(
+            NONROOT_SERVICE_UID,
+            0o100644,
+            NONROOT_SERVICE_UID,
+            "service artifact",
+        )
+        .expect("non-root effective-uid-owned 0644 artifact must be trusted");
+
+        let error = validate_trusted_artifact_metadata(
+            OTHER_UID,
+            0o100644,
+            NONROOT_SERVICE_UID,
+            "other-user artifact",
+        )
+        .expect_err("different non-service uid was trusted");
+        assert!(error.to_string().contains("untrusted owner"), "{error}");
     }
 
     #[cfg(unix)]
@@ -5191,15 +5216,21 @@ mod resolver_tests {
         use std::os::unix::fs::{symlink, PermissionsExt as _};
 
         let (_fixture, paths, _ca, _registry) = user_service_trust_fixture();
-        std::fs::set_permissions(
-            &paths.registry_credential.path,
-            std::fs::Permissions::from_mode(0o622),
-        )
-        .expect("make credential writable");
-        let error = load_trusted_registry_deployment_credentials_from(&paths)
-            .err()
-            .expect("group-writable credential was trusted");
-        assert!(error.to_string().contains("group/world writable"));
+        for mode in [0o664, 0o666] {
+            std::fs::set_permissions(
+                &paths.registry_credential.path,
+                std::fs::Permissions::from_mode(mode),
+            )
+            .expect("make credential writable");
+            let error = match load_trusted_registry_deployment_credentials_from(&paths) {
+                Ok(_) => panic!("group/world-writable credential was trusted"),
+                Err(error) => error,
+            };
+            assert!(
+                error.to_string().contains("group/world writable"),
+                "mode {mode:o} failed for the wrong reason: {error}"
+            );
+        }
 
         let real_credential = paths
             .registry_credential

--- a/docs/deployment-registry-trust.md
+++ b/docs/deployment-registry-trust.md
@@ -49,9 +49,11 @@ The OS-owned deployment seam is deliberately small and fail-closed:
   provisioned expected log head: schema, deployment domain, log DID, sequence,
   and head CID. The supplied log must match it exactly.
 
-By default, all installed files and parent directories must be real,
-root-owned paths and not group/world writable. Missing, malformed, symlinked,
-or incorrectly owned material makes production resolver startup fail closed.
+All installed files and parent directories must be real, owned by root or the
+daemon's effective service UID, and not group/world writable. This invariant is
+identical for fixed and explicitly overridden paths. Missing, malformed,
+symlinked, or incorrectly owned material makes production resolver startup fail
+closed.
 Missing log or checkpoint never selects a less restrictive verifier. Both JWT
 signature components are verified against the checkpointed active authority
 before its key is represented by an opaque verification-only capability. The
@@ -60,7 +62,7 @@ Discovery APIs.
 
 The repository does not yet contain an operator enrollment protocol. Deployments
 using this OS-owned source must therefore provision the `/etc` pin through their
-OS image, configuration manager, measured-boot policy, or equivalent root-owned
+OS image, configuration manager, measured-boot policy, or equivalent trusted
 mechanism, and project the registry JWT into the fixed `/run` location before
 starting hyprstream.
 
@@ -79,13 +81,13 @@ from systemd's absolute `$CREDENTIALS_DIRECTORY` as
 `$CREDENTIALS_DIRECTORY/registry-service.jwt`. Either variable being present
 but empty, relative, or containing `..` components is a startup error; it
 never falls back to a fixed path. When a variable is absent, only its fixed
-root-owned path is used.
+path is used.
 
-Explicit user-service artifacts and every real ancestor must be owned by root
-or the daemon's effective user and must not be group/world writable. Symlinks
-are rejected and the final file is opened with `O_NOFOLLOW`. This mode trusts
-the service account to provision its own development trust inputs; it does not
-turn XDG or general secret directories into authority.
+Every selected artifact and real ancestor must be owned by root or the daemon's
+effective user and must not be group/world writable. Symlinks are rejected and
+the final file is opened with `O_NOFOLLOW`. The service identity is the trusted
+principal in the non-root production model; this does not turn XDG or general
+secret directories into authority.
 
 Path selection changes no cryptographic rule. The CA is still exactly the
 mandatory 1,984-byte Ed25519 + ML-DSA-65 pair; the authority log must still

--- a/docs/deployment-trust-contract.md
+++ b/docs/deployment-trust-contract.md
@@ -8,7 +8,7 @@ has no PDS/host claim; consumers must not invent one.
 
 ## Fixed runtime artifacts
 
-Metal's root-owned projection service installs these files atomically after
+Metal's projection service installs these files atomically after
 validating them through `hyprstream trust verify-deployment`:
 
 | Artifact | Fixed path | Required representation |
@@ -18,9 +18,12 @@ validating them through `hyprstream trust verify-deployment`:
 | Authority head checkpoint | `/etc/hyprstream/trust/deployment-authority.head.json` | Independently provisioned `hyprstream.deployment-authority-checkpoint.v1` JSON containing the expected domain, log DID, sequence, and head CID |
 | Registry credential | `/run/hyprstream/credentials/registry-service.jwt` | Compact hybrid JWT with no whitespace or newline, profile `hyprstream.registry-deployment.v1`, audience `urn:hyprstream:service:registry`, lifetime at most 3,600 seconds |
 
-Every fixed-path file and parent directory is a regular root-owned OS path and
-must not be group/world writable. The verifier requires the log and checkpoint for
-direct-root and delegated credentials alike. A supplied log is accepted only
+Every fixed-path file and real parent directory must be owned by root or the
+daemon's effective service UID and must not be group/world writable. Symlinks
+are rejected. This same ownership rule applies to fixed and explicitly
+overridden paths: running non-root is a first-class production configuration,
+not a development-only exception. The verifier requires the log and checkpoint
+for direct-root and delegated credentials alike. A supplied log is accepted only
 when its verified DID, sequence, and head CID exactly equal the independently
 provisioned checkpoint; a signature-valid historical prefix therefore cannot
 reactivate a retired authority. The UCAN issuer must also remain in the
@@ -42,7 +45,7 @@ The trust directory supplies `deployment-ca.hybrid`,
 `CREDENTIALS_DIRECTORY` supplies `registry-service.jwt`. Each variable controls
 only its named side of the split; an absent variable falls back to the fixed
 path in the table, while an invalid present value fails startup without
-fallback. User-service paths require real, non-group/world-writable files and
+fallback. All selected paths require real, non-group/world-writable files and
 ancestors owned by root or the daemon's effective user, and symlinks are
 rejected.
 


### PR DESCRIPTION
## Summary
- apply one ownership invariant to fixed and overridden trust paths: owner UID must be root or the daemon effective UID
- retain absolute-path, real-directory ancestor, `O_NOFOLLOW`, and group/world-writable rejection
- cover non-root service ownership, root ownership, foreign UID, `0664`, `0666`, symlinked leaf, and symlinked ancestor cases
- update the canonical deployment trust contract and registry trust documentation for the non-root production model

This unblocks downstream staging ingest #102 and records the ownership model relevant to #1470.

## Validation
- `cargo test -p hyprstream-discovery trusted_artifact --lib -- --nocapture`
- `cargo test -p hyprstream-discovery user_service_paths --lib -- --nocapture`
- `cargo test -p hyprstream-discovery --lib --tests --no-fail-fast`
- `cargo test -p hyprstream --test did_trust_e2e_local -- --nocapture`
- `cargo test -p hyprstream --test did_trust_e2e -- --nocapture`
- `cargo clippy -p hyprstream-discovery --all-targets -- -D warnings`
- pre-commit repository-wide release Clippy

BuildQ used its supported 23 GiB minimum-free override after the default 25 GiB guard refused before Cargo; no cache was deleted or bypassed.

Independent-lane review is required before merge. This implementation lane must not merge the PR.