### PR TITLE
feat(trust): service-key enrollment capability in the delegation UCAN (#1562 H2)

### DIFF
--- a/crates/hyprstream-discovery/src/lib.rs
+++ b/crates/hyprstream-discovery/src/lib.rs
@@ -150,8 +150,10 @@ pub use service::{
     production_inference_rpc_client_at_transport, production_rpc_client,
     verify_genesis_deployment_artifacts,
     verify_deployment_artifacts_with_authority_log, verify_deployment_public_ca,
+    verify_service_key_enrollment,
     DeploymentAuthorityCheckpoint, DeploymentAuthorityLog, RegistryDelegationArtifact,
-    VerifiedDeploymentArtifacts,
+    ServiceKeyEnrollmentArtifact, ServiceKeyEnrollmentSigningBody,
+    VerifiedDeploymentArtifacts, VerifiedServiceKeyEnrollment,
 };
 #[cfg(feature = "test-fixtures")]
 #[doc(hidden)]

--- a/crates/hyprstream-discovery/src/service.rs
+++ b/crates/hyprstream-discovery/src/service.rs
@@ -1533,6 +1533,17 @@ const MAX_AUTHORITY_LOG_OPERATIONS: usize = 128;
 const MAX_REGISTRY_DELEGATION_BYTES: usize = 256 * 1024;
 const MAX_DEPLOYMENT_CLOUD_SECRET_BYTES: usize = 64 * 1024;
 const REGISTRY_DELEGATION_ABILITY: &str = "mint-registry-jwt";
+const SERVICE_KEY_ENROLLMENT_SCHEMA: &str = "hyprstream.service-key-enrollment.v1";
+const SERVICE_KEY_ENROLLMENT_ABILITY: &str = "enroll-service-key";
+const SERVICE_KEY_ENROLLMENT_KEY_TYPE: &str = "hybrid-ed25519-mldsa65";
+const SERVICE_KEY_ENROLLMENT_MAX_TTL_SECONDS: i64 = 3_600;
+/// Signature context (AAD) binding an enrollment attestation to its schema.
+const SERVICE_KEY_ENROLLMENT_SIGNATURE_CONTEXT: &[u8] = b"hyprstream.service-key-enrollment.v1";
+/// Fixed allowlist per hyprstream#1562: registry stays JWT-enrolled and
+/// policy-CA/authority keys are out of scope, so exactly these services may be
+/// enrolled by a delegated signer.
+const SERVICE_KEY_ENROLLMENT_ALLOWED_SERVICES: [&str; 2] = ["discovery", "policy"];
+const MAX_SERVICE_KEY_ENROLLMENT_BYTES: usize = 256 * 1024;
 
 /// Signed DidOp authority history embedded in a registry delegation.
 #[derive(Clone, Debug, Eq, PartialEq, serde::Serialize, serde::Deserialize)]
@@ -1568,6 +1579,74 @@ pub struct RegistryDelegationArtifact {
     pub authority_log_did: String,
     pub delegated_public_key_b64: String,
     pub ucan_b64: String,
+}
+
+/// Chain-signed attestation binding a discovery/policy service's live hybrid
+/// public key (the exact 1984-byte `bootstrap-pubkeys` entry) to the
+/// deployment authority, minted at activation by the delegated signer
+/// (hyprstream#1562). Public trust material: installed mode 0644, per-service.
+#[derive(Clone, Debug, Eq, PartialEq, serde::Serialize, serde::Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct ServiceKeyEnrollmentArtifact {
+    pub schema: String,
+    pub deployment_domain: String,
+    pub service: String,
+    /// Base64 of the exact 1984-byte hybrid public key (32-byte Ed25519
+    /// followed by 1952-byte ML-DSA-65).
+    pub hybrid_public_key_b64: String,
+    pub not_before: i64,
+    pub expires_at: i64,
+    /// The two-capability delegation authorizing the signing key.
+    pub delegation: RegistryDelegationArtifact,
+    /// Base64 of the hybrid Ed25519+ML-DSA-65 signature by the delegated
+    /// signer over [`ServiceKeyEnrollmentArtifact::signing_bytes`].
+    pub signature_b64: String,
+}
+
+/// The signed body of a [`ServiceKeyEnrollmentArtifact`]: every field except
+/// the signature, serialized with fixed struct-field order so the mint and the
+/// production verifier derive identical bytes.
+#[derive(Clone, Debug, Eq, PartialEq, serde::Serialize, serde::Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct ServiceKeyEnrollmentSigningBody {
+    pub schema: String,
+    pub deployment_domain: String,
+    pub service: String,
+    pub hybrid_public_key_b64: String,
+    pub not_before: i64,
+    pub expires_at: i64,
+    pub delegation: RegistryDelegationArtifact,
+}
+
+impl ServiceKeyEnrollmentArtifact {
+    /// The artifact with an empty signature, ready to be signed.
+    pub fn unsigned(body: ServiceKeyEnrollmentSigningBody) -> Self {
+        Self {
+            schema: body.schema,
+            deployment_domain: body.deployment_domain,
+            service: body.service,
+            hybrid_public_key_b64: body.hybrid_public_key_b64,
+            not_before: body.not_before,
+            expires_at: body.expires_at,
+            delegation: body.delegation,
+            signature_b64: String::new(),
+        }
+    }
+
+    /// Canonical bytes the delegated signer signs and the verifier checks.
+    pub fn signing_bytes(&self) -> Result<Vec<u8>> {
+        let body = ServiceKeyEnrollmentSigningBody {
+            schema: self.schema.clone(),
+            deployment_domain: self.deployment_domain.clone(),
+            service: self.service.clone(),
+            hybrid_public_key_b64: self.hybrid_public_key_b64.clone(),
+            not_before: self.not_before,
+            expires_at: self.expires_at,
+            delegation: self.delegation.clone(),
+        };
+        serde_json::to_vec(&body)
+            .map_err(|error| anyhow::anyhow!("encoding enrollment signing body: {error}"))
+    }
 }
 
 /// Non-optional Ed25519 + ML-DSA-65 deployment trust root.
@@ -2086,7 +2165,7 @@ fn validate_registry_deployment_credential_profile(
             active,
             u64::try_from(now).map_err(|_| anyhow::anyhow!("system clock precedes Unix epoch"))?,
         )?;
