### PR TITLE
fix(mac): typed dispatch labels for the staging bootstrap services (#1499)

### DIFF
--- a/crates/hyprstream-rpc/src/service/dispatch.rs
+++ b/crates/hyprstream-rpc/src/service/dispatch.rs
@@ -239,18 +239,28 @@ where
     // a PEP process-globally via `install_mac_dispatch_pep`, this gate denies
     // with `NoPepInstalled`; after installation its decision is authoritative.
     //
+    // **Typed method identity (#1499):** the PEP evaluates the typed
+    // `(service, leaf/method)` identity of the call. The leaf is the canonical
+    // request-union discriminant, decoded once here from the verified payload
+    // (a bounded structural read of the signed body — the value the generated
+    // handler will independently decode and act on). A payload that does not
+    // decode to a canonical request union contributes no method identity:
+    // `None` matches no declared row, so the call fails closed below rather
+    // than at the handler's own decode. The browser commitment
+    // (`browser_method_discriminator`) remains the cross-check input to
+    // `ensure_browser_method` and is unchanged by this decode.
+    //
     // Streaming continuations: the continuation produced by a permitted
     // handler inherits this dispatch-time Permit. Explicit re-check of
     // long-running continuations against revoked authority is a DEFERRED
     // follow-up (#1267 scope expansion — `StaleAuthority` variant is reserved
     // for that future gate, not used today).
-    let mac_decision = crate::auth::mac::check_dispatch_mac(
-        &ctx,
-        actual_service_domain,
-        ctx.browser_method_discriminator,
-    );
+    let dispatch_method =
+        crate::browser_provisioning::canonical_method_discriminator(&payload).ok();
+    let mac_decision =
+        crate::auth::mac::check_dispatch_mac(&ctx, actual_service_domain, dispatch_method);
     if let crate::auth::mac::MacDecision::Deny(reason) = mac_decision {
-        let mac_resource = match ctx.browser_method_discriminator {
+        let mac_resource = match dispatch_method {
             Some(method) => format!("{actual_service_domain}:method:{method}"),
             None => format!("{actual_service_domain}:*"),
         };

--- a/crates/hyprstream/src/mac/dispatch_labels.rs
+++ b/crates/hyprstream/src/mac/dispatch_labels.rs
@@ -1,0 +1,773 @@
+//! **Typed RPC dispatch labels** — the focused #1499 boot-labeling slice.
+//!
+//! The mandatory RPC dispatch PEP (`hyprstream_rpc::auth::mac::dispatch_pep`)
+//! evaluates a **typed declared `(service, leaf/method)` object identity** plus
+//! a **deliberate service subject clearance**. This module supplies both, keyed
+//! on the dispatch plane's own coordinates:
+//!
+//! - [`DispatchMethodId`] — the typed object identity: the canonical service
+//!   name plus the canonical request-union discriminant (the leaf/method),
+//!   decoded once from the verified payload by the dispatch pipeline. It is
+//!   **never** a VFS path, and bare service domains are never routed through
+//!   the VFS object-label adapter (`CompositeObjectLabelResolver`'s
+//!   `RpcObjectLabelResolver` impl now serves the VFS plane only).
+//! - [`ServiceSubjectClearance`] — the deliberate clearance a declared
+//!   bootstrap service holds as a *caller*, the dispatch-plane seed of the
+//!   v16 `ServiceEnrollmentManifest` clearance. The assurance axis is clamped
+//!   by the cryptographically verified key material at evaluation time, so the
+//!   declaration can never outrun what the envelope signature proved.
+//!
+//! ## Deny-by-default
+//!
+//! There is no wildcard, catch-all, prefix rule, or permissive default. An
+//! unknown service, an unknown leaf on a known service, a bare/VFS-shaped
+//! alias (`"/srv/policy"`, `"srv/policy"`), and a call whose payload carries
+//! no canonical method identity all resolve to `None` ⇒ `UnlabeledObject` ⇒
+//! deny before handler entry. A caller with no declared service clearance —
+//! including an anonymous caller, for whom the activation floor would
+//! otherwise suffice against a floor-labeled row — denies `NoClearance`. The
+//! permit of a declared bootstrap call is therefore justified by the
+//! *declared pair* (typed object + deliberate clearance), never by a
+//! fabricated anonymous/public clearance.
+//!
+//! ## Relationship to #1507 (v16)
+//!
+//! This is the smallest deny-by-default representation the production PEP can
+//! evaluate today. #1507 replaces the hand-maintained tables with the
+//! generated full-method inventory (transitional/target label columns, scope
+//! and signature policy) without changing the PEP contract: typed `(service,
+//! leaf)` resolution, declared subject clearance, activation-gated selection,
+//! and intrinsic lattice dominance all stay. Object labels here are
+//! deliberately the lattice floor (`SecurityLabel::bottom()`): the bootstrap
+//! identity-lifecycle leaves precede identity standing and must remain
+//! reachable under the permanent narrow-to-floor incident control
+//! (`FloorOnly`); every raising above the floor is #1507's reviewed
+//! transitional/target column work, not this slice.
+
+use hyprstream_rpc::auth::mac::{
+    Assurance, CompartmentSet, Level, MacDecision, MacDenyReason, MacDispatchPep,
+    RpcObjectLabelResolver, SecurityContext, SecurityLabel,
+};
+use hyprstream_rpc::service::EnvelopeContext;
+
+/// Subject-name prefix of a verified service identity (`service:{name}`).
+///
+/// Service JWTs minted by the CA carry `sub = "service:{name}"`
+/// (`crates/hyprstream-rpc-std/schema/policy.capnp`), so the verified subject
+/// produced by claims verification has this exact shape.
+pub const SERVICE_SUBJECT_PREFIX: &str = "service:";
+
+/// Canonical `PolicyRequest` union discriminants (the leaf/method axis of
+/// [`DispatchMethodId`]).
+///
+/// The values are the Cap'n Proto union discriminant ordinals — 0-based
+/// declaration order in `hyprstream-rpc-std/schema/policy.capnp`, which
+/// assigns no explicit discriminants. The drift test in this module decodes
+/// real serialized requests and pins these values to the schema; changing the
+/// union order fails CI rather than silently relabeling the dispatch plane.
+pub mod policy_methods {
+    /// `registerServiceKey` — a keyed service installs its identity with the
+    /// CA. Bootstrap-critical: it precedes identity standing.
+    pub const REGISTER_SERVICE_KEY: u16 = 18;
+    /// `refreshServiceToken` — a registered service renews the identity the
+    /// registration created. Same bootstrap identity-lifecycle class; without
+    /// a declared row the first hourly renewal would deny on any live node.
+    pub const REFRESH_SERVICE_TOKEN: u16 = 19;
+}
+
+/// The deliberate subject clearance declared for the staging bootstrap
+/// services: an internal system principal presenting a verified classical
+/// key. The assurance axis is a *ceiling*, not a grant — evaluation clamps it
+/// to the cryptographically verified key material (#548), so a caller whose
+/// envelope proved less derives less.
+pub const BOOTSTRAP_SERVICE_CLEARANCE: SecurityLabel = SecurityLabel {
+    level: Level::Internal,
+    assurance: Assurance::Classical,
+    compartments: CompartmentSet::EMPTY,
+};
+
+/// Typed dispatch object identity: canonical service name + canonical
+/// request-union discriminant. Never a VFS path; never interpreted by another
+/// plane's resolver.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct DispatchMethodId {
+    /// The canonical registered service name (`policy`, `discovery`, …).
+    pub service: &'static str,
+    /// The canonical request-union discriminant of the method leaf.
+    pub method: u16,
+}
+
+/// One declared `(service, leaf/method)` policy row: the typed object label
+/// for exactly one RPC method on exactly one service.
+#[derive(Debug, Clone, Copy)]
+pub struct DispatchMethodPolicy {
+    /// The typed object identity this row labels.
+    pub id: DispatchMethodId,
+    /// The symbolic leaf name (`registerServiceKey`) — audit and drift-test
+    /// evidence; resolution is by the numeric identity only.
+    pub method_name: &'static str,
+    /// The declared object label. Bootstrap rows are the lattice floor; see
+    /// the module docs for why no row may rise above it in this slice.
+    pub label: SecurityLabel,
+    /// Why this row exists and why its label is correct (reviewed text).
+    pub justification: &'static str,
+}
+
+/// The deliberate MAC clearance a declared service holds as a dispatch
+/// *caller* — the dispatch-plane seed of the v16 `ServiceEnrollmentManifest`
+/// service clearance.
+#[derive(Debug, Clone, Copy)]
+pub struct ServiceSubjectClearance {
+    /// The canonical service name (the `service:{name}` subject suffix).
+    pub service: &'static str,
+    /// The declared clearance. Assurance is clamped to the verified key
+    /// material at evaluation time.
+    pub clearance: SecurityLabel,
+    /// Why this clearance is correct for this service (reviewed text).
+    pub justification: &'static str,
+}
+
+/// The declared dispatch table: a closed, deny-by-default set of typed
+/// `(service, leaf/method)` object labels plus the deliberate per-service
+/// subject clearances. Consumed by [`DeclaredDispatchPep`]; replaceable by
+/// #1507's generated inventory without changing the PEP contract.
+#[derive(Debug, Clone, Copy)]
+pub struct DeclaredDispatchTable {
+    methods: &'static [DispatchMethodPolicy],
+    clearances: &'static [ServiceSubjectClearance],
+}
+
+impl DeclaredDispatchTable {
+    /// The production staging-bootstrap declarations (#1499).
+    ///
+    /// Object rows cover exactly the dispatch calls the fresh-state
+    /// `service start --services event,policy,discovery,registry,oauth` boot
+    /// graph makes: every keyed non-policy service registers its signing key
+    /// with the PolicyService CA at startup and renews that identity
+    /// hourly. Subject rows declare the deliberate caller clearance for all
+    /// five bootstrap services.
+    #[must_use]
+    pub fn production() -> &'static Self {
+        &PRODUCTION_TABLE
+    }
+
+    /// Construct a table from explicit rows (test fixtures). Production uses
+    /// [`Self::production`].
+    #[must_use]
+    pub const fn from_rows(
+        methods: &'static [DispatchMethodPolicy],
+        clearances: &'static [ServiceSubjectClearance],
+    ) -> Self {
+        Self {
+            methods,
+            clearances,
+        }
+    }
+
+    /// Every declared method row (table-driven test and audit evidence).
+    #[must_use]
+    pub fn methods(&self) -> &'static [DispatchMethodPolicy] {
+        self.methods
+    }
+
+    /// Every declared service subject clearance row.
+    #[must_use]
+    pub fn clearances(&self) -> &'static [ServiceSubjectClearance] {
+        self.clearances
+    }
+
+    /// Resolve the declared policy row for a typed `(service, leaf)` call.
+    ///
+    /// Exact match only: `method` must be `Some` (the canonical discriminant
+    /// committed by the verified payload) and the pair must be declared.
+    /// Unknown services, unknown leaves, VFS-shaped aliases, and calls with
+    /// no committed method identity all return `None` ⇒ deny.
+    #[must_use]
+    pub fn resolve_row(
+        &self,
+        service_domain: &str,
+        method: Option<u16>,
+    ) -> Option<&DispatchMethodPolicy> {
+        let method = method?;
+        self.methods
+            .iter()
+            .find(|row| row.id.service == service_domain && row.id.method == method)
+    }
+
+    /// The deliberate clearance declared for a service caller, if any.
+    ///
+    /// `service` is the canonical service name (the `service:` subject prefix
+    /// is stripped by the caller). Exact match; no declaration ⇒ `None` ⇒ the
+    /// caller has no dispatch authority (deny `NoClearance`).
+    #[must_use]
+    pub fn service_clearance(&self, service: &str) -> Option<SecurityLabel> {
+        self.clearances
+            .iter()
+            .find(|row| row.service == service)
+            .map(|row| row.clearance)
+    }
+}
+
+impl RpcObjectLabelResolver for DeclaredDispatchTable {
+    /// Typed dispatch-plane resolution. No path splitting, no prefix
+    /// matching, no VFS adapter: an exact declared `(service, leaf)` row or
+    /// `None` (deny).
+    fn resolve(&self, service_domain: &str, method: Option<u16>) -> Option<SecurityLabel> {
+        self.resolve_row(service_domain, method)
+            .map(|row| row.label)
+    }
+}
+
+/// The production dispatch PEP over the declared table.
+///
+/// Decision procedure (every missing input denies; no permissive mode):
+///
+/// 1. **Activation-selected context** — the coverage-gated operator control
+///    (`FloorOnly` ⇒ anonymous floor; `IdentityAware` ⇒ the verified
+///    Claims × VerifiedKeyMaterial derivation). `None` ⇒ `NoClearance`. The
+///    activation gate and the narrow-to-floor kill-switch are unchanged: a
+///    narrowed process still evaluates every dispatch, and only floor-labeled
+///    (bootstrap-critical) rows remain reachable.
+/// 2. **Deliberate service subject clearance** — the verified subject must be
+///    a `service:{name}` identity with a real authenticated envelope signer
+///    key AND a declared clearance in the table. The declared clearance is
+///    composed with the crypto-derived assurance (`SecurityContext::
+///    from_clearance` clamps down, never up). No declaration ⇒ `NoClearance`
+///    — an anonymous or undeclared caller can never ride the activation floor
+///    into a declared row.
+/// 3. **Typed object identity** — an exact declared `(service, leaf)` row.
+///    `None` ⇒ `UnlabeledObject`.
+/// 4. **Dominance** — BOTH the activation-selected context and the deliberate
+///    declared-service context must dominate the declared object label
+///    (`can_access`). Otherwise `FloorDeny`.
+///
+/// Like the genesis PEP it replaces at the install seam, this PEP performs no
+/// permit caching and holds no permissive state.
+pub struct DeclaredDispatchPep {
+    table: &'static DeclaredDispatchTable,
+    activation_controlled: bool,
+}
+
+impl DeclaredDispatchPep {
+    /// Construct over a declared table.
+    ///
+    /// Direct unit-test and embedding constructors keep the historical
+    /// identity-aware behavior (the verified context is used as-is);
+    /// production installs with [`Self::with_activation_control`].
+    #[must_use]
+    pub fn new(table: &'static DeclaredDispatchTable) -> Self {
+        Self {
+            table,
+            activation_controlled: false,
+        }
+    }
+
+    /// Select subject contexts through the process-global coverage gate.
+    /// Production's install path opts in explicitly.
+    #[must_use]
+    pub fn with_activation_control(mut self) -> Self {
+        self.activation_controlled = true;
+        self
+    }
+
+    /// The declared table this PEP evaluates.
+    #[must_use]
+    pub fn table(&self) -> &'static DeclaredDispatchTable {
+        self.table
+    }
+}
+
+/// Extract the canonical service name from a verified service subject.
+///
+/// The declared clearance attaches only to a `service:{name}` identity backed
+/// by a real authenticated envelope signer key — never to an anonymous
+/// subject and never to a keyless internal callback context
+/// (`EnvelopeContext::from_callback_service` zeroes `cnf`, so
+/// `authenticated_signer_key` refuses it).
+fn declared_service_subject(ctx: &EnvelopeContext) -> Option<String> {
+    ctx.authenticated_signer_key()?;
+    let subject = ctx.subject();
+    let name = subject.name()?;
+    name.strip_prefix(SERVICE_SUBJECT_PREFIX)
+        .filter(|suffix| !suffix.is_empty())
+        .map(str::to_owned)
+}
+
+impl MacDispatchPep for DeclaredDispatchPep {
+    fn check(
+        &self,
+        ctx: &EnvelopeContext,
+        service_domain: &str,
+        method: Option<u16>,
+    ) -> MacDecision {
+        // Preserve the verified context for the direct VFS/CAS/MoQ PEPs, whose
+        // low-level APIs carry Subject but not the full verified envelope.
+        // (Parity with DefaultMacDispatchPep.)
+        hyprstream_rpc::auth::mac::remember_verified_subject(ctx);
+
+        // 1. Activation-selected subject context (floor-only or verified
+        //    identity-aware). The operator gate is unchanged by this PEP.
+        let selected = if self.activation_controlled {
+            hyprstream_rpc::auth::mac::global_mac_activation_control()
+                .select_context(ctx.security_context())
+        } else {
+            ctx.security_context()
+        };
+        let Some(selected) = selected else {
+            return MacDecision::Deny(MacDenyReason::NoClearance);
+        };
+
+        // 2. Deliberate declared service subject clearance. The assurance axis
+        //    is clamped to the verified key material; the declaration cannot
+        //    outrun the crypto.
+        let Some(service_name) = declared_service_subject(ctx) else {
+            return MacDecision::Deny(MacDenyReason::NoClearance);
+        };
+        let Some(declared_clearance) = self.table.service_clearance(&service_name) else {
+            return MacDecision::Deny(MacDenyReason::NoClearance);
+        };
+        let service_ctx =
+            SecurityContext::from_clearance(declared_clearance, ctx.verified_key_material());
+
+        // 3. Typed declared (service, leaf) object identity.
+        let Some(row) = self.table.resolve_row(service_domain, method) else {
+            return MacDecision::Deny(MacDenyReason::UnlabeledObject);
+        };
+
+        // 4. Intrinsic lattice floor: both the activation-selected context and
+        //    the deliberate declared-service context must dominate the label.
+        if selected.can_access(&row.label) && service_ctx.can_access(&row.label) {
+            MacDecision::Permit
+        } else {
+            MacDecision::Deny(MacDenyReason::FloorDeny)
+        }
+    }
+}
+
+// ── Production declarations (the staging bootstrap set, #1499) ─────────────
+
+static BOOTSTRAP_METHODS: &[DispatchMethodPolicy] = &[
+    DispatchMethodPolicy {
+        id: DispatchMethodId {
+            service: "policy",
+            method: policy_methods::REGISTER_SERVICE_KEY,
+        },
+        method_name: "registerServiceKey",
+        label: SecurityLabel::bottom(),
+        justification: "a keyed service installs its identity with the CA; \
+             bootstrap-critical (it precedes identity standing) and reachable \
+             only by declared service subjects; handler-level CA-JWT, subject, \
+             and cnf binding checks are unchanged",
+    },
+    DispatchMethodPolicy {
+        id: DispatchMethodId {
+            service: "policy",
+            method: policy_methods::REFRESH_SERVICE_TOKEN,
+        },
+        method_name: "refreshServiceToken",
+        label: SecurityLabel::bottom(),
+        justification: "a registered service renews the identity registration \
+             created; same bootstrap identity-lifecycle class — the handler \
+             re-binds cnf to the verified caller key and requires prior \
+             registration",
+    },
+];
+
+static BOOTSTRAP_SERVICE_CLEARANCES: &[ServiceSubjectClearance] = &[
+    ServiceSubjectClearance {
+        service: "discovery",
+        clearance: BOOTSTRAP_SERVICE_CLEARANCE,
+        justification: "announce/presence precedes identity standing; \
+             discovery registers its key at boot",
+    },
+    ServiceSubjectClearance {
+        service: "event",
+        clearance: BOOTSTRAP_SERVICE_CLEARANCE,
+        justification: "the event bus is startup wiring, not content; \
+             declared so the bootstrap set holds one uniform deliberate \
+             clearance",
+    },
+    ServiceSubjectClearance {
+        service: "oauth",
+        clearance: BOOTSTRAP_SERVICE_CLEARANCE,
+        justification: "login/session issuance is how identity standing is \
+             acquired at all; oauth registers its key at boot",
+    },
+    ServiceSubjectClearance {
+        service: "policy",
+        clearance: BOOTSTRAP_SERVICE_CLEARANCE,
+        justification: "the CA itself; it makes no boot RPC calls, but its \
+             enrolled caller clearance is declared with the same deliberate \
+             value as the services it certifies",
+    },
+    ServiceSubjectClearance {
+        service: "registry",
+        clearance: BOOTSTRAP_SERVICE_CLEARANCE,
+        justification: "service/model registration is part of boot; registry \
+             registers its key at boot",
+    },
+];
+
+static PRODUCTION_TABLE: DeclaredDispatchTable =
+    DeclaredDispatchTable::from_rows(BOOTSTRAP_METHODS, BOOTSTRAP_SERVICE_CLEARANCES);
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used, clippy::expect_used)]
+mod tests {
+    use super::*;
+
+    // ── fixtures ────────────────────────────────────────────────────────
+
+    fn service_subject_ctx(service: &str, key_byte: u8) -> EnvelopeContext {
+        let signer = ed25519_dalek::SigningKey::from_bytes(&[key_byte; 32]);
+        EnvelopeContext::for_test_authenticated_subject(
+            hyprstream_rpc::Subject::new(format!("service:{service}")),
+            signer.verifying_key(),
+        )
+    }
+
+    fn user_subject_ctx() -> EnvelopeContext {
+        let signer = ed25519_dalek::SigningKey::from_bytes(&[0x77; 32]);
+        EnvelopeContext::for_test_authenticated_subject(
+            hyprstream_rpc::Subject::new("did:web:alice"),
+            signer.verifying_key(),
+        )
+    }
+
+    /// The production PEP exactly as the daemon installs it (floor-only
+    /// activation control, production table).
+    fn production_pep() -> DeclaredDispatchPep {
+        DeclaredDispatchPep::new(DeclaredDispatchTable::production()).with_activation_control()
+    }
+
+    // ── table coverage: every declared (service, leaf) + clearance ──────
+
+    #[test]
+    fn every_declared_call_resolves_to_the_intended_typed_label_and_clearance() {
+        let table = DeclaredDispatchTable::production();
+
+        // The fresh boot graph: discovery, registry, and oauth each call
+        // policy.registerServiceKey on fresh state; renewal uses
+        // policy.refreshServiceToken. Every declared row resolves to the
+        // intended typed label — the lattice floor, deliberate and reviewed.
+        let expected: &[(u16, &str)] = &[
+            (policy_methods::REGISTER_SERVICE_KEY, "registerServiceKey"),
+            (policy_methods::REFRESH_SERVICE_TOKEN, "refreshServiceToken"),
+        ];
+        assert_eq!(table.methods().len(), expected.len());
+        for (method, name) in expected {
+            let row = table
+                .resolve_row("policy", Some(*method))
+                .unwrap_or_else(|| panic!("declared row for policy.{name} must resolve"));
+            assert_eq!(row.method_name, *name);
+            assert_eq!(row.id.service, "policy");
+            assert_eq!(
+                row.label,
+                SecurityLabel::bottom(),
+                "bootstrap-critical row {name} stays at the floor (reachable under narrow-to-floor)"
+            );
+            assert!(!row.justification.is_empty());
+        }
+
+        // The five staging bootstrap services each hold the deliberate
+        // service subject clearance, and each declared caller's clearance
+        // dominates every declared object label (the boot calls evaluate).
+        let mut services: Vec<&str> = table.clearances().iter().map(|row| row.service).collect();
+        services.sort_unstable();
+        assert_eq!(
+            services,
+            ["discovery", "event", "oauth", "policy", "registry"]
+        );
+        for row in table.clearances() {
+            assert_eq!(row.clearance, BOOTSTRAP_SERVICE_CLEARANCE);
+            assert_eq!(
+                table.service_clearance(row.service),
+                Some(row.clearance),
+                "clearance lookup by canonical name"
+            );
+            assert!(!row.justification.is_empty());
+            for method in table.methods() {
+                let ctx = SecurityContext::from_clearance(
+                    row.clearance,
+                    hyprstream_rpc::auth::mac::VerifiedKeyMaterial::Classical,
+                );
+                assert!(
+                    ctx.can_access(&method.label),
+                    "declared clearance for {} must dominate declared label {} ({})",
+                    row.service,
+                    method.label,
+                    method.method_name
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn table_has_no_duplicate_or_unsorted_rows() {
+        let table = DeclaredDispatchTable::production();
+        let ids: Vec<DispatchMethodId> = table.methods().iter().map(|row| row.id).collect();
+        let mut sorted = ids.clone();
+        sorted.sort();
+        sorted.dedup();
+        assert_eq!(ids, sorted, "method rows must be sorted and unique");
+        let services: Vec<&str> = table.clearances().iter().map(|row| row.service).collect();
+        let mut sorted_services = services.clone();
+        sorted_services.sort_unstable();
+        sorted_services.dedup();
+        assert_eq!(
+            services, sorted_services,
+            "clearance rows must be sorted and unique"
+        );
+    }
+
+    // ── deny-by-default: unknown service / leaf / VFS alias ─────────────
+
+    #[test]
+    fn unknown_service_unknown_leaf_and_vfs_alias_resolve_to_none() {
+        let table = DeclaredDispatchTable::production();
+
+        // Unknown service, even with a declared method number.
+        assert!(table
+            .resolve_row("ghost", Some(policy_methods::REGISTER_SERVICE_KEY))
+            .is_none());
+        // Unknown leaf on a known service: resolveServiceKey (17) is a real
+        // policy method but NOT declared — declaration, not schema, is the
+        // authority.
+        assert!(table.resolve_row("policy", Some(17)).is_none());
+        // Out-of-schema leaf on a known service.
+        assert!(table.resolve_row("policy", Some(u16::MAX)).is_none());
+        // No committed method identity (a payload without a canonical
+        // discriminant) matches no declared row, even on a known service.
+        assert!(table.resolve_row("policy", None).is_none());
+        // Bare/VFS-shaped aliases never enter the VFS adapter and never match.
+        for alias in ["/srv/policy", "srv/policy", "/policy", "policy/", "/"] {
+            assert!(
+                table
+                    .resolve_row(alias, Some(policy_methods::REGISTER_SERVICE_KEY))
+                    .is_none(),
+                "VFS-shaped alias {alias:?} must not resolve"
+            );
+        }
+        // Case and whitespace variants are not canonical names.
+        assert!(table
+            .resolve_row("Policy", Some(policy_methods::REGISTER_SERVICE_KEY))
+            .is_none());
+        assert!(table
+            .resolve_row(" policy", Some(policy_methods::REGISTER_SERVICE_KEY))
+            .is_none());
+        // Undeclared service clearance.
+        assert!(table.service_clearance("ghost").is_none());
+        assert!(table.service_clearance("model").is_none());
+
+        // The RpcObjectLabelResolver view agrees (None ⇒ deny).
+        let resolver: &dyn RpcObjectLabelResolver = table;
+        assert!(resolver
+            .resolve("policy", Some(policy_methods::REGISTER_SERVICE_KEY))
+            .is_some());
+        assert!(resolver.resolve("policy", Some(17)).is_none());
+        assert!(resolver
+            .resolve("/srv/policy", Some(policy_methods::REGISTER_SERVICE_KEY))
+            .is_none());
+    }
+
+    // ── causal PEP pair over the production table ───────────────────────
+
+    #[test]
+    fn declared_call_permits_and_identical_undeclared_call_denies() {
+        let pep = production_pep();
+        let caller = service_subject_ctx("discovery", 0x61);
+
+        // Positive: the exact fresh-boot call — discovery registering its key.
+        let declared = pep.check(
+            &caller,
+            "policy",
+            Some(policy_methods::REGISTER_SERVICE_KEY),
+        );
+        assert_eq!(
+            declared,
+            MacDecision::Permit,
+            "declared (policy, registerServiceKey) from declared discovery must permit"
+        );
+
+        // Causal twin: identical caller, identical service, undeclared leaf.
+        let undeclared = pep.check(&caller, "policy", Some(17));
+        assert_eq!(
+            undeclared,
+            MacDecision::Deny(MacDenyReason::UnlabeledObject),
+            "an otherwise identical undeclared call must deny UnlabeledObject"
+        );
+
+        // Unknown service denies the same way.
+        assert_eq!(
+            pep.check(&caller, "ghost", Some(policy_methods::REGISTER_SERVICE_KEY)),
+            MacDecision::Deny(MacDenyReason::UnlabeledObject)
+        );
+
+        // VFS-shaped alias of a declared pair denies (never routed through the
+        // VFS adapter).
+        assert_eq!(
+            pep.check(
+                &caller,
+                "/srv/policy",
+                Some(policy_methods::REGISTER_SERVICE_KEY)
+            ),
+            MacDecision::Deny(MacDenyReason::UnlabeledObject)
+        );
+
+        // No committed method identity ⇒ no declared row ⇒ deny.
+        assert_eq!(
+            pep.check(&caller, "policy", None),
+            MacDecision::Deny(MacDenyReason::UnlabeledObject)
+        );
+    }
+
+    #[test]
+    fn permit_requires_the_deliberate_service_clearance_not_the_anonymous_floor() {
+        let pep = production_pep();
+
+        // An undeclared service subject denies even for a declared object row:
+        // the activation floor alone must NOT carry a caller into the table —
+        // that is the fabricated-anonymous-clearance hole this slice closes.
+        let ghost = service_subject_ctx("ghost", 0x62);
+        assert_eq!(
+            pep.check(&ghost, "policy", Some(policy_methods::REGISTER_SERVICE_KEY)),
+            MacDecision::Deny(MacDenyReason::NoClearance),
+            "undeclared service subject must deny NoClearance"
+        );
+
+        // A non-service (user) identity has no service clearance.
+        let user = user_subject_ctx();
+        assert_eq!(
+            pep.check(&user, "policy", Some(policy_methods::REGISTER_SERVICE_KEY)),
+            MacDecision::Deny(MacDenyReason::NoClearance)
+        );
+
+        // A keyless internal callback context (zeroed cnf) asserting a service
+        // subject has no authenticated signer key and must not inherit the
+        // declared clearance.
+        let callback = EnvelopeContext::from_callback_service(1, "discovery");
+        assert_eq!(
+            pep.check(
+                &callback,
+                "policy",
+                Some(policy_methods::REGISTER_SERVICE_KEY)
+            ),
+            MacDecision::Deny(MacDenyReason::NoClearance),
+            "keyless callback contexts must not claim a service clearance"
+        );
+
+        // Every declared bootstrap service caller permits the boot
+        // registration call (deliberate clearance composed with verified key
+        // material).
+        for service in ["discovery", "event", "oauth", "policy", "registry"] {
+            let ctx = service_subject_ctx(service, 0x63);
+            assert_eq!(
+                pep.check(&ctx, "policy", Some(policy_methods::REGISTER_SERVICE_KEY)),
+                MacDecision::Permit,
+                "declared service:{service} must permit the declared bootstrap call"
+            );
+        }
+    }
+
+    #[test]
+    fn floor_deny_when_declared_clearance_cannot_dominate_the_label() {
+        // Fixture table: a declared row above the declared clearance. Both
+        // dominance checks must hold; here the declared service context
+        // (Internal) cannot dominate a Secret object label.
+        static SECRET_ROW: &[DispatchMethodPolicy] = &[DispatchMethodPolicy {
+            id: DispatchMethodId {
+                service: "policy",
+                method: 7,
+            },
+            method_name: "fixture",
+            label: SecurityLabel {
+                level: Level::Secret,
+                assurance: Assurance::Unverified,
+                compartments: CompartmentSet::EMPTY,
+            },
+            justification: "test fixture: label deliberately above the declared clearance",
+        }];
+        static TABLE: DeclaredDispatchTable =
+            DeclaredDispatchTable::from_rows(SECRET_ROW, BOOTSTRAP_SERVICE_CLEARANCES);
+        let pep = DeclaredDispatchPep::new(&TABLE).with_activation_control();
+        let caller = service_subject_ctx("discovery", 0x64);
+        assert_eq!(
+            pep.check(&caller, "policy", Some(7)),
+            MacDecision::Deny(MacDenyReason::FloorDeny),
+            "a label above the declared clearance must FloorDeny"
+        );
+    }
+
+    // ── installed-PEP causal pair ───────────────────────────────────────
+    //
+    // The process-global install + "the PEP stayed installed" assertion lives
+    // in the integration binary `tests/mac_dispatch_boot_labeling.rs`, which
+    // owns its own globals; lib tests share this binary's global PEP slot with
+    // the `install_explicit_test_dispatch_pep` plumbing fixtures and cannot
+    // serialize against them.
+
+    // ── drift: declared discriminants == real schema discriminants ──────
+
+    #[test]
+    fn declared_policy_discriminants_match_the_serialized_schema() {
+        use capnp::message::Builder;
+
+        // registerServiceKey
+        let mut message = Builder::new_default();
+        {
+            let mut req =
+                message.init_root::<hyprstream_rpc_std::policy_capnp::policy_request::Builder>();
+            req.set_id(1);
+            let mut call = req.reborrow().init_register_service_key();
+            call.set_service_name("discovery");
+            call.set_verifying_key(&[0x42; 32]);
+            call.set_service_jwt("header.payload.signature");
+        }
+        let bytes = capnp::serialize::write_message_to_words(&message);
+        assert_eq!(
+            hyprstream_rpc::browser_provisioning::canonical_method_discriminator(&bytes).unwrap(),
+            policy_methods::REGISTER_SERVICE_KEY,
+            "the declared registerServiceKey discriminant must match the schema union ordinal"
+        );
+
+        // refreshServiceToken
+        let mut message = Builder::new_default();
+        {
+            let mut req =
+                message.init_root::<hyprstream_rpc_std::policy_capnp::policy_request::Builder>();
+            req.set_id(1);
+            req.reborrow()
+                .init_refresh_service_token()
+                .set_ttl_seconds(2_592_000);
+        }
+        let bytes = capnp::serialize::write_message_to_words(&message);
+        assert_eq!(
+            hyprstream_rpc::browser_provisioning::canonical_method_discriminator(&bytes).unwrap(),
+            policy_methods::REFRESH_SERVICE_TOKEN,
+            "the declared refreshServiceToken discriminant must match the schema union ordinal"
+        );
+    }
+
+    // ── drift: declared services exist in the factory inventory ─────────
+
+    #[test]
+    fn declared_bootstrap_services_are_registered_factories() {
+        let registered: Vec<&str> = hyprstream_service::list_factories()
+            .map(|factory| factory.name)
+            .collect();
+        for row in DeclaredDispatchTable::production().clearances() {
+            assert!(
+                registered.contains(&row.service),
+                "declared bootstrap service {} must be a registered service factory",
+                row.service
+            );
+        }
+        for row in DeclaredDispatchTable::production().methods() {
+            assert!(
+                registered.contains(&row.id.service),
+                "declared dispatch target {} must be a registered service factory",
+                row.id.service
+            );
+        }
+    }
+}

--- a/crates/hyprstream/src/mac/genesis.rs
+++ b/crates/hyprstream/src/mac/genesis.rs
@@ -477,6 +477,12 @@ impl ObjectLabelResolver for CompositeObjectLabelResolver {
 /// Adapt the genesis/bind carrier resolver to the canonical cross-plane MAC
 /// resolver contract. For the VFS plane, `service_domain` is the normalized
 /// absolute object path and there is no browser method discriminator.
+///
+/// **RPC dispatch no longer routes through this adapter** (#1499): the
+/// dispatch PEP evaluates typed `(service, leaf/method)` rows from
+/// [`crate::mac::dispatch_labels`], so a bare service domain is never split
+/// as a path here. This impl serves the VFS/9P plane only
+/// ([`crate::mac::pep::production_vfs_pep`]).
 impl hyprstream_rpc::auth::mac::RpcObjectLabelResolver for CompositeObjectLabelResolver {
     fn resolve(&self, service_domain: &str, _method: Option<u16>) -> Option<SecurityLabel> {
         let components: Vec<&str> = service_domain

--- a/crates/hyprstream/src/mac/mod.rs
+++ b/crates/hyprstream/src/mac/mod.rs
@@ -68,6 +68,11 @@ pub mod exchange;
 // S1 activation (#567): production genesis CONTENT + enumerator + composite
 // ObjectLabelResolver + boot-time coverage gate consumed by the active 9P PEP.
 pub mod genesis;
+// #1499: typed RPC dispatch labels — the declared (service, leaf/method)
+// object identity and deliberate service subject clearance the mandatory
+// dispatch PEP evaluates. Bare service domains never route through the VFS
+// object-label adapter.
+pub mod dispatch_labels;
 pub mod lattice;
 pub mod moq_audit;
 // #1319: audited MAC adapter at the tenant account-record read boundary.
@@ -112,10 +117,16 @@ pub use te::{
 /// Install the mandatory RPC-dispatch PEP in its activation-ready, floor-only
 /// state.  The coverage-gated operator control selects identity-aware contexts;
 /// installing this monitor does not perform that widening.
+///
+/// The object-label resolver is the typed dispatch table (#1499): declared
+/// `(service, leaf/method)` rows plus deliberate service subject clearances.
+/// Bare RPC service names are never mapped through the VFS object-label
+/// adapter (the genesis `CompositeObjectLabelResolver` now serves the VFS/9P
+/// plane only); unknown services, unknown leaves, and VFS-shaped aliases deny
+/// `UnlabeledObject` before handler entry.
 pub fn install_production_rpc_dispatch_pep() {
-    let resolver = GenesisGate::production().into_resolver();
     hyprstream_rpc::auth::mac::install_mac_dispatch_pep(std::sync::Arc::new(
-        hyprstream_rpc::auth::mac::DefaultMacDispatchPep::new(Box::new(resolver))
+        dispatch_labels::DeclaredDispatchPep::new(dispatch_labels::DeclaredDispatchTable::production())
             .with_activation_control(),
     ));
 }
@@ -152,6 +163,12 @@ pub use compiler::{
 pub use genesis::{
     floor_label, genesis_lattice, CompositeObjectLabelResolver, GeneratedNodeCoverage, GenesisGate,
     ManifestLabelSource, NamespaceEnumerator, NoManifests, SitePolicy,
+};
+// #1499: typed dispatch-plane labels + the production dispatch PEP over them.
+pub use dispatch_labels::{
+    policy_methods, DeclaredDispatchPep, DeclaredDispatchTable, DispatchMethodId,
+    DispatchMethodPolicy, ServiceSubjectClearance, BOOTSTRAP_SERVICE_CLEARANCE,
+    SERVICE_SUBJECT_PREFIX,
 };
 pub use moq_audit::{
     audited_moq_event_pep, production_moq_event_pep, MoqAuditSinkAdapter,

--- a/crates/hyprstream/tests/mac_dispatch_boot_labeling.rs
+++ b/crates/hyprstream/tests/mac_dispatch_boot_labeling.rs
@@ -1,0 +1,315 @@
+//! #1499 focused boot-labeling acceptance: the fresh-state `registerServiceKey`
+//! path through the **real production dispatch PEP**.
+//!
+//! This is the executable contract of the focused staging boot slice:
+//!
+//! 1. With the production PEP installed (`install_production_rpc_dispatch_pep`,
+//!    the exact seam `service start` runs at `main.rs`), a fresh-state
+//!    `registerServiceKey` from a declared bootstrap service (`discovery`)
+//!    passes the PEP and reaches the real `PolicyService` handler — without
+//!    `UnlabeledObject` and without a fabricated anonymous/public clearance
+//!    (the caller presents a verified CA-signed service identity, and the PEP
+//!    requires the declared service clearance).
+//! 2. The causal twin — the identical caller and service with an undeclared
+//!    leaf (`resolveServiceKey`) — denies `UnlabeledObject` before handler
+//!    entry, and the PEP remains installed afterwards.
+//! 3. A call to an undeclared service domain from the same declared caller
+//!    denies before handler entry (handler invocation counter stays zero).
+
+#![allow(clippy::expect_used, clippy::unwrap_used)]
+
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::Arc;
+
+use anyhow::Result;
+use async_trait::async_trait;
+use ed25519_dalek::{SigningKey, VerifyingKey};
+
+use hyprstream_core::auth::service_jwt::issue_or_load_service_jwt;
+use hyprstream_core::auth::PolicyManager;
+use hyprstream_core::config::TokenConfig;
+use hyprstream_core::services::generated::policy_client::{RegisterServiceKey, ResolveServiceKey};
+use hyprstream_core::services::{PolicyClient, PolicyService};
+use hyprstream_rpc::auth::mac::global_mac_dispatch_pep;
+use hyprstream_rpc::auth::ClusterKeySource;
+use hyprstream_rpc::dial::{dial_with_crypto_stores, register_inproc};
+use hyprstream_rpc::envelope::{InMemoryNonceCache, KeyedPqTrustStore};
+use hyprstream_rpc::node_identity::{derive_mesh_mldsa_key, derive_purpose_key};
+use hyprstream_rpc::service::{Continuation, EnvelopeContext, RequestService};
+use hyprstream_rpc::signer::LocalSigner;
+use hyprstream_rpc::transport::iroh_rpc::LocalServiceBridge;
+use hyprstream_rpc::transport::rpc_session::IrohRequestProcessor;
+use hyprstream_rpc::transport::TransportConfig;
+use hyprstream_service::{InprocManager, ServiceManager as _};
+
+const POLICY_ROOT_KEY: [u8; 32] = [0x52; 32];
+const DISCOVERY_KEY: [u8; 32] = [0x42; 32];
+const GHOST_CLIENT_KEY: [u8; 32] = [0x43; 32];
+const ISSUER: &str = "http://127.0.0.1:6791";
+
+/// Install this binary's process-wide hybrid trust view: envelope signature
+/// verification (Hybrid policy) with the PQ anchors of the fixture keys.
+/// These anchors authenticate keys; they grant no authorization.
+fn install_crypto() {
+    let mut store = KeyedPqTrustStore::new();
+    for bytes in [POLICY_ROOT_KEY, DISCOVERY_KEY, GHOST_CLIENT_KEY] {
+        let ed = SigningKey::from_bytes(&bytes);
+        let pq = derive_mesh_mldsa_key(&ed);
+        let pq_vk = hyprstream_rpc::crypto::pq::ml_dsa_vk_from_bytes(
+            &hyprstream_rpc::crypto::pq::ml_dsa_sk_to_vk_bytes(&pq),
+        )
+        .expect("fixture ML-DSA key");
+        store.bind(ed.verifying_key().to_bytes(), &pq_vk);
+    }
+    let _ = hyprstream_rpc::envelope::install_verify_config(
+        hyprstream_rpc::envelope::EnvelopeVerifyConfig {
+            policy: hyprstream_rpc::crypto::CryptoPolicy::Hybrid,
+            pq_store: Some(Arc::new(store)),
+        },
+    );
+    let _ = hyprstream_rpc::envelope::install_response_verify_config(
+        hyprstream_rpc::envelope::ResponseVerifyConfig {
+            policy: hyprstream_rpc::crypto::CryptoPolicy::Classical,
+            pq_store: None,
+        },
+    );
+}
+
+/// A real CA-signed service JWT for `service_name`, minted exactly as the
+/// wizard/bootstrap path mints it (`service_jwt::issue_or_load_service_jwt`)
+/// from the CA JWT key the PolicyService purpose-derives from its root key.
+fn mint_service_jwt(
+    dir: &tempfile::TempDir,
+    service_name: &str,
+    ca_jwt_key: &SigningKey,
+    service_vk: &VerifyingKey,
+) -> String {
+    let now = chrono::Utc::now().timestamp();
+    issue_or_load_service_jwt(
+        dir.path(),
+        service_name,
+        ca_jwt_key,
+        service_vk,
+        ISSUER,
+        now,
+    )
+    .expect("mint service JWT")
+}
+
+/// The PolicyService's JWT key source, wired the way the service factory wires
+/// `ServiceContext::cluster_key_source()` for the offline (no JWKS fetcher)
+/// path: the purpose-derived CA JWT key plus its composite pair.
+fn cluster_key_source(ca_jwt_key: &SigningKey) -> Arc<ClusterKeySource> {
+    let ca_pq_vk = hyprstream_rpc::crypto::pq::ml_dsa_sk_to_vk(&derive_mesh_mldsa_key(ca_jwt_key));
+    Arc::new(
+        ClusterKeySource::new(ca_jwt_key.verifying_key(), ISSUER.to_owned())
+            .with_ca_composite_key(ca_pq_vk),
+    )
+}
+
+/// Spawn a real PolicyService on a unique inproc endpoint and return a client
+/// bound to the given caller key + service JWT.
+async fn spawn_policy_and_client(
+    tag: &str,
+    caller_key: &SigningKey,
+    service_jwt: Option<String>,
+) -> Result<PolicyClient> {
+    let root_key = SigningKey::from_bytes(&POLICY_ROOT_KEY);
+    let ca_jwt_key = derive_purpose_key(&root_key, "hyprstream-jwt-v1");
+
+    let policy_dir = tempfile::TempDir::new()?;
+    let git2db = Arc::new(tokio::sync::RwLock::new(
+        git2db::Git2DB::open(policy_dir.path()).await?,
+    ));
+    let policy_service = PolicyService::new(
+        Arc::new(PolicyManager::permissive().await?),
+        Arc::new(root_key.clone()),
+        TokenConfig::default(),
+        git2db,
+        TransportConfig::inproc(tag),
+    )
+    .with_jwt_key_source(cluster_key_source(&ca_jwt_key));
+    let manager = InprocManager::new();
+    let _handle = manager.spawn(Box::new(policy_service)).await?;
+
+    PolicyClient::for_local_endpoint_bootstrap(
+        &format!("inproc://{tag}"),
+        caller_key.clone(),
+        root_key.verifying_key(),
+        service_jwt,
+    )
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn fresh_state_register_service_key_passes_production_dispatch_pep() -> Result<()> {
+    install_crypto();
+
+    // The exact production install seam `service start` runs (main.rs).
+    hyprstream_core::mac::install_production_rpc_dispatch_pep();
+    assert!(
+        global_mac_dispatch_pep().is_some(),
+        "the production dispatch PEP must be installed"
+    );
+
+    let root_key = SigningKey::from_bytes(&POLICY_ROOT_KEY);
+    let ca_jwt_key = derive_purpose_key(&root_key, "hyprstream-jwt-v1");
+    let discovery_key = SigningKey::from_bytes(&DISCOVERY_KEY);
+    let creds = tempfile::TempDir::new()?;
+    let discovery_jwt = mint_service_jwt(
+        &creds,
+        "discovery",
+        &ca_jwt_key,
+        &discovery_key.verifying_key(),
+    );
+
+    let tag = format!("mac-1499-policy-{}", uuid::Uuid::new_v4());
+    let client = spawn_policy_and_client(&tag, &discovery_key, Some(discovery_jwt.clone())).await?;
+
+    // Positive: the exact fresh-state boot call — discovery registers its
+    // signing key with the PolicyService CA. This must pass the production
+    // PEP (typed declared (policy, registerServiceKey) + deliberate
+    // service:discovery clearance) AND the handler's own CA-JWT checks.
+    //
+    // An `Ok` here is the proof the handler ran: the PEP deny, a claims
+    // failure, and a handler error all surface as `Err` (the PEP's deny is
+    // the signed error payload the client maps to `Err`, per the #1499
+    // staging log "registerServiceKey RPC failed ... MAC deny: ...").
+    let request = RegisterServiceKey {
+        service_name: "discovery".to_owned(),
+        verifying_key: discovery_key.verifying_key().as_bytes().to_vec(),
+        service_jwt: discovery_jwt,
+    };
+    client
+        .register_service_key(&request)
+        .await
+        .expect("declared registerServiceKey must pass the production dispatch PEP on fresh state");
+
+    assert!(
+        global_mac_dispatch_pep().is_some(),
+        "the dispatch PEP must remain installed after a permit"
+    );
+
+    // Causal twin: identical caller, identical service, undeclared leaf.
+    // `resolveServiceKey` is a real policy method (discriminant 17) that this
+    // slice deliberately does NOT declare — declaration, not schema, is the
+    // authority. It must deny before handler entry with UnlabeledObject.
+    let undeclared = client
+        .resolve_service_key(&ResolveServiceKey {
+            service_name: "registry".to_owned(),
+        })
+        .await;
+    let error = undeclared.expect_err("undeclared leaf must deny");
+    assert!(
+        format!("{error:?}").contains("UnlabeledObject"),
+        "undeclared leaf must deny UnlabeledObject, got: {error:?}"
+    );
+
+    assert!(
+        global_mac_dispatch_pep().is_some(),
+        "the dispatch PEP must remain installed after a deny"
+    );
+    Ok(())
+}
+
+/// An undeclared service domain denies before handler entry, with the handler
+/// never invoked — the staging failure shape (`subject=service:discovery`,
+/// unknown object) now failing closed for the right reason.
+struct CountingEchoService {
+    name: &'static str,
+    transport: TransportConfig,
+    signing_key: SigningKey,
+    invocations: Arc<AtomicUsize>,
+    key_source: Arc<dyn hyprstream_rpc::auth::JwtKeySource>,
+}
+
+#[async_trait(?Send)]
+impl RequestService for CountingEchoService {
+    async fn handle_request(
+        &self,
+        _ctx: &EnvelopeContext,
+        payload: &[u8],
+    ) -> Result<(Vec<u8>, Option<Continuation>)> {
+        self.invocations.fetch_add(1, Ordering::SeqCst);
+        Ok((payload.to_vec(), None))
+    }
+
+    fn name(&self) -> &str {
+        self.name
+    }
+
+    fn transport(&self) -> &TransportConfig {
+        &self.transport
+    }
+
+    fn signing_key(&self) -> SigningKey {
+        self.signing_key.clone()
+    }
+
+    fn jwt_key_source(&self) -> Option<Arc<dyn hyprstream_rpc::auth::JwtKeySource>> {
+        Some(Arc::clone(&self.key_source))
+    }
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn undeclared_service_domain_denies_before_handler_entry() -> Result<()> {
+    install_crypto();
+    hyprstream_core::mac::install_production_rpc_dispatch_pep();
+
+    let root_key = SigningKey::from_bytes(&POLICY_ROOT_KEY);
+    let ca_jwt_key = derive_purpose_key(&root_key, "hyprstream-jwt-v1");
+    let discovery_key = SigningKey::from_bytes(&DISCOVERY_KEY);
+    let creds = tempfile::TempDir::new()?;
+    let discovery_jwt = mint_service_jwt(
+        &creds,
+        "discovery",
+        &ca_jwt_key,
+        &discovery_key.verifying_key(),
+    );
+
+    // A live service whose domain is NOT in the declared table.
+    let invocations = Arc::new(AtomicUsize::new(0));
+    let service = CountingEchoService {
+        name: "ghost",
+        transport: TransportConfig::inproc("ghost"),
+        signing_key: SigningKey::from_bytes(&GHOST_CLIENT_KEY),
+        invocations: Arc::clone(&invocations),
+        key_source: cluster_key_source(&ca_jwt_key),
+    };
+    let bridge = LocalServiceBridge::spawn(service, Arc::new(InMemoryNonceCache::new()), 0)?;
+    let processor: Arc<dyn IrohRequestProcessor> = Arc::new(bridge);
+    register_inproc("ghost", &processor);
+
+    let ghost_signing = SigningKey::from_bytes(&GHOST_CLIENT_KEY);
+    let ghost_pq = derive_mesh_mldsa_key(&ghost_signing);
+    let ghost_pq_vk = hyprstream_rpc::crypto::pq::ml_dsa_vk_from_bytes(
+        &hyprstream_rpc::crypto::pq::ml_dsa_sk_to_vk_bytes(&ghost_pq),
+    )?;
+    let mut response_store = KeyedPqTrustStore::new();
+    response_store.bind(ghost_signing.verifying_key().to_bytes(), &ghost_pq_vk);
+    let client = dial_with_crypto_stores(
+        &TransportConfig::inproc("ghost"),
+        LocalSigner::new(discovery_key),
+        Some(ghost_signing.verifying_key()),
+        Some(discovery_jwt),
+        None,
+        Some(Arc::new(response_store)),
+    )?;
+
+    // A declared caller (service:discovery, verified JWT) calling an
+    // undeclared service domain: deny before handler entry.
+    let response = client
+        .call_for_service("ghost", b"must-not-reach-handler".to_vec())
+        .await?;
+    assert!(
+        response.is_empty(),
+        "the MAC denial must return the service's signed error payload, never handler bytes"
+    );
+    assert_eq!(
+        invocations.load(Ordering::SeqCst),
+        0,
+        "an undeclared service domain must deny before handler invocation"
+    );
+    assert!(global_mac_dispatch_pep().is_some());
+    drop(processor);
+    Ok(())
+}


### PR DESCRIPTION
## Summary

Focused, independently landable slice of #1499 — the concrete staging boot blocker (`registerServiceKey RPC failed for 'discovery': MAC deny: UnlabeledObject`), implemented on current main per the 2026-08-24 release-scope decision and the 2026-08-25 owner dispatch (lane A). It is the release prerequisite consumed by #1507 and deliberately contains **none** of #1507's WAL, transitional/target columns, generated full-table activation, or atomic activation program.

**Root cause:** the mandatory dispatch PEP's object-label resolver was `GenesisGate::production().into_resolver()` — the VFS-plane adapter (`RpcObjectLabelResolver for CompositeObjectLabelResolver`), which splits the bare service domain as a path: `policy` → `/policy` → no genesis assignment → `None` → `Deny(UnlabeledObject)` on *every* dispatch.

**This PR:**

- `crates/hyprstream/src/mac/dispatch_labels.rs` (new): `DispatchMethodId` — a typed `(service, leaf/method)` object identity (canonical service name + canonical request-union discriminant), never a VFS path — and the closed, deny-by-default `DeclaredDispatchTable`:
  - object rows: `policy.registerServiceKey` (discriminant 18) and `policy.refreshServiceToken` (19), labeled at the lattice floor `(Public, Unverified, {})` — bootstrap-critical leaves precede identity standing and must stay reachable under the permanent narrow-to-floor incident control; raising anything above the floor is #1507's reviewed transitional/target column work;
  - deliberate subject clearances for the five staging bootstrap services `event, policy, discovery, registry, oauth`: `(Internal, Classical, {})`, composed at evaluation with the crypto-verified key material (`SecurityContext::from_clearance` clamps assurance down, never up).
  - `DeclaredDispatchPep` permits only when BOTH the activation-selected context (floor-only or identity-aware, operator gate unchanged) AND the deliberate declared service clearance dominate the declared object label. A caller with no declared clearance — including an anonymous caller that would otherwise ride the floor — denies `NoClearance`. No fabricated anonymous/public clearance, no allow-all bootstrap bypass, no bare-name routing through the VFS adapter.
- `crates/hyprstream-rpc/src/service/dispatch.rs`: the PEP now receives the canonical method discriminant decoded once from the verified payload (the same value the generated handler independently decodes and acts on). A payload without a canonical discriminant contributes no method identity → matches no declared row → fails closed. The browser sealed-commitment cross-check (`ensure_browser_method`) is unchanged.
- `crates/hyprstream/src/mac/mod.rs`: `install_production_rpc_dispatch_pep` installs the declared PEP (still `.with_activation_control()`). The genesis composite resolver adapter remains and now serves the VFS/9P plane only.

Untouched: envelope/hybrid-credential/freshness/DID/signature/key-binding checks, the G1–G7 widening gate, the narrow-to-floor kill-switch, handler-level authz (the CA-JWT/subject/cnf checks in `handle_register_service_key`), and all #1535/#282/#873/#1027 surfaces.

## Acceptance evidence (section A of the owner-dispatch handoff)

1. **Table coverage** — `mac::dispatch_labels::tests::every_declared_call_resolves_to_the_intended_typed_label_and_clearance` proves every declared `(service, leaf)` resolves to its intended typed label and each of the five bootstrap services to its deliberate clearance (which dominates every declared label).
2. **Denials** — `unknown_service_unknown_leaf_and_vfs_alias_resolve_to_none`: unknown service, unknown-but-real leaf (`resolveServiceKey`, discriminant 17), out-of-schema leaf, method-less call, and VFS-shaped aliases (`/srv/policy`, `srv/policy`, `/policy`, …) all resolve `None` ⇒ deny.
3. **Causal PEP pair** — `declared_call_permits_and_identical_undeclared_call_denies` (unit, reason asserted) and the integration binary `tests/mac_dispatch_boot_labeling.rs`: a real CA-signed hybrid service JWT (`service:discovery`) through a real `PolicyService` over the inproc bridge with the **production** PEP installed — `registerServiceKey` permits and executes (handler registers the key), the identical caller's undeclared `resolveServiceKey` denies `UnlabeledObject`, an undeclared service domain denies before handler entry (invocation counter stays 0), and `global_mac_dispatch_pep()` remains installed after each decision.
4. **Existing negatives green** — `hyprstream-rpc` lib 1023 passed (envelope signature/replay/tamper, M3 hybrid matrix, downgrade/anchor, sealed-response, freshness, cross-direction replay suites included); `hyprstream` lib 1632 passed; integration: `uds_rpc_e2e`, `session_pq_overlay_dispatch` (13), `iroh_rpc_e2e` (5), `e2e_iroh_transport` (4), `inproc_bridged_e2e`, `inv2_receive_dispatch` (7), `browser_hybrid_e2e` (3), `envelope_canonicalization` (6), `mac_enforcing_gate` (2), `policy_over_iroh` (6), `did_trust_e2e` (7), `e2e_9p_walk` (2). No cryptographic rejection became an authorization permit.
5. **Fresh-state boot** — isolated-HOME run of the exact acceptance command `service start --foreground --services event,policy,discovery,registry,oauth` on this head reached `Services ready: [event, policy, discovery, oauth, registry]`; the PolicyService handler logged `Registered service verifying key` for discovery, oauth, and registry with `caller=service:{name}`; zero `registerServiceKey` failures; the PEP stayed installed (a post-readiness undeclared call, `service:oauth → discovery:method:1` = `getEndpoints`, denied `UnlabeledObject` — correct fail-closed behavior, reported as the observed next boundary for #1507's generated table). Evidence root: `~/.cache/hyprstream-1499-boot-evidence/` (SUMMARY.txt + logs + SHA256SUMS).
   - **Honesty note:** this is a local one-process boot on the development host with locally minted deployment-trust artifacts. The exact Ferrule image is **not** available in this repo/host, so no image-boot acceptance is claimed; image boot remains staging's gate per the 2026-08-20 blocker handoff.

## Dependencies and collisions

- **No dependency on PR #1528** (none found at code level; no symbol/type consumed from it).
- **File overlap with unlanded #1518** (`feat/1504-proof-v1-wire`): `crates/hyprstream-rpc/src/service/dispatch.rs`, `crates/hyprstream/src/mac/genesis.rs` (doc comment only), `crates/hyprstream/src/mac/mod.rs` (install seam). Implemented on current main per dispatch; #1518 reconciles these paths when it lands. Note `dispatch_pep.rs` itself is **not** modified here.
- No overlap with active PRs #1540/#1542/#1543 (networking lanes) and no edits to #1535 Event bookkeeping surfaces.

## Review request

Per the task protocol this stops at the draft and requests a fresh independent K3/Opus trust-boundary review through the coordinator. Not to be merged, approved, or queued from this lane; staging booted is **not** claimed.