### PR TITLE
mac(moq): typed track/prefix identity + declared track-policy resolver (WS-I, #1510)

### DIFF
--- a/crates/hyprstream-rpc/src/auth/mac/mod.rs
+++ b/crates/hyprstream-rpc/src/auth/mac/mod.rs
@@ -118,6 +118,7 @@ pub mod genesis;
 pub mod label;
 pub mod lattice;
 pub mod manifest;
+pub mod moq_resolve;
 pub mod pep;
 
 #[cfg(not(target_arch = "wasm32"))]
@@ -143,10 +144,19 @@ pub use manifest::{
     bind_time_label, import_label, ContentBoundLabel, LabeledObject, ObjectLabelResolver,
     ObjectRef, StaticNodeLabel,
 };
+pub use moq_resolve::{
+    DeclaredTrackPolicyResolver, DenyAllMoqEventResolver, MoqEventLabelResolver, MoqEventObjectRef,
+    MoqEventPlane, MoqEventPolicyRow, MoqEventPolicyTable, TrackPolicyError, MAX_TRACK_SEGMENTS,
+    MAX_TRACK_SEGMENT_BYTES, SUPPORTED_TRACK_POLICY_REVISION,
+};
 pub use pep::{
     ClearanceSource, DenyAllClearanceSource, MoqEventAction, MoqEventPep, MoqMacAuditReason,
     MoqMacAuditRecord, MoqMacAuditSink,
 };
+// `RpcObjectLabelResolver` stays exported for the RPC/VFS/9P planes. The
+// MoQ/event plane deliberately consumes only `MoqEventLabelResolver`
+// (v16 §10: coordinates cannot cross resolver types), so it is not
+// re-exported from `pep`.
 
 #[cfg(test)]
 #[allow(clippy::unwrap_used)]

--- a/crates/hyprstream-rpc/src/auth/mac/mod.rs
+++ b/crates/hyprstream-rpc/src/auth/mac/mod.rs
@@ -150,8 +150,9 @@ pub use moq_resolve::{
     MAX_TRACK_SEGMENT_BYTES, SUPPORTED_TRACK_POLICY_REVISION,
 };
 pub use pep::{
-    ClearanceSource, DenyAllClearanceSource, MoqEventAction, MoqEventPep, MoqMacAuditReason,
-    MoqMacAuditRecord, MoqMacAuditSink,
+    bounded_audit_coordinate, BOUNDED_AUDIT_COORDINATE_MAX_BYTES, ClearanceSource,
+    DenyAllClearanceSource, MAX_AUDIT_COORDINATE_PREFIX_BYTES, MoqEventAction, MoqEventPep,
+    MoqMacAuditReason, MoqMacAuditRecord, MoqMacAuditSink,
 };
 // `RpcObjectLabelResolver` stays exported for the RPC/VFS/9P planes. The
 // MoQ/event plane deliberately consumes only `MoqEventLabelResolver`

--- a/crates/hyprstream-rpc/src/auth/mac/moq_resolve.rs
+++ b/crates/hyprstream-rpc/src/auth/mac/moq_resolve.rs
@@ -287,6 +287,15 @@ pub enum TrackPolicyError {
         plane: MoqEventPlane,
         service_domain: String,
     },
+    /// A row declares a service domain that the declared plane's coordinate
+    /// grammar can never produce, so the row can match nothing and the
+    /// objects it names would instead resolve through a shorter prefix
+    /// row's label. Event coordinates split on `.` and reject `/` outright;
+    /// stream coordinates split on `/`.
+    UnrepresentableServiceDomain {
+        plane: MoqEventPlane,
+        service_domain: String,
+    },
 }
 
 impl std::fmt::Display for TrackPolicyError {
@@ -308,6 +317,15 @@ impl std::fmt::Display for TrackPolicyError {
                 "duplicate track-policy declaration for plane {:?} service {service_domain:?}",
                 plane
             ),
+            TrackPolicyError::UnrepresentableServiceDomain {
+                plane,
+                service_domain,
+            } => write!(
+                f,
+                "track-policy row declares service domain {service_domain:?} that the {:?} \
+                 plane grammar can never represent",
+                plane
+            ),
         }
     }
 }
@@ -327,9 +345,43 @@ pub struct MoqEventPolicyRow {
     pub label: SecurityLabel,
 }
 
