### PR TITLE
Discovery: add HA volatile-state backends

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7099,6 +7099,7 @@ dependencies = [
  "capnpc",
  "chrono",
  "ed25519-dalek 2.2.0",
+ "fred",
  "hex",
  "hyprstream-crypto",
  "hyprstream-k8s",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5466,9 +5466,12 @@ dependencies = [
  "parking_lot 0.12.4",
  "rand 0.8.5",
  "redis-protocol",
+ "rustls 0.23.40",
+ "rustls-native-certs 0.7.3",
  "semver",
  "socket2 0.5.10",
  "tokio",
+ "tokio-rustls 0.26.2",
  "tokio-stream",
  "tokio-util",
  "url",
@@ -6709,7 +6712,7 @@ dependencies = [
  "hyper-util",
  "log",
  "rustls 0.23.40",
- "rustls-native-certs",
+ "rustls-native-certs 0.8.1",
  "rustls-pki-types",
  "tokio",
  "tokio-rustls 0.26.2",
@@ -7100,6 +7103,7 @@ dependencies = [
  "chrono",
  "ed25519-dalek 2.2.0",
  "fred",
+ "futures",
  "hex",
  "hyprstream-crypto",
  "hyprstream-k8s",
@@ -13747,7 +13751,7 @@ dependencies = [
  "pin-project-lite",
  "quinn",
  "rustls 0.23.40",
- "rustls-native-certs",
+ "rustls-native-certs 0.8.1",
  "rustls-pki-types",
  "serde",
  "serde_json",
@@ -14414,6 +14418,19 @@ dependencies = [
 
 [[package]]
 name = "rustls-native-certs"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5bfb394eeed242e909609f56089eecfe5fda225042e8b171791b9c95f5931e5"
+dependencies = [
+ "openssl-probe",
+ "rustls-pemfile 2.2.0",
+ "rustls-pki-types",
+ "schannel",
+ "security-framework 2.11.1",
+]
+
+[[package]]
+name = "rustls-native-certs"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7fcff2dd52b58a8d98a70243663a0d234c4e2b79235637849d15913394a247d3"
@@ -14464,7 +14481,7 @@ dependencies = [
  "log",
  "once_cell",
  "rustls 0.23.40",
- "rustls-native-certs",
+ "rustls-native-certs 0.8.1",
  "rustls-platform-verifier-android",
  "rustls-webpki 0.103.13",
  "security-framework 3.5.0",
@@ -18371,7 +18388,7 @@ dependencies = [
  "http 1.3.1",
  "quinn",
  "rustls 0.23.40",
- "rustls-native-certs",
+ "rustls-native-certs 0.8.1",
  "thiserror 2.0.18",
  "tokio",
  "tracing",

--- a/crates/hyprstream-discovery/Cargo.toml
+++ b/crates/hyprstream-discovery/Cargo.toml
@@ -18,6 +18,9 @@ k8s = ["dep:hyprstream-k8s"]
 # Model-free downstream fixtures for the production selector boundary. Never
 # enabled by production features; `hyprstream` enables it only as a dev-dependency.
 test-fixtures = []
+# Native shared/tiered Discovery state. The dependency itself is target-gated
+# below so enabling the feature never pulls sockets into a WASM graph.
+valkey = ["dep:fred"]
 
 [dependencies]
 # Workspace crates
@@ -68,6 +71,7 @@ p256 = { workspace = true }
 # Production accepted-state authority is read directly from the concrete
 # checkpointed PDS store. No downstream callback/trait can supply authority.
 rocksdb = "0.23"
+fred = { version = "9", optional = true, features = ["i-scripts"] }
 
 [target.'cfg(unix)'.dependencies]
 libc = { workspace = true }

--- a/crates/hyprstream-discovery/Cargo.toml
+++ b/crates/hyprstream-discovery/Cargo.toml
@@ -20,7 +20,7 @@ k8s = ["dep:hyprstream-k8s"]
 test-fixtures = []
 # Native shared/tiered Discovery state. The dependency itself is target-gated
 # below so enabling the feature never pulls sockets into a WASM graph.
-valkey = ["dep:fred", "dep:tokio"]
+valkey = ["dep:fred"]
 
 [dependencies]
 # Workspace crates
@@ -39,6 +39,7 @@ hyprstream-crypto = { path = "../hyprstream-crypto" }
 
 # Async runtime
 async-trait = { workspace = true }
+futures = { workspace = true }
 
 # Serialization
 capnp = { workspace = true }
@@ -71,8 +72,8 @@ p256 = { workspace = true }
 # Production accepted-state authority is read directly from the concrete
 # checkpointed PDS store. No downstream callback/trait can supply authority.
 rocksdb = "0.23"
-fred = { version = "9", optional = true, features = ["i-scripts"] }
-tokio = { workspace = true, optional = true }
+fred = { version = "9", optional = true, features = ["i-scripts", "enable-rustls-ring"] }
+tokio = { workspace = true }
 
 [target.'cfg(unix)'.dependencies]
 libc = { workspace = true }

--- a/crates/hyprstream-discovery/Cargo.toml
+++ b/crates/hyprstream-discovery/Cargo.toml
@@ -20,7 +20,7 @@ k8s = ["dep:hyprstream-k8s"]
 test-fixtures = []
 # Native shared/tiered Discovery state. The dependency itself is target-gated
 # below so enabling the feature never pulls sockets into a WASM graph.
-valkey = ["dep:fred"]
+valkey = ["dep:fred", "dep:tokio"]
 
 [dependencies]
 # Workspace crates
@@ -72,6 +72,7 @@ p256 = { workspace = true }
 # checkpointed PDS store. No downstream callback/trait can supply authority.
 rocksdb = "0.23"
 fred = { version = "9", optional = true, features = ["i-scripts"] }
+tokio = { workspace = true, optional = true }
 
 [target.'cfg(unix)'.dependencies]
 libc = { workspace = true }

--- a/crates/hyprstream-discovery/src/lib.rs
+++ b/crates/hyprstream-discovery/src/lib.rs
@@ -53,6 +53,11 @@ pub mod generated {
 }
 
 mod service;
+mod state_store;
+pub use state_store::{
+    DiscoveryState, DiscoveryStateBackend, DiscoveryStateConfig, MemoryStateConfig,
+    TieredStateConfig, ValkeyStateConfig,
+};
 #[cfg(not(target_arch = "wasm32"))]
 mod checkpointed_pds;
 

--- a/crates/hyprstream-discovery/src/placement_index.rs
+++ b/crates/hyprstream-discovery/src/placement_index.rs
@@ -135,6 +135,13 @@ struct PlacementState {
 }
 
 impl PlacementIndex {
+    /// Capacity-test fixture for an already verified/warm projection. Admission
+    /// itself is exercised separately with real signed repository fixtures.
+    #[cfg(all(test, not(target_arch = "wasm32"), feature = "valkey"))]
+    pub(crate) fn seed_warm_node_for_test(&self, did: String, facts: NodeFacts) {
+        self.state.write().nodes.insert(did, facts);
+    }
+
     pub fn new() -> Self {
         Self::default()
     }

--- a/crates/hyprstream-discovery/src/service.rs
+++ b/crates/hyprstream-discovery/src/service.rs
@@ -27,13 +27,18 @@ use crate::generated::discovery_client::{
 };
 use crate::placement_index::PlacementIndex;
 use crate::scheduling;
+use crate::state_store::{
+    unix_millis_now, AnnouncedEndpoint, CachedEntityStatement, CachedEnvelopeKeyset,
+    DiscoveryState, DiscoveryStateStore, LiveAllocatable, MemoryStateStore,
+};
 
 use anyhow::{Context, Result};
 use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine as _};
 use hyprstream_rpc::identity::Did;
 use hyprstream_util::ttl_cache::TtlCache;
-use parking_lot::RwLock;
-use std::collections::{BTreeSet, HashMap};
+use std::collections::BTreeSet;
+#[cfg(any(test, feature = "test-fixtures"))]
+use std::collections::HashMap;
 use std::net::SocketAddr;
 use std::str::FromStr;
 use std::sync::Arc;
@@ -62,26 +67,6 @@ const ANNOUNCED_ENDPOINT_TTL: Duration = Duration::from_secs(90);
 /// `maxCandidates == 0` (unspecified) — keeps an unscoped query from returning
 /// the entire fleet in one response.
 const DEFAULT_MAX_CANDIDATES: usize = 100;
-
-/// One node's live allocatable capacity + load, as reported via
-/// `reportNodeLiveness`. Stored in a `TtlCache<Did, _>` — absence (never
-/// reported, or expired) hard-excludes the node from `queryCandidates`.
-#[derive(Clone, Debug)]
-struct LiveAllocatable {
-    /// resource name -> k8s-quantity, free right now.
-    allocatable: Vec<(String, String)>,
-    load_fraction: f32,
-    /// unix millis of this snapshot.
-    last_seen: i64,
-}
-
-fn unix_millis_now() -> i64 {
-    use std::time::{SystemTime, UNIX_EPOCH};
-    SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .map(|d| d.as_millis() as i64)
-        .unwrap_or(0)
-}
 
 /// Private checkpoint-bound projection used only while Discovery validates an
 /// announcement against the daemon-owned accepted-state source.
@@ -581,28 +566,6 @@ pub trait RecordResolver: Send + Sync {
 // DiscoveryService
 // ============================================================================
 
-/// Endpoint data stored per announced entry.
-#[derive(Clone)]
-struct AnnouncedEndpoint {
-    /// Socket kind (e.g. "quic", "rep")
-    socket_kind: String,
-    /// Endpoint string (e.g. "quic://localhost:0.0.0.0:4433")
-    endpoint: String,
-    /// Service JWT attesting to the service's identity and pubkey
-    service_jwt: String,
-    service_did: Did,
-    capabilities: BTreeSet<String>,
-    accepted_state_digest: Vec<u8>,
-    accepted_state_epoch: u64,
-    response_key_id: String,
-    request_kem_key_id: String,
-    request_kem_recipient: Vec<u8>,
-    expires_at_unix_ms: i64,
-    source_signer: [u8; 32],
-    /// Last heartbeat timestamp (Instant)
-    last_heartbeat: Instant,
-}
-
 /// Checkpoint-verifying accepted-current-state read used by production
 /// resolution. Implemented by the daemon-owned PDS reader from #1004.
 pub(super) trait AcceptedStateSource: Send + Sync {
@@ -709,25 +672,9 @@ impl StreamHandle for CurrentStreamHandle {
 
 /// Cloneable production resolver installed after Discovery bootstrap.
 struct DiscoveryServiceResolver {
-    announced_endpoints: Arc<RwLock<HashMap<String, Vec<AnnouncedEndpoint>>>>,
+    state_store: Arc<dyn DiscoveryStateStore>,
     accepted_state_source: Arc<dyn AcceptedStateSource>,
     discovery_client: Option<crate::DiscoveryClient>,
-}
-
-/// Phase 0.5 Stage D — cached signed OIDF entity statement.
-struct CachedEntityStatement {
-    /// Signed OpenID Federation 1.0 entity statement (compact JWS).
-    jwt: String,
-    /// Unix seconds when this was registered (set on push from issuer).
-    fetched_at: i64,
-}
-
-/// Phase 0.5 Stage D — cached envelope COSE_KeySet.
-struct CachedEnvelopeKeyset {
-    /// CBOR-encoded COSE_KeySet (RFC 9052 §7).
-    cose_keyset_cbor: Vec<u8>,
-    /// Unix seconds when this was registered.
-    fetched_at: i64,
 }
 
 /// Parse an `at://<did>/<collection>/<rkey>` URI into its three components.
@@ -777,17 +724,9 @@ pub struct DiscoveryService {
     /// so getRecord/getRepo report NOT_FOUND for everything.
     record_resolver: Option<Arc<dyn RecordResolver>>,
     accepted_state_source: Option<Arc<dyn AcceptedStateSource>>,
-    /// Endpoints announced by other services (cross-process).
-    /// Maps service_name → Vec<AnnouncedEndpoint>.
-    announced_endpoints: Arc<RwLock<HashMap<String, Vec<AnnouncedEndpoint>>>>,
-    /// Phase 0.5 Stage D — cached signed OIDF entity statements per issuer URL.
-    /// Pushed by IdPService/OAuth at startup + on every signing-key rotation.
-    /// Consumed by FederationKeyResolver before falling back to HTTPS.
-    entity_statements: RwLock<HashMap<String, CachedEntityStatement>>,
-    /// Phase 0.5 Stage D — cached envelope COSE_KeySets per service did:web.
-    /// Pushed by each service at startup + rotation. Consumed by RequestService
-    /// receivers verifying COSE_Sign1 envelope signatures.
-    envelope_keysets: RwLock<HashMap<String, CachedEnvelopeKeyset>>,
+    /// Backend-neutral volatile state. Memory is the safe single-process/WASM
+    /// default; configured native deployments may install shared/tiered stores.
+    state_store: Arc<dyn DiscoveryStateStore>,
     /// Pre-computed TLS endorsement: Sign(tls_key, ed25519_pubkey || domain).
     /// Empty when TLS endorsement is not available (e.g. self-signed certs).
     tls_endorsement: Vec<u8>,
@@ -801,10 +740,6 @@ pub struct DiscoveryService {
     /// marked before resolver access, so absent/invalid/non-node repos cannot
     /// turn heartbeat frequency into unbounded work.
     placement_ingest_attempts: TtlCache<Did, ()>,
-    /// #524 P1 — live allocatable capacity + load per node, TTL'd
-    /// (`LIVENESS_TTL`). Backs the hard-exclusion-on-staleness rule in
-    /// `queryCandidates`.
-    liveness: TtlCache<Did, LiveAllocatable>,
     // Infrastructure (for Spawnable)
     transport: TransportConfig,
 }
@@ -830,9 +765,7 @@ impl DiscoveryService {
             auth_provider: None,
             record_resolver: None,
             accepted_state_source: None,
-            announced_endpoints: Arc::new(RwLock::new(HashMap::new())),
-            entity_statements: RwLock::new(HashMap::new()),
-            envelope_keysets: RwLock::new(HashMap::new()),
+            state_store: MemoryStateStore::production_default(),
             tls_endorsement: Vec::new(),
             tls_domain: String::new(),
             placement_index: PlacementIndex::new(),
@@ -840,9 +773,14 @@ impl DiscoveryService {
                 LIVENESS_CACHE_MAX_ENTRIES,
                 LIVENESS_CACHE_REAP_BUDGET,
             ),
-            liveness: TtlCache::new(LIVENESS_CACHE_MAX_ENTRIES, LIVENESS_CACHE_REAP_BUDGET),
             transport,
         }
+    }
+
+    /// Install the configured volatile-state backend before the service is shared.
+    pub fn with_state(mut self, state: DiscoveryState) -> Self {
+        self.state_store = state.into_inner();
+        self
     }
 
     /// Set the pre-computed TLS endorsement and domain.
@@ -1082,7 +1020,7 @@ impl DiscoveryService {
         }
         PRODUCTION_RESOLVER
             .set(Arc::new(DiscoveryServiceResolver {
-                announced_endpoints: Arc::new(RwLock::new(HashMap::new())),
+                state_store: MemoryStateStore::production_default(),
                 accepted_state_source: source,
                 discovery_client: Some(discovery_client),
             }))
@@ -1104,7 +1042,7 @@ impl DiscoveryService {
     #[cfg(test)]
     fn production_resolver(&self) -> Result<DiscoveryServiceResolver> {
         Ok(DiscoveryServiceResolver {
-            announced_endpoints: Arc::clone(&self.announced_endpoints),
+            state_store: Arc::clone(&self.state_store),
             accepted_state_source: self.accepted_state_source.clone().ok_or_else(|| {
                 anyhow::anyhow!("Discovery accepted-state source is not installed")
             })?,
@@ -1125,7 +1063,7 @@ impl DiscoveryService {
 #[async_trait]
 impl Resolver for DiscoveryService {
     async fn resolve(&self, name: &str, kind: SocketKind) -> anyhow::Result<TransportConfig> {
-        if let Some(transport) = self.resolve_announced_endpoint(name, kind)? {
+        if let Some(transport) = self.resolve_announced_endpoint(name, kind).await? {
             return Ok(transport);
         }
 
@@ -1189,21 +1127,21 @@ impl DiscoveryServiceResolver {
                         request_kem_recipient: endpoint.request_kem_recipient,
                         expires_at_unix_ms: endpoint.expires_at_unix_ms,
                         source_signer,
-                        last_heartbeat: Instant::now(),
+                        live_until_unix_ms: endpoint
+                            .expires_at_unix_ms
+                            .min(unix_millis_now() + ANNOUNCED_ENDPOINT_TTL.as_millis() as i64),
                     })
                 })
                 .collect()
         } else {
-            self.announced_endpoints
-                .read()
-                .get(&query.service_name)
-                .cloned()
-                .unwrap_or_default()
+            self.state_store
+                .announcements_for(&query.service_name, unix_millis_now())
+                .await?
         };
 
         let mut candidates = Vec::new();
         for entry in entries {
-            if entry.last_heartbeat.elapsed() > ANNOUNCED_ENDPOINT_TTL
+            if !entry.is_live_at(unix_millis_now())
                 || entry.service_did.as_str().is_empty()
                 || entry.accepted_state_digest.len() != 64
             {
@@ -3200,7 +3138,7 @@ pub mod test_fixtures {
     #[derive(Clone)]
     pub struct ProductionInferenceFixture {
         service_name: String,
-        announced: Arc<RwLock<HashMap<String, Vec<AnnouncedEndpoint>>>>,
+        announced: Arc<MemoryStateStore>,
         states: Arc<FixtureAcceptedStates>,
         primary: FixtureAuthority,
         foreign: FixtureAuthority,
@@ -3268,7 +3206,13 @@ pub mod test_fixtures {
             request_kem_recipient: authority.request_kem_recipient.encode(),
             expires_at_unix_ms: 4_070_908_800_000,
             source_signer: authority.signing.verifying_key().to_bytes(),
-            last_heartbeat,
+            live_until_unix_ms: unix_millis_now()
+                .saturating_add(ANNOUNCED_ENDPOINT_TTL.as_millis() as i64)
+                .saturating_sub(
+                    Instant::now()
+                        .saturating_duration_since(last_heartbeat)
+                        .as_millis() as i64,
+                ),
         })
     }
 
@@ -3280,23 +3224,26 @@ pub mod test_fixtures {
                 states.clear();
                 states.insert(self.primary.state.did.clone(), self.primary.state.clone());
             }
-            let endpoints = transports
-                .iter()
-                .map(|transport| announcement(&self.primary, transport, Instant::now()))
-                .collect::<Result<Vec<_>>>()?;
-            self.announced
-                .write()
-                .insert(self.service_name.clone(), endpoints);
+            self.announced.clear_announcements_sync(&self.service_name);
+            for transport in transports {
+                self.announced.put_announcement_sync(
+                    &self.service_name,
+                    announcement(&self.primary, transport, Instant::now())?,
+                )?;
+            }
             Ok(())
         }
 
         /// Age every announcement beyond the production freshness bound.
         pub fn mark_stale(&self) {
-            if let Some(endpoints) = self.announced.write().get_mut(&self.service_name) {
-                for endpoint in endpoints {
-                    endpoint.last_heartbeat =
-                        Instant::now() - ANNOUNCED_ENDPOINT_TTL - Duration::from_secs(1);
-                }
+            for mut endpoint in self
+                .announced
+                .announcements_for_sync(&self.service_name, unix_millis_now())
+            {
+                endpoint.live_until_unix_ms = unix_millis_now() - 1;
+                let _ = self
+                    .announced
+                    .put_announcement_sync(&self.service_name, endpoint);
             }
         }
 
@@ -3306,11 +3253,10 @@ pub mod test_fixtures {
                 .0
                 .lock()
                 .insert(self.foreign.state.did.clone(), self.foreign.state.clone());
-            self.announced
-                .write()
-                .entry(self.service_name.clone())
-                .or_default()
-                .push(announcement(&self.foreign, transport, Instant::now())?);
+            self.announced.put_announcement_sync(
+                &self.service_name,
+                announcement(&self.foreign, transport, Instant::now())?,
+            )?;
             Ok(())
         }
     }
@@ -3331,7 +3277,7 @@ pub mod test_fixtures {
         let states = Arc::new(FixtureAcceptedStates(parking_lot::Mutex::new(
             HashMap::new(),
         )));
-        let announced = Arc::new(RwLock::new(HashMap::new()));
+        let announced = Arc::new(MemoryStateStore::default());
         let fixture = ProductionInferenceFixture {
             service_name: service_name.to_owned(),
             announced: Arc::clone(&announced),
@@ -3345,7 +3291,7 @@ pub mod test_fixtures {
         })?;
         PRODUCTION_RESOLVER
             .set(Arc::new(DiscoveryServiceResolver {
-                announced_endpoints: announced,
+                state_store: announced,
                 accepted_state_source: states,
                 discovery_client: None,
             }))
@@ -3606,21 +3552,20 @@ impl RpcClient for ProductionRpcClient {
 }
 
 impl DiscoveryService {
-    fn resolve_announced_endpoint(
+    async fn resolve_announced_endpoint(
         &self,
         name: &str,
         kind: SocketKind,
     ) -> anyhow::Result<Option<TransportConfig>> {
         let wanted = socket_kind_to_string(kind);
-        let announced = self.announced_endpoints.read();
-        let Some(endpoints) = announced.get(name) else {
-            return Ok(None);
-        };
-
+        let endpoints = self
+            .state_store
+            .announcements_for(name, unix_millis_now())
+            .await?;
         let Some(endpoint) = endpoints
             .iter()
             .filter(|ep| ep.socket_kind == wanted)
-            .find(|ep| ep.last_heartbeat.elapsed() <= ANNOUNCED_ENDPOINT_TTL)
+            .find(|ep| ep.is_live_at(unix_millis_now()))
         else {
             return Ok(None);
         };
@@ -4334,6 +4279,12 @@ mod resolver_tests {
         endpoint: &str,
         last_heartbeat: Instant,
     ) -> AnnouncedEndpoint {
+        let age_ms = Instant::now()
+            .saturating_duration_since(last_heartbeat)
+            .as_millis() as i64;
+        let live_until_unix_ms = unix_millis_now()
+            .saturating_add(ANNOUNCED_ENDPOINT_TTL.as_millis() as i64)
+            .saturating_sub(age_ms);
         AnnouncedEndpoint {
             socket_kind: socket_kind.to_owned(),
             endpoint: endpoint.to_owned(),
@@ -4345,9 +4296,9 @@ mod resolver_tests {
             response_key_id: String::new(),
             request_kem_key_id: String::new(),
             request_kem_recipient: Vec::new(),
-            expires_at_unix_ms: 0,
+            expires_at_unix_ms: i64::MAX,
             source_signer: [0; 32],
-            last_heartbeat,
+            live_until_unix_ms,
         }
     }
 
@@ -4409,9 +4360,11 @@ mod resolver_tests {
         } else {
             "quic://localhost:127.0.0.1:9".to_owned()
         };
-        let announced = Arc::new(RwLock::new(HashMap::from([(
-            "model".to_owned(),
-            vec![AnnouncedEndpoint {
+        let state_store = Arc::new(MemoryStateStore::default());
+        state_store
+            .put_announcement_sync(
+                "model",
+                AnnouncedEndpoint {
                 socket_kind: if local_reach { "rep" } else { "quic" }.to_owned(),
                 endpoint,
                 service_jwt: "verified-by-handler".to_owned(),
@@ -4426,18 +4379,42 @@ mod resolver_tests {
                 request_kem_recipient: kem.public().encode(),
                 expires_at_unix_ms: 4_070_908_800_000,
                 source_signer: signing.verifying_key().to_bytes(),
-                last_heartbeat: Instant::now(),
-            }],
-        )])));
+                live_until_unix_ms: unix_millis_now()
+                    + ANNOUNCED_ENDPOINT_TTL.as_millis() as i64,
+            },
+            )
+            .expect("seed announcement");
         let source = Arc::new(MutableAcceptedState(parking_lot::Mutex::new(Some(state))));
         (
             DiscoveryServiceResolver {
-                announced_endpoints: announced,
+                state_store,
                 accepted_state_source: Arc::clone(&source) as Arc<dyn AcceptedStateSource>,
                 discovery_client: None,
             },
             source,
         )
+    }
+
+    async fn mutate_endpoint(
+        resolver: &DiscoveryServiceResolver,
+        service_name: &str,
+        socket_kind: &str,
+        mutate: impl FnOnce(&mut AnnouncedEndpoint),
+    ) {
+        let mut endpoint = resolver
+            .state_store
+            .announcements_for(service_name, unix_millis_now())
+            .await
+            .expect("read fixture announcement")
+            .into_iter()
+            .find(|entry| entry.socket_kind == socket_kind)
+            .expect("fixture announcement");
+        mutate(&mut endpoint);
+        resolver
+            .state_store
+            .put_announcement(service_name, endpoint)
+            .await
+            .expect("replace fixture announcement");
     }
 
     #[tokio::test]
@@ -4498,13 +4475,10 @@ mod resolver_tests {
             .is_err());
 
         let (resolver, _) = production_fixture(false);
-        resolver
-            .announced_endpoints
-            .write()
-            .get_mut("model")
-            .and_then(|entries| entries.first_mut())
-            .expect("fixture announcement")
-            .request_kem_recipient = vec![0x01];
+        mutate_endpoint(&resolver, "model", "quic", |endpoint| {
+            endpoint.request_kem_recipient = vec![0x01];
+        })
+        .await;
         assert!(resolver
             .browser_provisioning(owned_browser_request())
             .await
@@ -4615,40 +4589,31 @@ mod resolver_tests {
 
         let (resolver, _) = production_fixture(false);
         let route_binding = binding_for(&resolver).await;
-        resolver
-            .announced_endpoints
-            .write()
-            .get_mut("model")
-            .and_then(|entries| entries.first_mut())
-            .expect("fixture route")
-            .endpoint = "quic://localhost:127.0.0.1:10".to_owned();
+        mutate_endpoint(&resolver, "model", "quic", |endpoint| {
+            endpoint.endpoint = "quic://localhost:127.0.0.1:10".to_owned();
+        })
+        .await;
         assert!(resolver
             .verify_browser_binding(&route_binding)
             .await
             .is_err());
 
         let (resolver, _) = production_fixture(false);
-        resolver
-            .announced_endpoints
-            .write()
-            .get_mut("model")
-            .and_then(|entries| entries.first_mut())
-            .expect("fixture pin")
-            .endpoint = format!(
-            "quic://localhost:127.0.0.1:9#{}",
-            URL_SAFE_NO_PAD.encode([0x51; 32])
-        );
+        mutate_endpoint(&resolver, "model", "quic", |endpoint| {
+            endpoint.endpoint = format!(
+                "quic://localhost:127.0.0.1:9#{}",
+                URL_SAFE_NO_PAD.encode([0x51; 32])
+            );
+        })
+        .await;
         let pin_binding = binding_for(&resolver).await;
-        resolver
-            .announced_endpoints
-            .write()
-            .get_mut("model")
-            .and_then(|entries| entries.first_mut())
-            .expect("fixture pin rotation")
-            .endpoint = format!(
-            "quic://localhost:127.0.0.1:9#{}",
-            URL_SAFE_NO_PAD.encode([0x52; 32])
-        );
+        mutate_endpoint(&resolver, "model", "quic", |endpoint| {
+            endpoint.endpoint = format!(
+                "quic://localhost:127.0.0.1:9#{}",
+                URL_SAFE_NO_PAD.encode([0x52; 32])
+            );
+        })
+        .await;
         assert!(resolver.verify_browser_binding(&pin_binding).await.is_err());
     }
 
@@ -4846,14 +4811,17 @@ mod resolver_tests {
     async fn generated_client_uses_ordinary_identity_bound_resolver_path() {
         let (resolver, _) = production_fixture(false);
         let entries = resolver
-            .announced_endpoints
-            .write()
-            .remove("model")
+            .state_store
+            .announcements_for("model", unix_millis_now())
+            .await
             .expect("fixture announcement");
-        resolver
-            .announced_endpoints
-            .write()
-            .insert("discovery".to_owned(), entries);
+        for endpoint in entries {
+            resolver
+                .state_store
+                .put_announcement("discovery", endpoint)
+                .await
+                .expect("seed discovery announcement");
+        }
         let resolver = Arc::new(resolver);
         let _ = PRODUCTION_RESOLVER.set(resolver);
         let client_signing = SigningKey::from_bytes(&[0x44; 32]);
@@ -5477,13 +5445,10 @@ mod resolver_tests {
     #[tokio::test]
     async fn stale_or_expired_production_evidence_is_rejected() {
         let (resolver, _) = production_fixture(false);
-        resolver
-            .announced_endpoints
-            .write()
-            .get_mut("model")
-            .and_then(|entries| entries.first_mut())
-            .expect("fixture service")
-            .last_heartbeat = Instant::now() - ANNOUNCED_ENDPOINT_TTL - Duration::from_secs(1);
+        mutate_endpoint(&resolver, "model", "quic", |endpoint| {
+            endpoint.live_until_unix_ms = unix_millis_now() - 1;
+        })
+        .await;
         assert!(resolver
             .resolve_service(ServiceQuery::network("model").expect("query"))
             .await
@@ -5501,15 +5466,22 @@ mod resolver_tests {
     #[tokio::test]
     async fn malformed_candidate_does_not_poison_valid_alternative() {
         let (resolver, _) = production_fixture(false);
-        {
-            let mut endpoints = resolver.announced_endpoints.write();
-            let entries = endpoints.get_mut("model").expect("fixture service");
-            let mut malformed = entries.first().expect("fixture endpoint").clone();
-            malformed.request_kem_recipient = vec![0xff];
-            malformed.socket_kind = "quic".to_owned();
-            malformed.endpoint = "quic://missing-port".to_owned();
-            entries.insert(0, malformed);
-        }
+        let mut malformed = resolver
+            .state_store
+            .announcements_for("model", unix_millis_now())
+            .await
+            .expect("fixture service")
+            .into_iter()
+            .next()
+            .expect("fixture endpoint");
+        malformed.request_kem_recipient = vec![0xff];
+        malformed.socket_kind = "iroh".to_owned();
+        malformed.endpoint = "iroh://invalid".to_owned();
+        resolver
+            .state_store
+            .put_announcement("model", malformed)
+            .await
+            .expect("seed malformed alternative");
 
         let resolved = resolver
             .resolve_service(ServiceQuery::network("model").expect("query"))
@@ -5528,13 +5500,10 @@ mod resolver_tests {
             .is_err());
 
         let (resolver, _) = production_fixture(false);
-        resolver
-            .announced_endpoints
-            .write()
-            .get_mut("model")
-            .and_then(|entries| entries.first_mut())
-            .expect("fixture service")
-            .accepted_state_digest = vec![0x77; 64];
+        mutate_endpoint(&resolver, "model", "quic", |endpoint| {
+            endpoint.accepted_state_digest = vec![0x77; 64];
+        })
+        .await;
         assert!(resolver
             .resolve_service(ServiceQuery::network("model").expect("query"))
             .await
@@ -5544,14 +5513,17 @@ mod resolver_tests {
     #[tokio::test]
     async fn resolver_uses_fresh_announced_quic_endpoint() {
         let svc = service();
-        svc.announced_endpoints.write().insert(
-            "model".to_owned(),
-            vec![legacy_endpoint(
+        svc.state_store
+            .put_announcement(
+                "model",
+                legacy_endpoint(
                 "quic",
                 "quic://model.hyprstream.svc.cluster.local:10.96.0.42:4433",
                 Instant::now(),
-            )],
-        );
+                ),
+            )
+            .await
+            .expect("seed announcement");
 
         let transport = match svc.resolve("model", SocketKind::Quic).await {
             Ok(transport) => transport,
@@ -5584,14 +5556,17 @@ mod resolver_tests {
     #[tokio::test]
     async fn resolver_rejects_stale_announced_quic_endpoint() {
         let svc = service();
-        svc.announced_endpoints.write().insert(
-            "model".to_owned(),
-            vec![legacy_endpoint(
+        svc.state_store
+            .put_announcement(
+                "model",
+                legacy_endpoint(
                 "quic",
                 "quic://model.hyprstream.svc.cluster.local:10.96.0.42:4433",
                 Instant::now() - (ANNOUNCED_ENDPOINT_TTL + Duration::from_secs(1)),
-            )],
-        );
+                ),
+            )
+            .await
+            .expect("seed stale announcement");
 
         let err = match svc.resolve("model", SocketKind::Quic).await {
             Ok(transport) => panic!("stale announced QUIC endpoint resolved to {transport:?}"),
@@ -5703,10 +5678,10 @@ impl DiscoveryHandler for DiscoveryService {
             .collect();
         drop(reg);
 
-        // Merge announced endpoints from other processes
-        let announced = self.announced_endpoints.read();
+        // Merge live announcements from the configured state backend.
+        let announced = self.state_store.all_announcements(unix_millis_now()).await?;
         let local_names: Vec<String> = summaries.iter().map(|s| s.name.clone()).collect();
-        for (name, endpoints) in announced.iter() {
+        for (name, endpoints) in &announced {
             if local_names.iter().any(|n| n == name) {
                 // Service exists locally — add announced socket kinds
                 if let Some(summary) = summaries.iter_mut().find(|s| s.name == *name) {
@@ -5770,29 +5745,29 @@ impl DiscoveryHandler for DiscoveryService {
             None => Vec::new(),
         };
 
-        // Merge announced endpoints from other processes (carry service JWT)
-        let announced = self.announced_endpoints.read();
-        if let Some(announced_eps) = announced.get(service_name) {
-            for ep in announced_eps {
-                // Don't duplicate if already present from local registry
-                if !endpoints.iter().any(|e| e.socket_kind == ep.socket_kind) {
-                    endpoints.push(EndpointInfo {
-                        socket_kind: ep.socket_kind.clone(),
-                        endpoint: ep.endpoint.clone(),
-                        service_jwt: ep.service_jwt.clone(),
-                        tls_endorsement: self.tls_endorsement.clone(),
-                        tls_domain: self.tls_domain.clone(),
-                        service_did: ep.service_did.clone(),
-                        capabilities: ep.capabilities.iter().cloned().collect(),
-                        accepted_state_digest: ep.accepted_state_digest.clone(),
-                        accepted_state_epoch: ep.accepted_state_epoch,
-                        response_key_id: ep.response_key_id.clone(),
-                        request_kem_key_id: ep.request_kem_key_id.clone(),
-                        request_kem_recipient: ep.request_kem_recipient.clone(),
-                        expires_at_unix_ms: ep.expires_at_unix_ms,
-                        source_signer: ep.source_signer.to_vec(),
-                    });
-                }
+        // Merge announced endpoints from other processes (carry service JWT).
+        for ep in self
+            .state_store
+            .announcements_for(service_name, unix_millis_now())
+            .await?
+        {
+            if !endpoints.iter().any(|e| e.socket_kind == ep.socket_kind) {
+                endpoints.push(EndpointInfo {
+                    socket_kind: ep.socket_kind,
+                    endpoint: ep.endpoint,
+                    service_jwt: ep.service_jwt,
+                    tls_endorsement: self.tls_endorsement.clone(),
+                    tls_domain: self.tls_domain.clone(),
+                    service_did: ep.service_did,
+                    capabilities: ep.capabilities.into_iter().collect(),
+                    accepted_state_digest: ep.accepted_state_digest,
+                    accepted_state_epoch: ep.accepted_state_epoch,
+                    response_key_id: ep.response_key_id,
+                    request_kem_key_id: ep.request_kem_key_id,
+                    request_kem_recipient: ep.request_kem_recipient,
+                    expires_at_unix_ms: ep.expires_at_unix_ms,
+                    source_signer: ep.source_signer.to_vec(),
+                });
             }
         }
 
@@ -6079,6 +6054,29 @@ impl DiscoveryHandler for DiscoveryService {
             );
         }
 
+        let now_unix_ms = unix_millis_now();
+        let heartbeat_expiry = now_unix_ms
+            .saturating_add(ANNOUNCED_ENDPOINT_TTL.as_millis() as i64);
+        let mut live_until_unix_ms = data.expires_at_unix_ms.min(heartbeat_expiry);
+        if identity_bound {
+            if let Some(source) = &self.accepted_state_source {
+                let state = source
+                    .accepted_state(data.service_did.as_str())?
+                    .ok_or_else(|| anyhow::anyhow!("announcement DID has no accepted-current state"))?;
+                anyhow::ensure!(
+                    state.epoch == data.accepted_state_epoch
+                        && state.head_digest.as_slice() == data.accepted_state_digest.as_slice(),
+                    "announcement does not match accepted-current state"
+                );
+                live_until_unix_ms =
+                    live_until_unix_ms.min(accepted_expiry_unix_ms(&state)?);
+            }
+        }
+        anyhow::ensure!(
+            live_until_unix_ms > now_unix_ms,
+            "announcement effective lifetime is already expired"
+        );
+
         let replacement = AnnouncedEndpoint {
             socket_kind: sock_kind.clone(),
             endpoint: endpoint.clone(),
@@ -6092,17 +6090,11 @@ impl DiscoveryHandler for DiscoveryService {
             request_kem_recipient: data.request_kem_recipient.clone(),
             expires_at_unix_ms: data.expires_at_unix_ms,
             source_signer: ctx.cnf,
-            last_heartbeat: Instant::now(),
+            live_until_unix_ms,
         };
-
-        let mut endpoints = self.announced_endpoints.write();
-        let entry = endpoints.entry(svc_name).or_default();
-        // Replace existing endpoint for the same socket kind, or add new
-        if let Some(existing) = entry.iter_mut().find(|e| e.socket_kind == sock_kind) {
-            *existing = replacement;
-        } else {
-            entry.push(replacement);
-        }
+        self.state_store
+            .put_announcement(&svc_name, replacement)
+            .await?;
 
         Ok(DiscoveryResponseVariant::AnnounceResult)
     }
@@ -6146,10 +6138,10 @@ impl DiscoveryHandler for DiscoveryService {
             jwt: data.jwt.clone(),
             fetched_at: unix_seconds_now(),
         };
-        let mut map = self.entity_statements.write();
-        map.insert(data.issuer.clone(), cached);
-        let total = map.len();
-        drop(map);
+        self.state_store
+            .put_entity_statement(&data.issuer, cached)
+            .await?;
+        let total = self.state_store.known_issuers().await?.len();
 
         info!(
             issuer = %data.issuer,
@@ -6167,14 +6159,13 @@ impl DiscoveryHandler for DiscoveryService {
         data: &str,
     ) -> Result<DiscoveryResponseVariant> {
         let issuer = data;
-        let map = self.entity_statements.read();
-        match map.get(issuer) {
+        match self.state_store.entity_statement(issuer).await? {
             Some(cached) => {
                 trace!(issuer = %issuer, "Discovery: entity statement cache hit");
                 Ok(DiscoveryResponseVariant::GetEntityStatementResult(
                     EntityStatement {
                         issuer: issuer.to_owned(),
-                        jwt: cached.jwt.clone(),
+                        jwt: cached.jwt,
                         fetched_at: cached.fetched_at,
                     },
                 ))
@@ -6212,15 +6203,13 @@ impl DiscoveryHandler for DiscoveryService {
             cose_keyset_cbor: data.cose_keyset_cbor.clone(),
             fetched_at: unix_seconds_now(),
         };
-        let mut map = self.envelope_keysets.write();
-        map.insert(data.service_did.as_str().to_owned(), cached);
-        let total = map.len();
-        drop(map);
+        self.state_store
+            .put_envelope_keyset(data.service_did.as_str(), cached)
+            .await?;
 
         info!(
             service_did = %data.service_did,
             caller = %ctx.subject(),
-            total_cached = total,
             "Discovery: envelope keyset registered"
         );
         Ok(DiscoveryResponseVariant::RegisterEnvelopeKeysetResult)
@@ -6233,14 +6222,13 @@ impl DiscoveryHandler for DiscoveryService {
         data: &str,
     ) -> Result<DiscoveryResponseVariant> {
         let service_did = data;
-        let map = self.envelope_keysets.read();
-        match map.get(service_did) {
+        match self.state_store.envelope_keyset(service_did).await? {
             Some(cached) => {
                 trace!(service_did = %service_did, "Discovery: envelope keyset cache hit");
                 Ok(DiscoveryResponseVariant::GetEnvelopeKeysetResult(
                     EnvelopeKeyset {
                         service_did: hyprstream_rpc::identity::Did::new(service_did.to_owned()),
-                        cose_keyset_cbor: cached.cose_keyset_cbor.clone(),
+                        cose_keyset_cbor: cached.cose_keyset_cbor,
                         fetched_at: cached.fetched_at,
                     },
                 ))
@@ -6272,8 +6260,7 @@ impl DiscoveryHandler for DiscoveryService {
                 details: String::new(),
             }));
         }
-        let map = self.entity_statements.read();
-        let issuers: Vec<String> = map.keys().cloned().collect();
+        let issuers = self.state_store.known_issuers().await?;
         Ok(DiscoveryResponseVariant::ListKnownIssuersResult(
             IssuerList { issuers },
         ))
@@ -6462,24 +6449,25 @@ impl DiscoveryHandler for DiscoveryService {
 
         // Hard liveness exclusion (decision #1): only nodes with a live,
         // unexpired `reportNodeLiveness` entry become candidates at all.
-        let candidates: Vec<Candidate> = self
-            .placement_index
-            .known_node_dids()
-            .into_iter()
-            .filter_map(|did| {
-                let live = self.liveness.get(&Did::new(did.clone()))?;
+        let mut candidates: Vec<Candidate> = Vec::new();
+        for did in self.placement_index.known_node_dids() {
+            if let Some(live) = self
+                .state_store
+                .liveness(&Did::new(did.clone()), unix_millis_now())
+                .await?
+            {
                 let labels = self.placement_index.effective_labels(&did);
                 let record_uri = self.placement_index.record_uri(&did).unwrap_or_default();
-                Some(Candidate {
+                candidates.push(Candidate {
                     did,
                     record_uri,
                     load_fraction: live.load_fraction,
                     allocatable: live.allocatable,
                     last_seen: live.last_seen,
                     labels,
-                })
-            })
-            .collect();
+                });
+            }
+        }
 
         let predicates: Vec<scheduling::Predicate<Candidate>> = vec![
             Box::new({
@@ -6631,8 +6619,10 @@ impl DiscoveryHandler for DiscoveryService {
             } else {
                 unix_millis_now()
             },
+            live_until_unix_ms: unix_millis_now()
+                .saturating_add(LIVENESS_TTL.as_millis() as i64),
         };
-        self.liveness.insert(data.node.clone(), live, LIVENESS_TTL);
+        self.state_store.put_liveness(&data.node, live).await?;
 
         if self.placement_index.record_uri(&node_did).is_none()
             && self.placement_ingest_attempts.insert_if_absent(
@@ -7272,7 +7262,11 @@ mod query_candidates_tests {
             DiscoveryResponseVariant::Error(ErrorInfo { ref code, .. }) if code == "UNAUTHORIZED"
         ));
         assert!(
-            svc.liveness.get(&Did::new(did.to_owned())).is_none(),
+            svc.state_store
+                .liveness(&Did::new(did.to_owned()), unix_millis_now())
+                .await
+                .expect("read liveness")
+                .is_none(),
             "denied DID must not receive a liveness entry"
         );
         assert!(
@@ -7312,8 +7306,10 @@ mod query_candidates_tests {
             "two heartbeats before retry expiry must produce one repo poll"
         );
         let live = svc
-            .liveness
-            .get(&Did::new(did.to_owned()))
+            .state_store
+            .liveness(&Did::new(did.to_owned()), unix_millis_now())
+            .await
+            .expect("read liveness")
             .expect("admitted heartbeat must still refresh liveness");
         assert!((live.load_fraction - 0.1).abs() < f32::EPSILON);
         assert_eq!(live.allocatable, vec![("cpu".to_owned(), "8".to_owned())]);

--- a/crates/hyprstream-discovery/src/service.rs
+++ b/crates/hyprstream-discovery/src/service.rs
@@ -498,6 +498,20 @@ fn to_scheduling_op(op: crate::generated::discovery_client::SelectorOp) -> sched
 /// provides a `PolicyAuthProvider` that wraps `PolicyClient`.
 #[async_trait(?Send)]
 pub trait AuthorizationProvider: Send + Sync {
+    /// One bounded authorization vector; implementations may amortize RPC
+    /// overhead but must retain one decision per resource in input order.
+    async fn check_batch(
+        &self, subject: &str, domain: &str, resources: &[String],
+        operation: &str, bearer: Option<&str>,
+    ) -> Result<Vec<bool>> {
+        anyhow::ensure!(resources.len() <= 256, "authorization batch exceeds 256");
+        let mut allowed = Vec::with_capacity(resources.len());
+        for resource in resources {
+            allowed.push(self.check(subject, domain, resource, operation, bearer).await.unwrap_or(false));
+        }
+        Ok(allowed)
+    }
+
     /// Check if a subject is authorized for the given operation on a resource.
     async fn check(
         &self,
@@ -6501,7 +6515,6 @@ impl DiscoveryHandler for DiscoveryService {
                 load_fraction: f32,
                 allocatable: Vec<(String, String)>,
                 last_seen: i64,
-                labels: Vec<(String, String)>,
             }
 
             let selectors: Vec<scheduling::LabelSelector> = data
@@ -6521,121 +6534,72 @@ impl DiscoveryHandler for DiscoveryService {
                 .map(|r| scheduling::ResourceRequest::new(r.name.clone(), r.min_quantity.clone()))
                 .collect();
 
-            // Hard liveness exclusion (decision #1): only nodes with a live,
-            // unexpired `reportNodeLiveness` entry become candidates at all.
+            // Exact totalMatching requires examining every eligible node, but
+            // not one or two Policy RPCs and a point GET per node. Read bounded
+            // shared snapshots and authorize in bounded vectors instead.
             let live_nodes = self.state_store.all_liveness(unix_millis_now()).await?;
-            let candidates: Vec<Candidate> = stream::iter(live_nodes)
-                .map(|(node, _)| async move {
-                    anyhow::ensure!(
-                        started.elapsed() < CANDIDATE_QUERY_TIMEOUT,
-                        "candidate query deadline exceeded; retry"
-                    );
-                    let did = node.as_str().to_owned();
-                    // Authorize before a query can trigger resolver work on this
-                    // replica. Liveness is shared, but placement facts still come only
-                    // from the verified repository ingestion path.
-                    if self
-                        .authorize(ctx, &format!("placement:candidate:{did}"), "query")
-                        .await
-                        .is_err()
-                    {
-                        return Ok(None);
-                    }
-                    anyhow::ensure!(
-                        self.ensure_placement_ingested(&node).await,
-                        "candidate projection ingestion is pending; retry"
-                    );
-                    let Some(record_uri) = self.placement_index.record_uri(&did) else {
-                        return Ok(None);
+            let eligible: Vec<_> = live_nodes.into_iter().filter(|(node, live)| {
+                resources.iter().all(|req| live.allocatable.iter()
+                    .find(|(name, _)| name == &req.name)
+                    .is_some_and(|(_, quantity)| req.satisfied_by(quantity)))
+                    && (self.placement_index.record_uri(node.as_str()).is_none()
+                        || selectors.iter().all(|selector| selector.matches(
+                            &self.placement_index.effective_labels(node.as_str()))))
+            }).map(|(node, _)| node).collect();
+            let authorized = stream::iter(eligible.chunks(256))
+                .map(|nodes| async move {
+                    anyhow::ensure!(started.elapsed() < CANDIDATE_QUERY_TIMEOUT,
+                        "candidate query deadline exceeded; retry");
+                    let resources: Vec<_> = nodes.iter()
+                        .map(|node| format!("placement:candidate:{node}")).collect();
+                    let decisions = match &self.auth_provider {
+                        Some(auth) => auth.check_batch(&ctx.subject().to_string(), "*",
+                            &resources, "query", ctx.jwt_token()).await?,
+                        None => vec![true; resources.len()],
                     };
-                    // Repository ingestion can take time; never return a node whose
-                    // heartbeat expired while this replica was loading its facts.
-                    let Some(live) = self.state_store.liveness(&node, unix_millis_now()).await?
-                    else {
-                        return Ok(None);
-                    };
-                    let labels = self.placement_index.effective_labels(&did);
-                    Ok::<_, anyhow::Error>(Some(Candidate {
-                        did,
-                        record_uri,
-                        load_fraction: live.load_fraction,
-                        allocatable: live.allocatable,
-                        last_seen: live.last_seen,
-                        labels,
-                    }))
+                    anyhow::ensure!(decisions.len() == nodes.len(), "invalid authorization decision count");
+                    Ok::<_, anyhow::Error>(nodes.iter().zip(decisions)
+                        .filter(|(_, allowed)| *allowed).map(|(node, _)| node.clone()).collect::<Vec<_>>())
                 })
                 .buffer_unordered(CANDIDATE_QUERY_CONCURRENCY)
-                .try_collect::<Vec<_>>()
-                .await?
-                .into_iter()
-                .flatten()
-                .collect();
+                .try_collect::<Vec<_>>().await?
+                .into_iter().flatten().collect::<Vec<_>>();
 
-            let predicates: Vec<scheduling::Predicate<Candidate>> = vec![
-                Box::new({
-                    let selectors = selectors.clone();
-                    move |c: &Candidate| {
-                        for sel in &selectors {
-                            if !sel.matches(&c.labels) {
-                                return Some(scheduling::RejectionReason(format!(
-                                    "label selector on {:?} did not match",
-                                    sel.key
-                                )));
-                            }
-                        }
-                        None
-                    }
-                }),
-                Box::new({
-                    let resources = resources.clone();
-                    move |c: &Candidate| {
-                        for req in &resources {
-                            let satisfied = c
-                                .allocatable
-                                .iter()
-                                .find(|(name, _)| name == &req.name)
-                                .is_some_and(|(_, quantity)| req.satisfied_by(quantity));
-                            if !satisfied {
-                                return Some(scheduling::RejectionReason(format!(
-                                    "resource {:?} not satisfied",
-                                    req.name
-                                )));
-                            }
-                        }
-                        None
-                    }
-                }),
-            ];
+            // No denied node can trigger repository hydration. Completed
+            // verified ingests survive a cold-query timeout, so retries progress.
+            stream::iter(&authorized).map(|node| async move {
+                anyhow::ensure!(started.elapsed() < CANDIDATE_QUERY_TIMEOUT,
+                    "candidate query deadline exceeded; retry");
+                anyhow::ensure!(self.ensure_placement_ingested(node).await,
+                    "candidate projection ingestion is pending; retry");
+                Ok::<_, anyhow::Error>(())
+            }).buffer_unordered(CANDIDATE_QUERY_CONCURRENCY)
+                .try_collect::<Vec<_>>().await?;
 
-            let outcomes = scheduling::filter(&candidates, &predicates);
-            let survivors: Vec<&Candidate> = outcomes
-                .iter()
-                .filter(|o| o.passed())
-                .map(|o| o.candidate)
-                .collect();
-
-            // Per-candidate fail-closed authz — async, so it runs as its own pass
-            // rather than inside a (sync) `scheduling::Predicate` closure. A denied
-            // node is silently dropped, never surfaced as an error.
-            let authorized: Vec<&Candidate> = stream::iter(survivors)
-                .map(|c| async move {
-                    let resource = format!("placement:candidate:{}", c.did);
-                    if self.authorize(ctx, &resource, "query").await.is_ok() {
-                        Some(c)
-                    } else {
-                        None
-                    }
-                })
-                .buffer_unordered(CANDIDATE_QUERY_CONCURRENCY)
-                .collect::<Vec<_>>()
-                .await
-                .into_iter()
-                .flatten()
-                .collect();
-            anyhow::ensure!(
-                started.elapsed() < CANDIDATE_QUERY_TIMEOUT,
-                "candidate query deadline exceeded; retry"
-            );
+            // Recheck expiry in one shared-clock snapshot after possibly slow
+            // hydration/authz, rather than issuing an awaited GET for each DID.
+            let mut live: std::collections::HashMap<_, _> = self.state_store.all_liveness(unix_millis_now())
+                .await?.into_iter().collect();
+            let mut candidates = Vec::new();
+            for node in authorized {
+                let did = node.as_str().to_owned();
+                let Some(record_uri) = self.placement_index.record_uri(&did) else { continue };
+                let Some(value) = live.remove(&node) else { continue };
+                let labels = self.placement_index.effective_labels(&did);
+                if !selectors.iter().all(|selector| selector.matches(&labels)) ||
+                    !resources.iter().all(|req| value.allocatable.iter()
+                        .find(|(name, _)| name == &req.name)
+                        .is_some_and(|(_, quantity)| req.satisfied_by(quantity))) {
+                    continue;
+                }
+                candidates.push(Candidate {
+                    did, record_uri, load_fraction: value.load_fraction,
+                    allocatable: value.allocatable, last_seen: value.last_seen,
+                });
+            }
+            let authorized: Vec<_> = candidates.iter().collect();
+            anyhow::ensure!(started.elapsed() < CANDIDATE_QUERY_TIMEOUT,
+                "candidate query deadline exceeded; retry");
 
             // Post-filter, post-authz, pre-bound — so callers can tell truncation
             // apart from "that's really all of them".
@@ -7407,6 +7371,70 @@ mod query_candidates_tests {
 
     #[cfg(all(not(target_arch = "wasm32"), feature = "valkey"))]
     #[tokio::test]
+    async fn valkey_capacity_query_batches_exact_count_and_ranking() {
+        use futures::{stream, StreamExt};
+        use std::sync::atomic::{AtomicUsize, Ordering::SeqCst};
+        struct BatchPolicy(Arc<AtomicUsize>);
+        #[async_trait(?Send)]
+        impl AuthorizationProvider for BatchPolicy {
+            async fn check(&self, _: &str, _: &str, _: &str, _: &str, _: Option<&str>) -> Result<bool> {
+                panic!("capacity query regressed to per-node Policy RPC");
+            }
+            async fn check_batch(&self, _: &str, _: &str, resources: &[String], _: &str, _: Option<&str>) -> Result<Vec<bool>> {
+                assert!(resources.len() <= 256);
+                self.0.fetch_add(1, SeqCst);
+                tokio::time::sleep(Duration::from_millis(10)).await;
+                Ok(resources.iter().map(|r| !r.ends_with("capacity-00001.example")).collect())
+            }
+        }
+        let Ok(url) = std::env::var("HYPRSTREAM_TEST_VALKEY_URL") else { return };
+        let config = crate::DiscoveryStateConfig {
+            backend: crate::DiscoveryStateBackend::Tiered, active_active: true,
+            valkey: crate::ValkeyStateConfig {
+                url, key_prefix: format!("capacity-query-{}-{}", std::process::id(), unix_millis_now()),
+                ..crate::ValkeyStateConfig::default()
+            }, ..crate::DiscoveryStateConfig::default()
+        };
+        let capacity = config.valkey.liveness_capacity;
+        assert_eq!(capacity, 65_536, "exercise advertised capacity without lowering it");
+        let state = DiscoveryState::connect(&config).await.unwrap();
+        let calls = Arc::new(AtomicUsize::new(0));
+        let svc = service_with(Box::new(BatchPolicy(calls.clone())), HashMap::new()).with_state(state);
+        // Warm verified placement projection: signature/admission behavior has
+        // separate real-CAR tests; this fixture isolates full-capacity querying.
+        for i in 0..capacity {
+            let did = format!("did:web:capacity-{i:05}.example");
+            svc.placement_index.seed_warm_node_for_test(did.clone(), crate::placement_index::NodeFacts {
+                record_uri: format!("at://{did}/ai.hyprstream.placement.node/3a"),
+                labels: vec![("zone".to_owned(), if i % 2 == 1 { "west" } else { "east" }.to_owned())],
+                ..Default::default()
+            });
+        }
+        stream::iter(0..capacity).map(|i| {
+            let store = &svc.state_store;
+            async move {
+                let now = unix_millis_now();
+                store.put_liveness(&Did::new(format!("did:web:capacity-{i:05}.example")), LiveAllocatable {
+                    allocatable: vec![("cpu".to_owned(), "8".to_owned())],
+                    load_fraction: 1.0 - i as f32 / capacity as f32,
+                    last_seen: now, live_until_unix_ms: now + 45_000,
+                }).await.unwrap();
+            }
+        }).buffer_unordered(256).collect::<Vec<_>>().await;
+        let mut request = empty_query(1);
+        request.selectors = vec![LabelSelector { key: "zone".to_owned(), op: SelectorOp::In, values: vec!["west".to_owned()] }];
+        request.resources = vec![ResourceRequest { name: "cpu".to_owned(), min_quantity: "4".to_owned() }];
+        let started = Instant::now();
+        let result = as_set(svc.handle_query_candidates(&test_ctx(), 1, &request).await.unwrap());
+        assert!(started.elapsed() < CANDIDATE_QUERY_TIMEOUT);
+        assert_eq!(result.total_matching, (capacity / 2 - 1) as u32);
+        assert_eq!(result.candidates.len(), 1);
+        assert_eq!(result.candidates[0].node, format!("did:web:capacity-{:05}.example", capacity - 1));
+        assert_eq!(calls.load(SeqCst), capacity / 2 / 256, "warm selector filtering precedes Policy RPC");
+    }
+
+    #[cfg(all(not(target_arch = "wasm32"), feature = "valkey"))]
+    #[tokio::test]
     async fn valkey_cold_candidate_query_hydrates_concurrently_without_truncation() {
         let Ok(url) = std::env::var("HYPRSTREAM_TEST_VALKEY_URL") else {
             return;
@@ -7613,11 +7641,13 @@ mod query_candidates_tests {
             0
         );
         // Expiring the shared record excludes it even from populated indexes.
-        replica_a
-            .state_store
-            .all_liveness(unix_millis_now() + LIVENESS_TTL.as_millis() as i64 + 1)
-            .await
-            .unwrap();
+        let now = unix_millis_now();
+        replica_a.state_store.put_liveness(&Did::new(did.to_owned()), LiveAllocatable {
+            allocatable: vec![], load_fraction: 0.1,
+            last_seen: now, live_until_unix_ms: now + 20,
+        }).await.unwrap();
+        // The shared clock cannot be advanced by passing a replica timestamp.
+        tokio::time::sleep(Duration::from_millis(50)).await;
         assert_eq!(
             as_set(
                 replica_b

--- a/crates/hyprstream-discovery/src/service.rs
+++ b/crates/hyprstream-discovery/src/service.rs
@@ -745,6 +745,32 @@ pub struct DiscoveryService {
 }
 
 impl DiscoveryService {
+    /// Populate this replica's verified placement projection for an admitted
+    /// shared live node. Failed/absent repos use the existing bounded retry gate.
+    async fn ensure_placement_ingested(&self, node: &Did) {
+        if self.placement_index.record_uri(node.as_str()).is_none()
+            && self.placement_ingest_attempts.insert_if_absent(
+                node.clone(),
+                (),
+                PLACEMENT_INGEST_RETRY_TTL,
+            )
+        {
+            if let Some(resolver) = &self.record_resolver {
+                if let Err(e) = self
+                    .placement_index
+                    .ingest_did(resolver.as_ref(), node.as_str())
+                    .await
+                {
+                    tracing::warn!(
+                        node = %node,
+                        error = %e,
+                        "placement directory ingestion failed for live node (liveness still recorded)"
+                    );
+                }
+            }
+        }
+    }
+
     /// Create a new discovery service with infrastructure.
     ///
     /// `signing_key` is used for envelope signing (should be the per-service key
@@ -5963,8 +5989,7 @@ impl DiscoveryHandler for DiscoveryService {
                 &data.request_kem_recipient,
             )?;
             anyhow::ensure!(
-                recipient.suite_id
-                    == hyprstream_rpc::crypto::hybrid_kem::SuiteId::HyKemX25519MlKem768
+                recipient.suite_id == hyprstream_rpc::crypto::hybrid_kem::SuiteId::HyKemX25519MlKem768
                     && recipient.eks.len() == recipient.suite_id.components().len(),
                 "identity-bound announcement requires suite-complete hybrid KEM material"
             );
@@ -6055,9 +6080,15 @@ impl DiscoveryHandler for DiscoveryService {
         }
 
         let now_unix_ms = unix_millis_now();
-        let heartbeat_expiry = now_unix_ms
-            .saturating_add(ANNOUNCED_ENDPOINT_TTL.as_millis() as i64);
-        let mut live_until_unix_ms = data.expires_at_unix_ms.min(heartbeat_expiry);
+        let heartbeat_expiry = now_unix_ms.saturating_add(ANNOUNCED_ENDPOINT_TTL.as_millis() as i64);
+        // Legacy clients omit identity expiry (Cap'n Proto defaults it to 0).
+        // Only identity-bound announcements carry a signed expiry constraint.
+        let expires_at_unix_ms = if identity_bound {
+            data.expires_at_unix_ms
+        } else {
+            heartbeat_expiry
+        };
+        let mut live_until_unix_ms = expires_at_unix_ms.min(heartbeat_expiry);
         if identity_bound {
             if let Some(source) = &self.accepted_state_source {
                 let state = source
@@ -6068,8 +6099,7 @@ impl DiscoveryHandler for DiscoveryService {
                         && state.head_digest.as_slice() == data.accepted_state_digest.as_slice(),
                     "announcement does not match accepted-current state"
                 );
-                live_until_unix_ms =
-                    live_until_unix_ms.min(accepted_expiry_unix_ms(&state)?);
+                live_until_unix_ms = live_until_unix_ms.min(accepted_expiry_unix_ms(&state)?);
             }
         }
         anyhow::ensure!(
@@ -6088,7 +6118,7 @@ impl DiscoveryHandler for DiscoveryService {
             response_key_id: data.response_key_id.clone(),
             request_kem_key_id: data.request_kem_key_id.clone(),
             request_kem_recipient: data.request_kem_recipient.clone(),
-            expires_at_unix_ms: data.expires_at_unix_ms,
+            expires_at_unix_ms,
             source_signer: ctx.cnf,
             live_until_unix_ms,
         };
@@ -6434,11 +6464,7 @@ impl DiscoveryHandler for DiscoveryService {
             .selectors
             .iter()
             .map(|s| {
-                scheduling::LabelSelector::new(
-                    s.key.clone(),
-                    to_scheduling_op(s.op),
-                    s.values.clone(),
-                )
+                scheduling::LabelSelector::new(s.key.clone(), to_scheduling_op(s.op), s.values.clone())
             })
             .collect();
         let resources: Vec<scheduling::ResourceRequest> = data
@@ -6450,23 +6476,36 @@ impl DiscoveryHandler for DiscoveryService {
         // Hard liveness exclusion (decision #1): only nodes with a live,
         // unexpired `reportNodeLiveness` entry become candidates at all.
         let mut candidates: Vec<Candidate> = Vec::new();
-        for did in self.placement_index.known_node_dids() {
-            if let Some(live) = self
-                .state_store
-                .liveness(&Did::new(did.clone()), unix_millis_now())
-                .await?
+        for (node, _) in self.state_store.all_liveness(unix_millis_now()).await? {
+            let did = node.as_str().to_owned();
+            // Authorize before a query can trigger resolver work on this
+            // replica. Liveness is shared, but placement facts still come only
+            // from the verified repository ingestion path.
+            if self
+                .authorize(ctx, &format!("placement:candidate:{did}"), "query")
+                .await
+                .is_err()
             {
-                let labels = self.placement_index.effective_labels(&did);
-                let record_uri = self.placement_index.record_uri(&did).unwrap_or_default();
-                candidates.push(Candidate {
-                    did,
-                    record_uri,
-                    load_fraction: live.load_fraction,
-                    allocatable: live.allocatable,
-                    last_seen: live.last_seen,
-                    labels,
-                });
+                continue;
             }
+            self.ensure_placement_ingested(&node).await;
+            let Some(record_uri) = self.placement_index.record_uri(&did) else {
+                continue;
+            };
+            // Repository ingestion can take time; never return a node whose
+            // heartbeat expired while this replica was loading its facts.
+            let Some(live) = self.state_store.liveness(&node, unix_millis_now()).await? else {
+                continue;
+            };
+            let labels = self.placement_index.effective_labels(&did);
+            candidates.push(Candidate {
+                did,
+                record_uri,
+                load_fraction: live.load_fraction,
+                allocatable: live.allocatable,
+                last_seen: live.last_seen,
+                labels,
+            });
         }
 
         let predicates: Vec<scheduling::Predicate<Candidate>> = vec![
@@ -6624,27 +6663,7 @@ impl DiscoveryHandler for DiscoveryService {
         };
         self.state_store.put_liveness(&data.node, live).await?;
 
-        if self.placement_index.record_uri(&node_did).is_none()
-            && self.placement_ingest_attempts.insert_if_absent(
-                data.node.clone(),
-                (),
-                PLACEMENT_INGEST_RETRY_TTL,
-            )
-        {
-            if let Some(resolver) = &self.record_resolver {
-                if let Err(e) = self
-                    .placement_index
-                    .ingest_did(resolver.as_ref(), &node_did)
-                    .await
-                {
-                    tracing::warn!(
-                        node = %node_did,
-                        error = %e,
-                        "placement directory ingestion failed for heartbeating node (liveness still recorded)"
-                    );
-                }
-            }
-        }
+        self.ensure_placement_ingested(&data.node).await;
 
         Ok(DiscoveryResponseVariant::ReportNodeLivenessResult)
     }
@@ -7224,6 +7243,172 @@ mod query_candidates_tests {
             resp,
             DiscoveryResponseVariant::ReportNodeLivenessResult
         ));
+    }
+
+    async fn assert_cross_replica_candidates(a: DiscoveryState, b: DiscoveryState) {
+        let did = "did:web:shared-node.example";
+        let rec = sample_node_record(did, vec![("zone", "shared")]);
+        let repos = HashMap::from([(did.to_owned(), node_repo_car(did, &rec))]);
+        let replica_a = service_with(Box::new(AllowAll), repos.clone()).with_state(a);
+        let replica_b = service_with(Box::new(AllowAll), repos.clone()).with_state(b.clone());
+        heartbeat(&replica_a, did, vec![("cpu", "8")], 0.25).await;
+        assert!(replica_b.placement_index.known_node_dids().is_empty());
+        let req = QueryCandidatesRequest {
+            selectors: vec![LabelSelector {
+                key: "zone".to_owned(),
+                op: SelectorOp::In,
+                values: vec!["shared".to_owned()],
+            }],
+            resources: vec![ResourceRequest {
+                name: "cpu".to_owned(),
+                min_quantity: "4".to_owned(),
+            }],
+            max_candidates: 0,
+        };
+        let result = as_set(
+            replica_b
+                .handle_query_candidates(&test_ctx(), 1, &req)
+                .await
+                .unwrap(),
+        );
+        assert_eq!(result.total_matching, 1);
+        assert_eq!(result.candidates[0].node, did);
+        assert_eq!(
+            result.candidates[0].record_uri,
+            format!("at://{did}/{}/3a", node::COLLECTION_NSID)
+        );
+        // A restarted replica and a policy-denied replica start without local
+        // placement state too. Only an authorized verified node is surfaced.
+        let restarted = service_with(Box::new(AllowAll), repos.clone()).with_state(b.clone());
+        assert_eq!(
+            as_set(
+                restarted
+                    .handle_query_candidates(&test_ctx(), 1, &req)
+                    .await
+                    .unwrap()
+            )
+            .total_matching,
+            1
+        );
+        let denied = service_with(Box::new(DenyNode(did.to_owned())), repos).with_state(b.clone());
+        assert_eq!(
+            as_set(
+                denied
+                    .handle_query_candidates(&test_ctx(), 1, &empty_query(0))
+                    .await
+                    .unwrap()
+            )
+            .total_matching,
+            0
+        );
+        assert!(denied.placement_index.known_node_dids().is_empty());
+        let missing_repo = service_with(Box::new(AllowAll), HashMap::new()).with_state(b);
+        assert_eq!(
+            as_set(
+                missing_repo
+                    .handle_query_candidates(&test_ctx(), 1, &empty_query(0))
+                    .await
+                    .unwrap()
+            )
+            .total_matching,
+            0
+        );
+        // Expiring the shared record excludes it even from populated indexes.
+        replica_a
+            .state_store
+            .all_liveness(unix_millis_now() + LIVENESS_TTL.as_millis() as i64 + 1)
+            .await
+            .unwrap();
+        assert_eq!(
+            as_set(
+                replica_b
+                    .handle_query_candidates(&test_ctx(), 1, &req)
+                    .await
+                    .unwrap()
+            )
+            .total_matching,
+            0
+        );
+    }
+
+    #[tokio::test]
+    async fn shared_liveness_seeds_replica_without_local_placement() {
+        let state = DiscoveryState::connect(&crate::DiscoveryStateConfig::default())
+            .await
+            .unwrap();
+        assert_cross_replica_candidates(state.clone(), state).await;
+    }
+
+    #[cfg(all(not(target_arch = "wasm32"), feature = "valkey"))]
+    #[tokio::test]
+    async fn valkey_shared_liveness_seeds_other_replica_and_restart() {
+        let Ok(url) = std::env::var("HYPRSTREAM_TEST_VALKEY_URL") else {
+            return;
+        };
+        for backend in [
+            crate::DiscoveryStateBackend::Valkey,
+            crate::DiscoveryStateBackend::Tiered,
+        ] {
+            let config = crate::DiscoveryStateConfig {
+                backend,
+                active_active: true,
+                valkey: crate::ValkeyStateConfig {
+                    url: url.clone(),
+                    key_prefix: format!(
+                        "pr1560-candidates-{}-{}-{backend:?}",
+                        std::process::id(),
+                        unix_millis_now()
+                    ),
+                    pool_size: 2,
+                    ..crate::ValkeyStateConfig::default()
+                },
+                ..crate::DiscoveryStateConfig::default()
+            };
+            let a = DiscoveryState::connect(&config).await.unwrap();
+            let b = DiscoveryState::connect(&config).await.unwrap();
+            assert_cross_replica_candidates(a, b).await;
+        }
+    }
+
+    #[tokio::test]
+    async fn legacy_announcement_without_identity_expiry_uses_heartbeat_ttl() {
+        let svc = service_with(Box::new(AllowAll), HashMap::new());
+        let request = ServiceAnnouncement {
+            service_name: "legacy".to_owned(),
+            socket_kind: "rep".to_owned(),
+            endpoint: "inproc://legacy".to_owned(),
+            service_jwt: None,
+            service_did: Did::new(String::new()),
+            capabilities: vec![],
+            accepted_state_digest: vec![],
+            accepted_state_epoch: 0,
+            response_key_id: String::new(),
+            request_kem_key_id: String::new(),
+            request_kem_recipient: vec![],
+            expires_at_unix_ms: 0,
+        };
+        let now = unix_millis_now();
+        assert!(matches!(
+            svc.handle_announce(&test_ctx(), 1, &request).await.unwrap(),
+            DiscoveryResponseVariant::AnnounceResult
+        ));
+        let entries = svc
+            .state_store
+            .announcements_for("legacy", now)
+            .await
+            .unwrap();
+        assert_eq!(entries.len(), 1);
+        assert!(entries[0].live_until_unix_ms >= now + ANNOUNCED_ENDPOINT_TTL.as_millis() as i64);
+        assert_eq!(entries[0].expires_at_unix_ms, entries[0].live_until_unix_ms);
+        assert!(svc
+            .state_store
+            .announcements_for("legacy", entries[0].live_until_unix_ms)
+            .await
+            .unwrap()
+            .is_empty());
+        let mut bound = request;
+        bound.service_did = Did::new("did:at9p:identity-bound".to_owned());
+        assert!(svc.handle_announce(&test_ctx(), 1, &bound).await.is_err());
     }
 
     /// A denied heartbeat must not create a volatile liveness entry or trigger

--- a/crates/hyprstream-discovery/src/service.rs
+++ b/crates/hyprstream-discovery/src/service.rs
@@ -29,7 +29,8 @@ use crate::placement_index::PlacementIndex;
 use crate::scheduling;
 use crate::state_store::{
     unix_millis_now, AnnouncedEndpoint, CachedEntityStatement, CachedEnvelopeKeyset,
-    DiscoveryState, DiscoveryStateStore, LiveAllocatable, MemoryStateStore,
+    DiscoveryState, DiscoveryStateStore, LiveAllocatable, MemoryStateStore, PutResult,
+    ANNOUNCED_ENDPOINT_TTL,
 };
 
 use anyhow::{Context, Result};
@@ -63,7 +64,6 @@ const LIVENESS_CACHE_REAP_BUDGET: usize = 32;
 const PLACEMENT_INGEST_RETRY_TTL: Duration = Duration::from_secs(300);
 const CANDIDATE_QUERY_CONCURRENCY: usize = 16;
 const CANDIDATE_QUERY_TIMEOUT: Duration = Duration::from_secs(5);
-const ANNOUNCED_ENDPOINT_TTL: Duration = Duration::from_secs(90);
 
 #[derive(Clone, Copy, PartialEq, Eq)]
 enum PlacementIngestStatus {
@@ -1222,8 +1222,9 @@ impl DiscoveryServiceResolver {
 
         let mut candidates = Vec::new();
         for entry in entries {
-            if !entry.is_live_at(unix_millis_now())
-                || entry.service_did.as_str().is_empty()
+            // The backend/remote Discovery already checked the volatile lease
+            // on its receipt clock. Signed/current authority is checked below.
+            if entry.service_did.as_str().is_empty()
                 || entry.accepted_state_digest.len() != 64
             {
                 continue;
@@ -3645,8 +3646,7 @@ impl DiscoveryService {
             .await?;
         let Some(endpoint) = endpoints
             .iter()
-            .filter(|ep| ep.socket_kind == wanted)
-            .find(|ep| ep.is_live_at(unix_millis_now()))
+            .find(|ep| ep.socket_kind == wanted)
         else {
             return Ok(None);
         };
@@ -4384,6 +4384,10 @@ mod resolver_tests {
     }
 
     fn accepted_state(tag: u8) -> (AcceptedAt9pState, SigningKey) {
+        accepted_state_with_expiry(tag, "2099-01-01T00:00:00Z")
+    }
+
+    fn accepted_state_with_expiry(tag: u8, expiry: &str) -> (AcceptedAt9pState, SigningKey) {
         let signing = SigningKey::from_bytes(&[tag; 32]);
         let pq_signing = hyprstream_rpc::node_identity::derive_mesh_mldsa_key(&signing);
         let keys = HybridKeyPair::new(
@@ -4407,7 +4411,7 @@ mod resolver_tests {
             1,
             [1; 64],
             body,
-            "2099-01-01T00:00:00Z".to_owned(),
+            expiry.to_owned(),
             &signing,
             &pq_signing,
         )
@@ -4758,6 +4762,116 @@ mod resolver_tests {
             .await
             .expect("ordinary announcement must resolve");
         assert_eq!(resolved.evidence().accepted_state_digest, state.head_digest);
+    }
+
+    #[cfg(all(not(target_arch = "wasm32"), feature = "valkey"))]
+    #[tokio::test]
+    async fn valkey_announcement_handler_lease_and_result_follow_shared_time() {
+        use crate::state_store::tests::ReplicaClock;
+        let Ok(url) = std::env::var("HYPRSTREAM_TEST_VALKEY_URL") else { return; };
+        for backend in [crate::DiscoveryStateBackend::Valkey, crate::DiscoveryStateBackend::Tiered] {
+            let config = crate::DiscoveryStateConfig {
+                backend, active_active: true,
+                valkey: crate::ValkeyStateConfig {
+                    url: url.clone(),
+                    key_prefix: format!("hs-handler-lease-{}-{}-{backend:?}", std::process::id(), unix_millis_now()),
+                    ..Default::default()
+                },
+                ..Default::default()
+            };
+            let (state, signing) = accepted_state(12);
+            let source = Arc::new(MutableAcceptedState(parking_lot::Mutex::new(Some(state.clone()))));
+            let root = SigningKey::from_bytes(&[0x61; 32]);
+            let service = DiscoveryService::new(Arc::new(root.clone()), root.verifying_key(), TransportConfig::inproc("lease-handler-test"))
+                .with_accepted_state_source(source.clone())
+                .with_state(DiscoveryState::connect(&config).await.unwrap());
+            let claims = hyprstream_rpc::auth::Claims::new("service:model".to_owned(),
+                chrono::Utc::now().timestamp(), chrono::Utc::now().timestamp() + 7_200)
+                .with_cnf_jwk(signing.verifying_key().as_bytes());
+            let pq = hyprstream_rpc::node_identity::derive_mesh_mldsa_key(&signing);
+            let envelope = hyprstream_rpc::SignedEnvelope::new_signed_hybrid(
+                hyprstream_rpc::RequestEnvelope::anonymous(Vec::new()), &signing, &pq);
+            let ctx = EnvelopeContext::from_verified_as_system(&envelope);
+            let kem = hyprstream_rpc::node_identity::derive_mesh_kem_recipient(&signing).unwrap();
+            let now = unix_millis_now();
+            let mut request = ServiceAnnouncement {
+                service_name: "model".to_owned(), socket_kind: "quic".to_owned(),
+                endpoint: "quic://localhost:127.0.0.1:9".to_owned(),
+                service_jwt: Some(hyprstream_rpc::auth::jwt::encode_service_jwt(&claims, &root)),
+                service_did: Did::from(state.did.clone()), capabilities: vec!["hyprstream-rpc/1".to_owned()],
+                accepted_state_digest: state.head_digest.to_vec(), accepted_state_epoch: state.epoch,
+                response_key_id: format!("{}#response-current", state.did),
+                request_kem_key_id: format!("{}#kem-current", state.did),
+                request_kem_recipient: kem.public().encode(), expires_at_unix_ms: now + 7_200_000,
+            };
+            for skew in [3_600_000, -3_600_000] {
+                let _clock = ReplicaClock::at(now + skew);
+                assert!(matches!(service.handle_announce(&ctx, 1, &request).await.unwrap(), DiscoveryResponseVariant::AnnounceResult));
+                let rows = service.state_store.announcements_for("model", now + skew).await.unwrap();
+                assert_eq!(rows.len(), 1, "successful response requires a stored publication");
+                assert!((now + 89_000..=now + 91_000).contains(&rows[0].live_until_unix_ms));
+                assert_eq!(rows[0].expires_at_unix_ms, request.expires_at_unix_ms);
+                assert_eq!(rows[0].request_kem_recipient, request.request_kem_recipient);
+                assert_eq!(rows[0].service_jwt, request.service_jwt.clone().unwrap());
+                // Repeated reads exercise populated L1, not only its first fill.
+                assert!(service.resolve_announced_endpoint("model", SocketKind::Quic).await.unwrap().is_some());
+                assert_eq!(service.state_store.all_announcements(now + skew).await.unwrap().len(), 1);
+                service.production_resolver().unwrap().resolve_service(ServiceQuery::network("model").unwrap()).await.unwrap();
+            }
+            // Legacy publication has no signed expiry, but receives the same
+            // bounded backend lease on both initial publication and refresh.
+            let mut legacy = request.clone();
+            legacy.service_name = "legacy".to_owned();
+            legacy.service_jwt = None;
+            legacy.service_did = Did::default();
+            legacy.capabilities.clear();
+            legacy.accepted_state_digest.clear();
+            legacy.accepted_state_epoch = 0;
+            legacy.response_key_id.clear();
+            legacy.request_kem_key_id.clear();
+            legacy.request_kem_recipient.clear();
+            legacy.expires_at_unix_ms = 0;
+            for skew in [3_600_000, -3_600_000] {
+                let _clock = ReplicaClock::at(now + skew);
+                assert!(matches!(service.handle_announce(&ctx, 1, &legacy).await.unwrap(), DiscoveryResponseVariant::AnnounceResult));
+                let rows = service.state_store.announcements_for("legacy", now + skew).await.unwrap();
+                assert_eq!(rows.len(), 1);
+                assert!((now + 89_000..=now + 91_000).contains(&rows[0].live_until_unix_ms));
+                assert_eq!(rows[0].expires_at_unix_ms, rows[0].live_until_unix_ms);
+            }
+
+            // Signed expiry is still an independent ceiling. A shorter valid
+            // signed deadline with the same epoch is an ignored older write;
+            // the handler must not claim it was published.
+            request.expires_at_unix_ms = now + 20_000;
+            assert!(service.handle_announce(&ctx, 2, &request).await.unwrap_err().to_string().contains("not stored"));
+
+            // Updated signed accepted-state evidence supplies a shorter current-state
+            // ceiling; the backend must not extend it to the receipt TTL.
+            let accepted_limit = (now / 1_000) * 1_000 + 20_000;
+            let accepted_expiry = chrono::DateTime::from_timestamp_millis(accepted_limit).unwrap()
+                .to_rfc3339_opts(chrono::SecondsFormat::Secs, true);
+            let (bounded, _) = accepted_state_with_expiry(12, &accepted_expiry);
+            *source.0.lock() = Some(bounded.clone());
+            request.expires_at_unix_ms = now + 7_200_000;
+            request.accepted_state_digest = bounded.head_digest.to_vec();
+            assert!(matches!(service.handle_announce(&ctx, 3, &request).await.unwrap(), DiscoveryResponseVariant::AnnounceResult));
+            let values = service.state_store.announcements_for("model", now).await.unwrap();
+            assert_eq!(values[0].live_until_unix_ms, accepted_limit);
+
+            // Both signed and accepted expiry reject under a behind clock, and
+            // neither rejection is reported as AnnounceResult.
+            let _clock = ReplicaClock::at(now - 3_600_000);
+            request.expires_at_unix_ms = now - 1;
+            assert!(service.handle_announce(&ctx, 4, &request).await.unwrap_err().to_string().contains("not stored"));
+            let expired_text = chrono::DateTime::from_timestamp_millis(now - 1).unwrap()
+                .to_rfc3339_opts(chrono::SecondsFormat::Secs, true);
+            let (expired, _) = accepted_state_with_expiry(12, &expired_text);
+            *source.0.lock() = Some(expired.clone());
+            request.expires_at_unix_ms = now + 7_200_000;
+            request.accepted_state_digest = expired.head_digest.to_vec();
+            assert!(service.handle_announce(&ctx, 5, &request).await.unwrap_err().to_string().contains("not stored"));
+        }
     }
 
     #[tokio::test]
@@ -5526,14 +5640,18 @@ mod resolver_tests {
     #[tokio::test]
     async fn stale_or_expired_production_evidence_is_rejected() {
         let (resolver, _) = production_fixture(false);
-        mutate_endpoint(&resolver, "model", "quic", |endpoint| {
-            endpoint.live_until_unix_ms = unix_millis_now() - 1;
-        })
-        .await;
-        assert!(resolver
-            .resolve_service(ServiceQuery::network("model").expect("query"))
-            .await
-            .is_err());
+        let expiry = resolver.state_store.announcements_for("model", unix_millis_now())
+            .await.unwrap()[0].live_until_unix_ms;
+        {
+            // Expired writes now correctly leave a prior valid value intact.
+            // Advance this memory backend's clock to expire the real lease
+            // instead of attempting to overwrite it with a rejected write.
+            let _clock = crate::state_store::tests::ReplicaClock::at(expiry);
+            assert!(resolver
+                .resolve_service(ServiceQuery::network("model").expect("query"))
+                .await
+                .is_err());
+        }
 
         let (resolver, source) = production_fixture(false);
         source.0.lock().as_mut().expect("fixture state").expires_at =
@@ -6037,7 +6155,7 @@ impl DiscoveryHandler for DiscoveryService {
                     && data
                         .request_kem_key_id
                         .starts_with(&format!("{}#", data.service_did))
-                    && data.expires_at_unix_ms > unix_millis_now(),
+                    && data.expires_at_unix_ms > 0,
                 "identity-bound announcement metadata is incomplete or expired"
             );
             let recipient = hyprstream_rpc::crypto::hybrid_kem::RecipientPublic::decode(
@@ -6134,16 +6252,15 @@ impl DiscoveryHandler for DiscoveryService {
             );
         }
 
-        let now_unix_ms = unix_millis_now();
-        let heartbeat_expiry = now_unix_ms.saturating_add(ANNOUNCED_ENDPOINT_TTL.as_millis() as i64);
         // Legacy clients omit identity expiry (Cap'n Proto defaults it to 0).
-        // Only identity-bound announcements carry a signed expiry constraint.
+        // Only identity-bound announcements carry a signed expiry constraint;
+        // backend receipt time sets the legacy application expiry and lease.
         let expires_at_unix_ms = if identity_bound {
             data.expires_at_unix_ms
         } else {
-            heartbeat_expiry
+            0
         };
-        let mut live_until_unix_ms = expires_at_unix_ms.min(heartbeat_expiry);
+        let mut live_until_unix_ms = if identity_bound { expires_at_unix_ms } else { i64::MAX };
         if identity_bound {
             if let Some(source) = &self.accepted_state_source {
                 let state = source
@@ -6157,10 +6274,6 @@ impl DiscoveryHandler for DiscoveryService {
                 live_until_unix_ms = live_until_unix_ms.min(accepted_expiry_unix_ms(&state)?);
             }
         }
-        anyhow::ensure!(
-            live_until_unix_ms > now_unix_ms,
-            "announcement effective lifetime is already expired"
-        );
 
         let replacement = AnnouncedEndpoint {
             socket_kind: sock_kind.clone(),
@@ -6177,9 +6290,11 @@ impl DiscoveryHandler for DiscoveryService {
             source_signer: ctx.cnf,
             live_until_unix_ms,
         };
-        self.state_store
+        let stored = self.state_store
             .put_announcement(&svc_name, replacement)
             .await?;
+        anyhow::ensure!(stored == PutResult::Stored,
+            "announcement was not stored: authority expired or publication superseded");
 
         Ok(DiscoveryResponseVariant::AnnounceResult)
     }

--- a/crates/hyprstream-discovery/src/service.rs
+++ b/crates/hyprstream-discovery/src/service.rs
@@ -6212,7 +6212,7 @@ impl DiscoveryHandler for DiscoveryService {
         self.state_store
             .put_entity_statement(&data.issuer, cached)
             .await?;
-        let total = self.state_store.known_issuers().await?.len();
+        let total = self.state_store.known_issuer_count().await?;
 
         info!(
             issuer = %data.issuer,

--- a/crates/hyprstream-discovery/src/service.rs
+++ b/crates/hyprstream-discovery/src/service.rs
@@ -61,7 +61,27 @@ const LIVENESS_CACHE_REAP_BUDGET: usize = 32;
 /// not yet contain a node record. This prevents heartbeat-rate resolver polls
 /// while allowing eventual recovery when a placement record is later published.
 const PLACEMENT_INGEST_RETRY_TTL: Duration = Duration::from_secs(300);
+const CANDIDATE_QUERY_CONCURRENCY: usize = 16;
+const CANDIDATE_QUERY_TIMEOUT: Duration = Duration::from_secs(5);
 const ANNOUNCED_ENDPOINT_TTL: Duration = Duration::from_secs(90);
+
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum PlacementIngestStatus {
+    Pending,
+    Complete,
+    Cancelled,
+}
+
+struct PlacementIngestGuard(Arc<parking_lot::Mutex<PlacementIngestStatus>>);
+
+impl Drop for PlacementIngestGuard {
+    fn drop(&mut self) {
+        let mut status = self.0.lock();
+        if *status == PlacementIngestStatus::Pending {
+            *status = PlacementIngestStatus::Cancelled;
+        }
+    }
+}
 
 /// Default bound applied to `queryCandidates` when the caller passes
 /// `maxCandidates == 0` (unspecified) — keeps an unscoped query from returning
@@ -739,7 +759,7 @@ pub struct DiscoveryService {
     /// Bounded retry gate for first-seen placement repository polls. A DID is
     /// marked before resolver access, so absent/invalid/non-node repos cannot
     /// turn heartbeat frequency into unbounded work.
-    placement_ingest_attempts: TtlCache<Did, ()>,
+    placement_ingest_attempts: TtlCache<Did, Arc<parking_lot::Mutex<PlacementIngestStatus>>>,
     // Infrastructure (for Spawnable)
     transport: TransportConfig,
 }
@@ -747,28 +767,49 @@ pub struct DiscoveryService {
 impl DiscoveryService {
     /// Populate this replica's verified placement projection for an admitted
     /// shared live node. Failed/absent repos use the existing bounded retry gate.
-    async fn ensure_placement_ingested(&self, node: &Did) {
-        if self.placement_index.record_uri(node.as_str()).is_none()
-            && self.placement_ingest_attempts.insert_if_absent(
-                node.clone(),
-                (),
-                PLACEMENT_INGEST_RETRY_TTL,
-            )
-        {
-            if let Some(resolver) = &self.record_resolver {
-                if let Err(e) = self
-                    .placement_index
-                    .ingest_did(resolver.as_ref(), node.as_str())
-                    .await
-                {
-                    tracing::warn!(
-                        node = %node,
-                        error = %e,
-                        "placement directory ingestion failed for live node (liveness still recorded)"
-                    );
+    async fn ensure_placement_ingested(&self, node: &Did) -> bool {
+        if self.placement_index.record_uri(node.as_str()).is_some() {
+            return true;
+        }
+        let attempt = Arc::new(parking_lot::Mutex::new(PlacementIngestStatus::Pending));
+        let attempt = if self.placement_ingest_attempts.insert_if_absent(
+            node.clone(),
+            Arc::clone(&attempt),
+            PLACEMENT_INGEST_RETRY_TTL,
+        ) {
+            attempt
+        } else {
+            let Some(existing) = self.placement_ingest_attempts.get(node) else {
+                return false;
+            };
+            {
+                let mut status = existing.lock();
+                match *status {
+                    PlacementIngestStatus::Complete => return true,
+                    PlacementIngestStatus::Pending => return false,
+                    PlacementIngestStatus::Cancelled => *status = PlacementIngestStatus::Pending,
                 }
             }
+            existing
+        };
+        // A cancelled query must not turn an unfinished ingest into a cached
+        // absence. Its next query can retry; concurrent queries fail closed.
+        let _guard = PlacementIngestGuard(Arc::clone(&attempt));
+        if let Some(resolver) = &self.record_resolver {
+            if let Err(e) = self
+                .placement_index
+                .ingest_did(resolver.as_ref(), node.as_str())
+                .await
+            {
+                tracing::warn!(
+                    node = %node,
+                    error = %e,
+                    "placement directory ingestion failed for live node (liveness still recorded)"
+                );
+            }
         }
+        *attempt.lock() = PlacementIngestStatus::Complete;
+        true
     }
 
     /// Create a new discovery service with infrastructure.
@@ -6451,158 +6492,201 @@ impl DiscoveryHandler for DiscoveryService {
         _request_id: u64,
         data: &QueryCandidatesRequest,
     ) -> Result<DiscoveryResponseVariant> {
-        struct Candidate {
-            did: String,
-            record_uri: String,
-            load_fraction: f32,
-            allocatable: Vec<(String, String)>,
-            last_seen: i64,
-            labels: Vec<(String, String)>,
-        }
+        use futures::{stream, StreamExt, TryStreamExt};
+        let query = async {
+            let started = Instant::now();
+            struct Candidate {
+                did: String,
+                record_uri: String,
+                load_fraction: f32,
+                allocatable: Vec<(String, String)>,
+                last_seen: i64,
+                labels: Vec<(String, String)>,
+            }
 
-        let selectors: Vec<scheduling::LabelSelector> = data
-            .selectors
-            .iter()
-            .map(|s| {
-                scheduling::LabelSelector::new(s.key.clone(), to_scheduling_op(s.op), s.values.clone())
-            })
-            .collect();
-        let resources: Vec<scheduling::ResourceRequest> = data
-            .resources
-            .iter()
-            .map(|r| scheduling::ResourceRequest::new(r.name.clone(), r.min_quantity.clone()))
-            .collect();
+            let selectors: Vec<scheduling::LabelSelector> = data
+                .selectors
+                .iter()
+                .map(|s| {
+                    scheduling::LabelSelector::new(
+                        s.key.clone(),
+                        to_scheduling_op(s.op),
+                        s.values.clone(),
+                    )
+                })
+                .collect();
+            let resources: Vec<scheduling::ResourceRequest> = data
+                .resources
+                .iter()
+                .map(|r| scheduling::ResourceRequest::new(r.name.clone(), r.min_quantity.clone()))
+                .collect();
 
-        // Hard liveness exclusion (decision #1): only nodes with a live,
-        // unexpired `reportNodeLiveness` entry become candidates at all.
-        let mut candidates: Vec<Candidate> = Vec::new();
-        for (node, _) in self.state_store.all_liveness(unix_millis_now()).await? {
-            let did = node.as_str().to_owned();
-            // Authorize before a query can trigger resolver work on this
-            // replica. Liveness is shared, but placement facts still come only
-            // from the verified repository ingestion path.
-            if self
-                .authorize(ctx, &format!("placement:candidate:{did}"), "query")
+            // Hard liveness exclusion (decision #1): only nodes with a live,
+            // unexpired `reportNodeLiveness` entry become candidates at all.
+            let live_nodes = self.state_store.all_liveness(unix_millis_now()).await?;
+            let candidates: Vec<Candidate> = stream::iter(live_nodes)
+                .map(|(node, _)| async move {
+                    anyhow::ensure!(
+                        started.elapsed() < CANDIDATE_QUERY_TIMEOUT,
+                        "candidate query deadline exceeded; retry"
+                    );
+                    let did = node.as_str().to_owned();
+                    // Authorize before a query can trigger resolver work on this
+                    // replica. Liveness is shared, but placement facts still come only
+                    // from the verified repository ingestion path.
+                    if self
+                        .authorize(ctx, &format!("placement:candidate:{did}"), "query")
+                        .await
+                        .is_err()
+                    {
+                        return Ok(None);
+                    }
+                    anyhow::ensure!(
+                        self.ensure_placement_ingested(&node).await,
+                        "candidate projection ingestion is pending; retry"
+                    );
+                    let Some(record_uri) = self.placement_index.record_uri(&did) else {
+                        return Ok(None);
+                    };
+                    // Repository ingestion can take time; never return a node whose
+                    // heartbeat expired while this replica was loading its facts.
+                    let Some(live) = self.state_store.liveness(&node, unix_millis_now()).await?
+                    else {
+                        return Ok(None);
+                    };
+                    let labels = self.placement_index.effective_labels(&did);
+                    Ok::<_, anyhow::Error>(Some(Candidate {
+                        did,
+                        record_uri,
+                        load_fraction: live.load_fraction,
+                        allocatable: live.allocatable,
+                        last_seen: live.last_seen,
+                        labels,
+                    }))
+                })
+                .buffer_unordered(CANDIDATE_QUERY_CONCURRENCY)
+                .try_collect::<Vec<_>>()
+                .await?
+                .into_iter()
+                .flatten()
+                .collect();
+
+            let predicates: Vec<scheduling::Predicate<Candidate>> = vec![
+                Box::new({
+                    let selectors = selectors.clone();
+                    move |c: &Candidate| {
+                        for sel in &selectors {
+                            if !sel.matches(&c.labels) {
+                                return Some(scheduling::RejectionReason(format!(
+                                    "label selector on {:?} did not match",
+                                    sel.key
+                                )));
+                            }
+                        }
+                        None
+                    }
+                }),
+                Box::new({
+                    let resources = resources.clone();
+                    move |c: &Candidate| {
+                        for req in &resources {
+                            let satisfied = c
+                                .allocatable
+                                .iter()
+                                .find(|(name, _)| name == &req.name)
+                                .is_some_and(|(_, quantity)| req.satisfied_by(quantity));
+                            if !satisfied {
+                                return Some(scheduling::RejectionReason(format!(
+                                    "resource {:?} not satisfied",
+                                    req.name
+                                )));
+                            }
+                        }
+                        None
+                    }
+                }),
+            ];
+
+            let outcomes = scheduling::filter(&candidates, &predicates);
+            let survivors: Vec<&Candidate> = outcomes
+                .iter()
+                .filter(|o| o.passed())
+                .map(|o| o.candidate)
+                .collect();
+
+            // Per-candidate fail-closed authz — async, so it runs as its own pass
+            // rather than inside a (sync) `scheduling::Predicate` closure. A denied
+            // node is silently dropped, never surfaced as an error.
+            let authorized: Vec<&Candidate> = stream::iter(survivors)
+                .map(|c| async move {
+                    let resource = format!("placement:candidate:{}", c.did);
+                    if self.authorize(ctx, &resource, "query").await.is_ok() {
+                        Some(c)
+                    } else {
+                        None
+                    }
+                })
+                .buffer_unordered(CANDIDATE_QUERY_CONCURRENCY)
+                .collect::<Vec<_>>()
                 .await
-                .is_err()
-            {
-                continue;
-            }
-            self.ensure_placement_ingested(&node).await;
-            let Some(record_uri) = self.placement_index.record_uri(&did) else {
-                continue;
-            };
-            // Repository ingestion can take time; never return a node whose
-            // heartbeat expired while this replica was loading its facts.
-            let Some(live) = self.state_store.liveness(&node, unix_millis_now()).await? else {
-                continue;
-            };
-            let labels = self.placement_index.effective_labels(&did);
-            candidates.push(Candidate {
-                did,
-                record_uri,
-                load_fraction: live.load_fraction,
-                allocatable: live.allocatable,
-                last_seen: live.last_seen,
-                labels,
+                .into_iter()
+                .flatten()
+                .collect();
+            anyhow::ensure!(
+                started.elapsed() < CANDIDATE_QUERY_TIMEOUT,
+                "candidate query deadline exceeded; retry"
+            );
+
+            // Post-filter, post-authz, pre-bound — so callers can tell truncation
+            // apart from "that's really all of them".
+            let total_matching = authorized.len() as u32;
+
+            let ranked = scheduling::rank(authorized, |a, b| {
+                a.load_fraction
+                    .partial_cmp(&b.load_fraction)
+                    .unwrap_or(std::cmp::Ordering::Equal)
+                    .then_with(|| a.did.cmp(&b.did))
             });
-        }
 
-        let predicates: Vec<scheduling::Predicate<Candidate>> = vec![
-            Box::new({
-                let selectors = selectors.clone();
-                move |c: &Candidate| {
-                    for sel in &selectors {
-                        if !sel.matches(&c.labels) {
-                            return Some(scheduling::RejectionReason(format!(
-                                "label selector on {:?} did not match",
-                                sel.key
-                            )));
-                        }
-                    }
-                    None
-                }
-            }),
-            Box::new({
-                let resources = resources.clone();
-                move |c: &Candidate| {
-                    for req in &resources {
-                        let satisfied = c
-                            .allocatable
-                            .iter()
-                            .find(|(name, _)| name == &req.name)
-                            .is_some_and(|(_, quantity)| req.satisfied_by(quantity));
-                        if !satisfied {
-                            return Some(scheduling::RejectionReason(format!(
-                                "resource {:?} not satisfied",
-                                req.name
-                            )));
-                        }
-                    }
-                    None
-                }
-            }),
-        ];
+            let max = if data.max_candidates == 0 {
+                DEFAULT_MAX_CANDIDATES
+            } else {
+                data.max_candidates as usize
+            };
+            let candidates_out: Vec<PlacementCandidate> = ranked
+                .into_iter()
+                .take(max)
+                .map(|c| PlacementCandidate {
+                    node: c.did.clone(),
+                    record_uri: c.record_uri.clone(),
+                    load_fraction: c.load_fraction,
+                    allocatable: c
+                        .allocatable
+                        .iter()
+                        .map(|(name, quantity)| Resource {
+                            name: name.clone(),
+                            quantity: quantity.clone(),
+                        })
+                        .collect(),
+                    last_seen: c.last_seen,
+                })
+                .collect();
 
-        let outcomes = scheduling::filter(&candidates, &predicates);
-        let survivors: Vec<&Candidate> = outcomes
-            .iter()
-            .filter(|o| o.passed())
-            .map(|o| o.candidate)
-            .collect();
-
-        // Per-candidate fail-closed authz — async, so it runs as its own pass
-        // rather than inside a (sync) `scheduling::Predicate` closure. A denied
-        // node is silently dropped, never surfaced as an error.
-        let mut authorized: Vec<&Candidate> = Vec::with_capacity(survivors.len());
-        for c in survivors {
-            let resource = format!("placement:candidate:{}", c.did);
-            if self.authorize(ctx, &resource, "query").await.is_ok() {
-                authorized.push(c);
-            }
-        }
-
-        // Post-filter, post-authz, pre-bound — so callers can tell truncation
-        // apart from "that's really all of them".
-        let total_matching = authorized.len() as u32;
-
-        let ranked = scheduling::rank(authorized, |a, b| {
-            a.load_fraction
-                .partial_cmp(&b.load_fraction)
-                .unwrap_or(std::cmp::Ordering::Equal)
-                .then_with(|| a.did.cmp(&b.did))
-        });
-
-        let max = if data.max_candidates == 0 {
-            DEFAULT_MAX_CANDIDATES
-        } else {
-            data.max_candidates as usize
+            Ok(DiscoveryResponseVariant::QueryCandidatesResult(
+                PlacementCandidateSet {
+                    candidates: candidates_out,
+                    total_matching,
+                },
+            ))
         };
-        let candidates_out: Vec<PlacementCandidate> = ranked
-            .into_iter()
-            .take(max)
-            .map(|c| PlacementCandidate {
-                node: c.did.clone(),
-                record_uri: c.record_uri.clone(),
-                load_fraction: c.load_fraction,
-                allocatable: c
-                    .allocatable
-                    .iter()
-                    .map(|(name, quantity)| Resource {
-                        name: name.clone(),
-                        quantity: quantity.clone(),
-                    })
-                    .collect(),
-                last_seen: c.last_seen,
-            })
-            .collect();
-
-        Ok(DiscoveryResponseVariant::QueryCandidatesResult(
-            PlacementCandidateSet {
-                candidates: candidates_out,
-                total_matching,
-            },
-        ))
+        #[cfg(not(target_arch = "wasm32"))]
+        {
+            tokio::time::timeout(CANDIDATE_QUERY_TIMEOUT, query)
+                .await
+                .map_err(|_| anyhow::anyhow!("candidate query deadline exceeded; retry"))?
+        }
+        #[cfg(target_arch = "wasm32")]
+        query.await
     }
 
     /// #524 P1 — node liveness heartbeat. The auto-generated dispatch gate
@@ -6646,6 +6730,7 @@ impl DiscoveryHandler for DiscoveryService {
             }));
         }
 
+        let received_at = unix_millis_now();
         let live = LiveAllocatable {
             allocatable: data
                 .allocatable
@@ -6653,13 +6738,10 @@ impl DiscoveryHandler for DiscoveryService {
                 .map(|r| (r.name.clone(), r.quantity.clone()))
                 .collect(),
             load_fraction: data.load_fraction,
-            last_seen: if data.ts != 0 {
-                data.ts
-            } else {
-                unix_millis_now()
-            },
-            live_until_unix_ms: unix_millis_now()
-                .saturating_add(LIVENESS_TTL.as_millis() as i64),
+            // Client clocks can move backwards or be arbitrarily future
+            // skewed. Freshness and ordering describe this admitted receipt.
+            last_seen: received_at,
+            live_until_unix_ms: received_at.saturating_add(LIVENESS_TTL.as_millis() as i64),
         };
         self.state_store.put_liveness(&data.node, live).await?;
 
@@ -7211,6 +7293,223 @@ mod query_candidates_tests {
         )
         .with_auth_provider(auth)
         .with_record_resolver(Arc::new(FixedRepoResolver { repos }))
+    }
+
+    struct ConcurrentRepoResolver {
+        inner: FixedRepoResolver,
+        barrier: Option<tokio::sync::Barrier>,
+        stall: std::sync::atomic::AtomicBool,
+        active: std::sync::atomic::AtomicUsize,
+        peak: std::sync::atomic::AtomicUsize,
+        resolved: parking_lot::Mutex<Vec<String>>,
+    }
+
+    struct ActiveResolution<'a>(&'a std::sync::atomic::AtomicUsize);
+    impl Drop for ActiveResolution<'_> {
+        fn drop(&mut self) {
+            self.0.fetch_sub(1, std::sync::atomic::Ordering::SeqCst);
+        }
+    }
+
+    #[async_trait(?Send)]
+    impl RecordResolver for ConcurrentRepoResolver {
+        async fn resolve_record(
+            &self,
+            _did: &str,
+            _collection: &str,
+            _rkey: &str,
+        ) -> Result<Option<RecordCarData>> {
+            Ok(None)
+        }
+        async fn resolve_repo(&self, did: &str) -> Result<Option<RecordCarData>> {
+            use std::sync::atomic::Ordering::SeqCst;
+            self.resolved.lock().push(did.to_owned());
+            let active = self.active.fetch_add(1, SeqCst) + 1;
+            let _guard = ActiveResolution(&self.active);
+            self.peak.fetch_max(active, SeqCst);
+            if self.stall.load(SeqCst) {
+                futures::future::pending::<()>().await;
+            }
+            if let Some(barrier) = &self.barrier {
+                barrier.wait().await;
+            }
+            self.inner.resolve_repo(did).await
+        }
+        async fn resolve_verifying_key(&self, did: &str) -> Result<Option<P256VerifyingKey>> {
+            self.inner.resolve_verifying_key(did).await
+        }
+    }
+
+    async fn assert_cold_query_concurrency(state: DiscoveryState) {
+        use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering::SeqCst};
+        let mut repos = HashMap::new();
+        let now = unix_millis_now();
+        for i in 0..33 {
+            let did = format!("did:web:cold-{i}.example");
+            repos.insert(
+                did.clone(),
+                node_repo_car(&did, &sample_node_record(&did, vec![])),
+            );
+            state
+                .clone()
+                .into_inner()
+                .put_liveness(
+                    &Did::new(did),
+                    LiveAllocatable {
+                        allocatable: vec![],
+                        load_fraction: 0.1,
+                        last_seen: now,
+                        live_until_unix_ms: now + 45_000,
+                    },
+                )
+                .await
+                .unwrap();
+        }
+        let resolver = Arc::new(ConcurrentRepoResolver {
+            inner: FixedRepoResolver { repos },
+            // A sequential implementation cannot complete even one batch.
+            barrier: Some(tokio::sync::Barrier::new(CANDIDATE_QUERY_CONCURRENCY)),
+            stall: AtomicBool::new(false),
+            active: AtomicUsize::new(0),
+            peak: AtomicUsize::new(0),
+            resolved: parking_lot::Mutex::new(vec![]),
+        });
+        let denied = "did:web:cold-32.example";
+        let svc = service_with(Box::new(DenyNode(denied.to_owned())), HashMap::new())
+            .with_record_resolver(resolver.clone())
+            .with_state(state);
+        let result = tokio::time::timeout(
+            Duration::from_secs(4),
+            svc.handle_query_candidates(&test_ctx(), 1, &empty_query(1)),
+        )
+        .await
+        .unwrap()
+        .unwrap();
+        let result = as_set(result);
+        assert_eq!(
+            result.total_matching, 32,
+            "maxCandidates must not hide incomplete hydration"
+        );
+        assert_eq!(result.candidates.len(), 1);
+        assert_eq!(resolver.peak.load(SeqCst), CANDIDATE_QUERY_CONCURRENCY);
+        assert_eq!(resolver.active.load(SeqCst), 0);
+        assert_eq!(resolver.resolved.lock().len(), 32);
+        assert!(!resolver.resolved.lock().iter().any(|did| did == denied));
+    }
+
+    #[tokio::test]
+    async fn cold_candidate_query_hydrates_concurrently_without_truncation() {
+        let state = DiscoveryState::connect(&crate::DiscoveryStateConfig::default())
+            .await
+            .unwrap();
+        assert_cold_query_concurrency(state).await;
+    }
+
+    #[cfg(all(not(target_arch = "wasm32"), feature = "valkey"))]
+    #[tokio::test]
+    async fn valkey_cold_candidate_query_hydrates_concurrently_without_truncation() {
+        let Ok(url) = std::env::var("HYPRSTREAM_TEST_VALKEY_URL") else {
+            return;
+        };
+        let config = crate::DiscoveryStateConfig {
+            backend: crate::DiscoveryStateBackend::Tiered,
+            active_active: true,
+            valkey: crate::ValkeyStateConfig {
+                url,
+                key_prefix: format!("cold-query-{}-{}", std::process::id(), unix_millis_now()),
+                ..crate::ValkeyStateConfig::default()
+            },
+            ..crate::DiscoveryStateConfig::default()
+        };
+        assert_cold_query_concurrency(DiscoveryState::connect(&config).await.unwrap()).await;
+    }
+
+    #[tokio::test]
+    async fn cold_candidate_deadline_cancels_ingest_and_retry_is_complete() {
+        use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering::SeqCst};
+        let did = "did:web:stalled.example";
+        let resolver = Arc::new(ConcurrentRepoResolver {
+            inner: FixedRepoResolver {
+                repos: HashMap::from([(
+                    did.to_owned(),
+                    node_repo_car(did, &sample_node_record(did, vec![])),
+                )]),
+            },
+            barrier: None,
+            stall: AtomicBool::new(true),
+            active: AtomicUsize::new(0),
+            peak: AtomicUsize::new(0),
+            resolved: parking_lot::Mutex::new(vec![]),
+        });
+        let svc =
+            service_with(Box::new(AllowAll), HashMap::new()).with_record_resolver(resolver.clone());
+        let now = unix_millis_now();
+        svc.state_store
+            .put_liveness(
+                &Did::new(did.to_owned()),
+                LiveAllocatable {
+                    allocatable: vec![],
+                    load_fraction: 0.1,
+                    last_seen: now,
+                    live_until_unix_ms: now + 45_000,
+                },
+            )
+            .await
+            .unwrap();
+        let error = tokio::time::timeout(
+            CANDIDATE_QUERY_TIMEOUT + Duration::from_secs(2),
+            svc.handle_query_candidates(&test_ctx(), 1, &empty_query(1)),
+        )
+        .await
+        .unwrap()
+        .err()
+        .unwrap();
+        assert!(error.to_string().contains("deadline exceeded"));
+        assert_eq!(
+            resolver.active.load(SeqCst),
+            0,
+            "deadline must drop outstanding repository work"
+        );
+        resolver.stall.store(false, SeqCst);
+        let result = as_set(
+            svc.handle_query_candidates(&test_ctx(), 1, &empty_query(1))
+                .await
+                .unwrap(),
+        );
+        assert_eq!(
+            result.total_matching, 1,
+            "cancelled ingest must not be cached as absence"
+        );
+        assert_eq!(resolver.resolved.lock().len(), 2);
+    }
+
+    #[tokio::test]
+    async fn heartbeat_uses_receipt_time_after_client_clock_rollback() {
+        let svc = service_with(Box::new(AllowAll), HashMap::new());
+        let node = Did::new("did:web:rollback.example".to_owned());
+        let start = unix_millis_now();
+        for ts in [start + 86_400_000, start - 86_400_000] {
+            let req = NodeLiveness {
+                node: node.clone(),
+                allocatable: vec![],
+                load_fraction: 0.2,
+                ts,
+            };
+            svc.handle_report_node_liveness(&test_ctx(), 1, &req)
+                .await
+                .unwrap();
+            let value = svc
+                .state_store
+                .liveness(&node, unix_millis_now())
+                .await
+                .unwrap()
+                .unwrap();
+            assert!(value.last_seen >= start && value.last_seen <= unix_millis_now());
+            assert_eq!(
+                value.live_until_unix_ms,
+                value.last_seen + LIVENESS_TTL.as_millis() as i64
+            );
+        }
     }
 
     fn test_ctx() -> EnvelopeContext {

--- a/crates/hyprstream-discovery/src/service.rs
+++ b/crates/hyprstream-discovery/src/service.rs
@@ -3628,6 +3628,132 @@ pub mod test_fixtures {
         request_kem_recipient: hyprstream_rpc::crypto::hybrid_kem::RecipientPublic,
     }
 
+    /// Multi-endpoint announcement backend for the fixture. The production
+    /// [`MemoryStateStore`] deliberately keeps one live announcement per
+    /// (service, socket kind) — the single-replica lease model — while
+    /// production retry sets with several same-authority reaches are served
+    /// from the remote Discovery `get_endpoints` fan-out. A resolver fixture
+    /// runs client-less, so it needs a backend that keeps every announced
+    /// endpoint to express those sets.
+    #[derive(Default)]
+    struct FixtureAnnouncementStore {
+        services: parking_lot::Mutex<HashMap<String, Vec<AnnouncedEndpoint>>>,
+    }
+
+    impl FixtureAnnouncementStore {
+        fn put_announcement_sync(&self, service_name: &str, endpoint: AnnouncedEndpoint) {
+            let mut services = self.services.lock();
+            let endpoints = services.entry(service_name.to_owned()).or_default();
+            endpoints.retain(|existing| existing.endpoint != endpoint.endpoint);
+            endpoints.push(endpoint);
+        }
+
+        fn announcements_for_sync(&self, service_name: &str, now_unix_ms: i64) -> Vec<AnnouncedEndpoint> {
+            self.services
+                .lock()
+                .get(service_name)
+                .into_iter()
+                .flatten()
+                .filter(|entry| entry.is_live_at(now_unix_ms))
+                .cloned()
+                .collect()
+        }
+
+        fn clear_announcements_sync(&self, service_name: &str) {
+            self.services.lock().remove(service_name);
+        }
+    }
+
+    #[cfg_attr(not(target_arch = "wasm32"), async_trait)]
+    #[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+    impl DiscoveryStateStore for FixtureAnnouncementStore {
+        async fn put_announcement(
+            &self,
+            service_name: &str,
+            endpoint: AnnouncedEndpoint,
+        ) -> Result<PutResult> {
+            self.put_announcement_sync(service_name, endpoint);
+            Ok(PutResult::Stored)
+        }
+
+        async fn announcements_for(
+            &self,
+            service_name: &str,
+            now_unix_ms: i64,
+        ) -> Result<Vec<AnnouncedEndpoint>> {
+            Ok(self.announcements_for_sync(service_name, now_unix_ms))
+        }
+
+        async fn all_announcements(
+            &self,
+            now_unix_ms: i64,
+        ) -> Result<Vec<(String, Vec<AnnouncedEndpoint>)>> {
+            Ok(self
+                .services
+                .lock()
+                .iter()
+                .map(|(service_name, endpoints)| {
+                    (
+                        service_name.clone(),
+                        endpoints
+                            .iter()
+                            .filter(|entry| entry.is_live_at(now_unix_ms))
+                            .cloned()
+                            .collect(),
+                    )
+                })
+                .collect())
+        }
+
+        // The resolver fixture exercises only the announcement plane; the
+        // remaining store surface belongs to the Discovery daemon backends and
+        // fails closed here rather than pretending to track it.
+        async fn put_liveness(&self, _node: &Did, _value: LiveAllocatable) -> Result<PutResult> {
+            anyhow::bail!("fixture announcement store does not track liveness")
+        }
+
+        #[cfg(test)]
+        async fn liveness(&self, _node: &Did, _now_unix_ms: i64) -> Result<Option<LiveAllocatable>> {
+            anyhow::bail!("fixture announcement store does not track liveness")
+        }
+
+        async fn all_liveness(&self, _now_unix_ms: i64) -> Result<Vec<(Did, LiveAllocatable)>> {
+            anyhow::bail!("fixture announcement store does not track liveness")
+        }
+
+        async fn put_entity_statement(
+            &self,
+            _issuer: &str,
+            _value: CachedEntityStatement,
+        ) -> Result<()> {
+            anyhow::bail!("fixture announcement store does not track entity statements")
+        }
+
+        async fn entity_statement(&self, _issuer: &str) -> Result<Option<CachedEntityStatement>> {
+            anyhow::bail!("fixture announcement store does not track entity statements")
+        }
+
+        async fn known_issuers(&self) -> Result<Vec<String>> {
+            anyhow::bail!("fixture announcement store does not track entity statements")
+        }
+
+        async fn known_issuer_count(&self) -> Result<usize> {
+            anyhow::bail!("fixture announcement store does not track entity statements")
+        }
+
+        async fn put_envelope_keyset(
+            &self,
+            _service_did: &str,
+            _value: CachedEnvelopeKeyset,
+        ) -> Result<()> {
+            anyhow::bail!("fixture announcement store does not track envelope keysets")
+        }
+
+        async fn envelope_keyset(&self, _service_did: &str) -> Result<Option<CachedEnvelopeKeyset>> {
+            anyhow::bail!("fixture announcement store does not track envelope keysets")
+        }
+    }
+
     /// Mutable handle for one process-global, model-free production resolver
     /// fixture. The resolver and dial hook are installed once; individual tests
     /// reset only the accepted-state and announcement data behind that fixed
@@ -3635,7 +3761,7 @@ pub mod test_fixtures {
     #[derive(Clone)]
     pub struct ProductionInferenceFixture {
         service_name: String,
-        announced: Arc<MemoryStateStore>,
+        announced: Arc<FixtureAnnouncementStore>,
         states: Arc<FixtureAcceptedStates>,
         primary: FixtureAuthority,
         foreign: FixtureAuthority,
@@ -3726,7 +3852,7 @@ pub mod test_fixtures {
                 self.announced.put_announcement_sync(
                     &self.service_name,
                     announcement(&self.primary, transport, Instant::now())?,
-                )?;
+                );
             }
             Ok(())
         }
@@ -3738,8 +3864,7 @@ pub mod test_fixtures {
                 .announcements_for_sync(&self.service_name, unix_millis_now())
             {
                 endpoint.live_until_unix_ms = unix_millis_now() - 1;
-                let _ = self
-                    .announced
+                self.announced
                     .put_announcement_sync(&self.service_name, endpoint);
             }
         }
@@ -3753,7 +3878,7 @@ pub mod test_fixtures {
             self.announced.put_announcement_sync(
                 &self.service_name,
                 announcement(&self.foreign, transport, Instant::now())?,
-            )?;
+            );
             Ok(())
         }
     }
@@ -3774,7 +3899,7 @@ pub mod test_fixtures {
         let states = Arc::new(FixtureAcceptedStates(parking_lot::Mutex::new(
             HashMap::new(),
         )));
-        let announced = Arc::new(MemoryStateStore::default());
+        let announced = Arc::new(FixtureAnnouncementStore::default());
         let fixture = ProductionInferenceFixture {
             service_name: service_name.to_owned(),
             announced: Arc::clone(&announced),

--- a/crates/hyprstream-discovery/src/state_store.rs
+++ b/crates/hyprstream-discovery/src/state_store.rs
@@ -1,0 +1,1775 @@
+//! Volatile Discovery state behind a backend-neutral contract.
+//!
+//! The values in this store are never identity or policy authority. Callers
+//! validate signed artifacts before writes and re-check accepted-current state
+//! before use. The shared backend only makes short-lived reach and liveness
+//! observations coherent across Discovery replicas.
+
+use anyhow::{bail, Result};
+use async_trait::async_trait;
+use hyprstream_rpc::identity::Did;
+use parking_lot::Mutex;
+use serde::{Deserialize, Serialize};
+use std::cmp::Reverse;
+use std::collections::{BTreeSet, BinaryHeap, HashMap};
+use std::sync::Arc;
+
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum DiscoveryStateBackend {
+    #[default]
+    Memory,
+    Valkey,
+    Tiered,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(default)]
+pub struct MemoryStateConfig {
+    pub announcement_capacity: usize,
+    pub liveness_capacity: usize,
+    pub artifact_capacity: usize,
+}
+
+impl Default for MemoryStateConfig {
+    fn default() -> Self {
+        Self {
+            announcement_capacity: 16_384,
+            liveness_capacity: 16_384,
+            artifact_capacity: 4_096,
+        }
+    }
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(default)]
+pub struct ValkeyStateConfig {
+    pub url: String,
+    pub key_prefix: String,
+    pub pool_size: usize,
+    pub announcement_capacity: usize,
+    pub liveness_capacity: usize,
+    pub artifact_capacity: usize,
+    /// Upper bound for a shared-state command. Required-HA callers receive an
+    /// error after this interval instead of waiting indefinitely or serving L1.
+    pub command_timeout_ms: u64,
+}
+
+impl Default for ValkeyStateConfig {
+    fn default() -> Self {
+        Self {
+            url: "redis://127.0.0.1:6379".to_owned(),
+            key_prefix: "hs".to_owned(),
+            pool_size: 8,
+            announcement_capacity: 65_536,
+            liveness_capacity: 65_536,
+            artifact_capacity: 16_384,
+            command_timeout_ms: 2_000,
+        }
+    }
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(default)]
+pub struct TieredStateConfig {
+    /// Maximum time an L1 value may be reused after its L2 revision was
+    /// observed. Every L1 hit still verifies the cheap L2 revision key.
+    pub l1_max_ttl_ms: u64,
+}
+
+impl Default for TieredStateConfig {
+    fn default() -> Self {
+        Self {
+            l1_max_ttl_ms: 1_000,
+        }
+    }
+}
+
+#[derive(Clone, Debug, Default, Serialize, Deserialize)]
+#[serde(default)]
+pub struct DiscoveryStateConfig {
+    pub backend: DiscoveryStateBackend,
+    /// Declares that more than one active Discovery replica may serve calls.
+    /// Such a deployment must select a shared backend.
+    pub active_active: bool,
+    pub memory: MemoryStateConfig,
+    pub valkey: ValkeyStateConfig,
+    pub tiered: TieredStateConfig,
+}
+
+/// Constructed backend handle accepted by [`crate::DiscoveryService`].
+#[derive(Clone)]
+pub struct DiscoveryState(Arc<dyn DiscoveryStateStore>);
+
+impl DiscoveryState {
+    pub async fn connect(config: &DiscoveryStateConfig) -> Result<Self> {
+        anyhow::ensure!(
+            config.memory.announcement_capacity > 0
+                && config.memory.liveness_capacity > 0
+                && config.memory.artifact_capacity > 0,
+            "Discovery memory capacities must be positive"
+        );
+        if config.active_active && config.backend == DiscoveryStateBackend::Memory {
+            bail!("discovery.state.active_active requires valkey or tiered backend");
+        }
+        if config.backend == DiscoveryStateBackend::Tiered {
+            anyhow::ensure!(
+                config.tiered.l1_max_ttl_ms > 0,
+                "Discovery tiered l1_max_ttl_ms must be positive"
+            );
+        }
+        let memory = || {
+            Arc::new(MemoryStateStore::new(
+                config.memory.announcement_capacity,
+                config.memory.liveness_capacity,
+                config.memory.artifact_capacity,
+            ))
+        };
+
+        match config.backend {
+            DiscoveryStateBackend::Memory => Ok(Self(memory())),
+            DiscoveryStateBackend::Valkey | DiscoveryStateBackend::Tiered => {
+                #[cfg(target_arch = "wasm32")]
+                {
+                    bail!("Valkey-backed Discovery state is unavailable on wasm32")
+                }
+                #[cfg(all(not(target_arch = "wasm32"), not(feature = "valkey")))]
+                {
+                    bail!("Valkey-backed Discovery state requires the valkey feature")
+                }
+                #[cfg(all(not(target_arch = "wasm32"), feature = "valkey"))]
+                {
+                    let valkey = Arc::new(ValkeyStateStore::connect(&config.valkey).await?);
+                    if config.backend == DiscoveryStateBackend::Valkey {
+                        Ok(Self(valkey))
+                    } else {
+                        Ok(Self(Arc::new(TieredStateStore::new(
+                            memory(),
+                            valkey,
+                            config.tiered.l1_max_ttl_ms,
+                        ))))
+                    }
+                }
+            }
+        }
+    }
+
+    pub(crate) fn into_inner(self) -> Arc<dyn DiscoveryStateStore> {
+        self.0
+    }
+}
+
+/// Endpoint data stored per announced entry.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub(crate) struct AnnouncedEndpoint {
+    pub(crate) socket_kind: String,
+    pub(crate) endpoint: String,
+    pub(crate) service_jwt: String,
+    pub(crate) service_did: Did,
+    pub(crate) capabilities: BTreeSet<String>,
+    pub(crate) accepted_state_digest: Vec<u8>,
+    pub(crate) accepted_state_epoch: u64,
+    pub(crate) response_key_id: String,
+    pub(crate) request_kem_key_id: String,
+    pub(crate) request_kem_recipient: Vec<u8>,
+    /// Signed/application expiry carried by the announcement.
+    pub(crate) expires_at_unix_ms: i64,
+    pub(crate) source_signer: [u8; 32],
+    /// Effective cache lifetime: no later than heartbeat, signed artifact, and
+    /// accepted-current-state expiry.
+    pub(crate) live_until_unix_ms: i64,
+}
+
+impl AnnouncedEndpoint {
+    pub(crate) fn is_live_at(&self, now_unix_ms: i64) -> bool {
+        now_unix_ms < self.live_until_unix_ms && now_unix_ms < self.expires_at_unix_ms
+    }
+
+    fn order(&self) -> (u64, i64) {
+        (self.accepted_state_epoch, self.expires_at_unix_ms)
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub(crate) struct LiveAllocatable {
+    pub(crate) allocatable: Vec<(String, String)>,
+    pub(crate) load_fraction: f32,
+    pub(crate) last_seen: i64,
+    pub(crate) live_until_unix_ms: i64,
+}
+
+impl LiveAllocatable {
+    fn is_live_at(&self, now_unix_ms: i64) -> bool {
+        now_unix_ms < self.live_until_unix_ms
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub(crate) struct CachedEntityStatement {
+    pub(crate) jwt: String,
+    pub(crate) fetched_at: i64,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub(crate) struct CachedEnvelopeKeyset {
+    pub(crate) cose_keyset_cbor: Vec<u8>,
+    pub(crate) fetched_at: i64,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum PutResult {
+    Stored,
+    IgnoredOlder,
+}
+
+/// Typed query surface needed by Discovery handlers and resolvers.
+///
+/// Native futures are `Send`; browser/embedded WASM uses the repository's
+/// established `?Send` convention. Implementations remain `Send + Sync` so a
+/// native service can share one store across handlers.
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+pub(crate) trait DiscoveryStateStore: Send + Sync {
+    async fn put_announcement(
+        &self,
+        service_name: &str,
+        endpoint: AnnouncedEndpoint,
+    ) -> Result<PutResult>;
+    async fn announcements_for(
+        &self,
+        service_name: &str,
+        now_unix_ms: i64,
+    ) -> Result<Vec<AnnouncedEndpoint>>;
+    async fn all_announcements(
+        &self,
+        now_unix_ms: i64,
+    ) -> Result<Vec<(String, Vec<AnnouncedEndpoint>)>>;
+
+    async fn put_liveness(&self, node: &Did, value: LiveAllocatable) -> Result<PutResult>;
+    async fn liveness(&self, node: &Did, now_unix_ms: i64) -> Result<Option<LiveAllocatable>>;
+
+    async fn put_entity_statement(&self, issuer: &str, value: CachedEntityStatement) -> Result<()>;
+    async fn entity_statement(&self, issuer: &str) -> Result<Option<CachedEntityStatement>>;
+    async fn known_issuers(&self) -> Result<Vec<String>>;
+
+    async fn put_envelope_keyset(
+        &self,
+        service_did: &str,
+        value: CachedEnvelopeKeyset,
+    ) -> Result<()>;
+    async fn envelope_keyset(&self, service_did: &str) -> Result<Option<CachedEnvelopeKeyset>>;
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Hash, PartialOrd, Ord)]
+struct AnnouncementKey {
+    service_name: String,
+    socket_kind: String,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
+enum ExpiringKey {
+    Announcement(AnnouncementKey),
+    Liveness(String),
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+struct ExpiryEntry {
+    expires_at_unix_ms: i64,
+    version: u64,
+    key: ExpiringKey,
+}
+
+impl Ord for ExpiryEntry {
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        self.expires_at_unix_ms
+            .cmp(&other.expires_at_unix_ms)
+            .then_with(|| self.version.cmp(&other.version))
+            .then_with(|| self.key.cmp(&other.key))
+    }
+}
+
+impl PartialOrd for ExpiryEntry {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+#[derive(Clone)]
+struct Versioned<T> {
+    value: T,
+    version: u64,
+}
+
+struct MemoryInner {
+    announcements: HashMap<AnnouncementKey, Versioned<AnnouncedEndpoint>>,
+    service_index: HashMap<String, BTreeSet<String>>,
+    liveness: HashMap<String, Versioned<LiveAllocatable>>,
+    expiry: BinaryHeap<Reverse<ExpiryEntry>>,
+    entity_statements: HashMap<String, CachedEntityStatement>,
+    envelope_keysets: HashMap<String, CachedEnvelopeKeyset>,
+    next_version: u64,
+}
+
+/// Bounded in-process backend used by single-replica and WASM deployments.
+pub(crate) struct MemoryStateStore {
+    inner: Mutex<MemoryInner>,
+    announcement_capacity: usize,
+    liveness_capacity: usize,
+    artifact_capacity: usize,
+}
+
+impl MemoryStateStore {
+    pub(crate) fn new(
+        announcement_capacity: usize,
+        liveness_capacity: usize,
+        artifact_capacity: usize,
+    ) -> Self {
+        Self {
+            inner: Mutex::new(MemoryInner {
+                announcements: HashMap::new(),
+                service_index: HashMap::new(),
+                liveness: HashMap::new(),
+                expiry: BinaryHeap::new(),
+                entity_statements: HashMap::new(),
+                envelope_keysets: HashMap::new(),
+                next_version: 1,
+            }),
+            announcement_capacity,
+            liveness_capacity,
+            artifact_capacity,
+        }
+    }
+
+    pub(crate) fn production_default() -> Arc<dyn DiscoveryStateStore> {
+        Arc::new(Self::new(16_384, 16_384, 4_096))
+    }
+
+    fn next_version(inner: &mut MemoryInner) -> u64 {
+        let version = inner.next_version;
+        inner.next_version = inner.next_version.saturating_add(1);
+        version
+    }
+
+    fn reap(inner: &mut MemoryInner, now_unix_ms: i64) {
+        while let Some(Reverse(head)) = inner.expiry.peek() {
+            if head.expires_at_unix_ms > now_unix_ms {
+                break;
+            }
+            let Some(Reverse(expired)) = inner.expiry.pop() else {
+                break;
+            };
+            match &expired.key {
+                ExpiringKey::Announcement(key) => {
+                    let remove = inner
+                        .announcements
+                        .get(key)
+                        .is_some_and(|entry| entry.version == expired.version);
+                    if remove {
+                        inner.announcements.remove(key);
+                        if let Some(kinds) = inner.service_index.get_mut(&key.service_name) {
+                            kinds.remove(&key.socket_kind);
+                            if kinds.is_empty() {
+                                inner.service_index.remove(&key.service_name);
+                            }
+                        }
+                    }
+                }
+                ExpiringKey::Liveness(node) => {
+                    let remove = inner
+                        .liveness
+                        .get(node)
+                        .is_some_and(|entry| entry.version == expired.version);
+                    if remove {
+                        inner.liveness.remove(node);
+                    }
+                }
+            }
+        }
+    }
+
+    pub(crate) fn put_announcement_sync(
+        &self,
+        service_name: &str,
+        endpoint: AnnouncedEndpoint,
+    ) -> Result<PutResult> {
+        let mut inner = self.inner.lock();
+        Self::reap(&mut inner, unix_millis_now());
+        let key = AnnouncementKey {
+            service_name: service_name.to_owned(),
+            socket_kind: endpoint.socket_kind.clone(),
+        };
+        if let Some(existing) = inner.announcements.get(&key) {
+            if existing.value.order() > endpoint.order() {
+                return Ok(PutResult::IgnoredOlder);
+            }
+        } else if inner.announcements.len() >= self.announcement_capacity {
+            bail!("Discovery memory announcement capacity exhausted");
+        }
+        let version = Self::next_version(&mut inner);
+        inner
+            .service_index
+            .entry(service_name.to_owned())
+            .or_default()
+            .insert(endpoint.socket_kind.clone());
+        inner.expiry.push(Reverse(ExpiryEntry {
+            expires_at_unix_ms: endpoint.live_until_unix_ms,
+            version,
+            key: ExpiringKey::Announcement(key.clone()),
+        }));
+        inner.announcements.insert(
+            key,
+            Versioned {
+                value: endpoint,
+                version,
+            },
+        );
+        Ok(PutResult::Stored)
+    }
+
+    pub(crate) fn announcements_for_sync(
+        &self,
+        service_name: &str,
+        now_unix_ms: i64,
+    ) -> Vec<AnnouncedEndpoint> {
+        let mut inner = self.inner.lock();
+        Self::reap(&mut inner, now_unix_ms);
+        inner
+            .service_index
+            .get(service_name)
+            .into_iter()
+            .flatten()
+            .filter_map(|socket_kind| {
+                inner
+                    .announcements
+                    .get(&AnnouncementKey {
+                        service_name: service_name.to_owned(),
+                        socket_kind: socket_kind.clone(),
+                    })
+                    .map(|entry| entry.value.clone())
+            })
+            .filter(|entry| entry.is_live_at(now_unix_ms))
+            .collect()
+    }
+
+    fn all_announcements_sync(&self, now_unix_ms: i64) -> Vec<(String, Vec<AnnouncedEndpoint>)> {
+        let mut inner = self.inner.lock();
+        Self::reap(&mut inner, now_unix_ms);
+        inner
+            .service_index
+            .iter()
+            .filter_map(|(service_name, socket_kinds)| {
+                let endpoints: Vec<_> = socket_kinds
+                    .iter()
+                    .filter_map(|socket_kind| {
+                        inner
+                            .announcements
+                            .get(&AnnouncementKey {
+                                service_name: service_name.clone(),
+                                socket_kind: socket_kind.clone(),
+                            })
+                            .map(|entry| entry.value.clone())
+                    })
+                    .filter(|entry| entry.is_live_at(now_unix_ms))
+                    .collect();
+                (!endpoints.is_empty()).then(|| (service_name.clone(), endpoints))
+            })
+            .collect()
+    }
+
+    #[cfg(any(feature = "valkey", test, feature = "test-fixtures"))]
+    pub(crate) fn clear_announcements_sync(&self, service_name: &str) {
+        let mut inner = self.inner.lock();
+        let Some(socket_kinds) = inner.service_index.remove(service_name) else {
+            return;
+        };
+        for socket_kind in socket_kinds {
+            inner.announcements.remove(&AnnouncementKey {
+                service_name: service_name.to_owned(),
+                socket_kind,
+            });
+        }
+    }
+
+    #[cfg(feature = "valkey")]
+    fn clear_all_announcements_sync(&self) {
+        let mut inner = self.inner.lock();
+        inner.announcements.clear();
+        inner.service_index.clear();
+    }
+
+    #[cfg(feature = "valkey")]
+    fn clear_liveness_sync(&self, node: &Did) {
+        self.inner.lock().liveness.remove(node.as_str());
+    }
+
+    #[cfg(feature = "valkey")]
+    fn clear_entity_statement_sync(&self, issuer: &str) {
+        self.inner.lock().entity_statements.remove(issuer);
+    }
+
+    #[cfg(feature = "valkey")]
+    fn clear_envelope_keyset_sync(&self, service_did: &str) {
+        self.inner.lock().envelope_keysets.remove(service_did);
+    }
+
+    #[cfg(feature = "valkey")]
+    fn clear_entity_statements_sync(&self) {
+        self.inner.lock().entity_statements.clear();
+    }
+}
+
+impl Default for MemoryStateStore {
+    fn default() -> Self {
+        Self::new(16_384, 16_384, 4_096)
+    }
+}
+
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
+#[cfg_attr(target_arch = "wasm32", async_trait(?Send))]
+impl DiscoveryStateStore for MemoryStateStore {
+    async fn put_announcement(
+        &self,
+        service_name: &str,
+        endpoint: AnnouncedEndpoint,
+    ) -> Result<PutResult> {
+        self.put_announcement_sync(service_name, endpoint)
+    }
+
+    async fn announcements_for(
+        &self,
+        service_name: &str,
+        now_unix_ms: i64,
+    ) -> Result<Vec<AnnouncedEndpoint>> {
+        Ok(self.announcements_for_sync(service_name, now_unix_ms))
+    }
+
+    async fn all_announcements(
+        &self,
+        now_unix_ms: i64,
+    ) -> Result<Vec<(String, Vec<AnnouncedEndpoint>)>> {
+        Ok(self.all_announcements_sync(now_unix_ms))
+    }
+
+    async fn put_liveness(&self, node: &Did, value: LiveAllocatable) -> Result<PutResult> {
+        let mut inner = self.inner.lock();
+        Self::reap(&mut inner, unix_millis_now());
+        let node = node.as_str().to_owned();
+        if let Some(existing) = inner.liveness.get(&node) {
+            if existing.value.last_seen > value.last_seen {
+                return Ok(PutResult::IgnoredOlder);
+            }
+        } else if inner.liveness.len() >= self.liveness_capacity {
+            bail!("Discovery memory liveness capacity exhausted");
+        }
+        let version = Self::next_version(&mut inner);
+        inner.expiry.push(Reverse(ExpiryEntry {
+            expires_at_unix_ms: value.live_until_unix_ms,
+            version,
+            key: ExpiringKey::Liveness(node.clone()),
+        }));
+        inner.liveness.insert(node, Versioned { value, version });
+        Ok(PutResult::Stored)
+    }
+
+    async fn liveness(&self, node: &Did, now_unix_ms: i64) -> Result<Option<LiveAllocatable>> {
+        let mut inner = self.inner.lock();
+        Self::reap(&mut inner, now_unix_ms);
+        Ok(inner
+            .liveness
+            .get(node.as_str())
+            .map(|entry| entry.value.clone())
+            .filter(|entry| entry.is_live_at(now_unix_ms)))
+    }
+
+    async fn put_entity_statement(&self, issuer: &str, value: CachedEntityStatement) -> Result<()> {
+        let mut inner = self.inner.lock();
+        if !inner.entity_statements.contains_key(issuer)
+            && inner.entity_statements.len() >= self.artifact_capacity
+        {
+            bail!("Discovery memory federation artifact capacity exhausted");
+        }
+        inner.entity_statements.insert(issuer.to_owned(), value);
+        Ok(())
+    }
+
+    async fn entity_statement(&self, issuer: &str) -> Result<Option<CachedEntityStatement>> {
+        Ok(self.inner.lock().entity_statements.get(issuer).cloned())
+    }
+
+    async fn known_issuers(&self) -> Result<Vec<String>> {
+        Ok(self
+            .inner
+            .lock()
+            .entity_statements
+            .keys()
+            .cloned()
+            .collect())
+    }
+
+    async fn put_envelope_keyset(
+        &self,
+        service_did: &str,
+        value: CachedEnvelopeKeyset,
+    ) -> Result<()> {
+        let mut inner = self.inner.lock();
+        if !inner.envelope_keysets.contains_key(service_did)
+            && inner.envelope_keysets.len() >= self.artifact_capacity
+        {
+            bail!("Discovery memory federation artifact capacity exhausted");
+        }
+        inner.envelope_keysets.insert(service_did.to_owned(), value);
+        Ok(())
+    }
+
+    async fn envelope_keyset(&self, service_did: &str) -> Result<Option<CachedEnvelopeKeyset>> {
+        Ok(self.inner.lock().envelope_keysets.get(service_did).cloned())
+    }
+}
+
+#[cfg(all(not(target_arch = "wasm32"), feature = "valkey"))]
+#[derive(Clone)]
+struct ValkeyStateStore {
+    pool: fred::prelude::RedisPool,
+    prefix: String,
+    announcement_capacity: usize,
+    liveness_capacity: usize,
+    artifact_capacity: usize,
+}
+
+#[cfg(all(not(target_arch = "wasm32"), feature = "valkey"))]
+impl ValkeyStateStore {
+    async fn connect(config: &ValkeyStateConfig) -> Result<Self> {
+        use anyhow::Context as _;
+        use fred::prelude::*;
+
+        anyhow::ensure!(
+            config.pool_size > 0,
+            "Discovery Valkey pool_size must be positive"
+        );
+        anyhow::ensure!(
+            config.command_timeout_ms > 0,
+            "Discovery Valkey command_timeout_ms must be positive"
+        );
+        anyhow::ensure!(
+            config.announcement_capacity > 0
+                && config.liveness_capacity > 0
+                && config.artifact_capacity > 0,
+            "Discovery Valkey capacities must be positive"
+        );
+        let redis = RedisConfig::from_url(&config.url).context("invalid Discovery Valkey URL")?;
+        let mut builder = Builder::from_config(redis);
+        builder.with_performance_config(|performance| {
+            performance.default_command_timeout =
+                std::time::Duration::from_millis(config.command_timeout_ms);
+        });
+        let pool = builder.build_pool(config.pool_size)?;
+        pool.connect();
+        pool.wait_for_connect().await?;
+        let _: String = pool.ping().await?;
+        Ok(Self {
+            pool,
+            // One hash tag keeps every Lua transaction in one cluster slot.
+            prefix: format!(
+                "{}:{{discovery-state}}",
+                config.key_prefix.trim_end_matches(':')
+            ),
+            announcement_capacity: config.announcement_capacity,
+            liveness_capacity: config.liveness_capacity,
+            artifact_capacity: config.artifact_capacity,
+        })
+    }
+
+    fn digest(value: &str) -> String {
+        blake3::hash(value.as_bytes()).to_hex().to_string()
+    }
+
+    fn key(&self, suffix: &str) -> String {
+        format!("{}:{suffix}", self.prefix)
+    }
+
+    fn service_id(service_name: &str) -> String {
+        Self::digest(service_name)
+    }
+
+    fn announcement_key(&self, service_name: &str, socket_kind: &str) -> String {
+        format!(
+            "{}:announcement:{}:{}",
+            self.prefix,
+            Self::service_id(service_name),
+            Self::digest(socket_kind)
+        )
+    }
+
+    fn announcement_index(&self, service_name: &str) -> String {
+        format!(
+            "{}:announcement-index:{}",
+            self.prefix,
+            Self::service_id(service_name)
+        )
+    }
+
+    fn announcement_revision_key(&self, service_name: &str) -> String {
+        format!(
+            "{}:announcement-revision:{}",
+            self.prefix,
+            Self::service_id(service_name)
+        )
+    }
+
+    async fn revision(&self, key: String) -> Result<u64> {
+        use fred::prelude::*;
+        Ok(self.pool.get::<Option<u64>, _>(key).await?.unwrap_or(0))
+    }
+
+    async fn announcement_revision(&self, service_name: &str) -> Result<u64> {
+        self.revision(self.announcement_revision_key(service_name))
+            .await
+    }
+
+    async fn announcement_global_revision(&self) -> Result<u64> {
+        self.revision(self.key("announcement-global-revision"))
+            .await
+    }
+
+    async fn liveness_revision(&self, node: &Did) -> Result<u64> {
+        self.revision(format!(
+            "{}:liveness-revision:{}",
+            self.prefix,
+            Self::digest(node.as_str())
+        ))
+        .await
+    }
+
+    async fn entity_revision(&self, issuer: &str) -> Result<u64> {
+        self.revision(format!(
+            "{}:entity-revision:{}",
+            self.prefix,
+            Self::digest(issuer)
+        ))
+        .await
+    }
+
+    async fn entity_global_revision(&self) -> Result<u64> {
+        self.revision(self.key("entity-global-revision")).await
+    }
+
+    async fn envelope_revision(&self, service_did: &str) -> Result<u64> {
+        self.revision(format!(
+            "{}:envelope-revision:{}",
+            self.prefix,
+            Self::digest(service_did)
+        ))
+        .await
+    }
+
+    async fn announcements_for_inner(
+        &self,
+        service_name: &str,
+        now_unix_ms: i64,
+    ) -> Result<Vec<AnnouncedEndpoint>> {
+        use fred::prelude::*;
+
+        let index = self.announcement_index(service_name);
+        let record_keys: Vec<String> = self.pool.smembers(&index).await?;
+        let mut live = Vec::with_capacity(record_keys.len());
+        for record_key in record_keys {
+            let encoded: Option<String> = self.pool.get(&record_key).await?;
+            match encoded {
+                Some(encoded) => {
+                    let endpoint: AnnouncedEndpoint = serde_json::from_str(&encoded)?;
+                    if endpoint.is_live_at(now_unix_ms) {
+                        live.push(endpoint);
+                    } else {
+                        let _: i64 = self.pool.del(&record_key).await?;
+                        let _: i64 = self.pool.srem(&index, &record_key).await?;
+                    }
+                }
+                None => {
+                    let _: i64 = self.pool.srem(&index, &record_key).await?;
+                }
+            }
+        }
+        Ok(live)
+    }
+}
+
+#[cfg(all(not(target_arch = "wasm32"), feature = "valkey"))]
+#[cfg_attr(not(target_arch = "wasm32"), async_trait)]
+impl DiscoveryStateStore for ValkeyStateStore {
+    async fn put_announcement(
+        &self,
+        service_name: &str,
+        endpoint: AnnouncedEndpoint,
+    ) -> Result<PutResult> {
+        use fred::prelude::*;
+
+        const PUT: &str = r#"
+local current = redis.call('GET', KEYS[1])
+redis.call('ZREMRANGEBYSCORE', KEYS[7], '-inf', ARGV[7])
+if not current and redis.call('ZCARD', KEYS[7]) >= tonumber(ARGV[8]) then
+  return redis.error_reply('Discovery Valkey announcement capacity exhausted')
+end
+if current then
+  local ok, decoded = pcall(cjson.decode, current)
+  if not ok then return redis.error_reply('corrupt Discovery announcement') end
+  local old_epoch = tonumber(decoded.accepted_state_epoch) or 0
+  local old_exp = tonumber(decoded.expires_at_unix_ms) or 0
+  local new_epoch = tonumber(ARGV[2])
+  local new_exp = tonumber(ARGV[3])
+  if old_epoch > new_epoch or (old_epoch == new_epoch and old_exp > new_exp) then
+    return 0
+  end
+end
+redis.call('SET', KEYS[1], ARGV[1], 'PXAT', ARGV[4])
+redis.call('SADD', KEYS[2], KEYS[1])
+redis.call('SADD', KEYS[3], ARGV[5])
+redis.call('HSET', KEYS[4], ARGV[5], ARGV[6])
+redis.call('INCR', KEYS[5])
+redis.call('INCR', KEYS[6])
+redis.call('ZADD', KEYS[7], ARGV[4], KEYS[1])
+return 1
+"#;
+        let service_id = Self::service_id(service_name);
+        let encoded = serde_json::to_string(&endpoint)?;
+        let stored: i64 = self
+            .pool
+            .eval(
+                PUT,
+                vec![
+                    self.announcement_key(service_name, &endpoint.socket_kind),
+                    self.announcement_index(service_name),
+                    self.key("services"),
+                    self.key("service-names"),
+                    self.announcement_revision_key(service_name),
+                    self.key("announcement-global-revision"),
+                    self.key("announcement-expiry"),
+                ],
+                vec![
+                    encoded,
+                    endpoint.accepted_state_epoch.to_string(),
+                    endpoint.expires_at_unix_ms.to_string(),
+                    endpoint.live_until_unix_ms.to_string(),
+                    service_id,
+                    service_name.to_owned(),
+                    unix_millis_now().to_string(),
+                    self.announcement_capacity.to_string(),
+                ],
+            )
+            .await?;
+        Ok(if stored == 1 {
+            PutResult::Stored
+        } else {
+            PutResult::IgnoredOlder
+        })
+    }
+
+    async fn announcements_for(
+        &self,
+        service_name: &str,
+        now_unix_ms: i64,
+    ) -> Result<Vec<AnnouncedEndpoint>> {
+        self.announcements_for_inner(service_name, now_unix_ms)
+            .await
+    }
+
+    async fn all_announcements(
+        &self,
+        now_unix_ms: i64,
+    ) -> Result<Vec<(String, Vec<AnnouncedEndpoint>)>> {
+        use fred::prelude::*;
+
+        let service_ids: Vec<String> = self.pool.smembers(self.key("services")).await?;
+        let mut all = Vec::with_capacity(service_ids.len());
+        for service_id in service_ids {
+            let service_name: Option<String> = self
+                .pool
+                .hget(self.key("service-names"), &service_id)
+                .await?;
+            let Some(service_name) = service_name else {
+                let _: i64 = self.pool.srem(self.key("services"), &service_id).await?;
+                continue;
+            };
+            let entries = self
+                .announcements_for_inner(&service_name, now_unix_ms)
+                .await?;
+            if entries.is_empty() {
+                let _: i64 = self.pool.srem(self.key("services"), &service_id).await?;
+                let _: i64 = self
+                    .pool
+                    .hdel(self.key("service-names"), &service_id)
+                    .await?;
+            } else {
+                all.push((service_name, entries));
+            }
+        }
+        Ok(all)
+    }
+
+    async fn put_liveness(&self, node: &Did, value: LiveAllocatable) -> Result<PutResult> {
+        use fred::prelude::*;
+
+        const PUT: &str = r#"
+local current = redis.call('GET', KEYS[1])
+redis.call('ZREMRANGEBYSCORE', KEYS[3], '-inf', ARGV[4])
+if not current and redis.call('ZCARD', KEYS[3]) >= tonumber(ARGV[5]) then
+  return redis.error_reply('Discovery Valkey liveness capacity exhausted')
+end
+if current then
+  local ok, decoded = pcall(cjson.decode, current)
+  if not ok then return redis.error_reply('corrupt Discovery liveness') end
+  if (tonumber(decoded.last_seen) or 0) > tonumber(ARGV[2]) then return 0 end
+end
+redis.call('SET', KEYS[1], ARGV[1], 'PXAT', ARGV[3])
+redis.call('INCR', KEYS[2])
+redis.call('ZADD', KEYS[3], ARGV[3], KEYS[1])
+return 1
+"#;
+        let node_id = Self::digest(node.as_str());
+        let stored: i64 = self
+            .pool
+            .eval(
+                PUT,
+                vec![
+                    format!("{}:liveness:{node_id}", self.prefix),
+                    format!("{}:liveness-revision:{node_id}", self.prefix),
+                    self.key("liveness-expiry"),
+                ],
+                vec![
+                    serde_json::to_string(&value)?,
+                    value.last_seen.to_string(),
+                    value.live_until_unix_ms.to_string(),
+                    unix_millis_now().to_string(),
+                    self.liveness_capacity.to_string(),
+                ],
+            )
+            .await?;
+        Ok(if stored == 1 {
+            PutResult::Stored
+        } else {
+            PutResult::IgnoredOlder
+        })
+    }
+
+    async fn liveness(&self, node: &Did, now_unix_ms: i64) -> Result<Option<LiveAllocatable>> {
+        use fred::prelude::*;
+        let encoded: Option<String> = self
+            .pool
+            .get(format!(
+                "{}:liveness:{}",
+                self.prefix,
+                Self::digest(node.as_str())
+            ))
+            .await?;
+        Ok(encoded
+            .map(|encoded| serde_json::from_str(&encoded))
+            .transpose()?
+            .filter(|value: &LiveAllocatable| value.is_live_at(now_unix_ms)))
+    }
+
+    async fn put_entity_statement(&self, issuer: &str, value: CachedEntityStatement) -> Result<()> {
+        use fred::prelude::*;
+        const PUT: &str = r#"
+if redis.call('EXISTS', KEYS[1]) == 0 and redis.call('SCARD', KEYS[2]) >= tonumber(ARGV[4]) then
+  return redis.error_reply('Discovery Valkey federation artifact capacity exhausted')
+end
+redis.call('SET', KEYS[1], ARGV[1])
+redis.call('SADD', KEYS[2], ARGV[2])
+redis.call('HSET', KEYS[3], ARGV[2], ARGV[3])
+redis.call('INCR', KEYS[4])
+redis.call('INCR', KEYS[5])
+return 1
+"#;
+        let id = Self::digest(issuer);
+        let _: i64 = self
+            .pool
+            .eval(
+                PUT,
+                vec![
+                    format!("{}:entity:{id}", self.prefix),
+                    self.key("issuers"),
+                    self.key("issuer-names"),
+                    format!("{}:entity-revision:{id}", self.prefix),
+                    self.key("entity-global-revision"),
+                ],
+                vec![
+                    serde_json::to_string(&value)?,
+                    id,
+                    issuer.to_owned(),
+                    self.artifact_capacity.to_string(),
+                ],
+            )
+            .await?;
+        Ok(())
+    }
+
+    async fn entity_statement(&self, issuer: &str) -> Result<Option<CachedEntityStatement>> {
+        use fred::prelude::*;
+        let encoded: Option<String> = self
+            .pool
+            .get(format!("{}:entity:{}", self.prefix, Self::digest(issuer)))
+            .await?;
+        encoded
+            .map(|encoded| serde_json::from_str(&encoded).map_err(Into::into))
+            .transpose()
+    }
+
+    async fn known_issuers(&self) -> Result<Vec<String>> {
+        use fred::prelude::*;
+        let ids: Vec<String> = self.pool.smembers(self.key("issuers")).await?;
+        let mut issuers = Vec::with_capacity(ids.len());
+        for id in ids {
+            if let Some(issuer) = self
+                .pool
+                .hget::<Option<String>, _, _>(self.key("issuer-names"), &id)
+                .await?
+            {
+                issuers.push(issuer);
+            }
+        }
+        Ok(issuers)
+    }
+
+    async fn put_envelope_keyset(
+        &self,
+        service_did: &str,
+        value: CachedEnvelopeKeyset,
+    ) -> Result<()> {
+        use fred::prelude::*;
+        const PUT: &str = r#"
+if redis.call('EXISTS', KEYS[1]) == 0 and redis.call('SCARD', KEYS[3]) >= tonumber(ARGV[2]) then
+  return redis.error_reply('Discovery Valkey federation artifact capacity exhausted')
+end
+redis.call('SET', KEYS[1], ARGV[1])
+redis.call('INCR', KEYS[2])
+redis.call('SADD', KEYS[3], KEYS[1])
+return 1
+"#;
+        let id = Self::digest(service_did);
+        let _: i64 = self
+            .pool
+            .eval(
+                PUT,
+                vec![
+                    format!("{}:envelope:{id}", self.prefix),
+                    format!("{}:envelope-revision:{id}", self.prefix),
+                    self.key("envelopes"),
+                ],
+                vec![
+                    serde_json::to_string(&value)?,
+                    self.artifact_capacity.to_string(),
+                ],
+            )
+            .await?;
+        Ok(())
+    }
+
+    async fn envelope_keyset(&self, service_did: &str) -> Result<Option<CachedEnvelopeKeyset>> {
+        use fred::prelude::*;
+        let encoded: Option<String> = self
+            .pool
+            .get(format!(
+                "{}:envelope:{}",
+                self.prefix,
+                Self::digest(service_did)
+            ))
+            .await?;
+        encoded
+            .map(|encoded| serde_json::from_str(&encoded).map_err(Into::into))
+            .transpose()
+    }
+}
+
+#[cfg(all(not(target_arch = "wasm32"), feature = "valkey"))]
+#[derive(Clone, Copy)]
+struct ObservedRevision {
+    revision: u64,
+    valid_until_unix_ms: i64,
+}
+
+#[cfg(all(not(target_arch = "wasm32"), feature = "valkey"))]
+struct TieredStateStore {
+    memory: Arc<MemoryStateStore>,
+    valkey: Arc<ValkeyStateStore>,
+    l1_max_ttl_ms: i64,
+    observed: Mutex<HashMap<String, ObservedRevision>>,
+}
+
+#[cfg(all(not(target_arch = "wasm32"), feature = "valkey"))]
+impl TieredStateStore {
+    fn new(
+        memory: Arc<MemoryStateStore>,
+        valkey: Arc<ValkeyStateStore>,
+        l1_max_ttl_ms: u64,
+    ) -> Self {
+        Self {
+            memory,
+            valkey,
+            l1_max_ttl_ms: i64::try_from(l1_max_ttl_ms).unwrap_or(i64::MAX),
+            observed: Mutex::new(HashMap::new()),
+        }
+    }
+
+    fn scope(kind: &str, value: &str) -> String {
+        format!("{kind}:{value}")
+    }
+
+    fn is_observed(&self, scope: &str, revision: u64, now_unix_ms: i64) -> bool {
+        self.observed.lock().get(scope).is_some_and(|observed| {
+            observed.revision == revision && now_unix_ms < observed.valid_until_unix_ms
+        })
+    }
+
+    fn observe(&self, scope: String, revision: u64, now_unix_ms: i64) {
+        self.observed.lock().insert(
+            scope,
+            ObservedRevision {
+                revision,
+                valid_until_unix_ms: now_unix_ms.saturating_add(self.l1_max_ttl_ms),
+            },
+        );
+    }
+
+    fn l1_announcement(
+        &self,
+        mut endpoint: AnnouncedEndpoint,
+        now_unix_ms: i64,
+    ) -> AnnouncedEndpoint {
+        endpoint.live_until_unix_ms = endpoint
+            .live_until_unix_ms
+            .min(now_unix_ms.saturating_add(self.l1_max_ttl_ms));
+        endpoint
+    }
+
+    fn l1_liveness(&self, mut value: LiveAllocatable, now_unix_ms: i64) -> LiveAllocatable {
+        value.live_until_unix_ms = value
+            .live_until_unix_ms
+            .min(now_unix_ms.saturating_add(self.l1_max_ttl_ms));
+        value
+    }
+}
+
+#[cfg(all(not(target_arch = "wasm32"), feature = "valkey"))]
+#[async_trait]
+impl DiscoveryStateStore for TieredStateStore {
+    async fn put_announcement(
+        &self,
+        service_name: &str,
+        endpoint: AnnouncedEndpoint,
+    ) -> Result<PutResult> {
+        let result = self
+            .valkey
+            .put_announcement(service_name, endpoint.clone())
+            .await?;
+        if result == PutResult::Stored {
+            let now = unix_millis_now();
+            self.memory
+                .put_announcement(service_name, self.l1_announcement(endpoint, now))
+                .await?;
+            let revision = self.valkey.announcement_revision(service_name).await?;
+            self.observe(Self::scope("announcement", service_name), revision, now);
+        }
+        Ok(result)
+    }
+
+    async fn announcements_for(
+        &self,
+        service_name: &str,
+        now_unix_ms: i64,
+    ) -> Result<Vec<AnnouncedEndpoint>> {
+        let scope = Self::scope("announcement", service_name);
+        let revision = self.valkey.announcement_revision(service_name).await?;
+        if self.is_observed(&scope, revision, now_unix_ms) {
+            return self
+                .memory
+                .announcements_for(service_name, now_unix_ms)
+                .await;
+        }
+        let values = self
+            .valkey
+            .announcements_for(service_name, now_unix_ms)
+            .await?;
+        self.memory.clear_announcements_sync(service_name);
+        for value in &values {
+            self.memory
+                .put_announcement(
+                    service_name,
+                    self.l1_announcement(value.clone(), now_unix_ms),
+                )
+                .await?;
+        }
+        self.observe(scope, revision, now_unix_ms);
+        Ok(values)
+    }
+
+    async fn all_announcements(
+        &self,
+        now_unix_ms: i64,
+    ) -> Result<Vec<(String, Vec<AnnouncedEndpoint>)>> {
+        let scope = "announcement-global".to_owned();
+        let revision = self.valkey.announcement_global_revision().await?;
+        if self.is_observed(&scope, revision, now_unix_ms) {
+            return self.memory.all_announcements(now_unix_ms).await;
+        }
+        let values = self.valkey.all_announcements(now_unix_ms).await?;
+        self.memory.clear_all_announcements_sync();
+        for (service_name, endpoints) in &values {
+            for endpoint in endpoints {
+                self.memory
+                    .put_announcement(
+                        service_name,
+                        self.l1_announcement(endpoint.clone(), now_unix_ms),
+                    )
+                    .await?;
+            }
+        }
+        self.observe(scope, revision, now_unix_ms);
+        Ok(values)
+    }
+
+    async fn put_liveness(&self, node: &Did, value: LiveAllocatable) -> Result<PutResult> {
+        let result = self.valkey.put_liveness(node, value.clone()).await?;
+        if result == PutResult::Stored {
+            let now = unix_millis_now();
+            self.memory
+                .put_liveness(node, self.l1_liveness(value, now))
+                .await?;
+            let revision = self.valkey.liveness_revision(node).await?;
+            self.observe(Self::scope("liveness", node.as_str()), revision, now);
+        }
+        Ok(result)
+    }
+
+    async fn liveness(&self, node: &Did, now_unix_ms: i64) -> Result<Option<LiveAllocatable>> {
+        let scope = Self::scope("liveness", node.as_str());
+        let revision = self.valkey.liveness_revision(node).await?;
+        if self.is_observed(&scope, revision, now_unix_ms) {
+            return self.memory.liveness(node, now_unix_ms).await;
+        }
+        let value = self.valkey.liveness(node, now_unix_ms).await?;
+        self.memory.clear_liveness_sync(node);
+        if let Some(value) = &value {
+            self.memory
+                .put_liveness(node, self.l1_liveness(value.clone(), now_unix_ms))
+                .await?;
+        }
+        self.observe(scope, revision, now_unix_ms);
+        Ok(value)
+    }
+
+    async fn put_entity_statement(&self, issuer: &str, value: CachedEntityStatement) -> Result<()> {
+        self.valkey
+            .put_entity_statement(issuer, value.clone())
+            .await?;
+        self.memory.put_entity_statement(issuer, value).await?;
+        let revision = self.valkey.entity_revision(issuer).await?;
+        self.observe(Self::scope("entity", issuer), revision, unix_millis_now());
+        Ok(())
+    }
+
+    async fn entity_statement(&self, issuer: &str) -> Result<Option<CachedEntityStatement>> {
+        let now = unix_millis_now();
+        let scope = Self::scope("entity", issuer);
+        let revision = self.valkey.entity_revision(issuer).await?;
+        if self.is_observed(&scope, revision, now) {
+            return self.memory.entity_statement(issuer).await;
+        }
+        let value = self.valkey.entity_statement(issuer).await?;
+        self.memory.clear_entity_statement_sync(issuer);
+        if let Some(value) = &value {
+            self.memory
+                .put_entity_statement(issuer, value.clone())
+                .await?;
+        }
+        self.observe(scope, revision, now);
+        Ok(value)
+    }
+
+    async fn known_issuers(&self) -> Result<Vec<String>> {
+        let now = unix_millis_now();
+        let scope = "entity-global".to_owned();
+        let revision = self.valkey.entity_global_revision().await?;
+        if self.is_observed(&scope, revision, now) {
+            return self.memory.known_issuers().await;
+        }
+        let issuers = self.valkey.known_issuers().await?;
+        self.memory.clear_entity_statements_sync();
+        for issuer in &issuers {
+            if let Some(value) = self.valkey.entity_statement(issuer).await? {
+                self.memory.put_entity_statement(issuer, value).await?;
+            }
+        }
+        self.observe(scope, revision, now);
+        Ok(issuers)
+    }
+
+    async fn put_envelope_keyset(
+        &self,
+        service_did: &str,
+        value: CachedEnvelopeKeyset,
+    ) -> Result<()> {
+        self.valkey
+            .put_envelope_keyset(service_did, value.clone())
+            .await?;
+        self.memory.put_envelope_keyset(service_did, value).await?;
+        let revision = self.valkey.envelope_revision(service_did).await?;
+        self.observe(
+            Self::scope("envelope", service_did),
+            revision,
+            unix_millis_now(),
+        );
+        Ok(())
+    }
+
+    async fn envelope_keyset(&self, service_did: &str) -> Result<Option<CachedEnvelopeKeyset>> {
+        let now = unix_millis_now();
+        let scope = Self::scope("envelope", service_did);
+        let revision = self.valkey.envelope_revision(service_did).await?;
+        if self.is_observed(&scope, revision, now) {
+            return self.memory.envelope_keyset(service_did).await;
+        }
+        let value = self.valkey.envelope_keyset(service_did).await?;
+        self.memory.clear_envelope_keyset_sync(service_did);
+        if let Some(value) = &value {
+            self.memory
+                .put_envelope_keyset(service_did, value.clone())
+                .await?;
+        }
+        self.observe(scope, revision, now);
+        Ok(value)
+    }
+}
+
+pub(crate) fn unix_millis_now() -> i64 {
+    use std::time::{SystemTime, UNIX_EPOCH};
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|duration| duration.as_millis() as i64)
+        .unwrap_or(0)
+}
+
+#[cfg(test)]
+mod tests {
+    #![allow(clippy::expect_used, clippy::indexing_slicing, clippy::unwrap_used)]
+
+    use super::*;
+
+    fn endpoint(kind: &str, epoch: u64, signed_expiry: i64, live_until: i64) -> AnnouncedEndpoint {
+        AnnouncedEndpoint {
+            socket_kind: kind.to_owned(),
+            endpoint: format!("iroh://{kind}"),
+            service_jwt: "jwt".to_owned(),
+            service_did: Did::new("did:at9p:test".to_owned()),
+            capabilities: BTreeSet::from(["discovery".to_owned()]),
+            accepted_state_digest: vec![7; 64],
+            accepted_state_epoch: epoch,
+            response_key_id: "did:at9p:test#response".to_owned(),
+            request_kem_key_id: "did:at9p:test#kem".to_owned(),
+            request_kem_recipient: vec![1, 2, 3],
+            expires_at_unix_ms: signed_expiry,
+            source_signer: [9; 32],
+            live_until_unix_ms: live_until,
+        }
+    }
+
+    async fn assert_announcement_backend_contract(store: &dyn DiscoveryStateStore) {
+        let now = unix_millis_now();
+        store
+            .put_announcement("model", endpoint("iroh", 1, now + 10_000, now + 50))
+            .await
+            .unwrap();
+        assert_eq!(
+            store.announcements_for("model", now).await.unwrap().len(),
+            1
+        );
+        store
+            .put_announcement("model", endpoint("iroh", 2, now + 10_000, now + 50))
+            .await
+            .unwrap();
+        assert_eq!(
+            store.announcements_for("model", now).await.unwrap()[0].accepted_state_epoch,
+            2
+        );
+
+        tokio::time::sleep(std::time::Duration::from_millis(80)).await;
+        assert!(store
+            .announcements_for("model", unix_millis_now())
+            .await
+            .unwrap()
+            .is_empty());
+
+        let now = unix_millis_now();
+        store
+            .put_announcement("policy", endpoint("iroh", 1, now + 10_000, now + 5_000))
+            .await
+            .unwrap();
+        let error = store
+            .put_announcement("other", endpoint("iroh", 1, now + 10_000, now + 5_000))
+            .await
+            .unwrap_err();
+        assert!(error.to_string().contains("capacity exhausted"));
+    }
+
+    #[tokio::test]
+    async fn memory_satisfies_announcement_backend_contract() {
+        assert_announcement_backend_contract(&MemoryStateStore::new(1, 1, 1)).await;
+    }
+
+    #[tokio::test]
+    async fn memory_replaces_by_key_without_fleet_scan() {
+        let store = MemoryStateStore::new(8, 8, 8);
+        let now = unix_millis_now();
+        store
+            .put_announcement("model", endpoint("iroh", 1, now + 10_000, now + 1_000))
+            .await
+            .unwrap();
+        store
+            .put_announcement("model", endpoint("iroh", 2, now + 20_000, now + 2_000))
+            .await
+            .unwrap();
+        let entries = store.announcements_for("model", now).await.unwrap();
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].accepted_state_epoch, 2);
+    }
+
+    #[tokio::test]
+    async fn memory_rejects_delayed_older_announcement() {
+        let store = MemoryStateStore::new(8, 8, 8);
+        let now = unix_millis_now();
+        store
+            .put_announcement("model", endpoint("iroh", 3, now + 20_000, now + 2_000))
+            .await
+            .unwrap();
+        assert_eq!(
+            store
+                .put_announcement("model", endpoint("iroh", 2, now + 30_000, now + 3_000))
+                .await
+                .unwrap(),
+            PutResult::IgnoredOlder
+        );
+        assert_eq!(
+            store.announcements_for("model", now).await.unwrap()[0].accepted_state_epoch,
+            3
+        );
+    }
+
+    #[tokio::test]
+    async fn memory_expiry_removes_secondary_index_entry() {
+        let store = MemoryStateStore::new(8, 8, 8);
+        let now = unix_millis_now();
+        store
+            .put_announcement("model", endpoint("iroh", 1, now + 10_000, now + 1))
+            .await
+            .unwrap();
+        assert!(store.all_announcements(now + 2).await.unwrap().is_empty());
+    }
+
+    #[tokio::test]
+    async fn memory_capacity_rejects_instead_of_evicting_live_reach() {
+        let store = MemoryStateStore::new(1, 1, 1);
+        let now = unix_millis_now();
+        store
+            .put_announcement("model", endpoint("iroh", 1, now + 10_000, now + 1_000))
+            .await
+            .unwrap();
+        let error = store
+            .put_announcement("policy", endpoint("iroh", 1, now + 10_000, now + 1_000))
+            .await
+            .unwrap_err();
+        assert!(error.to_string().contains("capacity exhausted"));
+    }
+
+    #[tokio::test]
+    async fn active_active_rejects_isolated_memory() {
+        let config = DiscoveryStateConfig {
+            active_active: true,
+            ..DiscoveryStateConfig::default()
+        };
+        let error = match DiscoveryState::connect(&config).await {
+            Ok(_) => panic!("active-active memory configuration was admitted"),
+            Err(error) => error,
+        };
+        assert!(error.to_string().contains("requires valkey or tiered"));
+    }
+
+    #[tokio::test]
+    async fn rejects_zero_memory_capacity_and_tiered_freshness() {
+        let mut memory = DiscoveryStateConfig::default();
+        memory.memory.announcement_capacity = 0;
+        let error = match DiscoveryState::connect(&memory).await {
+            Ok(_) => panic!("zero-capacity memory configuration was admitted"),
+            Err(error) => error,
+        };
+        assert!(error.to_string().contains("capacities must be positive"));
+
+        let mut tiered = DiscoveryStateConfig {
+            backend: DiscoveryStateBackend::Tiered,
+            ..DiscoveryStateConfig::default()
+        };
+        tiered.tiered.l1_max_ttl_ms = 0;
+        let error = match DiscoveryState::connect(&tiered).await {
+            Ok(_) => panic!("zero-freshness tiered configuration was admitted"),
+            Err(error) => error,
+        };
+        assert!(error.to_string().contains("l1_max_ttl_ms must be positive"));
+    }
+
+    #[cfg(all(not(target_arch = "wasm32"), feature = "valkey"))]
+    fn valkey_config(url: String, suffix: &str) -> ValkeyStateConfig {
+        ValkeyStateConfig {
+            url,
+            key_prefix: format!(
+                "hs-test-{}-{}-{suffix}",
+                std::process::id(),
+                unix_millis_now()
+            ),
+            pool_size: 2,
+            announcement_capacity: 64,
+            liveness_capacity: 64,
+            artifact_capacity: 64,
+            command_timeout_ms: 250,
+        }
+    }
+
+    #[cfg(all(not(target_arch = "wasm32"), feature = "valkey"))]
+    #[tokio::test]
+    async fn valkey_satisfies_announcement_backend_contract() {
+        let Ok(url) = std::env::var("HYPRSTREAM_TEST_VALKEY_URL") else {
+            return;
+        };
+        let mut config = valkey_config(url, "contract");
+        config.announcement_capacity = 1;
+        let store = ValkeyStateStore::connect(&config).await.unwrap();
+        assert_announcement_backend_contract(&store).await;
+    }
+
+    #[cfg(all(not(target_arch = "wasm32"), feature = "valkey"))]
+    #[tokio::test]
+    async fn valkey_two_replicas_share_all_discovery_state() {
+        let Ok(url) = std::env::var("HYPRSTREAM_TEST_VALKEY_URL") else {
+            return;
+        };
+        let config = valkey_config(url, "shared");
+        let replica_a = ValkeyStateStore::connect(&config).await.unwrap();
+        let replica_b = ValkeyStateStore::connect(&config).await.unwrap();
+        let now = unix_millis_now();
+
+        replica_a
+            .put_announcement("model", endpoint("iroh", 1, now + 30_000, now + 20_000))
+            .await
+            .unwrap();
+        assert_eq!(
+            replica_b
+                .announcements_for("model", now)
+                .await
+                .unwrap()
+                .len(),
+            1
+        );
+
+        replica_b
+            .put_liveness(
+                &Did::new("did:web:node.example".to_owned()),
+                LiveAllocatable {
+                    allocatable: vec![("cpu".to_owned(), "8".to_owned())],
+                    load_fraction: 0.25,
+                    last_seen: now,
+                    live_until_unix_ms: now + 20_000,
+                },
+            )
+            .await
+            .unwrap();
+        assert!(replica_a
+            .liveness(&Did::new("did:web:node.example".to_owned()), now)
+            .await
+            .unwrap()
+            .is_some());
+
+        replica_a
+            .put_entity_statement(
+                "https://issuer.example",
+                CachedEntityStatement {
+                    jwt: "statement".to_owned(),
+                    fetched_at: now / 1_000,
+                },
+            )
+            .await
+            .unwrap();
+        assert_eq!(
+            replica_b
+                .entity_statement("https://issuer.example")
+                .await
+                .unwrap()
+                .unwrap()
+                .jwt,
+            "statement"
+        );
+
+        replica_b
+            .put_envelope_keyset(
+                "did:web:service.example",
+                CachedEnvelopeKeyset {
+                    cose_keyset_cbor: vec![1, 2, 3],
+                    fetched_at: now / 1_000,
+                },
+            )
+            .await
+            .unwrap();
+        assert_eq!(
+            replica_a
+                .envelope_keyset("did:web:service.example")
+                .await
+                .unwrap()
+                .unwrap()
+                .cose_keyset_cbor,
+            vec![1, 2, 3]
+        );
+
+        // A newly connected replica sees the same state after process-local
+        // state is discarded.
+        let restarted = ValkeyStateStore::connect(&config).await.unwrap();
+        assert_eq!(
+            restarted
+                .announcements_for("model", now)
+                .await
+                .unwrap()
+                .len(),
+            1
+        );
+    }
+
+    #[cfg(all(not(target_arch = "wasm32"), feature = "valkey"))]
+    #[tokio::test]
+    async fn valkey_rejects_delayed_old_update_and_expires_server_side() {
+        let Ok(url) = std::env::var("HYPRSTREAM_TEST_VALKEY_URL") else {
+            return;
+        };
+        let config = valkey_config(url, "ordering");
+        let store = ValkeyStateStore::connect(&config).await.unwrap();
+        let now = unix_millis_now();
+        store
+            .put_announcement("model", endpoint("iroh", 4, now + 30_000, now + 20_000))
+            .await
+            .unwrap();
+        assert_eq!(
+            store
+                .put_announcement("model", endpoint("iroh", 3, now + 40_000, now + 20_000))
+                .await
+                .unwrap(),
+            PutResult::IgnoredOlder
+        );
+        assert_eq!(
+            store.announcements_for("model", now).await.unwrap()[0].accepted_state_epoch,
+            4
+        );
+
+        store
+            .put_announcement("short", endpoint("iroh", 1, now + 10_000, now + 50))
+            .await
+            .unwrap();
+        tokio::time::sleep(std::time::Duration::from_millis(80)).await;
+        assert!(store
+            .announcements_for("short", unix_millis_now())
+            .await
+            .unwrap()
+            .is_empty());
+    }
+
+    #[cfg(all(not(target_arch = "wasm32"), feature = "valkey"))]
+    #[tokio::test]
+    async fn tiered_revision_check_invalidates_other_replica_l1() {
+        let Ok(url) = std::env::var("HYPRSTREAM_TEST_VALKEY_URL") else {
+            return;
+        };
+        let config = valkey_config(url, "tiered");
+        let shared_a = Arc::new(ValkeyStateStore::connect(&config).await.unwrap());
+        let shared_b = Arc::new(ValkeyStateStore::connect(&config).await.unwrap());
+        let tier_a =
+            TieredStateStore::new(Arc::new(MemoryStateStore::new(8, 8, 8)), shared_a, 10_000);
+        let tier_b =
+            TieredStateStore::new(Arc::new(MemoryStateStore::new(8, 8, 8)), shared_b, 10_000);
+        let now = unix_millis_now();
+        tier_a
+            .put_announcement("model", endpoint("iroh", 1, now + 30_000, now + 20_000))
+            .await
+            .unwrap();
+        assert_eq!(
+            tier_b.announcements_for("model", now).await.unwrap()[0].accepted_state_epoch,
+            1
+        );
+        tier_a
+            .put_announcement("model", endpoint("iroh", 2, now + 40_000, now + 20_000))
+            .await
+            .unwrap();
+        assert_eq!(
+            tier_b.announcements_for("model", now).await.unwrap()[0].accepted_state_epoch,
+            2,
+            "L2 revision change must invalidate replica B's populated L1"
+        );
+    }
+
+    #[cfg(all(not(target_arch = "wasm32"), feature = "valkey"))]
+    #[tokio::test]
+    async fn tiered_does_not_resurrect_expired_l2_data() {
+        let Ok(url) = std::env::var("HYPRSTREAM_TEST_VALKEY_URL") else {
+            return;
+        };
+        let config = valkey_config(url, "tiered-expiry");
+        let shared = Arc::new(ValkeyStateStore::connect(&config).await.unwrap());
+        let tiered =
+            TieredStateStore::new(Arc::new(MemoryStateStore::new(8, 8, 8)), shared, 10_000);
+        let now = unix_millis_now();
+        tiered
+            .put_announcement("model", endpoint("iroh", 1, now + 10_000, now + 50))
+            .await
+            .unwrap();
+        assert_eq!(
+            tiered.announcements_for("model", now).await.unwrap().len(),
+            1
+        );
+
+        tokio::time::sleep(std::time::Duration::from_millis(80)).await;
+        assert!(tiered
+            .announcements_for("model", unix_millis_now())
+            .await
+            .unwrap()
+            .is_empty());
+    }
+
+    #[cfg(all(not(target_arch = "wasm32"), feature = "valkey"))]
+    #[tokio::test]
+    async fn tiered_fails_closed_after_l2_client_shutdown() {
+        use fred::prelude::ClientLike as _;
+
+        let Ok(url) = std::env::var("HYPRSTREAM_TEST_VALKEY_URL") else {
+            return;
+        };
+        let config = valkey_config(url, "tiered-outage");
+        let shared = Arc::new(ValkeyStateStore::connect(&config).await.unwrap());
+        let tiered = TieredStateStore::new(
+            Arc::new(MemoryStateStore::new(8, 8, 8)),
+            Arc::clone(&shared),
+            10_000,
+        );
+        let now = unix_millis_now();
+        tiered
+            .put_announcement("model", endpoint("iroh", 1, now + 30_000, now + 20_000))
+            .await
+            .unwrap();
+        assert_eq!(
+            tiered.announcements_for("model", now).await.unwrap().len(),
+            1
+        );
+
+        shared.pool.quit().await.unwrap();
+        let result = tokio::time::timeout(
+            std::time::Duration::from_secs(2),
+            tiered.announcements_for("model", unix_millis_now()),
+        )
+        .await
+        .expect("configured command timeout must bound an L2 outage");
+        assert!(
+            result.is_err(),
+            "tiered state must not return its populated L1"
+        );
+    }
+}

--- a/crates/hyprstream-discovery/src/state_store.rs
+++ b/crates/hyprstream-discovery/src/state_store.rs
@@ -58,7 +58,7 @@ pub struct ValkeyStateConfig {
 impl Default for ValkeyStateConfig {
     fn default() -> Self {
         Self {
-            url: "redis://127.0.0.1:6379".to_owned(),
+            url: String::new(),
             key_prefix: "hs".to_owned(),
             pool_size: 8,
             announcement_capacity: 65_536,
@@ -645,6 +645,10 @@ impl ValkeyStateStore {
         anyhow::ensure!(
             config.pool_size > 0,
             "Discovery Valkey pool_size must be positive"
+        );
+        anyhow::ensure!(
+            !config.url.trim().is_empty(),
+            "Discovery Valkey URL must be configured explicitly"
         );
         anyhow::ensure!(
             config.command_timeout_ms > 0,

--- a/crates/hyprstream-discovery/src/state_store.rs
+++ b/crates/hyprstream-discovery/src/state_store.rs
@@ -428,7 +428,7 @@ impl MemoryStateStore {
         }
     }
 
-    #[cfg(any(test, feature = "test-fixtures"))]
+    #[cfg(test)]
     pub(crate) fn put_announcement_sync(
         &self,
         service_name: &str,
@@ -528,7 +528,7 @@ impl MemoryStateStore {
             .collect()
     }
 
-    #[cfg(any(feature = "valkey", test, feature = "test-fixtures"))]
+    #[cfg(feature = "valkey")]
     pub(crate) fn clear_announcements_sync(&self, service_name: &str) {
         let mut inner = self.inner.lock();
         let Some(socket_kinds) = inner.service_index.remove(service_name) else {

--- a/crates/hyprstream-discovery/src/state_store.rs
+++ b/crates/hyprstream-discovery/src/state_store.rs
@@ -829,6 +829,7 @@ impl ValkeyStateStore {
     // Persistent family-wide generations bound revision storage independently
     // of identity churn. Never expire/reset these counters: recreating a scope
     // must not reuse a revision still attached to another replica's L1 value.
+    #[cfg(test)]
     async fn announcement_revision(&self) -> Result<u64> {
         self.revision(self.key("announcement-global-revision"))
             .await
@@ -844,7 +845,9 @@ impl ValkeyStateStore {
     // plus the last expired cohort; no historical service-name scan is needed.
     // All derived keys retain the deployment's cluster hash tag.
     const REAP_ANNOUNCEMENTS: &str = r#"
-local function reap(expiry, services, names, revision, now)
+local clock = redis.call('TIME')
+local now = tonumber(clock[1]) * 1000 + math.floor(tonumber(clock[2]) / 1000)
+local function reap(expiry, services, names, revision)
   local expired = redis.call('ZRANGEBYSCORE', expiry, '-inf', now)
   if #expired > 0 then redis.call('INCR', revision) end
   for _, key in ipairs(expired) do
@@ -860,6 +863,18 @@ local function reap(expiry, services, names, revision, now)
   end
 end
 "#;
+
+    async fn announcement_revision_at_shared_time(&self) -> Result<(u64, i64)> {
+        use fred::prelude::*;
+        // Cache hits need the same expiry clock as L2. Reap before reading the
+        // generation so an expired L2 value cannot remain valid in another L1.
+        self.pool.eval(
+            format!("{}\nreap(KEYS[1], KEYS[2], KEYS[3], KEYS[4])\nreturn {{redis.call('GET', KEYS[4]) or '0', now}}", Self::REAP_ANNOUNCEMENTS),
+            vec![self.key("announcement-expiry"), self.key("services"),
+                self.key("service-names"), self.key("announcement-global-revision")],
+            Vec::<String>::new(),
+        ).await.map_err(Into::into)
+    }
 
     async fn entity_revision(&self) -> Result<u64> {
         // Survives eviction/reinsertion: no per-issuer tombstones and no ABA
@@ -879,7 +894,6 @@ end
     async fn announcements_for_inner(
         &self,
         service_name: &str,
-        now_unix_ms: i64,
     ) -> Result<Vec<AnnouncedEndpoint>> {
         use fred::prelude::*;
 
@@ -887,14 +901,14 @@ end
         // refresh the same key, so GET followed by a separate DEL/SREM can
         // delete its newer value or remove its live index membership.
         const LIST: &str = r#"
-reap(KEYS[4], KEYS[2], KEYS[3], KEYS[5], ARGV[1])
+reap(KEYS[4], KEYS[2], KEYS[3], KEYS[5])
 local live = {}
 for _, key in ipairs(redis.call('SMEMBERS', KEYS[1])) do
   local encoded = redis.call('GET', key)
   if encoded then
     local ok, value = pcall(cjson.decode, encoded)
     if not ok then return redis.error_reply('corrupt Discovery announcement') end
-    if tonumber(value.live_until_unix_ms) > tonumber(ARGV[1]) and tonumber(value.expires_at_unix_ms) > tonumber(ARGV[1]) then
+    if tonumber(value.live_until_unix_ms) > now and tonumber(value.expires_at_unix_ms) > now then
       table.insert(live, encoded)
     else
       redis.call('INCR', KEYS[5])
@@ -908,8 +922,8 @@ for _, key in ipairs(redis.call('SMEMBERS', KEYS[1])) do
   end
 end
 if redis.call('SCARD', KEYS[1]) == 0 then
-  redis.call('SREM', KEYS[2], ARGV[2])
-  redis.call('HDEL', KEYS[3], ARGV[2])
+  redis.call('SREM', KEYS[2], ARGV[1])
+  redis.call('HDEL', KEYS[3], ARGV[1])
 end
 return live
 "#;
@@ -924,7 +938,7 @@ return live
                     self.key("announcement-expiry"),
                     self.key("announcement-global-revision"),
                 ],
-                vec![now_unix_ms.to_string(), Self::service_id(service_name)],
+                vec![Self::service_id(service_name)],
             )
             .await?;
         encoded
@@ -945,9 +959,10 @@ impl DiscoveryStateStore for ValkeyStateStore {
         use fred::prelude::*;
 
         const PUT: &str = r#"
-reap(KEYS[6], KEYS[3], KEYS[4], KEYS[5], ARGV[7])
+reap(KEYS[6], KEYS[3], KEYS[4], KEYS[5])
+if tonumber(ARGV[4]) <= now then return 0 end
 local current = redis.call('GET', KEYS[1])
-if not current and redis.call('ZCARD', KEYS[6]) >= tonumber(ARGV[8]) then
+if not current and redis.call('ZCARD', KEYS[6]) >= tonumber(ARGV[7]) then
   return redis.error_reply('Discovery Valkey announcement capacity exhausted')
 end
 if current then
@@ -993,7 +1008,6 @@ return 1
                         .to_string(),
                     service_id,
                     service_name.to_owned(),
-                    unix_millis_now().to_string(),
                     self.announcement_capacity.to_string(),
                 ],
             )
@@ -1008,15 +1022,15 @@ return 1
     async fn announcements_for(
         &self,
         service_name: &str,
-        now_unix_ms: i64,
+        _now_unix_ms: i64,
     ) -> Result<Vec<AnnouncedEndpoint>> {
-        self.announcements_for_inner(service_name, now_unix_ms)
+        self.announcements_for_inner(service_name)
             .await
     }
 
     async fn all_announcements(
         &self,
-        now_unix_ms: i64,
+        _now_unix_ms: i64,
     ) -> Result<Vec<(String, Vec<AnnouncedEndpoint>)>> {
         use fred::prelude::*;
 
@@ -1024,15 +1038,19 @@ return 1
         // expiry index. Reap and refresh still serialize, and a listing never
         // labels an L1 snapshot or performs round trips per service.
         const LIST: &str = r#"
-reap(KEYS[1], KEYS[2], KEYS[3], KEYS[4], ARGV[1])
+reap(KEYS[1], KEYS[2], KEYS[3], KEYS[4])
 local values = {}
 for _, key in ipairs(redis.call('ZRANGE', KEYS[1], 0, -1)) do
   local value = redis.call('GET', key)
   if value then
-    local service = string.match(key, ':announcement:([^:]+):[^:]+$')
-    local name = redis.call('HGET', KEYS[3], service)
-    if not name then return redis.error_reply('missing Discovery service name') end
-    table.insert(values, {name, value})
+    local ok, decoded = pcall(cjson.decode, value)
+    if not ok then return redis.error_reply('corrupt Discovery announcement') end
+    if tonumber(decoded.live_until_unix_ms) > now and tonumber(decoded.expires_at_unix_ms) > now then
+      local service = string.match(key, ':announcement:([^:]+):[^:]+$')
+      local name = redis.call('HGET', KEYS[3], service)
+      if not name then return redis.error_reply('missing Discovery service name') end
+      table.insert(values, {name, value})
+    end
   end
 end
 return values
@@ -1047,15 +1065,13 @@ return values
                     self.key("service-names"),
                     self.key("announcement-global-revision"),
                 ],
-                vec![now_unix_ms.to_string()],
+                Vec::<String>::new(),
             )
             .await?;
         let mut all: HashMap<String, Vec<AnnouncedEndpoint>> = HashMap::new();
         for (name, value) in encoded {
             let endpoint: AnnouncedEndpoint = serde_json::from_str(&value)?;
-            if endpoint.is_live_at(now_unix_ms) {
-                all.entry(name).or_default().push(endpoint);
-            }
+            all.entry(name).or_default().push(endpoint);
         }
         Ok(all.into_iter().collect())
     }
@@ -1384,11 +1400,11 @@ impl DiscoveryStateStore for TieredStateStore {
     async fn announcements_for(
         &self,
         service_name: &str,
-        now_unix_ms: i64,
+        _now_unix_ms: i64,
     ) -> Result<Vec<AnnouncedEndpoint>> {
         let _operation = self.operation("announcement", service_name).lock().await;
         let scope = Self::scope("announcement", service_name);
-        let revision = self.valkey.announcement_revision().await?;
+        let (revision, now_unix_ms) = self.valkey.announcement_revision_at_shared_time().await?;
         if self.is_observed(&scope, revision, now_unix_ms) {
             return self
                 .memory
@@ -1534,7 +1550,18 @@ impl DiscoveryStateStore for TieredStateStore {
     }
 }
 
+#[cfg(test)]
+thread_local! {
+    // Used only by current-thread clock-skew tests; never changes the host or
+    // the clock of another concurrently running test/Valkey driver thread.
+    static TEST_REPLICA_TIME: std::cell::Cell<Option<i64>> = const { std::cell::Cell::new(None) };
+}
+
 pub(crate) fn unix_millis_now() -> i64 {
+    #[cfg(test)]
+    if let Some(now) = TEST_REPLICA_TIME.with(std::cell::Cell::get) {
+        return now;
+    }
     use std::time::{SystemTime, UNIX_EPOCH};
     SystemTime::now()
         .duration_since(UNIX_EPOCH)
@@ -1745,11 +1772,12 @@ mod tests {
             10_000,
         );
         let now = unix_millis_now();
+        let cohort_expiry = now + 5_000;
         for i in 0..256 {
             let name = format!("service:{i}:λ");
             for kind in ["iroh", "quic"] {
                 writer
-                    .put_announcement(&name, endpoint(kind, 1, now + 60_000, now + 60_000))
+                    .put_announcement(&name, endpoint(kind, 1, cohort_expiry, cohort_expiry))
                     .await
                     .unwrap();
             }
@@ -1774,6 +1802,13 @@ mod tests {
             )
             .await
             .unwrap();
+        // Caller time cannot expire shared values. Keep the original name,
+        // value, index cleanup, and capacity assertions, but wait for the
+        // cohort's real server-side lease instead of advancing a replica.
+        assert_eq!(reader.all_announcements(now + 60_001).await.unwrap().len(), 256);
+        tokio::time::sleep(std::time::Duration::from_millis(
+            (cohort_expiry + 50 - unix_millis_now()).max(0) as u64,
+        )).await;
         let remaining = reader.all_announcements(now + 60_001).await.unwrap();
         assert_eq!(remaining.len(), 1);
         assert_eq!(remaining[0].0, "service:0:λ");
@@ -2096,6 +2131,120 @@ mod tests {
             artifact_capacity: 64,
             command_timeout_ms: 250,
         }
+    }
+
+    #[cfg(all(not(target_arch = "wasm32"), feature = "valkey"))]
+    struct ReplicaClock;
+
+    #[cfg(all(not(target_arch = "wasm32"), feature = "valkey"))]
+    impl ReplicaClock {
+        fn at(now: i64) -> Self {
+            TEST_REPLICA_TIME.with(|clock| {
+                assert!(clock.replace(Some(now)).is_none());
+            });
+            Self
+        }
+    }
+
+    #[cfg(all(not(target_arch = "wasm32"), feature = "valkey"))]
+    impl Drop for ReplicaClock {
+        fn drop(&mut self) {
+            TEST_REPLICA_TIME.with(|clock| clock.set(None));
+        }
+    }
+
+    #[cfg(all(not(target_arch = "wasm32"), feature = "valkey"))]
+    #[tokio::test]
+    async fn valkey_announcement_reaping_ignores_replica_clock_skew() {
+        use fred::prelude::*;
+
+        let Ok(url) = std::env::var("HYPRSTREAM_TEST_VALKEY_URL") else {
+            return;
+        };
+        // Each entry point gets its own still-live anchor. The clock guard
+        // also affects put_announcement's implicit host-clock call before the
+        // repair, not just the explicit timestamp arguments on read methods.
+        for operation in ["put", "point", "list", "tiered"] {
+            let config = valkey_config(url.clone(), operation);
+            let shared = Arc::new(ValkeyStateStore::connect(&config).await.unwrap());
+            let replica = Arc::new(ValkeyStateStore::connect(&config).await.unwrap());
+            let tiered = TieredStateStore::new(
+                Arc::new(MemoryStateStore::new(8, 8, 8)), replica.clone(), 30_000,
+            );
+            let now: i64 = shared.pool.eval(
+                "local t = redis.call('TIME'); return tonumber(t[1])*1000 + math.floor(tonumber(t[2])/1000)",
+                Vec::<String>::new(), Vec::<String>::new(),
+            ).await.unwrap();
+            shared.put_announcement("anchor", endpoint("iroh", 1, now + 60_000, now + 30_000)).await.unwrap();
+            if operation == "tiered" {
+                assert_eq!(tiered.announcements_for("anchor", now).await.unwrap().len(), 1);
+            }
+            let revision = shared.announcement_revision().await.unwrap();
+            let ahead = now + 3_600_000;
+            {
+                let _clock = ReplicaClock::at(ahead);
+                match operation {
+                    "put" => {
+                        replica.put_announcement("writer", endpoint("iroh", 1, ahead + 60_000, ahead + 30_000)).await.unwrap();
+                    }
+                    "point" => assert_eq!(replica.announcements_for("anchor", ahead).await.unwrap().len(), 1),
+                    "list" => assert_eq!(replica.all_announcements(ahead).await.unwrap().len(), 1),
+                    "tiered" => assert_eq!(tiered.announcements_for("anchor", ahead).await.unwrap().len(), 1),
+                    _ => unreachable!(),
+                }
+            }
+            assert_eq!(shared.announcements_for("anchor", now).await.unwrap().len(), 1, "{operation} deleted another replica's live announcement");
+            let exists: bool = shared.pool.exists(shared.announcement_key("anchor", "iroh")).await.unwrap();
+            assert!(exists);
+            assert_eq!(shared.announcement_revision().await.unwrap(), revision + u64::from(operation == "put"));
+        }
+    }
+
+    #[cfg(all(not(target_arch = "wasm32"), feature = "valkey"))]
+    #[tokio::test]
+    async fn valkey_announcement_shared_expiry_rejects_behind_replica_revival() {
+        use fred::prelude::*;
+
+        let Ok(url) = std::env::var("HYPRSTREAM_TEST_VALKEY_URL") else {
+            return;
+        };
+        let config = valkey_config(url, "announcement-expiry-clock");
+        let shared = Arc::new(ValkeyStateStore::connect(&config).await.unwrap());
+        let tiered = TieredStateStore::new(
+            Arc::new(MemoryStateStore::new(8, 8, 8)), shared.clone(), 30_000,
+        );
+        let now: i64 = shared.pool.eval(
+            "local t = redis.call('TIME'); return tonumber(t[1])*1000 + math.floor(tonumber(t[2])/1000)",
+            Vec::<String>::new(), Vec::<String>::new(),
+        ).await.unwrap();
+        // Either signed/accepted authority or the shorter effective heartbeat
+        // lease can expire first; neither becomes a new receipt-relative lease.
+        let expiry = now + 300;
+        for (name, signed, live) in [("signed", expiry, now + 60_000), ("lease", now + 60_000, expiry)] {
+            shared.put_announcement(name, endpoint("iroh", 1, signed, live)).await.unwrap();
+            let pxat: i64 = shared.pool.eval("return redis.call('PEXPIRETIME', KEYS[1])",
+                vec![shared.announcement_key(name, "iroh")], Vec::<String>::new()).await.unwrap();
+            assert_eq!(pxat, expiry, "preserve the absolute authority/lease ceiling");
+            assert_eq!(tiered.announcements_for(name, now).await.unwrap().len(), 1);
+        }
+        let revision = shared.announcement_revision().await.unwrap();
+        tokio::time::sleep(std::time::Duration::from_millis(400)).await;
+        let behind = now - 3_600_000;
+        let _clock = ReplicaClock::at(behind);
+        for name in ["signed", "lease"] {
+            // Exercise an already-populated L1 before any separate listing
+            // reaps L2 or invalidates its revision for us.
+            assert!(tiered.announcements_for(name, behind).await.unwrap().is_empty());
+            assert!(shared.announcements_for(name, behind).await.unwrap().is_empty());
+            assert_eq!(shared.put_announcement(name, endpoint("iroh", 2, expiry, now + 60_000)).await.unwrap(), PutResult::IgnoredOlder);
+        }
+        assert!(shared.all_announcements(behind).await.unwrap().is_empty());
+        assert!(shared.announcement_revision().await.unwrap() > revision);
+        let metadata: Vec<usize> = shared.pool.eval(
+            "return {redis.call('ZCARD', KEYS[1]), redis.call('SCARD', KEYS[2]), redis.call('HLEN', KEYS[3])}",
+            vec![shared.key("announcement-expiry"), shared.key("services"), shared.key("service-names")], Vec::<String>::new(),
+        ).await.unwrap();
+        assert_eq!(metadata, vec![0, 0, 0], "expired writes must not resurrect secondary indexes");
     }
 
     #[cfg(all(not(target_arch = "wasm32"), feature = "valkey"))]

--- a/crates/hyprstream-discovery/src/state_store.rs
+++ b/crates/hyprstream-discovery/src/state_store.rs
@@ -247,6 +247,8 @@ pub(crate) trait DiscoveryStateStore: Send + Sync {
 
     async fn put_liveness(&self, node: &Did, value: LiveAllocatable) -> Result<PutResult>;
     async fn liveness(&self, node: &Did, now_unix_ms: i64) -> Result<Option<LiveAllocatable>>;
+    /// Bounded enumeration of live nodes from the authoritative backend.
+    async fn all_liveness(&self, now_unix_ms: i64) -> Result<Vec<(Did, LiveAllocatable)>>;
 
     async fn put_entity_statement(&self, issuer: &str, value: CachedEntityStatement) -> Result<()>;
     async fn entity_statement(&self, issuer: &str) -> Result<Option<CachedEntityStatement>>;
@@ -350,6 +352,28 @@ impl MemoryStateStore {
         version
     }
 
+    // Replacement/declined L1 fills must not accumulate an unbounded heap of
+    // stale expiry versions while the actual maps remain capacity-bounded.
+    fn compact_expiry(inner: &mut MemoryInner) {
+        let limit = 2 * (inner.announcements.len() + inner.liveness.len());
+        if inner.expiry.len() > limit {
+            let MemoryInner {
+                announcements,
+                liveness,
+                expiry,
+                ..
+            } = inner;
+            expiry.retain(|Reverse(entry)| match &entry.key {
+                ExpiringKey::Announcement(key) => announcements
+                    .get(key)
+                    .is_some_and(|value| value.version == entry.version),
+                ExpiringKey::Liveness(node) => liveness
+                    .get(node)
+                    .is_some_and(|value| value.version == entry.version),
+            });
+        }
+    }
+
     fn reap(inner: &mut MemoryInner, now_unix_ms: i64) {
         while let Some(Reverse(head)) = inner.expiry.peek() {
             if head.expires_at_unix_ms > now_unix_ms {
@@ -423,6 +447,7 @@ impl MemoryStateStore {
                 version,
             },
         );
+        Self::compact_expiry(&mut inner);
         Ok(PutResult::Stored)
     }
 
@@ -488,18 +513,14 @@ impl MemoryStateStore {
                 socket_kind,
             });
         }
-    }
-
-    #[cfg(feature = "valkey")]
-    fn clear_all_announcements_sync(&self) {
-        let mut inner = self.inner.lock();
-        inner.announcements.clear();
-        inner.service_index.clear();
+        Self::compact_expiry(&mut inner);
     }
 
     #[cfg(feature = "valkey")]
     fn clear_liveness_sync(&self, node: &Did) {
-        self.inner.lock().liveness.remove(node.as_str());
+        let mut inner = self.inner.lock();
+        inner.liveness.remove(node.as_str());
+        Self::compact_expiry(&mut inner);
     }
 
     #[cfg(feature = "valkey")]
@@ -510,11 +531,6 @@ impl MemoryStateStore {
     #[cfg(feature = "valkey")]
     fn clear_envelope_keyset_sync(&self, service_did: &str) {
         self.inner.lock().envelope_keysets.remove(service_did);
-    }
-
-    #[cfg(feature = "valkey")]
-    fn clear_entity_statements_sync(&self) {
-        self.inner.lock().entity_statements.clear();
     }
 }
 
@@ -568,6 +584,7 @@ impl DiscoveryStateStore for MemoryStateStore {
             key: ExpiringKey::Liveness(node.clone()),
         }));
         inner.liveness.insert(node, Versioned { value, version });
+        Self::compact_expiry(&mut inner);
         Ok(PutResult::Stored)
     }
 
@@ -579,6 +596,17 @@ impl DiscoveryStateStore for MemoryStateStore {
             .get(node.as_str())
             .map(|entry| entry.value.clone())
             .filter(|entry| entry.is_live_at(now_unix_ms)))
+    }
+
+    async fn all_liveness(&self, now_unix_ms: i64) -> Result<Vec<(Did, LiveAllocatable)>> {
+        let mut inner = self.inner.lock();
+        Self::reap(&mut inner, now_unix_ms);
+        Ok(inner
+            .liveness
+            .iter()
+            .filter(|(_, entry)| entry.value.is_live_at(now_unix_ms))
+            .map(|(node, entry)| (Did::new(node.clone()), entry.value.clone()))
+            .collect())
     }
 
     async fn put_entity_statement(&self, issuer: &str, value: CachedEntityStatement) -> Result<()> {
@@ -627,9 +655,19 @@ impl DiscoveryStateStore for MemoryStateStore {
 }
 
 #[cfg(all(not(target_arch = "wasm32"), feature = "valkey"))]
+#[derive(Serialize, Deserialize)]
+struct StoredLiveness {
+    node: Did,
+    #[serde(flatten)]
+    value: LiveAllocatable,
+}
+
+#[cfg(all(not(target_arch = "wasm32"), feature = "valkey"))]
 #[derive(Clone)]
 struct ValkeyStateStore {
     pool: fred::prelude::RedisPool,
+    // The last store owner closes this channel, stopping the driver runtime.
+    _driver: Arc<tokio::sync::oneshot::Sender<()>>,
     prefix: String,
     announcement_capacity: usize,
     liveness_capacity: usize,
@@ -666,12 +704,56 @@ impl ValkeyStateStore {
             performance.default_command_timeout =
                 std::time::Duration::from_millis(config.command_timeout_ms);
         });
-        let pool = builder.build_pool(config.pool_size)?;
-        pool.connect();
-        pool.wait_for_connect().await?;
-        let _: String = pool.ping().await?;
+        // fred spawns drivers on the current runtime. Give them a runtime
+        // owned by this store, independent of a temporary factory/bootstrap
+        // runtime and of the caller's executor. Closing the last owner also
+        // shuts down the runtime; cancelled/failed connects cannot leak it.
+        let (ready_tx, ready_rx) = tokio::sync::oneshot::channel();
+        let (shutdown_tx, shutdown_rx) = tokio::sync::oneshot::channel();
+        let pool_size = config.pool_size;
+        let timeout = std::time::Duration::from_millis(config.command_timeout_ms);
+        std::thread::Builder::new()
+            .name("discovery-valkey".to_owned())
+            .spawn(move || {
+                let runtime = match tokio::runtime::Builder::new_current_thread()
+                    .enable_all()
+                    .build()
+                {
+                    Ok(runtime) => runtime,
+                    Err(error) => {
+                        let _ = ready_tx.send(Err(anyhow::Error::from(error)));
+                        return;
+                    }
+                };
+                runtime.block_on(async move {
+                    let connected: Result<RedisPool> = async {
+                        let pool = builder.build_pool(pool_size)?;
+                        pool.connect();
+                        tokio::time::timeout(timeout, pool.wait_for_connect()).await??;
+                        let _: String = pool.ping().await?;
+                        Ok(pool)
+                    }
+                    .await;
+                    match connected {
+                        Ok(pool) => {
+                            if ready_tx.send(Ok(pool.clone())).is_ok() {
+                                let _ = shutdown_rx.await;
+                                let _ = tokio::time::timeout(timeout, pool.quit()).await;
+                            }
+                        }
+                        Err(error) => {
+                            let _ = ready_tx.send(Err(error));
+                        }
+                    }
+                });
+            })
+            .context("start Discovery Valkey driver")?;
+        let pool = ready_rx
+            .await
+            .context("Discovery Valkey driver stopped during startup")??;
         Ok(Self {
             pool,
+            _driver: Arc::new(shutdown_tx),
             // One hash tag keeps every Lua transaction in one cluster slot.
             prefix: format!(
                 "{}:{{discovery-state}}",
@@ -730,11 +812,6 @@ impl ValkeyStateStore {
             .await
     }
 
-    async fn announcement_global_revision(&self) -> Result<u64> {
-        self.revision(self.key("announcement-global-revision"))
-            .await
-    }
-
     async fn liveness_revision(&self, node: &Did) -> Result<u64> {
         self.revision(format!(
             "{}:liveness-revision:{}",
@@ -753,10 +830,6 @@ impl ValkeyStateStore {
         .await
     }
 
-    async fn entity_global_revision(&self) -> Result<u64> {
-        self.revision(self.key("entity-global-revision")).await
-    }
-
     async fn envelope_revision(&self, service_did: &str) -> Result<u64> {
         self.revision(format!(
             "{}:envelope-revision:{}",
@@ -773,27 +846,51 @@ impl ValkeyStateStore {
     ) -> Result<Vec<AnnouncedEndpoint>> {
         use fred::prelude::*;
 
-        let index = self.announcement_index(service_name);
-        let record_keys: Vec<String> = self.pool.smembers(&index).await?;
-        let mut live = Vec::with_capacity(record_keys.len());
-        for record_key in record_keys {
-            let encoded: Option<String> = self.pool.get(&record_key).await?;
-            match encoded {
-                Some(encoded) => {
-                    let endpoint: AnnouncedEndpoint = serde_json::from_str(&encoded)?;
-                    if endpoint.is_live_at(now_unix_ms) {
-                        live.push(endpoint);
-                    } else {
-                        let _: i64 = self.pool.del(&record_key).await?;
-                        let _: i64 = self.pool.srem(&index, &record_key).await?;
-                    }
-                }
-                None => {
-                    let _: i64 = self.pool.srem(&index, &record_key).await?;
-                }
-            }
-        }
-        Ok(live)
+        // Cleanup must share the transaction with reads: a later writer may
+        // refresh the same key, so GET followed by a separate DEL/SREM can
+        // delete its newer value or remove its live index membership.
+        const LIST: &str = r#"
+local live = {}
+for _, key in ipairs(redis.call('SMEMBERS', KEYS[1])) do
+  local encoded = redis.call('GET', key)
+  if encoded then
+    local ok, value = pcall(cjson.decode, encoded)
+    if not ok then return redis.error_reply('corrupt Discovery announcement') end
+    if tonumber(value.live_until_unix_ms) > tonumber(ARGV[1]) and tonumber(value.expires_at_unix_ms) > tonumber(ARGV[1]) then
+      table.insert(live, encoded)
+    else
+      redis.call('DEL', key)
+      redis.call('SREM', KEYS[1], key)
+      redis.call('ZREM', KEYS[4], key)
+    end
+  else
+    redis.call('SREM', KEYS[1], key)
+    redis.call('ZREM', KEYS[4], key)
+  end
+end
+if redis.call('SCARD', KEYS[1]) == 0 then
+  redis.call('SREM', KEYS[2], ARGV[2])
+  redis.call('HDEL', KEYS[3], ARGV[2])
+end
+return live
+"#;
+        let encoded: Vec<String> = self
+            .pool
+            .eval(
+                LIST,
+                vec![
+                    self.announcement_index(service_name),
+                    self.key("services"),
+                    self.key("service-names"),
+                    self.key("announcement-expiry"),
+                ],
+                vec![now_unix_ms.to_string(), Self::service_id(service_name)],
+            )
+            .await?;
+        encoded
+            .into_iter()
+            .map(|value| serde_json::from_str(&value).map_err(Into::into))
+            .collect()
     }
 }
 
@@ -890,19 +987,12 @@ return 1
                 .hget(self.key("service-names"), &service_id)
                 .await?;
             let Some(service_name) = service_name else {
-                let _: i64 = self.pool.srem(self.key("services"), &service_id).await?;
                 continue;
             };
             let entries = self
                 .announcements_for_inner(&service_name, now_unix_ms)
                 .await?;
-            if entries.is_empty() {
-                let _: i64 = self.pool.srem(self.key("services"), &service_id).await?;
-                let _: i64 = self
-                    .pool
-                    .hdel(self.key("service-names"), &service_id)
-                    .await?;
-            } else {
+            if !entries.is_empty() {
                 all.push((service_name, entries));
             }
         }
@@ -939,7 +1029,10 @@ return 1
                     self.key("liveness-expiry"),
                 ],
                 vec![
-                    serde_json::to_string(&value)?,
+                    serde_json::to_string(&StoredLiveness {
+                        node: node.clone(),
+                        value: value.clone(),
+                    })?,
                     value.last_seen.to_string(),
                     value.live_until_unix_ms.to_string(),
                     unix_millis_now().to_string(),
@@ -968,6 +1061,38 @@ return 1
             .map(|encoded| serde_json::from_str(&encoded))
             .transpose()?
             .filter(|value: &LiveAllocatable| value.is_live_at(now_unix_ms)))
+    }
+
+    async fn all_liveness(&self, now_unix_ms: i64) -> Result<Vec<(Did, LiveAllocatable)>> {
+        use fred::prelude::*;
+        // The expiry index is capacity-bounded on every write. Enumerate it
+        // atomically with the values so concurrent expiry/replacement cannot
+        // leave a process-local candidate seed out of sync with shared state.
+        const LIST: &str = r#"
+redis.call('ZREMRANGEBYSCORE', KEYS[1], '-inf', ARGV[1])
+local values = {}
+for _, key in ipairs(redis.call('ZRANGE', KEYS[1], 0, -1)) do
+  local value = redis.call('GET', key)
+  if value then table.insert(values, value) end
+end
+return values
+"#;
+        let encoded: Vec<String> = self
+            .pool
+            .eval(
+                LIST,
+                vec![self.key("liveness-expiry")],
+                vec![now_unix_ms.to_string()],
+            )
+            .await?;
+        let mut live = Vec::with_capacity(encoded.len());
+        for value in encoded {
+            let record: StoredLiveness = serde_json::from_str(&value)?;
+            if record.value.is_live_at(now_unix_ms) {
+                live.push((record.node, record.value));
+            }
+        }
+        Ok(live)
     }
 
     async fn put_entity_statement(&self, issuer: &str, value: CachedEntityStatement) -> Result<()> {
@@ -1096,6 +1221,8 @@ struct TieredStateStore {
     valkey: Arc<ValkeyStateStore>,
     l1_max_ttl_ms: i64,
     observed: Mutex<HashMap<String, ObservedRevision>>,
+    // Keep cache contents and revision labels in one local operation order.
+    operation: tokio::sync::Mutex<()>,
 }
 
 #[cfg(all(not(target_arch = "wasm32"), feature = "valkey"))]
@@ -1110,6 +1237,7 @@ impl TieredStateStore {
             valkey,
             l1_max_ttl_ms: i64::try_from(l1_max_ttl_ms).unwrap_or(i64::MAX),
             observed: Mutex::new(HashMap::new()),
+            operation: tokio::sync::Mutex::new(()),
         }
     }
 
@@ -1124,7 +1252,17 @@ impl TieredStateStore {
     }
 
     fn observe(&self, scope: String, revision: u64, now_unix_ms: i64) {
-        self.observed.lock().insert(
+        let mut observed = self.observed.lock();
+        observed.retain(|_, value| now_unix_ms < value.valid_until_unix_ms);
+        let capacity = self
+            .memory
+            .announcement_capacity
+            .saturating_add(self.memory.liveness_capacity)
+            .saturating_add(self.memory.artifact_capacity.saturating_mul(2));
+        if observed.len() >= capacity {
+            observed.clear();
+        }
+        observed.insert(
             scope,
             ObservedRevision {
                 revision,
@@ -1160,19 +1298,14 @@ impl DiscoveryStateStore for TieredStateStore {
         service_name: &str,
         endpoint: AnnouncedEndpoint,
     ) -> Result<PutResult> {
-        let result = self
-            .valkey
-            .put_announcement(service_name, endpoint.clone())
-            .await?;
-        if result == PutResult::Stored {
-            let now = unix_millis_now();
-            self.memory
-                .put_announcement(service_name, self.l1_announcement(endpoint, now))
-                .await?;
-            let revision = self.valkey.announcement_revision(service_name).await?;
-            self.observe(Self::scope("announcement", service_name), revision, now);
-        }
-        Ok(result)
+        let _operation = self.operation.lock().await;
+        // Invalidate before the command, including on ambiguous write errors
+        // or cancellation. Never tag a caller's value with a later revision.
+        self.observed
+            .lock()
+            .remove(&Self::scope("announcement", service_name));
+        self.memory.clear_announcements_sync(service_name);
+        self.valkey.put_announcement(service_name, endpoint).await
     }
 
     async fn announcements_for(
@@ -1180,6 +1313,7 @@ impl DiscoveryStateStore for TieredStateStore {
         service_name: &str,
         now_unix_ms: i64,
     ) -> Result<Vec<AnnouncedEndpoint>> {
+        let _operation = self.operation.lock().await;
         let scope = Self::scope("announcement", service_name);
         let revision = self.valkey.announcement_revision(service_name).await?;
         if self.is_observed(&scope, revision, now_unix_ms) {
@@ -1192,16 +1326,27 @@ impl DiscoveryStateStore for TieredStateStore {
             .valkey
             .announcements_for(service_name, now_unix_ms)
             .await?;
+        self.observed.lock().remove(&scope);
         self.memory.clear_announcements_sync(service_name);
+        // L1 admission is optional; only a complete nonempty result is marked
+        // observed. Oversized scopes are served from L2 without partial hits.
         for value in &values {
-            self.memory
+            if self
+                .memory
                 .put_announcement(
                     service_name,
                     self.l1_announcement(value.clone(), now_unix_ms),
                 )
-                .await?;
+                .await
+                .is_err()
+            {
+                self.memory.clear_announcements_sync(service_name);
+                return Ok(values);
+            }
         }
-        self.observe(scope, revision, now_unix_ms);
+        if !values.is_empty() {
+            self.observe(scope, revision, now_unix_ms);
+        }
         Ok(values)
     }
 
@@ -1209,68 +1354,56 @@ impl DiscoveryStateStore for TieredStateStore {
         &self,
         now_unix_ms: i64,
     ) -> Result<Vec<(String, Vec<AnnouncedEndpoint>)>> {
-        let scope = "announcement-global".to_owned();
-        let revision = self.valkey.announcement_global_revision().await?;
-        if self.is_observed(&scope, revision, now_unix_ms) {
-            return self.memory.all_announcements(now_unix_ms).await;
-        }
-        let values = self.valkey.all_announcements(now_unix_ms).await?;
-        self.memory.clear_all_announcements_sync();
-        for (service_name, endpoints) in &values {
-            for endpoint in endpoints {
-                self.memory
-                    .put_announcement(
-                        service_name,
-                        self.l1_announcement(endpoint.clone(), now_unix_ms),
-                    )
-                    .await?;
-            }
-        }
-        self.observe(scope, revision, now_unix_ms);
-        Ok(values)
+        // A bounded L1 is not a complete replica of L2. Listings always read
+        // authoritative indexes and cannot invalidate point-cache snapshots.
+        self.valkey.all_announcements(now_unix_ms).await
     }
 
     async fn put_liveness(&self, node: &Did, value: LiveAllocatable) -> Result<PutResult> {
-        let result = self.valkey.put_liveness(node, value.clone()).await?;
-        if result == PutResult::Stored {
-            let now = unix_millis_now();
-            self.memory
-                .put_liveness(node, self.l1_liveness(value, now))
-                .await?;
-            let revision = self.valkey.liveness_revision(node).await?;
-            self.observe(Self::scope("liveness", node.as_str()), revision, now);
-        }
-        Ok(result)
+        let _operation = self.operation.lock().await;
+        self.observed
+            .lock()
+            .remove(&Self::scope("liveness", node.as_str()));
+        self.memory.clear_liveness_sync(node);
+        self.valkey.put_liveness(node, value).await
     }
 
     async fn liveness(&self, node: &Did, now_unix_ms: i64) -> Result<Option<LiveAllocatable>> {
+        let _operation = self.operation.lock().await;
         let scope = Self::scope("liveness", node.as_str());
         let revision = self.valkey.liveness_revision(node).await?;
         if self.is_observed(&scope, revision, now_unix_ms) {
             return self.memory.liveness(node, now_unix_ms).await;
         }
         let value = self.valkey.liveness(node, now_unix_ms).await?;
+        self.observed.lock().remove(&scope);
         self.memory.clear_liveness_sync(node);
         if let Some(value) = &value {
-            self.memory
+            if self
+                .memory
                 .put_liveness(node, self.l1_liveness(value.clone(), now_unix_ms))
-                .await?;
+                .await
+                .is_ok()
+            {
+                self.observe(scope, revision, now_unix_ms);
+            }
         }
-        self.observe(scope, revision, now_unix_ms);
         Ok(value)
     }
 
+    async fn all_liveness(&self, now_unix_ms: i64) -> Result<Vec<(Did, LiveAllocatable)>> {
+        self.valkey.all_liveness(now_unix_ms).await
+    }
+
     async fn put_entity_statement(&self, issuer: &str, value: CachedEntityStatement) -> Result<()> {
-        self.valkey
-            .put_entity_statement(issuer, value.clone())
-            .await?;
-        self.memory.put_entity_statement(issuer, value).await?;
-        let revision = self.valkey.entity_revision(issuer).await?;
-        self.observe(Self::scope("entity", issuer), revision, unix_millis_now());
-        Ok(())
+        let _operation = self.operation.lock().await;
+        self.observed.lock().remove(&Self::scope("entity", issuer));
+        self.memory.clear_entity_statement_sync(issuer);
+        self.valkey.put_entity_statement(issuer, value).await
     }
 
     async fn entity_statement(&self, issuer: &str) -> Result<Option<CachedEntityStatement>> {
+        let _operation = self.operation.lock().await;
         let now = unix_millis_now();
         let scope = Self::scope("entity", issuer);
         let revision = self.valkey.entity_revision(issuer).await?;
@@ -1278,32 +1411,23 @@ impl DiscoveryStateStore for TieredStateStore {
             return self.memory.entity_statement(issuer).await;
         }
         let value = self.valkey.entity_statement(issuer).await?;
+        self.observed.lock().remove(&scope);
         self.memory.clear_entity_statement_sync(issuer);
         if let Some(value) = &value {
-            self.memory
+            if self
+                .memory
                 .put_entity_statement(issuer, value.clone())
-                .await?;
+                .await
+                .is_ok()
+            {
+                self.observe(scope, revision, now);
+            }
         }
-        self.observe(scope, revision, now);
         Ok(value)
     }
 
     async fn known_issuers(&self) -> Result<Vec<String>> {
-        let now = unix_millis_now();
-        let scope = "entity-global".to_owned();
-        let revision = self.valkey.entity_global_revision().await?;
-        if self.is_observed(&scope, revision, now) {
-            return self.memory.known_issuers().await;
-        }
-        let issuers = self.valkey.known_issuers().await?;
-        self.memory.clear_entity_statements_sync();
-        for issuer in &issuers {
-            if let Some(value) = self.valkey.entity_statement(issuer).await? {
-                self.memory.put_entity_statement(issuer, value).await?;
-            }
-        }
-        self.observe(scope, revision, now);
-        Ok(issuers)
+        self.valkey.known_issuers().await
     }
 
     async fn put_envelope_keyset(
@@ -1311,20 +1435,16 @@ impl DiscoveryStateStore for TieredStateStore {
         service_did: &str,
         value: CachedEnvelopeKeyset,
     ) -> Result<()> {
-        self.valkey
-            .put_envelope_keyset(service_did, value.clone())
-            .await?;
-        self.memory.put_envelope_keyset(service_did, value).await?;
-        let revision = self.valkey.envelope_revision(service_did).await?;
-        self.observe(
-            Self::scope("envelope", service_did),
-            revision,
-            unix_millis_now(),
-        );
-        Ok(())
+        let _operation = self.operation.lock().await;
+        self.observed
+            .lock()
+            .remove(&Self::scope("envelope", service_did));
+        self.memory.clear_envelope_keyset_sync(service_did);
+        self.valkey.put_envelope_keyset(service_did, value).await
     }
 
     async fn envelope_keyset(&self, service_did: &str) -> Result<Option<CachedEnvelopeKeyset>> {
+        let _operation = self.operation.lock().await;
         let now = unix_millis_now();
         let scope = Self::scope("envelope", service_did);
         let revision = self.valkey.envelope_revision(service_did).await?;
@@ -1332,13 +1452,18 @@ impl DiscoveryStateStore for TieredStateStore {
             return self.memory.envelope_keyset(service_did).await;
         }
         let value = self.valkey.envelope_keyset(service_did).await?;
+        self.observed.lock().remove(&scope);
         self.memory.clear_envelope_keyset_sync(service_did);
         if let Some(value) = &value {
-            self.memory
+            if self
+                .memory
                 .put_envelope_keyset(service_did, value.clone())
-                .await?;
+                .await
+                .is_ok()
+            {
+                self.observe(scope, revision, now);
+            }
         }
-        self.observe(scope, revision, now);
         Ok(value)
     }
 }
@@ -1775,5 +1900,301 @@ mod tests {
             result.is_err(),
             "tiered state must not return its populated L1"
         );
+    }
+    #[tokio::test]
+    async fn memory_liveness_enumeration_excludes_expiry_and_remains_bounded() {
+        let store = MemoryStateStore::new(1, 1, 1);
+        let node = Did::new("did:web:live.example".to_owned());
+        let now = unix_millis_now();
+        for i in 0..100 {
+            store
+                .put_liveness(
+                    &node,
+                    LiveAllocatable {
+                        allocatable: vec![],
+                        load_fraction: 0.1,
+                        last_seen: now + i,
+                        live_until_unix_ms: now + 30_000,
+                    },
+                )
+                .await
+                .unwrap();
+        }
+        assert_eq!(store.all_liveness(now).await.unwrap()[0].0, node);
+        assert!(store.inner.lock().expiry.len() <= 2);
+        assert!(store.all_liveness(now + 30_000).await.unwrap().is_empty());
+    }
+
+    #[cfg(all(not(target_arch = "wasm32"), feature = "valkey"))]
+    #[tokio::test]
+    async fn valkey_driver_survives_temporary_bootstrap_runtime() {
+        let Ok(url) = std::env::var("HYPRSTREAM_TEST_VALKEY_URL") else {
+            return;
+        };
+        for backend in [DiscoveryStateBackend::Valkey, DiscoveryStateBackend::Tiered] {
+            let config = DiscoveryStateConfig {
+                backend,
+                active_active: true,
+                valkey: valkey_config(url.clone(), &format!("bootstrap-{backend:?}")),
+                ..DiscoveryStateConfig::default()
+            };
+            // Match the synchronous production factory, including exiting its
+            // thread and dropping its current-thread runtime before any use.
+            let state = std::thread::spawn(move || {
+                tokio::runtime::Builder::new_current_thread()
+                    .enable_all()
+                    .build()
+                    .unwrap()
+                    .block_on(DiscoveryState::connect(&config))
+                    .unwrap()
+            })
+            .join()
+            .unwrap();
+            let store = state.into_inner();
+            let now = unix_millis_now();
+            store
+                .put_announcement("model", endpoint("iroh", 1, now + 30_000, now + 20_000))
+                .await
+                .unwrap();
+            assert_eq!(
+                store.announcements_for("model", now).await.unwrap().len(),
+                1
+            );
+            tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+            assert_eq!(
+                store
+                    .all_announcements(unix_millis_now())
+                    .await
+                    .unwrap()
+                    .len(),
+                1
+            );
+        }
+    }
+
+    #[cfg(all(not(target_arch = "wasm32"), feature = "valkey"))]
+    #[tokio::test]
+    async fn tiered_capacity_never_limits_authoritative_results_or_writes() {
+        let Ok(url) = std::env::var("HYPRSTREAM_TEST_VALKEY_URL") else {
+            return;
+        };
+        let shared = Arc::new(
+            ValkeyStateStore::connect(&valkey_config(url, "capacity"))
+                .await
+                .unwrap(),
+        );
+        let memory = Arc::new(MemoryStateStore::new(1, 1, 1));
+        let tier = TieredStateStore::new(memory.clone(), shared, 10_000);
+        let now = unix_millis_now();
+        for name in ["a", "b", "c"] {
+            tier.put_announcement(name, endpoint("iroh", 1, now + 30_000, now + 20_000))
+                .await
+                .unwrap();
+            assert_eq!(tier.announcements_for(name, now).await.unwrap().len(), 1);
+            let node = Did::new(format!("did:web:{name}.example"));
+            tier.put_liveness(
+                &node,
+                LiveAllocatable {
+                    allocatable: vec![],
+                    load_fraction: 0.1,
+                    last_seen: now,
+                    live_until_unix_ms: now + 20_000,
+                },
+            )
+            .await
+            .unwrap();
+            assert!(tier.liveness(&node, now).await.unwrap().is_some());
+            tier.put_entity_statement(
+                name,
+                CachedEntityStatement {
+                    jwt: name.to_owned(),
+                    fetched_at: now,
+                },
+            )
+            .await
+            .unwrap();
+            assert!(tier.entity_statement(name).await.unwrap().is_some());
+            tier.put_envelope_keyset(
+                name,
+                CachedEnvelopeKeyset {
+                    cose_keyset_cbor: vec![1],
+                    fetched_at: now,
+                },
+            )
+            .await
+            .unwrap();
+            assert!(tier.envelope_keyset(name).await.unwrap().is_some());
+        }
+        for _ in 0..2 {
+            assert_eq!(tier.all_announcements(now).await.unwrap().len(), 3);
+            assert_eq!(tier.all_liveness(now).await.unwrap().len(), 3);
+            assert_eq!(tier.known_issuers().await.unwrap().len(), 3);
+        }
+        // A single service can also be larger than L1. Never mark a partial
+        // result as observed, including after repeated declined cache fills.
+        tier.put_announcement("a", endpoint("quic", 1, now + 30_000, now + 20_000))
+            .await
+            .unwrap();
+        for i in 0..50 {
+            assert_eq!(tier.announcements_for("a", now).await.unwrap().len(), 2);
+            let absent = format!("missing-{i}");
+            assert!(tier
+                .announcements_for(&absent, now)
+                .await
+                .unwrap()
+                .is_empty());
+            assert!(tier.entity_statement(&absent).await.unwrap().is_none());
+            assert!(tier.envelope_keyset(&absent).await.unwrap().is_none());
+            assert!(tier
+                .liveness(&Did::new(absent), now)
+                .await
+                .unwrap()
+                .is_none());
+        }
+        let cache = memory.inner.lock();
+        assert!(cache.announcements.len() <= 1);
+        assert!(cache.liveness.len() <= 1);
+        assert!(cache.entity_statements.len() <= 1);
+        assert!(cache.envelope_keysets.len() <= 1);
+        assert!(cache.expiry.len() <= 4);
+        assert!(tier.observed.lock().len() <= 4);
+    }
+
+    #[cfg(all(not(target_arch = "wasm32"), feature = "valkey"))]
+    #[tokio::test]
+    async fn tiered_writes_invalidate_instead_of_tagging_caller_values() {
+        let Ok(url) = std::env::var("HYPRSTREAM_TEST_VALKEY_URL") else {
+            return;
+        };
+        let config = valkey_config(url, "write-race");
+        let shared = Arc::new(ValkeyStateStore::connect(&config).await.unwrap());
+        let other = ValkeyStateStore::connect(&config).await.unwrap();
+        let tier = TieredStateStore::new(Arc::new(MemoryStateStore::new(8, 8, 8)), shared, 10_000);
+        let now = unix_millis_now();
+        let node = Did::new("did:web:node.example".to_owned());
+        // Two writers contend on all value families. An older announcement or
+        // heartbeat may be fenced; unordered artifacts follow completion order.
+        for epoch in 1..=8 {
+            let a = endpoint("iroh", epoch, now + 30_000, now + 20_000);
+            let b = endpoint("iroh", epoch + 1, now + 30_000, now + 20_000);
+            let (left, right) = tokio::join!(
+                tier.put_announcement("model", a),
+                other.put_announcement("model", b)
+            );
+            left.unwrap();
+            right.unwrap();
+            assert!(!tier.observed.lock().contains_key("announcement:model"));
+            assert_eq!(
+                tier.announcements_for("model", now).await.unwrap()[0].accepted_state_epoch,
+                epoch + 1
+            );
+            let a = LiveAllocatable {
+                allocatable: vec![],
+                load_fraction: 0.1,
+                last_seen: now + epoch as i64,
+                live_until_unix_ms: now + 20_000,
+            };
+            let mut b = a.clone();
+            b.last_seen += 1;
+            b.load_fraction = 0.9;
+            let (left, right) = tokio::join!(
+                tier.put_liveness(&node, a),
+                other.put_liveness(&node, b.clone())
+            );
+            left.unwrap();
+            right.unwrap();
+            assert!(!tier
+                .observed
+                .lock()
+                .contains_key(&TieredStateStore::scope("liveness", node.as_str())));
+            assert_eq!(
+                tier.liveness(&node, now)
+                    .await
+                    .unwrap()
+                    .unwrap()
+                    .load_fraction,
+                b.load_fraction
+            );
+            let a = CachedEntityStatement {
+                jwt: "a".to_owned(),
+                fetched_at: now,
+            };
+            let b = CachedEntityStatement {
+                jwt: "b".to_owned(),
+                fetched_at: now,
+            };
+            let (left, right) = tokio::join!(
+                tier.put_entity_statement("issuer", a),
+                other.put_entity_statement("issuer", b)
+            );
+            left.unwrap();
+            right.unwrap();
+            assert!(!tier.observed.lock().contains_key("entity:issuer"));
+            assert_eq!(
+                tier.entity_statement("issuer").await.unwrap(),
+                other.entity_statement("issuer").await.unwrap()
+            );
+            let a = CachedEnvelopeKeyset {
+                cose_keyset_cbor: vec![1],
+                fetched_at: now,
+            };
+            let b = CachedEnvelopeKeyset {
+                cose_keyset_cbor: vec![2],
+                fetched_at: now,
+            };
+            let (left, right) = tokio::join!(
+                tier.put_envelope_keyset("service", a),
+                other.put_envelope_keyset("service", b)
+            );
+            left.unwrap();
+            right.unwrap();
+            assert!(!tier.observed.lock().contains_key("envelope:service"));
+            assert_eq!(
+                tier.envelope_keyset("service").await.unwrap(),
+                other.envelope_keyset("service").await.unwrap()
+            );
+        }
+    }
+    #[cfg(all(not(target_arch = "wasm32"), feature = "valkey"))]
+    #[tokio::test]
+    async fn valkey_legacy_liveness_encoding_fails_closed_until_heartbeat() {
+        use fred::prelude::*;
+        let Ok(url) = std::env::var("HYPRSTREAM_TEST_VALKEY_URL") else {
+            return;
+        };
+        let store = ValkeyStateStore::connect(&valkey_config(url, "legacy-liveness"))
+            .await
+            .unwrap();
+        let node = Did::new("did:web:legacy-node.example".to_owned());
+        let now = unix_millis_now();
+        let value = LiveAllocatable {
+            allocatable: vec![],
+            load_fraction: 0.1,
+            last_seen: now,
+            live_until_unix_ms: now + 30_000,
+        };
+        store.put_liveness(&node, value.clone()).await.unwrap();
+        // Reproduce the pre-repair wire value, which had no enumerable DID.
+        let _: String = store
+            .pool
+            .eval(
+                "return redis.call('SET', KEYS[1], ARGV[1], 'KEEPTTL')",
+                vec![format!(
+                    "{}:liveness:{}",
+                    store.prefix,
+                    ValkeyStateStore::digest(node.as_str())
+                )],
+                vec![serde_json::to_string(&value).unwrap()],
+            )
+            .await
+            .unwrap();
+        assert!(store
+            .all_liveness(now)
+            .await
+            .unwrap_err()
+            .to_string()
+            .contains("node"));
+        store.put_liveness(&node, value).await.unwrap();
+        assert_eq!(store.all_liveness(now).await.unwrap()[0].0, node);
     }
 }

--- a/crates/hyprstream-discovery/src/state_store.rs
+++ b/crates/hyprstream-discovery/src/state_store.rs
@@ -254,6 +254,7 @@ pub(crate) trait DiscoveryStateStore: Send + Sync {
     async fn put_entity_statement(&self, issuer: &str, value: CachedEntityStatement) -> Result<()>;
     async fn entity_statement(&self, issuer: &str) -> Result<Option<CachedEntityStatement>>;
     async fn known_issuers(&self) -> Result<Vec<String>>;
+    async fn known_issuer_count(&self) -> Result<usize>;
 
     async fn put_envelope_keyset(
         &self,
@@ -620,7 +621,16 @@ impl DiscoveryStateStore for MemoryStateStore {
         if !inner.entity_statements.contains_key(issuer)
             && inner.entity_statements.len() >= self.artifact_capacity
         {
-            bail!("Discovery memory federation artifact capacity exhausted");
+            // These are inert artifacts, verified again at use. Retain the
+            // newest fetched entries without interpreting JWT expiry as trust.
+            if let Some(oldest) = inner
+                .entity_statements
+                .iter()
+                .min_by_key(|(name, value)| (value.fetched_at, *name))
+                .map(|(name, _)| name.clone())
+            {
+                inner.entity_statements.remove(&oldest);
+            }
         }
         inner.entity_statements.insert(issuer.to_owned(), value);
         Ok(())
@@ -638,6 +648,10 @@ impl DiscoveryStateStore for MemoryStateStore {
             .keys()
             .cloned()
             .collect())
+    }
+
+    async fn known_issuer_count(&self) -> Result<usize> {
+        Ok(self.inner.lock().entity_statements.len())
     }
 
     async fn put_envelope_keyset(
@@ -842,13 +856,10 @@ local function reap(expiry, services, names, revision, now)
 end
 "#;
 
-    async fn entity_revision(&self, issuer: &str) -> Result<u64> {
-        self.revision(format!(
-            "{}:entity-revision:{}",
-            self.prefix,
-            Self::digest(issuer)
-        ))
-        .await
+    async fn entity_revision(&self) -> Result<u64> {
+        // Survives eviction/reinsertion: no per-issuer tombstones and no ABA
+        // when another replica still has an evicted artifact in L1.
+        self.revision(self.key("entity-global-revision")).await
     }
 
     async fn envelope_revision(&self, service_did: &str) -> Result<u64> {
@@ -1145,13 +1156,19 @@ return values
         use fred::prelude::*;
         const PUT: &str = r#"
 if redis.call('EXISTS', KEYS[1]) == 0 and redis.call('SCARD', KEYS[2]) >= tonumber(ARGV[4]) then
-  return redis.error_reply('Discovery Valkey federation artifact capacity exhausted')
+  local oldest = redis.call('ZRANGE', KEYS[5], 0, 0)[1]
+  if not oldest then return redis.error_reply('Discovery issuer cache index is inconsistent') end
+  local oldkey = string.gsub(KEYS[1], ':entity:[^:]+$', ':entity:' .. oldest)
+  redis.call('DEL', oldkey)
+  redis.call('SREM', KEYS[2], oldest)
+  redis.call('HDEL', KEYS[3], oldest)
+  redis.call('ZREM', KEYS[5], oldest)
 end
 redis.call('SET', KEYS[1], ARGV[1])
 redis.call('SADD', KEYS[2], ARGV[2])
 redis.call('HSET', KEYS[3], ARGV[2], ARGV[3])
 redis.call('INCR', KEYS[4])
-redis.call('INCR', KEYS[5])
+redis.call('ZADD', KEYS[5], ARGV[5], ARGV[2])
 return 1
 "#;
         let id = Self::digest(issuer);
@@ -1163,14 +1180,15 @@ return 1
                     format!("{}:entity:{id}", self.prefix),
                     self.key("issuers"),
                     self.key("issuer-names"),
-                    format!("{}:entity-revision:{id}", self.prefix),
                     self.key("entity-global-revision"),
+                    self.key("issuer-fetched"),
                 ],
                 vec![
                     serde_json::to_string(&value)?,
                     id,
                     issuer.to_owned(),
                     self.artifact_capacity.to_string(),
+                    value.fetched_at.to_string(),
                 ],
             )
             .await?;
@@ -1190,18 +1208,12 @@ return 1
 
     async fn known_issuers(&self) -> Result<Vec<String>> {
         use fred::prelude::*;
-        let ids: Vec<String> = self.pool.smembers(self.key("issuers")).await?;
-        let mut issuers = Vec::with_capacity(ids.len());
-        for id in ids {
-            if let Some(issuer) = self
-                .pool
-                .hget::<Option<String>, _, _>(self.key("issuer-names"), &id)
-                .await?
-            {
-                issuers.push(issuer);
-            }
-        }
-        Ok(issuers)
+        Ok(self.pool.hvals(self.key("issuer-names")).await?)
+    }
+
+    async fn known_issuer_count(&self) -> Result<usize> {
+        use fred::prelude::*;
+        Ok(self.pool.scard(self.key("issuers")).await?)
     }
 
     async fn put_envelope_keyset(
@@ -1452,9 +1464,13 @@ impl DiscoveryStateStore for TieredStateStore {
         let _operation = self.operation.lock().await;
         let now = unix_millis_now();
         let scope = Self::scope("entity", issuer);
-        let revision = self.valkey.entity_revision(issuer).await?;
+        let revision = self.valkey.entity_revision().await?;
         if self.is_observed(&scope, revision, now) {
-            return self.memory.entity_statement(issuer).await;
+            // A fill of a different issuer can evict this L1 entry without a
+            // shared write. Missing L1 data is a miss, never cached absence.
+            if let Some(value) = self.memory.entity_statement(issuer).await? {
+                return Ok(Some(value));
+            }
         }
         let value = self.valkey.entity_statement(issuer).await?;
         self.observed.lock().remove(&scope);
@@ -1474,6 +1490,10 @@ impl DiscoveryStateStore for TieredStateStore {
 
     async fn known_issuers(&self) -> Result<Vec<String>> {
         self.valkey.known_issuers().await
+    }
+
+    async fn known_issuer_count(&self) -> Result<usize> {
+        self.valkey.known_issuer_count().await
     }
 
     async fn put_envelope_keyset(
@@ -1852,6 +1872,190 @@ mod tests {
             Err(error) => error,
         };
         assert!(error.to_string().contains("l1_max_ttl_ms must be positive"));
+    }
+
+    async fn assert_issuer_eviction_contract(store: &dyn DiscoveryStateStore) {
+        for (issuer, fetched_at) in [
+            ("old", 1),
+            ("refresh", 2),
+            ("keep", 3),
+            ("refresh", 4),
+            ("new", 5),
+        ] {
+            store
+                .put_entity_statement(
+                    issuer,
+                    CachedEntityStatement {
+                        jwt: format!("inert:{issuer}:{fetched_at}"),
+                        fetched_at,
+                    },
+                )
+                .await
+                .unwrap();
+        }
+        assert_eq!(store.known_issuer_count().await.unwrap(), 3);
+        let mut names = store.known_issuers().await.unwrap();
+        names.sort();
+        assert_eq!(names, ["keep", "new", "refresh"]);
+        assert!(store.entity_statement("old").await.unwrap().is_none());
+        assert_eq!(
+            store
+                .entity_statement("refresh")
+                .await
+                .unwrap()
+                .unwrap()
+                .fetched_at,
+            4
+        );
+        store
+            .put_entity_statement(
+                "old",
+                CachedEntityStatement {
+                    jwt: "reinserted".to_owned(),
+                    fetched_at: 6,
+                },
+            )
+            .await
+            .unwrap();
+        assert!(store.entity_statement("keep").await.unwrap().is_none());
+        assert_eq!(
+            store.entity_statement("old").await.unwrap().unwrap().jwt,
+            "reinserted"
+        );
+    }
+
+    #[tokio::test]
+    async fn memory_issuer_cache_evicts_oldest_and_accepts_reinsertion() {
+        assert_issuer_eviction_contract(&MemoryStateStore::new(1, 1, 3)).await;
+    }
+
+    #[cfg(all(not(target_arch = "wasm32"), feature = "valkey"))]
+    #[tokio::test]
+    async fn valkey_issuer_cache_churn_bounds_metadata_and_invalidates_other_l1() {
+        use fred::prelude::*;
+        let Ok(url) = std::env::var("HYPRSTREAM_TEST_VALKEY_URL") else {
+            return;
+        };
+        let mut config = valkey_config(url, "issuer-churn");
+        config.artifact_capacity = 3;
+        let writer = Arc::new(ValkeyStateStore::connect(&config).await.unwrap());
+        assert_issuer_eviction_contract(writer.as_ref()).await;
+        let reader = TieredStateStore::new(
+            Arc::new(MemoryStateStore::new(1, 1, 1)),
+            Arc::new(ValkeyStateStore::connect(&config).await.unwrap()),
+            60_000,
+        );
+        // A smaller L1 must refetch entries evicted by other fills even if L2
+        // has not changed. Previously an observed-but-missing entry returned None.
+        for issuer in ["old", "refresh", "old"] {
+            assert!(reader.entity_statement(issuer).await.unwrap().is_some());
+        }
+        let generation = writer.entity_revision().await.unwrap();
+        for i in 0..96 {
+            writer
+                .put_entity_statement(
+                    &format!("issuer-{i}"),
+                    CachedEntityStatement {
+                        jwt: format!("inert-{i}"),
+                        fetched_at: 100 + i,
+                    },
+                )
+                .await
+                .unwrap();
+            assert_eq!(writer.known_issuer_count().await.unwrap(), 3);
+        }
+        assert!(reader.entity_statement("old").await.unwrap().is_none());
+        let counts: Vec<usize> = writer.pool.eval(
+            "return {redis.call('SCARD', KEYS[1]), redis.call('HLEN', KEYS[2]), redis.call('ZCARD', KEYS[3]), #redis.call('KEYS', ARGV[1]), #redis.call('KEYS', ARGV[2])}",
+            vec![writer.key("issuers"), writer.key("issuer-names"), writer.key("issuer-fetched")],
+            vec![writer.key("*"), writer.key("*revision*")],
+        ).await.unwrap();
+        assert_eq!(counts, [3, 3, 3, 7, 1]);
+        assert!(writer.entity_revision().await.unwrap() > generation);
+        writer
+            .put_entity_statement(
+                "old",
+                CachedEntityStatement {
+                    jwt: "new-generation".to_owned(),
+                    fetched_at: 1000,
+                },
+            )
+            .await
+            .unwrap();
+        assert_eq!(
+            reader.entity_statement("old").await.unwrap().unwrap().jwt,
+            "new-generation"
+        );
+        // Retain a positive old snapshot across eviction AND reinsertion (ABA).
+        for i in 0..3 {
+            writer
+                .put_entity_statement(
+                    &format!("replacement-{i}"),
+                    CachedEntityStatement {
+                        jwt: "other".to_owned(),
+                        fetched_at: 2000 + i,
+                    },
+                )
+                .await
+                .unwrap();
+        }
+        writer
+            .put_entity_statement(
+                "old",
+                CachedEntityStatement {
+                    jwt: "after-aba".to_owned(),
+                    fetched_at: 3000,
+                },
+            )
+            .await
+            .unwrap();
+        assert_eq!(
+            reader.entity_statement("old").await.unwrap().unwrap().jwt,
+            "after-aba"
+        );
+        assert!(reader.observed.lock().len() <= 4);
+    }
+
+    #[cfg(all(not(target_arch = "wasm32"), feature = "valkey"))]
+    #[tokio::test]
+    async fn valkey_issuer_listing_and_count_return_complete_bounded_cache() {
+        let Ok(url) = std::env::var("HYPRSTREAM_TEST_VALKEY_URL") else {
+            return;
+        };
+        let mut config = valkey_config(url, "issuer-list-count");
+        config.artifact_capacity = 128;
+        let writer = Arc::new(ValkeyStateStore::connect(&config).await.unwrap());
+        let reader = TieredStateStore::new(
+            Arc::new(MemoryStateStore::new(1, 1, 1)),
+            writer.clone(),
+            60_000,
+        );
+        let mut expected = Vec::new();
+        for i in 0..256 {
+            let name = format!("https://issuer:{i}:λ.example");
+            writer
+                .put_entity_statement(
+                    &name,
+                    CachedEntityStatement {
+                        jwt: "inert".to_owned(),
+                        fetched_at: i,
+                    },
+                )
+                .await
+                .unwrap();
+            if i >= 128 {
+                expected.push(name);
+            }
+        }
+        expected.sort();
+        for _ in 0..2 {
+            let mut actual = reader.known_issuers().await.unwrap();
+            actual.sort();
+            assert_eq!(actual, expected);
+            assert_eq!(reader.known_issuer_count().await.unwrap(), 128);
+        }
+        assert!(reader.memory.inner.lock().entity_statements.is_empty());
+        assert!(reader.observed.lock().is_empty());
     }
 
     #[cfg(all(not(target_arch = "wasm32"), feature = "valkey"))]

--- a/crates/hyprstream-discovery/src/state_store.rs
+++ b/crates/hyprstream-discovery/src/state_store.rs
@@ -14,6 +14,8 @@ use std::cmp::Reverse;
 use std::collections::{BTreeSet, BinaryHeap, HashMap};
 use std::sync::Arc;
 
+pub(crate) const ANNOUNCED_ENDPOINT_TTL: std::time::Duration = std::time::Duration::from_secs(90);
+
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "kebab-case")]
 pub enum DiscoveryStateBackend {
@@ -172,15 +174,27 @@ pub(crate) struct AnnouncedEndpoint {
     pub(crate) response_key_id: String,
     pub(crate) request_kem_key_id: String,
     pub(crate) request_kem_recipient: Vec<u8>,
-    /// Signed/application expiry carried by the announcement.
+    /// Signed/application expiry carried by the announcement. Zero on a
+    /// legacy write requests a backend-receipt-bounded application expiry.
     pub(crate) expires_at_unix_ms: i64,
     pub(crate) source_signer: [u8; 32],
-    /// Effective cache lifetime: no later than heartbeat, signed artifact, and
-    /// accepted-current-state expiry.
+    /// On write: independently verified signed/current-state authority ceiling.
+    /// On read: effective lifetime, also capped by the backend's receipt + TTL.
     pub(crate) live_until_unix_ms: i64,
 }
 
 impl AnnouncedEndpoint {
+    fn receipt_lease(mut self, now: i64) -> Option<Self> {
+        let heartbeat_expiry = now.saturating_add(ANNOUNCED_ENDPOINT_TTL.as_millis() as i64);
+        if self.expires_at_unix_ms == 0 {
+            self.expires_at_unix_ms = heartbeat_expiry;
+        }
+        self.live_until_unix_ms = heartbeat_expiry
+            .min(self.expires_at_unix_ms)
+            .min(self.live_until_unix_ms);
+        self.is_live_at(now).then_some(self)
+    }
+
     pub(crate) fn is_live_at(&self, now_unix_ms: i64) -> bool {
         now_unix_ms < self.live_until_unix_ms && now_unix_ms < self.expires_at_unix_ms
     }
@@ -414,13 +428,23 @@ impl MemoryStateStore {
         }
     }
 
+    #[cfg(any(test, feature = "test-fixtures"))]
     pub(crate) fn put_announcement_sync(
         &self,
         service_name: &str,
         endpoint: AnnouncedEndpoint,
     ) -> Result<PutResult> {
+        self.put_announcement_at(service_name, endpoint, unix_millis_now())
+    }
+
+    fn put_announcement_at(
+        &self,
+        service_name: &str,
+        endpoint: AnnouncedEndpoint,
+        now_unix_ms: i64,
+    ) -> Result<PutResult> {
         let mut inner = self.inner.lock();
-        Self::reap(&mut inner, unix_millis_now());
+        Self::reap(&mut inner, now_unix_ms);
         let key = AnnouncementKey {
             service_name: service_name.to_owned(),
             socket_kind: endpoint.socket_kind.clone(),
@@ -551,7 +575,11 @@ impl DiscoveryStateStore for MemoryStateStore {
         service_name: &str,
         endpoint: AnnouncedEndpoint,
     ) -> Result<PutResult> {
-        self.put_announcement_sync(service_name, endpoint)
+        let now = unix_millis_now();
+        let Some(endpoint) = endpoint.receipt_lease(now) else {
+            return Ok(PutResult::IgnoredOlder);
+        };
+        self.put_announcement_at(service_name, endpoint, now)
     }
 
     async fn announcements_for(
@@ -960,7 +988,11 @@ impl DiscoveryStateStore for ValkeyStateStore {
 
         const PUT: &str = r#"
 reap(KEYS[6], KEYS[3], KEYS[4], KEYS[5])
-if tonumber(ARGV[4]) <= now then return 0 end
+local signed_expiry = tonumber(ARGV[3])
+local heartbeat_expiry = now + tonumber(ARGV[8])
+if signed_expiry == 0 then signed_expiry = heartbeat_expiry end
+local expiry = math.min(heartbeat_expiry, signed_expiry, tonumber(ARGV[4]))
+if expiry <= now then return 0 end
 local current = redis.call('GET', KEYS[1])
 if not current and redis.call('ZCARD', KEYS[6]) >= tonumber(ARGV[7]) then
   return redis.error_reply('Discovery Valkey announcement capacity exhausted')
@@ -971,21 +1003,35 @@ if current then
   local old_epoch = tonumber(decoded.accepted_state_epoch) or 0
   local old_exp = tonumber(decoded.expires_at_unix_ms) or 0
   local new_epoch = tonumber(ARGV[2])
-  local new_exp = tonumber(ARGV[3])
+  local new_exp = signed_expiry
   if old_epoch > new_epoch or (old_epoch == new_epoch and old_exp > new_exp) then
     return 0
   end
 end
-redis.call('SET', KEYS[1], ARGV[1], 'PXAT', ARGV[4])
+-- Only the effective lease (and legacy application expiry) is computed here.
+-- Preserve all other JSON fields/arrays exactly as encoded by Rust, not cjson.
+local encoded = string.sub(ARGV[1], 1, -2) .. ',"live_until_unix_ms":' .. string.format('%.0f', expiry)
+if tonumber(ARGV[3]) == 0 then
+  encoded = encoded .. ',"expires_at_unix_ms":' .. string.format('%.0f', signed_expiry)
+end
+encoded = encoded .. '}'
+redis.call('SET', KEYS[1], encoded, 'PXAT', expiry)
 redis.call('SADD', KEYS[2], KEYS[1])
 redis.call('SADD', KEYS[3], ARGV[5])
 redis.call('HSET', KEYS[4], ARGV[5], ARGV[6])
 redis.call('INCR', KEYS[5])
-redis.call('ZADD', KEYS[6], ARGV[4], KEYS[1])
+redis.call('ZADD', KEYS[6], expiry, KEYS[1])
 return 1
 "#;
         let service_id = Self::service_id(service_name);
-        let encoded = serde_json::to_string(&endpoint)?;
+        let mut payload = serde_json::to_value(&endpoint)?;
+        let fields = payload.as_object_mut()
+            .ok_or_else(|| anyhow::anyhow!("announcement must encode as an object"))?;
+        fields.remove("live_until_unix_ms");
+        if endpoint.expires_at_unix_ms == 0 {
+            fields.remove("expires_at_unix_ms");
+        }
+        let encoded = serde_json::to_string(&payload)?;
         let stored: i64 = self
             .pool
             .eval(
@@ -1002,13 +1048,11 @@ return 1
                     encoded,
                     endpoint.accepted_state_epoch.to_string(),
                     endpoint.expires_at_unix_ms.to_string(),
-                    endpoint
-                        .live_until_unix_ms
-                        .min(endpoint.expires_at_unix_ms)
-                        .to_string(),
+                    endpoint.live_until_unix_ms.to_string(),
                     service_id,
                     service_name.to_owned(),
                     self.announcement_capacity.to_string(),
+                    ANNOUNCED_ENDPOINT_TTL.as_millis().to_string(),
                 ],
             )
             .await?;
@@ -1422,11 +1466,11 @@ impl DiscoveryStateStore for TieredStateStore {
         for value in &values {
             if self
                 .memory
-                .put_announcement(
+                .put_announcement_at(
                     service_name,
                     self.l1_announcement(value.clone(), now_unix_ms),
+                    now_unix_ms,
                 )
-                .await
                 .is_err()
             {
                 self.memory.clear_announcements_sync(service_name);
@@ -1570,7 +1614,7 @@ pub(crate) fn unix_millis_now() -> i64 {
 }
 
 #[cfg(test)]
-mod tests {
+pub(crate) mod tests {
     #![allow(clippy::expect_used, clippy::indexing_slicing, clippy::unwrap_used)]
 
     use super::*;
@@ -2133,12 +2177,10 @@ mod tests {
         }
     }
 
-    #[cfg(all(not(target_arch = "wasm32"), feature = "valkey"))]
-    struct ReplicaClock;
+    pub(crate) struct ReplicaClock;
 
-    #[cfg(all(not(target_arch = "wasm32"), feature = "valkey"))]
     impl ReplicaClock {
-        fn at(now: i64) -> Self {
+        pub(crate) fn at(now: i64) -> Self {
             TEST_REPLICA_TIME.with(|clock| {
                 assert!(clock.replace(Some(now)).is_none());
             });
@@ -2146,10 +2188,43 @@ mod tests {
         }
     }
 
-    #[cfg(all(not(target_arch = "wasm32"), feature = "valkey"))]
     impl Drop for ReplicaClock {
         fn drop(&mut self) {
             TEST_REPLICA_TIME.with(|clock| clock.set(None));
+        }
+    }
+
+    #[cfg(all(not(target_arch = "wasm32"), feature = "valkey"))]
+    #[tokio::test]
+    async fn valkey_announcement_lease_uses_receipt_and_preserves_payload() {
+        use fred::prelude::*;
+        let Ok(url) = std::env::var("HYPRSTREAM_TEST_VALKEY_URL") else { return; };
+        let store = ValkeyStateStore::connect(&valkey_config(url, "announcement-write-lease")).await.unwrap();
+        let now: i64 = store.pool.eval(
+            "local t = redis.call('TIME'); return tonumber(t[1])*1000 + math.floor(tonumber(t[2])/1000)",
+            Vec::<String>::new(), Vec::<String>::new(),
+        ).await.unwrap();
+        for skew in [-3_600_000, 3_600_000] {
+            let name = format!("lease-{skew}");
+            let mut value = endpoint("iroh", 1, now + 7_200_000, now + 7_200_000);
+            value.capabilities.clear();
+            value.service_jwt = "payload with \"live_until_unix_ms\":123 and λ".to_owned();
+            value.source_signer = [255; 32];
+            let mut expected = serde_json::to_value(&value).unwrap();
+            expected.as_object_mut().unwrap().remove("live_until_unix_ms");
+            let _clock = ReplicaClock::at(now + skew);
+            assert_eq!(store.put_announcement(&name, value).await.unwrap(), PutResult::Stored);
+            let rows: (String, i64, i64, i64) = store.pool.eval(
+                "local t = redis.call('TIME'); return {redis.call('GET', KEYS[1]), redis.call('PEXPIRETIME', KEYS[1]), tonumber(redis.call('ZSCORE', KEYS[2], KEYS[1])), tonumber(t[1])*1000 + math.floor(tonumber(t[2])/1000)}",
+                vec![store.announcement_key(&name, "iroh"), store.key("announcement-expiry")], Vec::<String>::new(),
+            ).await.unwrap();
+            let mut actual: serde_json::Value = serde_json::from_str(&rows.0).unwrap();
+            let encoded_expiry = actual.as_object_mut().unwrap().remove("live_until_unix_ms").unwrap().as_i64().unwrap();
+            assert_eq!(actual, expected, "only the effective lease field may change");
+            assert_eq!(encoded_expiry, rows.1);
+            assert_eq!(encoded_expiry, rows.2);
+            assert!((89_000..=90_000).contains(&(encoded_expiry - rows.3)), "bounded shared receipt lease, independent of replica skew");
+            assert_eq!(store.announcements_for(&name, now + skew).await.unwrap().len(), 1);
         }
     }
 

--- a/crates/hyprstream-discovery/src/state_store.rs
+++ b/crates/hyprstream-discovery/src/state_store.rs
@@ -794,32 +794,44 @@ impl ValkeyStateStore {
         )
     }
 
-    fn announcement_revision_key(&self, service_name: &str) -> String {
-        format!(
-            "{}:announcement-revision:{}",
-            self.prefix,
-            Self::service_id(service_name)
-        )
-    }
-
     async fn revision(&self, key: String) -> Result<u64> {
         use fred::prelude::*;
         Ok(self.pool.get::<Option<u64>, _>(key).await?.unwrap_or(0))
     }
 
-    async fn announcement_revision(&self, service_name: &str) -> Result<u64> {
-        self.revision(self.announcement_revision_key(service_name))
+    // Persistent family-wide generations bound revision storage independently
+    // of identity churn. Never expire/reset these counters: recreating a scope
+    // must not reuse a revision still attached to another replica's L1 value.
+    async fn announcement_revision(&self) -> Result<u64> {
+        self.revision(self.key("announcement-global-revision"))
             .await
     }
 
-    async fn liveness_revision(&self, node: &Did) -> Result<u64> {
-        self.revision(format!(
-            "{}:liveness-revision:{}",
-            self.prefix,
-            Self::digest(node.as_str())
-        ))
-        .await
+    async fn liveness_revision(&self) -> Result<u64> {
+        self.revision(self.key("liveness-global-revision")).await
     }
+
+    // Reap values and ALL secondary metadata in the same transaction as the
+    // capacity check/read. The expiry index contains at most the live capacity
+    // plus the last expired cohort; no historical service-name scan is needed.
+    // All derived keys retain the deployment's cluster hash tag.
+    const REAP_ANNOUNCEMENTS: &str = r#"
+local function reap(expiry, services, names, revision, now)
+  local expired = redis.call('ZRANGEBYSCORE', expiry, '-inf', now)
+  if #expired > 0 then redis.call('INCR', revision) end
+  for _, key in ipairs(expired) do
+    local service = string.match(key, ':announcement:([^:]+):[^:]+$')
+    local index = string.gsub(key, ':announcement:[^:]+:[^:]+$', ':announcement-index:' .. service)
+    redis.call('DEL', key)
+    redis.call('SREM', index, key)
+    redis.call('ZREM', expiry, key)
+    if redis.call('SCARD', index) == 0 then
+      redis.call('SREM', services, service)
+      redis.call('HDEL', names, service)
+    end
+  end
+end
+"#;
 
     async fn entity_revision(&self, issuer: &str) -> Result<u64> {
         self.revision(format!(
@@ -850,6 +862,7 @@ impl ValkeyStateStore {
         // refresh the same key, so GET followed by a separate DEL/SREM can
         // delete its newer value or remove its live index membership.
         const LIST: &str = r#"
+reap(KEYS[4], KEYS[2], KEYS[3], KEYS[5], ARGV[1])
 local live = {}
 for _, key in ipairs(redis.call('SMEMBERS', KEYS[1])) do
   local encoded = redis.call('GET', key)
@@ -859,6 +872,7 @@ for _, key in ipairs(redis.call('SMEMBERS', KEYS[1])) do
     if tonumber(value.live_until_unix_ms) > tonumber(ARGV[1]) and tonumber(value.expires_at_unix_ms) > tonumber(ARGV[1]) then
       table.insert(live, encoded)
     else
+      redis.call('INCR', KEYS[5])
       redis.call('DEL', key)
       redis.call('SREM', KEYS[1], key)
       redis.call('ZREM', KEYS[4], key)
@@ -877,12 +891,13 @@ return live
         let encoded: Vec<String> = self
             .pool
             .eval(
-                LIST,
+                format!("{}{LIST}", Self::REAP_ANNOUNCEMENTS),
                 vec![
                     self.announcement_index(service_name),
                     self.key("services"),
                     self.key("service-names"),
                     self.key("announcement-expiry"),
+                    self.key("announcement-global-revision"),
                 ],
                 vec![now_unix_ms.to_string(), Self::service_id(service_name)],
             )
@@ -905,9 +920,9 @@ impl DiscoveryStateStore for ValkeyStateStore {
         use fred::prelude::*;
 
         const PUT: &str = r#"
+reap(KEYS[6], KEYS[3], KEYS[4], KEYS[5], ARGV[7])
 local current = redis.call('GET', KEYS[1])
-redis.call('ZREMRANGEBYSCORE', KEYS[7], '-inf', ARGV[7])
-if not current and redis.call('ZCARD', KEYS[7]) >= tonumber(ARGV[8]) then
+if not current and redis.call('ZCARD', KEYS[6]) >= tonumber(ARGV[8]) then
   return redis.error_reply('Discovery Valkey announcement capacity exhausted')
 end
 if current then
@@ -926,8 +941,7 @@ redis.call('SADD', KEYS[2], KEYS[1])
 redis.call('SADD', KEYS[3], ARGV[5])
 redis.call('HSET', KEYS[4], ARGV[5], ARGV[6])
 redis.call('INCR', KEYS[5])
-redis.call('INCR', KEYS[6])
-redis.call('ZADD', KEYS[7], ARGV[4], KEYS[1])
+redis.call('ZADD', KEYS[6], ARGV[4], KEYS[1])
 return 1
 "#;
         let service_id = Self::service_id(service_name);
@@ -935,13 +949,12 @@ return 1
         let stored: i64 = self
             .pool
             .eval(
-                PUT,
+                format!("{}{PUT}", Self::REAP_ANNOUNCEMENTS),
                 vec![
                     self.announcement_key(service_name, &endpoint.socket_kind),
                     self.announcement_index(service_name),
                     self.key("services"),
                     self.key("service-names"),
-                    self.announcement_revision_key(service_name),
                     self.key("announcement-global-revision"),
                     self.key("announcement-expiry"),
                 ],
@@ -949,7 +962,10 @@ return 1
                     encoded,
                     endpoint.accepted_state_epoch.to_string(),
                     endpoint.expires_at_unix_ms.to_string(),
-                    endpoint.live_until_unix_ms.to_string(),
+                    endpoint
+                        .live_until_unix_ms
+                        .min(endpoint.expires_at_unix_ms)
+                        .to_string(),
                     service_id,
                     service_name.to_owned(),
                     unix_millis_now().to_string(),
@@ -979,7 +995,13 @@ return 1
     ) -> Result<Vec<(String, Vec<AnnouncedEndpoint>)>> {
         use fred::prelude::*;
 
-        let service_ids: Vec<String> = self.pool.smembers(self.key("services")).await?;
+        // Reap before enumerating names, so listing work is bounded by current
+        // capacity rather than every identity that has ever announced.
+        let service_ids: Vec<String> = self.pool.eval(
+            format!("{}\nreap(KEYS[1], KEYS[2], KEYS[3], KEYS[4], ARGV[1])\nreturn redis.call('SMEMBERS', KEYS[2])", Self::REAP_ANNOUNCEMENTS),
+            vec![self.key("announcement-expiry"), self.key("services"), self.key("service-names"), self.key("announcement-global-revision")],
+            vec![now_unix_ms.to_string()],
+        ).await?;
         let mut all = Vec::with_capacity(service_ids.len());
         for service_id in service_ids {
             let service_name: Option<String> = self
@@ -1025,7 +1047,7 @@ return 1
                 PUT,
                 vec![
                     format!("{}:liveness:{node_id}", self.prefix),
-                    format!("{}:liveness-revision:{node_id}", self.prefix),
+                    self.key("liveness-global-revision"),
                     self.key("liveness-expiry"),
                 ],
                 vec![
@@ -1315,7 +1337,7 @@ impl DiscoveryStateStore for TieredStateStore {
     ) -> Result<Vec<AnnouncedEndpoint>> {
         let _operation = self.operation.lock().await;
         let scope = Self::scope("announcement", service_name);
-        let revision = self.valkey.announcement_revision(service_name).await?;
+        let revision = self.valkey.announcement_revision().await?;
         if self.is_observed(&scope, revision, now_unix_ms) {
             return self
                 .memory
@@ -1371,7 +1393,7 @@ impl DiscoveryStateStore for TieredStateStore {
     async fn liveness(&self, node: &Did, now_unix_ms: i64) -> Result<Option<LiveAllocatable>> {
         let _operation = self.operation.lock().await;
         let scope = Self::scope("liveness", node.as_str());
-        let revision = self.valkey.liveness_revision(node).await?;
+        let revision = self.valkey.liveness_revision().await?;
         if self.is_observed(&scope, revision, now_unix_ms) {
             return self.memory.liveness(node, now_unix_ms).await;
         }
@@ -2058,6 +2080,168 @@ mod tests {
         assert!(cache.envelope_keysets.len() <= 1);
         assert!(cache.expiry.len() <= 4);
         assert!(tier.observed.lock().len() <= 4);
+    }
+
+    #[cfg(all(not(target_arch = "wasm32"), feature = "valkey"))]
+    #[tokio::test]
+    async fn valkey_expired_identity_churn_bounds_metadata_and_listing_work() {
+        use fred::prelude::*;
+
+        let Ok(url) = std::env::var("HYPRSTREAM_TEST_VALKEY_URL") else {
+            return;
+        };
+        let mut config = valkey_config(url, "metadata-churn");
+        config.announcement_capacity = 4;
+        config.liveness_capacity = 4;
+        let store = Arc::new(ValkeyStateStore::connect(&config).await.unwrap());
+        let tier = TieredStateStore::new(
+            Arc::new(MemoryStateStore::new(4, 4, 4)),
+            store.clone(),
+            30_000,
+        );
+        let now = unix_millis_now();
+        let anchor = Did::new("did:web:anchor.example".to_owned());
+        store
+            .put_announcement("anchor", endpoint("iroh", 1, now + 30_000, now + 30_000))
+            .await
+            .unwrap();
+        store
+            .put_liveness(
+                &anchor,
+                LiveAllocatable {
+                    allocatable: vec![],
+                    load_fraction: 0.1,
+                    last_seen: now,
+                    live_until_unix_ms: now + 30_000,
+                },
+            )
+            .await
+            .unwrap();
+        tier.announcements_for("anchor", now).await.unwrap();
+        tier.liveness(&anchor, now).await.unwrap();
+        let announcement_generation = store.announcement_revision().await.unwrap();
+        let liveness_generation = store.liveness_revision().await.unwrap();
+
+        // No historical service is ever individually read. Each cohort expires
+        // server-side before the next one; 36 distinct identities exceed the
+        // live capacity nine times while the anchor's L1 snapshot stays warm.
+        for cohort in 0..12 {
+            let now = unix_millis_now();
+            for slot in 0..3 {
+                let name = format!("churn-{cohort}-{slot}");
+                store
+                    .put_announcement(&name, endpoint("iroh", 1, now + 100, now + 100))
+                    .await
+                    .unwrap();
+                store
+                    .put_liveness(
+                        &Did::new(format!("did:web:{name}.example")),
+                        LiveAllocatable {
+                            allocatable: vec![],
+                            load_fraction: 0.2,
+                            last_seen: now,
+                            live_until_unix_ms: now + 100,
+                        },
+                    )
+                    .await
+                    .unwrap();
+            }
+            // Inspect the backing namespace BEFORE any listing can clean it.
+            // KEYS is test-only, confined to this test's unique prefix.
+            let counts: Vec<usize> = store.pool.eval(
+                "return {redis.call('SCARD', KEYS[1]), redis.call('HLEN', KEYS[2]), #redis.call('KEYS', ARGV[1]), #redis.call('KEYS', ARGV[2]), #redis.call('KEYS', ARGV[3])}",
+                vec![store.key("services"), store.key("service-names")],
+                vec![store.key("*"), store.key("announcement-index:*"), store.key("*revision*")],
+            ).await.unwrap();
+            // services is exactly the worklist consumed by all_announcements.
+            assert!(
+                counts[0] <= 4,
+                "global listing work grew with history: {counts:?}"
+            );
+            assert!(counts[1] <= 4, "service names leaked: {counts:?}");
+            assert!(counts[2] <= 3 * 4 + 6, "backend keys leaked: {counts:?}");
+            assert!(counts[3] <= 4, "per-service indexes leaked: {counts:?}");
+            assert_eq!(counts[4], 2, "only two global generations may persist");
+            tokio::time::sleep(std::time::Duration::from_millis(150)).await;
+        }
+        let now = unix_millis_now();
+        let all = store.all_announcements(now).await.unwrap();
+        assert_eq!(all.len(), 1);
+        assert_eq!(all[0].0, "anchor");
+        assert_eq!(store.all_liveness(now).await.unwrap().len(), 1);
+        let count: usize = store.pool.scard(store.key("services")).await.unwrap();
+        assert_eq!(count, 1, "expired cohort must leave no listing work");
+        assert!(store.announcement_revision().await.unwrap() > announcement_generation);
+        assert!(store.liveness_revision().await.unwrap() > liveness_generation);
+
+        // Replace the still-cached anchor with a short-lived value on L2, then
+        // expire and recreate the SAME scopes. Revisions must not reset/ABA.
+        store
+            .put_announcement("anchor", endpoint("iroh", 2, now + 100, now + 100))
+            .await
+            .unwrap();
+        store
+            .put_liveness(
+                &anchor,
+                LiveAllocatable {
+                    allocatable: vec![],
+                    load_fraction: 0.5,
+                    last_seen: now,
+                    live_until_unix_ms: now + 100,
+                },
+            )
+            .await
+            .unwrap();
+        tokio::time::sleep(std::time::Duration::from_millis(150)).await;
+        let now = unix_millis_now();
+        assert!(store.all_announcements(now).await.unwrap().is_empty());
+        assert!(store.all_liveness(now).await.unwrap().is_empty());
+        let keys: Vec<String> = store
+            .pool
+            .eval(
+                "return redis.call('KEYS', ARGV[1])",
+                Vec::<String>::new(),
+                vec![store.key("*")],
+            )
+            .await
+            .unwrap();
+        assert_eq!(
+            keys.len(),
+            2,
+            "only persistent generations survive expiry: {keys:?}"
+        );
+        let expired_generation = store.announcement_revision().await.unwrap();
+        let expired_liveness_generation = store.liveness_revision().await.unwrap();
+        store
+            .put_announcement("anchor", endpoint("iroh", 3, now + 30_000, now + 30_000))
+            .await
+            .unwrap();
+        store
+            .put_liveness(
+                &anchor,
+                LiveAllocatable {
+                    allocatable: vec![],
+                    load_fraction: 0.9,
+                    last_seen: now,
+                    live_until_unix_ms: now + 30_000,
+                },
+            )
+            .await
+            .unwrap();
+        assert!(store.announcement_revision().await.unwrap() > expired_generation);
+        assert!(store.liveness_revision().await.unwrap() > expired_liveness_generation);
+        assert_eq!(
+            tier.announcements_for("anchor", now).await.unwrap()[0].accepted_state_epoch,
+            3
+        );
+        assert_eq!(
+            tier.liveness(&anchor, now)
+                .await
+                .unwrap()
+                .unwrap()
+                .load_fraction,
+            0.9
+        );
     }
 
     #[cfg(all(not(target_arch = "wasm32"), feature = "valkey"))]

--- a/crates/hyprstream-discovery/src/state_store.rs
+++ b/crates/hyprstream-discovery/src/state_store.rs
@@ -194,6 +194,7 @@ impl AnnouncedEndpoint {
 pub(crate) struct LiveAllocatable {
     pub(crate) allocatable: Vec<(String, String)>,
     pub(crate) load_fraction: f32,
+    /// Server receipt time, never the reporting node's clock.
     pub(crate) last_seen: i64,
     pub(crate) live_until_unix_ms: i64,
 }
@@ -571,7 +572,12 @@ impl DiscoveryStateStore for MemoryStateStore {
         Self::reap(&mut inner, unix_millis_now());
         let node = node.as_str().to_owned();
         if let Some(existing) = inner.liveness.get(&node) {
-            if existing.value.last_seen > value.last_seen {
+            // Both fields derive from receipt time. A newer receipt may
+            // shorten lifetime; a newer lifetime also supersedes legacy
+            // client-clock skew without waiting for the old value to expire.
+            if existing.value.last_seen > value.last_seen
+                && existing.value.live_until_unix_ms >= value.live_until_unix_ms
+            {
                 return Ok(PutResult::IgnoredOlder);
             }
         } else if inner.liveness.len() >= self.liveness_capacity {
@@ -698,6 +704,9 @@ impl ValkeyStateStore {
                 && config.artifact_capacity > 0,
             "Discovery Valkey capacities must be positive"
         );
+        // Fred's URL parser constructs a rustls config. Initialize the existing
+        // external TLS policy first, including in standalone state-store use.
+        hyprstream_rpc::transport::pq_provider::install_pq_crypto_provider()?;
         let redis = RedisConfig::from_url(&config.url).context("invalid Discovery Valkey URL")?;
         let mut builder = Builder::from_config(redis);
         builder.with_performance_config(|performance| {
@@ -995,30 +1004,44 @@ return 1
     ) -> Result<Vec<(String, Vec<AnnouncedEndpoint>)>> {
         use fred::prelude::*;
 
-        // Reap before enumerating names, so listing work is bounded by current
-        // capacity rather than every identity that has ever announced.
-        let service_ids: Vec<String> = self.pool.eval(
-            format!("{}\nreap(KEYS[1], KEYS[2], KEYS[3], KEYS[4], ARGV[1])\nreturn redis.call('SMEMBERS', KEYS[2])", Self::REAP_ANNOUNCEMENTS),
-            vec![self.key("announcement-expiry"), self.key("services"), self.key("service-names"), self.key("announcement-global-revision")],
-            vec![now_unix_ms.to_string()],
-        ).await?;
-        let mut all = Vec::with_capacity(service_ids.len());
-        for service_id in service_ids {
-            let service_name: Option<String> = self
-                .pool
-                .hget(self.key("service-names"), &service_id)
-                .await?;
-            let Some(service_name) = service_name else {
-                continue;
-            };
-            let entries = self
-                .announcements_for_inner(&service_name, now_unix_ms)
-                .await?;
-            if !entries.is_empty() {
-                all.push((service_name, entries));
+        // One transaction returns names and values from the capacity-bounded
+        // expiry index. Reap and refresh still serialize, and a listing never
+        // labels an L1 snapshot or performs round trips per service.
+        const LIST: &str = r#"
+reap(KEYS[1], KEYS[2], KEYS[3], KEYS[4], ARGV[1])
+local values = {}
+for _, key in ipairs(redis.call('ZRANGE', KEYS[1], 0, -1)) do
+  local value = redis.call('GET', key)
+  if value then
+    local service = string.match(key, ':announcement:([^:]+):[^:]+$')
+    local name = redis.call('HGET', KEYS[3], service)
+    if not name then return redis.error_reply('missing Discovery service name') end
+    table.insert(values, {name, value})
+  end
+end
+return values
+"#;
+        let encoded: Vec<(String, String)> = self
+            .pool
+            .eval(
+                format!("{}{LIST}", Self::REAP_ANNOUNCEMENTS),
+                vec![
+                    self.key("announcement-expiry"),
+                    self.key("services"),
+                    self.key("service-names"),
+                    self.key("announcement-global-revision"),
+                ],
+                vec![now_unix_ms.to_string()],
+            )
+            .await?;
+        let mut all: HashMap<String, Vec<AnnouncedEndpoint>> = HashMap::new();
+        for (name, value) in encoded {
+            let endpoint: AnnouncedEndpoint = serde_json::from_str(&value)?;
+            if endpoint.is_live_at(now_unix_ms) {
+                all.entry(name).or_default().push(endpoint);
             }
         }
-        Ok(all)
+        Ok(all.into_iter().collect())
     }
 
     async fn put_liveness(&self, node: &Did, value: LiveAllocatable) -> Result<PutResult> {
@@ -1033,7 +1056,8 @@ end
 if current then
   local ok, decoded = pcall(cjson.decode, current)
   if not ok then return redis.error_reply('corrupt Discovery liveness') end
-  if (tonumber(decoded.last_seen) or 0) > tonumber(ARGV[2]) then return 0 end
+  if (tonumber(decoded.last_seen) or 0) > tonumber(ARGV[2]) and
+     (tonumber(decoded.live_until_unix_ms) or 0) >= tonumber(ARGV[3]) then return 0 end
 end
 redis.call('SET', KEYS[1], ARGV[1], 'PXAT', ARGV[3])
 redis.call('INCR', KEYS[2])
@@ -1563,6 +1587,172 @@ mod tests {
     #[tokio::test]
     async fn memory_satisfies_announcement_backend_contract() {
         assert_announcement_backend_contract(&MemoryStateStore::new(1, 1, 1)).await;
+    }
+
+    async fn assert_receipt_ordered_liveness(store: &dyn DiscoveryStateStore) {
+        let node = Did::new("did:web:clock-rollback.example".to_owned());
+        let now = unix_millis_now();
+        let mut value = LiveAllocatable {
+            allocatable: vec![("cpu".to_owned(), "1".to_owned())],
+            load_fraction: 0.9,
+            // Legacy client-clock record must not poison subsequent receipts.
+            last_seen: now + 86_400_000,
+            live_until_unix_ms: now + 100,
+        };
+        store.put_liveness(&node, value.clone()).await.unwrap();
+        value.last_seen = now;
+        value.load_fraction = 0.2;
+        value.allocatable[0].1 = "8".to_owned();
+        value.live_until_unix_ms = now + 500;
+        assert_eq!(
+            store.put_liveness(&node, value.clone()).await.unwrap(),
+            PutResult::Stored
+        );
+        assert_eq!(
+            store.liveness(&node, now + 200).await.unwrap(),
+            Some(value.clone())
+        );
+        let mut delayed = value.clone();
+        delayed.last_seen = now - 1;
+        delayed.live_until_unix_ms = now + 300;
+        delayed.load_fraction = 1.0;
+        assert_eq!(
+            store.put_liveness(&node, delayed).await.unwrap(),
+            PutResult::IgnoredOlder
+        );
+        assert_eq!(store.liveness(&node, now + 200).await.unwrap(), Some(value));
+        assert!(store.liveness(&node, now + 501).await.unwrap().is_none());
+
+        // Liveness refreshes do not renew a signed announcement's authority.
+        store
+            .put_announcement("clock", endpoint("iroh", 1, now + 50, now + 500))
+            .await
+            .unwrap();
+        assert!(store
+            .announcements_for("clock", now + 51)
+            .await
+            .unwrap()
+            .is_empty());
+    }
+
+    #[tokio::test]
+    async fn memory_heartbeat_receipt_survives_clock_rollback() {
+        assert_receipt_ordered_liveness(&MemoryStateStore::new(8, 8, 8)).await;
+    }
+
+    #[cfg(all(not(target_arch = "wasm32"), feature = "valkey"))]
+    #[tokio::test]
+    async fn valkey_heartbeat_receipt_survives_clock_rollback() {
+        let Ok(url) = std::env::var("HYPRSTREAM_TEST_VALKEY_URL") else {
+            return;
+        };
+        let shared = Arc::new(
+            ValkeyStateStore::connect(&valkey_config(url, "rollback"))
+                .await
+                .unwrap(),
+        );
+        let tiered = TieredStateStore::new(Arc::new(MemoryStateStore::new(8, 8, 8)), shared, 1000);
+        assert_receipt_ordered_liveness(&tiered).await;
+    }
+
+    #[cfg(all(not(target_arch = "wasm32"), feature = "valkey"))]
+    #[tokio::test]
+    async fn rediss_uses_tls_and_rejects_plaintext_valkey() {
+        use fred::prelude::RedisConfig;
+        hyprstream_rpc::transport::install_pq_crypto_provider().unwrap();
+        assert!(RedisConfig::from_url("rediss://localhost:6379")
+            .unwrap()
+            .tls
+            .is_some());
+        assert!(RedisConfig::from_url("redis://localhost:6379")
+            .unwrap()
+            .tls
+            .is_none());
+        let Ok(url) = std::env::var("HYPRSTREAM_TEST_VALKEY_URL") else {
+            return;
+        };
+        let mut config = valkey_config(url.clone(), "tls");
+        let plaintext = ValkeyStateStore::connect(&config).await.unwrap();
+        assert!(plaintext
+            .all_announcements(unix_millis_now())
+            .await
+            .unwrap()
+            .is_empty());
+        config.url = url.replacen("redis://", "rediss://", 1);
+        let start = std::time::Instant::now();
+        assert!(
+            ValkeyStateStore::connect(&config).await.is_err(),
+            "TLS must not downgrade to plaintext"
+        );
+        assert!(start.elapsed() < std::time::Duration::from_secs(3));
+    }
+
+    #[cfg(all(not(target_arch = "wasm32"), feature = "valkey"))]
+    #[tokio::test]
+    async fn valkey_batched_listing_preserves_names_values_and_cleanup() {
+        let Ok(url) = std::env::var("HYPRSTREAM_TEST_VALKEY_URL") else {
+            return;
+        };
+        let mut config = valkey_config(url, "batched-list");
+        config.announcement_capacity = 512;
+        let writer = ValkeyStateStore::connect(&config).await.unwrap();
+        let reader = TieredStateStore::new(
+            Arc::new(MemoryStateStore::new(1, 1, 1)),
+            Arc::new(ValkeyStateStore::connect(&config).await.unwrap()),
+            10_000,
+        );
+        let now = unix_millis_now();
+        for i in 0..256 {
+            let name = format!("service:{i}:λ");
+            for kind in ["iroh", "quic"] {
+                writer
+                    .put_announcement(&name, endpoint(kind, 1, now + 60_000, now + 60_000))
+                    .await
+                    .unwrap();
+            }
+        }
+        assert_eq!(
+            reader
+                .announcements_for("service:0:λ", now)
+                .await
+                .unwrap()
+                .len(),
+            2
+        );
+        let entries = reader.all_announcements(now).await.unwrap();
+        assert_eq!(entries.len(), 256);
+        assert!(entries
+            .iter()
+            .all(|(name, values)| name.starts_with("service:") && values.len() == 2));
+        writer
+            .put_announcement(
+                "service:0:λ",
+                endpoint("iroh", 2, now + 90_000, now + 90_000),
+            )
+            .await
+            .unwrap();
+        let remaining = reader.all_announcements(now + 60_001).await.unwrap();
+        assert_eq!(remaining.len(), 1);
+        assert_eq!(remaining[0].0, "service:0:λ");
+        assert_eq!(remaining[0].1.len(), 1);
+        assert_eq!(remaining[0].1[0].accepted_state_epoch, 2);
+        // Reaping restores live capacity and cannot populate/poison point L1.
+        writer
+            .put_announcement("new", endpoint("iroh", 1, now + 90_000, now + 90_000))
+            .await
+            .unwrap();
+        assert_eq!(
+            reader
+                .announcements_for("service:0:λ", now + 60_001)
+                .await
+                .unwrap()[0]
+                .accepted_state_epoch,
+            2
+        );
+        assert_eq!(
+            reader.all_announcements(now + 60_001).await.unwrap().len(),
+            2
+        );
     }
 
     #[tokio::test]

--- a/crates/hyprstream-discovery/src/state_store.rs
+++ b/crates/hyprstream-discovery/src/state_store.rs
@@ -247,6 +247,7 @@ pub(crate) trait DiscoveryStateStore: Send + Sync {
     ) -> Result<Vec<(String, Vec<AnnouncedEndpoint>)>>;
 
     async fn put_liveness(&self, node: &Did, value: LiveAllocatable) -> Result<PutResult>;
+    #[cfg(test)]
     async fn liveness(&self, node: &Did, now_unix_ms: i64) -> Result<Option<LiveAllocatable>>;
     /// Bounded enumeration of live nodes from the authoritative backend.
     async fn all_liveness(&self, now_unix_ms: i64) -> Result<Vec<(Did, LiveAllocatable)>>;
@@ -595,6 +596,7 @@ impl DiscoveryStateStore for MemoryStateStore {
         Ok(PutResult::Stored)
     }
 
+    #[cfg(test)]
     async fn liveness(&self, node: &Did, now_unix_ms: i64) -> Result<Option<LiveAllocatable>> {
         let mut inner = self.inner.lock();
         Self::reap(&mut inner, now_unix_ms);
@@ -678,6 +680,8 @@ impl DiscoveryStateStore for MemoryStateStore {
 #[derive(Serialize, Deserialize)]
 struct StoredLiveness {
     node: Did,
+    #[serde(default)]
+    shared_receipt: bool,
     #[serde(flatten)]
     value: LiveAllocatable,
 }
@@ -830,6 +834,7 @@ impl ValkeyStateStore {
             .await
     }
 
+    #[cfg(test)]
     async fn liveness_revision(&self) -> Result<u64> {
         self.revision(self.key("liveness-global-revision")).await
     }
@@ -1059,20 +1064,20 @@ return values
         use fred::prelude::*;
 
         const PUT: &str = r#"
+local clock = redis.call('TIME')
+local now = tonumber(clock[1]) * 1000 + math.floor(tonumber(clock[2]) / 1000)
 local current = redis.call('GET', KEYS[1])
-redis.call('ZREMRANGEBYSCORE', KEYS[3], '-inf', ARGV[4])
-if not current and redis.call('ZCARD', KEYS[3]) >= tonumber(ARGV[5]) then
+redis.call('ZREMRANGEBYSCORE', KEYS[3], '-inf', now)
+if not current and redis.call('ZCARD', KEYS[3]) >= tonumber(ARGV[3]) then
   return redis.error_reply('Discovery Valkey liveness capacity exhausted')
 end
-if current then
-  local ok, decoded = pcall(cjson.decode, current)
-  if not ok then return redis.error_reply('corrupt Discovery liveness') end
-  if (tonumber(decoded.last_seen) or 0) > tonumber(ARGV[2]) and
-     (tonumber(decoded.live_until_unix_ms) or 0) >= tonumber(ARGV[3]) then return 0 end
-end
-redis.call('SET', KEYS[1], ARGV[1], 'PXAT', ARGV[3])
+local expiry = now + tonumber(ARGV[2])
+-- Preserve JSON arrays/numeric payload exactly: Lua cjson turns [] into {}.
+local encoded = string.sub(ARGV[1], 1, -2) .. ',"last_seen":' .. string.format('%.0f', now)
+  .. ',"live_until_unix_ms":' .. string.format('%.0f', expiry) .. '}'
+redis.call('SET', KEYS[1], encoded, 'PXAT', expiry)
 redis.call('INCR', KEYS[2])
-redis.call('ZADD', KEYS[3], ARGV[3], KEYS[1])
+redis.call('ZADD', KEYS[3], expiry, KEYS[1])
 return 1
 "#;
         let node_id = Self::digest(node.as_str());
@@ -1086,13 +1091,11 @@ return 1
                     self.key("liveness-expiry"),
                 ],
                 vec![
-                    serde_json::to_string(&StoredLiveness {
-                        node: node.clone(),
-                        value: value.clone(),
-                    })?,
-                    value.last_seen.to_string(),
-                    value.live_until_unix_ms.to_string(),
-                    unix_millis_now().to_string(),
+                    serde_json::to_string(&serde_json::json!({
+                        "node": node, "allocatable": value.allocatable,
+                        "load_fraction": value.load_fraction, "shared_receipt": true,
+                    }))?,
+                    value.live_until_unix_ms.saturating_sub(value.last_seen).clamp(1, 45_000).to_string(),
                     self.liveness_capacity.to_string(),
                 ],
             )
@@ -1104,7 +1107,8 @@ return 1
         })
     }
 
-    async fn liveness(&self, node: &Did, now_unix_ms: i64) -> Result<Option<LiveAllocatable>> {
+    #[cfg(test)]
+    async fn liveness(&self, node: &Did, _now_unix_ms: i64) -> Result<Option<LiveAllocatable>> {
         use fred::prelude::*;
         let encoded: Option<String> = self
             .pool
@@ -1115,22 +1119,34 @@ return 1
             ))
             .await?;
         Ok(encoded
-            .map(|encoded| serde_json::from_str(&encoded))
-            .transpose()?
-            .filter(|value: &LiveAllocatable| value.is_live_at(now_unix_ms)))
+            .map(|encoded| serde_json::from_str::<StoredLiveness>(&encoded))
+            .transpose()?.filter(|record| record.shared_receipt).map(|record| record.value))
     }
 
-    async fn all_liveness(&self, now_unix_ms: i64) -> Result<Vec<(Did, LiveAllocatable)>> {
+    async fn all_liveness(&self, _now_unix_ms: i64) -> Result<Vec<(Did, LiveAllocatable)>> {
         use fred::prelude::*;
         // The expiry index is capacity-bounded on every write. Enumerate it
         // atomically with the values so concurrent expiry/replacement cannot
         // leave a process-local candidate seed out of sync with shared state.
         const LIST: &str = r#"
-redis.call('ZREMRANGEBYSCORE', KEYS[1], '-inf', ARGV[1])
+local clock = redis.call('TIME')
+local now = tonumber(clock[1]) * 1000 + math.floor(tonumber(clock[2]) / 1000)
+redis.call('ZREMRANGEBYSCORE', KEYS[1], '-inf', now)
 local values = {}
 for _, key in ipairs(redis.call('ZRANGE', KEYS[1], 0, -1)) do
   local value = redis.call('GET', key)
-  if value then table.insert(values, value) end
+  if value then
+    local record = cjson.decode(value)
+    if record.shared_receipt == true then
+      table.insert(values, value)
+    else
+      -- Legacy replica-clock rows have no trustworthy shared lifetime. Retire
+      -- only this volatile row; the next admitted heartbeat recreates it.
+      redis.call('DEL', key)
+      redis.call('ZREM', KEYS[1], key)
+      redis.call('INCR', KEYS[2])
+    end
+  end
 end
 return values
 "#;
@@ -1138,16 +1154,14 @@ return values
             .pool
             .eval(
                 LIST,
-                vec![self.key("liveness-expiry")],
-                vec![now_unix_ms.to_string()],
+                vec![self.key("liveness-expiry"), self.key("liveness-global-revision")],
+                Vec::<String>::new(),
             )
             .await?;
         let mut live = Vec::with_capacity(encoded.len());
         for value in encoded {
             let record: StoredLiveness = serde_json::from_str(&value)?;
-            if record.value.is_live_at(now_unix_ms) {
-                live.push((record.node, record.value));
-            }
+            live.push((record.node, record.value));
         }
         Ok(live)
     }
@@ -1347,12 +1361,6 @@ impl TieredStateStore {
         endpoint
     }
 
-    fn l1_liveness(&self, mut value: LiveAllocatable, now_unix_ms: i64) -> LiveAllocatable {
-        value.live_until_unix_ms = value
-            .live_until_unix_ms
-            .min(now_unix_ms.saturating_add(self.l1_max_ttl_ms));
-        value
-    }
 }
 
 #[cfg(all(not(target_arch = "wasm32"), feature = "valkey"))]
@@ -1433,27 +1441,12 @@ impl DiscoveryStateStore for TieredStateStore {
         self.valkey.put_liveness(node, value).await
     }
 
+    #[cfg(test)]
     async fn liveness(&self, node: &Did, now_unix_ms: i64) -> Result<Option<LiveAllocatable>> {
         let _operation = self.operation("liveness", node.as_str()).lock().await;
-        let scope = Self::scope("liveness", node.as_str());
-        let revision = self.valkey.liveness_revision().await?;
-        if self.is_observed(&scope, revision, now_unix_ms) {
-            return self.memory.liveness(node, now_unix_ms).await;
-        }
-        let value = self.valkey.liveness(node, now_unix_ms).await?;
-        self.observed.lock().remove(&scope);
-        self.memory.clear_liveness_sync(node);
-        if let Some(value) = &value {
-            if self
-                .memory
-                .put_liveness(node, self.l1_liveness(value.clone(), now_unix_ms))
-                .await
-                .is_ok()
-            {
-                self.observe(scope, revision, now_unix_ms);
-            }
-        }
-        Ok(value)
+        // One authoritative GET is cheaper than revision + value on a miss,
+        // and leaves expiry entirely on the shared clock, even with host skew.
+        self.valkey.liveness(node, now_unix_ms).await
     }
 
     async fn all_liveness(&self, now_unix_ms: i64) -> Result<Vec<(Did, LiveAllocatable)>> {
@@ -1673,13 +1666,36 @@ mod tests {
         let Ok(url) = std::env::var("HYPRSTREAM_TEST_VALKEY_URL") else {
             return;
         };
-        let shared = Arc::new(
-            ValkeyStateStore::connect(&valkey_config(url, "rollback"))
-                .await
-                .unwrap(),
-        );
-        let tiered = TieredStateStore::new(Arc::new(MemoryStateStore::new(8, 8, 8)), shared, 1000);
-        assert_receipt_ordered_liveness(&tiered).await;
+        use fred::prelude::*;
+        let config = valkey_config(url, "rollback");
+        let shared = Arc::new(ValkeyStateStore::connect(&config).await.unwrap());
+        let other = ValkeyStateStore::connect(&config).await.unwrap();
+        let tiered = TieredStateStore::new(Arc::new(MemoryStateStore::new(8, 8, 8)), shared.clone(), 1000);
+        let node = Did::new("did:web:skew.example".to_owned());
+        let now = unix_millis_now();
+        let mut value = LiveAllocatable {
+            allocatable: vec![], load_fraction: 0.9,
+            last_seen: now + 86_400_000, live_until_unix_ms: now + 86_400_400,
+        };
+        tiered.put_liveness(&node, value.clone()).await.unwrap();
+        let first = tiered.liveness(&node, i64::MAX).await.unwrap().unwrap();
+        assert!((first.last_seen - now).abs() < 5000);
+        value.last_seen = now - 86_400_000;
+        value.live_until_unix_ms = value.last_seen + 400;
+        value.load_fraction = 0.2;
+        value.allocatable = vec![("cpu".to_owned(), "8".to_owned())];
+        assert_eq!(other.put_liveness(&node, value).await.unwrap(), PutResult::Stored);
+        let latest = tiered.liveness(&node, i64::MAX).await.unwrap().unwrap();
+        assert!(latest.last_seen >= first.last_seen);
+        assert_eq!(latest.load_fraction, 0.2);
+        assert_eq!(latest.allocatable[0].1, "8");
+        assert_eq!(latest.live_until_unix_ms - latest.last_seen, 400);
+        assert_eq!(tiered.all_liveness(i64::MAX).await.unwrap().len(), 1);
+        let ttl: i64 = shared.pool.pttl(format!("{}:liveness:{}", shared.prefix, ValkeyStateStore::digest(node.as_str()))).await.unwrap();
+        assert!((1..=400).contains(&ttl), "expiry uses shared receipt, not ahead host time");
+        tokio::time::sleep(std::time::Duration::from_millis(450)).await;
+        assert!(tiered.liveness(&node, i64::MIN).await.unwrap().is_none());
+        assert!(tiered.all_liveness(i64::MIN).await.unwrap().is_empty());
     }
 
     #[cfg(all(not(target_arch = "wasm32"), feature = "valkey"))]
@@ -2828,7 +2844,7 @@ mod tests {
                     .unwrap()
                     .unwrap()
                     .load_fraction,
-                b.load_fraction
+                other.liveness(&node, now).await.unwrap().unwrap().load_fraction
             );
             let a = CachedEntityStatement {
                 jwt: "a".to_owned(),
@@ -2906,9 +2922,8 @@ mod tests {
         assert!(store
             .all_liveness(now)
             .await
-            .unwrap_err()
-            .to_string()
-            .contains("node"));
+            .unwrap()
+            .is_empty());
         store.put_liveness(&node, value).await.unwrap();
         assert_eq!(store.all_liveness(now).await.unwrap()[0].0, node);
     }

--- a/crates/hyprstream-discovery/src/state_store.rs
+++ b/crates/hyprstream-discovery/src/state_store.rs
@@ -1279,8 +1279,10 @@ struct TieredStateStore {
     valkey: Arc<ValkeyStateStore>,
     l1_max_ttl_ms: i64,
     observed: Mutex<HashMap<String, ObservedRevision>>,
-    // Keep cache contents and revision labels in one local operation order.
-    operation: tokio::sync::Mutex<()>,
+    // Serialize cache contents/revision labels within a scope, while unrelated
+    // network reads and heartbeats can use the pool concurrently. Fixed storage
+    // avoids accumulating a mutex for every historical identity.
+    operations: [tokio::sync::Mutex<()>; 64],
 }
 
 #[cfg(all(not(target_arch = "wasm32"), feature = "valkey"))]
@@ -1295,12 +1297,17 @@ impl TieredStateStore {
             valkey,
             l1_max_ttl_ms: i64::try_from(l1_max_ttl_ms).unwrap_or(i64::MAX),
             observed: Mutex::new(HashMap::new()),
-            operation: tokio::sync::Mutex::new(()),
+            operations: std::array::from_fn(|_| tokio::sync::Mutex::new(())),
         }
     }
 
     fn scope(kind: &str, value: &str) -> String {
         format!("{kind}:{value}")
+    }
+
+    fn operation(&self, kind: &str, value: &str) -> &tokio::sync::Mutex<()> {
+        let digest = blake3::hash(Self::scope(kind, value).as_bytes());
+        &self.operations[usize::from(digest.as_bytes()[0]) % self.operations.len()]
     }
 
     fn is_observed(&self, scope: &str, revision: u64, now_unix_ms: i64) -> bool {
@@ -1356,7 +1363,7 @@ impl DiscoveryStateStore for TieredStateStore {
         service_name: &str,
         endpoint: AnnouncedEndpoint,
     ) -> Result<PutResult> {
-        let _operation = self.operation.lock().await;
+        let _operation = self.operation("announcement", service_name).lock().await;
         // Invalidate before the command, including on ambiguous write errors
         // or cancellation. Never tag a caller's value with a later revision.
         self.observed
@@ -1371,7 +1378,7 @@ impl DiscoveryStateStore for TieredStateStore {
         service_name: &str,
         now_unix_ms: i64,
     ) -> Result<Vec<AnnouncedEndpoint>> {
-        let _operation = self.operation.lock().await;
+        let _operation = self.operation("announcement", service_name).lock().await;
         let scope = Self::scope("announcement", service_name);
         let revision = self.valkey.announcement_revision().await?;
         if self.is_observed(&scope, revision, now_unix_ms) {
@@ -1418,7 +1425,7 @@ impl DiscoveryStateStore for TieredStateStore {
     }
 
     async fn put_liveness(&self, node: &Did, value: LiveAllocatable) -> Result<PutResult> {
-        let _operation = self.operation.lock().await;
+        let _operation = self.operation("liveness", node.as_str()).lock().await;
         self.observed
             .lock()
             .remove(&Self::scope("liveness", node.as_str()));
@@ -1427,7 +1434,7 @@ impl DiscoveryStateStore for TieredStateStore {
     }
 
     async fn liveness(&self, node: &Did, now_unix_ms: i64) -> Result<Option<LiveAllocatable>> {
-        let _operation = self.operation.lock().await;
+        let _operation = self.operation("liveness", node.as_str()).lock().await;
         let scope = Self::scope("liveness", node.as_str());
         let revision = self.valkey.liveness_revision().await?;
         if self.is_observed(&scope, revision, now_unix_ms) {
@@ -1454,14 +1461,14 @@ impl DiscoveryStateStore for TieredStateStore {
     }
 
     async fn put_entity_statement(&self, issuer: &str, value: CachedEntityStatement) -> Result<()> {
-        let _operation = self.operation.lock().await;
+        let _operation = self.operation("entity", issuer).lock().await;
         self.observed.lock().remove(&Self::scope("entity", issuer));
         self.memory.clear_entity_statement_sync(issuer);
         self.valkey.put_entity_statement(issuer, value).await
     }
 
     async fn entity_statement(&self, issuer: &str) -> Result<Option<CachedEntityStatement>> {
-        let _operation = self.operation.lock().await;
+        let _operation = self.operation("entity", issuer).lock().await;
         let now = unix_millis_now();
         let scope = Self::scope("entity", issuer);
         let revision = self.valkey.entity_revision().await?;
@@ -1501,7 +1508,7 @@ impl DiscoveryStateStore for TieredStateStore {
         service_did: &str,
         value: CachedEnvelopeKeyset,
     ) -> Result<()> {
-        let _operation = self.operation.lock().await;
+        let _operation = self.operation("envelope", service_did).lock().await;
         self.observed
             .lock()
             .remove(&Self::scope("envelope", service_did));
@@ -1510,7 +1517,7 @@ impl DiscoveryStateStore for TieredStateStore {
     }
 
     async fn envelope_keyset(&self, service_did: &str) -> Result<Option<CachedEnvelopeKeyset>> {
-        let _operation = self.operation.lock().await;
+        let _operation = self.operation("envelope", service_did).lock().await;
         let now = unix_millis_now();
         let scope = Self::scope("envelope", service_did);
         let revision = self.valkey.envelope_revision(service_did).await?;
@@ -2386,6 +2393,136 @@ mod tests {
                 1
             );
         }
+    }
+
+    #[cfg(all(not(target_arch = "wasm32"), feature = "valkey"))]
+    #[tokio::test]
+    async fn tiered_scoped_operations_allow_unrelated_liveness_and_heartbeats_to_progress() {
+        use futures::{stream, StreamExt};
+        use std::time::Duration;
+        let Ok(url) = std::env::var("HYPRSTREAM_TEST_VALKEY_URL") else {
+            return;
+        };
+        let shared = Arc::new(
+            ValkeyStateStore::connect(&valkey_config(url, "striped-concurrency"))
+                .await
+                .unwrap(),
+        );
+        let tier = TieredStateStore::new(
+            Arc::new(MemoryStateStore::new(64, 64, 64)),
+            shared.clone(),
+            60_000,
+        );
+        let now = unix_millis_now();
+        // Pick sixteen distinct stripes so the regression is deterministic,
+        // including when the hash happens to collide for adjacent node names.
+        let mut nodes: Vec<Did> = Vec::new();
+        for i in 0..1024 {
+            let node = Did::new(format!("did:web:concurrent-{i}.example"));
+            if nodes.iter().all(|other| {
+                !std::ptr::eq(
+                    tier.operation("liveness", other.as_str()),
+                    tier.operation("liveness", node.as_str()),
+                )
+            }) {
+                nodes.push(node);
+            }
+            if nodes.len() == 16 {
+                break;
+            }
+        }
+        assert_eq!(nodes.len(), 16);
+        for node in &nodes {
+            shared
+                .put_liveness(
+                    node,
+                    LiveAllocatable {
+                        allocatable: vec![],
+                        load_fraction: 0.1,
+                        last_seen: now,
+                        live_until_unix_ms: now + 60_000,
+                    },
+                )
+                .await
+                .unwrap();
+        }
+        // Hold one scope exactly as a delayed read/write does across its L2
+        // awaits. A store-wide mutex prevents every other operation below from
+        // finishing; striped ordering lets all fifteen real Valkey reads pass.
+        let stalled = tier.operation("liveness", nodes[0].as_str()).lock().await;
+        let mut reads = stream::iter(
+            nodes
+                .iter()
+                .map(|node| {
+                    let tier = &tier;
+                    async move { (node, tier.liveness(node, now).await) }
+                }),
+        )
+        .buffer_unordered(16);
+        tokio::time::timeout(Duration::from_secs(2), async {
+            for _ in 0..15 {
+                let (node, result) = reads.next().await.unwrap();
+                assert_ne!(node, &nodes[0]);
+                assert_eq!(result.unwrap().unwrap().load_fraction, 0.1);
+            }
+        })
+        .await
+        .expect("unrelated tiered liveness reads serialized behind a stalled scope");
+        assert!(
+            tokio::time::timeout(Duration::from_millis(20), reads.next())
+                .await
+                .is_err()
+        );
+
+        let heartbeat = LiveAllocatable {
+            allocatable: vec![],
+            load_fraction: 0.8,
+            last_seen: now + 1,
+            live_until_unix_ms: now + 60_001,
+        };
+        tokio::time::timeout(
+            Duration::from_secs(2),
+            tier.put_liveness(&nodes[1], heartbeat.clone()),
+        )
+        .await
+        .expect("unrelated heartbeat serialized behind a stalled scope")
+        .unwrap();
+        // Same-scope writes still wait. Cancelling a queued operation must not
+        // corrupt the cache or leave the stripe permanently locked.
+        assert!(tokio::time::timeout(
+            Duration::from_millis(20),
+            tier.put_liveness(&nodes[0], heartbeat.clone())
+        )
+        .await
+        .is_err());
+        drop(reads);
+        drop(stalled);
+        assert_eq!(
+            tier.liveness(&nodes[0], now)
+                .await
+                .unwrap()
+                .unwrap()
+                .load_fraction,
+            0.1
+        );
+        tier.put_liveness(&nodes[0], heartbeat).await.unwrap();
+        assert_eq!(
+            tier.liveness(&nodes[0], now)
+                .await
+                .unwrap()
+                .unwrap()
+                .load_fraction,
+            0.8
+        );
+        assert_eq!(
+            tier.liveness(&nodes[1], now)
+                .await
+                .unwrap()
+                .unwrap()
+                .load_fraction,
+            0.8
+        );
+        assert_eq!(tier.operations.len(), 64);
     }
 
     #[cfg(all(not(target_arch = "wasm32"), feature = "valkey"))]

--- a/crates/hyprstream-rpc-std/schema/policy.capnp
+++ b/crates/hyprstream-rpc-std/schema/policy.capnp
@@ -92,6 +92,9 @@ struct PolicyRequest {
     # Requires 'exchange' permission on 'policy:exchange-wit' in Casbin policy.
     exchangeWit @21 :ExchangeWit
       $scope(manage) $mcpDescription("Exchange the caller's envelope WIT for an OAuth at+jwt; identity from signed envelope");
+    # Bounded vector of the same envelope-authenticated checks (maximum 256).
+    checkBatch @22 :PolicyCheckBatch
+      $scopeExempt("the authz check itself cannot require authz — circular dependency");
   }
 }
 
@@ -108,6 +111,14 @@ struct PolicyCheck {
 
   # Operation being performed (e.g., "infer", "query", "write")
   operation @3 :Text;
+}
+
+struct PolicyCheckBatch {
+  checks @0 :List(PolicyCheck);
+}
+
+struct PolicyCheckBatchResult {
+  allowed @0 :List(Bool);
 }
 
 # JWT token issuance parameters
@@ -256,6 +267,7 @@ struct PolicyResponse {
 
     # at+jwt from exchangeWit
     exchangeWitResult @22 :TokenInfo;
+    checkBatchResult @23 :PolicyCheckBatchResult;
   }
 }
 

--- a/crates/hyprstream/Cargo.toml
+++ b/crates/hyprstream/Cargo.toml
@@ -232,7 +232,8 @@ opentelemetry-stdout = { workspace = true, optional = true }
 # any Hyprstream build from silently omitting this profile.
 default = ["gittorrent", "xet", "systemd", "otel", "kata-vm", "nspawn", "credential-pds"]
 cuda = []
-valkey = ["dep:fred"]  # Enable Valkey/Redis-backed user and token stores
+valkey = ["dep:fred"]  # Enable legacy Valkey/Redis-backed user and token stores
+discovery-valkey = ["hyprstream-discovery/valkey"]  # Shared/tiered Discovery state
 pglite = ["dep:pglite-rs"]  # Enable PGlite embedded relational UserStore (#1376)
 postgres = ["dep:deadpool-postgres", "dep:tokio-postgres", "dep:tokio-postgres-rustls", "dep:webpki-roots"]  # Networked Postgres UserStore for RDS (#1401)
 credential-pds = ["pglite"]  # Production credential/PDS service profile; intentionally excludes metrics/DuckDB

--- a/crates/hyprstream/src/config/mod.rs
+++ b/crates/hyprstream/src/config/mod.rs
@@ -1774,6 +1774,10 @@ pub struct DiscoveryServiceConfig {
     /// QUIC/WebTransport port. None = no QUIC, Some(0) = ephemeral, Some(N) = explicit.
     #[serde(default)]
     pub quic_port: Option<u16>,
+    /// Volatile Discovery state. Memory is the single-process/WASM default;
+    /// active-active deployments must select Valkey or tiered memory+Valkey.
+    #[serde(default)]
+    pub state: hyprstream_discovery::DiscoveryStateConfig,
 }
 
 /// TUI display server configuration.

--- a/crates/hyprstream/src/config/mod.rs
+++ b/crates/hyprstream/src/config/mod.rs
@@ -3122,6 +3122,30 @@ impl From<&crate::config::server::SamplingParamDefaults> for SamplingParams {
 #[cfg(test)]
 mod tests {
     #[test]
+    fn discovery_state_documentation_configures_root_backend() {
+        let doc = include_str!("../../../../docs/discovery-state.md");
+        let example = doc
+            .split_once("```toml\n")
+            .unwrap_or_else(|| panic!("TOML example"))
+            .1
+            .split_once("```")
+            .unwrap_or_else(|| panic!("closed TOML example"))
+            .0;
+        let config: HyprConfig = toml::from_str(example).unwrap_or_else(|e| panic!("{e}"));
+        let state = config.discovery.state;
+        assert_eq!(
+            state.backend,
+            hyprstream_discovery::DiscoveryStateBackend::Tiered
+        );
+        assert!(state.active_active);
+        assert_eq!(state.memory.announcement_capacity, 16_384);
+        assert_eq!(state.valkey.announcement_capacity, 65_536);
+        assert_eq!(state.valkey.key_prefix, "production");
+        assert_eq!(state.valkey.url, "rediss://discovery-state.example:6379");
+        assert_eq!(state.tiered.l1_max_ttl_ms, 1_000);
+    }
+
+    #[test]
     fn credentials_backend_default_matches_build_profile() {
         let config: CredentialsConfig =
             toml::from_str("").unwrap_or_else(|error| panic!("{error}"));

--- a/crates/hyprstream/src/services/discovery.rs
+++ b/crates/hyprstream/src/services/discovery.rs
@@ -50,6 +50,31 @@ impl PolicyAuthProvider {
 
 #[async_trait(?Send)]
 impl AuthorizationProvider for PolicyAuthProvider {
+    async fn check_batch(
+        &self, subject: &str, domain: &str, resources: &[String],
+        operation: &str, bearer: Option<&str>,
+    ) -> anyhow::Result<Vec<bool>> {
+        use crate::services::generated::policy_client::PolicyCheckBatch;
+        anyhow::ensure!(resources.len() <= 256, "authorization batch exceeds 256");
+        let client = match bearer {
+            Some(token) => self.client.clone().with_delegated_bearer(token.to_owned()),
+            None => {
+                let upstream = hyprstream_rpc::envelope::Subject::new(subject);
+                anyhow::ensure!(!upstream.is_federated() && upstream.name()
+                    .is_some_and(|name| name == "system" || name.starts_with("service:")),
+                    "service-mediated user policy check requires verified bearer");
+                self.client.clone()
+            }
+        };
+        let request = PolicyCheckBatch { checks: resources.iter().map(|resource| PolicyCheck {
+            subject: subject.to_owned(), domain: domain.to_owned(),
+            resource: resource.clone(), operation: operation.to_owned(),
+        }).collect() };
+        let result = client.check_batch(&request).await?;
+        anyhow::ensure!(result.allowed.len() == resources.len(), "invalid policy batch decision count");
+        Ok(result.allowed)
+    }
+
     async fn check(
         &self,
         subject: &str,

--- a/crates/hyprstream/src/services/factories.rs
+++ b/crates/hyprstream/src/services/factories.rs
@@ -2542,6 +2542,18 @@ fn create_discovery_service(ctx: &ServiceContext) -> anyhow::Result<Box<dyn Spaw
         ctx.jwt_verifying_key(),
         ctx.transport("discovery", SocketKind::Rep),
     )
+    .with_state({
+        let state_config = config.discovery.state.clone();
+        std::thread::spawn(move || -> anyhow::Result<hyprstream_discovery::DiscoveryState> {
+            let runtime = tokio::runtime::Builder::new_current_thread()
+                .enable_all()
+                .build()
+                .context("build Discovery state bootstrap runtime")?;
+            runtime.block_on(hyprstream_discovery::DiscoveryState::connect(&state_config))
+        })
+        .join()
+        .map_err(|_| anyhow::anyhow!("Discovery state bootstrap thread panicked"))??
+    })
     .with_auth_provider(Box::new(auth_provider))
     .with_record_resolver(std::sync::Arc::clone(&record_resolver)
         as std::sync::Arc<dyn hyprstream_discovery::RecordResolver>);

--- a/crates/hyprstream/src/services/factories.rs
+++ b/crates/hyprstream/src/services/factories.rs
@@ -2543,6 +2543,8 @@ fn create_discovery_service(ctx: &ServiceContext) -> anyhow::Result<Box<dyn Spaw
         ctx.transport("discovery", SocketKind::Rep),
     )
     .with_state({
+        // Shared backends retain their own driver runtime after this temporary
+        // bootstrap runtime exits; service state owns its shutdown lifetime.
         let state_config = config.discovery.state.clone();
         std::thread::spawn(move || -> anyhow::Result<hyprstream_discovery::DiscoveryState> {
             let runtime = tokio::runtime::Builder::new_current_thread()

--- a/crates/hyprstream/src/services/policy.rs
+++ b/crates/hyprstream/src/services/policy.rs
@@ -9,7 +9,7 @@ use crate::auth::policy_templates;
 use crate::services::{EnvelopeContext, RequestService};
 use crate::services::generated::policy_client::{
     ErrorInfo, PolicyHandler, PolicyResponseVariant, TokenInfo, ScopeList,
-    PolicyCheck, IssueToken,
+    PolicyCheck, PolicyCheckBatch, PolicyCheckBatchResult, IssueToken,
     ApplyTemplate, ApplyDraft, RollbackPolicy, GetHistory, GetDiff,
     PolicyInfo, PolicyRule, Grouping,
     PolicyHistory, PolicyHistoryEntry, DraftStatus,
@@ -515,6 +515,19 @@ impl PolicyHandler for PolicyService {
         } else {
             anyhow::bail!("Unauthorized: {} cannot {} on {}", subject, operation, resource)
         }
+    }
+
+    async fn handle_check_batch(
+        &self, ctx: &EnvelopeContext, request_id: u64, data: &PolicyCheckBatch,
+    ) -> Result<PolicyResponseVariant> {
+        anyhow::ensure!(data.checks.len() <= 256, "policy check batch exceeds 256");
+        let mut allowed = Vec::with_capacity(data.checks.len());
+        for check in &data.checks {
+            // Reuse the exact single-check subject/tenant/audit boundary.
+            let result = self.handle_check(ctx, request_id, check).await?;
+            allowed.push(matches!(result, PolicyResponseVariant::CheckResult(true)));
+        }
+        Ok(PolicyResponseVariant::CheckBatchResult(PolicyCheckBatchResult { allowed }))
     }
 
     async fn handle_check(
@@ -2576,6 +2589,8 @@ mod tests {
             .expect("test: per-origin federation grant");
 
         let endpoint = format!("policy-delegation-{}", rand::random::<u64>());
+        manager.add_policy_with_domain("alice", "did:web:tenant-a.example",
+            "placement:candidate:*", "query", "allow").await.expect("capacity grant");
         let policy_key = SigningKey::from_bytes(&[0x70; 32]);
         let actor_key = SigningKey::from_bytes(&[0x71; 32]);
         let actor_verifying_key = actor_key.verifying_key();
@@ -2676,6 +2691,34 @@ mod tests {
             .await
             .expect("test: tenant user decision");
         assert!(allowed, "verified delegated user grant must be effective");
+
+        let provider = crate::services::discovery::PolicyAuthProvider::new(client.clone());
+        let batched = hyprstream_discovery::AuthorizationProvider::check_batch(
+            &provider, "alice", "forged-other-tenant",
+            &["model:allowed".to_owned(), "model:deputy-only".to_owned()],
+            "infer.generate", Some(&user_token),
+        ).await.expect("real batched Policy RPC with delegated identity");
+        assert_eq!(batched, vec![true, false], "batch preserves user authority, not deputy grants");
+        assert!(hyprstream_discovery::AuthorizationProvider::check_batch(
+            &provider, "alice", "*", &["model:allowed".to_owned()], "infer.generate", None,
+        ).await.is_err(), "batch cannot mediate a user without verified bearer");
+        assert!(client.clone().with_delegated_bearer(user_token.clone()).check_batch(&PolicyCheckBatch {
+            checks: vec![PolicyCheck { subject: String::new(), domain: String::new(),
+                resource: "model:allowed".to_owned(), operation: "infer.generate".to_owned() }; 257],
+        }).await.is_err(), "batch bound enforced by server, not only adapter");
+
+        // Exercise the real adapter, generated wire codec and Policy handler
+        // for a full configured fleet, separately from Valkey snapshot timing.
+        use futures::{stream, StreamExt, TryStreamExt};
+        let resources: Vec<_> = (0..65_536).map(|i| format!("placement:candidate:did:web:capacity-{i}.example")).collect();
+        let started = std::time::Instant::now();
+        let decisions = stream::iter(resources.chunks(256)).map(|batch| {
+            hyprstream_discovery::AuthorizationProvider::check_batch(&provider,
+                "alice", "*", batch, "query", Some(&user_token))
+        }).buffer_unordered(16).try_collect::<Vec<_>>().await.expect("full-fleet Policy batch RPC");
+        assert_eq!(decisions.iter().flatten().filter(|allowed| **allowed).count(), 65_536);
+        assert!(started.elapsed() < std::time::Duration::from_secs(5),
+            "healthy Policy batching exceeded candidate deadline: {:?}", started.elapsed());
 
         let cross_tenant = client
             .clone()

--- a/docs/discovery-state.md
+++ b/docs/discovery-state.md
@@ -38,6 +38,8 @@ l1_max_ttl_ms = 1000
 first verifies its L2 revision, and cached lifetime is clamped to both the L1
 freshness window and the signed/effective record expiry. An L2 error is
 returned to the caller rather than serving an isolated or expired L1 value.
+The Valkey URL has no implicit loopback default and must be configured
+explicitly whenever `valkey` or `tiered` is selected.
 
 All keys for one configured prefix share a Valkey cluster hash tag so atomic
 Lua updates remain in one slot. Use a deployment-specific prefix when multiple

--- a/docs/discovery-state.md
+++ b/docs/discovery-state.md
@@ -1,0 +1,44 @@
+# Discovery volatile state
+
+Discovery keeps endpoint announcements, node liveness, and cached federation
+artifacts behind one typed state contract. These records are volatile routing
+inputs, not identity or policy authority: handlers validate writes and
+resolution re-checks accepted-current state and policy before use.
+
+The default is bounded in-process memory and is appropriate for one Discovery
+process, tests, embedded use, and WASM. An active-active deployment must build
+Hyprstream with the `discovery-valkey` feature and explicitly select either
+`valkey` or `tiered`. Startup rejects `active_active = true` with the memory
+backend; there is no connectivity-driven fallback.
+
+```toml
+[services.discovery.state]
+backend = "tiered"
+active_active = true
+
+[services.discovery.state.memory]
+announcement_capacity = 16384
+liveness_capacity = 16384
+artifact_capacity = 4096
+
+[services.discovery.state.valkey]
+url = "rediss://discovery-state.example:6379"
+key_prefix = "production"
+pool_size = 8
+announcement_capacity = 65536
+liveness_capacity = 65536
+artifact_capacity = 16384
+command_timeout_ms = 2000
+
+[services.discovery.state.tiered]
+l1_max_ttl_ms = 1000
+```
+
+`tiered` is a bounded memory L1 with write-through to Valkey. Every L1 use
+first verifies its L2 revision, and cached lifetime is clamped to both the L1
+freshness window and the signed/effective record expiry. An L2 error is
+returned to the caller rather than serving an isolated or expired L1 value.
+
+All keys for one configured prefix share a Valkey cluster hash tag so atomic
+Lua updates remain in one slot. Use a deployment-specific prefix when multiple
+independent Hyprstream environments share a Valkey cluster.

--- a/docs/discovery-state.md
+++ b/docs/discovery-state.md
@@ -50,7 +50,7 @@ or turns a successful shared write into a cache-capacity error. Cache values
 and revision bookkeeping are bounded; unknown-key misses are not cached. An L2
 error is returned to the caller rather than serving an isolated or expired L1
 value.
-Announcement and liveness revisions use one persistent generation counter per
+Announcement, liveness, and issuer-cache revisions use one persistent generation counter per
 family, not one key per service/node. A write can therefore invalidate unrelated
 L1 entries in the same family; counters must never expire or reset while any
 replica retains L1 state. Announcement writes and listings atomically reap
@@ -58,10 +58,19 @@ expired values, service indexes, and name metadata before admitting new state
 or enumerating services. Backend metadata and listing work are bounded by the
 configured live capacity even when identities continually change.
 
+Entity statements are inert cached artifacts, not a registered-issuer authority.
+At capacity, a new issuer atomically evicts the existing entry with the oldest
+server `fetched_at` timestamp, including its name and ordering metadata. Updating
+an issuer refreshes its eviction order. Memory and Valkey use the same policy;
+JWT claims do not control cache eviction or replace verification at use. Issuer
+listing reads the bounded names hash in one command; registration obtains only
+the count with `SCARD`. Envelope keysets retain their separate bounded admission
+policy and do not share the issuer eviction index.
+
 When upgrading from the experimental per-scope revision implementation, stop
 all old replicas and retire its configured **volatile Discovery key prefix**,
 then restart all replicas with an empty prefix and let services reannounce.
-Old writers do not update the new liveness generation, and previously orphaned
+Old writers do not maintain the new issuer eviction index or liveness generation, and previously orphaned
 metadata has already lost its expiry-index membership; it cannot be reclaimed
 by normal expiry traversal. This is not a rolling-compatible state migration.
 Do not clear shared generations with running replicas, or touch the separate

--- a/docs/discovery-state.md
+++ b/docs/discovery-state.md
@@ -123,6 +123,12 @@ liveness never grants identity, placement labels, or policy authority.
 Cross-service announcement listings read names and values in one Lua operation
 over the capacity-bounded expiry index, together with atomic metadata cleanup.
 They do not perform network round trips per service or populate point-cache L1.
+Announcement writes, point reads, listings, and tiered revision checks take
+Valkey TIME inside the same transaction as reaping/live checks. Replica wall
+clocks cannot delete globally live entries or keep an expired L1 entry alive.
+PXAT remains the earlier absolute signed/accepted-state and effective lease
+expiry; shared receipt time never renews that authority ceiling. Already-expired
+writes are ignored before value/index admission.
 
 Heartbeat `last_seen` is the admitted server receipt time; the node's `ts` cannot
 poison ordering after future skew or clock rollback. Shared writes take Valkey

--- a/docs/discovery-state.md
+++ b/docs/discovery-state.md
@@ -50,6 +50,23 @@ or turns a successful shared write into a cache-capacity error. Cache values
 and revision bookkeeping are bounded; unknown-key misses are not cached. An L2
 error is returned to the caller rather than serving an isolated or expired L1
 value.
+Announcement and liveness revisions use one persistent generation counter per
+family, not one key per service/node. A write can therefore invalidate unrelated
+L1 entries in the same family; counters must never expire or reset while any
+replica retains L1 state. Announcement writes and listings atomically reap
+expired values, service indexes, and name metadata before admitting new state
+or enumerating services. Backend metadata and listing work are bounded by the
+configured live capacity even when identities continually change.
+
+When upgrading from the experimental per-scope revision implementation, stop
+all old replicas and retire its configured **volatile Discovery key prefix**,
+then restart all replicas with an empty prefix and let services reannounce.
+Old writers do not update the new liveness generation, and previously orphaned
+metadata has already lost its expiry-index membership; it cannot be reclaimed
+by normal expiry traversal. This is not a rolling-compatible state migration.
+Do not clear shared generations with running replicas, or touch the separate
+checkpointed PDS identity store as part of this volatile-state reset.
+
 The Valkey URL has no implicit loopback default and must be configured
 explicitly whenever `valkey` or `tiered` is selected.
 

--- a/docs/discovery-state.md
+++ b/docs/discovery-state.md
@@ -12,16 +12,16 @@ Hyprstream with the `discovery-valkey` feature and explicitly select either
 backend; there is no connectivity-driven fallback.
 
 ```toml
-[services.discovery.state]
+[discovery.state]
 backend = "tiered"
 active_active = true
 
-[services.discovery.state.memory]
+[discovery.state.memory]
 announcement_capacity = 16384
 liveness_capacity = 16384
 artifact_capacity = 4096
 
-[services.discovery.state.valkey]
+[discovery.state.valkey]
 url = "rediss://discovery-state.example:6379"
 key_prefix = "production"
 pool_size = 8
@@ -30,17 +30,49 @@ liveness_capacity = 65536
 artifact_capacity = 16384
 command_timeout_ms = 2000
 
-[services.discovery.state.tiered]
+[discovery.state.tiered]
 l1_max_ttl_ms = 1000
 ```
 
-`tiered` is a bounded memory L1 with write-through to Valkey. Every L1 use
-first verifies its L2 revision, and cached lifetime is clamped to both the L1
-freshness window and the signed/effective record expiry. An L2 error is
-returned to the caller rather than serving an isolated or expired L1 value.
+`discovery` is a root configuration table; `services` contains only the startup
+list. Putting these settings under `services.discovery` does not configure the
+backend.
+
+`tiered` uses bounded memory for point lookups over authoritative Valkey state.
+Writes invalidate local entries before updating Valkey; they never cache a
+caller value under a subsequently observed revision. Local cache operations
+are serialized, and fills bind their snapshot to a revision read before the
+values. Every L1 use verifies its L2 revision, and cached lifetime is clamped
+to both the L1 freshness window and the signed/effective record expiry.
+Listings (announcements, live nodes, issuers) read Valkey directly. Oversized
+point results skip L1 admission; a full L1 never rejects a healthy L2 result
+or turns a successful shared write into a cache-capacity error. Cache values
+and revision bookkeeping are bounded; unknown-key misses are not cached. An L2
+error is returned to the caller rather than serving an isolated or expired L1
+value.
 The Valkey URL has no implicit loopback default and must be configured
 explicitly whenever `valkey` or `tiered` is selected.
 
 All keys for one configured prefix share a Valkey cluster hash tag so atomic
 Lua updates remain in one slot. Use a deployment-specific prefix when multiple
 independent Hyprstream environments share a Valkey cluster.
+
+Shared backends own a dedicated connection-driver runtime until the last state
+handle is dropped. They remain usable after synchronous factory bootstrap exits;
+startup and commands fail closed on connection errors, with bounded timeouts.
+
+Candidate queries enumerate the shared, capacity-bounded liveness index. A
+replica then ingests missing placement records through the existing verified
+repository resolver and bounded retry gate. Nodes without verified placement
+facts, query authorization, or a still-live heartbeat are excluded. Shared
+liveness never grants identity, placement labels, or policy authority.
+
+Identity-bound announcements remain limited by signed and accepted-state
+expiry. Legacy non-identity-bound announcements use the heartbeat TTL when the
+wire identity-expiry field is absent; they do not acquire identity evidence.
+
+Run the repaired state encoding on every active-active replica. Liveness
+records written by the earlier experimental implementation lack the node DID
+needed for enumeration and must be refreshed by a heartbeat (or expire). A
+mixed deployment with old writers fails closed on those records; it does not
+silently omit nodes or substitute local candidates.

--- a/docs/discovery-state.md
+++ b/docs/discovery-state.md
@@ -40,8 +40,10 @@ backend.
 
 `tiered` uses bounded memory for point lookups over authoritative Valkey state.
 Writes invalidate local entries before updating Valkey; they never cache a
-caller value under a subsequently observed revision. Local cache operations
-are serialized, and fills bind their snapshot to a revision read before the
+caller value under a subsequently observed revision. Operations on the same
+cache scope are serialized through a fixed array of 64 mutexes; unrelated
+scopes can use the Valkey pool concurrently. Hash collisions share a mutex,
+but identity churn cannot grow a lock map. Fills bind their snapshot to a revision read before the
 values. Every L1 use verifies its L2 revision, and cached lifetime is clamped
 to both the L1 freshness window and the signed/effective record expiry.
 Listings (announcements, live nodes, issuers) read Valkey directly. Oversized

--- a/docs/discovery-state.md
+++ b/docs/discovery-state.md
@@ -94,10 +94,23 @@ startup and commands fail closed on connection errors, with bounded timeouts.
 
 Candidate queries enumerate the shared, capacity-bounded liveness index. A
 replica then ingests missing placement records through the existing verified
-repository resolver and bounded retry gate. Authorization, ingestion, and live
-point reads run with at most 16 concurrent node operations per query; final
-authorization is also concurrent. Native queries have a five-second deadline
-covering enumeration through final authorization. A deadline or still-pending
+repository resolver and bounded retry gate. Resource and already-warm label filtering precede RPC work;
+Policy authorizes bounded vectors of at most 256 resources, with at most 16
+batches in flight. The batch handler reuses the exact single-check verified
+subject/tenant/audit boundary and requires an ordered decision for every entry.
+There is no authorization cache or duplicate second authorization pass. Denied
+nodes never trigger hydration. Two bulk liveness snapshots replace per-node
+Valkey reads; the second excludes expiry during authorization/hydration. Ranking
+and exact authorized `totalMatching` still inspect all eligible survivors before
+applying maxCandidates. The exact-count contract inherently requires O(fleet)
+local work; a small result limit cannot justify an incomplete count. A warm
+65,536-node tiered query is exercised at the advertised capacity.
+
+Cold verified-repository hydration remains bounded at 16 operations. A completely
+cold large fleet can require retries or prior heartbeat-driven ingestion; bounded
+batch authorization does not pretend that arbitrary remote repository reads can
+finish within one deadline. Native queries retain the five-second deadline
+covering enumeration through final filtering. A deadline or still-pending
 ingest returns an error requiring retry, never a successful partial candidate
 set or understated `totalMatching`. Completed verified records remain available
 for the retry; cancelled ingests are retryable and are not cached as absence.
@@ -112,10 +125,18 @@ over the capacity-bounded expiry index, together with atomic metadata cleanup.
 They do not perform network round trips per service or populate point-cache L1.
 
 Heartbeat `last_seen` is the admitted server receipt time; the node's `ts` cannot
-poison ordering after future skew or clock rollback. Stores accept a newer
-receipt even if it shortens lifetime; a newer receipt-derived lifetime also
-supersedes legacy client-clock skew. A write with an older receipt and no newer
-lifetime cannot replace fresher state. This changes no identity authority:
+poison ordering after future skew or clock rollback. Shared writes take Valkey
+TIME atomically with storage and PXAT expiry (at most the 45-second heartbeat
+TTL); replica absolute timestamps never select ordering or expiry. Concurrent
+shared writes follow Valkey receipt order, not a comparison of caller clocks.
+Shared listings reap with Valkey TIME and point reads use Valkey key expiry;
+tiered liveness does not use host-clock L1 caching. Memory-only deployments keep
+their local receipt ordering. The bounded listing retires legacy volatile rows
+without the shared-receipt marker, since their clock-derived lifetime cannot be
+trusted; a new admitted heartbeat replaces them. No PDS state reset is involved.
+Deploy the batch-capable Policy service before Discovery uses batching; an old
+Policy endpoint fails closed, without a fleet-sized per-node RPC fallback.
+This changes no identity authority:
 signed/accepted announcement expiry
 is independently enforced, and refreshing liveness does not renew it.
 

--- a/docs/discovery-state.md
+++ b/docs/discovery-state.md
@@ -68,7 +68,10 @@ Do not clear shared generations with running replicas, or touch the separate
 checkpointed PDS identity store as part of this volatile-state reset.
 
 The Valkey URL has no implicit loopback default and must be configured
-explicitly whenever `valkey` or `tiered` is selected.
+explicitly whenever `valkey` or `tiered` is selected. Native Valkey builds enable
+Fred's Rustls backend: `rediss://` uses TLS and rejects a plaintext server.
+The connection initializes the existing external-interoperability TLS provider;
+Valkey and its TLS dependencies remain excluded from the WASM target.
 
 All keys for one configured prefix share a Valkey cluster hash tag so atomic
 Lua updates remain in one slot. Use a deployment-specific prefix when multiple
@@ -80,9 +83,30 @@ startup and commands fail closed on connection errors, with bounded timeouts.
 
 Candidate queries enumerate the shared, capacity-bounded liveness index. A
 replica then ingests missing placement records through the existing verified
-repository resolver and bounded retry gate. Nodes without verified placement
-facts, query authorization, or a still-live heartbeat are excluded. Shared
+repository resolver and bounded retry gate. Authorization, ingestion, and live
+point reads run with at most 16 concurrent node operations per query; final
+authorization is also concurrent. Native queries have a five-second deadline
+covering enumeration through final authorization. A deadline or still-pending
+ingest returns an error requiring retry, never a successful partial candidate
+set or understated `totalMatching`. Completed verified records remain available
+for the retry; cancelled ingests are retryable and are not cached as absence.
+The WASM memory path uses the same concurrency bound and checks elapsed time
+between operations, without pulling in a native timer or socket backend.
+Nodes without verified placement facts, query authorization, or a still-live
+heartbeat are excluded. Shared
 liveness never grants identity, placement labels, or policy authority.
+
+Cross-service announcement listings read names and values in one Lua operation
+over the capacity-bounded expiry index, together with atomic metadata cleanup.
+They do not perform network round trips per service or populate point-cache L1.
+
+Heartbeat `last_seen` is the admitted server receipt time; the node's `ts` cannot
+poison ordering after future skew or clock rollback. Stores accept a newer
+receipt even if it shortens lifetime; a newer receipt-derived lifetime also
+supersedes legacy client-clock skew. A write with an older receipt and no newer
+lifetime cannot replace fresher state. This changes no identity authority:
+signed/accepted announcement expiry
+is independently enforced, and refreshing liveness does not renew it.
 
 Identity-bound announcements remain limited by signed and accepted-state
 expiry. Legacy non-identity-bound announcements use the heartbeat TTL when the

--- a/docs/discovery-state.md
+++ b/docs/discovery-state.md
@@ -126,9 +126,15 @@ They do not perform network round trips per service or populate point-cache L1.
 Announcement writes, point reads, listings, and tiered revision checks take
 Valkey TIME inside the same transaction as reaping/live checks. Replica wall
 clocks cannot delete globally live entries or keep an expired L1 entry alive.
-PXAT remains the earlier absolute signed/accepted-state and effective lease
-expiry; shared receipt time never renews that authority ceiling. Already-expired
-writes are ignored before value/index admission.
+The handler supplies the independent signed/current-state authority ceiling;
+Valkey computes the effective lease as TIME plus 90 seconds, capped by that
+ceiling. Encoded lifetime, PXAT, and expiry-index score are identical. Only the
+effective lifetime and the legacy application expiry are computed in Lua;
+all other payload values and array types retain Rust's encoding. Memory-only
+publication uses its own receipt time. Tiered L1 copies the already-derived
+lease and uses shared time for insertion/reaping; it never renews that lease.
+Expired or superseded writes return an error from announce instead of a false
+successful publication. Shared receipt time never renews expired authority.
 
 Heartbeat `last_seen` is the admitted server receipt time; the node's `ts` cannot
 poison ordering after future skew or clock rollback. Shared writes take Valkey

--- a/scripts/loopback-baseline.txt
+++ b/scripts/loopback-baseline.txt
@@ -5,7 +5,6 @@
 # is not banked via --update. Files that reach zero drop out on
 # the next --update. Do NOT hand-edit counts upward — the diff
 # is review-visible and that is the only defense.
-1	crates/hyprstream-discovery/src/service.rs
 1	crates/hyprstream-flight/src/cli/commands/sql.rs
 1	crates/hyprstream-flight/src/cli/handlers.rs
 2	crates/hyprstream-flight/src/client.rs


### PR DESCRIPTION
Discovery replicas can share volatile endpoint announcements, node liveness, and federation artifacts through a typed async state contract. Adds bounded memory, shared Valkey, and bounded memory-over-Valkey modes, selected through root `[discovery.state]`. Active-active memory is rejected at startup, and backend failures propagate without isolated local fallback. Identity and policy authority remain separate from this routing state.

The HA implementation keeps connection drivers alive beyond factory bootstrap, enumerates candidates from shared liveness, and ingests each replica’s missing placement facts through the verified repository resolver. Candidate authorization, liveness expiry, and legacy non-identity-bound heartbeat TTLs are preserved.

Tiered writes invalidate L1 before the shared command; only read snapshots can populate L1 with a previously read revision. Local cache operations are serialized, listings read L2 directly, and oversized point results skip cache admission. L1 capacity never rejects a healthy authoritative result or a successful shared write. Revision bookkeeping and expiry heaps are bounded, and announcement read/expiry cleanup is atomic with respect to concurrent refreshes.

Validation (all Cargo commands through the fleet BuildQ wrapper):

- `cargo test -p hyprstream-discovery --features valkey --lib -- --nocapture`: 149 passed with real Valkey 8.1.9, including eight new regressions for runtime lifetime, cache bounds/concurrent writers, cross-replica candidates/restart, and legacy behavior.
- `cargo test -p hyprstream --features discovery-valkey discovery_state_documentation_configures_root_backend --lib -- --nocapture`: passed; parses the documentation’s actual TOML into the application config.
- `cargo clippy -p hyprstream-discovery --features valkey --all-targets -- -D warnings`: passed.
- `.github/scripts/browser-wasm-check.sh`: passed; target-specific `cargo tree` confirms `fred` is absent from the WASM dependency graph with `valkey` enabled.
- Changed Rust formatting, whitespace, and loopback burn-down checks: passed.
- Required foreground commit hook: `cargo clippy --workspace --all-targets --release -- -D warnings`: passed.

Rollout caveat: all active-active replicas must use the repaired liveness encoding. Earlier experimental records lack their node DID and fail closed until a heartbeat refreshes them or they expire; mixed old writers are unsupported. Tests cover rejection and heartbeat repair. Tiered point-cache operations are serialized and listings incur L2 reads; no large-scale throughput benchmark is claimed.

Closes #1559.
