### PR TITLE
feat(auth): service signing-key public sidecars + service ensure-key CLI (#1562 H1)

### DIFF
--- a/crates/hyprstream/src/auth/identity_store.rs
+++ b/crates/hyprstream/src/auth/identity_store.rs
@@ -118,6 +118,51 @@ pub fn write_secret_exclusive(dir: &std::path::Path, name: &str, value: &[u8]) -
     }
 }
 
+/// Write a named **public** trust artifact to `dir` atomically (tempfile +
+/// rename).
+///
+/// Same atomic-write contract as [`write_secret`], but for non-secret material
+/// (public keys, attestations): the resulting file has mode 0644 so other
+/// local readers (e.g. a credential-mint unit mounting the directory) can
+/// consume it. NEVER pass secret material here.
+pub fn write_public(dir: &std::path::Path, name: &str, value: &[u8]) -> Result<()> {
+    use std::io::Write as _;
+    ensure_secrets_dir(dir)?;
+    let path = dir.join(name);
+
+    let mut tmp = tempfile::NamedTempFile::new_in(dir)
+        .with_context(|| format!("failed to create temp file in '{}'", dir.display()))?;
+
+    tmp.write_all(value)
+        .with_context(|| format!("failed to write public file in '{}'", dir.display()))?;
+
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        std::fs::set_permissions(tmp.path(), std::fs::Permissions::from_mode(0o644))
+            .with_context(|| format!("failed to chmod public file in '{}'", dir.display()))?;
+    }
+
+    tmp.persist(&path)
+        .with_context(|| format!("failed to persist public file to '{}'", path.display()))?;
+
+    tracing::debug!("wrote public file '{}'", path.display());
+    Ok(())
+}
+
+/// Write a public artifact only when it is missing or its content differs.
+///
+/// Keeps re-provisioning and service restarts idempotent: an up-to-date
+/// sidecar is left untouched (no mtime churn, no rewrite).
+fn write_public_if_changed(dir: &std::path::Path, name: &str, value: &[u8]) -> Result<()> {
+    if let Some(existing) = read_secret(dir, name)? {
+        if existing == value {
+            return Ok(());
+        }
+    }
+    write_public(dir, name, value)
+}
+
 /// Returns `true` if `dir` exists and is writable (or can be created).
 ///
 /// Uses `tempfile::tempfile_in` so no named probe file is left on disk,
@@ -172,6 +217,8 @@ fn missing_in_readonly(secrets_dir: &std::path::Path, name: &str) -> anyhow::Err
 ///   ca-mldsa-pubkey   # CA derived ML-DSA-65 verifying key (public, all services)
 ///   {service}/
 ///     signing-key     # service's own Ed25519 private key
+///     signing-key.pub # service's Ed25519 verifying key (public sidecar, 0644)
+///     service-pubkey.hybrid  # hybrid bootstrap entry (public sidecar, 0644)
 ///     service-jwt     # CA-signed JWT certificate
 ///   bootstrap-pubkeys # JSON: { "policy": "base64...", "discovery": "base64..." }
 /// ```
@@ -212,6 +259,77 @@ pub fn validate_service_name(name: &str) -> Result<()> {
     Ok(())
 }
 