-        &delegated_ca
+        &delegated_ca.delegated
     } else if let Some((_installed_authority_log, active)) = enrolled.as_ref() {
         anyhow::ensure!(
             active.rotation_keys.iter().any(|key| {
@@ -2160,16 +2239,126 @@ impl hyprstream_rpc::auth::ucan::UcanVerifier for AuthoritySetUcanVerifier<'_> {
     }
 }
 
+/// The exact registry-mint capability every delegation must carry.
+fn registry_mint_capability(
+    deployment_domain: &str,
+    delegated_public_key_b64: &str,
+) -> hyprstream_rpc::auth::ucan::Capability {
+    use hyprstream_rpc::auth::ucan::{Ability, Capability, CaveatValue, Caveats, Resource};
+
+    let mut caveats = std::collections::BTreeMap::new();
+    caveats.insert(
+        "audience".to_owned(),
+        CaveatValue::Text(REGISTRY_DEPLOYMENT_CREDENTIAL_AUDIENCE.to_owned()),
+    );
+    caveats.insert(
+        "deployment_domain".to_owned(),
+        CaveatValue::Text(deployment_domain.to_owned()),
+    );
+    caveats.insert(
+        "delegated_public_key_b64".to_owned(),
+        CaveatValue::Text(delegated_public_key_b64.to_owned()),
+    );
+    caveats.insert(
+        "max_ttl_seconds".to_owned(),
+        CaveatValue::Int(REGISTRY_DEPLOYMENT_CREDENTIAL_MAX_TTL_SECONDS),
+    );
+    caveats.insert(
+        "profile".to_owned(),
+        CaveatValue::Text(REGISTRY_DEPLOYMENT_CREDENTIAL_PROFILE.to_owned()),
+    );
+    Capability::with_caveats(
+        Resource::new(format!(
+            "hyprstream://deployment/{deployment_domain}/service/registry"
+        )),
+        Ability::new(REGISTRY_DELEGATION_ABILITY),
+        Caveats(caveats),
+    )
+}
+
+/// The exact service-key-enrollment capability (hyprstream#1562): a fixed
+/// allowlist, hybrid-only key type, and a one-hour attestation TTL ceiling.
+fn service_key_enrollment_capability(
+    deployment_domain: &str,
+    delegated_public_key_b64: &str,
+) -> hyprstream_rpc::auth::ucan::Capability {
+    use hyprstream_rpc::auth::ucan::{Ability, Capability, CaveatValue, Caveats, Resource};
+
+    let mut caveats = std::collections::BTreeMap::new();
+    caveats.insert(
+        "deployment_domain".to_owned(),
+        CaveatValue::Text(deployment_domain.to_owned()),
+    );
+    caveats.insert(
+        "delegated_public_key_b64".to_owned(),
+        CaveatValue::Text(delegated_public_key_b64.to_owned()),
+    );
+    caveats.insert(
+        "allowed_services".to_owned(),
+        CaveatValue::List(
+            SERVICE_KEY_ENROLLMENT_ALLOWED_SERVICES
+                .iter()
+                .map(|service| (*service).to_owned())
+                .collect(),
+        ),
+    );
+    caveats.insert(
+        "key_type".to_owned(),
+        CaveatValue::Text(SERVICE_KEY_ENROLLMENT_KEY_TYPE.to_owned()),
+    );
+    caveats.insert(
+        "max_attestation_ttl_seconds".to_owned(),
+        CaveatValue::Int(SERVICE_KEY_ENROLLMENT_MAX_TTL_SECONDS),
+    );
+    Capability::with_caveats(
+        Resource::new(format!(
+            "hyprstream://deployment/{deployment_domain}/service-key-enrollment"
+        )),
+        Ability::new(SERVICE_KEY_ENROLLMENT_ABILITY),
+        Caveats(caveats),
+    )
+}
+
+/// Exact-set capability validation (hyprstream#1562): a delegation is either
+/// the legacy registry-only scope minted before enrollment existed, or exactly
+/// the registry + enrollment pair. Anything narrower, wider, or reordered is
+/// rejected. Returns true when the enrollment capability is present.
+fn delegation_capability_set_grants_enrollment(
+    capabilities: &[hyprstream_rpc::auth::ucan::Capability],
+    deployment_domain: &str,
+    delegated_public_key_b64: &str,
+) -> Result<bool> {
+    let registry = registry_mint_capability(deployment_domain, delegated_public_key_b64);
+    let enrollment = service_key_enrollment_capability(deployment_domain, delegated_public_key_b64);
+    if capabilities.len() == 1 && capabilities[0] == registry {
+        return Ok(false);
+    }
+    anyhow::ensure!(
+        capabilities.len() == 2
+            && capabilities.contains(&registry)
+            && capabilities.contains(&enrollment),
+        "delegation capability set is not the exact registry or registry+enrollment scope"
+    );
+    Ok(true)
+}
+
+/// Outcome of validating a delegation artifact: the authenticated delegated
+/// signer, whether it may enroll service keys, and the delegation expiry that
+/// caps anything it mints.
+struct ValidatedRegistryDelegation {
+    delegated: HybridDeploymentCa,
+    grants_service_key_enrollment: bool,
+    expires_at: u64,
+}
+
 fn validate_registry_delegation_artifact(
     root: &HybridDeploymentCa,
     artifact: &RegistryDelegationArtifact,
     installed_authority_log: &DeploymentAuthorityLog,
     active: &crate::did_op::VerifiedDidOpLog,
     now: u64,
-) -> Result<HybridDeploymentCa> {
-    use hyprstream_rpc::auth::ucan::{
-        validate as validate_ucan, Ability, Capability, CaveatValue, Caveats, Resource, Ucan,
-    };
+) -> Result<ValidatedRegistryDelegation> {
+    use hyprstream_rpc::auth::ucan::{validate as validate_ucan, Ucan};
 
     anyhow::ensure!(
         artifact.schema == REGISTRY_DELEGATION_SCHEMA,
@@ -2221,44 +2410,20 @@ fn validate_registry_delegation_artifact(
         ucan.audience().to_ed25519()? == delegated.ed25519.to_bytes(),
         "registry delegation audience does not match delegated signer"
     );
-    let mut caveats = std::collections::BTreeMap::new();
-    caveats.insert(
-        "audience".to_owned(),
-        CaveatValue::Text(REGISTRY_DEPLOYMENT_CREDENTIAL_AUDIENCE.to_owned()),
-    );
-    caveats.insert(
-        "deployment_domain".to_owned(),
-        CaveatValue::Text(root.domain()),
-    );
-    caveats.insert(
-        "delegated_public_key_b64".to_owned(),
-        CaveatValue::Text(artifact.delegated_public_key_b64.clone()),
-    );
-    caveats.insert(
-        "max_ttl_seconds".to_owned(),
-        CaveatValue::Int(REGISTRY_DEPLOYMENT_CREDENTIAL_MAX_TTL_SECONDS),
-    );
-    caveats.insert(
-        "profile".to_owned(),
-        CaveatValue::Text(REGISTRY_DEPLOYMENT_CREDENTIAL_PROFILE.to_owned()),
-    );
-    let expected = Capability::with_caveats(
-        Resource::new(format!(
-            "hyprstream://deployment/{}/service/registry",
-            root.domain()
-        )),
-        Ability::new(REGISTRY_DELEGATION_ABILITY),
-        Caveats(caveats),
-    );
-    anyhow::ensure!(
-        ucan.capabilities() == [expected],
-        "registry delegation capability is not the exact registry-only scope"
-    );
-    anyhow::ensure!(
-        ucan.payload.expiration.is_some(),
-        "registry delegation must expire"
-    );
-    Ok(delegated)
+    let grants_service_key_enrollment = delegation_capability_set_grants_enrollment(
+        ucan.capabilities(),
+        &root.domain(),
+        &artifact.delegated_public_key_b64,
+    )?;
+    let expires_at = ucan
+        .payload
+        .expiration
+        .ok_or_else(|| anyhow::anyhow!("registry delegation must expire"))?;
+    Ok(ValidatedRegistryDelegation {
+        delegated,
+        grants_service_key_enrollment,
+        expires_at,
+    })
 }
 
 fn validate_deployment_authority_log(
@@ -2416,6 +2581,160 @@ pub fn verify_deployment_artifacts_with_authority_log(
         deployment_domain: ca.domain(),
         registry_public_key,
         expires_at,
+    })
+}
+
+/// Result of verifying a service-key enrollment attestation: the authenticated
+/// hybrid public key for one allowlisted service. This exposes no authority or
+/// signing material.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct VerifiedServiceKeyEnrollment {
+    pub deployment_domain: String,
+    pub service: String,
+    /// The exact 1984-byte `bootstrap-pubkeys` entry (32-byte Ed25519, then
+    /// 1952-byte ML-DSA-65).
+    pub hybrid_public_key: Vec<u8>,
+    pub expires_at: i64,
+}
+
+/// Verify a `hyprstream.service-key-enrollment.v1` attestation against the
+/// public root, the installed/current authority log, and its independently
+/// trusted head (hyprstream#1562).
+///
+/// Fail-closed on: wrong schema/domain, a service outside the fixed
+/// allowlist, a malformed or wrong-length hybrid key, an attestation lifetime
+/// above one hour or past the delegation expiry, expiry at the current time,
+/// a delegation that does not carry the exact enrollment capability, and any
+/// signature half that does not verify against the delegated signer.
+pub fn verify_service_key_enrollment(
+    public_ca: &[u8],
+    authority_log_json: &[u8],
+    authority_checkpoint_json: &[u8],
+    attestation_json: &[u8],
+) -> Result<VerifiedServiceKeyEnrollment> {
+    anyhow::ensure!(
+        authority_log_json.len() <= MAX_DEPLOYMENT_CLOUD_SECRET_BYTES,
+        "installed deployment authority log is too large"
+    );
+    anyhow::ensure!(
+        authority_checkpoint_json.len() <= MAX_DEPLOYMENT_CLOUD_SECRET_BYTES,
+        "installed deployment authority checkpoint is too large"
+    );
+    anyhow::ensure!(
+        attestation_json.len() <= MAX_SERVICE_KEY_ENROLLMENT_BYTES,
+        "service-key enrollment attestation is too large"
+    );
+    let ca = HybridDeploymentCa::from_os_pin(public_ca)?;
+    let authority_log: DeploymentAuthorityLog = serde_json::from_slice(authority_log_json)
+        .map_err(|error| {
+            anyhow::anyhow!("installed deployment authority log is malformed: {error}")
+        })?;
+    let authority_checkpoint: DeploymentAuthorityCheckpoint =
+        serde_json::from_slice(authority_checkpoint_json).map_err(|error| {
+            anyhow::anyhow!("installed deployment authority checkpoint is malformed: {error}")
+        })?;
+    let active = validate_deployment_authority_log(&ca, &authority_log, &authority_checkpoint)?;
+    let attestation: ServiceKeyEnrollmentArtifact = serde_json::from_slice(attestation_json)
+        .map_err(|error| {
+            anyhow::anyhow!("service-key enrollment attestation is malformed: {error}")
+        })?;
+    anyhow::ensure!(
+        attestation.schema == SERVICE_KEY_ENROLLMENT_SCHEMA,
+        "unsupported service-key enrollment schema"
+    );
+    anyhow::ensure!(
+        attestation.deployment_domain == ca.domain(),
+        "enrollment deployment domain does not match pinned root"
+    );
+    anyhow::ensure!(
+        SERVICE_KEY_ENROLLMENT_ALLOWED_SERVICES.contains(&attestation.service.as_str()),
+        "enrollment service is outside the fixed discovery/policy allowlist"
+    );
+    let hybrid_public_key = base64::engine::general_purpose::STANDARD
+        .decode(&attestation.hybrid_public_key_b64)
+        .context("decoding enrolled hybrid public key")?;
+    anyhow::ensure!(
+        hybrid_public_key.len() == DEPLOYMENT_CA_ROOT_BYTES,
+        "enrolled hybrid public key must be exactly {DEPLOYMENT_CA_ROOT_BYTES} bytes \
+         (32-byte Ed25519 followed by 1952-byte ML-DSA-65)"
+    );
+    // Well-formedness of both halves; the mint cannot recompute the ML-DSA-65
+    // half from a public sidecar, so a truncated or classical-only key must
+    // fail here rather than at first use.
+    HybridDeploymentCa::from_public_key_bytes(
+        &hybrid_public_key[..ED25519_PUBLIC_KEY_BYTES],
+        &hybrid_public_key[ED25519_PUBLIC_KEY_BYTES..],
+    )?;
+
+    let now = chrono::Utc::now().timestamp();
+    let latest_future_time = now
+        .checked_add(REGISTRY_DEPLOYMENT_CREDENTIAL_CLOCK_SKEW_SECONDS)
+        .ok_or_else(|| anyhow::anyhow!("enrollment clock-skew arithmetic overflow"))?;
+    anyhow::ensure!(
+        attestation.not_before >= 0,
+        "enrollment not_before is negative"
+    );
+    anyhow::ensure!(
+        attestation.not_before <= latest_future_time,
+        "enrollment is not yet valid"
+    );
+    anyhow::ensure!(
+        attestation.not_before < attestation.expires_at,
+        "enrollment not_before is not before expires_at"
+    );
+    let lifetime = attestation
+        .expires_at
+        .checked_sub(attestation.not_before)
+        .ok_or_else(|| anyhow::anyhow!("enrollment lifetime arithmetic overflow"))?;
+    anyhow::ensure!(
+        lifetime <= SERVICE_KEY_ENROLLMENT_MAX_TTL_SECONDS,
+        "enrollment lifetime exceeds the inclusive one-hour limit"
+    );
+    anyhow::ensure!(now < attestation.expires_at, "enrollment has expired");
+
+    let validated = validate_registry_delegation_artifact(
+        &ca,
+        &attestation.delegation,
+        &authority_log,
+        &active,
+        u64::try_from(now).map_err(|_| anyhow::anyhow!("system clock precedes Unix epoch"))?,
+    )?;
+    anyhow::ensure!(
+        validated.grants_service_key_enrollment,
+        "delegation does not carry the service-key-enrollment capability"
+    );
+    anyhow::ensure!(
+        attestation.deployment_domain == attestation.delegation.deployment_domain,
+        "enrollment domain does not match its delegation"
+    );
+    anyhow::ensure!(
+        attestation.expires_at >= 0
+            && u64::try_from(attestation.expires_at)
+                .map_err(|_| anyhow::anyhow!("enrollment expiry conversion failed"))?
+                <= validated.expires_at,
+        "enrollment expiry exceeds the delegation expiry"
+    );
+
+    let signature = base64::engine::general_purpose::STANDARD
+        .decode(&attestation.signature_b64)
+        .context("decoding enrollment signature")?;
+    // Signature verification is deliberately last: no parsed material becomes a
+    // trusted key unless the exact artifact is authenticated by the delegated
+    // signer the root authorized.
+    hyprstream_rpc::crypto::cose_sign::verify_composite(
+        &signature,
+        &validated.delegated.ed25519,
+        Some(&validated.delegated.ml_dsa_65),
+        &attestation.signing_bytes()?,
+        SERVICE_KEY_ENROLLMENT_SIGNATURE_CONTEXT,
+        true,
+    )
+    .context("enrollment hybrid signature rejected")?;
+    Ok(VerifiedServiceKeyEnrollment {
+        deployment_domain: attestation.deployment_domain,
+        service: attestation.service,
+        hybrid_public_key,
+        expires_at: attestation.expires_at,
     })
 }
 

--- a/crates/hyprstream-rpc/src/auth/ucan/capability.rs
+++ b/crates/hyprstream-rpc/src/auth/ucan/capability.rs
@@ -170,6 +170,8 @@ pub enum CaveatValue {
     Int(i64),
     /// A boolean restriction.
     Bool(bool),
+    /// A list-of-strings restriction (e.g. a fixed allowlist).
+    List(Vec<String>),
 }
 
 impl Caveats {
@@ -379,6 +381,21 @@ mod tests {
     }
 
     // ---- set_attenuates --------------------------------------------------
+
+    #[test]
+    fn caveat_value_list_round_trips_through_cbor() {
+        let mut map = BTreeMap::new();
+        map.insert(
+            "allowed_services".to_owned(),
+            CaveatValue::List(vec!["discovery".to_owned(), "policy".to_owned()]),
+        );
+        let capability =
+            Capability::with_caveats(res("mac://model/qwen"), ab("infer"), Caveats(map));
+        let mut bytes = Vec::new();
+        ciborium::ser::into_writer(&capability, &mut bytes).unwrap();
+        let decoded: Capability = ciborium::de::from_reader(bytes.as_slice()).unwrap();
+        assert_eq!(decoded, capability);
+    }
 
     #[test]
     fn set_attenuates_every_claimed_must_be_covered() {

--- a/crates/hyprstream/src/cli/commands/mod.rs
+++ b/crates/hyprstream/src/cli/commands/mod.rs
@@ -13,9 +13,9 @@ pub use git::{GitAction, GitCommand};
 pub use policy::{PolicyCommand, RoleCommand, TokenCommand};
 pub use training::{TrainingAction, TrainingCommand};
 pub use trust::{
-    DelegateRegistrySignerArgs, InstallDeploymentTrustArgs, MintAnchorCapsuleArgs,
-    MintDeploymentCaArgs, MintRegistryJwtArgs, RotateAuthorityArgs, TrustCommand,
-    VerifyDeploymentArgs,
+    DelegateRegistrySignerArgs, EnrollServiceKeyArgs, InstallDeploymentTrustArgs,
+    MintAnchorCapsuleArgs, MintDeploymentCaArgs, MintRegistryJwtArgs, RotateAuthorityArgs,
+    TrustCommand, VerifyDeploymentArgs,
 };
 pub use user::{UserCommand, UserKeysCommand, UserKeysImportFormat};
 pub use worker::{ImageCommand, WorkerAction};

--- a/crates/hyprstream/src/cli/commands/trust.rs
+++ b/crates/hyprstream/src/cli/commands/trust.rs
@@ -22,6 +22,9 @@ pub enum TrustCommand {
     DelegateRegistrySigner(DelegateRegistrySignerArgs),
     /// Mint the one-hour registry deployment credential.
     MintRegistryJwt(MintRegistryJwtArgs),
+    /// Attest a discovery/policy service's live hybrid public key into the
+    /// deployment trust chain (hyprstream#1562).
+    EnrollServiceKey(EnrollServiceKeyArgs),
     /// Verify deployment artifacts through the production verifier.
     VerifyDeployment(VerifyDeploymentArgs),
     /// Add or replace an authority key through the signed rotation log.
@@ -282,6 +285,62 @@ pub struct MintRegistryJwtArgs {
     /// Out-of-band cloud-secret publisher manifest (never pass its values to Terraform).
     #[arg(long, default_value = "deployment-trust.contract.json")]
     pub contract: PathBuf,
+
+    /// Replace existing output files.
+    #[arg(long)]
+    pub force: bool,
+}
+
+#[derive(Debug, Args)]
+pub struct EnrollServiceKeyArgs {
+    /// Raw 1984-byte public deployment root.
+    #[arg(long, default_value = "deployment-ca.hybrid")]
+    pub public_ca: PathBuf,
+
+    /// Installed/current public authority log.
+    #[arg(long, default_value = "deployment-authority.log.json")]
+    pub authority_log: PathBuf,
+
+    /// Independently trusted expected authority-log head.
+    #[arg(long, default_value = "deployment-authority.head.json")]
+    pub authority_checkpoint: PathBuf,
+
+    /// Age identity file. Repeatable for native or plugin identities.
+    #[arg(long = "identity", value_name = "AGE_IDENTITY_FILE")]
+    pub identities: Vec<PathBuf>,
+
+    /// age-plugin-yubikey identity file. Repeatable; decryption requires the token.
+    #[arg(long = "yubikey-identity", value_name = "AGE_YUBIKEY_IDENTITY_FILE")]
+    pub yubikey_identities: Vec<PathBuf>,
+
+    /// Break-glass: use the age-wrapped recovery copy of a PIV Ed25519 key.
+    #[arg(long)]
+    pub software_recovery: bool,
+
+    /// Age-encrypted delegated online signer carrying the enrollment scope.
+    #[arg(long, value_name = "DELEGATED_KEY.age")]
+    pub via_delegated_signer: PathBuf,
+
+    /// Two-capability delegation authorizing --via-delegated-signer.
+    #[arg(long, value_name = "DELEGATION.json")]
+    pub delegation: PathBuf,
+
+    /// Service whose key is enrolled (fixed allowlist, hyprstream#1562).
+    #[arg(long, value_parser = ["discovery", "policy"])]
+    pub service: String,
+
+    /// Raw 1984-byte hybrid service public key (`service-pubkey.hybrid`:
+    /// 32-byte Ed25519 followed by 1952-byte ML-DSA-65).
+    #[arg(long, value_name = "PATH")]
+    pub service_public_key: PathBuf,
+
+    /// Attestation lifetime in seconds; the capability caps this at one hour.
+    #[arg(long, default_value_t = 3600, value_parser = clap::value_parser!(u32).range(1..=3600))]
+    pub ttl_seconds: u32,
+
+    /// Service-key enrollment attestation output (public, 0644).
+    #[arg(long, default_value = "service-key-enrollment.json")]
+    pub attestation: PathBuf,
 
     /// Replace existing output files.
     #[arg(long)]

--- a/crates/hyprstream/src/cli/trust.rs
+++ b/crates/hyprstream/src/cli/trust.rs
@@ -8,9 +8,9 @@
 
 use crate::auth::age_seal::{AgeIdentities, AgeRecipients};
 use crate::cli::commands::{
-    DelegateRegistrySignerArgs, InstallDeploymentTrustArgs, MintAnchorCapsuleArgs,
-    MintDeploymentCaArgs, MintRegistryJwtArgs, RotateAuthorityArgs, TrustCommand,
-    VerifyDeploymentArgs,
+    DelegateRegistrySignerArgs, EnrollServiceKeyArgs, InstallDeploymentTrustArgs,
+    MintAnchorCapsuleArgs, MintDeploymentCaArgs, MintRegistryJwtArgs, RotateAuthorityArgs,
+    TrustCommand, VerifyDeploymentArgs,
 };
 use anyhow::{anyhow, bail, ensure, Context, Result};
 use base64::{
@@ -24,6 +24,7 @@ use hyprstream_discovery::did_op::{
 use hyprstream_discovery::{
     DeploymentAuthorityCheckpoint as AuthorityCheckpointFile,
     DeploymentAuthorityLog as AuthorityLogFile, RegistryDelegationArtifact as DelegationArtifact,
+    ServiceKeyEnrollmentArtifact, ServiceKeyEnrollmentSigningBody,
 };
 use hyprstream_pds::at9p::{
     CapsuleBody, HybridKeyPair, ServiceEndpoint, ServiceEntry, ServiceType, Transport,
@@ -69,6 +70,14 @@ const PUBLISHER_MANIFEST_SCHEMA: &str = "hyprstream.deployment-trust-publisher-m
 const ANCHOR_REACH_SERVICE: &str = "#ns";
 const DELEGATION_RESOURCE_PREFIX: &str = "hyprstream://deployment";
 const DELEGATION_ABILITY: &str = "mint-registry-jwt";
+const ENROLLMENT_SCHEMA: &str = "hyprstream.service-key-enrollment.v1";
+const ENROLLMENT_ABILITY: &str = "enroll-service-key";
+const ENROLLMENT_KEY_TYPE: &str = "hybrid-ed25519-mldsa65";
+const ENROLLMENT_SIGNATURE_CONTEXT: &[u8] = b"hyprstream.service-key-enrollment.v1";
+/// Fixed allowlist per hyprstream#1562: registry stays JWT-enrolled and
+/// policy-CA/authority keys are out of scope.
+const ENROLLMENT_ALLOWED_SERVICES: [&str; 2] = ["discovery", "policy"];
+const MAX_ENROLLMENT_BYTES: usize = 256 * 1024;
 const MAX_AUTHORITY_LOG_OPERATIONS: usize = 128;
 const MAX_DELEGATION_BYTES: usize = 256 * 1024;
 const MAX_CLOUD_SECRET_BYTES: usize = 64 * 1024;
@@ -256,6 +265,7 @@ pub fn handle_trust_command(command: TrustCommand) -> Result<()> {
         TrustCommand::MintDeploymentCa(args) => mint_deployment_ca(&args),
         TrustCommand::DelegateRegistrySigner(args) => delegate_registry_signer(&args),
         TrustCommand::MintRegistryJwt(args) => mint_registry_jwt(&args),
+        TrustCommand::EnrollServiceKey(args) => enroll_service_key(&args),
         TrustCommand::VerifyDeployment(args) => verify_deployment(&args),
         TrustCommand::RotateAuthority(args) => rotate_authority(&args),
         TrustCommand::Install(args) => install_deployment_trust(&args),
@@ -424,18 +434,22 @@ fn delegate_registry_signer(args: &DelegateRegistrySignerArgs) -> Result<()> {
     let expiration = now
         .checked_add(args.delegation_ttl_seconds)
         .ok_or_else(|| anyhow!("delegation expiration overflow"))?;
-    let capability =
-        registry_mint_capability(&authority.bundle.deployment_domain, &delegated_public);
+    // hyprstream#1562: one artifact, one delegated signer — the delegation
+    // carries both the registry-mint and the service-key-enrollment scope.
+    let capabilities = vec![
+        registry_mint_capability(&authority.bundle.deployment_domain, &delegated_public),
+        service_key_enrollment_capability(&authority.bundle.deployment_domain, &delegated_public),
+    ];
     let payload = UcanPayload {
         issuer: Did::from_ed25519(&authority.ed.verifying_key().to_bytes()),
         audience: Did::from_ed25519(&delegated_ed.verifying_key().to_bytes()),
-        capabilities: vec![capability],
+        capabilities,
         not_before: Some(now),
         expiration: Some(expiration),
         nonce: random_bytes(16),
     };
     let ucan = sign_ucan(payload, &authority.ed, &authority.pq)?;
-    validate_registry_delegation_ucan(
+    validate_delegation_ucan(
         &ucan,
         &authority.bundle.deployment_domain,
         &delegated_public,
@@ -483,6 +497,11 @@ fn delegate_registry_signer(args: &DelegateRegistrySignerArgs) -> Result<()> {
                 "aud": REGISTRY_AUDIENCE,
                 "profile": REGISTRY_PROFILE,
                 "max_ttl_seconds": 3600
+            },
+            "enrollment_scope": {
+                "allowed_services": ENROLLMENT_ALLOWED_SERVICES,
+                "key_type": ENROLLMENT_KEY_TYPE,
+                "max_attestation_ttl_seconds": 3600
             }
         }))?
     );
@@ -630,6 +649,127 @@ fn mint_registry_jwt(args: &MintRegistryJwtArgs) -> Result<()> {
         PendingOutput::new(&args.contract, pretty_json_bytes(&contract)?, 0o600),
     ])?;
     println!("{}", serde_json::to_string_pretty(&contract)?);
+    Ok(())
+}
+
+/// Mint a chain-signed service-key enrollment attestation (hyprstream#1562).
+///
+/// Same trust anchors and post-mint self-verify through the production
+/// verifier as `mint_registry_jwt`; the input contract is public-only — the
+/// 1984-byte hybrid sidecar, never the service's seed.
+fn enroll_service_key(args: &EnrollServiceKeyArgs) -> Result<()> {
+    preflight_outputs([&args.attestation], args.force)?;
+    ensure!(
+        ENROLLMENT_ALLOWED_SERVICES.contains(&args.service.as_str()),
+        "service is outside the fixed discovery/policy enrollment allowlist"
+    );
+    let public_ca = read_limited(&args.public_ca, PUBLIC_CA_BYTES)?;
+    let root_domain = hyprstream_discovery::verify_deployment_public_ca(&public_ca)?;
+    let service_public_key = read_limited(&args.service_public_key, PUBLIC_CA_BYTES)?;
+    ensure!(
+        service_public_key.len() == PUBLIC_CA_BYTES,
+        "service public key must be exactly {PUBLIC_CA_BYTES} bytes \
+         (32-byte Ed25519 followed by 1952-byte ML-DSA-65; key type {ENROLLMENT_KEY_TYPE})"
+    );
+    let identities = combined_identities(&args.identities, &args.yubikey_identities)?;
+    let authority_log_bytes = read_limited(&args.authority_log, MAX_CLOUD_SECRET_BYTES)?;
+    let installed_log: AuthorityLogFile =
+        serde_json::from_slice(&authority_log_bytes).context("decode installed authority log")?;
+    let authority_checkpoint_bytes =
+        read_limited(&args.authority_checkpoint, MAX_CLOUD_SECRET_BYTES)?;
+    let installed_checkpoint: AuthorityCheckpointFile =
+        serde_json::from_slice(&authority_checkpoint_bytes)
+            .context("decode installed authority checkpoint")?;
+
+    let artifact: DelegationArtifact = read_json_limited(&args.delegation, MAX_DELEGATION_BYTES)?;
+    let now = now_unix_u64()?;
+    let grants_enrollment = validate_delegation_artifact(
+        &public_ca,
+        &installed_log,
+        &installed_checkpoint,
+        &artifact,
+        now,
+    )?;
+    ensure!(
+        grants_enrollment,
+        "delegation does not carry the service-key-enrollment capability"
+    );
+    let delegated = decrypt_authority(
+        &args.via_delegated_signer,
+        &identities,
+        args.software_recovery,
+    )?;
+    ensure!(
+        delegated.bundle.purpose == AuthorityPurpose::RegistryDelegatedSigner,
+        "selected key is not a registry delegated signer"
+    );
+    let declared = STANDARD
+        .decode(&artifact.delegated_public_key_b64)
+        .context("decode delegated public key")?;
+    ensure!(
+        delegated.public_bytes() == declared,
+        "delegated private key does not match the root-authorized delegation"
+    );
+    ensure!(
+        delegated.bundle.deployment_domain == root_domain,
+        "signer is bound to a different deployment domain"
+    );
+
+    let expires_at = now
+        .checked_add(u64::from(args.ttl_seconds))
+        .ok_or_else(|| anyhow!("attestation expiration overflow"))?;
+    let body = ServiceKeyEnrollmentSigningBody {
+        schema: ENROLLMENT_SCHEMA.to_owned(),
+        deployment_domain: root_domain.clone(),
+        service: args.service.clone(),
+        hybrid_public_key_b64: STANDARD.encode(&service_public_key),
+        not_before: i64::try_from(now).context("system clock precedes Unix epoch")?,
+        expires_at: i64::try_from(expires_at).context("attestation expiry conversion")?,
+        delegation: artifact,
+    };
+    let mut attestation = ServiceKeyEnrollmentArtifact::unsigned(body);
+    let signature = sign_nested(
+        &attestation.signing_bytes()?,
+        ENROLLMENT_SIGNATURE_CONTEXT,
+        &delegated.ed,
+        &delegated.pq,
+    )?;
+    attestation.signature_b64 = STANDARD.encode(&signature);
+    let attestation_json = pretty_json_bytes(&attestation)?;
+    ensure!(
+        attestation_json.len() <= MAX_ENROLLMENT_BYTES,
+        "attestation exceeds the 256 KiB enrollment contract"
+    );
+    let verified = hyprstream_discovery::verify_service_key_enrollment(
+        &public_ca,
+        &authority_log_bytes,
+        &authority_checkpoint_bytes,
+        &attestation_json,
+    )
+    .context("production enrollment verifier rejected minted attestation")?;
+    ensure!(
+        verified.service == args.service
+            && verified.hybrid_public_key == service_public_key
+            && verified.deployment_domain == root_domain,
+        "production verification result does not match minted inputs"
+    );
+
+    commit_outputs(vec![PendingOutput::new(
+        &args.attestation,
+        attestation_json,
+        0o644,
+    )])?;
+    println!(
+        "{}",
+        serde_json::to_string_pretty(&serde_json::json!({
+            "schema": "hyprstream.service-key-enrollment-output.v1",
+            "deployment_domain": root_domain,
+            "service": args.service,
+            "attestation_path": display_path(&args.attestation),
+            "attestation_expires_at": expires_at,
+            "key_type": ENROLLMENT_KEY_TYPE,
+        }))?
+    );
     Ok(())
 }
 
@@ -1920,6 +2060,69 @@ fn registry_mint_capability(deployment_domain: &str, delegated_public: &[u8]) ->
     )
 }
 
+/// The exact service-key-enrollment capability (hyprstream#1562): fixed
+/// discovery/policy allowlist, hybrid-only key type, one-hour attestation TTL.
+fn service_key_enrollment_capability(
+    deployment_domain: &str,
+    delegated_public: &[u8],
+) -> Capability {
+    let mut caveats = BTreeMap::new();
+    caveats.insert(
+        "deployment_domain".to_owned(),
+        CaveatValue::Text(deployment_domain.to_owned()),
+    );
+    caveats.insert(
+        "delegated_public_key_b64".to_owned(),
+        CaveatValue::Text(STANDARD.encode(delegated_public)),
+    );
+    caveats.insert(
+        "allowed_services".to_owned(),
+        CaveatValue::List(
+            ENROLLMENT_ALLOWED_SERVICES
+                .iter()
+                .map(|service| (*service).to_owned())
+                .collect(),
+        ),
+    );
+    caveats.insert(
+        "key_type".to_owned(),
+        CaveatValue::Text(ENROLLMENT_KEY_TYPE.to_owned()),
+    );
+    caveats.insert(
+        "max_attestation_ttl_seconds".to_owned(),
+        CaveatValue::Int(3_600),
+    );
+    Capability::with_caveats(
+        Resource::new(format!(
+            "{DELEGATION_RESOURCE_PREFIX}/{deployment_domain}/service-key-enrollment"
+        )),
+        Ability::new(ENROLLMENT_ABILITY),
+        Caveats(caveats),
+    )
+}
+
+/// Exact-set capability validation (hyprstream#1562): a delegation is either
+/// the legacy registry-only scope minted before enrollment existed, or exactly
+/// the registry + enrollment pair. Returns true when enrollment is granted.
+fn delegation_capability_set_grants_enrollment(
+    capabilities: &[Capability],
+    deployment_domain: &str,
+    delegated_public: &[u8],
+) -> Result<bool> {
+    let registry = registry_mint_capability(deployment_domain, delegated_public);
+    let enrollment = service_key_enrollment_capability(deployment_domain, delegated_public);
+    if capabilities.len() == 1 && capabilities[0] == registry {
+        return Ok(false);
+    }
+    ensure!(
+        capabilities.len() == 2
+            && capabilities.contains(&registry)
+            && capabilities.contains(&enrollment),
+        "delegation capability set is not the exact registry or registry+enrollment scope"
+    );
+    Ok(true)
+}
+
 fn sign_ucan(payload: UcanPayload, ed: &LoadedEdSigner, pq: &MlDsaSigningKey) -> Result<Ucan> {
     let payload_bytes = payload.signing_bytes()?;
     let signature = sign_nested(
@@ -2173,13 +2376,17 @@ impl UcanVerifier for AuthorityUcanVerifier<'_> {
     }
 }
 
-fn validate_registry_delegation_ucan(
+/// Validate one root-authorized delegation UCAN. Exact-set capability check
+/// (hyprstream#1562): the legacy registry-only scope and the registry +
+/// service-key-enrollment scope are both accepted; returns true when the
+/// enrollment capability is present.
+fn validate_delegation_ucan(
     ucan: &Ucan,
     deployment_domain: &str,
     delegated_public: &[u8],
     active_keys: &[HybridRotationKey],
     now: u64,
-) -> Result<()> {
+) -> Result<bool> {
     ensure!(
         ucan.proofs.is_empty(),
         "registry delegation must be one root-authorized link"
@@ -2201,19 +2408,16 @@ fn validate_registry_delegation_ucan(
         ucan.audience().to_ed25519()? == delegated_ed,
         "delegation audience does not match delegated signer"
     );
-    ensure!(
-        ucan.capabilities()
-            == [registry_mint_capability(
-                deployment_domain,
-                delegated_public
-            )],
-        "delegation capability is not the exact registry-only scope"
-    );
+    let grants_enrollment = delegation_capability_set_grants_enrollment(
+        ucan.capabilities(),
+        deployment_domain,
+        delegated_public,
+    )?;
     ensure!(
         ucan.payload.expiration.is_some(),
         "registry delegation must expire"
     );
-    Ok(())
+    Ok(grants_enrollment)
 }
 
 fn validate_delegation_artifact(
@@ -2222,7 +2426,7 @@ fn validate_delegation_artifact(
     authority_checkpoint: &AuthorityCheckpointFile,
     artifact: &DelegationArtifact,
     now: u64,
-) -> Result<()> {
+) -> Result<bool> {
     ensure!(
         artifact.schema == DELEGATION_SCHEMA,
         "unsupported delegation schema"
@@ -2248,7 +2452,7 @@ fn validate_delegation_artifact(
         "delegation UCAN is too large"
     );
     let ucan = Ucan::from_cbor(&ucan_bytes)?;
-    validate_registry_delegation_ucan(
+    validate_delegation_ucan(
         &ucan,
         &artifact.deployment_domain,
         &delegated_public,
@@ -3252,6 +3456,409 @@ mod tests {
         assert_eq!(
             capability.caveats.0["max_ttl_seconds"],
             CaveatValue::Int(3600)
+        );
+    }
+
+    fn test_genesis(
+        root: &LoadedAuthority,
+    ) -> (Vec<u8>, AuthorityLogFile, AuthorityCheckpointFile) {
+        let root_rotation_key = HybridRotationKey::new(
+            root.ed.verifying_key().to_bytes(),
+            ml_dsa_sk_to_vk_bytes(&root.pq),
+        )
+        .unwrap();
+        let genesis = sign_did_op(
+            DidOp {
+                sequence: 0,
+                prev: None,
+                rotation_keys: vec![root_rotation_key],
+                signature: placeholder_did_signature(),
+            },
+            &root.ed,
+            &root.pq,
+        )
+        .unwrap();
+        let log = authority_log_from_ops(&root.bundle.deployment_domain, vec![genesis]).unwrap();
+        let checkpoint = checkpoint_for(&log);
+        (root.public_bytes(), log, checkpoint)
+    }
+
+    fn delegation_ucan(
+        root: &LoadedAuthority,
+        delegated: &LoadedAuthority,
+        capabilities: Vec<Capability>,
+        now: u64,
+    ) -> Ucan {
+        sign_ucan(
+            UcanPayload {
+                issuer: Did::from_ed25519(&root.ed.verifying_key().to_bytes()),
+                audience: Did::from_ed25519(&delegated.ed.verifying_key().to_bytes()),
+                capabilities,
+                not_before: Some(now),
+                expiration: Some(now + 3_600),
+                nonce: random_bytes(16),
+            },
+            &root.ed,
+            &root.pq,
+        )
+        .unwrap()
+    }
+
+    fn delegation_artifact(
+        root: &LoadedAuthority,
+        log: &AuthorityLogFile,
+        delegated: &LoadedAuthority,
+        capabilities: Vec<Capability>,
+        now: u64,
+    ) -> DelegationArtifact {
+        let ucan = delegation_ucan(root, delegated, capabilities, now);
+        DelegationArtifact {
+            schema: DELEGATION_SCHEMA.to_owned(),
+            deployment_domain: root.bundle.deployment_domain.clone(),
+            authority_log_did: log.did.clone(),
+            delegated_public_key_b64: STANDARD.encode(delegated.public_bytes()),
+            ucan_b64: STANDARD.encode(ucan.to_cbor().unwrap()),
+        }
+    }
+
+    fn registry_and_enrollment_capabilities(
+        root: &LoadedAuthority,
+        delegated: &LoadedAuthority,
+    ) -> (Vec<Capability>, Vec<Capability>) {
+        let registry = vec![registry_mint_capability(
+            &root.bundle.deployment_domain,
+            &delegated.public_bytes(),
+        )];
+        let dual = vec![
+            registry[0].clone(),
+            service_key_enrollment_capability(
+                &root.bundle.deployment_domain,
+                &delegated.public_bytes(),
+            ),
+        ];
+        (registry, dual)
+    }
+
+    fn enrollment_fixture() -> (
+        LoadedAuthority,
+        LoadedAuthority,
+        Vec<u8>,
+        AuthorityLogFile,
+        AuthorityCheckpointFile,
+        Vec<u8>,
+        u64,
+    ) {
+        let root = test_authority(AuthorityPurpose::Root, None);
+        let delegated = test_authority(
+            AuthorityPurpose::RegistryDelegatedSigner,
+            Some(root.bundle.deployment_domain.clone()),
+        );
+        let (public_ca, log, checkpoint) = test_genesis(&root);
+        let service_ed = SigningKey::generate(&mut rand::rngs::OsRng);
+        let (service_pq, _) = ml_dsa_generate_keypair();
+        let service_public = public_pair_bytes(&service_ed.verifying_key(), &service_pq);
+        let now = now_unix_u64().unwrap();
+        (
+            root,
+            delegated,
+            public_ca,
+            log,
+            checkpoint,
+            service_public,
+            now,
+        )
+    }
+
+    fn mint_test_attestation(
+        delegated: &LoadedAuthority,
+        artifact: DelegationArtifact,
+        service: &str,
+        service_public_key: &[u8],
+        now: u64,
+        ttl_seconds: u64,
+    ) -> ServiceKeyEnrollmentArtifact {
+        let body = ServiceKeyEnrollmentSigningBody {
+            schema: ENROLLMENT_SCHEMA.to_owned(),
+            deployment_domain: delegated.bundle.deployment_domain.clone(),
+            service: service.to_owned(),
+            hybrid_public_key_b64: STANDARD.encode(service_public_key),
+            not_before: i64::try_from(now).unwrap(),
+            expires_at: i64::try_from(now + ttl_seconds).unwrap(),
+            delegation: artifact,
+        };
+        let mut attestation = ServiceKeyEnrollmentArtifact::unsigned(body);
+        let signature = sign_nested(
+            &attestation.signing_bytes().unwrap(),
+            ENROLLMENT_SIGNATURE_CONTEXT,
+            &delegated.ed,
+            &delegated.pq,
+        )
+        .unwrap();
+        attestation.signature_b64 = STANDARD.encode(&signature);
+        attestation
+    }
+
+    fn verify_test_attestation(
+        public_ca: &[u8],
+        log: &AuthorityLogFile,
+        checkpoint: &AuthorityCheckpointFile,
+        attestation: &ServiceKeyEnrollmentArtifact,
+    ) -> Result<hyprstream_discovery::VerifiedServiceKeyEnrollment> {
+        hyprstream_discovery::verify_service_key_enrollment(
+            public_ca,
+            &serde_json::to_vec(log)?,
+            &serde_json::to_vec(checkpoint)?,
+            &serde_json::to_vec(attestation)?,
+        )
+    }
+
+    #[test]
+    fn legacy_single_capability_delegation_still_validates() {
+        let (root, delegated, public_ca, log, checkpoint, _service, now) = enrollment_fixture();
+        let (legacy, _dual) = registry_and_enrollment_capabilities(&root, &delegated);
+        let active = validate_authority_log(&public_ca, &log, &checkpoint).unwrap();
+        // The exact single-capability delegation shape minted 2026-08-30 and
+        // live in production staging inputs must keep validating.
+        let ucan = delegation_ucan(&root, &delegated, legacy.clone(), now);
+        let grants = validate_delegation_ucan(
+            &ucan,
+            &root.bundle.deployment_domain,
+            &delegated.public_bytes(),
+            &active.rotation_keys,
+            now,
+        )
+        .unwrap();
+        assert!(!grants, "legacy delegation must not grant enrollment");
+        let artifact = delegation_artifact(&root, &log, &delegated, legacy, now);
+        let grants =
+            validate_delegation_artifact(&public_ca, &log, &checkpoint, &artifact, now).unwrap();
+        assert!(!grants);
+    }
+
+    #[test]
+    fn dual_capability_delegation_validates() {
+        let (root, delegated, public_ca, log, checkpoint, _service, now) = enrollment_fixture();
+        let (_legacy, dual) = registry_and_enrollment_capabilities(&root, &delegated);
+        let active = validate_authority_log(&public_ca, &log, &checkpoint).unwrap();
+        let ucan = delegation_ucan(&root, &delegated, dual.clone(), now);
+        let grants = validate_delegation_ucan(
+            &ucan,
+            &root.bundle.deployment_domain,
+            &delegated.public_bytes(),
+            &active.rotation_keys,
+            now,
+        )
+        .unwrap();
+        assert!(grants, "two-capability delegation must grant enrollment");
+        let artifact = delegation_artifact(&root, &log, &delegated, dual, now);
+        let grants =
+            validate_delegation_artifact(&public_ca, &log, &checkpoint, &artifact, now).unwrap();
+        assert!(grants);
+        // A delegated registry JWT carrying the two-capability artifact still
+        // passes the production verifier.
+        let registry = SigningKey::generate(&mut rand::rngs::OsRng);
+        let token = encode_registry_jwt(
+            &delegated,
+            registry.verifying_key().as_bytes(),
+            i64::try_from(now).unwrap(),
+            i64::try_from(now + 60).unwrap(),
+            Some(&URL_SAFE_NO_PAD.encode(serde_json::to_vec(&artifact).unwrap())),
+        )
+        .unwrap();
+        verify_with_log(&public_ca, &log, &checkpoint, &token).unwrap();
+    }
+
+    #[test]
+    fn delegation_capability_set_rejects_non_exact_sets() {
+        let (root, delegated, public_ca, log, checkpoint, _service, now) = enrollment_fixture();
+        let (legacy, dual) = registry_and_enrollment_capabilities(&root, &delegated);
+        let active = validate_authority_log(&public_ca, &log, &checkpoint).unwrap();
+        let validate = |capabilities: Vec<Capability>| {
+            let ucan = delegation_ucan(&root, &delegated, capabilities, now);
+            validate_delegation_ucan(
+                &ucan,
+                &root.bundle.deployment_domain,
+                &delegated.public_bytes(),
+                &active.rotation_keys,
+                now,
+            )
+        };
+        // Enrollment without the registry scope is not an exact set.
+        assert!(validate(vec![dual[1].clone()]).is_err());
+        // Registry plus an unrelated extra capability widens the scope.
+        assert!(validate(vec![
+            legacy[0].clone(),
+            Capability::new(
+                Resource::new("hyprstream://deployment/domain/service/other"),
+                Ability::new("admin")
+            ),
+        ])
+        .is_err());
+        // An enrollment capability with a widened allowlist differs from the
+        // exact fixed-allowlist capability.
+        let mut widened = service_key_enrollment_capability(
+            &root.bundle.deployment_domain,
+            &delegated.public_bytes(),
+        );
+        widened.caveats.0.insert(
+            "allowed_services".to_owned(),
+            CaveatValue::List(vec![
+                "discovery".to_owned(),
+                "policy".to_owned(),
+                "registry".to_owned(),
+            ]),
+        );
+        assert!(validate(vec![legacy[0].clone(), widened]).is_err());
+    }
+
+    #[test]
+    fn enrollment_capability_is_exact_and_fixed() {
+        let (pq, _) = ml_dsa_generate_keypair();
+        let ed = SigningKey::generate(&mut rand::rngs::OsRng);
+        let public = public_pair_bytes(&ed.verifying_key(), &pq);
+        let capability = service_key_enrollment_capability("domain", &public);
+        assert_eq!(capability.ability.as_str(), ENROLLMENT_ABILITY);
+        assert_eq!(
+            capability.resource.as_str(),
+            "hyprstream://deployment/domain/service-key-enrollment"
+        );
+        assert!(!capability.resource.as_str().contains('*'));
+        assert_eq!(
+            capability.caveats.0["allowed_services"],
+            CaveatValue::List(vec!["discovery".to_owned(), "policy".to_owned()])
+        );
+        assert_eq!(
+            capability.caveats.0["key_type"],
+            CaveatValue::Text(ENROLLMENT_KEY_TYPE.to_owned())
+        );
+        assert_eq!(
+            capability.caveats.0["max_attestation_ttl_seconds"],
+            CaveatValue::Int(3_600)
+        );
+    }
+
+    #[test]
+    fn service_key_enrollment_artifact_schema_round_trip() {
+        let (root, delegated, _public_ca, log, _checkpoint, service_public, now) =
+            enrollment_fixture();
+        let (_legacy, dual) = registry_and_enrollment_capabilities(&root, &delegated);
+        let artifact = delegation_artifact(&root, &log, &delegated, dual, now);
+        let attestation = mint_test_attestation(
+            &delegated,
+            artifact,
+            "discovery",
+            &service_public,
+            now,
+            3_600,
+        );
+        let bytes = serde_json::to_vec(&attestation).unwrap();
+        let decoded: ServiceKeyEnrollmentArtifact = serde_json::from_slice(&bytes).unwrap();
+        assert_eq!(decoded, attestation);
+        assert_eq!(decoded.schema, ENROLLMENT_SCHEMA);
+        // Canonical signing bytes are stable across a round trip.
+        assert_eq!(
+            decoded.signing_bytes().unwrap(),
+            attestation.signing_bytes().unwrap()
+        );
+        // Unknown fields are rejected.
+        let mut value = serde_json::to_value(&attestation).unwrap();
+        value
+            .as_object_mut()
+            .unwrap()
+            .insert("attacker".to_owned(), serde_json::json!(true));
+        assert!(serde_json::from_value::<ServiceKeyEnrollmentArtifact>(value).is_err());
+    }
+
+    #[test]
+    fn service_key_enrollment_mint_verifies_through_production_verifier() {
+        let (root, delegated, public_ca, log, checkpoint, service_public, now) =
+            enrollment_fixture();
+        let (_legacy, dual) = registry_and_enrollment_capabilities(&root, &delegated);
+        let artifact = delegation_artifact(&root, &log, &delegated, dual, now);
+        let attestation =
+            mint_test_attestation(&delegated, artifact, "policy", &service_public, now, 3_600);
+        let verified =
+            verify_test_attestation(&public_ca, &log, &checkpoint, &attestation).unwrap();
+        assert_eq!(verified.service, "policy");
+        assert_eq!(verified.hybrid_public_key, service_public);
+        assert_eq!(verified.deployment_domain, root.bundle.deployment_domain);
+        assert_eq!(verified.expires_at, i64::try_from(now + 3_600).unwrap());
+    }
+
+    #[test]
+    fn service_key_enrollment_rejects_wrong_service_key_type_and_ttl() {
+        let (root, delegated, public_ca, log, checkpoint, service_public, now) =
+            enrollment_fixture();
+        let (legacy, dual) = registry_and_enrollment_capabilities(&root, &delegated);
+        let dual_artifact = || delegation_artifact(&root, &log, &delegated, dual.clone(), now);
+        // Wrong service: outside the fixed discovery/policy allowlist.
+        let wrong_service = mint_test_attestation(
+            &delegated,
+            dual_artifact(),
+            "registry",
+            &service_public,
+            now,
+            3_600,
+        );
+        assert!(
+            verify_test_attestation(&public_ca, &log, &checkpoint, &wrong_service).is_err(),
+            "enrollment of a non-allowlisted service was accepted"
+        );
+        // Wrong key type: a classical-only 32-byte key, not the 1984-byte hybrid.
+        let classical_only = mint_test_attestation(
+            &delegated,
+            dual_artifact(),
+            "discovery",
+            &service_public[..32],
+            now,
+            3_600,
+        );
+        assert!(
+            verify_test_attestation(&public_ca, &log, &checkpoint, &classical_only).is_err(),
+            "enrollment of a classical-only key was accepted"
+        );
+        // TTL above the one-hour capability ceiling.
+        let over_ttl = mint_test_attestation(
+            &delegated,
+            dual_artifact(),
+            "discovery",
+            &service_public,
+            now,
+            3_601,
+        );
+        assert!(
+            verify_test_attestation(&public_ca, &log, &checkpoint, &over_ttl).is_err(),
+            "enrollment with TTL > 3600 was accepted"
+        );
+        // A legacy registry-only delegation never authorizes enrollment.
+        let legacy_artifact = delegation_artifact(&root, &log, &delegated, legacy, now);
+        let legacy_scope = mint_test_attestation(
+            &delegated,
+            legacy_artifact,
+            "discovery",
+            &service_public,
+            now,
+            3_600,
+        );
+        assert!(
+            verify_test_attestation(&public_ca, &log, &checkpoint, &legacy_scope).is_err(),
+            "enrollment under a registry-only delegation was accepted"
+        );
+        // Any tampering breaks the hybrid signature.
+        let mut tampered = mint_test_attestation(
+            &delegated,
+            dual_artifact(),
+            "discovery",
+            &service_public,
+            now,
+            3_600,
+        );
+        let mut signature = STANDARD.decode(&tampered.signature_b64).unwrap();
+        signature[0] ^= 0x01;
+        tampered.signature_b64 = STANDARD.encode(&signature);
+        assert!(
+            verify_test_attestation(&public_ca, &log, &checkpoint, &tampered).is_err(),
+            "enrollment with a corrupted signature was accepted"
         );
     }
 

--- a/docs/deployment-trust-ceremony.md
+++ b/docs/deployment-trust-ceremony.md
@@ -226,7 +226,10 @@ with it the ability to mint registry credentials until the delegation expires. T
 unattended operation, and it is why the delegation is scoped to the registry service and given a
 short life rather than being a second root. It is *not* a path to the root authority — the root
 bundle is sealed to a disjoint recipient set that this identity cannot open, and it never touches a
-deployed host.
+deployed host. Where the delegation also carries the service-key-enrollment capability, compromise
+additionally yields the ability to attest this host's discovery/policy hybrid keys under the same
+expiry — a key binding, not an authorization: it cannot mint service JWTs, rotate the authority, or
+enroll registry/CA keys, and it seeds only the compromised host's own bootstrap trust store.
 
 Two consequences worth planning for: keep the delegation TTL short enough that a compromise window
 you would tolerate is the same window you actually have, and treat rotating the delegated signer —


### PR DESCRIPTION
## hyprstream#1562 work item H2 — service-key enrollment capability

Implements ordered item 3 (MR-H2) of the 2026-08-31 design comment on #1562. Depends on #1564 (H1) at the wiring level only: this CLI reads the 1984-byte `service-pubkey.hybrid` sidecar H1 teaches services to write, but no H1 code is imported, so the branch is based on `main` and reviewable independently.

### What changes

- **Delegation UCAN gains a second capability** — `enroll-service-key` on `hyprstream://deployment/{domain}/service-key-enrollment` with caveats `deployment_domain`, `delegated_public_key_b64`, `allowed_services=["discovery","policy"]` (fixed allowlist; registry stays JWT-enrolled, policy-CA/authority keys out of scope), `key_type="hybrid-ed25519-mldsa65"`, `max_attestation_ttl_seconds=3600`. `trust delegate-registry-signer` now emits the two-capability UCAN into the existing `registry-signer.delegation.json` — same artifact schema, one signer, no new plan-time trust input.
- **Validation moves from exact-one to exact-set** in both copies of the delegation validator (the mint self-check in `cli/trust.rs`, renamed `validate_delegation_ucan`; the production verifier `validate_registry_delegation_artifact` in `hyprstream-discovery`). Exactly `{registry}` (legacy — the delegation minted 2026-08-30 that is live in production staging inputs keeps validating unchanged) or exactly `{registry, enrollment}`; anything narrower, wider, or reordered-widened rejects.
- **New artifact schema** `hyprstream.service-key-enrollment.v1` in `hyprstream-discovery`: domain, service, the exact 1984-byte `bootstrap-pubkeys` hybrid entry, `not_before`/`expires_at`, embedded `RegistryDelegationArtifact`, and a hybrid Ed25519+ML-DSA-65 signature by the delegated signer over the canonical body (`ServiceKeyEnrollmentSigningBody`, fixed field order so mint and verifier derive identical bytes).
- **New production verifier** `hyprstream_discovery::verify_service_key_enrollment(...) -> VerifiedServiceKeyEnrollment`: chain validation through the pinned root + authority log + checkpoint, exact-set UCAN check requiring the enrollment capability, fixed service allowlist, hybrid-tuple well-formedness (32+1952), one-hour lifetime ceiling, attestation expiry ≤ delegation expiry, fail-closed on expiry, signature last.
- **New CLI** `hyprstream trust enroll-service-key --service <discovery|policy> --service-public-key <service-pubkey.hybrid> --via-delegated-signer … --delegation … --attestation <out>` — same trust anchors as `mint-registry-jwt`, public-only input contract, post-mint self-verify through the production verifier before writing output (0644, per-service).
- `CaveatValue` gains a `List(Vec<String>)` variant for the fixed-allowlist caveat (additive to the untagged CBOR/JSON encoding; existing values unchanged).
- Ceremony doc tradeoff paragraph gains the enrollment-capability sentence per the design.

### Concurrency notes (staging deploy wave)

- **PR #1563** (fd-1561) also touches `cli/commands/trust.rs` and `cli/trust.rs`. Expected trivial conflicts only: my hunks are the new `EnrollServiceKey` enum variant + args struct (appended) and the dispatch arm/import lines; the delegation-validation changes sit in functions #1563 does not modify. The `--via-delegated-signer-fd` form from the design is deliberately **not** implemented here — it is #1563's FD-flag pattern and should follow once #1563 lands.
- **PR #1564** (H1) touches `cli/commands/mod.rs`; my touch is the one-line `EnrollServiceKeyArgs` re-export — trivial conflict either direction.

### Validation (hyprstream-build skill, BuildQ target-1, rustc 1.97.0, cuda130 libtorch)

- `cargo test -p hyprstream --lib cli::` — **114/114**, incl. 6 new: legacy single-capability delegation still validates; dual-capability validates (+ a delegated registry JWT embedding the two-capability artifact still passes the production verifier); non-exact sets reject (enrollment-only, registry+unrelated, widened allowlist); enrollment capability shape is exact; `service-key-enrollment.v1` round-trip + `deny_unknown_fields`; end-to-end mint→production-verifier acceptance; rejections for wrong service / classical-only key / TTL 3601 / registry-only delegation / corrupted signature.
- `cargo test -p hyprstream-discovery --lib` — **128/128**.
- `cargo test -p hyprstream-rpc --lib auth::ucan` — **44/44**, incl. the new `List` caveat CBOR round-trip.
- `cargo clippy -p hyprstream-rpc -p hyprstream-discovery -p hyprstream --all-targets -- -D warnings` — clean.
- Pre-commit hook (workspace release clippy, mirrors CI) — clean.
- E2E smoke on the built binary: `mint-deployment-ca` → `delegate-registry-signer` (output now shows `enrollment_scope`) → `enroll-service-key --service discovery` mints a self-verified attestation (0644); `--service registry` and `--ttl-seconds 3601` are refused at parse time.

### Not in this PR (per the ordered breakdown)

- H3: `verify-deployment --service-key-attestation` flag and fail-closed attestation consumption in OsOwnedFiles bootstrap mode.
- metal MR-M2/M3: delegation re-mint and enrollment-unit wiring.

DRAFT — do not merge.