### PR TITLE
fix(services): resolve rootless policy clients through IPC transport

### DIFF
--- a/crates/hyprstream/src/bin/main.rs
+++ b/crates/hyprstream/src/bin/main.rs
@@ -57,6 +57,7 @@ use std::sync::Arc;
 // Unified service manager API
 use hyprstream_service::{get_factory, InprocManager, ServiceContext, ServiceManager};
 use hyprstream_rpc::transport::TransportConfig;
+use hyprstream_rpc::registry::SocketKind;
 use hyprstream_rpc::{SigningKey, VerifyingKey};
 
 fn supports_tui() -> bool {
@@ -2759,6 +2760,7 @@ fn main() -> Result<()> {
                                             }
                                         }
                                     };
+                                    let discovery_transport = ctx.transport("discovery", SocketKind::Rep);
                                     let shared = hyprstream_service::QuicSharedConfig {
                                         cert_chain,
                                         key_der,
@@ -2771,7 +2773,8 @@ fn main() -> Result<()> {
                                         // #358: producer-chosen relay rendezvous (None = direct-only).
                                         moq_relay,
                                         native_announcement_publisher: Some(std::sync::Arc::new(
-                                            |request: hyprstream_service::NativeAnnouncementRequest| {
+                                            move |request: hyprstream_service::NativeAnnouncementRequest| {
+                                                let discovery_transport = discovery_transport.clone();
                                                 std::thread::spawn(move || {
                                                     let runtime = match tokio::runtime::Builder::new_current_thread()
                                                         .enable_all()
@@ -2784,7 +2787,8 @@ fn main() -> Result<()> {
                                                         }
                                                     };
                                                     runtime.block_on(async move {
-                                                        let client = match hyprstream_discovery::DiscoveryClient::for_local_bootstrap(
+                                                        let client = match hyprstream_discovery::DiscoveryClient::for_local_transport_bootstrap(
+                                                            &discovery_transport,
                                                             request.signing_key,
                                                             request.discovery_verifying_key,
                                                             None,

--- a/crates/hyprstream/src/bin/main.rs
+++ b/crates/hyprstream/src/bin/main.rs
@@ -991,6 +991,7 @@ fn handle_quick_command(
                         };
                         handle_training_infer(
                             registry,
+                            hyprstream_rpc::registry::global().endpoint("policy", SocketKind::Rep),
                             &model,
                             &prompt_text,
                             image,
@@ -1025,6 +1026,7 @@ fn handle_quick_command(
                     } => {
                         handle_training_batch(
                             registry,
+                            hyprstream_rpc::registry::global().endpoint("policy", SocketKind::Rep),
                             &model,
                             input,
                             input_dir,

--- a/crates/hyprstream/src/cli/training_handlers.rs
+++ b/crates/hyprstream/src/cli/training_handlers.rs
@@ -325,6 +325,7 @@ fn save_training_config(
 #[allow(clippy::too_many_arguments)]
 pub async fn handle_training_infer(
     registry: &RegistryClient,
+    policy_transport: hyprstream_rpc::transport::TransportConfig,
     model_ref_str: &str,
     prompt: &str,
     image_path: Option<String>,
@@ -389,7 +390,7 @@ pub async fn handle_training_infer(
         verifying_key,
         signing_key.clone(),
         transport,
-        hyprstream_rpc::transport::TransportConfig::inproc("policy"),
+        policy_transport,
         None, // CLI: no FsOps
     );
     let spawner = ServiceSpawner::threaded();
@@ -564,6 +565,7 @@ async fn collect_inference_stream(
 #[allow(clippy::too_many_arguments)]
 pub async fn handle_training_batch(
     registry: &RegistryClient,
+    policy_transport: hyprstream_rpc::transport::TransportConfig,
     model_ref_str: &str,
     input_files: Vec<String>,
     input_dir: Option<PathBuf>,
@@ -684,7 +686,7 @@ pub async fn handle_training_batch(
         verifying_key,
         signing_key.clone(),
         transport,
-        hyprstream_rpc::transport::TransportConfig::inproc("policy"),
+        policy_transport,
         None, // CLI: no FsOps
     );
     let spawner = ServiceSpawner::threaded();

--- a/crates/hyprstream/src/cli/training_handlers.rs
+++ b/crates/hyprstream/src/cli/training_handlers.rs
@@ -389,6 +389,7 @@ pub async fn handle_training_infer(
         verifying_key,
         signing_key.clone(),
         transport,
+        hyprstream_rpc::transport::TransportConfig::inproc("policy"),
         None, // CLI: no FsOps
     );
     let spawner = ServiceSpawner::threaded();
@@ -683,6 +684,7 @@ pub async fn handle_training_batch(
         verifying_key,
         signing_key.clone(),
         transport,
+        hyprstream_rpc::transport::TransportConfig::inproc("policy"),
         None, // CLI: no FsOps
     );
     let spawner = ServiceSpawner::threaded();

--- a/crates/hyprstream/src/services/factories.rs
+++ b/crates/hyprstream/src/services/factories.rs
@@ -1908,6 +1908,8 @@ fn create_oauth_service(ctx: &ServiceContext) -> anyhow::Result<Box<dyn Spawnabl
         config.account.clone(),
         sk,
         ctx.transport("oauth", SocketKind::Rep),
+        ctx.transport("policy", SocketKind::Rep),
+        ctx.transport("discovery", SocketKind::Rep),
         ctx.verifying_key(),
         ctx.jwt_verifying_key(),
     )
@@ -1959,6 +1961,7 @@ fn create_mcp_service(ctx: &ServiceContext) -> anyhow::Result<Box<dyn Spawnable>
         verifying_key: ctx.verifying_key(),
         signing_key: sk.clone(),
         transport: ctx.transport("mcp", SocketKind::Rep),
+        policy_transport: ctx.transport("policy", SocketKind::Rep),
         ctx: None, // ServiceContext not yet available as Arc — handlers use signing_key directly
         policy_verifying_key: policy_vk,
         expected_audience: Some(config.mcp.resource_url()),

--- a/crates/hyprstream/src/services/factories.rs
+++ b/crates/hyprstream/src/services/factories.rs
@@ -56,6 +56,32 @@ fn service_token(signing_key: &SigningKey) -> Option<String> {
         .and_then(|att| att.jwt)
 }
 
+/// Construct a Policy client through the service context's resolved transport.
+///
+/// `for_local_bootstrap` reads only the process-local endpoint registry. That
+/// is appropriate for co-located services, but a rootless Quadlet starts each
+/// service in a separate process. `ServiceContext::transport` preserves the
+/// in-process endpoint when applicable and resolves the shared IPC socket when
+/// `--ipc` is selected.
+fn policy_client_for_context(
+    ctx: &ServiceContext,
+    signing_key: SigningKey,
+    policy_vk: hyprstream_rpc::crypto::VerifyingKey,
+    token: Option<String>,
+) -> anyhow::Result<PolicyClient> {
+    let transport = ctx.transport("policy", SocketKind::Rep);
+    PolicyClient::for_local_transport_bootstrap(&transport, signing_key, policy_vk, token)
+}
+
+fn policy_client_for_transport(
+    transport: &hyprstream_rpc::transport::TransportConfig,
+    signing_key: SigningKey,
+    policy_vk: hyprstream_rpc::crypto::VerifyingKey,
+    token: Option<String>,
+) -> anyhow::Result<PolicyClient> {
+    PolicyClient::for_local_transport_bootstrap(transport, signing_key, policy_vk, token)
+}
+
 /// Shared Git2DB registry instance. Lazily initialized by the first factory
 /// that needs it. Both PolicyService and RegistryService share this instance.
 static SHARED_GIT2DB: std::sync::OnceLock<Arc<RwLock<Git2DB>>> = std::sync::OnceLock::new();
@@ -275,7 +301,7 @@ fn resolve_registration_jwt(
 /// seeded into the trust store so that peer-client construction
 /// (`service_token`) and the background renewal task can read it.
 fn register_service_key(
-    _ctx: &ServiceContext,
+    ctx: &ServiceContext,
     service_name: &str,
     signing_key: &SigningKey,
 ) -> anyhow::Result<()> {
@@ -324,8 +350,13 @@ fn register_service_key(
     let policy_vk = hyprstream_service::global_trust_store()
         .resolve_one("policy")
         .ok_or_else(|| anyhow::anyhow!("trust store has no policy key"))?;
-    let policy_client =
-        PolicyClient::for_local_bootstrap(signing_key.clone(), policy_vk, Some(jwt.clone()))?;
+    let policy_transport = ctx.transport("policy", SocketKind::Rep);
+    let policy_client = policy_client_for_transport(
+        &policy_transport,
+        signing_key.clone(),
+        policy_vk,
+        Some(jwt.clone()),
+    )?;
 
     let request = RegisterServiceKey {
         service_name: service_name.to_owned(),
@@ -350,6 +381,7 @@ fn register_service_key(
         signing_key.clone(),
         creds_dir,
         secrets_profile,
+        policy_transport,
     );
 
     Ok(())
@@ -379,6 +411,7 @@ fn spawn_jwt_renewal_task(
     signing_key: SigningKey,
     credentials_dir: std::path::PathBuf,
     secrets_profile: crate::auth::identity_store::SecretsProfile,
+    policy_transport: hyprstream_rpc::transport::TransportConfig,
 ) {
     let service_name = service_name.to_owned();
     tokio::spawn(async move {
@@ -436,7 +469,8 @@ fn spawn_jwt_renewal_task(
                 (vk, svc_jwt)
             };
 
-            let policy_client = match PolicyClient::for_local_bootstrap(
+            let policy_client = match policy_client_for_transport(
+                &policy_transport,
                 signing_key.clone(),
                 policy_vk,
                 Some(current_jwt),
@@ -920,8 +954,7 @@ fn create_registry_service(ctx: &ServiceContext) -> anyhow::Result<Box<dyn Spawn
     let policy_vk = hyprstream_service::global_trust_store()
         .resolve_one("policy")
         .ok_or_else(|| anyhow::anyhow!("trust store has no policy key"))?;
-    let policy_client =
-        PolicyClient::for_local_bootstrap(sk.clone(), policy_vk, service_token(&sk))?;
+    let policy_client = policy_client_for_context(ctx, sk.clone(), policy_vk, service_token(&sk))?;
 
     // #910a — the registry service is the sole PDS-record writer AND the sole
     // holder of the `#atproto` private key: it opens the durable store
@@ -1182,8 +1215,7 @@ fn create_model_service(ctx: &ServiceContext) -> anyhow::Result<Box<dyn Spawnabl
     let policy_vk = hyprstream_service::global_trust_store()
         .resolve_one("policy")
         .ok_or_else(|| anyhow::anyhow!("trust store has no policy key"))?;
-    let policy_client =
-        PolicyClient::for_local_bootstrap(sk.clone(), policy_vk, service_token(&sk))?;
+    let policy_client = policy_client_for_context(ctx, sk.clone(), policy_vk, service_token(&sk))?;
 
     // Create registry client
     let registry_client: RegistryClient =
@@ -1434,11 +1466,7 @@ fn create_worker_service(ctx: &ServiceContext) -> anyhow::Result<Box<dyn Spawnab
     let policy_vk = hyprstream_service::global_trust_store()
         .resolve_one("policy")
         .ok_or_else(|| anyhow::anyhow!("trust store has no policy key"))?;
-    let policy_client = crate::services::PolicyClient::for_local_bootstrap(
-        sk.clone(),
-        policy_vk,
-        service_token(&sk),
-    )?;
+    let policy_client = policy_client_for_context(ctx, sk.clone(), policy_vk, service_token(&sk))?;
     worker_service.set_authorize_fn(super::worker::build_authorize_fn(policy_client));
     if let Some(issuer) = ctx.oauth_issuer_url() {
         worker_service.set_expected_audience(issuer.to_owned());
@@ -1513,11 +1541,7 @@ fn create_workflow_service(ctx: &ServiceContext) -> anyhow::Result<Box<dyn Spawn
     let policy_vk = hyprstream_service::global_trust_store()
         .resolve_one("policy")
         .ok_or_else(|| anyhow::anyhow!("trust store has no policy key"))?;
-    let policy_client = crate::services::PolicyClient::for_local_bootstrap(
-        sk.clone(),
-        policy_vk,
-        service_token(&sk),
-    )?;
+    let policy_client = policy_client_for_context(ctx, sk.clone(), policy_vk, service_token(&sk))?;
     workflow_service.set_authorize_fn(crate::services::worker::build_authorize_fn(policy_client));
     if let Some(issuer) = ctx.oauth_issuer_url() {
         workflow_service.set_expected_audience(issuer.to_owned());
@@ -1604,8 +1628,7 @@ fn create_oai_service(ctx: &ServiceContext) -> anyhow::Result<Box<dyn Spawnable>
     let policy_vk = hyprstream_service::global_trust_store()
         .resolve_one("policy")
         .ok_or_else(|| anyhow::anyhow!("trust store has no policy key"))?;
-    let policy_client =
-        PolicyClient::for_local_bootstrap(sk.clone(), policy_vk, service_token(&sk))?;
+    let policy_client = policy_client_for_context(ctx, sk.clone(), policy_vk, service_token(&sk))?;
 
     // Create registry client
     let registry_client: RegistryClient =
@@ -1708,8 +1731,7 @@ fn create_xet_service(ctx: &ServiceContext) -> anyhow::Result<Box<dyn Spawnable>
     let policy_vk = hyprstream_service::global_trust_store()
         .resolve_one("policy")
         .ok_or_else(|| anyhow::anyhow!("trust store has no policy key"))?;
-    let policy_client =
-        PolicyClient::for_local_bootstrap(sk.clone(), policy_vk, service_token(&sk))?;
+    let policy_client = policy_client_for_context(ctx, sk.clone(), policy_vk, service_token(&sk))?;
     let federation_resolver = Arc::new(
         crate::auth::FederationKeyResolver::new(&config.oauth.trusted_issuers)
             .with_policy_client(Arc::new(policy_client)),
@@ -1804,8 +1826,7 @@ fn create_flight_service(ctx: &ServiceContext) -> anyhow::Result<Box<dyn Spawnab
     let policy_vk = hyprstream_service::global_trust_store()
         .resolve_one("policy")
         .ok_or_else(|| anyhow::anyhow!("trust store has no policy key"))?;
-    let policy_client =
-        PolicyClient::for_local_bootstrap(sk.clone(), policy_vk, service_token(&sk))?;
+    let policy_client = policy_client_for_context(ctx, sk.clone(), policy_vk, service_token(&sk))?;
     let federation_resolver = Arc::new(
         crate::auth::FederationKeyResolver::new(&config.oauth.trusted_issuers)
             .with_policy_client(Arc::new(policy_client.clone())),
@@ -1966,7 +1987,8 @@ fn create_mcp_service(ctx: &ServiceContext) -> anyhow::Result<Box<dyn Spawnable>
         if let Some(fed) = federation_key_source {
             fed
         } else {
-            let fallback_policy_client = std::sync::Arc::new(PolicyClient::for_local_bootstrap(
+            let fallback_policy_client = std::sync::Arc::new(policy_client_for_context(
+                ctx,
                 ctx.service_signing_key("mcp"),
                 policy_vk,
                 service_token(&sk),
@@ -2402,8 +2424,7 @@ fn create_tui_service(ctx: &ServiceContext) -> anyhow::Result<Box<dyn Spawnable>
     let policy_vk = hyprstream_service::global_trust_store()
         .resolve_one("policy")
         .ok_or_else(|| anyhow::anyhow!("trust store has no policy key"))?;
-    let policy_client =
-        PolicyClient::for_local_bootstrap(sk.clone(), policy_vk, service_token(&sk))?;
+    let policy_client = policy_client_for_context(ctx, sk.clone(), policy_vk, service_token(&sk))?;
 
     // Build the direct-VFS PEP before exposing the namespace. Failure to open
     // its signed WAL aborts construction; there is no unarmed fallback.
@@ -2495,8 +2516,7 @@ fn create_discovery_service(ctx: &ServiceContext) -> anyhow::Result<Box<dyn Spaw
     let policy_vk = hyprstream_service::global_trust_store()
         .resolve_one("policy")
         .ok_or_else(|| anyhow::anyhow!("trust store has no policy key"))?;
-    let policy_client =
-        PolicyClient::for_local_bootstrap(sk.clone(), policy_vk, service_token(&sk))?;
+    let policy_client = policy_client_for_context(ctx, sk.clone(), policy_vk, service_token(&sk))?;
     let auth_provider = crate::services::discovery::PolicyAuthProvider::new(policy_client);
 
     // #431 — record resolver backing getRecord/getRepo, over the durable
@@ -2639,8 +2659,7 @@ fn create_metrics_service(ctx: &ServiceContext) -> anyhow::Result<Box<dyn Spawna
     let policy_vk = hyprstream_service::global_trust_store()
         .resolve_one("policy")
         .ok_or_else(|| anyhow::anyhow!("trust store has no policy key"))?;
-    let policy_client =
-        PolicyClient::for_local_bootstrap(sk.clone(), policy_vk, service_token(&sk))?;
+    let policy_client = policy_client_for_context(ctx, sk.clone(), policy_vk, service_token(&sk))?;
 
     let mut metrics_service = MetricsService::new(
         orchestrator,
@@ -2722,6 +2741,28 @@ fn compute_tls_endorsement(
 #[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {
     use super::*;
+
+    /// Rootless Quadlets run each service in a distinct process, so the
+    /// process-local endpoint registry cannot resolve Policy for Discovery or
+    /// its downstream peers. The typed IPC transport remains lazy: creating a
+    /// client for the shared socket must not require a co-located registration.
+    #[test]
+    fn policy_client_accepts_unregistered_ipc_transport() {
+        let signing_key = SigningKey::from_bytes(&[0x63; 32]);
+        let transport =
+            hyprstream_rpc::transport::TransportConfig::ipc("/run/hyprstream/policy.sock");
+
+        let client = policy_client_for_transport(
+            &transport,
+            signing_key.clone(),
+            signing_key.verifying_key(),
+            None,
+        );
+        assert!(
+            client.is_ok(),
+            "IPC policy client must be lazy at first boot"
+        );
+    }
 
     #[test]
     fn at9p_verify_factory_uses_canonical_service_name() {

--- a/crates/hyprstream/src/services/factories.rs
+++ b/crates/hyprstream/src/services/factories.rs
@@ -1238,6 +1238,7 @@ fn create_model_service(ctx: &ServiceContext) -> anyhow::Result<Box<dyn Spawnabl
                 policy_client,
                 registry_client,
                 ctx.transport("model", SocketKind::Rep),
+                ctx.transport("policy", SocketKind::Rep),
             )
         })
     })?;
@@ -1312,6 +1313,7 @@ fn create_inference_service(ctx: &ServiceContext) -> anyhow::Result<Box<dyn Spaw
         sk.verifying_key(),
         sk.clone(),
         ctx.transport(&instance_name, SocketKind::Rep),
+        ctx.transport("policy", SocketKind::Rep),
         None,
     )
     .with_instance_identity(

--- a/crates/hyprstream/src/services/inference.rs
+++ b/crates/hyprstream/src/services/inference.rs
@@ -2859,6 +2859,7 @@ pub struct InferenceServiceConfig {
     /// created in the caller's runtime will fail with "Tokio context being shutdown" when
     /// used on a different thread's runtime.
     policy_signing_key: SigningKey,
+    policy_transport: hyprstream_rpc::transport::TransportConfig,
     transport: hyprstream_rpc::transport::TransportConfig,
     fs: Option<WorktreeClient>,
     /// Expected audience for JWT validation (resource URL)
@@ -2901,6 +2902,7 @@ impl InferenceServiceConfig {
         server_pubkey: VerifyingKey,
         signing_key: SigningKey,
         transport: hyprstream_rpc::transport::TransportConfig,
+        policy_transport: hyprstream_rpc::transport::TransportConfig,
         fs: Option<WorktreeClient>,
     ) -> Self {
         let policy_signing_key = signing_key.clone();
@@ -2911,6 +2913,7 @@ impl InferenceServiceConfig {
             server_pubkey,
             signing_key,
             policy_signing_key,
+            policy_transport,
             transport,
             fs,
             expected_audience: None,
@@ -3229,6 +3232,7 @@ impl hyprstream_service::Spawnable for InferenceServiceConfig {
                 server_pubkey,
                 signing_key: svc_signing_key,
                 policy_signing_key,
+                policy_transport,
                 transport: _transport,
                 fs,
                 expected_audience,
@@ -3279,8 +3283,9 @@ impl hyprstream_service::Spawnable for InferenceServiceConfig {
                         .ok_or_else(|| {
                             anyhow::anyhow!("trust store has no policy key — startup must populate it")
                         })?;
-                    let policy_client =
-                        PolicyClient::for_local_bootstrap(policy_signing_key, policy_vk, None)?;
+                    let policy_client = PolicyClient::for_local_transport_bootstrap(
+                        &policy_transport, policy_signing_key, policy_vk, None,
+                    )?;
                     let service = InferenceService::initialize(
                         model_path,
                         config,
@@ -3495,6 +3500,7 @@ mod tenant_binding_tests {
             hyprstream_rpc::transport::TransportConfig::inproc(
                 "inference-stream-plane-test",
             ),
+            hyprstream_rpc::transport::TransportConfig::inproc("policy"),
             None,
         )
         .with_stream_plane(Arc::clone(&reach), Arc::clone(&origin));
@@ -3516,6 +3522,7 @@ mod tenant_binding_tests {
             hyprstream_rpc::transport::TransportConfig::inproc(
                 "inference-legacy-readiness-test",
             ),
+            hyprstream_rpc::transport::TransportConfig::inproc("policy"),
             None,
         );
 

--- a/crates/hyprstream/src/services/mcp_service.rs
+++ b/crates/hyprstream/src/services/mcp_service.rs
@@ -151,6 +151,9 @@ pub struct McpConfig {
     pub signing_key: SigningKey,
     /// RPC transport for control plane
     pub transport: TransportConfig,
+    /// Policy RPC transport resolved by the factory. This is an IPC socket when
+    /// MCP runs in its own rootless Quadlet process.
+    pub policy_transport: TransportConfig,
     /// Service context for client construction (optional for backward compat)
     pub ctx: Option<Arc<ServiceContext>>,
     /// PolicyService verifying key — used to create the internal PolicyClient
@@ -936,7 +939,8 @@ impl McpService {
             tool_reg.by_uuid.len(),
         );
 
-        let policy_client = PolicyClient::for_local_bootstrap(
+        let policy_client = PolicyClient::for_local_transport_bootstrap(
+            &config.policy_transport,
             config.signing_key.clone(),
             config.policy_verifying_key,
             None,
@@ -1502,6 +1506,26 @@ mod tests {
 
     fn signing_key(seed: u8) -> SigningKey {
         SigningKey::from_bytes(&[seed; 32])
+    }
+
+    /// MCP must be constructible before any in-process endpoint registry has
+    /// been populated: rootless Quadlets reach Policy through the shared IPC
+    /// socket selected by the factory.
+    #[test]
+    fn mcp_accepts_unregistered_ipc_policy_transport() {
+        let signing_key = signing_key(0x51);
+        let config = McpConfig {
+            verifying_key: signing_key.verifying_key(),
+            signing_key: signing_key.clone(),
+            transport: TransportConfig::ipc("/run/hyprstream/mcp.sock"),
+            policy_transport: TransportConfig::ipc("/run/hyprstream/policy.sock"),
+            ctx: None,
+            policy_verifying_key: signing_key.verifying_key(),
+            expected_audience: None,
+            jwt_key_source: None,
+        };
+
+        assert!(McpService::new(config).is_ok());
     }
 
     /// #989: workflow tools must be advertised to MCP clients. Proves both that

--- a/crates/hyprstream/src/services/model.rs
+++ b/crates/hyprstream/src/services/model.rs
@@ -188,6 +188,7 @@ pub struct ModelServiceInner {
     registry: RegistryClient,
     // Infrastructure (for Spawnable)
     transport: TransportConfig,
+    policy_transport: TransportConfig,
     /// Expected JWT audience for token validation (RFC 8707).
     expected_audience: Option<String>,
     /// Unified JWT key source for verifying JWTs (local and federated).
@@ -414,6 +415,7 @@ impl ModelService {
         policy_client: PolicyClient,
         registry: RegistryClient,
         transport: TransportConfig,
+        policy_transport: TransportConfig,
     ) -> Result<Self> {
         config.inference_deployment.validate()?;
         // SAFETY: 5 is a valid non-zero value
@@ -436,6 +438,7 @@ impl ModelService {
             event_publisher,
             registry,
             transport,
+            policy_transport,
             expected_audience: None,
             jwt_key_source: None,
             discovery_client: None,
@@ -994,6 +997,7 @@ impl ModelService {
             self.signing_key.verifying_key(),
             self.signing_key.clone(),
             transport.clone(),
+            self.policy_transport.clone(),
             fs,
         )
         .with_instance_identity(
@@ -2763,6 +2767,7 @@ mod tests {
             PolicyClient::new(Arc::clone(&infrastructure_rpc)),
             RegistryClient::new(infrastructure_rpc),
             TransportConfig::inproc("selector-model-service"),
+            TransportConfig::inproc("policy"),
         )
         .await
         .unwrap_or_else(|error| panic!("construct model-free selector service failed: {error}"))

--- a/crates/hyprstream/src/services/oauth/mod.rs
+++ b/crates/hyprstream/src/services/oauth/mod.rs
@@ -432,9 +432,15 @@ pub struct OAuthService {
     account_config: crate::account::AccountZoneConfig,
     /// Global QUIC configuration for cert-hash publication in DID doc (#185).
     quic_config: Option<crate::config::QuicConfig>,
-    /// Signing key for creating the PolicyClient inside `run()`.
+    /// Signing key for creating RPC clients inside `run()`.
     signing_key: hyprstream_rpc::prelude::SigningKey,
     control_transport: TransportConfig,
+    /// Policy transport resolved by the factory. This is an IPC socket when
+    /// OAuth runs in its own rootless Quadlet process.
+    policy_transport: TransportConfig,
+    /// Discovery transport resolved by the factory. This is an IPC socket when
+    /// OAuth runs in its own rootless Quadlet process.
+    discovery_transport: TransportConfig,
     #[allow(dead_code)]
     verifying_key: ed25519_dalek::VerifyingKey,
     /// JWT verifying key (CA key) for JWKS endpoint. This is the key that verifies
@@ -456,6 +462,8 @@ impl OAuthService {
         account_config: crate::account::AccountZoneConfig,
         signing_key: hyprstream_rpc::prelude::SigningKey,
         control_transport: TransportConfig,
+        policy_transport: TransportConfig,
+        discovery_transport: TransportConfig,
         verifying_key: ed25519_dalek::VerifyingKey,
         jwt_verifying_key: ed25519_dalek::VerifyingKey,
     ) -> Self {
@@ -466,6 +474,8 @@ impl OAuthService {
             quic_config: None,
             signing_key,
             control_transport,
+            policy_transport,
+            discovery_transport,
             verifying_key,
             jwt_verifying_key: jwt_verifying_key.to_bytes(),
             jti_blocklist: None,
@@ -562,7 +572,8 @@ impl Spawnable for OAuthService {
                     ));
                 }
             };
-            let policy_client = PolicyClient::for_local_bootstrap(
+            let policy_client = PolicyClient::for_local_transport_bootstrap(
+                &self.policy_transport,
                 self.signing_key.clone(),
                 policy_vk,
                 None,
@@ -580,7 +591,8 @@ impl Spawnable for OAuthService {
                     ));
                 }
             };
-            let discovery_client = crate::services::DiscoveryClient::for_local_bootstrap(
+            let discovery_client = crate::services::DiscoveryClient::for_local_transport_bootstrap(
+                &self.discovery_transport,
                 self.signing_key.clone(),
                 discovery_vk,
                 None,
@@ -1110,6 +1122,38 @@ pub fn protected_resource_metadata(
 mod tests {
     use super::registration::validate_redirect_uri;
     use super::*;
+
+    /// OAuth owns a separate runtime, so its peer clients are made in `run`.
+    /// The production path must retain the factory-resolved IPC transports;
+    /// process-local bootstrap cannot see Policy or Discovery across rootless
+    /// Quadlet process boundaries.
+    #[test]
+    fn oauth_run_uses_factory_resolved_peer_transports() {
+        let source = include_str!("mod.rs");
+        let production = source
+            .split("// Tests")
+            .next()
+            .expect("tests banner must bound production source");
+        let run_start = production
+            .find("impl Spawnable for OAuthService")
+            .expect("OAuthService must implement Spawnable");
+        let run = &production[run_start..];
+
+        assert!(run.contains(
+            "PolicyClient::for_local_transport_bootstrap(\n                &self.policy_transport,"
+        ));
+        assert!(run.contains(
+            "DiscoveryClient::for_local_transport_bootstrap(\n                &self.discovery_transport,"
+        ));
+        assert!(
+            !run.contains("PolicyClient::for_local_bootstrap("),
+            "OAuth must not use the process-local Policy registry"
+        );
+        assert!(
+            !run.contains("DiscoveryClient::for_local_bootstrap("),
+            "OAuth must not use the process-local Discovery registry"
+        );
+    }
 
     fn encode_form(fields: &[(&str, &str)]) -> String {
         let mut serializer = url::form_urlencoded::Serializer::new(String::new());


### PR DESCRIPTION
## Problem

Rootless Quadlets run each Hyprstream service in a separate process. Service factories and JWT renewal used `PolicyClient::for_local_bootstrap`, which relies on the process-local endpoint registry. After Policy starts successfully, Discovery then fails before readiness because it cannot find Policy’s endpoint locally.

## Change

Resolve the Policy transport through `ServiceContext::transport("policy", SocketKind::Rep)`. This retains the in-process registry transport for co-located runs and selects the shared `/run/hyprstream/policy.sock` IPC endpoint for rootless Quadlets. Apply it to every Policy client factory and the registration renewal task.

## Verification

- `hyprstream-build.sh run -- cargo test -p hyprstream policy_client_accepts_unregistered_ipc_transport --lib`
- Mandatory pre-commit Clippy gate: `cargo clippy --workspace --all-targets --release -- -D warnings`

This unblocks the observed staging Discovery error: `local bootstrap requires an explicitly registered service endpoint`.