+/// File name of the public Ed25519 sidecar written alongside a service's
+/// `signing-key` seed: the raw 32-byte verifying key.
+pub const SIGNING_KEY_PUB_NAME: &str = "signing-key.pub";
+
+/// File name of the public hybrid (Ed25519 ‖ ML-DSA-65) sidecar written
+/// alongside a service's `signing-key` seed.
+///
+/// Contents are exactly the service's 1984-byte `bootstrap-pubkeys` entry
+/// value (see `docs/bootstrap-pubkeys-format.md`), so a bootstrap-enrollment
+/// mint can consume it without ever touching secret material — the ML-DSA-65
+/// half is derived from the Ed25519 seed and cannot be recomputed from a
+/// public key alone.
+pub const SERVICE_PUBKEY_HYBRID_NAME: &str = "service-pubkey.hybrid";
+
+/// The directory holding `service_name`'s signing key under `secrets_dir` for
+/// the given profile.
+///
+/// Mirrors [`resolve_service_signing_key`]'s file layout: "policy" and any
+/// per-service-scoped directory use the flat layout, everything else gets a
+/// `{service_name}/` subdirectory.
+pub fn service_signing_key_dir(
+    secrets_dir: &std::path::Path,
+    service_name: &str,
+    profile: SecretsProfile,
+) -> std::path::PathBuf {
+    match (profile, service_name) {
+        (_, "policy") | (SecretsProfile::PerServiceScoped, _) => secrets_dir.to_path_buf(),
+        (SecretsProfile::SharedDirectory, _) => secrets_dir.join(service_name),
+    }
+}
+
+/// Write the public sidecars for a service signing key next to its seed:
+///
+/// - [`SIGNING_KEY_PUB_NAME`] — the 32-byte Ed25519 verifying key.
+/// - [`SERVICE_PUBKEY_HYBRID_NAME`] — the 1984-byte hybrid `bootstrap-pubkeys`
+///   entry (Ed25519 ‖ derived ML-DSA-65) for bootstrap enrollment.
+///
+/// Both are public trust material (mode 0644) derived from the key's public
+/// half only; the seed never appears in either. Idempotent: a sidecar whose
+/// content already matches is left untouched.
+pub fn ensure_service_key_sidecars(
+    service_dir: &std::path::Path,
+    service_key: &SigningKey,
+) -> Result<()> {
+    write_public_if_changed(
+        service_dir,
+        SIGNING_KEY_PUB_NAME,
+        service_key.verifying_key().as_bytes(),
+    )?;
+    let hybrid = BootstrapPubkey::for_service_key(service_key)?.to_key_bytes();
+    write_public_if_changed(service_dir, SERVICE_PUBKEY_HYBRID_NAME, &hybrid)?;
+    Ok(())
+}
+
+/// Best-effort sidecar write from the key loader.
+///
+/// Never fails key loading over a public sidecar (e.g. on a read-only
+/// credentials mount): the sidecar is backfilled on every writable load and
+/// by `hyprstream service ensure-key`.
+fn backfill_service_key_sidecars(
+    service_dir: &std::path::Path,
+    service_name: &str,
+    service_key: &SigningKey,
+) {
+    if let Err(e) = ensure_service_key_sidecars(service_dir, service_key) {
+        tracing::warn!(
+            "could not write public key sidecars for service '{service_name}': {e:#}"
+        );
+    }
+}
+
 pub fn load_or_generate_service_signing_key(
     credentials_dir: &std::path::Path,
     service_name: &str,
@@ -227,6 +345,9 @@ pub fn load_or_generate_service_signing_key(
         let sk = SigningKey::from_bytes(&arr);
         bytes.zeroize();
         arr.zeroize();
+        // Backfill the public sidecars for pre-existing seeds (written on
+        // generate below, but a seed written by an older version has none).
+        backfill_service_key_sidecars(&service_dir, service_name, &sk);
         tracing::info!("Loaded Ed25519 signing key for service '{service_name}'");
         return Ok(sk);
     }
@@ -240,6 +361,7 @@ pub fn load_or_generate_service_signing_key(
     match write_secret_exclusive(&service_dir, NAME, &raw) {
         Ok(true) => {
             raw.zeroize();
+            backfill_service_key_sidecars(&service_dir, service_name, &key);
             tracing::info!("Generated new Ed25519 signing key for service '{service_name}'");
             Ok(key)
         }
@@ -258,6 +380,7 @@ pub fn load_or_generate_service_signing_key(
             let sk = SigningKey::from_bytes(&arr);
             bytes.zeroize();
             arr.zeroize();
+            backfill_service_key_sidecars(&service_dir, service_name, &sk);
             Ok(sk)
         }
         Err(e) => {
@@ -1909,6 +2032,139 @@ mod tests {
             resolve_service_signing_key(dir.path(), "model", SecretsProfile::SharedDirectory)
                 .unwrap();
         assert_eq!(model_1.to_bytes(), model_2.to_bytes());
+    }
+
+    // ── service key public sidecars (#1562 H1) ──────────────────────────────
+
+    #[cfg(unix)]
+    fn file_mode(path: &std::path::Path) -> u32 {
+        use std::os::unix::fs::PermissionsExt;
+        std::fs::metadata(path).unwrap().permissions().mode() & 0o777
+    }
+
+    #[test]
+    fn test_service_key_sidecars_written_on_generate() {
+        let dir = TempDir::new().unwrap();
+        let key = load_or_generate_service_signing_key(dir.path(), "discovery").unwrap();
+        let svc = dir.path().join("discovery");
+
+        let pub_bytes = std::fs::read(svc.join(SIGNING_KEY_PUB_NAME)).unwrap();
+        assert_eq!(pub_bytes, key.verifying_key().as_bytes());
+
+        let hybrid_bytes = std::fs::read(svc.join(SERVICE_PUBKEY_HYBRID_NAME)).unwrap();
+        let expected = BootstrapPubkey::for_service_key(&key).unwrap().to_key_bytes();
+        assert_eq!(hybrid_bytes, expected);
+        assert_eq!(hybrid_bytes.len(), 1984);
+
+        #[cfg(unix)]
+        {
+            assert_eq!(file_mode(&svc.join("signing-key")), 0o600);
+            assert_eq!(file_mode(&svc.join(SIGNING_KEY_PUB_NAME)), 0o644);
+            assert_eq!(file_mode(&svc.join(SERVICE_PUBKEY_HYBRID_NAME)), 0o644);
+        }
+    }
+
+    #[test]
+    fn test_service_key_sidecars_backfilled_on_load_of_preexisting_seed() {
+        let dir = TempDir::new().unwrap();
+        // Simulate a pre-H1 install: only the seed exists, no sidecars.
+        let seed = SigningKey::generate(&mut rand::rngs::OsRng);
+        write_secret(&dir.path().join("discovery"), "signing-key", &seed.to_bytes()).unwrap();
+        let svc = dir.path().join("discovery");
+        assert!(!svc.join(SIGNING_KEY_PUB_NAME).exists());
+        assert!(!svc.join(SERVICE_PUBKEY_HYBRID_NAME).exists());
+
+        let loaded = load_or_generate_service_signing_key(dir.path(), "discovery").unwrap();
+        assert_eq!(
+            loaded.to_bytes(),
+            seed.to_bytes(),
+            "load must adopt the existing seed, not rotate it"
+        );
+
+        let pub_bytes = std::fs::read(svc.join(SIGNING_KEY_PUB_NAME)).unwrap();
+        assert_eq!(pub_bytes, seed.verifying_key().as_bytes());
+        let hybrid_bytes = std::fs::read(svc.join(SERVICE_PUBKEY_HYBRID_NAME)).unwrap();
+        assert_eq!(
+            hybrid_bytes,
+            BootstrapPubkey::for_service_key(&seed).unwrap().to_key_bytes()
+        );
+        #[cfg(unix)]
+        {
+            assert_eq!(file_mode(&svc.join(SIGNING_KEY_PUB_NAME)), 0o644);
+            assert_eq!(file_mode(&svc.join(SERVICE_PUBKEY_HYBRID_NAME)), 0o644);
+        }
+    }
+
+    #[test]
+    fn test_service_key_sidecars_idempotent() {
+        let dir = TempDir::new().unwrap();
+        let first = load_or_generate_service_signing_key(dir.path(), "registry").unwrap();
+        let svc = dir.path().join("registry");
+        let pub1 = std::fs::read(svc.join(SIGNING_KEY_PUB_NAME)).unwrap();
+        let hyb1 = std::fs::read(svc.join(SERVICE_PUBKEY_HYBRID_NAME)).unwrap();
+
+        let second = load_or_generate_service_signing_key(dir.path(), "registry").unwrap();
+        assert_eq!(
+            first.to_bytes(),
+            second.to_bytes(),
+            "re-running must not rotate the key"
+        );
+        assert_eq!(std::fs::read(svc.join(SIGNING_KEY_PUB_NAME)).unwrap(), pub1);
+        assert_eq!(std::fs::read(svc.join(SERVICE_PUBKEY_HYBRID_NAME)).unwrap(), hyb1);
+        #[cfg(unix)]
+        {
+            assert_eq!(file_mode(&svc.join(SIGNING_KEY_PUB_NAME)), 0o644);
+            assert_eq!(file_mode(&svc.join(SERVICE_PUBKEY_HYBRID_NAME)), 0o644);
+        }
+    }
+
+    #[test]
+    fn test_service_key_sidecars_contain_no_secret_material() {
+        let dir = TempDir::new().unwrap();
+        let key = load_or_generate_service_signing_key(dir.path(), "model").unwrap();
+        let seed = key.to_bytes();
+        let svc = dir.path().join("model");
+
+        for name in [SIGNING_KEY_PUB_NAME, SERVICE_PUBKEY_HYBRID_NAME] {
+            let bytes = std::fs::read(svc.join(name)).unwrap();
+            assert_ne!(bytes, seed.as_slice());
+            assert!(
+                !bytes.windows(seed.len()).any(|w| w == seed.as_slice()),
+                "{name} must not embed the seed anywhere"
+            );
+        }
+
+        // Positive control: the sidecar bytes are exactly the public derivation
+        // of the seed — Ed25519 verifying key, then the derived ML-DSA-65
+        // verifying key.
+        let pub_bytes = std::fs::read(svc.join(SIGNING_KEY_PUB_NAME)).unwrap();
+        assert_eq!(pub_bytes, key.verifying_key().as_bytes());
+        let pq_sk = hyprstream_rpc::node_identity::derive_mesh_mldsa_key(&key);
+        let pq_vk = hyprstream_rpc::crypto::pq::ml_dsa_sk_to_vk_bytes(&pq_sk);
+        let hybrid_bytes = std::fs::read(svc.join(SERVICE_PUBKEY_HYBRID_NAME)).unwrap();
+        assert_eq!(&hybrid_bytes[..32], key.verifying_key().as_bytes());
+        assert_eq!(&hybrid_bytes[32..], pq_vk.as_slice());
+    }
+
+    #[test]
+    fn test_service_signing_key_dir_matches_resolve_layout() {
+        let base = std::path::Path::new("/credentials");
+        assert_eq!(
+            service_signing_key_dir(base, "policy", SecretsProfile::SharedDirectory),
+            base
+        );
+        assert_eq!(
+            service_signing_key_dir(base, "policy", SecretsProfile::PerServiceScoped),
+            base
+        );
+        assert_eq!(
+            service_signing_key_dir(base, "model", SecretsProfile::PerServiceScoped),
+            base
+        );
+        assert_eq!(
+            service_signing_key_dir(base, "model", SecretsProfile::SharedDirectory),
+            base.join("model")
+        );
     }
 
     // ── bootstrap-pubkeys wire format ────────────────────────────────────────

--- a/crates/hyprstream/src/bin/main.rs
+++ b/crates/hyprstream/src/bin/main.rs
@@ -2256,6 +2256,26 @@ fn main() -> Result<()> {
         }
     }
 
+    // ── `service ensure-key` early dispatch ─────────────────────────────────
+    // Key materialization for provisioning/keygen units: it must work on a
+    // fresh install (before any bootstrap-pubkeys exist) and must not start
+    // any services, so dispatch before the registry bootstrap below — same
+    // rationale as `service repair`.
+    if let Some(("service", sub_m)) = matches.subcommand() {
+        if let Some(("ensure-key", ek_m)) = sub_m.subcommand() {
+            // `name` is a required positional; a missing value is a clap bug,
+            // not operator error, so fail loudly rather than guess.
+            let name = ek_m
+                .get_one::<String>("name")
+                .cloned()
+                .ok_or_else(|| anyhow::anyhow!("service ensure-key: missing required <name>"))?;
+            return hyprstream_core::cli::service_handlers::handle_service_ensure_key(
+                Some(&config),
+                &name,
+            );
+        }
+    }
+
     // Start registry service ONCE at CLI level
     let _registry_runtime = tokio::runtime::Builder::new_multi_thread()
         .enable_all()
@@ -3103,6 +3123,16 @@ fn main() -> Result<()> {
                         || async move {
                             hyprstream_core::cli::service_handlers::run_repair_checks(&models_dir, verbose).await
                         },
+                    )?;
+                }
+
+                ServiceAction::EnsureKey { name } => {
+                    // Normally handled by the early dispatch above (before any
+                    // services start). Defense-in-depth fallback if that
+                    // dispatch is ever bypassed.
+                    hyprstream_core::cli::service_handlers::handle_service_ensure_key(
+                        Some(ctx.config()),
+                        &name,
                     )?;
                 }
             }

--- a/crates/hyprstream/src/cli/bootstrap_manager.rs
+++ b/crates/hyprstream/src/cli/bootstrap_manager.rs
@@ -809,6 +809,18 @@ fn provision_service_identities(
             service_name.to_owned(),
             identity_store::BootstrapPubkey::for_service_key(&service_key)?,
         );
+
+        // Publish the public sidecars (`signing-key.pub`, `service-pubkey.hybrid`)
+        // next to the key so the bootstrap-enrollment mint can read them without
+        // secret material (#1562 H1). For non-policy services the key loader
+        // already wrote them — an idempotent no-op here; for policy this writes
+        // them flat, alongside the node/CA seed.
+        let sidecar_dir = identity_store::service_signing_key_dir(
+            credentials_dir,
+            service_name,
+            identity_store::SecretsProfile::SharedDirectory,
+        );
+        identity_store::ensure_service_key_sidecars(&sidecar_dir, &service_key)?;
     }
 
     identity_store::write_bootstrap_pubkeys_hybrid(credentials_dir, &bootstrap_pubkeys)?;

