### PR TITLE
build: update OpenSSL crates for OpenSSL 4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11063,15 +11063,14 @@ checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 
 [[package]]
 name = "openssl"
-version = "0.10.73"
+version = "0.10.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8505734d46c8ab1e19a1dce3aef597ad87dcb4c37e7188231769bd6bd51cebf8"
+checksum = "77823a27f0babb03091cb9ed9ef80af3b39dbc82f97e8fa530374b7dafd87a45"
 dependencies = [
  "bitflags 2.11.0",
  "cfg-if 1.0.3",
  "foreign-types 0.3.2",
  "libc",
- "once_cell",
  "openssl-macros",
  "openssl-sys",
 ]
@@ -11104,9 +11103,9 @@ dependencies = [
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.109"
+version = "0.9.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90096e2e47630d78b7d1c20952dc621f957103f8bc2c8359ec81290d75238571"
+checksum = "b47e7e6bb2c38cd930d25a23b40fa52e068c10e85f3e03a7f5ba5aaca5713695"
 dependencies = [
  "cc",
  "libc",


### PR DESCRIPTION
## Summary
- update the workspace lockfile using Cargo's resolver to openssl 0.10.81 and openssl-sys 0.9.117
- keep the lockfile diff narrow (only the two package records; openssl 0.10.81 drops its once_cell dependency)

## Rationale
Fedora Rawhide's OpenSSL 4 build needs the newer Rust bindings, while Hummingbird remains on its OpenSSL 3 baseline. Reverse-dependency inspection covers native-tls/reqwest, git2/libgit2, nydus, and Hyprstream's workspace consumers without unrelated lock churn.

## Downstream
This is the upstream replacement for FerruleOS RPM MR !25 patch 0001. Once merged, the RPM owner can remove that patch. MR !25 head `4edc544ede173e227fe70d19cf98240569e4cd1f` / green pipeline `2782336514` are historical downstream context; this PR requires its own fresh CI.

No merge or downstream pin was performed.