+/// Plane-representability guard: a declared service domain must be
+/// producible by the declared plane's own coordinate grammar, or the row is
+/// dead — it can match nothing, while the object it names still parses with
+/// the domain's *prefix* as its service coordinate and can silently take a
+/// weaker neighbouring row's label.
+///
+/// This is deliberately **not** a second identity rule: the canonical rule
+/// ([`validate_service_domain`]) stays the one authority on what a service
+/// domain *is* (and it admits `.`/`/` because the RPC/VFS planes use
+/// dotted and path-shaped domains). This guard only asks whether this
+/// plane's grammar — which splits the event coordinate on `.` (segment 0 =
+/// service, `/` rejected outright as a broadcast-path alias) and the
+/// stream coordinate on `/` (segment 1 = service) — could ever yield the
+/// declared domain back.
+fn check_plane_representable(
+    plane: MoqEventPlane,
+    service_domain: &str,
+) -> Result<(), TrackPolicyError> {
+    let unrepresentable = match plane {
+        MoqEventPlane::Event => service_domain.contains('.') || service_domain.contains('/'),
+        MoqEventPlane::Stream => service_domain.contains('/'),
+    };
+    if unrepresentable {
+        return Err(TrackPolicyError::UnrepresentableServiceDomain {
+            plane,
+            service_domain: service_domain.to_owned(),
+        });
+    }
+    Ok(())
+}
+
 impl MoqEventPolicyRow {
-    /// Build a row, rejecting a noncanonical service domain at construction
-    /// (the shared rule — there is no plane-local rewrite).
+    /// Build a row, rejecting a noncanonical service domain (the shared
+    /// rule — there is no plane-local rewrite) and a domain the declared
+    /// plane's grammar can never represent. `MoqEventPolicyTable::build`
+    /// re-checks both: this type's fields are public, so a struct literal
+    /// bypasses this constructor.
     pub fn new(
         plane: MoqEventPlane,
         service_domain: impl Into<String>,
@@ -339,6 +391,7 @@ impl MoqEventPolicyRow {
         if validate_service_domain(&service_domain).is_err() {
             return Err(TrackPolicyError::NoncanonicalServiceDomain(service_domain));
         }
+        check_plane_representable(plane, &service_domain)?;
         Ok(Self {
             plane,
             service_domain,
@@ -364,10 +417,13 @@ impl MoqEventPolicyTable {
     /// Build the table from declared rows.
     ///
     /// Fails (returning no table) on a revision newer than supported, a
-    /// noncanonical service domain, or two rows declaring the same plane +
-    /// service with different labels. Older or equal revisions are accepted:
-    /// a newer *server* understanding an older table is forward-compatible;
-    /// the reverse is not, and denies.
+    /// noncanonical service domain, a service domain the declared plane's
+    /// grammar can never represent (checked here, not only in
+    /// [`MoqEventPolicyRow::new`], because the row fields are public and a
+    /// struct literal must not bypass the guard), or two rows declaring the
+    /// same plane + service with different labels. Older or equal revisions
+    /// are accepted: a newer *server* understanding an older table is
+    /// forward-compatible; the reverse is not, and denies.
     pub fn build(
         revision: u32,
         rows: impl IntoIterator<Item = MoqEventPolicyRow>,
@@ -385,6 +441,7 @@ impl MoqEventPolicyTable {
                     row.service_domain,
                 ));
             }
+            check_plane_representable(row.plane, &row.service_domain)?;
             let key = (row.plane, row.service_domain);
             if let Some(existing) = map.get(&key) {
                 if *existing != row.label {
@@ -791,6 +848,107 @@ mod tests {
             ],
         )
         .unwrap();
+    }
+
+    // ── plane representability: no dead stronger rows (B1) ───────────
+
+    /// The exact B1 event shape: a dead `foo.bar` SECRET row next to a live
+    /// `foo` PUBLIC row. Before the guard, both were accepted, the
+    /// `foo.bar` row matched nothing (the event grammar splits on `.`, so
+    /// `foo.bar.created` parses with service `foo`), and the object silently
+    /// took the weaker PUBLIC label. Now the declaration refuses.
+    #[test]
+    fn unrepresentable_event_domain_cannot_downgrade_declared_label() {
+        // The constructor rejects early…
+        let err =
+            MoqEventPolicyRow::new(MoqEventPlane::Event, "foo.bar", secret_label()).unwrap_err();
+        assert_eq!(
+            err,
+            TrackPolicyError::UnrepresentableServiceDomain {
+                plane: MoqEventPlane::Event,
+                service_domain: "foo.bar".to_owned(),
+            }
+        );
+        // …and so does `/`, which the event grammar rejects outright.
+        MoqEventPolicyRow::new(MoqEventPlane::Event, "foo/bar", secret_label()).unwrap_err();
+
+        // The struct-literal bypass (row fields are pub) is caught at
+        // `build`, which re-runs the guard for exactly that reason.
+        let literal_row = MoqEventPolicyRow {
+            plane: MoqEventPlane::Event,
+            service_domain: "foo.bar".to_owned(),
+            label: secret_label(),
+        };
+        let prefix_row =
+            MoqEventPolicyRow::new(MoqEventPlane::Event, "foo", public_label()).unwrap();
+        let err =
+            MoqEventPolicyTable::build(SUPPORTED_TRACK_POLICY_REVISION, [literal_row, prefix_row])
+                .unwrap_err();
+        assert_eq!(
+            err,
+            TrackPolicyError::UnrepresentableServiceDomain {
+                plane: MoqEventPlane::Event,
+                service_domain: "foo.bar".to_owned(),
+            }
+        );
+
+        // Causal shape, for the record: with only the representable `foo`
+        // row declared, the object the dead row was written to protect
+        // parses under service `foo` and takes its label — which is why an
+        // unrepresentable stronger row must refuse construction instead of
+        // being accepted as dead.
+        let table = MoqEventPolicyTable::build(
+            SUPPORTED_TRACK_POLICY_REVISION,
+            [MoqEventPolicyRow::new(MoqEventPlane::Event, "foo", public_label()).unwrap()],
+        )
+        .unwrap();
+        let object = MoqEventObjectRef::parse(MoqEventPlane::Event, "foo.bar.created").unwrap();
+        assert_eq!(object.service_domain(), "foo");
+        assert_eq!(table.resolve(&object), Some(public_label()));
+    }
+
+    /// The stream shape: a dead `a/b` SECRET row next to a live `a` PUBLIC
+    /// row (`t/a/b/c` parses with service `a`). Same guard, same refusal.
+    #[test]
+    fn unrepresentable_stream_domain_cannot_downgrade_declared_label() {
+        let err = MoqEventPolicyRow::new(MoqEventPlane::Stream, "a/b", secret_label()).unwrap_err();
+        assert_eq!(
+            err,
+            TrackPolicyError::UnrepresentableServiceDomain {
+                plane: MoqEventPlane::Stream,
+                service_domain: "a/b".to_owned(),
+            }
+        );
+
+        // Struct-literal bypass attempt at `build`.
+        let literal_row = MoqEventPolicyRow {
+            plane: MoqEventPlane::Stream,
+            service_domain: "a/b".to_owned(),
+            label: secret_label(),
+        };
+        let prefix_row =
+            MoqEventPolicyRow::new(MoqEventPlane::Stream, "a", public_label()).unwrap();
+        let err =
+            MoqEventPolicyTable::build(SUPPORTED_TRACK_POLICY_REVISION, [literal_row, prefix_row])
+                .unwrap_err();
+        assert_eq!(
+            err,
+            TrackPolicyError::UnrepresentableServiceDomain {
+                plane: MoqEventPlane::Stream,
+                service_domain: "a/b".to_owned(),
+            }
+        );
+
+        // Causal shape: `t/a/b/c` parses with service `a` and takes the
+        // declared `a` label.
+        let table = MoqEventPolicyTable::build(
+            SUPPORTED_TRACK_POLICY_REVISION,
+            [MoqEventPolicyRow::new(MoqEventPlane::Stream, "a", public_label()).unwrap()],
+        )
+        .unwrap();
+        let object = MoqEventObjectRef::parse(MoqEventPlane::Stream, "t/a/b/c").unwrap();
+        assert_eq!(object.service_domain(), "a");
+        assert_eq!(table.resolve(&object), Some(public_label()));
     }
 
     #[test]

--- a/crates/hyprstream-rpc/src/auth/mac/moq_resolve.rs
+++ b/crates/hyprstream-rpc/src/auth/mac/moq_resolve.rs
@@ -1,0 +1,729 @@
+//! Typed MoQ/event object identity + declared track-policy resolver (v16 §10,
+//! WS-I / #1510).
+//!
+//! The MoQ/event plane previously passed its track/prefix string into the
+//! *RPC/VFS* resolver's service-domain coordinate
+//! (`pep.rs` → [`super::dispatch_pep::RpcObjectLabelResolver`]), so a track
+//! name was reinterpreted as a VFS path. v16 §10 removes that shared string
+//! coordinate: every plane owns a typed object reference and a plane-specific
+//! resolver, and "strings are parsed exactly once at the plane boundary and
+//! cannot be reinterpreted by another resolver".
+//!
+//! This module is that end state for MoQ/event:
+//!
+//! - [`MoqEventObjectRef`] is the exact decoded typed identity. A boundary
+//!   string parses into it exactly once ([`MoqEventObjectRef::parse`]) or the
+//!   check denies — there is no string path fallback and no rewriting of
+//!   unknown input after the fact.
+//! - The service coordinate inside the identity is validated by the **one**
+//!   canonical service-domain rule
+//!   ([`validate_service_domain`][crate::envelope::validate_service_domain],
+//!   1..=[`MAX_SERVICE_DOMAIN_BYTES`] bytes) — not a second, plane-local
+//!   identity rule.
+//! - [`MoqEventLabelResolver`] is the plane's own resolver trait
+//!   (a `MoqEventObjectRef` in, a [`SecurityLabel`] out). It is deliberately
+//!   *not* the RPC resolver: dispatch, VFS/9P, CAS, and MoQ/event coordinates
+//!   cannot cross resolver types.
+//! - [`MoqEventPolicyTable`] is the declared track-policy metadata — the
+//!   authoritative label source for this plane. Lookup is an exact typed match
+//!   against declared rows; unknown, unlisted, or newer-vocabulary inputs
+//!   deny. There is no floor allowlist and no bootstrap exception: a table
+//!   that declares nothing labels nothing.
+//!
+//! ## Dependency on the generated dispatch inventory (WS-D)
+//!
+//! The end-state source of declared rows is the generated method-policy
+//! inventory (WS-D / #1505), which emits one reviewed row per annotated leaf
+//! across the service schemas. Until that inventory lands, the table is the
+//! **interface seam**: it is built from explicitly declared
+//! [`MoqEventPolicyRow`]s and rejects (not ignores) malformed input at
+//! construction. WS-D's generated code converts its inventory into rows here
+//! through one reviewed conversion — this module must not duplicate the
+//! annotation table.
+//!
+//! This module compiles for wasm32 (pure types + the shared canonicalization
+//! rule); the PEP that consumes it remains native-only, matching
+//! [`super::pep`].
+
+use std::collections::BTreeMap;
+
+use super::label::SecurityLabel;
+use crate::envelope::{validate_service_domain, MAX_SERVICE_DOMAIN_BYTES};
+
+/// Maximum number of segments in a track/prefix identity. A bound on parse
+/// work per admission check; not the service-domain rule (which is
+/// byte-length based and applies only to the service segment).
+pub const MAX_TRACK_SEGMENTS: usize = 8;
+
+/// Maximum length in bytes of one non-service identity segment. Distinct from
+/// [`MAX_SERVICE_DOMAIN_BYTES`], which bounds only the canonical service
+/// domain through the shared rule.
+pub const MAX_TRACK_SEGMENT_BYTES: usize = 128;
+
+/// The track-policy vocabulary revision this resolver understands. A policy
+/// table stamped with a *newer* revision (emitted by a newer generator whose
+/// vocabulary this build does not know) is rejected rather than partially
+/// interpreted — the "newer identities deny" rule.
+pub const SUPPORTED_TRACK_POLICY_REVISION: u32 = 1;
+
+/// Drift guard: the plane grammar is specified against the shared canonical
+/// service-domain cap (Gate-2 value 7 froze `aud` at 128 bytes through the
+/// same constant). If the shared rule's bound changes, this module's bounds
+/// must be re-reviewed together.
+const _: () = assert!(
+    MAX_SERVICE_DOMAIN_BYTES == 128,
+    "the shared canonical service-domain cap changed; re-review the MoQ/event plane grammar bounds"
+);
+
+/// The MoQ data plane a coordinate belongs to. Closed and exhaustive: adding
+/// a plane is a resolver-contract change, not a string reinterpretation.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum MoqEventPlane {
+    /// Event-bus topic prefixes (`{source}.{entity}.{event}` dot grammar;
+    /// the authz coordinate is the `{source}` prefix).
+    Event,
+    /// MoQ stream tracks / broadcast paths (`{tenant}/{service}/{topic}/…`
+    /// and `local/{service}/…` slash grammars).
+    Stream,
+}
+
+impl MoqEventPlane {
+    /// Wire-stable discriminant for decoded ingress.
+    pub const fn discriminant(self) -> u16 {
+        match self {
+            MoqEventPlane::Event => 0,
+            MoqEventPlane::Stream => 1,
+        }
+    }
+
+    /// Decode a plane discriminant. Unknown values return `None` — the
+    /// boundary denies rather than falling back to a default plane.
+    pub const fn from_discriminant(value: u16) -> Option<Self> {
+        match value {
+            0 => Some(MoqEventPlane::Event),
+            1 => Some(MoqEventPlane::Stream),
+            _ => None,
+        }
+    }
+}
+
+/// The exact decoded track/prefix identity for one MoQ/event object.
+///
+/// Constructed only by [`Self::parse`] at the plane boundary. The service
+/// coordinate is canonical (shared 1..=128-byte rule); the remaining segments
+/// are preserved verbatim so the identity is exact, and the plane makes it
+/// non-reinterpretable by any other plane's resolver.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct MoqEventObjectRef {
+    plane: MoqEventPlane,
+    service_domain: String,
+    segments: Box<[String]>,
+}
+
+impl MoqEventObjectRef {
+    /// Parse the plane's coordinate grammar exactly once.
+    ///
+    /// Returns `None` for every deviation — wrong segment count, empty or
+    /// oversized segments, path-traversal segments, a `/` inside an event
+    /// coordinate (which would alias the broadcast-path namespace), or a
+    /// noncanonical service segment. Unknown input denies; it is never
+    /// rewritten.
+    pub fn parse(plane: MoqEventPlane, coordinate: &str) -> Option<Self> {
+        match plane {
+            MoqEventPlane::Event => Self::parse_dot_coordinate(coordinate),
+            MoqEventPlane::Stream => Self::parse_slash_coordinate(coordinate),
+        }
+    }
+
+    /// Parse an event-plane topic prefix: dot-separated, 1..=
+    /// [`MAX_TRACK_SEGMENTS`] segments, segment 0 is the canonical service
+    /// domain (the event `source`). Segments never contain `/`: the event
+    /// namespace is flat per source, and a `/` would alias a broadcast path.
+    fn parse_dot_coordinate(coordinate: &str) -> Option<Self> {
+        let mut segments = Vec::new();
+        for segment in coordinate.split('.') {
+            check_segment(segment)?;
+            // The event namespace is flat per source: a `/` in an event
+            // segment would alias the slash-separated broadcast-path
+            // namespace, so it denies here rather than parse ambiguously.
+            if segment.contains('/') {
+                return None;
+            }
+            segments.push(segment.to_owned());
+        }
+        if segments.len() > MAX_TRACK_SEGMENTS {
+            return None;
+        }
+        let service_domain = canonical_domain(&segments[0])?;
+        Some(Self {
+            plane: MoqEventPlane::Event,
+            service_domain,
+            segments: segments.into(),
+        })
+    }
+
+    /// Parse a stream-plane track/broadcast name: slash-separated,
+    /// 2..=[`MAX_TRACK_SEGMENTS`] segments, segment 1 is the canonical
+    /// service domain (`{tenant}/{service}/…` and `local/{service}/…` both
+    /// carry it at index 1). A lone segment has no service coordinate and
+    /// denies.
+    fn parse_slash_coordinate(coordinate: &str) -> Option<Self> {
+        let mut segments = Vec::new();
+        for segment in coordinate.split('/') {
+            check_segment(segment)?;
+            segments.push(segment.to_owned());
+        }
+        if segments.len() < 2 || segments.len() > MAX_TRACK_SEGMENTS {
+            return None;
+        }
+        let service_domain = canonical_domain(&segments[1])?;
+        Some(Self {
+            plane: MoqEventPlane::Stream,
+            service_domain,
+            segments: segments.into(),
+        })
+    }
+
+    /// The plane this identity belongs to.
+    pub fn plane(&self) -> MoqEventPlane {
+        self.plane
+    }
+
+    /// The canonical service domain of the declaring service.
+    pub fn service_domain(&self) -> &str {
+        &self.service_domain
+    }
+
+    /// The exact (verbatim, post-validation) identity segments.
+    pub fn segments(&self) -> &[String] {
+        &self.segments
+    }
+
+    /// The raw coordinate this ref would audit as (plane-tagged; the audit
+    /// trail records what was decoded, never a reinterpretation).
+    pub fn audit_coordinate(&self) -> String {
+        let separator = match self.plane {
+            MoqEventPlane::Event => '.',
+            MoqEventPlane::Stream => '/',
+        };
+        let mut out = String::new();
+        for segment in &self.segments[..] {
+            if !out.is_empty() {
+                out.push(separator);
+            }
+            out.push_str(segment);
+        }
+        out
+    }
+}
+
+/// Validate one non-service identity segment: non-empty, bounded, no NUL, no
+/// path-traversal names. (The service segment additionally passes the shared
+/// canonical service-domain rule.)
+fn check_segment(segment: &str) -> Option<()> {
+    if segment.is_empty()
+        || segment.len() > MAX_TRACK_SEGMENT_BYTES
+        || segment == "."
+        || segment == ".."
+        || segment.as_bytes().contains(&0)
+    {
+        return None;
+    }
+    Some(())
+}
+
+/// Apply the one canonical service-domain rule. A segment that is not
+/// already canonical denies — it is never rewritten.
+fn canonical_domain(segment: &str) -> Option<String> {
+    validate_service_domain(segment).ok()?;
+    Some(segment.to_owned())
+}
+
+/// The MoQ/event plane's own object-label resolver (v16 §10).
+///
+/// Takes the typed [`MoqEventObjectRef`] only — never a bare string, never
+/// another plane's coordinate. `None` ⇒ unlabeled ⇒ deny (D2/D3).
+pub trait MoqEventLabelResolver: Send + Sync {
+    fn resolve(&self, object: &MoqEventObjectRef) -> Option<SecurityLabel>;
+}
+
+/// Fail-closed resolver: every object is unlabeled. The structural default
+/// when no declared track-policy table exists; combined with an installed
+/// PEP it denies everything regardless of clearance.
+#[derive(Debug, Default, Clone, Copy)]
+pub struct DenyAllMoqEventResolver;
+
+impl MoqEventLabelResolver for DenyAllMoqEventResolver {
+    fn resolve(&self, _object: &MoqEventObjectRef) -> Option<SecurityLabel> {
+        None
+    }
+}
+
+/// Why a declared track-policy table could not be built. Construction
+/// failure is fail-closed: the caller keeps no partial table.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum TrackPolicyError {
+    /// The table's vocabulary revision is newer than
+    /// [`SUPPORTED_TRACK_POLICY_REVISION`]; this build refuses to partially
+    /// interpret it.
+    UnsupportedRevision { table: u32, supported: u32 },
+    /// A row declares a service domain that fails the canonical rule.
+    NoncanonicalServiceDomain(String),
+    /// Two rows declare the same plane + service domain with different
+    /// labels. Ambiguous declarations are rejected, never merged.
+    DuplicateDeclaration {
+        plane: MoqEventPlane,
+        service_domain: String,
+    },
+}
+
+impl std::fmt::Display for TrackPolicyError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            TrackPolicyError::UnsupportedRevision { table, supported } => write!(
+                f,
+                "track-policy revision {table} is newer than supported revision {supported}"
+            ),
+            TrackPolicyError::NoncanonicalServiceDomain(domain) => write!(
+                f,
+                "track-policy row declares noncanonical service domain {domain:?}"
+            ),
+            TrackPolicyError::DuplicateDeclaration {
+                plane,
+                service_domain,
+            } => write!(
+                f,
+                "duplicate track-policy declaration for plane {:?} service {service_domain:?}",
+                plane
+            ),
+        }
+    }
+}
+
+impl std::error::Error for TrackPolicyError {}
+
+/// One declared track-policy row: the declaring service's label for its
+/// objects on one plane. The generated dispatch inventory (WS-D) is the
+/// end-state producer; rows are otherwise declared explicitly.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct MoqEventPolicyRow {
+    /// The plane this declaration covers.
+    pub plane: MoqEventPlane,
+    /// The canonical service domain of the declaring service.
+    pub service_domain: String,
+    /// The label for the declared service's objects on that plane.
+    pub label: SecurityLabel,
+}
+
+impl MoqEventPolicyRow {
+    /// Build a row, rejecting a noncanonical service domain at construction
+    /// (the shared rule — there is no plane-local rewrite).
+    pub fn new(
+        plane: MoqEventPlane,
+        service_domain: impl Into<String>,
+        label: SecurityLabel,
+    ) -> Result<Self, TrackPolicyError> {
+        let service_domain = service_domain.into();
+        if validate_service_domain(&service_domain).is_err() {
+            return Err(TrackPolicyError::NoncanonicalServiceDomain(service_domain));
+        }
+        Ok(Self {
+            plane,
+            service_domain,
+            label,
+        })
+    }
+}
+
+/// Declared track-policy metadata: the closed, validated set of rows the
+/// resolver trusts. This is the reviewed seam onto the generated inventory.
+///
+/// Lookup is an exact typed match on `(plane, canonical service domain)`.
+/// Anything not declared — unknown service, other plane, empty table — is
+/// unlabeled and denies. There is no ancestor walk, no floor, and no
+/// bootstrap exception.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct MoqEventPolicyTable {
+    revision: u32,
+    rows: BTreeMap<(MoqEventPlane, String), SecurityLabel>,
+}
+
+impl MoqEventPolicyTable {
+    /// Build the table from declared rows.
+    ///
+    /// Fails (returning no table) on a revision newer than supported, a
+    /// noncanonical service domain, or two rows declaring the same plane +
+    /// service with different labels. Older or equal revisions are accepted:
+    /// a newer *server* understanding an older table is forward-compatible;
+    /// the reverse is not, and denies.
+    pub fn build(
+        revision: u32,
+        rows: impl IntoIterator<Item = MoqEventPolicyRow>,
+    ) -> Result<Self, TrackPolicyError> {
+        if revision > SUPPORTED_TRACK_POLICY_REVISION {
+            return Err(TrackPolicyError::UnsupportedRevision {
+                table: revision,
+                supported: SUPPORTED_TRACK_POLICY_REVISION,
+            });
+        }
+        let mut map = BTreeMap::new();
+        for row in rows {
+            if validate_service_domain(&row.service_domain).is_err() {
+                return Err(TrackPolicyError::NoncanonicalServiceDomain(
+                    row.service_domain,
+                ));
+            }
+            let key = (row.plane, row.service_domain);
+            if let Some(existing) = map.get(&key) {
+                if *existing != row.label {
+                    return Err(TrackPolicyError::DuplicateDeclaration {
+                        plane: row.plane,
+                        service_domain: key.1,
+                    });
+                }
+                continue;
+            }
+            map.insert(key, row.label);
+        }
+        Ok(Self {
+            revision,
+            rows: map,
+        })
+    }
+
+    /// The table that declares nothing. Every lookup is unlisted and denies;
+    /// this is the honest pre-inventory state, not a bypass.
+    pub fn empty() -> Self {
+        Self {
+            revision: SUPPORTED_TRACK_POLICY_REVISION,
+            rows: BTreeMap::new(),
+        }
+    }
+
+    /// The vocabulary revision this table was declared at.
+    pub fn revision(&self) -> u32 {
+        self.revision
+    }
+
+    /// Number of declared rows.
+    pub fn len(&self) -> usize {
+        self.rows.len()
+    }
+
+    /// Whether no rows are declared.
+    pub fn is_empty(&self) -> bool {
+        self.rows.is_empty()
+    }
+
+    /// Exact typed lookup: the declared label for this object's plane +
+    /// canonical service domain, or `None` when unlisted.
+    pub fn resolve(&self, object: &MoqEventObjectRef) -> Option<SecurityLabel> {
+        self.rows
+            .get(&(object.plane, object.service_domain.clone()))
+            .copied()
+    }
+}
+
+/// The production resolver: exact-match lookup against a validated declared
+/// track-policy table.
+#[derive(Debug, Clone)]
+pub struct DeclaredTrackPolicyResolver {
+    table: MoqEventPolicyTable,
+}
+
+impl DeclaredTrackPolicyResolver {
+    /// Wrap a validated table.
+    pub fn new(table: MoqEventPolicyTable) -> Self {
+        Self { table }
+    }
+
+    /// The declared table this resolver enforces.
+    pub fn table(&self) -> &MoqEventPolicyTable {
+        &self.table
+    }
+}
+
+impl MoqEventLabelResolver for DeclaredTrackPolicyResolver {
+    fn resolve(&self, object: &MoqEventObjectRef) -> Option<SecurityLabel> {
+        self.table.resolve(object)
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+mod tests {
+    use super::*;
+    use crate::auth::mac::{Assurance, CompartmentSet, Level};
+
+    fn public_label() -> SecurityLabel {
+        SecurityLabel::new(Level::Public, Assurance::Classical, CompartmentSet::EMPTY)
+    }
+
+    fn secret_label() -> SecurityLabel {
+        SecurityLabel::new(Level::Secret, Assurance::PqHybrid, CompartmentSet::EMPTY)
+    }
+
+    // ── plane discriminants ───────────────────────────────────────────
+
+    #[test]
+    fn plane_discriminants_decode_exactly_the_known_set() {
+        assert_eq!(
+            MoqEventPlane::from_discriminant(MoqEventPlane::Event.discriminant()),
+            Some(MoqEventPlane::Event)
+        );
+        assert_eq!(
+            MoqEventPlane::from_discriminant(MoqEventPlane::Stream.discriminant()),
+            Some(MoqEventPlane::Stream)
+        );
+        for unknown in [2u16, 3, 7, u16::MAX] {
+            assert_eq!(MoqEventPlane::from_discriminant(unknown), None);
+        }
+    }
+
+    // ── event-prefix identity ─────────────────────────────────────────
+
+    #[test]
+    fn event_prefix_parses_source_as_canonical_service_domain() {
+        let object =
+            MoqEventObjectRef::parse(MoqEventPlane::Event, "worker").expect("bare source parses");
+        assert_eq!(object.plane(), MoqEventPlane::Event);
+        assert_eq!(object.service_domain(), "worker");
+        assert_eq!(object.segments(), ["worker"].map(String::from).as_slice());
+
+        let object = MoqEventObjectRef::parse(MoqEventPlane::Event, "registry.repo789.push")
+            .expect("topic prefix parses");
+        assert_eq!(object.service_domain(), "registry");
+        assert_eq!(
+            object.segments(),
+            ["registry", "repo789", "push"].map(String::from).as_slice()
+        );
+    }
+
+    #[test]
+    fn event_prefix_rejects_noncanonical_service_domains() {
+        // The shared canonical rule: lowercase-initial, charset, 1..=128
+        // bytes. None of these are rewritten — they deny.
+        for bad in [
+            "", "Worker",  // uppercase
+            "_worker", // starts with underscore, not letter/digit
+            "wor ker", // space
+            "wo:rker", // internal map-key separator
+            "wor/ker", // broadcast-path alias
+        ] {
+            assert!(
+                MoqEventObjectRef::parse(MoqEventPlane::Event, bad).is_none(),
+                "{bad:?} must not parse as an event prefix"
+            );
+        }
+    }
+
+    #[test]
+    fn event_prefix_rejects_oversized_and_unbounded_input() {
+        let long_segment = "w".repeat(MAX_TRACK_SEGMENT_BYTES + 1);
+        assert!(MoqEventObjectRef::parse(MoqEventPlane::Event, &long_segment).is_none());
+
+        let too_many = ["worker"; MAX_TRACK_SEGMENTS + 1].join(".");
+        assert!(MoqEventObjectRef::parse(MoqEventPlane::Event, &too_many).is_none());
+
+        let oversized_domain = "w".repeat(MAX_SERVICE_DOMAIN_BYTES + 1);
+        assert!(
+            MoqEventObjectRef::parse(MoqEventPlane::Event, &oversized_domain).is_none(),
+            "service domain beyond the shared 128-byte rule denies"
+        );
+    }
+
+    #[test]
+    fn event_prefix_rejects_empty_segments() {
+        for bad in [".worker", "worker.", "worker..push", "wor..ker"] {
+            assert!(MoqEventObjectRef::parse(MoqEventPlane::Event, bad).is_none());
+        }
+    }
+
+    // ── stream-track identity ─────────────────────────────────────────
+
+    #[test]
+    fn stream_track_parses_service_at_second_segment() {
+        let object = MoqEventObjectRef::parse(MoqEventPlane::Stream, "alice/streams/run-1/i0")
+            .expect("tenant track parses");
+        assert_eq!(object.plane(), MoqEventPlane::Stream);
+        assert_eq!(object.service_domain(), "streams");
+        assert_eq!(
+            object.segments(),
+            ["alice", "streams", "run-1", "i0"]
+                .map(String::from)
+                .as_slice()
+        );
+
+        let object = MoqEventObjectRef::parse(MoqEventPlane::Stream, "local/streams/deadbeef")
+            .expect("broadcast path parses");
+        assert_eq!(object.service_domain(), "streams");
+
+        let object = MoqEventObjectRef::parse(MoqEventPlane::Stream, "local/events/worker")
+            .expect("event broadcast path parses under the stream grammar");
+        assert_eq!(object.service_domain(), "events");
+    }
+
+    #[test]
+    fn stream_track_rejects_single_segment_and_bad_grammar() {
+        // A lone segment has no service coordinate.
+        assert!(MoqEventObjectRef::parse(MoqEventPlane::Stream, "alice").is_none());
+        // Empty segments and traversal names deny.
+        for bad in [
+            "/streams/x",
+            "alice//run",
+            "alice/streams/run/",
+            "./streams/x",
+            "alice/../streams/run",
+        ] {
+            assert!(
+                MoqEventObjectRef::parse(MoqEventPlane::Stream, bad).is_none(),
+                "{bad:?} must not parse"
+            );
+        }
+        // Noncanonical service segment denies.
+        assert!(MoqEventObjectRef::parse(MoqEventPlane::Stream, "alice/Streams/x").is_none());
+    }
+
+    #[test]
+    fn identities_are_not_reinterpretable_across_grammars() {
+        // An event coordinate with a '/' cannot smuggle a broadcast path.
+        assert!(MoqEventObjectRef::parse(MoqEventPlane::Event, "local/events/worker").is_none());
+        // A stream coordinate and an event coordinate for similar-looking
+        // strings remain distinct typed identities (different plane, domain).
+        let stream = MoqEventObjectRef::parse(MoqEventPlane::Stream, "local/events/worker")
+            .expect("stream grammar applies");
+        let event = MoqEventObjectRef::parse(MoqEventPlane::Event, "events.worker")
+            .expect("event grammar applies");
+        assert_eq!(stream.service_domain(), "events");
+        assert_eq!(event.service_domain(), "events");
+        assert_ne!(stream, event, "plane is part of identity");
+    }
+
+    #[test]
+    fn audit_coordinate_round_trips_the_decoded_segments() {
+        let object = MoqEventObjectRef::parse(MoqEventPlane::Stream, "alice/streams/run-1/i0")
+            .expect("parses");
+        assert_eq!(object.audit_coordinate(), "alice/streams/run-1/i0");
+        let object =
+            MoqEventObjectRef::parse(MoqEventPlane::Event, "registry.repo789.push").unwrap();
+        assert_eq!(object.audit_coordinate(), "registry.repo789.push");
+    }
+
+    // ── declared policy table ─────────────────────────────────────────
+
+    fn declared_table() -> MoqEventPolicyTable {
+        MoqEventPolicyTable::build(
+            SUPPORTED_TRACK_POLICY_REVISION,
+            [
+                MoqEventPolicyRow::new(MoqEventPlane::Event, "worker", secret_label()).unwrap(),
+                MoqEventPolicyRow::new(MoqEventPlane::Event, "registry", public_label()).unwrap(),
+                MoqEventPolicyRow::new(MoqEventPlane::Stream, "streams", public_label()).unwrap(),
+            ],
+        )
+        .unwrap()
+    }
+
+    #[test]
+    fn table_resolves_exactly_the_declared_plane_and_service() {
+        let table = declared_table();
+        let worker =
+            MoqEventObjectRef::parse(MoqEventPlane::Event, "worker.sandbox1.started").unwrap();
+        assert_eq!(table.resolve(&worker), Some(secret_label()));
+
+        // The same service on the *other* plane is a different object:
+        // `worker` is declared for events only, so a stream track whose
+        // service segment is `worker` is unlisted.
+        let worker_as_stream =
+            MoqEventObjectRef::parse(MoqEventPlane::Stream, "tenant/worker/topic1/i0").unwrap();
+        assert_eq!(worker_as_stream.service_domain(), "worker");
+        assert_eq!(table.resolve(&worker_as_stream), None);
+
+        let streams = MoqEventObjectRef::parse(MoqEventPlane::Stream, "a/streams/b/c").unwrap();
+        assert_eq!(table.resolve(&streams), Some(public_label()));
+    }
+
+    #[test]
+    fn unlisted_services_and_empty_table_deny() {
+        let table = declared_table();
+        let unknown = MoqEventObjectRef::parse(MoqEventPlane::Event, "inference.session.x")
+            .expect("parses, but is unlisted");
+        assert_eq!(table.resolve(&unknown), None);
+
+        let empty = MoqEventPolicyTable::empty();
+        assert!(empty.is_empty());
+        let declared = MoqEventObjectRef::parse(MoqEventPlane::Event, "worker").unwrap();
+        assert_eq!(
+            empty.resolve(&declared),
+            None,
+            "empty table denies everything"
+        );
+    }
+
+    #[test]
+    fn newer_table_revision_is_rejected_not_partially_interpreted() {
+        let err = MoqEventPolicyTable::build(
+            SUPPORTED_TRACK_POLICY_REVISION + 1,
+            [MoqEventPolicyRow::new(MoqEventPlane::Event, "worker", public_label()).unwrap()],
+        )
+        .unwrap_err();
+        assert_eq!(
+            err,
+            TrackPolicyError::UnsupportedRevision {
+                table: SUPPORTED_TRACK_POLICY_REVISION + 1,
+                supported: SUPPORTED_TRACK_POLICY_REVISION,
+            }
+        );
+        // An older/equal revision is accepted (forward compatibility runs one
+        // way: newer server, older table).
+        MoqEventPolicyTable::build(
+            SUPPORTED_TRACK_POLICY_REVISION,
+            [MoqEventPolicyRow::new(MoqEventPlane::Event, "worker", public_label()).unwrap()],
+        )
+        .unwrap();
+    }
+
+    #[test]
+    fn table_construction_is_fail_closed() {
+        // Noncanonical row domain rejects.
+        let err =
+            MoqEventPolicyRow::new(MoqEventPlane::Event, "Worker", public_label()).unwrap_err();
+        assert_eq!(
+            err,
+            TrackPolicyError::NoncanonicalServiceDomain("Worker".to_owned())
+        );
+
+        // Conflicting duplicate declarations reject — never merged.
+        let err = MoqEventPolicyTable::build(
+            SUPPORTED_TRACK_POLICY_REVISION,
+            [
+                MoqEventPolicyRow::new(MoqEventPlane::Event, "worker", public_label()).unwrap(),
+                MoqEventPolicyRow::new(MoqEventPlane::Event, "worker", secret_label()).unwrap(),
+            ],
+        )
+        .unwrap_err();
+        assert_eq!(
+            err,
+            TrackPolicyError::DuplicateDeclaration {
+                plane: MoqEventPlane::Event,
+                service_domain: "worker".to_owned(),
+            }
+        );
+
+        // Identical duplicate rows are idempotent, not ambiguous.
+        MoqEventPolicyTable::build(
+            SUPPORTED_TRACK_POLICY_REVISION,
+            [
+                MoqEventPolicyRow::new(MoqEventPlane::Event, "worker", public_label()).unwrap(),
+                MoqEventPolicyRow::new(MoqEventPlane::Event, "worker", public_label()).unwrap(),
+            ],
+        )
+        .unwrap();
+    }
+
+    #[test]
+    fn deny_all_resolver_labels_nothing() {
+        let resolver = DenyAllMoqEventResolver;
+        let object = MoqEventObjectRef::parse(MoqEventPlane::Event, "worker").unwrap();
+        assert_eq!(resolver.resolve(&object), None);
+    }
+}

--- a/crates/hyprstream-rpc/src/auth/mac/moq_resolve.rs
+++ b/crates/hyprstream-rpc/src/auth/mac/moq_resolve.rs
@@ -139,9 +139,17 @@ impl MoqEventObjectRef {
     /// [`MAX_TRACK_SEGMENTS`] segments, segment 0 is the canonical service
     /// domain (the event `source`). Segments never contain `/`: the event
     /// namespace is flat per source, and a `/` would alias a broadcast path.
+    ///
+    /// The ninth segment is rejected on observation — before it is cloned or
+    /// otherwise worked on — so an attacker-controlled name cannot amplify
+    /// allocation past `MAX_TRACK_SEGMENTS` bounded segments no matter how
+    /// many separators it carries.
     fn parse_dot_coordinate(coordinate: &str) -> Option<Self> {
-        let mut segments = Vec::new();
+        let mut segments = Vec::with_capacity(MAX_TRACK_SEGMENTS);
         for segment in coordinate.split('.') {
+            if segments.len() == MAX_TRACK_SEGMENTS {
+                return None;
+            }
             check_segment(segment)?;
             // The event namespace is flat per source: a `/` in an event
             // segment would alias the slash-separated broadcast-path
@@ -150,9 +158,6 @@ impl MoqEventObjectRef {
                 return None;
             }
             segments.push(segment.to_owned());
-        }
-        if segments.len() > MAX_TRACK_SEGMENTS {
-            return None;
         }
         let service_domain = canonical_domain(&segments[0])?;
         Some(Self {
@@ -167,13 +172,20 @@ impl MoqEventObjectRef {
     /// service domain (`{tenant}/{service}/…` and `local/{service}/…` both
     /// carry it at index 1). A lone segment has no service coordinate and
     /// denies.
+    ///
+    /// Like the event grammar, the ninth segment is rejected on observation,
+    /// before it is cloned or otherwise worked on: allocation is structurally
+    /// bounded at `MAX_TRACK_SEGMENTS` segments however long the name is.
     fn parse_slash_coordinate(coordinate: &str) -> Option<Self> {
-        let mut segments = Vec::new();
+        let mut segments = Vec::with_capacity(MAX_TRACK_SEGMENTS);
         for segment in coordinate.split('/') {
+            if segments.len() == MAX_TRACK_SEGMENTS {
+                return None;
+            }
             check_segment(segment)?;
             segments.push(segment.to_owned());
         }
-        if segments.len() < 2 || segments.len() > MAX_TRACK_SEGMENTS {
+        if segments.len() < 2 {
             return None;
         }
         let service_domain = canonical_domain(&segments[1])?;
@@ -518,18 +530,79 @@ mod tests {
     }
 
     #[test]
-    fn event_prefix_rejects_oversized_and_unbounded_input() {
+    fn event_prefix_rejects_oversized_segments_and_domain() {
         let long_segment = "w".repeat(MAX_TRACK_SEGMENT_BYTES + 1);
         assert!(MoqEventObjectRef::parse(MoqEventPlane::Event, &long_segment).is_none());
-
-        let too_many = ["worker"; MAX_TRACK_SEGMENTS + 1].join(".");
-        assert!(MoqEventObjectRef::parse(MoqEventPlane::Event, &too_many).is_none());
 
         let oversized_domain = "w".repeat(MAX_SERVICE_DOMAIN_BYTES + 1);
         assert!(
             MoqEventObjectRef::parse(MoqEventPlane::Event, &oversized_domain).is_none(),
             "service domain beyond the shared 128-byte rule denies"
         );
+    }
+
+    // ── segment-count bound: reject the ninth on observation ──────────
+
+    fn dot_name(count: usize) -> String {
+        vec!["worker"; count].join(".")
+    }
+
+    fn slash_name(count: usize) -> String {
+        vec!["worker"; count].join("/")
+    }
+
+    #[test]
+    fn exactly_eight_segments_parse_in_both_syntaxes() {
+        let event = MoqEventObjectRef::parse(MoqEventPlane::Event, &dot_name(MAX_TRACK_SEGMENTS))
+            .expect("eight dot segments parse");
+        assert_eq!(event.segments().len(), MAX_TRACK_SEGMENTS);
+
+        let stream =
+            MoqEventObjectRef::parse(MoqEventPlane::Stream, &slash_name(MAX_TRACK_SEGMENTS))
+                .expect("eight slash segments parse");
+        assert_eq!(stream.segments().len(), MAX_TRACK_SEGMENTS);
+    }
+
+    #[test]
+    fn ninth_segment_rejects_in_both_syntaxes() {
+        // Every segment is individually valid; only the count rejects.
+        assert!(
+            MoqEventObjectRef::parse(MoqEventPlane::Event, &dot_name(MAX_TRACK_SEGMENTS + 1))
+                .is_none()
+        );
+        assert!(MoqEventObjectRef::parse(
+            MoqEventPlane::Stream,
+            &slash_name(MAX_TRACK_SEGMENTS + 1)
+        )
+        .is_none());
+    }
+
+    #[test]
+    fn very_large_names_reject_without_segment_amplification() {
+        // A million individually-valid segments: the parsers reject on
+        // observing the ninth, so neither clones segment 9..=N. Before the
+        // on-observation bound this loop cloned every attacker-controlled
+        // segment before the count check.
+        let million_dots = ["a"; 1_000_000].join(".");
+        assert!(MoqEventObjectRef::parse(MoqEventPlane::Event, &million_dots).is_none());
+        let million_slashes = ["a"; 1_000_000].join("/");
+        assert!(MoqEventObjectRef::parse(MoqEventPlane::Stream, &million_slashes).is_none());
+
+        // A very large ninth tail after eight valid segments: rejected at the
+        // ninth boundary too, bounding both work and allocation by segment
+        // count rather than by name length.
+        let huge_tail = format!(
+            "{}.{}",
+            dot_name(MAX_TRACK_SEGMENTS),
+            "x".repeat(4 * 1024 * 1024)
+        );
+        assert!(MoqEventObjectRef::parse(MoqEventPlane::Event, &huge_tail).is_none());
+        let huge_tail = format!(
+            "{}/{}",
+            slash_name(MAX_TRACK_SEGMENTS),
+            "x".repeat(4 * 1024 * 1024)
+        );
+        assert!(MoqEventObjectRef::parse(MoqEventPlane::Stream, &huge_tail).is_none());
     }
 
     #[test]

--- a/crates/hyprstream-rpc/src/auth/mac/pep.rs
+++ b/crates/hyprstream-rpc/src/auth/mac/pep.rs
@@ -1,16 +1,28 @@
-//! MoQ / event-plane MAC policy-enforcement point (epic #547, #1271).
+//! MoQ / event-plane MAC policy-enforcement point (epic #547, #1271; typed
+//! resolver v16 §10 / #1510).
 //!
-//! This plane consumes the shared RPC-PEP contract rather than defining a
-//! parallel decision vocabulary. An installed [`MoqEventPep`] returns
-//! [`MacDecision`] and resolves labels through [`RpcObjectLabelResolver`].
-//! Missing clearance and missing labels deny, as does a failed lattice-floor
-//! check. Callers preserve the pre-activation behavior by not installing this
-//! PEP; dormant event/MoQ paths remain pass-through.
+//! This plane consumes the shared RPC-PEP decision contract
+//! ([`MacDecision`]) rather than defining a parallel decision vocabulary,
+//! and resolves labels through this plane's **own** typed resolver
+//! ([`MoqEventLabelResolver`]). A track/prefix string is parsed into the
+//! exact typed identity ([`MoqEventObjectRef`]) exactly once at the boundary
+//! helper ([`MoqEventPep::check_event_prefix`] /
+//! [`MoqEventPep::check_stream_track`]); the resolver never sees a string,
+//! so a MoQ/event coordinate can no longer occupy the RPC/VFS resolver's
+//! service-domain slot. Unknown or noncanonical coordinates, unlisted
+//! services, missing clearance, and missing labels all deny; a failed
+//! lattice-floor check denies. Callers preserve the pre-activation behavior
+//! by not installing this PEP; dormant event/MoQ paths remain pass-through.
 
 use std::sync::Arc;
 
 #[cfg(not(target_arch = "wasm32"))]
-use super::dispatch_pep::{MacDecision, MacDenyReason, RpcObjectLabelResolver};
+use super::dispatch_pep::{MacDecision, MacDenyReason};
+// The typed identity and resolver are consumed only by the native check
+// paths; on wasm32 the PEP keeps its historical type-only surface (same gate
+// pattern as the dispatch PEP).
+#[cfg(not(target_arch = "wasm32"))]
+use super::moq_resolve::{MoqEventLabelResolver, MoqEventObjectRef, MoqEventPlane};
 use super::{SecurityContext, SecurityLabel};
 use crate::envelope::Subject;
 
@@ -29,6 +41,29 @@ pub enum MoqEventAction {
     JoinDecrypt,
 }
 
+impl MoqEventAction {
+    /// Wire-stable discriminant for decoded ingress.
+    pub const fn discriminant(self) -> u16 {
+        match self {
+            MoqEventAction::Publish => 0,
+            MoqEventAction::Subscribe => 1,
+            MoqEventAction::JoinDecrypt => 2,
+        }
+    }
+
+    /// Decode an action discriminant. Unknown values return `None`: an
+    /// ingress carrying a verb this PEP does not know denies — it never
+    /// falls back to a coarse default action.
+    pub const fn from_discriminant(value: u16) -> Option<Self> {
+        match value {
+            0 => Some(MoqEventAction::Publish),
+            1 => Some(MoqEventAction::Subscribe),
+            2 => Some(MoqEventAction::JoinDecrypt),
+            _ => None,
+        }
+    }
+}
+
 /// Resolve a verified event/MoQ subject to its MAC security context.
 ///
 /// The event plane does not have an [`EnvelopeContext`](crate::service::EnvelopeContext),
@@ -44,6 +79,14 @@ pub enum MoqMacAuditReason {
     /// A denial returned by the canonical shared MAC contract.
     #[cfg(not(target_arch = "wasm32"))]
     Mac(MacDenyReason),
+    /// The boundary coordinate did not decode into a typed identity.
+    ///
+    /// Malformed grammar, a noncanonical service segment, or an internal
+    /// bookkeeping key (e.g. a tenant-qualified map key) passed where an
+    /// object identity is required. The shared decision surfaces this as
+    /// `Deny(UnlabeledObject)`; this variant keeps the precise cause in the
+    /// plane's audit trail.
+    UnknownObjectIdentity,
     /// An authorizer was installed, but moq-net exposed no per-track callback.
     ///
     /// The transport denies the whole session until #276 lands rather than
@@ -62,7 +105,9 @@ pub enum MoqMacAuditReason {
 pub struct MoqMacAuditRecord {
     /// Independently verified subject, or `None` for anonymous.
     pub subject: Option<String>,
-    /// Track or event prefix whose access was denied.
+    /// Track or event prefix whose access was denied (the raw boundary
+    /// coordinate as received — an audit trail, never an authorization
+    /// input).
     pub object: String,
     /// Operation that was denied.
     pub action: MoqEventAction,
@@ -89,17 +134,18 @@ pub trait MoqMacAuditSink: Send + Sync {
 /// on an installed instance is fail-closed.
 pub struct MoqEventPep {
     #[cfg(not(target_arch = "wasm32"))]
-    resolver: Arc<dyn RpcObjectLabelResolver>,
+    resolver: Arc<dyn MoqEventLabelResolver>,
     clearance: Arc<dyn ClearanceSource>,
     audit: Arc<dyn MoqMacAuditSink>,
 }
 
 impl MoqEventPep {
-    /// Construct an active, fail-closed PEP from the canonical object-label
-    /// resolver, verified-subject clearance source, and mandatory audit sink.
+    /// Construct an active, fail-closed PEP from this plane's typed
+    /// object-label resolver, verified-subject clearance source, and
+    /// mandatory audit sink.
     #[cfg(not(target_arch = "wasm32"))]
     pub fn new(
-        resolver: Arc<dyn RpcObjectLabelResolver>,
+        resolver: Arc<dyn MoqEventLabelResolver>,
         clearance: Arc<dyn ClearanceSource>,
         audit: Arc<dyn MoqMacAuditSink>,
     ) -> Self {
@@ -141,24 +187,25 @@ impl MoqEventPep {
         }
     }
 
-    /// Check the per-track/per-event label ceiling.
+    /// Check the per-track/per-event label ceiling for an already-decoded
+    /// typed identity.
     ///
-    /// `track_or_prefix` occupies the canonical resolver's service-domain
-    /// coordinate. MoQ/event checks have no browser method discriminator, so
-    /// the resolver always receives `None`.
+    /// This is the typed core: the object is an
+    /// [`MoqEventObjectRef`], never a string, so no caller can smuggle
+    /// another plane's coordinate into this plane's resolver.
     #[must_use]
     #[cfg(not(target_arch = "wasm32"))]
     pub fn check(
         &self,
         subject: &Subject,
-        track_or_prefix: &str,
+        object: &MoqEventObjectRef,
         action: MoqEventAction,
     ) -> MacDecision {
         let Some(subject_ctx) = self.clearance.clearance(subject) else {
             let reason = MacDenyReason::NoClearance;
             self.audit_deny(
                 subject,
-                track_or_prefix,
+                &object.audit_coordinate(),
                 action,
                 None,
                 None,
@@ -166,11 +213,11 @@ impl MoqEventPep {
             );
             return MacDecision::Deny(reason);
         };
-        let Some(object_label) = self.resolver.resolve(track_or_prefix, None) else {
+        let Some(object_label) = self.resolver.resolve(object) else {
             let reason = MacDenyReason::UnlabeledObject;
             self.audit_deny(
                 subject,
-                track_or_prefix,
+                &object.audit_coordinate(),
                 action,
                 Some(*subject_ctx.clearance()),
                 None,
@@ -184,13 +231,71 @@ impl MoqEventPep {
             let reason = MacDenyReason::FloorDeny;
             self.audit_deny(
                 subject,
-                track_or_prefix,
+                &object.audit_coordinate(),
                 action,
                 Some(*subject_ctx.clearance()),
                 Some(object_label),
                 MoqMacAuditReason::Mac(reason),
             );
             MacDecision::Deny(reason)
+        }
+    }
+
+    /// Boundary check for an event-plane topic prefix.
+    ///
+    /// Parses the dot grammar exactly once; a coordinate that does not
+    /// decode into a typed identity (including the tenant-qualified
+    /// internal map keys the confidential path uses, which are not object
+    /// identities) denies and is audited as such.
+    #[must_use]
+    #[cfg(not(target_arch = "wasm32"))]
+    pub fn check_event_prefix(
+        &self,
+        subject: &Subject,
+        prefix: &str,
+        action: MoqEventAction,
+    ) -> MacDecision {
+        match MoqEventObjectRef::parse(MoqEventPlane::Event, prefix) {
+            Some(object) => self.check(subject, &object, action),
+            None => {
+                self.audit_deny(
+                    subject,
+                    prefix,
+                    action,
+                    None,
+                    None,
+                    MoqMacAuditReason::UnknownObjectIdentity,
+                );
+                MacDecision::Deny(MacDenyReason::UnlabeledObject)
+            }
+        }
+    }
+
+    /// Boundary check for a stream-plane track / broadcast name.
+    ///
+    /// Parses the slash grammar exactly once; malformed or noncanonical
+    /// names deny and are audited as unknown identities.
+    #[must_use]
+    #[cfg(not(target_arch = "wasm32"))]
+    pub fn check_stream_track(
+        &self,
+        subject: &Subject,
+        track: &str,
+        action: MoqEventAction,
+    ) -> MacDecision {
+        match MoqEventObjectRef::parse(MoqEventPlane::Stream, track) {
+            Some(object) => self.check(subject, &object, action),
+            None => {
+                self.audit_deny(
+                    subject,
+                    track,
+                    action,
+                    None,
+                    None,
+                    MoqMacAuditReason::UnknownObjectIdentity,
+                );
+                MacDecision::Deny(MacDenyReason::UnlabeledObject)
+            }
         }
     }
 
@@ -212,7 +317,7 @@ impl MoqEventPep {
     }
 
     #[cfg(not(target_arch = "wasm32"))]
-    pub fn resolver(&self) -> &Arc<dyn RpcObjectLabelResolver> {
+    pub fn resolver(&self) -> &Arc<dyn MoqEventLabelResolver> {
         &self.resolver
     }
 
@@ -236,7 +341,8 @@ impl ClearanceSource for DenyAllClearanceSource {
 mod tests {
     use super::*;
     use crate::auth::mac::{
-        Assurance, CompartmentSet, DenyAllObjectResolver, Level, VerifiedKeyMaterial,
+        Assurance, CompartmentSet, DenyAllMoqEventResolver, Level, MoqEventPolicyRow,
+        MoqEventPolicyTable, VerifiedKeyMaterial,
     };
     use parking_lot::Mutex;
 
@@ -248,19 +354,22 @@ mod tests {
         SecurityLabel::new(Level::Secret, Assurance::PqHybrid, CompartmentSet::EMPTY)
     }
 
-    struct StaticResolver {
-        secret_track: String,
-    }
-
-    impl RpcObjectLabelResolver for StaticResolver {
-        fn resolve(&self, service_domain: &str, method: Option<u16>) -> Option<SecurityLabel> {
-            assert_eq!(method, None, "event/MoQ checks are not browser RPC");
-            if service_domain == self.secret_track {
-                Some(secret_label())
-            } else {
-                Some(public_label())
-            }
-        }
+    /// Declared track policy: the event `worker` source is secret, `registry`
+    /// and the stream `streams` service are public.
+    fn declared_resolver() -> crate::auth::mac::DeclaredTrackPolicyResolver {
+        crate::auth::mac::DeclaredTrackPolicyResolver::new(
+            MoqEventPolicyTable::build(
+                1,
+                [
+                    MoqEventPolicyRow::new(MoqEventPlane::Event, "worker", secret_label()).unwrap(),
+                    MoqEventPolicyRow::new(MoqEventPlane::Event, "registry", public_label())
+                        .unwrap(),
+                    MoqEventPolicyRow::new(MoqEventPlane::Stream, "streams", public_label())
+                        .unwrap(),
+                ],
+            )
+            .unwrap(),
+        )
     }
 
     struct TieredClearance {
@@ -295,11 +404,21 @@ mod tests {
         }
     }
 
+    fn pep(resolver: Arc<dyn MoqEventLabelResolver>, audit: &Arc<RecordingAudit>) -> MoqEventPep {
+        MoqEventPep::new(
+            resolver,
+            Arc::new(TieredClearance {
+                cleared_did: "did:web:cleared".to_owned(),
+            }),
+            audit.clone(),
+        )
+    }
+
     #[test]
     fn installed_pep_audits_every_missing_clearance_deny() {
         let audit = Arc::new(RecordingAudit::default());
         let pep = MoqEventPep::new(
-            Arc::new(DenyAllObjectResolver),
+            Arc::new(DenyAllMoqEventResolver),
             Arc::new(DenyAllClearanceSource),
             audit.clone(),
         );
@@ -309,7 +428,7 @@ mod tests {
             MoqEventAction::JoinDecrypt,
         ] {
             assert_eq!(
-                pep.check(&Subject::anonymous(), "any", action),
+                pep.check_event_prefix(&Subject::anonymous(), "registry", action),
                 MacDecision::Deny(MacDenyReason::NoClearance)
             );
         }
@@ -323,17 +442,11 @@ mod tests {
     #[test]
     fn installed_pep_denies_unlabeled_object() {
         let audit = Arc::new(RecordingAudit::default());
-        let pep = MoqEventPep::new(
-            Arc::new(DenyAllObjectResolver),
-            Arc::new(TieredClearance {
-                cleared_did: "did:web:cleared".to_owned(),
-            }),
-            audit.clone(),
-        );
+        let pep = pep(Arc::new(DenyAllMoqEventResolver), &audit);
         assert_eq!(
-            pep.check(
+            pep.check_event_prefix(
                 &Subject::new("did:web:cleared"),
-                "missing",
+                "inference",
                 MoqEventAction::Subscribe,
             ),
             MacDecision::Deny(MacDenyReason::UnlabeledObject)
@@ -349,32 +462,24 @@ mod tests {
     #[test]
     fn installed_pep_enforces_label_ceiling_for_every_action() {
         let audit = Arc::new(RecordingAudit::default());
-        let pep = MoqEventPep::new(
-            Arc::new(StaticResolver {
-                secret_track: "tenant/streams/secret".to_owned(),
-            }),
-            Arc::new(TieredClearance {
-                cleared_did: "did:web:cleared".to_owned(),
-            }),
-            audit.clone(),
-        );
+        let pep = pep(Arc::new(declared_resolver()), &audit);
         for action in [
             MoqEventAction::Publish,
             MoqEventAction::Subscribe,
             MoqEventAction::JoinDecrypt,
         ] {
             assert_eq!(
-                pep.check(
+                pep.check_event_prefix(
                     &Subject::new("did:web:public"),
-                    "tenant/streams/secret",
+                    "worker.sandbox1.started",
                     action,
                 ),
                 MacDecision::Deny(MacDenyReason::FloorDeny)
             );
             assert_eq!(
-                pep.check(
+                pep.check_event_prefix(
                     &Subject::new("did:web:cleared"),
-                    "tenant/streams/secret",
+                    "worker.sandbox1.started",
                     action,
                 ),
                 MacDecision::Permit
@@ -385,5 +490,112 @@ mod tests {
         assert!(records
             .iter()
             .all(|record| record.reason == MoqMacAuditReason::Mac(MacDenyReason::FloorDeny)));
+    }
+
+    #[test]
+    fn known_stream_tracks_resolve_and_permit_through_the_typed_boundary() {
+        let audit = Arc::new(RecordingAudit::default());
+        let pep = pep(Arc::new(declared_resolver()), &audit);
+        // Public clearance dominates the declared public `streams` label.
+        assert_eq!(
+            pep.check_stream_track(
+                &Subject::new("did:web:public"),
+                "alice/streams/run-1/i0",
+                MoqEventAction::Subscribe,
+            ),
+            MacDecision::Permit
+        );
+        // The same service on the event plane is a different, unlisted object.
+        assert_eq!(
+            pep.check_event_prefix(
+                &Subject::new("did:web:public"),
+                "streams.session.x",
+                MoqEventAction::Subscribe,
+            ),
+            MacDecision::Deny(MacDenyReason::UnlabeledObject)
+        );
+    }
+
+    #[test]
+    fn unknown_or_noncanonical_coordinates_deny_as_unknown_identities() {
+        let audit = Arc::new(RecordingAudit::default());
+        let pep = pep(Arc::new(declared_resolver()), &audit);
+        let subject = Subject::new("did:web:cleared");
+
+        // Malformed event grammar (uppercase service segment, map-key form).
+        for bad in ["Worker", "5:acmeworker", "wor/ker"] {
+            assert_eq!(
+                pep.check_event_prefix(&subject, bad, MoqEventAction::Publish),
+                MacDecision::Deny(MacDenyReason::UnlabeledObject),
+                "{bad:?} must not decode"
+            );
+        }
+        // Malformed stream grammar (single segment, traversal).
+        for bad in ["alice", "alice/../streams/run"] {
+            assert_eq!(
+                pep.check_stream_track(&subject, bad, MoqEventAction::Subscribe),
+                MacDecision::Deny(MacDenyReason::UnlabeledObject),
+                "{bad:?} must not decode"
+            );
+        }
+
+        let records = audit.records.lock();
+        assert_eq!(records.len(), 5);
+        assert!(records
+            .iter()
+            .all(|record| record.reason == MoqMacAuditReason::UnknownObjectIdentity));
+    }
+
+    #[test]
+    fn unknown_plane_and_action_discriminants_have_no_typed_value_to_check() {
+        // An ingress that decoded an unknown plane or verb cannot construct
+        // the typed inputs of `check`; it denies before the PEP is reached.
+        for unknown in [2u16, 3, u16::MAX] {
+            assert_eq!(MoqEventPlane::from_discriminant(unknown), None);
+        }
+        for unknown in [3u16, 4, u16::MAX] {
+            assert_eq!(MoqEventAction::from_discriminant(unknown), None);
+        }
+        // The known set round-trips.
+        for action in [
+            MoqEventAction::Publish,
+            MoqEventAction::Subscribe,
+            MoqEventAction::JoinDecrypt,
+        ] {
+            assert_eq!(
+                MoqEventAction::from_discriminant(action.discriminant()),
+                Some(action)
+            );
+        }
+        for plane in [MoqEventPlane::Event, MoqEventPlane::Stream] {
+            assert_eq!(
+                MoqEventPlane::from_discriminant(plane.discriminant()),
+                Some(plane)
+            );
+        }
+    }
+
+    #[test]
+    fn empty_declared_table_denies_every_parseable_identity() {
+        let audit = Arc::new(RecordingAudit::default());
+        let pep = pep(
+            Arc::new(crate::auth::mac::DeclaredTrackPolicyResolver::new(
+                MoqEventPolicyTable::empty(),
+            )),
+            &audit,
+        );
+        let subject = Subject::new("did:web:cleared");
+        assert_eq!(
+            pep.check_event_prefix(&subject, "worker", MoqEventAction::Publish),
+            MacDecision::Deny(MacDenyReason::UnlabeledObject)
+        );
+        assert_eq!(
+            pep.check_stream_track(
+                &subject,
+                "alice/streams/run-1/i0",
+                MoqEventAction::Subscribe
+            ),
+            MacDecision::Deny(MacDenyReason::UnlabeledObject)
+        );
     }
 }

--- a/crates/hyprstream-rpc/src/auth/mac/pep.rs
+++ b/crates/hyprstream-rpc/src/auth/mac/pep.rs
@@ -105,9 +105,11 @@ pub enum MoqMacAuditReason {
 pub struct MoqMacAuditRecord {
     /// Independently verified subject, or `None` for anonymous.
     pub subject: Option<String>,
-    /// Track or event prefix whose access was denied (the raw boundary
-    /// coordinate as received — an audit trail, never an authorization
-    /// input).
+    /// Track or event prefix whose access was denied — an audit trail, never
+    /// an authorization input. Accepted typed objects audit their full
+    /// coordinate; a coordinate that failed to parse audits only its
+    /// bounded representation (see [`bounded_audit_coordinate`]), so the
+    /// durable record is bounded independently of attacker input.
     pub object: String,
     /// Operation that was denied.
     pub action: MoqEventAction,
@@ -126,6 +128,50 @@ pub struct MoqMacAuditRecord {
 /// attempt a durable audit write for every denial.
 pub trait MoqMacAuditSink: Send + Sync {
     fn record_deny(&self, record: &MoqMacAuditRecord) -> Result<(), String>;
+}
+
+/// Verbatim prefix of a malformed coordinate kept in a deny audit record.
+/// Anything beyond it is represented by the digest/length marker of
+/// [`bounded_audit_coordinate`].
+pub const MAX_AUDIT_COORDINATE_PREFIX_BYTES: usize = 64;
+
+/// Hard upper bound on the audit object text produced for one malformed
+/// coordinate: the fixed prefix cap plus the widest marker the format emits
+/// (`"~b3:" + 16 hex digest chars + "~len:" + u64 decimal`).
+pub const BOUNDED_AUDIT_COORDINATE_MAX_BYTES: usize =
+    MAX_AUDIT_COORDINATE_PREFIX_BYTES + "~b3:0000000000000000~len:18446744073709551615".len();
+
+/// Deterministic bounded audit identity for a coordinate that failed to parse
+/// into a typed object (`PRRT_kwDONmv2Pc6a2ZGv`, v16 §14: audit is a trail,
+/// never an authorization input).
+///
+/// A malformed name can be attacker-sized, and the deny path would otherwise
+/// clone and durably persist it in full — input-sized allocation and disk
+/// amplification per denial. This representation keeps at most a
+/// [`MAX_AUDIT_COORDINATE_PREFIX_BYTES`] prefix (truncated on a UTF-8 char
+/// boundary, deterministically) plus a BLAKE3-8 digest and byte length of
+/// the *complete* raw input, so distinct oversized inputs remain
+/// distinguishable while the persisted text is bounded independently of the
+/// input. Inputs already within the prefix cap are recorded verbatim.
+///
+/// This is audit-only: it never feeds an authorization decision, and the
+/// accepted-parse deny paths keep auditing the full decoded
+/// [`MoqEventObjectRef::audit_coordinate`] (already parser-bounded).
+#[must_use]
+pub fn bounded_audit_coordinate(raw: &str) -> String {
+    if raw.len() <= MAX_AUDIT_COORDINATE_PREFIX_BYTES {
+        return raw.to_owned();
+    }
+    let mut cut = MAX_AUDIT_COORDINATE_PREFIX_BYTES;
+    while !raw.is_char_boundary(cut) {
+        cut -= 1;
+    }
+    let digest = blake3::hash(raw.as_bytes());
+    let digest_hex: String = digest.as_bytes()[..8]
+        .iter()
+        .map(|byte| format!("{byte:02x}"))
+        .collect();
+    format!("{}~b3:{digest_hex}~len:{}", &raw[..cut], raw.len())
 }
 
 /// The installed MoQ/event MAC floor.
@@ -246,7 +292,9 @@ impl MoqEventPep {
     /// Parses the dot grammar exactly once; a coordinate that does not
     /// decode into a typed identity (including the tenant-qualified
     /// internal map keys the confidential path uses, which are not object
-    /// identities) denies and is audited as such.
+    /// identities) denies and is audited as such — with only its bounded
+    /// representation in the audit record, so a malformed attacker-sized
+    /// name cannot amplify allocation or the durable WAL.
     #[must_use]
     #[cfg(not(target_arch = "wasm32"))]
     pub fn check_event_prefix(
@@ -260,7 +308,7 @@ impl MoqEventPep {
             None => {
                 self.audit_deny(
                     subject,
-                    prefix,
+                    &bounded_audit_coordinate(prefix),
                     action,
                     None,
                     None,
@@ -274,7 +322,9 @@ impl MoqEventPep {
     /// Boundary check for a stream-plane track / broadcast name.
     ///
     /// Parses the slash grammar exactly once; malformed or noncanonical
-    /// names deny and are audited as unknown identities.
+    /// names deny and are audited as unknown identities — bounded, as
+    /// above, so an oversized malformed track cannot amplify the audit
+    /// trail.
     #[must_use]
     #[cfg(not(target_arch = "wasm32"))]
     pub fn check_stream_track(
@@ -288,7 +338,7 @@ impl MoqEventPep {
             None => {
                 self.audit_deny(
                     subject,
-                    track,
+                    &bounded_audit_coordinate(track),
                     action,
                     None,
                     None,
@@ -597,5 +647,126 @@ mod tests {
             ),
             MacDecision::Deny(MacDenyReason::UnlabeledObject)
         );
+    }
+
+    // ── bounded malformed-coordinate audit (PRRT_kwDONmv2Pc6a2ZGv) ────
+
+    fn oversized_event_coordinate() -> String {
+        // Second segment far beyond MAX_TRACK_SEGMENT_BYTES: parse fails at
+        // the segment cap, so this is the malformed-path deny.
+        format!("worker.{}", "x".repeat(4 * 1024 * 1024))
+    }
+
+    fn oversized_stream_coordinate() -> String {
+        // A ninth tail after eight valid segments: parse fails at the
+        // on-observation segment-count bound.
+        format!("{}/{}", ["a"; 8].join("/"), "y".repeat(4 * 1024 * 1024))
+    }
+
+    #[test]
+    fn malformed_event_coordinate_denies_with_bounded_audited_object() {
+        let audit = Arc::new(RecordingAudit::default());
+        let pep = pep(Arc::new(declared_resolver()), &audit);
+        let subject = Subject::new("did:web:cleared");
+
+        // Fail-closed decision preserved.
+        assert_eq!(
+            pep.check_event_prefix(
+                &subject,
+                &oversized_event_coordinate(),
+                MoqEventAction::Publish,
+            ),
+            MacDecision::Deny(MacDenyReason::UnlabeledObject)
+        );
+
+        let records = audit.records.lock();
+        assert_eq!(records.len(), 1);
+        let object = &records[0].object;
+        // Persisted audit text is bounded independently of the 4 MiB input.
+        assert!(
+            object.len() <= BOUNDED_AUDIT_COORDINATE_MAX_BYTES,
+            "audited object {object:?} exceeds the explicit cap"
+        );
+        // Carries the digest and length markers of the complete raw input.
+        let marker_start = object.rfind("~b3:").unwrap();
+        let (prefix, marker) = object.split_at(marker_start);
+        assert!(prefix.len() <= MAX_AUDIT_COORDINATE_PREFIX_BYTES);
+        let raw_len = oversized_event_coordinate().len();
+        assert_eq!(
+            marker.len(),
+            "~b3:".len() + 16 + "~len:".len() + raw_len.to_string().len(),
+            "marker is the fixed-shape 16-hex digest plus the exact raw length"
+        );
+        assert!(marker.ends_with(&format!("~len:{raw_len}")));
+    }
+
+    #[test]
+    fn malformed_stream_coordinate_denies_with_bounded_audited_object() {
+        let audit = Arc::new(RecordingAudit::default());
+        let pep = pep(Arc::new(declared_resolver()), &audit);
+        let subject = Subject::new("did:web:cleared");
+
+        assert_eq!(
+            pep.check_stream_track(
+                &subject,
+                &oversized_stream_coordinate(),
+                MoqEventAction::Subscribe,
+            ),
+            MacDecision::Deny(MacDenyReason::UnlabeledObject)
+        );
+
+        let records = audit.records.lock();
+        assert_eq!(records.len(), 1);
+        let object = &records[0].object;
+        assert!(object.len() <= BOUNDED_AUDIT_COORDINATE_MAX_BYTES);
+        let raw_len = oversized_stream_coordinate().len();
+        assert!(object.ends_with(&format!("~len:{raw_len}")));
+        assert!(object.contains("~b3:"));
+    }
+
+    #[test]
+    fn differing_oversized_malformed_tails_do_not_collide_in_audit() {
+        let a = format!("worker.{}", "x".repeat(4 * 1024 * 1024));
+        let b = format!("worker.{}", "z".repeat(4 * 1024 * 1024));
+        // Same bounded prefix shape, different oversized tails.
+        let bounded_a = bounded_audit_coordinate(&a);
+        let bounded_b = bounded_audit_coordinate(&b);
+        assert_ne!(bounded_a, bounded_b, "digest must distinguish the tails");
+
+        // Through the PEP boundary too: two denies, two distinct audited
+        // objects, both under the cap.
+        let audit = Arc::new(RecordingAudit::default());
+        let pep = pep(Arc::new(declared_resolver()), &audit);
+        let subject = Subject::new("did:web:cleared");
+        for input in [&a, &b] {
+            assert_eq!(
+                pep.check_event_prefix(&subject, input, MoqEventAction::Publish),
+                MacDecision::Deny(MacDenyReason::UnlabeledObject)
+            );
+        }
+        let records = audit.records.lock();
+        assert_eq!(records.len(), 2);
+        assert_ne!(records[0].object, records[1].object);
+        assert!(records[0].object.len() <= BOUNDED_AUDIT_COORDINATE_MAX_BYTES);
+        assert!(records[1].object.len() <= BOUNDED_AUDIT_COORDINATE_MAX_BYTES);
+        // And each matches the standalone helper's deterministic output.
+        assert_eq!(records[0].object, bounded_a);
+        assert_eq!(records[1].object, bounded_b);
+    }
+
+    #[test]
+    fn bounded_audit_coordinate_is_small_input_verbatim_and_utf8_safe() {
+        // Small malformed inputs (the tenant map-key form) record verbatim.
+        assert_eq!(bounded_audit_coordinate("5:tenantworker"), "5:tenantworker");
+
+        // A multibyte char straddling the prefix cut truncates on a char
+        // boundary: deterministic across calls, within the prefix cap, and
+        // never panics.
+        let straddling = format!("{}é{}", "a".repeat(63), "z".repeat(256));
+        let bounded = bounded_audit_coordinate(&straddling);
+        assert!(bounded.len() <= BOUNDED_AUDIT_COORDINATE_MAX_BYTES);
+        let prefix_end = bounded.find("~b3:").unwrap();
+        assert!(prefix_end <= MAX_AUDIT_COORDINATE_PREFIX_BYTES);
+        assert_eq!(bounded, bounded_audit_coordinate(&straddling));
     }
 }

--- a/crates/hyprstream-rpc/src/events.rs
+++ b/crates/hyprstream-rpc/src/events.rs
@@ -353,6 +353,14 @@ impl EventAuthz for AllowAllEventAuthz {
 /// Constructing this type installs an active PEP, so all missing clearance or
 /// object labels fail closed. Uninstalled publishers/subscribers use
 /// [`DenyAllEventAuthz`], never a dormant permit fallback.
+///
+/// Typed identity (v16 §10 / #1510): each check parses the topic-prefix
+/// grammar exactly once at this boundary. A `prefix` that is not an object
+/// identity — including the tenant-qualified internal map keys the
+/// confidential paths pass (e.g. `"5:tenantworker"`), which are bookkeeping
+/// keys, not identities — denies as an unknown identity. Confidential-prefix
+/// admission therefore stays fail-closed until the event plane carries its
+/// tenant-qualified identity as typed data.
 pub struct MacEventAuthz {
     pep: MoqEventPep,
 }
@@ -366,21 +374,24 @@ impl MacEventAuthz {
 impl EventAuthz for MacEventAuthz {
     fn can_publish(&self, caller: &Subject, prefix: &str) -> bool {
         matches!(
-            self.pep.check(caller, prefix, MoqEventAction::Publish),
+            self.pep
+                .check_event_prefix(caller, prefix, MoqEventAction::Publish),
             MacDecision::Permit
         )
     }
 
     fn can_subscribe(&self, caller: &Subject, prefix: &str) -> bool {
         matches!(
-            self.pep.check(caller, prefix, MoqEventAction::Subscribe),
+            self.pep
+                .check_event_prefix(caller, prefix, MoqEventAction::Subscribe),
             MacDecision::Permit
         )
     }
 
     fn can_join_decrypt(&self, caller: &Subject, prefix: &str) -> bool {
         matches!(
-            self.pep.check(caller, prefix, MoqEventAction::JoinDecrypt),
+            self.pep
+                .check_event_prefix(caller, prefix, MoqEventAction::JoinDecrypt),
             MacDecision::Permit
         )
     }

--- a/crates/hyprstream-rpc/src/moq_authz.rs
+++ b/crates/hyprstream-rpc/src/moq_authz.rs
@@ -323,6 +323,10 @@ pub type SharedSubscribeAuthorizer = Arc<dyn SubscribeAuthorizer>;
 /// (the §7.5 DH-derived topic capability) never substitutes for this decision —
 /// it gates metadata visibility, the MAC floor gates the labeled content.
 ///
+/// Typed identity (v16 §10 / #1510): the track name is parsed into the
+/// stream-plane typed identity exactly once at this boundary; a name that
+/// does not decode denies as an unknown identity.
+///
 /// Constructing this adapter installs an active PEP, so missing clearance and
 /// missing labels deny. Leaving the containing transport's authorizer unset is
 /// the dormant pre-activation state and remains pass-through.
@@ -345,7 +349,7 @@ impl SubscribeAuthorizer for MacSubscribeAuthorizer {
         };
         if matches!(
             self.pep
-                .check(&subject, track_name, MoqEventAction::Subscribe),
+                .check_stream_track(&subject, track_name, MoqEventAction::Subscribe),
             MacDecision::Permit
         ) {
             SubscribeDecision::Allow
@@ -604,7 +608,7 @@ mod scope_tests {
     #[test]
     fn mac_subscribe_authorizer_fail_closed_denies_all() {
         use crate::auth::mac::{
-            DenyAllClearanceSource, DenyAllObjectResolver, MoqMacAuditReason, MoqMacAuditRecord,
+            DenyAllClearanceSource, DenyAllMoqEventResolver, MoqMacAuditReason, MoqMacAuditRecord,
             MoqMacAuditSink,
         };
         use parking_lot::Mutex;
@@ -624,7 +628,7 @@ mod scope_tests {
         let audit = Arc::new(RecordingAudit::default());
         let authz = Arc::new(super::MacSubscribeAuthorizer::new(
             crate::auth::mac::MoqEventPep::new(
-                Arc::new(DenyAllObjectResolver),
+                Arc::new(DenyAllMoqEventResolver),
                 Arc::new(DenyAllClearanceSource),
                 audit.clone(),
             ),

--- a/crates/hyprstream/src/bin/main.rs
+++ b/crates/hyprstream/src/bin/main.rs
@@ -2930,11 +2930,20 @@ fn main() -> Result<()> {
                                 if !hyprstream_rpc::events::event_authz_installed() {
                                     let audit_stream =
                                         format!("moq-event-{}", service_names.join("-"));
+                                    // Declared MoQ/event track policy (v16 §10 /
+                                    // #1510). The generated dispatch inventory
+                                    // (WS-D / #1505) is the end-state producer of
+                                    // these rows; until it lands the empty table
+                                    // is the honest state and every unlisted
+                                    // track/prefix denies.
+                                    let track_policy =
+                                        hyprstream_rpc::auth::mac::MoqEventPolicyTable::empty();
                                     let pep =
                                         hyprstream_core::mac::production_moq_event_pep(
                                             signing_key.clone(),
                                             &config.oauth,
                                             &audit_stream,
+                                            track_policy,
                                         )
                                         .await
                                         .context(

--- a/crates/hyprstream/src/mac/audit.rs
+++ b/crates/hyprstream/src/mac/audit.rs
@@ -248,6 +248,10 @@ pub enum DecisionReason {
     MoqNoPepInstalled,
     /// A streaming continuation's MoQ authority was stale or revoked.
     MoqStaleAuthority,
+    /// The MoQ/event boundary coordinate did not decode into a typed
+    /// track/prefix identity (malformed grammar, noncanonical service
+    /// segment, or an internal map key passed as an identity).
+    MoqUnknownObjectIdentity,
     /// Track admission was denied because moq-net has no #276 callback.
     MoqTrackAdmissionHookUnavailable,
 
@@ -294,6 +298,7 @@ impl DecisionReason {
             DecisionReason::MoqUnlabeledSubject => "moq_unlabeled_subject",
             DecisionReason::MoqNoPepInstalled => "moq_no_pep_installed",
             DecisionReason::MoqStaleAuthority => "moq_stale_authority",
+            DecisionReason::MoqUnknownObjectIdentity => "moq_unknown_object_identity",
             DecisionReason::MoqTrackAdmissionHookUnavailable => {
                 "moq_track_admission_hook_unavailable"
             }

--- a/crates/hyprstream/src/mac/moq_audit.rs
+++ b/crates/hyprstream/src/mac/moq_audit.rs
@@ -11,8 +11,9 @@ use std::time::{SystemTime, UNIX_EPOCH};
 use anyhow::Context as _;
 use ed25519_dalek::SigningKey;
 use hyprstream_rpc::auth::mac::{
-    ClearanceSource, MacDenyReason, MoqEventAction, MoqEventPep, MoqMacAuditReason,
-    MoqMacAuditRecord, MoqMacAuditSink, RpcObjectLabelResolver, SecurityLabel,
+    ClearanceSource, DeclaredTrackPolicyResolver, MacDenyReason, MoqEventAction,
+    MoqEventLabelResolver, MoqEventPep, MoqEventPolicyTable, MoqMacAuditReason, MoqMacAuditRecord,
+    MoqMacAuditSink, SecurityLabel,
 };
 use hyprstream_rpc::envelope::Subject;
 
@@ -71,7 +72,7 @@ impl MoqMacAuditSink for MoqAuditSinkAdapter {
 /// Construct an active MoQ/event PEP whose denials flow to the canonical MAC
 /// audit sink. Production passes a signed [`crate::mac::WalAuditStore`].
 pub fn audited_moq_event_pep(
-    resolver: Arc<dyn RpcObjectLabelResolver>,
+    resolver: Arc<dyn MoqEventLabelResolver>,
     clearance: Arc<dyn ClearanceSource>,
     sink: Arc<dyn AuditSink>,
 ) -> MoqEventPep {
@@ -82,12 +83,21 @@ pub fn audited_moq_event_pep(
     )
 }
 
-/// Assemble the production MoQ/event PEP from the genesis resolver, verified
-/// subject contexts, and the mandatory signed audit WAL.
+/// Assemble the production MoQ/event PEP from the declared track-policy
+/// table, verified subject contexts, and the mandatory signed audit WAL.
+///
+/// v16 §10 / #1510: the MoQ/event plane resolves labels from **declared
+/// track policy metadata**, never from the VFS/genesis resolver — a
+/// track/prefix must not occupy the RPC/VFS service-domain coordinate. The
+/// `track_policy` table is the reviewed seam onto the generated dispatch
+/// inventory (WS-D / #1505): until that inventory lands, callers pass the
+/// empty table and every unlisted track/prefix denies. This assembly has no
+/// bootstrap exception and no legacy-resolver path.
 pub async fn production_moq_event_pep(
     signing_key: SigningKey,
     oauth: &crate::config::OAuthConfig,
     audit_stream: &str,
+    track_policy: MoqEventPolicyTable,
 ) -> anyhow::Result<MoqEventPep> {
     anyhow::ensure!(
         !audit_stream.is_empty()
@@ -112,9 +122,8 @@ pub async fn production_moq_event_pep(
         signer,
     )
     .context("open MoQ MAC audit store")?;
-    let resolver = crate::mac::GenesisGate::production().into_resolver();
     Ok(audited_moq_event_pep(
-        Arc::new(resolver),
+        Arc::new(DeclaredTrackPolicyResolver::new(track_policy)),
         Arc::new(VerifiedClaimsMoqClearanceSource),
         Arc::new(audit_store),
     ))
@@ -147,6 +156,7 @@ const fn audit_reason(reason: MoqMacAuditReason) -> DecisionReason {
         MoqMacAuditReason::Mac(MacDenyReason::UnlabeledObject) => DecisionReason::UnlabeledObject,
         MoqMacAuditReason::Mac(MacDenyReason::FloorDeny) => DecisionReason::FloorDeny,
         MoqMacAuditReason::Mac(MacDenyReason::StaleAuthority) => DecisionReason::MoqStaleAuthority,
+        MoqMacAuditReason::UnknownObjectIdentity => DecisionReason::MoqUnknownObjectIdentity,
         MoqMacAuditReason::TrackAdmissionHookUnavailable => {
             DecisionReason::MoqTrackAdmissionHookUnavailable
         }
@@ -159,8 +169,8 @@ mod tests {
     use super::*;
     use crate::mac::{AuditError, AuditSigner, AuditVerifier, WalAuditStore};
     use hyprstream_rpc::auth::mac::{
-        Assurance, CompartmentSet, DenyAllObjectResolver, Level, SecurityContext,
-        VerifiedKeyMaterial,
+        Assurance, CompartmentSet, DeclaredTrackPolicyResolver, DenyAllMoqEventResolver, Level,
+        MoqEventPolicyRow, MoqEventPolicyTable, SecurityContext, VerifiedKeyMaterial,
     };
     use hyprstream_rpc::envelope::Subject;
     use tempfile::tempdir;
@@ -195,20 +205,36 @@ mod tests {
         }
     }
 
+    /// Declared table: `registry` events are public; nothing else is listed.
+    fn declared_table() -> MoqEventPolicyTable {
+        MoqEventPolicyTable::build(
+            1,
+            [MoqEventPolicyRow::new(
+                hyprstream_rpc::auth::mac::MoqEventPlane::Event,
+                "registry",
+                SecurityLabel::new(Level::Public, Assurance::Classical, CompartmentSet::EMPTY),
+            )
+            .unwrap()],
+        )
+        .unwrap()
+    }
+
     #[test]
-    fn cross_tenant_moq_deny_is_durable_in_signed_wal() {
+    fn unlisted_moq_prefix_deny_is_durable_in_signed_wal() {
         let dir = tempdir().unwrap();
         let wal = Arc::new(WalAuditStore::open(dir.path(), StubSigner).unwrap());
         let pep = audited_moq_event_pep(
-            Arc::new(DenyAllObjectResolver),
+            Arc::new(DeclaredTrackPolicyResolver::new(declared_table())),
             Arc::new(PublicClearance),
             wal.clone(),
         );
 
+        // `worker` parses as a typed identity but is not in the declared
+        // table — an unlisted service denies.
         assert_eq!(
-            pep.check(
+            pep.check_event_prefix(
                 &Subject::new("did:web:tenant-a"),
-                "tenant-b/events/private",
+                "worker.sandbox123.started",
                 MoqEventAction::Subscribe,
             ),
             hyprstream_rpc::auth::mac::MacDecision::Deny(
@@ -225,11 +251,84 @@ mod tests {
         assert_eq!(records[0].subject_id.as_deref(), Some("did:web:tenant-a"));
         assert_eq!(
             records[0].object_id.as_deref(),
-            Some("tenant-b/events/private")
+            Some("worker.sandbox123.started")
         );
         assert_eq!(
             records[0].action,
             Action::from_scope_action(ScopeAction::Subscribe)
+        );
+    }
+
+    #[test]
+    fn unknown_identity_deny_is_durable_with_its_own_reason() {
+        let dir = tempdir().unwrap();
+        let wal = Arc::new(WalAuditStore::open(dir.path(), StubSigner).unwrap());
+        let pep = audited_moq_event_pep(
+            Arc::new(DeclaredTrackPolicyResolver::new(declared_table())),
+            Arc::new(PublicClearance),
+            wal.clone(),
+        );
+
+        // The confidential path's tenant-qualified map key is not an object
+        // identity: it denies as an unknown identity, not as an unlisted one.
+        assert_eq!(
+            pep.check_event_prefix(
+                &Subject::new("did:web:tenant-a"),
+                "5:tenantworker",
+                MoqEventAction::Publish,
+            ),
+            hyprstream_rpc::auth::mac::MacDecision::Deny(
+                hyprstream_rpc::auth::mac::MacDenyReason::UnlabeledObject
+            )
+        );
+
+        let records = wal.verify_journal(&StubSigner).unwrap();
+        assert_eq!(records.len(), 1);
+        assert_eq!(records[0].reason, DecisionReason::MoqUnknownObjectIdentity);
+        assert_eq!(records[0].object_id.as_deref(), Some("5:tenantworker"));
+    }
+
+    #[test]
+    fn declared_public_prefix_permits_and_audits_nothing() {
+        let dir = tempdir().unwrap();
+        let wal = Arc::new(WalAuditStore::open(dir.path(), StubSigner).unwrap());
+        let pep = audited_moq_event_pep(
+            Arc::new(DeclaredTrackPolicyResolver::new(declared_table())),
+            Arc::new(PublicClearance),
+            wal.clone(),
+        );
+
+        assert_eq!(
+            pep.check_event_prefix(
+                &Subject::new("did:web:tenant-a"),
+                "registry.repo789.push",
+                MoqEventAction::Subscribe,
+            ),
+            hyprstream_rpc::auth::mac::MacDecision::Permit
+        );
+        // Only denials flow to the deny sink today (the permit-side WAL is
+        // WS-F's class-reserved record).
+        assert!(wal.verify_journal(&StubSigner).unwrap().is_empty());
+    }
+
+    #[test]
+    fn fail_closed_missing_artifact_deny_all_resolver() {
+        let dir = tempdir().unwrap();
+        let wal = Arc::new(WalAuditStore::open(dir.path(), StubSigner).unwrap());
+        let pep = audited_moq_event_pep(
+            Arc::new(DenyAllMoqEventResolver),
+            Arc::new(PublicClearance),
+            wal.clone(),
+        );
+        assert_eq!(
+            pep.check_event_prefix(
+                &Subject::new("did:web:tenant-a"),
+                "registry.repo789.push",
+                MoqEventAction::Subscribe,
+            ),
+            hyprstream_rpc::auth::mac::MacDecision::Deny(
+                hyprstream_rpc::auth::mac::MacDenyReason::UnlabeledObject
+            )
         );
     }
 }

--- a/crates/hyprstream/src/services/factories.rs
+++ b/crates/hyprstream/src/services/factories.rs
@@ -506,11 +506,17 @@ fn create_event_service(ctx: &ServiceContext) -> anyhow::Result<Box<dyn Spawnabl
     if !hyprstream_rpc::events::event_authz_installed() {
         let config = load_config();
         let sk = ctx.service_signing_key("event");
+        // Declared MoQ/event track policy (v16 §10 / #1510). The generated
+        // dispatch inventory (WS-D / #1505) is the end-state producer of these
+        // rows; until it lands the empty table is the honest state and every
+        // unlisted track/prefix denies.
+        let track_policy = hyprstream_rpc::auth::mac::MoqEventPolicyTable::empty();
         let pep = tokio::task::block_in_place(|| {
             tokio::runtime::Handle::current().block_on(crate::mac::production_moq_event_pep(
                 sk,
                 &config.oauth,
                 "moq-event",
+                track_policy,
             ))
         })
         .context("construct MoQ/event MAC PEP")?;


### PR DESCRIPTION
Implements WS-I / #1510 — the end-state typed MoQ/event resolver required before WS-F (v16 §10, part of program epic #1501; Gate-2 packet value 7 applied via the shared `MAX_SERVICE_DOMAIN_BYTES` rule).

## What changes

The MoQ/event plane stops passing its track/prefix string through the RPC/VFS resolver's service-domain coordinate (the exact shim v16 §10 removes at `auth/mac/pep.rs` and `mac/moq_audit.rs`). It now owns a typed identity and a plane-specific resolver:

- **New `hyprstream-rpc/src/auth/mac/moq_resolve.rs`**
  - `MoqEventObjectRef` — the exact decoded track/prefix identity (plane + canonical service domain + verbatim segments). Parsed exactly once at the plane boundary; every deviation denies and is never rewritten.
  - The service coordinate is validated by the **one** canonical service-domain rule (`envelope::validate_service_domain`, 1..=128 bytes) — no second, plane-local identity rule. A compile-time drift guard pins the module to the shared 128-byte cap.
  - `MoqEventPlane` / `MoqEventAction` wire-stable discriminants with `from_discriminant`: unknown values have no typed value to check and deny — never a coarse fallback.
  - `MoqEventLabelResolver` trait + `DenyAllMoqEventResolver` (fail-closed default). Deliberately *not* `RpcObjectLabelResolver`: dispatch, VFS/9P, CAS, and MoQ/event coordinates cannot cross resolver types.
  - Declared track-policy metadata (the authoritative label source for this plane, per §10): `MoqEventPolicyRow` / `MoqEventPolicyTable` / `DeclaredTrackPolicyResolver`, with `SUPPORTED_TRACK_POLICY_REVISION`. Construction is fail-closed: a newer vocabulary revision, a noncanonical service domain, or two conflicting declarations for the same `(plane, service)` all reject — no partial table is kept. Lookup is exact typed match: unknown, unlisted, or cross-plane coordinates deny. There is no ancestor walk, floor allowlist, or bootstrap exception.

- **`auth/mac/pep.rs`** — `MoqEventPep` retyped onto `MoqEventLabelResolver`. `check` is the typed core (`&MoqEventObjectRef` in, never a string); `check_event_prefix` / `check_stream_track` are the parse-once boundary helpers used by both exposed transports. A coordinate that does not decode into a typed identity denies and is audited under the new `MoqMacAuditReason::UnknownObjectIdentity` → `DecisionReason::MoqUnknownObjectIdentity` (`moq_unknown_object_identity`), surfaced through the shared decision contract as `Deny(UnlabeledObject)`.

- **Boundary adapters** — `MacEventAuthz` (`events.rs`, event-bus plane) and `MacSubscribeAuthorizer` (`moq_authz.rs`, quinn `/moq` + iroh `moql` subscribe plane) now call the parse-once helpers. Internal tenant-qualified map keys (`"5:tenantworker"`) are bookkeeping keys, not object identities: they deny as unknown identities, so confidential-prefix admission stays fail-closed until the event plane carries tenant-qualified identity as typed data (WS-E/F seam).

- **`mac/moq_audit.rs`** — `production_moq_event_pep` takes the declared `MoqEventPolicyTable` explicitly and assembles `DeclaredTrackPolicyResolver`. The `GenesisGate::production().into_resolver()` line (the legacy VFS resolver shim) is deleted. Production callers (`bin/main.rs`, `services/factories.rs`) pass `MoqEventPolicyTable::empty()` with the dependency recorded in a comment — outcome-preserving, since representative event prefixes and tenant tracks already resolved to `None` ⇒ deny through the removed genesis path.

## Dependency on WS-D (#1505) — recorded, not duplicated

The end-state producer of declared rows is the generated dispatch inventory. `MoqEventPolicyTable::build(revision, rows)` is the smallest reviewed interface seam: WS-D converts its generated `DispatchMethodPolicy` rows into `MoqEventPolicyRow`s through one reviewed conversion. This PR does not duplicate the annotation table, and it does not block on D: without generated rows the empty table is the honest declared state and every unlisted track/prefix denies.

## Not activated here

No WS-F activation, no proof-mandatory flip, no target-label enforcement. The PEP remains dormant-by-not-installed wherever no authorizer is installed; installed PEPs are fail-closed exactly as before.

## Tests

Focused resolver tests across `moq_resolve.rs`, `pep.rs`, and `moq_audit.rs`:
- known event/MoQ methods: every action over both boundary grammars against declared rows (permit/floor-deny per clearance);
- unknown discriminants: plane `{2,3,u16::MAX}` and action `{3,4,u16::MAX}` decode to `None`; the known set round-trips;
- service-domain canonicalization: uppercase, `_`-initial, spaces, `:`, `/`-aliasing, and >128-byte domains deny at parse; noncanonical rows reject at table construction;
- fail-closed missing artifacts: empty table, `DenyAllMoqEventResolver`, newer-revision table rejected, unlisted `(plane, service)` including the same service on the other plane ⇒ `UnlabeledObject`;
- signed WAL: unlisted deny and unknown-identity deny land in the journal with the right `DecisionReason`; a declared-public permit writes no deny record.

Validation (BuildQ-only): `cargo test -p hyprstream-rpc --release --lib` → 1014 passed / 0 failed / 4 ignored; `cargo test -p hyprstream --release --lib mac::moq_audit` green; `cargo check -p hyprstream --release --bins` clean (production call sites); `cargo check -p hyprstream-rpc --target wasm32-unknown-unknown` clean. No disk-guard (exit 75) stops encountered.

Closes nothing on its own; #1510 stays open for WS-F's G1/G2 enumeration and the WS-D row producer.

Folded-issue note: #726/#820/#555/#1128 are the tracked MoQ/event policy surfaces this resolver is the enforcement point for; the outer relay-authorization work in #726 lands separately on C's credential threading (#1206/#1207).