--- a/crates/hyprstream/src/cli/commands/mod.rs
+++ b/crates/hyprstream/src/cli/commands/mod.rs
@@ -283,4 +283,20 @@ pub enum ServiceAction {
         #[arg(long, short = 'v')]
         verbose: bool,
     },
+
+    /// Generate or load a service's signing key and write its public sidecars
+    ///
+    /// Runs the same key loader the service itself uses (with
+    /// `resolve_service_signing_key` semantics, so `policy` resolves to the
+    /// flat node/CA key), then ensures the public sidecars exist next to the
+    /// seed: `signing-key.pub` (32-byte Ed25519 verifying key, 0644) and
+    /// `service-pubkey.hybrid` (1984-byte hybrid bootstrap entry, 0644).
+    ///
+    /// Idempotent: an existing key is loaded, never rotated, and up-to-date
+    /// sidecars are left untouched. Does not start any services — intended
+    /// for provisioning/keygen units that run before service startup.
+    EnsureKey {
+        /// Service name (e.g. registry, discovery, policy)
+        name: String,
+    },
 }

--- a/crates/hyprstream/src/cli/service_handlers.rs
+++ b/crates/hyprstream/src/cli/service_handlers.rs
@@ -1187,6 +1187,39 @@ pub fn handle_print_cert_hash(quic_config: &crate::config::QuicConfig) -> Result
     Ok(())
 }
 
