### PR TITLE
fix(license): restore AGPL service boundary

### DIFF
--- a/.github/license-boundary.toml
+++ b/.github/license-boundary.toml
@@ -9,8 +9,16 @@ mit_packages = [
 ]
 
 agpl_packages = [
+  "hyprstream",
+  "hyprstream-appview",
+  "hyprstream-discovery",
   "hyprstream-flight",
+  "hyprstream-k8s-pds",
+  "hyprstream-ledger",
   "hyprstream-metrics",
+  "hyprstream-pds",
+  "hyprstream-pds-service",
+  "hyprstream-service",
   "hyprstream-vfs-server",
   "hyprstream-workers",
 ]
@@ -18,25 +26,17 @@ agpl_packages = [
 apache_packages = [
   "chat-core",
   "git2db",
-  "hyprstream",
   "hyprstream-9p",
-  "hyprstream-appview",
   "hyprstream-compositor",
   "hyprstream-containedfs",
   "hyprstream-crypto",
-  "hyprstream-discovery",
   "hyprstream-k8s",
-  "hyprstream-k8s-pds",
-  "hyprstream-ledger",
   "hyprstream-p2p",
-  "hyprstream-pds",
-  "hyprstream-pds-service",
   "hyprstream-resource",
   "hyprstream-rpc",
   "hyprstream-rpc-build",
   "hyprstream-rpc-derive",
   "hyprstream-rpc-std",
-  "hyprstream-service",
   "hyprstream-tui",
   "hyprstream-util",
   "hyprstream-vfs",
@@ -67,23 +67,16 @@ permissive_roots = [
   "git-xet-filter",
   "git2db",
   "hyprstream-9p",
-  "hyprstream-appview",
   "hyprstream-compositor",
   "hyprstream-containedfs",
   "hyprstream-crypto",
-  "hyprstream-discovery",
   "hyprstream-k8s",
-  "hyprstream-k8s-pds",
-  "hyprstream-ledger",
   "hyprstream-p2p",
-  "hyprstream-pds",
-  "hyprstream-pds-service",
   "hyprstream-resource",
   "hyprstream-rpc",
   "hyprstream-rpc-build",
   "hyprstream-rpc-derive",
   "hyprstream-rpc-std",
-  "hyprstream-service",
   "hyprstream-tui",
   "hyprstream-util",
   "hyprstream-vfs",
@@ -93,11 +86,4 @@ permissive_roots = [
   "hyprstream-workers-wasmtime",
   "hyprstream-workers-wasmtime-fsguest",
   "waxterm",
-]
-
-# Apache-declared application source may aggregate AGPL components. Combined
-# distributions carry the AGPL obligation even though the application's own
-# source files remain Apache-2.0.
-agpl_aggregators = [
-  "hyprstream",
 ]

--- a/.github/workflows/archlinux.yml
+++ b/.github/workflows/archlinux.yml
@@ -28,6 +28,7 @@ jobs:
           base-devel \
           rustup \
           cmake \
+          clang \
           capnproto \
           openssl \
           pkg-config \

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -56,7 +56,7 @@ Multiple agents may share the one checkout at the repo root. That checkout has a
 
 | Crate | Purpose |
 |-------|---------|
-| `hyprstream` | Apache-2.0 main app: runtime, storage, git, training, API, services, CLI, native MAC; its combined distribution currently carries AGPL obligations through `hyprstream-flight` |
+| `hyprstream` | AGPL-3.0-only main app: runtime, storage, git, training, API, services, CLI, native MAC |
 | `git2db` | Git repository management library (has own CLAUDE.md) |
 | `git-xet-filter` | XET/LFS large file storage (libgit2 filter) |
 | `gittorrent` | P2P model distribution |
@@ -275,15 +275,16 @@ See: `README.md`, `DEVELOP.md`, `CONTRIBUTING.md`, `crates/git2db/CLAUDE.md`, `d
 
 ## Licensing
 
-- **MIT**: exactly `bitsandbytes-sys`, `cas-serve`, and `git-xet-filter`.
-- **AGPL-3.0-only**: exactly `hyprstream-flight`, `hyprstream-metrics`,
+- **MIT**: exactly `bitsandbytes-sys`, `cas-serve`, `git-xet-filter`, and
+  `hyprstream-pay`.
+- **AGPL-3.0-only**: the `hyprstream` application plus
+  `hyprstream-appview`, `hyprstream-discovery`, `hyprstream-flight`,
+  `hyprstream-k8s-pds`, `hyprstream-ledger`, `hyprstream-metrics`,
+  `hyprstream-pds`, `hyprstream-pds-service`, `hyprstream-service`,
   `hyprstream-vfs-server`, and `hyprstream-workers`.
-- **Apache-2.0**: every other local Cargo package, including `hyprstream`.
+- **Apache-2.0**: every other local Cargo package.
 
-Those are source-package declarations, not a waiver of combined-distribution
-obligations. The Apache-declared `hyprstream` application currently aggregates
-the AGPL-declared `hyprstream-flight` package, so a combined distribution must
-satisfy the applicable AGPL terms. The exhaustive owner map, the one declared
-aggregator, and the reusable permissive-only roots are enforced by
-`.github/license-boundary.toml`; reusable roots must have no Cargo-resolved path
-to any local AGPL package.
+Those are source-package declarations; third-party dependencies retain their
+own licenses. The exhaustive owner map and reusable permissive-only roots are
+enforced by `.github/license-boundary.toml`; every permissive package must have
+no Cargo-resolved path to any local AGPL package.

--- a/README.md
+++ b/README.md
@@ -547,19 +547,21 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines.
 
 Licensing is assigned per crate:
 
-**MIT** — `bitsandbytes-sys`, `cas-serve`, and `git-xet-filter`.
+**MIT** — `bitsandbytes-sys`, `cas-serve`, `git-xet-filter`, and
+`hyprstream-pay`.
 
-**AGPL-3.0-only** — `hyprstream-metrics`, `hyprstream-flight`,
+**AGPL-3.0-only** — the `hyprstream` application and its service-facing crates:
+`hyprstream-appview`, `hyprstream-discovery`, `hyprstream-flight`,
+`hyprstream-k8s-pds`, `hyprstream-ledger`, `hyprstream-metrics`,
+`hyprstream-pds`, `hyprstream-pds-service`, `hyprstream-service`,
 `hyprstream-vfs-server`, and `hyprstream-workers`.
 
-**Apache-2.0** — every other local Cargo package.
+**Apache-2.0** — every other local Cargo package: reusable libraries, RPC and
+transport substrate, build tooling, clients, and sandbox guests.
 
-These are source-package declarations. They are distinct from the obligations
-for a combined distribution: for example, the Apache-declared `hyprstream`
-application currently aggregates AGPL components through
-`hyprstream-flight`, so a combined distribution must satisfy the applicable
-AGPL terms. Reusable permissive-only roots are listed separately and guarded
-against acquiring an AGPL dependency in
+These are source-package declarations; third-party dependencies retain their
+own licenses. Reusable permissive packages are guarded against acquiring an
+AGPL dependency in
 `.github/license-boundary.toml`. The policy is exhaustive and CI requires every
 local package manifest to match it exactly.
 

--- a/archlinux/PKGBUILD
+++ b/archlinux/PKGBUILD
@@ -5,7 +5,7 @@ pkgrel=1
 pkgdesc="Agentic infrastructure for continuously learning applications"
 arch=('x86_64')
 url="https://github.com/hyprstream/hyprstream"
-license=('AGPL3' 'MIT')
+license=('AGPL-3.0-only' 'Apache-2.0' 'MIT')
 depends=('capnproto' 'cuda' 'python-pytorch-opt-cuda')
 makedepends=('base-devel' 'rustup' 'cmake')
 source=("hyprstream::git+https://github.com/hyprstream/hyprstream.git#branch=main")
@@ -26,4 +26,5 @@ package() {
   install -Dm755 "target/release/hyprstream" "$pkgdir/usr/bin/hyprstream"
   install -Dm644 LICENSE-MIT "$pkgdir/usr/share/licenses/$pkgname/LICENSE-MIT"
   install -Dm644 LICENSE-AGPLV3 "$pkgdir/usr/share/licenses/$pkgname/LICENSE-AGPLV3"
+  install -Dm644 LICENSE-APACHE "$pkgdir/usr/share/licenses/$pkgname/LICENSE-APACHE"
 }

--- a/archlinux/PKGBUILD
+++ b/archlinux/PKGBUILD
@@ -7,7 +7,7 @@ arch=('x86_64')
 url="https://github.com/hyprstream/hyprstream"
 license=('AGPL-3.0-only' 'Apache-2.0' 'MIT')
 depends=('capnproto' 'cuda' 'python-pytorch-opt-cuda')
-makedepends=('base-devel' 'rustup' 'cmake')
+makedepends=('base-devel' 'rustup' 'cmake' 'clang')
 source=("hyprstream::git+https://github.com/hyprstream/hyprstream.git#branch=main")
 sha256sums=("SKIP")     
 

--- a/crates/git2db/README.md
+++ b/crates/git2db/README.md
@@ -1,6 +1,6 @@
 # git2db - Git-native Repository Management
 
-[![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
+[![License: Apache 2.0](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](../../LICENSE-APACHE)
 
 git2db provides a high-level Rust interface for managing Git repositories as a database system, with advanced features like storage drivers for space-efficient worktrees and large file (XET) integration.
 
@@ -441,7 +441,7 @@ Contributions welcome! Please see the main project [CONTRIBUTING.md](../../CONTR
 
 ## License
 
-MIT License - See [LICENSE](LICENSE) for details.
+Apache License 2.0 — see [LICENSE-APACHE](../../LICENSE-APACHE) for details.
 
 ---
 

--- a/crates/hyprstream-appview/Cargo.toml
+++ b/crates/hyprstream-appview/Cargo.toml
@@ -2,7 +2,7 @@
 name = "hyprstream-appview"
 version = "0.1.0"
 edition.workspace = true
-license = "Apache-2.0"
+license = "AGPL-3.0-only"
 repository.workspace = true
 description = "Derived, clearance-filtered identity inventory AppView"
 

--- a/crates/hyprstream-discovery/Cargo.toml
+++ b/crates/hyprstream-discovery/Cargo.toml
@@ -2,7 +2,7 @@
 name = "hyprstream-discovery"
 version = "0.1.0"
 edition.workspace = true
-license = "Apache-2.0"
+license = "AGPL-3.0-only"
 repository.workspace = true
 description = "Service discovery and endpoint resolution for hyprstream"
 

--- a/crates/hyprstream-k8s-pds/Cargo.toml
+++ b/crates/hyprstream-k8s-pds/Cargo.toml
@@ -2,7 +2,7 @@
 name = "hyprstream-k8s-pds"
 version = "0.1.0"
 edition.workspace = true
-license = "Apache-2.0"
+license = "AGPL-3.0-only"
 repository.workspace = true
 description = "AGPL tenant-grant and PDS allocation adapter for hyprstream-k8s"
 

--- a/crates/hyprstream-k8s/tests/apache_boundary.rs
+++ b/crates/hyprstream-k8s/tests/apache_boundary.rs
@@ -8,8 +8,8 @@
 //! names. Full metadata resolution remains in the causal fixtures. When
 //! #1417's omission-checked `.github/license-boundary.toml` is present, its
 //! `agpl_packages` partition augments manifest metadata. Every MIT/Apache
-//! package must be exactly one of a strict reusable `permissive_root` or an
-//! `agpl_aggregator` with a real resolved path to a local AGPL package.
+//! package must be a strict reusable `permissive_root` with no resolved path
+//! to a local AGPL package.
 
 #![allow(clippy::expect_used, clippy::panic, clippy::unwrap_used)]
 
@@ -128,10 +128,6 @@ fn policy_permissive_roots(workspace_root: &Path) -> Result<BTreeSet<String>, St
     policy_packages(workspace_root, "permissive_roots")
 }
 
-fn policy_agpl_aggregators(workspace_root: &Path) -> Result<BTreeSet<String>, String> {
-    policy_packages(workspace_root, "agpl_aggregators")
-}
-
 fn policy_permissive_packages(workspace_root: &Path) -> Result<BTreeSet<String>, String> {
     let mut permissive = policy_packages(workspace_root, "mit_packages")?;
     permissive.extend(policy_packages(workspace_root, "apache_packages")?);
@@ -169,31 +165,18 @@ fn policy_standalone_manifests(workspace_root: &Path) -> Result<Vec<PathBuf>, St
         .collect()
 }
 
-fn validate_permissive_role_partition(
-    workspace_root: &Path,
-) -> Result<(BTreeSet<String>, BTreeSet<String>), String> {
+fn validate_permissive_root_partition(workspace_root: &Path) -> Result<BTreeSet<String>, String> {
     let permissive = policy_permissive_packages(workspace_root)?;
     let roots = policy_permissive_roots(workspace_root)?;
-    let aggregators = policy_agpl_aggregators(workspace_root)?;
-    let overlap = roots
-        .intersection(&aggregators)
-        .cloned()
-        .collect::<Vec<_>>();
-    if !overlap.is_empty() {
-        return Err(format!(
-            "permissive root/AGPL aggregator overlap: {overlap:?}"
-        ));
-    }
-    let roles = roots.union(&aggregators).cloned().collect::<BTreeSet<_>>();
-    let omissions = permissive.difference(&roles).cloned().collect::<Vec<_>>();
-    let non_permissive = roles.difference(&permissive).cloned().collect::<Vec<_>>();
+    let omissions = permissive.difference(&roots).cloned().collect::<Vec<_>>();
+    let non_permissive = roots.difference(&permissive).cloned().collect::<Vec<_>>();
     if !omissions.is_empty() || !non_permissive.is_empty() {
         return Err(format!(
-            "permissive role partition mismatch; omissions: {omissions:?}; \
-             non-permissive roles: {non_permissive:?}"
+            "permissive root partition mismatch; omissions: {omissions:?}; \
+             non-permissive roots: {non_permissive:?}"
         ));
     }
-    Ok((roots, aggregators))
+    Ok(roots)
 }
 
 fn resolved_metadata(
@@ -676,17 +659,13 @@ fn assert_transitive_patch_resolved(
 }
 
 #[test]
-fn production_every_permissive_package_has_the_declared_resolved_role() {
+fn production_every_permissive_package_is_a_strict_root() {
     let workspace_root = Path::new(env!("CARGO_MANIFEST_DIR"))
         .join("../..")
         .canonicalize()
         .expect("canonical workspace root");
-    let (roots, aggregators) = validate_permissive_role_partition(&workspace_root).unwrap();
+    let roots = validate_permissive_root_partition(&workspace_root).unwrap();
     assert!(!roots.is_empty(), "policy must select reusable roots");
-    assert!(
-        !aggregators.is_empty(),
-        "policy must select AGPL aggregators"
-    );
 
     let mut workspace_metadata =
         local_metadata(&workspace_root, &workspace_root.join("Cargo.toml")).unwrap();
@@ -705,9 +684,8 @@ fn production_every_permissive_package_has_the_declared_resolved_role() {
         workspace_metadata.packages.push(package);
     }
 
-    let roles = roots.union(&aggregators).cloned().collect::<BTreeSet<_>>();
     let mut checked = BTreeSet::new();
-    for package_name in &roles {
+    for package_name in &roots {
         let package = workspace_metadata
             .packages
             .iter()
@@ -752,23 +730,13 @@ fn production_every_permissive_package_has_the_declared_resolved_role() {
             )
         };
 
-        if roots.contains(package_name) {
-            boundary.unwrap_or_else(|error| {
-                panic!("reusable permissive root {package_name} is not strict: {error}")
-            });
-        } else {
-            let error = boundary.expect_err(&format!(
-                "AGPL aggregator {package_name} has no real AGPL path"
-            ));
-            assert!(
-                error.contains("permissive-root-to-AGPL dependency"),
-                "AGPL aggregator {package_name} failed for a non-boundary reason: {error}"
-            );
-        }
+        boundary.unwrap_or_else(|error| {
+            panic!("reusable permissive root {package_name} is not strict: {error}")
+        });
         checked.insert(package_name.clone());
     }
 
-    assert_eq!(checked, roles, "every permissive package must be checked");
+    assert_eq!(checked, roots, "every permissive package must be checked");
 }
 
 #[test]
@@ -1108,7 +1076,7 @@ anyhow = "=99.0.0""#,
 }
 
 #[test]
-fn patched_local_agpl_app_omitted_from_both_roles_is_rejected() {
+fn patched_local_agpl_app_omitted_from_permissive_roots_is_rejected() {
     let (directory, root_manifest) = patched_anyhow_fixture(
         r#"[dependencies]
 anyhow = "=99.0.0""#,
@@ -1131,7 +1099,6 @@ mit_packages = []
 agpl_packages = ["anyhow"]
 apache_packages = ["app"]
 permissive_roots = []
-agpl_aggregators = []
 "#,
     );
 
@@ -1140,10 +1107,10 @@ agpl_aggregators = []
         resolved_error.contains("app -> anyhow"),
         "fixture must prove the registry declaration resolves to local AGPL: {resolved_error}"
     );
-    let role_error = validate_permissive_role_partition(directory.path()).unwrap_err();
+    let role_error = validate_permissive_root_partition(directory.path()).unwrap_err();
     assert!(
         role_error.contains("omissions: [\"app\"]"),
-        "an app omitted from both resolved roles must fail closed: {role_error}"
+        "an app omitted from permissive roots must fail closed: {role_error}"
     );
 }
 

--- a/crates/hyprstream-ledger/Cargo.toml
+++ b/crates/hyprstream-ledger/Cargo.toml
@@ -2,7 +2,7 @@
 name = "hyprstream-ledger"
 version = "0.1.0"
 edition.workspace = true
-license = "Apache-2.0"
+license = "AGPL-3.0-only"
 repository.workspace = true
 description = "Embedded double-entry credit engine (accounting plane): LedgerBackend trait, MemLedger reference/oracle, two-phase transfer state machine (#923)"
 

--- a/crates/hyprstream-p2p/LICENSE
+++ b/crates/hyprstream-p2p/LICENSE
@@ -1,3 +1,8 @@
+Third-party license notice
+
+Portions derived from Chris Ball's original JavaScript GitTorrent remain
+licensed under the following MIT license:
+
 The MIT License (MIT)
 
 Copyright 2025 (c) Erica Windisch, Cyberdione Labs

--- a/crates/hyprstream-p2p/README.md
+++ b/crates/hyprstream-p2p/README.md
@@ -205,6 +205,8 @@ Pull requests are welcome! The project follows standard Rust conventions:
 
 ## License
 
-MIT License. Copyright (c) Erica Windisch
+Apache License 2.0 — see [LICENSE-APACHE](../../LICENSE-APACHE) for the current
+crate license. Portions derived from Chris Ball's original JavaScript GitTorrent
+retain their MIT notice in [LICENSE](LICENSE).
 
 Credit to Chris Ball for his inspirational work on the original Javascript-based Gittorrent.

--- a/crates/hyprstream-pay/Cargo.toml
+++ b/crates/hyprstream-pay/Cargo.toml
@@ -6,7 +6,8 @@ license = "MIT"
 repository.workspace = true
 description = "MIT-licensed settlement/tariff RPC contract + client stub — the protocol surface cyberdione-product links against (#1399)"
 
-# This crate is intentionally MIT-only (not dual MIT/AGPL like hyprstream).
+# This protocol crate is intentionally MIT-only; the Hyprstream application is
+# AGPL-3.0-only.
 # It contains ONLY the protocol traits, types, capability model, and a client
 # stub. The AGPL service implementation lives in `hyprstream::services::pay`.
 

--- a/crates/hyprstream-pay/src/lib.rs
+++ b/crates/hyprstream-pay/src/lib.rs
@@ -3,7 +3,8 @@
 //! The **protocol surface** for the pay-wave: `SettlementIssuer` +
 //! `TariffProvider` traits, shared types, capability model, and a client stub.
 //!
-//! This crate is MIT-only (not dual MIT/AGPL like `hyprstream`). It contains
+//! This protocol crate is MIT-only; the Hyprstream application is
+//! AGPL-3.0-only. This crate contains
 //! ONLY the protocol definitions. The AGPL service implementation — which
 //! verifies PQ-hybrid attestations server-side, checks the restricted
 //! settlement store, and calls the ledger's internal credit path — lives in

--- a/crates/hyprstream-pds-service/Cargo.toml
+++ b/crates/hyprstream-pds-service/Cargo.toml
@@ -2,7 +2,7 @@
 name = "hyprstream-pds-service"
 version = "0.1.0"
 edition.workspace = true
-license = "Apache-2.0"
+license = "AGPL-3.0-only"
 repository.workspace = true
 description = "Tenant-scoped PDS account record service over the Hyprstream 9P mount plane"
 

--- a/crates/hyprstream-pds/Cargo.toml
+++ b/crates/hyprstream-pds/Cargo.toml
@@ -2,7 +2,7 @@
 name = "hyprstream-pds"
 version = "0.1.0"
 edition.workspace = true
-license = "Apache-2.0"
+license = "AGPL-3.0-only"
 repository.workspace = true
 description = "atproto PDS record store — DAG-CBOR records, MST, signed commits, CAR proofs (#392)"
 

--- a/crates/hyprstream-rpc-std/src/lib.rs
+++ b/crates/hyprstream-rpc-std/src/lib.rs
@@ -4,7 +4,7 @@
 //! generated client types for all standard hyprstream services (model,
 //! registry, inference, policy, mcp, etc.).
 //!
-//! MIT licensed. Depends only on hyprstream-rpc (also MIT).
+//! Apache-2.0 licensed. Depends only on hyprstream-rpc (also Apache-2.0).
 //! Compiles to native and wasm32.
 
 #![allow(dead_code, unused_imports)]

--- a/crates/hyprstream-service/Cargo.toml
+++ b/crates/hyprstream-service/Cargo.toml
@@ -2,7 +2,7 @@
 name = "hyprstream-service"
 version = "0.1.0"
 edition.workspace = true
-license = "Apache-2.0"
+license = "AGPL-3.0-only"
 repository.workspace = true
 description = "Pluggable service orchestration for hyprstream (spawner, factory, manager)"
 

--- a/crates/hyprstream/Cargo.toml
+++ b/crates/hyprstream/Cargo.toml
@@ -5,7 +5,7 @@ edition.workspace = true
 description = "Agentic Infrastructure"
 documentation = "https://docs.rs/hyprstream"
 readme = "README.md"
-license = "Apache-2.0"
+license = "AGPL-3.0-only"
 exclude = [
     "**/*.pyc",
     "**/__pycache__/",

--- a/deny.toml
+++ b/deny.toml
@@ -47,12 +47,52 @@ allow = [
 # Owner-approved first-party AGPL packages. Keep AGPL name-scoped rather than
 # adding it to the global allow list.
 [[licenses.exceptions]]
+name = "hyprstream"
+version = "*"
+allow = ["AGPL-3.0-only"]
+
+[[licenses.exceptions]]
+name = "hyprstream-appview"
+version = "*"
+allow = ["AGPL-3.0-only"]
+
+[[licenses.exceptions]]
+name = "hyprstream-discovery"
+version = "*"
+allow = ["AGPL-3.0-only"]
+
+[[licenses.exceptions]]
 name = "hyprstream-metrics"
 version = "*"
 allow = ["AGPL-3.0-only"]
 
 [[licenses.exceptions]]
 name = "hyprstream-flight"
+version = "*"
+allow = ["AGPL-3.0-only"]
+
+[[licenses.exceptions]]
+name = "hyprstream-k8s-pds"
+version = "*"
+allow = ["AGPL-3.0-only"]
+
+[[licenses.exceptions]]
+name = "hyprstream-ledger"
+version = "*"
+allow = ["AGPL-3.0-only"]
+
+[[licenses.exceptions]]
+name = "hyprstream-pds"
+version = "*"
+allow = ["AGPL-3.0-only"]
+
+[[licenses.exceptions]]
+name = "hyprstream-pds-service"
+version = "*"
+allow = ["AGPL-3.0-only"]
+
+[[licenses.exceptions]]
+name = "hyprstream-service"
 version = "*"
 allow = ["AGPL-3.0-only"]
 

--- a/install.sh
+++ b/install.sh
@@ -31,8 +31,9 @@ log_warn() { echo -e "${YELLOW}[WARN]${NC} $*"; }
 log_error() { echo -e "${RED}[ERROR]${NC} $*" >&2; }
 
 GITHUB_REPO="hyprstream/hyprstream"
-LICENSE_URL="https://github.com/hyprstream/hyprstream/blob/main/LICENSE-MIT"
+MIT_LICENSE_URL="https://github.com/hyprstream/hyprstream/blob/main/LICENSE-MIT"
 AGPL_LICENSE_URL="https://github.com/hyprstream/hyprstream/blob/main/LICENSE-AGPLV3"
+APACHE_LICENSE_URL="https://github.com/hyprstream/hyprstream/blob/main/LICENSE-APACHE"
 TMPDIR_PATH=""
 AUTO_INSTALL="${HYPRSTREAM_AUTO_INSTALL:-0}"
 
@@ -353,9 +354,11 @@ main() {
     resolve_version
 
     echo ""
-    log_info "Hyprstream is dual-licensed under MIT and AGPL-3.0."
-    log_info "  MIT:      ${LICENSE_URL}"
+    log_info "The Hyprstream application is licensed under AGPL-3.0-only."
+    log_info "Reusable components and dependencies retain their stated licenses."
     log_info "  AGPL-3.0: ${AGPL_LICENSE_URL}"
+    log_info "  Apache-2.0: ${APACHE_LICENSE_URL}"
+    log_info "  MIT: ${MIT_LICENSE_URL}"
     echo ""
     if ! confirm "Do you accept the license terms?"; then
         log_error "License not accepted. Aborting."

--- a/scripts/check_license_boundary.py
+++ b/scripts/check_license_boundary.py
@@ -428,32 +428,17 @@ def main(root: Path = ROOT) -> None:
     permissive_roots = named_package_set(
         config, "permissive_roots", set(manifests)
     )
-    agpl_aggregators = named_package_set(
-        config, "agpl_aggregators", set(manifests)
-    )
     non_permissive_roots = permissive_roots - permissive
     if non_permissive_roots:
         fail(
             "permissive_roots contains non-MIT/Apache package(s): "
             f"{sorted(non_permissive_roots)}"
         )
-    non_permissive_aggregators = agpl_aggregators - permissive
-    if non_permissive_aggregators:
-        fail(
-            "agpl_aggregators contains non-MIT/Apache package(s): "
-            f"{sorted(non_permissive_aggregators)}"
-        )
-    root_aggregator_overlap = permissive_roots & agpl_aggregators
-    if root_aggregator_overlap:
-        fail(
-            "permissive root/AGPL aggregator overlap: "
-            f"{sorted(root_aggregator_overlap)}"
-        )
-    role_omissions = permissive - permissive_roots - agpl_aggregators
+    role_omissions = permissive - permissive_roots
     if role_omissions:
         fail(
-            "permissive package role omission; classify each as a reusable "
-            f"root or AGPL aggregator: {sorted(role_omissions)}"
+            "permissive package root omission; every MIT/Apache package must "
+            f"be guarded: {sorted(role_omissions)}"
         )
 
     paths_to_agpl = resolved_paths_for_permissive_packages(
@@ -468,18 +453,10 @@ def main(root: Path = ROOT) -> None:
         if path is not None:
             fail("permissive-root-to-AGPL dependency: " + " -> ".join(path))
 
-    for aggregator in sorted(agpl_aggregators):
-        if paths_to_agpl[aggregator] is None:
-            fail(
-                f"AGPL aggregator {aggregator!r} does not reach an AGPL package; "
-                "remove stale combined-distribution obligation"
-            )
-
     print(
         "license boundary OK: "
         f"{len(permissive_roots)} reusable MIT/Apache roots do not reach "
-        f"{len(agpl)} AGPL packages; {len(agpl_aggregators)} declared AGPL "
-        f"aggregator; {len(manifests)} package licenses match policy"
+        f"{len(agpl)} AGPL packages; {len(manifests)} package licenses match policy"
     )
 
 

--- a/scripts/tests/test_check_license_boundary.py
+++ b/scripts/tests/test_check_license_boundary.py
@@ -36,7 +36,6 @@ class LicenseBoundaryFixtures(unittest.TestCase):
         agpl_packages: tuple[str, ...] = ("service",),
         apache_packages: tuple[str, ...] = ("apache", "middle"),
         permissive_roots: tuple[str, ...] = ("apache", "middle"),
-        agpl_aggregators: tuple[str, ...] = (),
         policy_text: str | None = None,
     ) -> subprocess.CompletedProcess[str]:
         with tempfile.TemporaryDirectory() as directory:
@@ -127,7 +126,6 @@ class LicenseBoundaryFixtures(unittest.TestCase):
                     "standalone_manifests = "
                     f"['crates/{service_name}/Cargo.toml']\n"
                     f"permissive_roots = {list(permissive_roots)!r}\n"
-                    f"agpl_aggregators = {list(agpl_aggregators)!r}\n"
                 )
             (root / ".github" / "license-boundary.toml").write_text(
                 policy_text, encoding="utf-8"
@@ -179,21 +177,20 @@ class LicenseBoundaryFixtures(unittest.TestCase):
 
     def test_transitive_mit_root_dependency_fails_with_complete_path(self) -> None:
         result = self.run_fixture(
-            package_names=("mit-root", "middle", "service"),
+            package_names=("mit-root", "z-middle", "service"),
             license_declarations=(
                 'license = "MIT"',
                 'license = "Apache-2.0"',
                 'license = "AGPL-3.0-only"',
             ),
             mit_packages=("mit-root",),
-            apache_packages=("middle",),
-            permissive_roots=("mit-root",),
-            agpl_aggregators=("middle",),
-            apache_manifest='[dependencies]\nmiddle = { path = "../middle" }\n',
+            apache_packages=("z-middle",),
+            permissive_roots=("mit-root", "z-middle"),
+            apache_manifest='[dependencies]\nz-middle = { path = "../z-middle" }\n',
             middle_manifest='[dependencies]\nservice = { path = "../service" }\n',
         )
         self.assert_boundary_failure(result)
-        self.assertIn("mit-root -> middle -> service", result.stderr)
+        self.assertIn("mit-root -> z-middle -> service", result.stderr)
 
     def test_renamed_dependency_fails(self) -> None:
         result = self.run_fixture(
@@ -242,8 +239,17 @@ class LicenseBoundaryFixtures(unittest.TestCase):
             "bitsandbytes-sys": "MIT",
             "cas-serve": "MIT",
             "git-xet-filter": "MIT",
-            "hyprstream-metrics": "AGPL-3.0-only",
+            "hyprstream-pay": "MIT",
+            "hyprstream": "AGPL-3.0-only",
+            "hyprstream-appview": "AGPL-3.0-only",
+            "hyprstream-discovery": "AGPL-3.0-only",
             "hyprstream-flight": "AGPL-3.0-only",
+            "hyprstream-k8s-pds": "AGPL-3.0-only",
+            "hyprstream-ledger": "AGPL-3.0-only",
+            "hyprstream-metrics": "AGPL-3.0-only",
+            "hyprstream-pds": "AGPL-3.0-only",
+            "hyprstream-pds-service": "AGPL-3.0-only",
+            "hyprstream-service": "AGPL-3.0-only",
             "hyprstream-vfs-server": "AGPL-3.0-only",
             "hyprstream-workers": "AGPL-3.0-only",
         }
@@ -264,15 +270,21 @@ class LicenseBoundaryFixtures(unittest.TestCase):
                 self.assertNotEqual(result.returncode, 0)
                 self.assertIn("resolved manifest license", result.stderr)
 
-    def test_former_provisional_agpl_package_is_now_apache(self) -> None:
+    def test_service_package_is_agpl(self) -> None:
         result = self.run_fixture(
             package_names=("hyprstream-k8s-pds", "middle", "service"),
-            apache_packages=("hyprstream-k8s-pds", "middle"),
-            permissive_roots=("hyprstream-k8s-pds", "middle"),
+            license_declarations=(
+                'license = "AGPL-3.0-only"',
+                'license = "Apache-2.0"',
+                'license = "AGPL-3.0-only"',
+            ),
+            apache_packages=("middle",),
+            agpl_packages=("hyprstream-k8s-pds", "service"),
+            permissive_roots=("middle",),
         )
         self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
 
-    def test_former_provisional_agpl_package_in_old_class_fails(self) -> None:
+    def test_service_package_in_apache_class_fails(self) -> None:
         result = self.run_fixture(
             package_names=("hyprstream-k8s-pds", "middle", "service"),
             apache_packages=("middle",),
@@ -400,7 +412,6 @@ class LicenseBoundaryFixtures(unittest.TestCase):
                         [
                             "standalone_manifests = ['crates/service/Cargo.toml']",
                             "permissive_roots = ['apache']",
-                            "agpl_aggregators = []",
                         ]
                     )
                     result = self.run_fixture(policy_text="\n".join(lines) + "\n")
@@ -432,30 +443,34 @@ class LicenseBoundaryFixtures(unittest.TestCase):
         self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
         self.assertIn("3 package licenses match policy", result.stdout)
 
-    def test_apache_application_agpl_aggregation_is_explicit_and_allowed(self) -> None:
+    def test_agpl_application_can_depend_on_an_agpl_service(self) -> None:
         result = self.run_fixture(
             package_names=("hyprstream", "middle", "hyprstream-flight"),
-            apache_packages=("hyprstream", "middle"),
-            agpl_packages=("hyprstream-flight",),
+            license_declarations=(
+                'license = "AGPL-3.0-only"',
+                'license = "Apache-2.0"',
+                'license = "AGPL-3.0-only"',
+            ),
+            apache_packages=("middle",),
+            agpl_packages=("hyprstream", "hyprstream-flight"),
             permissive_roots=("middle",),
-            agpl_aggregators=("hyprstream",),
             apache_manifest=(
                 "[dependencies]\n"
                 'hyprstream-flight = { path = "../hyprstream-flight" }\n'
             ),
         )
         self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
-        self.assertIn("1 declared AGPL aggregator", result.stdout)
+        self.assertIn("2 AGPL packages", result.stdout)
 
-    def test_undeclared_agpl_aggregation_fails(self) -> None:
+    def test_omitted_permissive_root_fails(self) -> None:
         result = self.run_fixture(
             apache_manifest='[dependencies]\nservice = { path = "../service" }\n',
             permissive_roots=(),
         )
         self.assertNotEqual(result.returncode, 0)
-        self.assertIn("permissive package role omission", result.stderr)
+        self.assertIn("permissive package root omission", result.stderr)
 
-    def test_patched_local_agpl_dependency_cannot_escape_role_classification(self) -> None:
+    def test_patched_local_agpl_dependency_cannot_escape_root_classification(self) -> None:
         result = self.run_fixture(
             package_names=("app", "middle", "anyhow"),
             package_versions=("0.1.0", "0.1.0", "99.0.0"),
@@ -470,25 +485,8 @@ class LicenseBoundaryFixtures(unittest.TestCase):
             permissive_roots=("middle",),
         )
         self.assertNotEqual(result.returncode, 0)
-        self.assertIn("permissive package role omission", result.stderr)
+        self.assertIn("permissive package root omission", result.stderr)
         self.assertIn("'app'", result.stderr)
-
-    def test_aggregator_cannot_be_a_permissive_root(self) -> None:
-        result = self.run_fixture(
-            apache_manifest='[dependencies]\nservice = { path = "../service" }\n',
-            permissive_roots=("apache",),
-            agpl_aggregators=("apache",),
-        )
-        self.assertNotEqual(result.returncode, 0)
-        self.assertIn("permissive root/AGPL aggregator overlap", result.stderr)
-
-    def test_stale_agpl_aggregation_obligation_fails(self) -> None:
-        result = self.run_fixture(
-            permissive_roots=("middle",),
-            agpl_aggregators=("apache",),
-        )
-        self.assertNotEqual(result.returncode, 0)
-        self.assertIn("does not reach an AGPL package", result.stderr)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- restore `AGPL-3.0-only` for the Hyprstream application and service-facing crates, including `hyprstream-service`
- retain Apache-2.0 for reusable libraries and MIT for the four utility packages
- remove the Apache application / AGPL aggregator exception so every permissive package must remain dependency-isolated from AGPL
- align cargo-deny, README, installer, crate notices, and Arch package metadata with the owner-approved map
- add the missing Arch `clang` build dependency required by `librocksdb-sys` bindgen in the clean package-build environment

The resulting first-party map is 12 AGPL packages, 22 Apache packages, and 4 MIT packages. Third-party dependencies retain their own licenses.

This supplies the actual relicensing change that draft PR #1416 was waiting for; #1416 must still be rebased and reviewed independently before it can land.

## Validation

- `python3 scripts/check_license_boundary.py`
- `python3 -m unittest discover -s scripts/tests -p 'test_check_license_boundary.py'` (30 passed)
- `cargo test -p hyprstream-k8s --test apache_boundary -- --nocapture` (13 passed)
- `cargo clippy -p hyprstream-k8s --test apache_boundary -- -D warnings`
- `cargo deny check bans licenses`
- repository pre-commit Clippy gate
- `bash -n install.sh`
- `bash -n archlinux/PKGBUILD`
- `rustfmt --check crates/hyprstream-k8s/tests/apache_boundary.rs`
- `git diff --check`

## Ownership

The owner has confirmed contributor CLA coverage for this relicensing decision.
