### PR TITLE
feat: support pinned source archive provenance

### DIFF
--- a/crates/hyprstream/build.rs
+++ b/crates/hyprstream/build.rs
@@ -6,7 +6,11 @@ use std::env;
 use std::path::Path;
 use std::process::Command;
 
+#[path = "src/build_info.rs"]
+mod build_info;
+
 fn main() {
+    println!("cargo:rerun-if-env-changed=HYPRSTREAM_SOURCE_COMMIT");
     if std::env::var("DOCS_RS").is_ok() {
         return;
     }
@@ -111,8 +115,7 @@ fn compile_capnp_schemas() {
 /// - GIT_BRANCH: sanitized branch name (e.g., "main", "feature-auth")
 /// - GIT_DIRTY: "true" or "false"
 fn capture_git_info() {
-    // Get commit SHA (short)
-    let sha = Command::new("git")
+    let git_sha = Command::new("git")
         .args(["rev-parse", "--short=7", "HEAD"])
         .output()
         .ok()
@@ -121,17 +124,17 @@ fn capture_git_info() {
         .unwrap_or_default();
 
     // Get branch name
-    let branch = Command::new("git")
+    let git_branch = Command::new("git")
         .args(["rev-parse", "--abbrev-ref", "HEAD"])
         .output()
         .ok()
         .filter(|o| o.status.success())
         .map(|o| String::from_utf8_lossy(&o.stdout).trim().to_owned())
-        .map(|b| if b == "HEAD" { String::new() } else { b }) // Detached HEAD
+        .map(|b| if b == "HEAD" { String::new() } else { b })
         .unwrap_or_default();
 
     // Check if worktree is dirty
-    let dirty = Command::new("git")
+    let git_dirty = Command::new("git")
         .args(["status", "--porcelain"])
         .output()
         .ok()
@@ -139,31 +142,30 @@ fn capture_git_info() {
         .map(|o| !o.stdout.is_empty())
         .unwrap_or(false);
 
+    let fallback = build_info::GitInfo {
+        sha: git_sha,
+        branch: git_branch,
+        dirty: git_dirty,
+    };
+    let source_commit = env::var_os("HYPRSTREAM_SOURCE_COMMIT").map(|value| {
+        value
+            .into_string()
+            .unwrap_or_else(|_| panic!("HYPRSTREAM_SOURCE_COMMIT must be valid UTF-8"))
+    });
+    let info = build_info::resolve(source_commit.as_deref(), fallback)
+        .unwrap_or_else(|error| panic!("invalid HYPRSTREAM_SOURCE_COMMIT: {error}"));
+
     // Sanitize branch name for filesystem safety
-    let sanitized_branch = sanitize_git_ref(&branch);
+    let sanitized_branch = sanitize_git_ref(&info.branch);
 
     // Export individual components as environment variables
-    println!("cargo:rustc-env=GIT_SHA={}", sha);
+    println!("cargo:rustc-env=GIT_SHA={}", info.sha);
     println!("cargo:rustc-env=GIT_BRANCH={}", sanitized_branch);
-    println!("cargo:rustc-env=GIT_DIRTY={}", dirty);
+    println!("cargo:rustc-env=GIT_DIRTY={}", info.dirty);
 
     // Build complete version string
     let cargo_version = env::var("CARGO_PKG_VERSION").unwrap_or_else(|_| "unknown".to_owned());
-    let build_version = if sha.is_empty() {
-        cargo_version
-    } else {
-        let mut v = format!("{}+", cargo_version);
-        if !sanitized_branch.is_empty() {
-            v.push_str(&sanitized_branch);
-            v.push('.');
-        }
-        v.push('g');
-        v.push_str(&sha);
-        if dirty {
-            v.push_str(".dirty");
-        }
-        v
-    };
+    let build_version = build_info::build_version(&cargo_version, &info, &sanitized_branch);
     println!("cargo:rustc-env=BUILD_VERSION={}", build_version);
 }
 

--- a/crates/hyprstream/src/build_info.rs
+++ b/crates/hyprstream/src/build_info.rs
@@ -1,0 +1,52 @@
+//! Pure build provenance resolution shared by the build script and tests.
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct GitInfo {
+    pub sha: String,
+    pub branch: String,
+    pub dirty: bool,
+}
+
+/// Validate and shorten the trusted source-archive commit override.
+pub fn source_archive_info(value: &str) -> Result<GitInfo, String> {
+    if value.len() != 40
+        || !value
+            .bytes()
+            .all(|byte| byte.is_ascii_digit() || matches!(byte, b'a'..=b'f'))
+    {
+        return Err(
+            "HYPRSTREAM_SOURCE_COMMIT must be exactly 40 lowercase hexadecimal characters"
+                .to_owned(),
+        );
+    }
+
+    Ok(GitInfo {
+        sha: value[..7].to_owned(),
+        branch: String::new(),
+        dirty: false,
+    })
+}
+
+/// Apply the source-archive override, preserving the live-Git fallback when absent.
+pub fn resolve(source_commit: Option<&str>, git_fallback: GitInfo) -> Result<GitInfo, String> {
+    source_commit.map_or(Ok(git_fallback), source_archive_info)
+}
+
+/// Construct the version string emitted by the build script.
+pub fn build_version(cargo_version: &str, info: &GitInfo, sanitized_branch: &str) -> String {
+    if info.sha.is_empty() {
+        return cargo_version.to_owned();
+    }
+
+    let mut version = format!("{cargo_version}+");
+    if !sanitized_branch.is_empty() {
+        version.push_str(sanitized_branch);
+        version.push('.');
+    }
+    version.push('g');
+    version.push_str(&info.sha);
+    if info.dirty {
+        version.push_str(".dirty");
+    }
+    version
+}

--- a/crates/hyprstream/tests/build_info.rs
+++ b/crates/hyprstream/tests/build_info.rs
@@ -1,0 +1,86 @@
+#[path = "../src/build_info.rs"]
+mod build_info;
+
+use build_info::{build_version, resolve, source_archive_info, GitInfo};
+
+const VALID_COMMIT: &str = "0123456789abcdef0123456789abcdef01234567";
+
+#[test]
+fn valid_source_commit_uses_seven_character_prefix() {
+    assert_eq!(
+        source_archive_info(VALID_COMMIT).ok(),
+        Some(GitInfo {
+            sha: "0123456".to_owned(),
+            branch: String::new(),
+            dirty: false
+        })
+    );
+}
+
+#[test]
+fn invalid_source_commit_is_rejected() {
+    for value in [
+        "",
+        "0123456",
+        "0123456789abcdef0123456789abcdef0123456G",
+        "0123456789ABCDEF0123456789abcdef01234567",
+    ] {
+        assert!(
+            source_archive_info(value).is_err(),
+            "accepted invalid commit {value:?}"
+        );
+    }
+}
+
+#[test]
+fn source_commit_takes_precedence_over_git_probe() {
+    let fallback = GitInfo {
+        sha: "githead".to_owned(),
+        branch: "feature/x".to_owned(),
+        dirty: true,
+    };
+    assert_eq!(
+        resolve(Some(VALID_COMMIT), fallback).map(|info| info.sha),
+        Ok("0123456".to_owned())
+    );
+    assert_eq!(
+        resolve(
+            Some(VALID_COMMIT),
+            GitInfo {
+                sha: "githead".to_owned(),
+                branch: "feature/x".to_owned(),
+                dirty: true
+            }
+        )
+        .map(|info| info.branch),
+        Ok(String::new())
+    );
+}
+
+#[test]
+fn source_archive_is_branchless_and_clean() {
+    let info = source_archive_info(VALID_COMMIT);
+    assert_eq!(
+        info.as_ref().ok().map(|value| value.branch.as_str()),
+        Some("")
+    );
+    assert_eq!(info.as_ref().ok().map(|value| value.dirty), Some(false));
+    assert_eq!(
+        source_archive_info(VALID_COMMIT).map(|value| build_version("0.5.0", &value, "")),
+        Ok("0.5.0+g0123456".to_owned())
+    );
+}
+
+#[test]
+fn absent_source_commit_preserves_git_fallback() {
+    let fallback = GitInfo {
+        sha: "abc1234".to_owned(),
+        branch: "feature-auth".to_owned(),
+        dirty: true,
+    };
+    assert_eq!(resolve(None, fallback.clone()), Ok(fallback.clone()));
+    assert_eq!(
+        build_version("0.5.0", &fallback, "feature-auth"),
+        "0.5.0+feature-auth.gabc1234.dirty"
+    );
+}


### PR DESCRIPTION
## Summary
- add a validated `HYPRSTREAM_SOURCE_COMMIT` override for source archives
- derive the seven-character GIT_SHA/BUILD_VERSION prefix while forcing branchless, clean provenance
- retain the current live-Git fallback when the override is absent
- add rerun tracking and pure, worktree-free tests for valid/invalid input, precedence, archive cleanliness, and fallback

## Downstream
This is the upstream replacement for FerruleOS RPM MR !25 patch 0002 (`build.rs` source provenance). Once merged, the RPM owner can remove that patch and keep the exact merged commit as the source pin. MR !25 head `4edc544ede173e227fe70d19cf98240569e4cd1f` / green pipeline `2782336514` are historical downstream context; this PR requires its own fresh CI.

No merge or downstream pin was performed.