+/// Handle `service ensure-key` — materialize a service's signing key and its
+/// public sidecars without starting any services.
+///
+/// Runs the same loader the service itself uses (`resolve_service_signing_key`,
+/// so `policy` resolves to the flat node/CA key), then guarantees the public
+/// sidecars exist next to the seed:
+///
+/// - `signing-key.pub` — 32-byte Ed25519 verifying key (mode 0644)
+/// - `service-pubkey.hybrid` — 1984-byte hybrid bootstrap entry (mode 0644)
+///
+/// Idempotent: an existing key is loaded, never rotated, and up-to-date
+/// sidecars are left untouched. Prints the base64 public key and the sidecar
+/// paths for provisioning units that wire them into a credential mint.
+pub fn handle_service_ensure_key(config: Option<&crate::config::HyprConfig>, name: &str) -> Result<()> {
+    use base64::Engine as _;
+    use crate::auth::identity_store;
+
+    identity_store::validate_service_name(name)?;
+    let secrets_dir = identity_store::credentials_dir_for_config(config)?;
+    let profile = identity_store::SecretsProfile::from_env()?;
+    let key = identity_store::resolve_service_signing_key(&secrets_dir, name, profile)?;
+    let key_dir = identity_store::service_signing_key_dir(&secrets_dir, name, profile);
+    identity_store::ensure_service_key_sidecars(&key_dir, &key)?;
+
+    let pubkey_b64 = base64::engine::general_purpose::URL_SAFE_NO_PAD
+        .encode(key.verifying_key().as_bytes());
+    println!("service '{name}' signing key ensured");
+    println!("  public key (base64): {pubkey_b64}");
+    println!("  {}", key_dir.join(identity_store::SIGNING_KEY_PUB_NAME).display());
+    println!("  {}", key_dir.join(identity_store::SERVICE_PUBKEY_HYBRID_NAME).display());
+    Ok(())
+}
+
 /// Update shell profiles to include bin_dir in PATH
 fn update_shell_profiles(home: &Path, bin_dir: &Path) -> Result<Vec<String>> {
     let path_line = format!(r#"export PATH="{}:$PATH""#, bin_dir.display());

--- a/docs/bootstrap-pubkeys-format.md
+++ b/docs/bootstrap-pubkeys-format.md
@@ -124,6 +124,24 @@ itself, can report precisely which services are stale. This rule is scoped to
 the node's own services: external classical clients and federated peers do not
 appear in this file and are unaffected by it.
 
+## Per-service public sidecars
+
+Each service also publishes its own entry as standalone public files next to
+its signing-key seed, written (and backfilled for pre-existing seeds) by the
+key loader and by `hyprstream service ensure-key <name>`:
+
+- `{service}/signing-key.pub` — the raw 32-byte Ed25519 verifying key.
+- `{service}/service-pubkey.hybrid` — the raw 1984-byte hybrid entry value
+  (before base64), byte-for-byte the same value this file encodes for that
+  service.
+
+Both are public trust material (mode 0644) derived from the key's public half
+only; the seed never appears in either. They exist so consumers that need one
+service's live public key — the registry credential mint, the bootstrap
+enrollment mint — can read it from a volume mount without access to any secret
+material. For `policy`, whose key is the flat node/CA key, the sidecars are
+written flat alongside `credentials/signing-key`.
+
 ## Which service names matter
 
 The wizard mints a keypair for every registered factory, but the runtime only


### PR DESCRIPTION
## Summary

Implements **hyprstream#1562 work item H1** (per the 2026-08-31 design comment, ordered item 1): public sidecars for service signing keys + an idempotent `hyprstream service ensure-key` CLI. No trust-semantics change. Unblocks metal MR-M1 (registry live-key mint).

- `load_or_generate_service_signing_key` (`auth/identity_store.rs`) now writes **`{service}/signing-key.pub`** (raw 32-byte Ed25519 verifying key, atomic tempfile+rename, mode 0644) on generate and **backfills it on load** of a pre-existing seed.
- A second public sidecar **`{service}/service-pubkey.hybrid`** — the exact 1984-byte `bootstrap-pubkeys` entry value (Ed25519 ‖ derived ML-DSA-65) — is written alongside, giving the bootstrap-enrollment mint a public-only input (the ML-DSA-65 half is derived from the Ed25519 secret and cannot be recomputed from a public key).
- Both sidecars are public trust material only (0644); the seed never appears in either. Writes are idempotent (content-matched, no mtime churn) and **best-effort** in the loader so a read-only credentials mount never fails key loading.
- New **`hyprstream service ensure-key <name>`** runs the same loader with `resolve_service_signing_key` semantics (so `policy` resolves to the flat node/CA key), guarantees the sidecars, and prints the base64 public key + sidecar paths — **without starting any services** (early dispatch before the registry bootstrap, same pattern as `service repair`).
- Bootstrap provisioning (`provision_service_identities`) publishes the same sidecars for every service (flat for policy, alongside the node/CA seed).
- `docs/bootstrap-pubkeys-format.md` documents the sidecar files.

## Overlap with #1563

Zero file overlap: #1563 touches `auth/age_seal.rs`, `cli/commands/trust.rs`, `cli/trust.rs`, `cli/trust_ceremony.rs`; this PR adds a variant in `cli/commands/mod.rs` plus `identity_store.rs` / `bootstrap_manager.rs` / `service_handlers.rs` / `bin/main.rs`. No expected conflict.

## Tests

New tests in `auth::identity_store`:

- sidecars written on first generate (contents + 0600 seed / 0644 sidecar modes)
- sidecars backfilled on load of a pre-existing seed (adopts seed, no rotation)
- idempotency (re-run returns same key, sidecars byte-identical)
- no-secret-in-sidecar (seed absent from sidecar bytes; sidecar == exact public derivation)
- `service_signing_key_dir` layout parity with `resolve_service_signing_key`

Validation run (BuildQ warm target-1, rustc 1.97.0, cuda130 libtorch):

- `cargo test -p hyprstream --lib auth::identity_store` — 47/47 pass
- `cargo test -p hyprstream --lib cli::` — 107/107 pass
- `cargo clippy -p hyprstream --all-targets -- -D warnings` — clean
- pre-commit hook (workspace release clippy, mirrors CI) — clean
- E2E smoke: built binary `hyprstream service ensure-key discovery` (generates seed + both sidecars, modes 600/644/644), re-run idempotent (same pubkey), `service ensure-key policy` writes flat sidecars; no services started.

Refs #1562 (H1).