### PR TITLE
fix(mac): authorize staged model bootstrap registration

### DIFF
--- a/crates/hyprstream/src/mac/dispatch_labels.rs
+++ b/crates/hyprstream/src/mac/dispatch_labels.rs
@@ -388,6 +388,12 @@ static BOOTSTRAP_SERVICE_CLEARANCES: &[ServiceSubjectClearance] = &[
              clearance",
     },
     ServiceSubjectClearance {
+        service: "model",
+        clearance: BOOTSTRAP_SERVICE_CLEARANCE,
+        justification: "the staged synthetic model registers its key before \
+             its inference RPC surface can start",
+    },
+    ServiceSubjectClearance {
         service: "oauth",
         clearance: BOOTSTRAP_SERVICE_CLEARANCE,
         justification: "login/session issuance is how identity standing is \
@@ -469,14 +475,14 @@ mod tests {
             assert!(!row.justification.is_empty());
         }
 
-        // The five staging bootstrap services each hold the deliberate
+        // The six staging bootstrap services each hold the deliberate
         // service subject clearance, and each declared caller's clearance
         // dominates every declared object label (the boot calls evaluate).
         let mut services: Vec<&str> = table.clearances().iter().map(|row| row.service).collect();
         services.sort_unstable();
         assert_eq!(
             services,
-            ["discovery", "event", "oauth", "policy", "registry"]
+            ["discovery", "event", "model", "oauth", "policy", "registry"]
         );
         for row in table.clearances() {
             assert_eq!(row.clearance, BOOTSTRAP_SERVICE_CLEARANCE);
@@ -557,7 +563,7 @@ mod tests {
             .is_none());
         // Undeclared service clearance.
         assert!(table.service_clearance("ghost").is_none());
-        assert!(table.service_clearance("model").is_none());
+        assert!(table.service_clearance("metrics").is_none());
 
         // The RpcObjectLabelResolver view agrees (None ⇒ deny).
         let resolver: &dyn RpcObjectLabelResolver = table;
@@ -659,7 +665,7 @@ mod tests {
         // Every declared bootstrap service caller permits the boot
         // registration call (deliberate clearance composed with verified key
         // material).
-        for service in ["discovery", "event", "oauth", "policy", "registry"] {
+        for service in ["discovery", "event", "model", "oauth", "policy", "registry"] {
             let ctx = service_subject_ctx(service, 0x63);
             assert_eq!(
                 pep.check(&ctx, "policy", Some(policy_methods::REGISTER_SERVICE_KEY)),


### PR DESCRIPTION
The staging runtime starts `model` after registry and streams, but the closed production dispatch-clearance table omitted `model` even though model registration is explicitly part of boot. The mandatory dispatch PEP therefore denied its `policy.registerServiceKey` call with `MAC deny: NoClearance`, leaving the deployment fail-closed.

Add only the `model` service-subject clearance at the existing bootstrap floor; object rows remain unchanged and undeclared callers remain denied.

Validated locally:
- `cargo test -p hyprstream mac::dispatch_labels --lib` (BuildQ)
- repository pre-commit strict `cargo clippy --workspace --all-targets --release -- -D warnings` with the canonical cached CUDA 13.0 libtorch environment
- `rustfmt --check crates/hyprstream/src/mac/dispatch_labels.rs`