### PR TITLE
ci(docker): decouple flavor build legs from publish-cpu-manifest

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -66,6 +66,23 @@ jobs:
       packages: write
       attestations: write
       id-token: write
+    # Decouple the flavor legs from each other's consumers: the only
+    # downstream job, publish-cpu-manifest, composes the CPU index from the
+    # cpu leg's sha-<rev>-cpu-amd64 staging tag (plus build-docker-arm64's
+    # -cpu-arm64 tag); needs is per-JOB, not per-leg, so without this a
+    # failed cuda/rocm leg fails the whole build-docker job and SKIPS the
+    # CPU manifest publish (run 33420411621: transient ghcr.io 429 on rocm71
+    # killed an otherwise-good CPU publish). The cuda*/rocm71 flavors are
+    # single-arch amd64 and push their own final tags (latest-cuda128,
+    # semver, ...) directly from their build-push step, so each flavor's
+    # publish path is already self-contained within its leg and nothing
+    # downstream consumes them. Let a non-cpu leg fail without failing the
+    # matrix job. The cpu leg stays critical: if IT fails, build-docker
+    # still fails and publish-cpu-manifest is skipped rather than composing
+    # a partial/stale index. A failed non-cpu leg remains visible as a red
+    # leg in the run, but the run conclusion is green — on release tags,
+    # check the leg list for a missing flavor before announcing.
+    continue-on-error: ${{ matrix.variant != 'cpu' }}
 
     strategy:
       fail-fast: false


### PR DESCRIPTION
## Problem

Run [33420411621](https://github.com/hyprstream/hyprstream/actions/runs/33420411621) (main @ `2bb804d53`): the `build-docker (rocm71)` matrix leg failed on a transient ghcr.io 429 during the registry cache/blob copy. Every other leg — cuda130, cuda128, cpu, and `build-docker-arm64` — succeeded, but `needs` is per-**job**, not per-leg, so the failed leg failed the whole `build-docker` job and `publish-cpu-manifest` was **skipped**. No CPU manifest (`sha-<rev>-cpu`, `latest-cpu`, `edge-cpu`) was published for an otherwise-good main revision.

## Analysis

`publish-cpu-manifest` composes the CPU OCI index from exactly two inputs:

- `ghcr.io/hyprstream/hyprstream:sha-<rev>-cpu-amd64` — pushed by the **cpu** leg of `build-docker`
- `ghcr.io/hyprstream/hyprstream:sha-<rev>-cpu-arm64` — pushed by `build-docker-arm64`

The cuda128/cuda130/rocm71 flavors are single-arch (amd64-only) and push their own final tags (`latest-cuda128`, semver tags on releases, …) directly from their `docker/build-push-action` step — that is why the run showed only one publish job. Each flavor's publish path is already self-contained within its own leg; nothing downstream consumes the accel legs' outputs.

## Fix (1 line + comment)

Job-level `continue-on-error: ${{ matrix.variant != 'cpu' }}` on `build-docker`:

- **cpu leg fails** → `build-docker` still fails → `publish-cpu-manifest` skipped. Safety preserved: the manifest job can never compose a partial/stale index from a missing arch staging tag. Same for a `build-docker-arm64` failure (its `needs` entry is unchanged).
- **cuda/rocm leg fails** → the leg records failure (still red in the run's job list) but no longer fails the matrix job, so the CPU manifest publishes. The failed flavor's own tags are simply absent — no other publish path is affected, and with `fail-fast: false` the sibling accel legs were never blocked either.

The alternative — `if: always()` + per-need result checks — cannot express per-leg granularity (`needs.<job>.result` is job-level), and splitting the matrix into per-flavor jobs would duplicate the ~90-line build steps block for no behavioral gain.

## Residual risk (intentional, documented in the inline comment)

With `continue-on-error`, a failed accel leg leaves the **run conclusion green**. On release tag pushes, a missing `1.2.3-rocm71` / `-cuda128` / `-cuda130` tag is visible only by opening the run and seeing the red leg — the comment on the line calls this out ("on release tags, check the leg list for a missing flavor before announcing"). This is strictly better than the status quo, where the same transient failure additionally killed the CPU publish and still required a re-run.

## Retry knob for the 429 — not added

`docker-build.yml` has no retry/backoff pattern anywhere (no `nick-fields/retry`, no wrapper script), so per convention no new machinery was introduced. The decoupling makes a transient accel-flavor 429 non-fatal for the rest of the release; a re-run of the single failed leg remains the remedy.

## Validation

- Cannot execute the workflow locally; needs/continue-on-error semantics reasoned through explicitly above and in the inline comment.
- `python3 -c yaml.safe_load` — YAML parses.
- `actionlint v1.7.12` (respecting the repo's `.github/actionlint.yaml` runner labels) on the changed file: clean except one **pre-existing** SC2129 shellcheck style note in the untouched arm64 step (line 278 on `origin/main` → 295 after the comment block; verified identical on the pristine file).
- Change is pure workflow-strategy YAML — no new permissions, no script changes; nothing for CodeQL Analyze (actions) to flag.
- Repo pre-commit hook (workspace release clippy `-D warnings` via buildq, cached cuda130 libtorch) passed at commit time.

**DRAFT — do not merge / do not mark ready.**