### PR TITLE
ci(docker): stagger ghcr cache import, drop dead buildcache-base ref

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -89,18 +89,32 @@ jobs:
       matrix:
         variant: [cpu, cuda128, cuda130, rocm71]
         include:
+          # delay_seconds de-synchronizes the four legs' registry cache-import
+          # bursts. All legs start simultaneously behind one NAT IP, and each
+          # mode=max cache-from import fires hundreds of blob GETs at ghcr.io
+          # at once; ghcr answers with 429 Too Many Requests (runs
+          # 33420411621, 33429089855: rocm71/cuda128 died in "Build and push
+          # Docker image" on "httpReadSeeker: failed open ... 429"). A small
+          # deterministic per-variant offset keeps the t=0 import bursts from
+          # colliding. It does NOT help a leg that trips the limiter later in
+          # its build (one failure was ~26 min in) — that residual risk is
+          # accepted; #1567 already contains the blast radius of a failed leg.
           - variant: cpu
             tag_suffix: cpu
             docker_variant: cpu
+            delay_seconds: 0
           - variant: cuda128
             tag_suffix: cuda128
             docker_variant: cuda128
+            delay_seconds: 30
           - variant: cuda130
             tag_suffix: cuda130
             docker_variant: cuda130
+            delay_seconds: 60
           - variant: rocm71
             tag_suffix: rocm71
             docker_variant: rocm71
+            delay_seconds: 90
 
     steps:
     - name: Clean up disk space before build
@@ -154,6 +168,15 @@ jobs:
           type=semver,pattern={{version}},suffix=-cpu-amd64,enable=${{ matrix.variant == 'cpu' }}
           type=semver,pattern={{major}}.{{minor}},suffix=-cpu-amd64,enable=${{ matrix.variant == 'cpu' }}
 
+    - name: Stagger registry cache-import start
+      # Sleep the per-variant offset (see matrix include above) so the four
+      # legs don't open their ghcr.io blob-GET bursts at the same instant.
+      # Runs BEFORE the build step (not earlier) so the offset lands right at
+      # the cache-from import and isn't eaten by step-startup jitter.
+      run: |
+        echo "delaying ${{ matrix.variant }} leg by ${{ matrix.delay_seconds }}s to stagger ghcr.io cache import"
+        sleep "${{ matrix.delay_seconds }}"
+
     - name: Build and push Docker image
       uses: docker/build-push-action@v6
       with:
@@ -165,10 +188,14 @@ jobs:
         tags: ${{ steps.meta.outputs.tags }}
         labels: ${{ steps.meta.outputs.labels }}
         platforms: linux/amd64
-        # Registry cache: no 10GB limit, persists across branches, faster than GHA cache
+        # Registry cache: no 10GB limit, persists across branches, faster than
+        # GHA cache. cache-from intentionally lists ONLY the per-variant ref:
+        # the former buildcache-base importer was never pushed by any job
+        # (git log -S confirms it was cache-from-only since its introduction),
+        # so every leg wasted ghcr.io requests probing a dead ref — extra
+        # pressure against the 429 rate limiter for zero benefit.
         cache-from: |
           type=registry,ref=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:buildcache-${{ matrix.variant }}
-          type=registry,ref=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:buildcache-base
         cache-to: type=registry,ref=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:buildcache-${{ matrix.variant }},mode=max
 
     - name: Generate SBOM


### PR DESCRIPTION
## Problem

Follow-up to #1567 (which decoupled the cpu manifest publish from accel-leg failures). This PR attacks the root cause of the ghcr.io 429s.

Evidence — three consecutive main-branch publishes (runs `33420411621`, `33429089855` + its `--failed` rerun): one or two accel matrix legs (`rocm71`, `cuda128`) die in the `Build and push Docker image` step with:

```
failed to compute cache key: failed to copy: httpReadSeeker: failed open:
unexpected status from GET https://ghcr.io/v2/hyprstream/hyprstream/blobs/sha256:…: 429 Too Many Requests
→ buildx failed with: toomanyrequests: retry-after: ~100-400ms
```

The failing operation is the registry cache **import** (`cache-from type=registry`), a blob-GET read burst. Four matrix legs start simultaneously on runners behind one NAT IP; `mode=max` cache import fires hundreds of blob GETs at ghcr at once, and the per-IP rate limiter pushes back.

Additionally, every leg imports `buildcache-base`, a ref that **does not exist** (`not found` in logs) — each leg wastes rate-limit budget probing a dead importer before falling back.

## Fix (minimal, no new machinery)

1. **Drop the dead `buildcache-base` cache-from ref.** Verified genuinely never produced: `git log --all -S buildcache-base` shows it was cache-from-only since its introduction (`539d331e5`); `cache-to` has always targeted only `buildcache-<variant>`. Nothing in the repo pushes that tag.
2. **De-synchronize the legs.** New per-variant `delay_seconds` in the matrix include entries (`cpu: 0, cuda128: 30, cuda130: 60, rocm71: 90`), slept in a dedicated step immediately before `Build and push Docker image`, so the t=0 cache-import bursts don't collide. Deterministic (no `$RANDOM`), one `run` step, heavily commented per workflow convention.

Explicitly NOT done (per investigation constraints):

- No retry machinery — the workflow has no retry pattern, and #1567 already contains the blast radius of a failed non-cpu leg (re-run of the single failed leg remains the remedy).
- No change to `cache-to` modes; registry caching is kept (`mode=max` unchanged).

## Semantics (reasoned through — the workflow can't run locally)

- The stagger step runs right before the build step (not earlier in the job) so the offset lands at the cache-from import and isn't eaten by step-startup jitter (checkout/login/metadata run before it).
- `sleep "${{ matrix.delay_seconds }}"` — every matrix leg has a `delay_seconds` entry via `include` (the `variant:` list members are all augmented by matching `include` entries), so the value is always defined.
- The sleep adds at most 90s of wall-clock to the longest leg; legs are `fail-fast: false` and independent, and `continue-on-error` semantics from #1567 are untouched.
- Cache correctness is unaffected: cache keys/content are unchanged, only request timing. A leg that starts later imports a cache that is at most slightly fresher (if a sibling leg's `cache-to` push landed meanwhile — harmless; buildkit picks the best matching records).
- Removing `buildcache-base` can only *reduce* import coverage if that ref existed — it doesn't, so behavior is identical minus the wasted 404 probes.

## Residual risk

- One observed failure happened **~26 min into a leg**, i.e. not the t=0 burst. A stagger does not help a leg that trips the limiter mid-build (e.g. during a late layer-fetch burst). Accepted: #1567 makes such a failure non-fatal to the CPU publish, and the t=0 collision is the dominant, reproducible pattern in the three incident runs. If mid-build 429s persist, the next lever would be reducing import breadth (e.g. `mode=min` import or fewer cache refs), not retry loops.

## Validation

- `python yaml.safe_load` — parses.
- `actionlint` v1.7.12 with repo `.github/actionlint.yaml`: head vs `origin/main` — **identical finding sets** (single pre-existing SC2129 style note in the untouched arm64 step; line-shifted only). No new findings.
- Repo pre-commit hook (workspace release clippy `-D warnings` via buildq, cached cuda130 libtorch) passed at commit time.
