### PR TITLE
fix(policy): resolve CLI policy client through deployment IPC

### DIFF
--- a/crates/git2db/src/stage.rs
+++ b/crates/git2db/src/stage.rs
@@ -5,7 +5,7 @@
 use crate::errors::{Git2DBError, Git2DBResult};
 use crate::registry::{Git2DB, RepoId};
 use crate::repo_accessor::RepositoryAccessor;
-use git2::{IndexAddOption, Oid, Repository, Status, StatusOptions};
+use git2::{IndexAddOption, Repository, Status, StatusOptions};
 use std::path::{Path, PathBuf};
 
 /// Manager for repository staging area
@@ -122,55 +122,6 @@ impl<'a> StageManager<'a> {
                 .write()
                 .map_err(|e| Git2DBError::internal(format!("Failed to write index: {e}")))?;
 
-            Ok(())
-        })
-        .await
-        .map_err(|e| Git2DBError::internal(format!("Task join error: {e}")))?
-    }
-
-    /// Snapshot the current index tree without changing the staging area.
-    ///
-    /// Callers that must make a worktree mutation atomic with a later commit
-    /// can restore this tree if committing the staged mutation fails.
-    pub async fn snapshot(&self) -> Git2DBResult<Oid> {
-        let repo_path = self.repo_path()?;
-
-        tokio::task::spawn_blocking(move || -> Git2DBResult<Oid> {
-            let repo = Repository::open(&repo_path).map_err(|e| {
-                Git2DBError::repository(&repo_path, format!("Failed to open repository: {e}"))
-            })?;
-            let mut index = repo
-                .index()
-                .map_err(|e| Git2DBError::internal(format!("Failed to get index: {e}")))?;
-            index
-                .write_tree()
-                .map_err(|e| Git2DBError::internal(format!("Failed to snapshot index: {e}")))
-        })
-        .await
-        .map_err(|e| Git2DBError::internal(format!("Task join error: {e}")))?
-    }
-
-    /// Restore a previously snapshotted index tree without changing the
-    /// working tree.
-    pub async fn restore(&self, snapshot: Oid) -> Git2DBResult<()> {
-        let repo_path = self.repo_path()?;
-
-        tokio::task::spawn_blocking(move || -> Git2DBResult<()> {
-            let repo = Repository::open(&repo_path).map_err(|e| {
-                Git2DBError::repository(&repo_path, format!("Failed to open repository: {e}"))
-            })?;
-            let tree = repo.find_tree(snapshot).map_err(|e| {
-                Git2DBError::internal(format!("Failed to read index snapshot: {e}"))
-            })?;
-            let mut index = repo
-                .index()
-                .map_err(|e| Git2DBError::internal(format!("Failed to get index: {e}")))?;
-            index
-                .read_tree(&tree)
-                .map_err(|e| Git2DBError::internal(format!("Failed to restore index: {e}")))?;
-            index
-                .write()
-                .map_err(|e| Git2DBError::internal(format!("Failed to write index: {e}")))?;
             Ok(())
         })
         .await
@@ -335,52 +286,4 @@ impl<'a> StageManager<'a> {
     pub async fn is_empty(&self) -> Git2DBResult<bool> {
         Ok(self.staged_files().await?.is_empty())
     }
-}
-
-#[cfg(test)]
-mod tests {
-    use crate::{Git2DB, RepoId};
-
-    #[allow(clippy::expect_used)]
-    #[tokio::test]
-    async fn restore_returns_index_to_exact_snapshot_without_changing_worktree() {
-        let temp = tempfile::tempdir().expect("test registry directory");
-        let registry = Git2DB::open(temp.path())
-            .await
-            .expect("open test registry");
-        let repo_id = RepoId::from_uuid(crate::registry::registry_self_uuid());
-        let handle = registry.repo(&repo_id).expect("self-tracked registry handle");
-        let repo = handle.open_repo().expect("open self-tracked registry repository");
-        let workdir = repo.workdir().expect("registry worktree").to_path_buf();
-        let path = workdir.join("policy.csv");
-
-        std::fs::write(&path, "before\n").expect("write initial policy");
-        handle
-            .staging()
-            .add("policy.csv")
-            .await
-            .expect("stage initial policy");
-        handle.commit("test: initial policy").await.expect("commit initial policy");
-
-        let snapshot = handle.staging().snapshot().await.expect("snapshot index");
-        std::fs::write(&path, "rejected\n").expect("write rejected policy");
-        handle
-            .staging()
-            .add("policy.csv")
-            .await
-            .expect("stage rejected policy");
-
-        handle
-            .staging()
-            .restore(snapshot)
-            .await
-            .expect("restore index snapshot");
-
-        assert!(
-            handle.staging().is_empty().await.expect("staging status"),
-            "restoring the snapshot must remove the rejected staged change"
-        );
-        assert_eq!(std::fs::read_to_string(path).expect("read worktree"), "rejected\n");
-    }
-
 }

--- a/crates/git2db/src/stage.rs
+++ b/crates/git2db/src/stage.rs
@@ -5,7 +5,7 @@
 use crate::errors::{Git2DBError, Git2DBResult};
 use crate::registry::{Git2DB, RepoId};
 use crate::repo_accessor::RepositoryAccessor;
-use git2::{IndexAddOption, Repository, Status, StatusOptions};
+use git2::{IndexAddOption, Oid, Repository, Status, StatusOptions};
 use std::path::{Path, PathBuf};
 
 /// Manager for repository staging area
@@ -122,6 +122,55 @@ impl<'a> StageManager<'a> {
                 .write()
                 .map_err(|e| Git2DBError::internal(format!("Failed to write index: {e}")))?;
 
+            Ok(())
+        })
+        .await
+        .map_err(|e| Git2DBError::internal(format!("Task join error: {e}")))?
+    }
+
+    /// Snapshot the current index tree without changing the staging area.
+    ///
+    /// Callers that must make a worktree mutation atomic with a later commit
+    /// can restore this tree if committing the staged mutation fails.
+    pub async fn snapshot(&self) -> Git2DBResult<Oid> {
+        let repo_path = self.repo_path()?;
+
+        tokio::task::spawn_blocking(move || -> Git2DBResult<Oid> {
+            let repo = Repository::open(&repo_path).map_err(|e| {
+                Git2DBError::repository(&repo_path, format!("Failed to open repository: {e}"))
+            })?;
+            let mut index = repo
+                .index()
+                .map_err(|e| Git2DBError::internal(format!("Failed to get index: {e}")))?;
+            index
+                .write_tree()
+                .map_err(|e| Git2DBError::internal(format!("Failed to snapshot index: {e}")))
+        })
+        .await
+        .map_err(|e| Git2DBError::internal(format!("Task join error: {e}")))?
+    }
+
+    /// Restore a previously snapshotted index tree without changing the
+    /// working tree.
+    pub async fn restore(&self, snapshot: Oid) -> Git2DBResult<()> {
+        let repo_path = self.repo_path()?;
+
+        tokio::task::spawn_blocking(move || -> Git2DBResult<()> {
+            let repo = Repository::open(&repo_path).map_err(|e| {
+                Git2DBError::repository(&repo_path, format!("Failed to open repository: {e}"))
+            })?;
+            let tree = repo.find_tree(snapshot).map_err(|e| {
+                Git2DBError::internal(format!("Failed to read index snapshot: {e}"))
+            })?;
+            let mut index = repo
+                .index()
+                .map_err(|e| Git2DBError::internal(format!("Failed to get index: {e}")))?;
+            index
+                .read_tree(&tree)
+                .map_err(|e| Git2DBError::internal(format!("Failed to restore index: {e}")))?;
+            index
+                .write()
+                .map_err(|e| Git2DBError::internal(format!("Failed to write index: {e}")))?;
             Ok(())
         })
         .await
@@ -290,7 +339,48 @@ impl<'a> StageManager<'a> {
 
 #[cfg(test)]
 mod tests {
-    
+    use crate::{Git2DB, RepoId};
 
-    // Tests will be added for staging operations
+    #[allow(clippy::expect_used)]
+    #[tokio::test]
+    async fn restore_returns_index_to_exact_snapshot_without_changing_worktree() {
+        let temp = tempfile::tempdir().expect("test registry directory");
+        let registry = Git2DB::open(temp.path())
+            .await
+            .expect("open test registry");
+        let repo_id = RepoId::from_uuid(crate::registry::registry_self_uuid());
+        let handle = registry.repo(&repo_id).expect("self-tracked registry handle");
+        let repo = handle.open_repo().expect("open self-tracked registry repository");
+        let workdir = repo.workdir().expect("registry worktree").to_path_buf();
+        let path = workdir.join("policy.csv");
+
+        std::fs::write(&path, "before\n").expect("write initial policy");
+        handle
+            .staging()
+            .add("policy.csv")
+            .await
+            .expect("stage initial policy");
+        handle.commit("test: initial policy").await.expect("commit initial policy");
+
+        let snapshot = handle.staging().snapshot().await.expect("snapshot index");
+        std::fs::write(&path, "rejected\n").expect("write rejected policy");
+        handle
+            .staging()
+            .add("policy.csv")
+            .await
+            .expect("stage rejected policy");
+
+        handle
+            .staging()
+            .restore(snapshot)
+            .await
+            .expect("restore index snapshot");
+
+        assert!(
+            handle.staging().is_empty().await.expect("staging status"),
+            "restoring the snapshot must remove the rejected staged change"
+        );
+        assert_eq!(std::fs::read_to_string(path).expect("read worktree"), "rejected\n");
+    }
+
 }

--- a/crates/hyprstream/src/cli/policy_handlers.rs
+++ b/crates/hyprstream/src/cli/policy_handlers.rs
@@ -27,13 +27,31 @@ use std::process::Command;
 
 /// Create a PolicyClient for RPC calls.
 ///
-/// The top-level CLI installs the authenticated production resolver before it
-/// dispatches policy commands. It resolves the policy service's same-host IPC
-/// endpoint and pinned response key from deployment trust. Do not use the
-/// process-local bootstrap registry here: a `podman exec` CLI is a distinct
-/// process and therefore cannot inherit the server process's registrations.
+/// PolicyService's identity is the node root/CA key, so the local bootstrap
+/// caller and the target response verifier intentionally use the same pinned
+/// key. The endpoint registry's IPC default is deterministic from the runtime
+/// directory; unlike `registered_endpoint`, it is available to a separate
+/// `podman exec` process that did not start the PolicyService itself.
 fn create_policy_client(signing_key: &SigningKey) -> Result<PolicyClient> {
-    PolicyClient::from_resolver(signing_key.clone(), None)
+    let registry = hyprstream_rpc::registry::try_global()
+        .ok_or_else(|| anyhow::anyhow!("EndpointRegistry not initialized"))?;
+    let transport = policy_ipc_transport(&registry)?;
+    PolicyClient::for_local_transport_bootstrap(
+        &transport,
+        signing_key.clone(),
+        signing_key.verifying_key(),
+        None,
+    )
+}
+
+/// Resolve the deterministic same-host PolicyService REP socket without
+/// requiring a process-local service registration.
+fn policy_ipc_transport(
+    registry: &hyprstream_rpc::registry::EndpointRegistry,
+) -> Result<hyprstream_rpc::transport::TransportConfig> {
+    registry
+        .try_endpoint("policy", hyprstream_rpc::registry::SocketKind::Rep)
+        .context("resolve local PolicyService IPC endpoint")
 }
 
 /// Handle `policy show` - Display the running policy via RPC
@@ -693,20 +711,23 @@ mod tests {
     }
 
     #[test]
-    fn policy_cli_client_uses_authenticated_process_resolver() {
-        let source = include_str!("policy_handlers.rs");
-        let client_factory = source
-            .split("/// Handle `policy show`")
-            .next()
-            .expect("policy client factory precedes policy handlers");
+    fn policy_cli_uses_ipc_default_without_process_local_registration() {
+        let registry = hyprstream_rpc::registry::EndpointRegistry::new(
+            hyprstream_rpc::registry::EndpointMode::Ipc,
+            Some(std::path::PathBuf::from("/run/hyprstream")),
+        );
 
         assert!(
-            client_factory.contains("PolicyClient::from_resolver(signing_key.clone(), None)"),
-            "policy CLI must use the resolver installed by top-level bootstrap"
+            registry
+                .registered_endpoint("policy", hyprstream_rpc::registry::SocketKind::Rep)
+                .is_none(),
+            "this simulates the distinct podman-exec CLI process"
         );
-        assert!(
-            !client_factory.contains("PolicyClient::for_local_bootstrap("),
-            "a distinct CLI process has no server-local endpoint registry"
+        let transport = policy_ipc_transport(&registry)
+            .expect("IPC mode must provide the deterministic policy REP socket");
+        assert_eq!(
+            transport.endpoint_string(),
+            "ipc:///run/hyprstream/policy.sock",
         );
     }
 }

--- a/crates/hyprstream/src/cli/policy_handlers.rs
+++ b/crates/hyprstream/src/cli/policy_handlers.rs
@@ -27,14 +27,13 @@ use std::process::Command;
 
 /// Create a PolicyClient for RPC calls.
 ///
-/// Bootstrap: PolicyService key needed to create the PolicyClient for peer key resolution.
+/// The top-level CLI installs the authenticated production resolver before it
+/// dispatches policy commands. It resolves the policy service's same-host IPC
+/// endpoint and pinned response key from deployment trust. Do not use the
+/// process-local bootstrap registry here: a `podman exec` CLI is a distinct
+/// process and therefore cannot inherit the server process's registrations.
 fn create_policy_client(signing_key: &SigningKey) -> Result<PolicyClient> {
-    PolicyClient::for_local_bootstrap(
-        signing_key.clone(),
-        // Bootstrap: PolicyService uses the root key
-        signing_key.verifying_key(),
-        None,
-    )
+    PolicyClient::from_resolver(signing_key.clone(), None)
 }
 
 /// Handle `policy show` - Display the running policy via RPC
@@ -691,5 +690,23 @@ mod tests {
         let claims = hyprstream_rpc::auth::decode_unverified(&token)
             .expect("minted token must decode");
         assert_eq!(claims.sub, "alice");
+    }
+
+    #[test]
+    fn policy_cli_client_uses_authenticated_process_resolver() {
+        let source = include_str!("policy_handlers.rs");
+        let client_factory = source
+            .split("/// Handle `policy show`")
+            .next()
+            .expect("policy client factory precedes policy handlers");
+
+        assert!(
+            client_factory.contains("PolicyClient::from_resolver(signing_key.clone(), None)"),
+            "policy CLI must use the resolver installed by top-level bootstrap"
+        );
+        assert!(
+            !client_factory.contains("PolicyClient::for_local_bootstrap("),
+            "a distinct CLI process has no server-local endpoint registry"
+        );
     }
 }

--- a/crates/hyprstream/src/mac/dispatch_labels.rs
+++ b/crates/hyprstream/src/mac/dispatch_labels.rs
@@ -66,6 +66,26 @@ pub const SERVICE_SUBJECT_PREFIX: &str = "service:";
 /// real serialized requests and pins these values to the schema; changing the
 /// union order fails CI rather than silently relabeling the dispatch plane.
 pub mod policy_methods {
+    /// `check` — inspect the local effective policy.
+    pub const CHECK: u16 = 1;
+    /// `getPolicy` — read the local control-plane policy.
+    pub const GET_POLICY: u16 = 4;
+    /// `applyTemplate` — install a reviewed bootstrap template.
+    pub const APPLY_TEMPLATE: u16 = 5;
+    /// `applyDraft` — commit a local policy draft.
+    pub const APPLY_DRAFT: u16 = 6;
+    /// `rollback` — restore a local policy revision.
+    pub const ROLLBACK: u16 = 7;
+    /// `getHistory` — inspect local policy revisions.
+    pub const GET_HISTORY: u16 = 8;
+    /// `getDiff` — inspect a local policy draft.
+    pub const GET_DIFF: u16 = 9;
+    /// `getDraftStatus` — inspect local draft state.
+    pub const GET_DRAFT_STATUS: u16 = 10;
+    /// `addGrouping` — add a local role assignment.
+    pub const ADD_GROUPING: u16 = 11;
+    /// `removeGrouping` — remove a local role assignment.
+    pub const REMOVE_GROUPING: u16 = 12;
     /// `registerServiceKey` — a keyed service installs its identity with the
     /// CA. Bootstrap-critical: it precedes identity standing.
     pub const REGISTER_SERVICE_KEY: u16 = 18;
@@ -140,12 +160,12 @@ pub struct DeclaredDispatchTable {
 impl DeclaredDispatchTable {
     /// The production staging-bootstrap declarations (#1499).
     ///
-    /// Object rows cover exactly the dispatch calls the fresh-state
+    /// Object rows cover the fresh-state
     /// `service start --services event,policy,discovery,registry,model,oai,oauth` boot
-    /// graph makes: every keyed non-policy service registers its signing key
-    /// with the PolicyService CA at startup and renews that identity
-    /// hourly. Subject rows declare the deliberate caller clearance for all
-    /// seven bootstrap services.
+    /// graph plus the PolicyService authority's local policy-control-plane
+    /// commands. The production wrapper further restricts those local commands
+    /// to the verified, tokenless `service:policy` authority. Subject rows
+    /// declare the deliberate caller clearance for all seven bootstrap services.
     #[must_use]
     pub fn production() -> &'static Self {
         &PRODUCTION_TABLE
@@ -348,6 +368,66 @@ impl MacDispatchPep for DeclaredDispatchPep {
 
 static BOOTSTRAP_METHODS: &[DispatchMethodPolicy] = &[
     DispatchMethodPolicy {
+        id: DispatchMethodId { service: "policy", method: policy_methods::CHECK },
+        method_name: "check",
+        label: SecurityLabel::bottom(),
+        justification: "verified local PolicyService control-plane inspection; only the tokenless policy authority reaches this row",
+    },
+    DispatchMethodPolicy {
+        id: DispatchMethodId { service: "policy", method: policy_methods::GET_POLICY },
+        method_name: "getPolicy",
+        label: SecurityLabel::bottom(),
+        justification: "verified local PolicyService control-plane read; only the tokenless policy authority reaches this row",
+    },
+    DispatchMethodPolicy {
+        id: DispatchMethodId { service: "policy", method: policy_methods::APPLY_TEMPLATE },
+        method_name: "applyTemplate",
+        label: SecurityLabel::bottom(),
+        justification: "verified local PolicyService installs a reviewed bootstrap template; the handler still enforces Casbin writeback",
+    },
+    DispatchMethodPolicy {
+        id: DispatchMethodId { service: "policy", method: policy_methods::APPLY_DRAFT },
+        method_name: "applyDraft",
+        label: SecurityLabel::bottom(),
+        justification: "verified local PolicyService commits a local draft; the handler still enforces Casbin writeback",
+    },
+    DispatchMethodPolicy {
+        id: DispatchMethodId { service: "policy", method: policy_methods::ROLLBACK },
+        method_name: "rollback",
+        label: SecurityLabel::bottom(),
+        justification: "verified local PolicyService restores a local revision; the handler still enforces Casbin writeback",
+    },
+    DispatchMethodPolicy {
+        id: DispatchMethodId { service: "policy", method: policy_methods::GET_HISTORY },
+        method_name: "getHistory",
+        label: SecurityLabel::bottom(),
+        justification: "verified local PolicyService control-plane history read; only the tokenless policy authority reaches this row",
+    },
+    DispatchMethodPolicy {
+        id: DispatchMethodId { service: "policy", method: policy_methods::GET_DIFF },
+        method_name: "getDiff",
+        label: SecurityLabel::bottom(),
+        justification: "verified local PolicyService control-plane draft inspection; only the tokenless policy authority reaches this row",
+    },
+    DispatchMethodPolicy {
+        id: DispatchMethodId { service: "policy", method: policy_methods::GET_DRAFT_STATUS },
+        method_name: "getDraftStatus",
+        label: SecurityLabel::bottom(),
+        justification: "verified local PolicyService draft-state inspection; only the tokenless policy authority reaches this row",
+    },
+    DispatchMethodPolicy {
+        id: DispatchMethodId { service: "policy", method: policy_methods::ADD_GROUPING },
+        method_name: "addGrouping",
+        label: SecurityLabel::bottom(),
+        justification: "verified local PolicyService role update; the handler still enforces Casbin writeback",
+    },
+    DispatchMethodPolicy {
+        id: DispatchMethodId { service: "policy", method: policy_methods::REMOVE_GROUPING },
+        method_name: "removeGrouping",
+        label: SecurityLabel::bottom(),
+        justification: "verified local PolicyService role removal; the handler still enforces Casbin writeback",
+    },
+    DispatchMethodPolicy {
         id: DispatchMethodId {
             service: "policy",
             method: policy_methods::REGISTER_SERVICE_KEY,
@@ -408,9 +488,8 @@ static BOOTSTRAP_SERVICE_CLEARANCES: &[ServiceSubjectClearance] = &[
     ServiceSubjectClearance {
         service: "policy",
         clearance: BOOTSTRAP_SERVICE_CLEARANCE,
-        justification: "the CA itself; it makes no boot RPC calls, but its \
-             enrolled caller clearance is declared with the same deliberate \
-             value as the services it certifies",
+        justification: "the CA itself; its local control-plane rows are separately \
+             restricted to the verified tokenless service:policy authority",
     },
     ServiceSubjectClearance {
         service: "registry",
@@ -458,11 +537,20 @@ mod tests {
     fn every_declared_call_resolves_to_the_intended_typed_label_and_clearance() {
         let table = DeclaredDispatchTable::production();
 
-        // The fresh boot graph: discovery, registry, model, oai, and oauth each call
-        // policy.registerServiceKey on fresh state; renewal uses
-        // policy.refreshServiceToken. Every declared row resolves to the
-        // intended typed label — the lattice floor, deliberate and reviewed.
+        // The fresh boot graph declares the local PolicyService control-plane
+        // operations plus registration and renewal. Every declared row resolves
+        // to the intended typed label — the lattice floor, deliberate and reviewed.
         let expected: &[(u16, &str)] = &[
+            (policy_methods::CHECK, "check"),
+            (policy_methods::GET_POLICY, "getPolicy"),
+            (policy_methods::APPLY_TEMPLATE, "applyTemplate"),
+            (policy_methods::APPLY_DRAFT, "applyDraft"),
+            (policy_methods::ROLLBACK, "rollback"),
+            (policy_methods::GET_HISTORY, "getHistory"),
+            (policy_methods::GET_DIFF, "getDiff"),
+            (policy_methods::GET_DRAFT_STATUS, "getDraftStatus"),
+            (policy_methods::ADD_GROUPING, "addGrouping"),
+            (policy_methods::REMOVE_GROUPING, "removeGrouping"),
             (policy_methods::REGISTER_SERVICE_KEY, "registerServiceKey"),
             (policy_methods::REFRESH_SERVICE_TOKEN, "refreshServiceToken"),
         ];

--- a/crates/hyprstream/src/mac/dispatch_labels.rs
+++ b/crates/hyprstream/src/mac/dispatch_labels.rs
@@ -66,26 +66,24 @@ pub const SERVICE_SUBJECT_PREFIX: &str = "service:";
 /// real serialized requests and pins these values to the schema; changing the
 /// union order fails CI rather than silently relabeling the dispatch plane.
 pub mod policy_methods {
-    /// `check` — inspect the local effective policy.
-    pub const CHECK: u16 = 1;
     /// `getPolicy` — read the local control-plane policy.
-    pub const GET_POLICY: u16 = 4;
+    pub const GET_POLICY: u16 = 3;
     /// `applyTemplate` — install a reviewed bootstrap template.
-    pub const APPLY_TEMPLATE: u16 = 5;
+    pub const APPLY_TEMPLATE: u16 = 4;
     /// `applyDraft` — commit a local policy draft.
-    pub const APPLY_DRAFT: u16 = 6;
+    pub const APPLY_DRAFT: u16 = 5;
     /// `rollback` — restore a local policy revision.
-    pub const ROLLBACK: u16 = 7;
+    pub const ROLLBACK: u16 = 6;
     /// `getHistory` — inspect local policy revisions.
-    pub const GET_HISTORY: u16 = 8;
+    pub const GET_HISTORY: u16 = 7;
     /// `getDiff` — inspect a local policy draft.
-    pub const GET_DIFF: u16 = 9;
+    pub const GET_DIFF: u16 = 8;
     /// `getDraftStatus` — inspect local draft state.
-    pub const GET_DRAFT_STATUS: u16 = 10;
+    pub const GET_DRAFT_STATUS: u16 = 9;
     /// `addGrouping` — add a local role assignment.
-    pub const ADD_GROUPING: u16 = 11;
+    pub const ADD_GROUPING: u16 = 10;
     /// `removeGrouping` — remove a local role assignment.
-    pub const REMOVE_GROUPING: u16 = 12;
+    pub const REMOVE_GROUPING: u16 = 11;
     /// `registerServiceKey` — a keyed service installs its identity with the
     /// CA. Bootstrap-critical: it precedes identity standing.
     pub const REGISTER_SERVICE_KEY: u16 = 18;
@@ -368,12 +366,6 @@ impl MacDispatchPep for DeclaredDispatchPep {
 
 static BOOTSTRAP_METHODS: &[DispatchMethodPolicy] = &[
     DispatchMethodPolicy {
-        id: DispatchMethodId { service: "policy", method: policy_methods::CHECK },
-        method_name: "check",
-        label: SecurityLabel::bottom(),
-        justification: "verified local PolicyService control-plane inspection; only the tokenless policy authority reaches this row",
-    },
-    DispatchMethodPolicy {
         id: DispatchMethodId { service: "policy", method: policy_methods::GET_POLICY },
         method_name: "getPolicy",
         label: SecurityLabel::bottom(),
@@ -541,7 +533,6 @@ mod tests {
         // operations plus registration and renewal. Every declared row resolves
         // to the intended typed label — the lattice floor, deliberate and reviewed.
         let expected: &[(u16, &str)] = &[
-            (policy_methods::CHECK, "check"),
             (policy_methods::GET_POLICY, "getPolicy"),
             (policy_methods::APPLY_TEMPLATE, "applyTemplate"),
             (policy_methods::APPLY_DRAFT, "applyDraft"),
@@ -827,6 +818,145 @@ mod tests {
     #[test]
     fn declared_policy_discriminants_match_the_serialized_schema() {
         use capnp::message::Builder;
+
+        // getPolicy
+        let mut message = Builder::new_default();
+        {
+            let mut req =
+                message.init_root::<hyprstream_rpc_std::policy_capnp::policy_request::Builder>();
+            req.set_id(1);
+            req.set_get_policy(());
+        }
+        let bytes = capnp::serialize::write_message_to_words(&message);
+        assert_eq!(
+            hyprstream_rpc::browser_provisioning::canonical_method_discriminator(&bytes).unwrap(),
+            policy_methods::GET_POLICY,
+            "the declared getPolicy discriminant must match the schema union ordinal"
+        );
+
+        // applyTemplate
+        let mut message = Builder::new_default();
+        {
+            let mut req =
+                message.init_root::<hyprstream_rpc_std::policy_capnp::policy_request::Builder>();
+            req.set_id(1);
+            req.reborrow().init_apply_template().set_name("public-read");
+        }
+        let bytes = capnp::serialize::write_message_to_words(&message);
+        assert_eq!(
+            hyprstream_rpc::browser_provisioning::canonical_method_discriminator(&bytes).unwrap(),
+            policy_methods::APPLY_TEMPLATE,
+            "the declared applyTemplate discriminant must match the schema union ordinal"
+        );
+
+        // applyDraft
+        let mut message = Builder::new_default();
+        {
+            let mut req =
+                message.init_root::<hyprstream_rpc_std::policy_capnp::policy_request::Builder>();
+            req.set_id(1);
+            req.reborrow().init_apply_draft();
+        }
+        let bytes = capnp::serialize::write_message_to_words(&message);
+        assert_eq!(
+            hyprstream_rpc::browser_provisioning::canonical_method_discriminator(&bytes).unwrap(),
+            policy_methods::APPLY_DRAFT,
+            "the declared applyDraft discriminant must match the schema union ordinal"
+        );
+
+        // rollback
+        let mut message = Builder::new_default();
+        {
+            let mut req =
+                message.init_root::<hyprstream_rpc_std::policy_capnp::policy_request::Builder>();
+            req.set_id(1);
+            req.reborrow().init_rollback().set_git_ref("HEAD");
+        }
+        let bytes = capnp::serialize::write_message_to_words(&message);
+        assert_eq!(
+            hyprstream_rpc::browser_provisioning::canonical_method_discriminator(&bytes).unwrap(),
+            policy_methods::ROLLBACK,
+            "the declared rollback discriminant must match the schema union ordinal"
+        );
+
+        // getHistory
+        let mut message = Builder::new_default();
+        {
+            let mut req =
+                message.init_root::<hyprstream_rpc_std::policy_capnp::policy_request::Builder>();
+            req.set_id(1);
+            req.reborrow().init_get_history().set_count(1);
+        }
+        let bytes = capnp::serialize::write_message_to_words(&message);
+        assert_eq!(
+            hyprstream_rpc::browser_provisioning::canonical_method_discriminator(&bytes).unwrap(),
+            policy_methods::GET_HISTORY,
+            "the declared getHistory discriminant must match the schema union ordinal"
+        );
+
+        // getDiff
+        let mut message = Builder::new_default();
+        {
+            let mut req =
+                message.init_root::<hyprstream_rpc_std::policy_capnp::policy_request::Builder>();
+            req.set_id(1);
+            req.reborrow().init_get_diff();
+        }
+        let bytes = capnp::serialize::write_message_to_words(&message);
+        assert_eq!(
+            hyprstream_rpc::browser_provisioning::canonical_method_discriminator(&bytes).unwrap(),
+            policy_methods::GET_DIFF,
+            "the declared getDiff discriminant must match the schema union ordinal"
+        );
+
+        // getDraftStatus
+        let mut message = Builder::new_default();
+        {
+            let mut req =
+                message.init_root::<hyprstream_rpc_std::policy_capnp::policy_request::Builder>();
+            req.set_id(1);
+            req.set_get_draft_status(());
+        }
+        let bytes = capnp::serialize::write_message_to_words(&message);
+        assert_eq!(
+            hyprstream_rpc::browser_provisioning::canonical_method_discriminator(&bytes).unwrap(),
+            policy_methods::GET_DRAFT_STATUS,
+            "the declared getDraftStatus discriminant must match the schema union ordinal"
+        );
+
+        // addGrouping
+        let mut message = Builder::new_default();
+        {
+            let mut req =
+                message.init_root::<hyprstream_rpc_std::policy_capnp::policy_request::Builder>();
+            req.set_id(1);
+            let mut call = req.reborrow().init_add_grouping();
+            call.set_user("bootstrap-user");
+            call.set_role("viewer");
+        }
+        let bytes = capnp::serialize::write_message_to_words(&message);
+        assert_eq!(
+            hyprstream_rpc::browser_provisioning::canonical_method_discriminator(&bytes).unwrap(),
+            policy_methods::ADD_GROUPING,
+            "the declared addGrouping discriminant must match the schema union ordinal"
+        );
+
+        // removeGrouping
+        let mut message = Builder::new_default();
+        {
+            let mut req =
+                message.init_root::<hyprstream_rpc_std::policy_capnp::policy_request::Builder>();
+            req.set_id(1);
+            let mut call = req.reborrow().init_remove_grouping();
+            call.set_user("bootstrap-user");
+            call.set_role("viewer");
+        }
+        let bytes = capnp::serialize::write_message_to_words(&message);
+        assert_eq!(
+            hyprstream_rpc::browser_provisioning::canonical_method_discriminator(&bytes).unwrap(),
+            policy_methods::REMOVE_GROUPING,
+            "the declared removeGrouping discriminant must match the schema union ordinal"
+        );
 
         // registerServiceKey
         let mut message = Builder::new_default();

--- a/crates/hyprstream/src/mac/dispatch_labels.rs
+++ b/crates/hyprstream/src/mac/dispatch_labels.rs
@@ -293,6 +293,51 @@ impl DeclaredDispatchPep {
     pub fn table(&self) -> &'static DeclaredDispatchTable {
         self.table
     }
+
+    /// Evaluate an already-established subject context against the typed table.
+    ///
+    /// This remains crate-private so production callers cannot substitute an
+    /// arbitrary clearance for an unverified envelope. The local policy
+    /// bootstrap wrapper uses it only after proving its exact bearerless,
+    /// non-federated root authority and derives this context from the
+    /// authenticated service clearance.
+    pub(crate) fn check_with_explicit_context(
+        &self,
+        ctx: &EnvelopeContext,
+        service_domain: &str,
+        method: Option<u16>,
+        selected: SecurityContext,
+    ) -> MacDecision {
+        hyprstream_rpc::auth::mac::remember_verified_subject(ctx);
+        self.check_selected_context(ctx, service_domain, method, selected)
+    }
+
+    fn check_selected_context(
+        &self,
+        ctx: &EnvelopeContext,
+        service_domain: &str,
+        method: Option<u16>,
+        selected: SecurityContext,
+    ) -> MacDecision {
+        let Some(service_name) = declared_service_subject(ctx) else {
+            return MacDecision::Deny(MacDenyReason::NoClearance);
+        };
+        let Some(declared_clearance) = self.table.service_clearance(&service_name) else {
+            return MacDecision::Deny(MacDenyReason::NoClearance);
+        };
+        let service_ctx =
+            SecurityContext::from_clearance(declared_clearance, ctx.verified_key_material());
+
+        let Some(row) = self.table.resolve_row(service_domain, method) else {
+            return MacDecision::Deny(MacDenyReason::UnlabeledObject);
+        };
+
+        if selected.can_access(&row.label) && service_ctx.can_access(&row.label) {
+            MacDecision::Permit
+        } else {
+            MacDecision::Deny(MacDenyReason::FloorDeny)
+        }
+    }
 }
 
 /// Extract the canonical service name from a verified service subject.
@@ -338,27 +383,7 @@ impl MacDispatchPep for DeclaredDispatchPep {
         // 2. Deliberate declared service subject clearance. The assurance axis
         //    is clamped to the verified key material; the declaration cannot
         //    outrun the crypto.
-        let Some(service_name) = declared_service_subject(ctx) else {
-            return MacDecision::Deny(MacDenyReason::NoClearance);
-        };
-        let Some(declared_clearance) = self.table.service_clearance(&service_name) else {
-            return MacDecision::Deny(MacDenyReason::NoClearance);
-        };
-        let service_ctx =
-            SecurityContext::from_clearance(declared_clearance, ctx.verified_key_material());
-
-        // 3. Typed declared (service, leaf) object identity.
-        let Some(row) = self.table.resolve_row(service_domain, method) else {
-            return MacDecision::Deny(MacDenyReason::UnlabeledObject);
-        };
-
-        // 4. Intrinsic lattice floor: both the activation-selected context and
-        //    the deliberate declared-service context must dominate the label.
-        if selected.can_access(&row.label) && service_ctx.can_access(&row.label) {
-            MacDecision::Permit
-        } else {
-            MacDecision::Deny(MacDenyReason::FloorDeny)
-        }
+        self.check_selected_context(ctx, service_domain, method, selected)
     }
 }
 

--- a/crates/hyprstream/src/mac/mod.rs
+++ b/crates/hyprstream/src/mac/mod.rs
@@ -125,10 +125,58 @@ pub use te::{
 /// plane only); unknown services, unknown leaves, and VFS-shaped aliases deny
 /// `UnlabeledObject` before handler entry.
 pub fn install_production_rpc_dispatch_pep() {
+    let default = dispatch_labels::DeclaredDispatchPep::new(
+        dispatch_labels::DeclaredDispatchTable::production(),
+    )
+    .with_activation_control();
     hyprstream_rpc::auth::mac::install_mac_dispatch_pep(std::sync::Arc::new(
-        dispatch_labels::DeclaredDispatchPep::new(dispatch_labels::DeclaredDispatchTable::production())
-            .with_activation_control(),
+        ProductionDispatchPep { default },
     ));
+}
+
+/// Production typed dispatch policy with a further restriction for the local
+/// PolicyService control plane. The table declares its exact method set; this
+/// wrapper makes those rows reachable only to the cryptographically verified,
+/// non-federated, bearerless `service:policy` authority. It can only add denies
+/// to the table PEP, never bypass a missing typed declaration.
+struct ProductionDispatchPep {
+    default: dispatch_labels::DeclaredDispatchPep,
+}
+
+impl hyprstream_rpc::auth::mac::MacDispatchPep for ProductionDispatchPep {
+    fn check(
+        &self,
+        ctx: &hyprstream_rpc::service::EnvelopeContext,
+        service_domain: &str,
+        method: Option<u16>,
+    ) -> hyprstream_rpc::auth::mac::MacDecision {
+        let is_local_policy_control_plane = service_domain == "policy"
+            && matches!(
+                method,
+                Some(
+                    policy_methods::CHECK
+                        | policy_methods::GET_POLICY
+                        | policy_methods::APPLY_TEMPLATE
+                        | policy_methods::APPLY_DRAFT
+                        | policy_methods::ROLLBACK
+                        | policy_methods::GET_HISTORY
+                        | policy_methods::GET_DIFF
+                        | policy_methods::GET_DRAFT_STATUS
+                        | policy_methods::ADD_GROUPING
+                        | policy_methods::REMOVE_GROUPING
+                )
+            );
+        if is_local_policy_control_plane
+            && !(ctx.jwt_token().is_none()
+                && !ctx.subject().is_federated()
+                && ctx.subject().name() == Some("service:policy"))
+        {
+            return hyprstream_rpc::auth::mac::MacDecision::Deny(
+                hyprstream_rpc::auth::mac::MacDenyReason::NoClearance,
+            );
+        }
+        self.default.check(ctx, service_domain, method)
+    }
 }
 
 /// Explicit permit fixture for unit tests that exercise service plumbing
@@ -150,6 +198,48 @@ pub(crate) fn install_explicit_test_dispatch_pep() {
     }
 
     hyprstream_rpc::auth::mac::install_mac_dispatch_pep(std::sync::Arc::new(ExplicitTestPep));
+}
+
+#[cfg(test)]
+mod production_dispatch_tests {
+    use super::*;
+    use hyprstream_rpc::auth::mac::{MacDecision, MacDispatchPep};
+    use hyprstream_rpc::envelope::Subject;
+    use hyprstream_rpc::service::EnvelopeContext;
+
+    fn production_pep() -> ProductionDispatchPep {
+        ProductionDispatchPep {
+            default: dispatch_labels::DeclaredDispatchPep::new(
+                dispatch_labels::DeclaredDispatchTable::production(),
+            )
+            .with_activation_control(),
+        }
+    }
+
+    #[test]
+    fn local_policy_control_plane_requires_the_exact_tokenless_policy_authority() {
+        let signer = ed25519_dalek::SigningKey::from_bytes(&[0x91; 32]).verifying_key();
+        let policy =
+            EnvelopeContext::for_test_authenticated_subject(Subject::new("service:policy"), signer);
+        let registry = EnvelopeContext::for_test_authenticated_subject(
+            Subject::new("service:registry"),
+            signer,
+        );
+        let pep = production_pep();
+
+        assert_eq!(
+            pep.check(&policy, "policy", Some(policy_methods::APPLY_TEMPLATE)),
+            MacDecision::Permit,
+        );
+        assert_eq!(
+            pep.check(&registry, "policy", Some(policy_methods::APPLY_TEMPLATE)),
+            MacDecision::Deny(hyprstream_rpc::auth::mac::MacDenyReason::NoClearance),
+        );
+        assert_eq!(
+            pep.check(&policy, "policy", Some(17)),
+            MacDecision::Deny(hyprstream_rpc::auth::mac::MacDenyReason::UnlabeledObject),
+        );
+    }
 }
 // S5 (#571): the UCAN→TE policy compiler — compile a validated grant into a
 // CompiledPolicy, verify it grants no privilege beyond the grant, and sign it

--- a/crates/hyprstream/src/mac/mod.rs
+++ b/crates/hyprstream/src/mac/mod.rs
@@ -239,7 +239,7 @@ mod production_dispatch_tests {
             MacDecision::Deny(hyprstream_rpc::auth::mac::MacDenyReason::UnlabeledObject),
         );
         assert_eq!(
-            pep.check(&policy, "policy", Some(1)),
+            pep.check(&policy, "policy", Some(0)),
             MacDecision::Deny(hyprstream_rpc::auth::mac::MacDenyReason::UnlabeledObject),
             "policy check must not report the root authority's access as another user's result",
         );

--- a/crates/hyprstream/src/mac/mod.rs
+++ b/crates/hyprstream/src/mac/mod.rs
@@ -154,8 +154,7 @@ impl hyprstream_rpc::auth::mac::MacDispatchPep for ProductionDispatchPep {
             && matches!(
                 method,
                 Some(
-                    policy_methods::CHECK
-                        | policy_methods::GET_POLICY
+                    policy_methods::GET_POLICY
                         | policy_methods::APPLY_TEMPLATE
                         | policy_methods::APPLY_DRAFT
                         | policy_methods::ROLLBACK
@@ -238,6 +237,11 @@ mod production_dispatch_tests {
         assert_eq!(
             pep.check(&policy, "policy", Some(17)),
             MacDecision::Deny(hyprstream_rpc::auth::mac::MacDenyReason::UnlabeledObject),
+        );
+        assert_eq!(
+            pep.check(&policy, "policy", Some(1)),
+            MacDecision::Deny(hyprstream_rpc::auth::mac::MacDenyReason::UnlabeledObject),
+            "policy check must not report the root authority's access as another user's result",
         );
     }
 }

--- a/crates/hyprstream/src/mac/mod.rs
+++ b/crates/hyprstream/src/mac/mod.rs
@@ -165,13 +165,31 @@ impl hyprstream_rpc::auth::mac::MacDispatchPep for ProductionDispatchPep {
                         | policy_methods::REMOVE_GROUPING
                 )
             );
-        if is_local_policy_control_plane
-            && !(ctx.jwt_token().is_none()
+        if is_local_policy_control_plane {
+            if !(ctx.jwt_token().is_none()
                 && !ctx.subject().is_federated()
                 && ctx.subject().name() == Some("service:policy"))
-        {
-            return hyprstream_rpc::auth::mac::MacDecision::Deny(
-                hyprstream_rpc::auth::mac::MacDenyReason::NoClearance,
+            {
+                return hyprstream_rpc::auth::mac::MacDecision::Deny(
+                    hyprstream_rpc::auth::mac::MacDenyReason::NoClearance,
+                );
+            }
+
+            // This root-signed local bootstrap path intentionally carries no
+            // bearer claims. Keep its verified, declared policy-service
+            // context explicit so identity-aware activation does not turn the
+            // narrow control plane into `NoClearance` merely for being
+            // tokenless. The typed table and exact local-method guard still
+            // decide what it can reach.
+            let selected = SecurityContext::from_clearance(
+                BOOTSTRAP_SERVICE_CLEARANCE,
+                ctx.verified_key_material(),
+            );
+            return self.default.check_with_explicit_context(
+                ctx,
+                service_domain,
+                method,
+                selected,
             );
         }
         self.default.check(ctx, service_domain, method)
@@ -225,10 +243,18 @@ mod production_dispatch_tests {
             signer,
         );
         let pep = production_pep();
+        let no_activation = dispatch_labels::DeclaredDispatchPep::new(
+            dispatch_labels::DeclaredDispatchTable::production(),
+        );
 
         assert_eq!(
             pep.check(&policy, "policy", Some(policy_methods::APPLY_TEMPLATE)),
             MacDecision::Permit,
+        );
+        assert_eq!(
+            no_activation.check(&policy, "policy", Some(policy_methods::APPLY_TEMPLATE)),
+            MacDecision::Deny(hyprstream_rpc::auth::mac::MacDenyReason::NoClearance),
+            "the production wrapper must supply the explicit verified bootstrap context",
         );
         assert_eq!(
             pep.check(&registry, "policy", Some(policy_methods::APPLY_TEMPLATE)),

--- a/crates/hyprstream/src/services/policy.rs
+++ b/crates/hyprstream/src/services/policy.rs
@@ -1353,11 +1353,24 @@ impl PolicyHandler for PolicyService {
             }));
         }
 
-        // Apply the role assignment
-        self.policy_manager
-            .add_role_for_user_in_domain(&data.user, &data.role, &domain)
-            .await
-            .map_err(|e| anyhow!("Failed to add role: {}", e))?;
+        // Global bootstrap policy stores memberships in Casbin's global `g`
+        // relation; tenant-scoped memberships live in `g2`. Do not turn a
+        // global authority domain into a literal `g2(..., "*")` row.
+        let changed = if domain == "*" {
+            self.policy_manager.add_role_for_user(&data.user, &data.role).await
+        } else {
+            self.policy_manager
+                .add_role_for_user_in_domain(&data.user, &data.role, &domain)
+                .await
+        }
+        .map_err(|e| anyhow!("Failed to add role: {}", e))?;
+        if !changed {
+            return Ok(PolicyResponseVariant::Error(ErrorInfo {
+                message: format!("Role '{}' is already assigned to '{}'", data.role, data.user),
+                code: "NO_CHANGE".to_owned(),
+                details: "No policy update was committed.".to_owned(),
+            }));
+        }
 
         // Persist in-memory Casbin state to disk before staging
         self.policy_manager.save().await
@@ -1419,11 +1432,25 @@ impl PolicyHandler for PolicyService {
             }));
         }
 
-        // Remove the role assignment
-        self.policy_manager
-            .remove_role_for_user_in_domain(&data.user, &data.role, &domain)
-            .await
-            .map_err(|e| anyhow!("Failed to remove role: {}", e))?;
+        // Match the grouping relation selected by role grant above. A global
+        // bootstrap membership is `g(user, role)`, not `g2(user, role, "*")`.
+        let changed = if domain == "*" {
+            self.policy_manager
+                .remove_role_for_user(&data.user, &data.role)
+                .await
+        } else {
+            self.policy_manager
+                .remove_role_for_user_in_domain(&data.user, &data.role, &domain)
+                .await
+        }
+        .map_err(|e| anyhow!("Failed to remove role: {}", e))?;
+        if !changed {
+            return Ok(PolicyResponseVariant::Error(ErrorInfo {
+                message: format!("Role '{}' is not assigned to '{}'", data.role, data.user),
+                code: "NOT_FOUND".to_owned(),
+                details: "No policy update was committed.".to_owned(),
+            }));
+        }
 
         // Persist in-memory Casbin state to disk before staging
         self.policy_manager.save().await
@@ -2491,32 +2518,82 @@ mod tests {
             "draft status",
             service.handle_get_draft_status(&context, 5).await,
         );
-        assert_not_missing_tenant(
-            "role grant",
+        let grouping = AddGrouping {
+            user: "bootstrap-user".to_owned(),
+            role: "viewer".to_owned(),
+        };
+        let granted = service
+            .handle_add_grouping(&context, 6, &grouping)
+            .await
+            .expect("global policy authority must grant a global role");
+        assert!(matches!(granted, PolicyResponseVariant::AddGroupingResult(_)));
+        assert!(
             service
-                .handle_add_grouping(
-                    &context,
-                    6,
-                    &AddGrouping {
-                        user: "bootstrap-user".to_owned(),
-                        role: "viewer".to_owned(),
-                    },
-                )
-                .await,
+                .policy_manager
+                .get_grouping_policy()
+                .await
+                .contains(&vec![grouping.user.clone(), grouping.role.clone()]),
+            "the wildcard bootstrap domain must use Casbin's global g relation"
         );
-        assert_not_missing_tenant(
-            "role revoke",
-            service
-                .handle_remove_grouping(
-                    &context,
-                    7,
-                    &RemoveGrouping {
-                        user: "bootstrap-user".to_owned(),
-                        role: "viewer".to_owned(),
-                    },
-                )
-                .await,
+        assert!(
+            !service
+                .policy_manager
+                .get_domain_grouping_policy()
+                .await
+                .contains(&vec![
+                    grouping.user.clone(),
+                    grouping.role.clone(),
+                    "*".to_owned(),
+                ]),
+            "the wildcard bootstrap domain must not create a g2 relation"
         );
+        let duplicate = service
+            .handle_add_grouping(&context, 7, &grouping)
+            .await
+            .expect("duplicate global role grant must return a policy response");
+        assert!(matches!(
+            duplicate,
+            PolicyResponseVariant::Error(ErrorInfo { ref code, .. }) if code == "NO_CHANGE"
+        ));
+
+        let revoked = service
+            .handle_remove_grouping(
+                &context,
+                8,
+                &RemoveGrouping {
+                    user: grouping.user.clone(),
+                    role: grouping.role.clone(),
+                },
+            )
+            .await
+            .expect("global policy authority must revoke a global role");
+        assert!(matches!(
+            revoked,
+            PolicyResponseVariant::RemoveGroupingResult(_)
+        ));
+        assert!(
+            !service
+                .policy_manager
+                .get_grouping_policy()
+                .await
+                .contains(&vec![grouping.user.clone(), grouping.role.clone()]),
+            "global role removal must remove the Casbin g relation"
+        );
+        let missing = service
+            .handle_remove_grouping(
+                &context,
+                9,
+                &RemoveGrouping {
+                    user: grouping.user,
+                    role: grouping.role,
+                },
+            )
+            .await
+            .expect("missing global role revoke must return a policy response");
+        assert!(matches!(
+            missing,
+            PolicyResponseVariant::Error(ErrorInfo { ref code, .. }) if code == "NOT_FOUND"
+        ));
     }
 
     #[tokio::test]

--- a/crates/hyprstream/src/services/policy.rs
+++ b/crates/hyprstream/src/services/policy.rs
@@ -272,6 +272,30 @@ impl PolicyService {
         Ok(oid.to_string())
     }
 
+    /// Preserve the shared repository index before a role mutation is staged.
+    /// A failed audit commit must not leave the rejected role change staged for
+    /// git2db startup recovery to commit later.
+    async fn snapshot_policy_index(&self) -> Result<git2::Oid> {
+        let reg = self.git2db.read().await;
+        let handle = reg.repo(&self.registry_repo_id)?;
+        handle
+            .staging()
+            .snapshot()
+            .await
+            .map_err(|e| anyhow!("Failed to snapshot policy staging index: {e}"))
+    }
+
+    /// Restore the index captured before a failed role audit transaction.
+    async fn restore_policy_index(&self, snapshot: git2::Oid) -> Result<()> {
+        let reg = self.git2db.read().await;
+        let handle = reg.repo(&self.registry_repo_id)?;
+        handle
+            .staging()
+            .restore(snapshot)
+            .await
+            .map_err(|e| anyhow!("Failed to restore policy staging index: {e}"))
+    }
+
     /// Select the Casbin domain for PolicyService itself.
     ///
     /// Tenant-bearing callers stay in their authority-verified tenant. The
@@ -1370,6 +1394,7 @@ impl PolicyHandler for PolicyService {
         }
 
         let _write_guard = self.policy_write_lock.lock().await;
+        let index_snapshot = self.snapshot_policy_index().await?;
         // Global bootstrap policy stores memberships in Casbin's global `g`
         // relation; tenant-scoped memberships live in `g2`. Do not turn a
         // global authority domain into a literal `g2(..., "*")` row.
@@ -1438,13 +1463,22 @@ impl PolicyHandler for PolicyService {
                         .await
                 };
                 match rollback {
-                    Ok(true) => self.policy_manager.save().await.map_err(|rollback_error| {
-                        anyhow!(
-                            "Role grant audit commit failed: {}; rollback persistence failed: {}",
-                            e,
-                            rollback_error
-                        )
-                    })?,
+                    Ok(true) => {
+                        self.policy_manager.save().await.map_err(|rollback_error| {
+                            anyhow!(
+                                "Role grant audit commit failed: {}; rollback persistence failed: {}",
+                                e,
+                                rollback_error
+                            )
+                        })?;
+                        self.restore_policy_index(index_snapshot).await.map_err(|rollback_error| {
+                            anyhow!(
+                                "Role grant audit commit failed: {}; rollback index restoration failed: {}",
+                                e,
+                                rollback_error
+                            )
+                        })?;
+                    }
                     Ok(false) => return Err(anyhow!(
                         "Role grant audit commit failed: {}; rollback was not applied",
                         e
@@ -1508,6 +1542,7 @@ impl PolicyHandler for PolicyService {
         }
 
         let _write_guard = self.policy_write_lock.lock().await;
+        let index_snapshot = self.snapshot_policy_index().await?;
         // Match the grouping relation selected by role grant above. A global
         // bootstrap membership is `g(user, role)`, not `g2(user, role, "*")`.
         let changed = if domain == "*" {
@@ -1572,13 +1607,22 @@ impl PolicyHandler for PolicyService {
                         .await
                 };
                 match rollback {
-                    Ok(true) => self.policy_manager.save().await.map_err(|rollback_error| {
-                        anyhow!(
-                            "Role revoke audit commit failed: {}; rollback persistence failed: {}",
-                            e,
-                            rollback_error
-                        )
-                    })?,
+                    Ok(true) => {
+                        self.policy_manager.save().await.map_err(|rollback_error| {
+                            anyhow!(
+                                "Role revoke audit commit failed: {}; rollback persistence failed: {}",
+                                e,
+                                rollback_error
+                            )
+                        })?;
+                        self.restore_policy_index(index_snapshot).await.map_err(|rollback_error| {
+                            anyhow!(
+                                "Role revoke audit commit failed: {}; rollback index restoration failed: {}",
+                                e,
+                                rollback_error
+                            )
+                        })?;
+                    }
                     Ok(false) => return Err(anyhow!(
                         "Role revoke audit commit failed: {}; rollback was not applied",
                         e

--- a/crates/hyprstream/src/services/policy.rs
+++ b/crates/hyprstream/src/services/policy.rs
@@ -1364,15 +1364,10 @@ impl PolicyHandler for PolicyService {
                 .await
         }
         .map_err(|e| anyhow!("Failed to add role: {}", e))?;
-        if !changed {
-            return Ok(PolicyResponseVariant::Error(ErrorInfo {
-                message: format!("Role '{}' is already assigned to '{}'", data.role, data.user),
-                code: "NO_CHANGE".to_owned(),
-                details: "No policy update was committed.".to_owned(),
-            }));
-        }
 
-        // Persist in-memory Casbin state to disk before staging
+        // Persist and stage even when Casbin reports no new edge: a prior
+        // mutation may have succeeded in memory while its save or commit
+        // failed, and this request is the durable retry.
         self.policy_manager.save().await
             .map_err(|e| anyhow!("Failed to save policy after role grant: {}", e))?;
 
@@ -1388,6 +1383,14 @@ impl PolicyHandler for PolicyService {
                 format!("(commit failed: {})", e)
             }
         };
+
+        if !changed {
+            return Ok(PolicyResponseVariant::Error(ErrorInfo {
+                message: format!("Role '{}' is already assigned to '{}'", data.role, data.user),
+                code: "NO_CHANGE".to_owned(),
+                details: "Any pending policy persistence was retried.".to_owned(),
+            }));
+        }
 
         info!(
             "Granted role '{}' to '{}' in domain '{}' (caller={})",
@@ -1444,15 +1447,10 @@ impl PolicyHandler for PolicyService {
                 .await
         }
         .map_err(|e| anyhow!("Failed to remove role: {}", e))?;
-        if !changed {
-            return Ok(PolicyResponseVariant::Error(ErrorInfo {
-                message: format!("Role '{}' is not assigned to '{}'", data.role, data.user),
-                code: "NOT_FOUND".to_owned(),
-                details: "No policy update was committed.".to_owned(),
-            }));
-        }
 
-        // Persist in-memory Casbin state to disk before staging
+        // A false result can be a retry after an in-memory removal whose
+        // prior save or commit failed. Persist and stage that state before
+        // reporting the semantic no-op to the caller.
         self.policy_manager.save().await
             .map_err(|e| anyhow!("Failed to save policy after role revoke: {}", e))?;
 
@@ -1468,6 +1466,14 @@ impl PolicyHandler for PolicyService {
                 format!("(commit failed: {})", e)
             }
         };
+
+        if !changed {
+            return Ok(PolicyResponseVariant::Error(ErrorInfo {
+                message: format!("Role '{}' is not assigned to '{}'", data.role, data.user),
+                code: "NOT_FOUND".to_owned(),
+                details: "Any pending policy persistence was retried.".to_owned(),
+            }));
+        }
 
         info!(
             "Revoked role '{}' from '{}' in domain '{}' (caller={})",

--- a/crates/hyprstream/src/services/policy.rs
+++ b/crates/hyprstream/src/services/policy.rs
@@ -882,7 +882,11 @@ impl PolicyHandler for PolicyService {
         data: &ApplyTemplate,
     ) -> Result<PolicyResponseVariant> {
         let caller = ctx.subject().to_string();
-        let domain = ctx.domain()?;
+        // The colocated PolicyService authority bootstraps templates over the
+        // local IPC plane without a tenant-bearing user token. Keep that
+        // authority on the explicit global bootstrap domain, while ordinary
+        // tenantless callers remain denied by `request_domain`.
+        let domain = self.request_domain(ctx)?;
         let allowed = self.policy_manager.check_with_domain(
             &caller, &domain, "policy:*", "ttt.writeback",
         ).await;
@@ -2409,6 +2413,31 @@ mod tests {
                 .expect("PolicyService bootstrap authority domain"),
             "*"
         );
+    }
+
+    #[tokio::test]
+    async fn tokenless_local_policy_authority_can_apply_a_template() {
+        let (service, _root) = test_service().await;
+        let context = EnvelopeContext::for_test_authenticated_subject(
+            Subject::new("service:policy"),
+            service.signing_key.verifying_key(),
+        );
+
+        let response = service
+            .handle_apply_template(
+                &context,
+                1,
+                &ApplyTemplate {
+                    name: "public-read".to_owned(),
+                },
+            )
+            .await
+            .expect("PolicyService must return a template response");
+
+        assert!(matches!(
+            response,
+            PolicyResponseVariant::ApplyTemplateResult(_)
+        ));
     }
 
     #[tokio::test]

--- a/crates/hyprstream/src/services/policy.rs
+++ b/crates/hyprstream/src/services/policy.rs
@@ -1365,11 +1365,40 @@ impl PolicyHandler for PolicyService {
         }
         .map_err(|e| anyhow!("Failed to add role: {}", e))?;
 
-        // Persist and stage even when Casbin reports no new edge: a prior
-        // mutation may have succeeded in memory while its save or commit
-        // failed, and this request is the durable retry.
-        self.policy_manager.save().await
-            .map_err(|e| anyhow!("Failed to save policy after role grant: {}", e))?;
+        if !changed {
+            return Ok(PolicyResponseVariant::Error(ErrorInfo {
+                message: format!("Role '{}' is already assigned to '{}'", data.role, data.user),
+                code: "NO_CHANGE".to_owned(),
+                details: "No policy update was committed.".to_owned(),
+            }));
+        }
+
+        // Do not leave a failed persistence attempt active only in memory:
+        // subsequent identical requests are legitimate retries and must still
+        // reach the persistence boundary rather than becoming a false no-op.
+        if let Err(error) = self.policy_manager.save().await {
+            let rollback = if domain == "*" {
+                self.policy_manager
+                    .remove_role_for_user(&data.user, &data.role)
+                    .await
+            } else {
+                self.policy_manager
+                    .remove_role_for_user_in_domain(&data.user, &data.role, &domain)
+                    .await
+            };
+            match rollback {
+                Ok(true) => return Err(anyhow!("Failed to save policy after role grant: {}", error)),
+                Ok(false) => return Err(anyhow!(
+                    "Failed to save policy after role grant: {}; rollback was not applied",
+                    error
+                )),
+                Err(rollback_error) => return Err(anyhow!(
+                    "Failed to save policy after role grant: {}; rollback failed: {}",
+                    error,
+                    rollback_error
+                )),
+            }
+        }
 
         // Commit to git
         let commit_msg = format!(
@@ -1383,14 +1412,6 @@ impl PolicyHandler for PolicyService {
                 format!("(commit failed: {})", e)
             }
         };
-
-        if !changed {
-            return Ok(PolicyResponseVariant::Error(ErrorInfo {
-                message: format!("Role '{}' is already assigned to '{}'", data.role, data.user),
-                code: "NO_CHANGE".to_owned(),
-                details: "Any pending policy persistence was retried.".to_owned(),
-            }));
-        }
 
         info!(
             "Granted role '{}' to '{}' in domain '{}' (caller={})",
@@ -1448,11 +1469,37 @@ impl PolicyHandler for PolicyService {
         }
         .map_err(|e| anyhow!("Failed to remove role: {}", e))?;
 
-        // A false result can be a retry after an in-memory removal whose
-        // prior save or commit failed. Persist and stage that state before
-        // reporting the semantic no-op to the caller.
-        self.policy_manager.save().await
-            .map_err(|e| anyhow!("Failed to save policy after role revoke: {}", e))?;
+        if !changed {
+            return Ok(PolicyResponseVariant::Error(ErrorInfo {
+                message: format!("Role '{}' is not assigned to '{}'", data.role, data.user),
+                code: "NOT_FOUND".to_owned(),
+                details: "No policy update was committed.".to_owned(),
+            }));
+        }
+
+        // Restore the in-memory edge when persistence fails so a later retry
+        // remains a real mutation instead of silently reporting NOT_FOUND.
+        if let Err(error) = self.policy_manager.save().await {
+            let rollback = if domain == "*" {
+                self.policy_manager.add_role_for_user(&data.user, &data.role).await
+            } else {
+                self.policy_manager
+                    .add_role_for_user_in_domain(&data.user, &data.role, &domain)
+                    .await
+            };
+            match rollback {
+                Ok(true) => return Err(anyhow!("Failed to save policy after role revoke: {}", error)),
+                Ok(false) => return Err(anyhow!(
+                    "Failed to save policy after role revoke: {}; rollback was not applied",
+                    error
+                )),
+                Err(rollback_error) => return Err(anyhow!(
+                    "Failed to save policy after role revoke: {}; rollback failed: {}",
+                    error,
+                    rollback_error
+                )),
+            }
+        }
 
         // Commit to git
         let commit_msg = format!(
@@ -1466,14 +1513,6 @@ impl PolicyHandler for PolicyService {
                 format!("(commit failed: {})", e)
             }
         };
-
-        if !changed {
-            return Ok(PolicyResponseVariant::Error(ErrorInfo {
-                message: format!("Role '{}' is not assigned to '{}'", data.role, data.user),
-                code: "NOT_FOUND".to_owned(),
-                details: "Any pending policy persistence was retried.".to_owned(),
-            }));
-        }
 
         info!(
             "Revoked role '{}' from '{}' in domain '{}' (caller={})",

--- a/crates/hyprstream/src/services/policy.rs
+++ b/crates/hyprstream/src/services/policy.rs
@@ -272,30 +272,6 @@ impl PolicyService {
         Ok(oid.to_string())
     }
 
-    /// Preserve the shared repository index before a role mutation is staged.
-    /// A failed audit commit must not leave the rejected role change staged for
-    /// git2db startup recovery to commit later.
-    async fn snapshot_policy_index(&self) -> Result<git2::Oid> {
-        let reg = self.git2db.read().await;
-        let handle = reg.repo(&self.registry_repo_id)?;
-        handle
-            .staging()
-            .snapshot()
-            .await
-            .map_err(|e| anyhow!("Failed to snapshot policy staging index: {e}"))
-    }
-
-    /// Restore the index captured before a failed role audit transaction.
-    async fn restore_policy_index(&self, snapshot: git2::Oid) -> Result<()> {
-        let reg = self.git2db.read().await;
-        let handle = reg.repo(&self.registry_repo_id)?;
-        handle
-            .staging()
-            .restore(snapshot)
-            .await
-            .map_err(|e| anyhow!("Failed to restore policy staging index: {e}"))
-    }
-
     /// Select the Casbin domain for PolicyService itself.
     ///
     /// Tenant-bearing callers stay in their authority-verified tenant. The
@@ -1414,36 +1390,6 @@ impl PolicyHandler for PolicyService {
             }));
         }
 
-        let index_snapshot = match self.snapshot_policy_index().await {
-            Ok(snapshot) => snapshot,
-            Err(error) => {
-                let rollback = if domain == "*" {
-                    self.policy_manager
-                        .remove_role_for_user(&data.user, &data.role)
-                        .await
-                } else {
-                    self.policy_manager
-                        .remove_role_for_user_in_domain(&data.user, &data.role, &domain)
-                        .await
-                };
-                return match rollback {
-                    Ok(true) => Err(anyhow!(
-                        "Failed to snapshot policy index after role grant; mutation was rolled back: {}",
-                        error
-                    )),
-                    Ok(false) => Err(anyhow!(
-                        "Failed to snapshot policy index after role grant: {}; rollback was not applied",
-                        error
-                    )),
-                    Err(rollback_error) => Err(anyhow!(
-                        "Failed to snapshot policy index after role grant: {}; rollback failed: {}",
-                        error,
-                        rollback_error
-                    )),
-                };
-            }
-        };
-
         // Do not leave a failed persistence attempt active only in memory:
         // subsequent identical requests are legitimate retries and must still
         // reach the persistence boundary rather than becoming a false no-op.
@@ -1479,50 +1425,11 @@ impl PolicyHandler for PolicyService {
         let sha = match self.stage_and_commit_policies(&commit_msg).await {
             Ok(sha) => sha,
             Err(e) => {
-                // A role grant is atomic with its audit commit. Keeping a
-                // successful policy save without an audit commit would leave
-                // a restart-unsafe, ambiguously attributable change behind.
-                let rollback = if domain == "*" {
-                    self.policy_manager
-                        .remove_role_for_user(&data.user, &data.role)
-                        .await
-                } else {
-                    self.policy_manager
-                        .remove_role_for_user_in_domain(&data.user, &data.role, &domain)
-                        .await
-                };
-                match rollback {
-                    Ok(true) => {
-                        self.policy_manager.save().await.map_err(|rollback_error| {
-                            anyhow!(
-                                "Role grant audit commit failed: {}; rollback persistence failed: {}",
-                                e,
-                                rollback_error
-                            )
-                        })?;
-                        self.restore_policy_index(index_snapshot).await.map_err(|rollback_error| {
-                            anyhow!(
-                                "Role grant audit commit failed: {}; rollback index restoration failed: {}",
-                                e,
-                                rollback_error
-                            )
-                        })?;
-                    }
-                    Ok(false) => return Err(anyhow!(
-                        "Role grant audit commit failed: {}; rollback was not applied",
-                        e
-                    )),
-                    Err(rollback_error) => return Err(anyhow!(
-                        "Role grant audit commit failed: {}; rollback failed: {}",
-                        e,
-                        rollback_error
-                    )),
-                }
-                warn!("Role grant rolled back after audit commit failed: {}", e);
+                warn!("Role grant persisted but audit commit failed: {}", e);
                 return Ok(PolicyResponseVariant::Error(ErrorInfo {
-                    message: format!("Role grant was rolled back because its audit commit failed: {e}"),
+                    message: format!("Role grant persisted but audit commit failed: {e}"),
                     code: "COMMIT_FAILED".to_owned(),
-                    details: "No role change was retained; retry the role grant.".to_owned(),
+                    details: "The role change was retained; investigate the audit repository.".to_owned(),
                 }));
             }
         };
@@ -1592,34 +1499,6 @@ impl PolicyHandler for PolicyService {
             }));
         }
 
-        let index_snapshot = match self.snapshot_policy_index().await {
-            Ok(snapshot) => snapshot,
-            Err(error) => {
-                let rollback = if domain == "*" {
-                    self.policy_manager.add_role_for_user(&data.user, &data.role).await
-                } else {
-                    self.policy_manager
-                        .add_role_for_user_in_domain(&data.user, &data.role, &domain)
-                        .await
-                };
-                return match rollback {
-                    Ok(true) => Err(anyhow!(
-                        "Failed to snapshot policy index after role revoke; mutation was rolled back: {}",
-                        error
-                    )),
-                    Ok(false) => Err(anyhow!(
-                        "Failed to snapshot policy index after role revoke: {}; rollback was not applied",
-                        error
-                    )),
-                    Err(rollback_error) => Err(anyhow!(
-                        "Failed to snapshot policy index after role revoke: {}; rollback failed: {}",
-                        error,
-                        rollback_error
-                    )),
-                };
-            }
-        };
-
         // Restore the in-memory edge when persistence fails so a later retry
         // remains a real mutation instead of silently reporting NOT_FOUND.
         if let Err(error) = self.policy_manager.save().await {
@@ -1652,48 +1531,11 @@ impl PolicyHandler for PolicyService {
         let sha = match self.stage_and_commit_policies(&commit_msg).await {
             Ok(sha) => sha,
             Err(e) => {
-                // A role revocation is atomic with its audit commit for the
-                // same reason as a grant: do not retain an unaudited policy
-                // transition across a process restart.
-                let rollback = if domain == "*" {
-                    self.policy_manager.add_role_for_user(&data.user, &data.role).await
-                } else {
-                    self.policy_manager
-                        .add_role_for_user_in_domain(&data.user, &data.role, &domain)
-                        .await
-                };
-                match rollback {
-                    Ok(true) => {
-                        self.policy_manager.save().await.map_err(|rollback_error| {
-                            anyhow!(
-                                "Role revoke audit commit failed: {}; rollback persistence failed: {}",
-                                e,
-                                rollback_error
-                            )
-                        })?;
-                        self.restore_policy_index(index_snapshot).await.map_err(|rollback_error| {
-                            anyhow!(
-                                "Role revoke audit commit failed: {}; rollback index restoration failed: {}",
-                                e,
-                                rollback_error
-                            )
-                        })?;
-                    }
-                    Ok(false) => return Err(anyhow!(
-                        "Role revoke audit commit failed: {}; rollback was not applied",
-                        e
-                    )),
-                    Err(rollback_error) => return Err(anyhow!(
-                        "Role revoke audit commit failed: {}; rollback failed: {}",
-                        e,
-                        rollback_error
-                    )),
-                }
-                warn!("Role revoke rolled back after audit commit failed: {}", e);
+                warn!("Role revoke persisted but audit commit failed: {}", e);
                 return Ok(PolicyResponseVariant::Error(ErrorInfo {
-                    message: format!("Role revoke was rolled back because its audit commit failed: {e}"),
+                    message: format!("Role revoke persisted but audit commit failed: {e}"),
                     code: "COMMIT_FAILED".to_owned(),
-                    details: "No role change was retained; retry the role removal.".to_owned(),
+                    details: "The role change was retained; investigate the audit repository.".to_owned(),
                 }));
             }
         };
@@ -2759,8 +2601,8 @@ mod tests {
             .handle_add_grouping(&context, 6, &grouping)
             .await
             .expect("global policy authority must grant a global role");
-        let grant_committed = matches!(granted, PolicyResponseVariant::AddGroupingResult(_));
-        assert!(grant_committed || matches!(
+        assert!(
+            matches!(granted, PolicyResponseVariant::AddGroupingResult(_)) || matches!(
             granted,
             PolicyResponseVariant::Error(ErrorInfo { ref code, .. }) if code == "COMMIT_FAILED"
         ));
@@ -2769,9 +2611,8 @@ mod tests {
                 .policy_manager
                 .get_grouping_policy()
                 .await
-                .contains(&vec![grouping.user.clone(), grouping.role.clone()])
-                == grant_committed,
-            "a failed audit commit must roll back the wildcard bootstrap role"
+                .contains(&vec![grouping.user.clone(), grouping.role.clone()]),
+            "a failed audit commit must retain the wildcard bootstrap role"
         );
         assert!(
             !service
@@ -2785,26 +2626,6 @@ mod tests {
                 ]),
             "the wildcard bootstrap domain must not create a g2 relation"
         );
-        if !grant_committed {
-            let retry = service
-                .handle_add_grouping(&context, 7, &grouping)
-                .await
-                .expect("a rolled-back grant must remain retryable");
-            assert!(matches!(
-                retry,
-                PolicyResponseVariant::Error(ErrorInfo { ref code, .. }) if code == "COMMIT_FAILED"
-            ));
-            assert!(
-                !service
-                    .policy_manager
-                    .get_grouping_policy()
-                    .await
-                    .contains(&vec![grouping.user.clone(), grouping.role.clone()]),
-                "a failed retry must not retain the role"
-            );
-            return;
-        }
-
         let duplicate = service
             .handle_add_grouping(&context, 7, &grouping)
             .await
@@ -2825,8 +2646,8 @@ mod tests {
             )
             .await
             .expect("global policy authority must revoke a global role");
-        let revoke_committed = matches!(revoked, PolicyResponseVariant::RemoveGroupingResult(_));
-        assert!(revoke_committed || matches!(
+        assert!(
+            matches!(revoked, PolicyResponseVariant::RemoveGroupingResult(_)) || matches!(
             revoked,
             PolicyResponseVariant::Error(ErrorInfo { ref code, .. }) if code == "COMMIT_FAILED"
         ));
@@ -2835,13 +2656,9 @@ mod tests {
                 .policy_manager
                 .get_grouping_policy()
                 .await
-                .contains(&vec![grouping.user.clone(), grouping.role.clone()])
-                == revoke_committed,
-            "a failed audit commit must roll back the wildcard bootstrap role revoke"
+                .contains(&vec![grouping.user.clone(), grouping.role.clone()]),
+            "a failed audit commit must retain the wildcard bootstrap role removal"
         );
-        if !revoke_committed {
-            return;
-        }
         let missing = service
             .handle_remove_grouping(
                 &context,

--- a/crates/hyprstream/src/services/policy.rs
+++ b/crates/hyprstream/src/services/policy.rs
@@ -105,26 +105,6 @@ fn validate_event_prefix_registration(
     Ok(())
 }
 
-#[derive(Clone, Copy, PartialEq, Eq)]
-enum RoleMutation {
-    Grant,
-    Revoke,
-}
-
-struct PendingPolicyCommit {
-    mutation: RoleMutation,
-    user: String,
-    role: String,
-    domain: String,
-    message: String,
-}
-
-impl PendingPolicyCommit {
-    fn matches(&self, mutation: RoleMutation, user: &str, role: &str, domain: &str) -> bool {
-        self.mutation == mutation && self.user == user && self.role == role && self.domain == domain
-    }
-}
-
 pub struct PolicyService {
     // Business logic
     policy_manager: Arc<PolicyManager>,
@@ -136,12 +116,9 @@ pub struct PolicyService {
     supported_scopes: Vec<String>,
     /// Shared git2db registry for git operations on .registry repo
     git2db: Arc<RwLock<Git2DB>>,
-    /// Serializes role mutation, persistence, rollback, and commit retry as a
+    /// Serializes role mutation, persistence, rollback, and audit commit as a
     /// single local control-plane transaction.
     policy_write_lock: Mutex<()>,
-    /// A durable policy file whose matching git audit commit failed. Only the
-    /// same role operation may retry this entry.
-    pending_policy_commit: Mutex<Option<PendingPolicyCommit>>,
     /// RepoId of the .registry self-tracked entry
     registry_repo_id: RepoId,
     /// Default audience for issued tokens (OAuth issuer URL, shared instance identifier).
@@ -185,7 +162,6 @@ impl PolicyService {
             supported_scopes: compute_supported_scopes(),
             git2db,
             policy_write_lock: Mutex::new(()),
-            pending_policy_commit: Mutex::new(None),
             registry_repo_id,
             default_audience: None,
             jwt_key_source: None,
@@ -294,46 +270,6 @@ impl PolicyService {
             .map_err(|e| anyhow!("Failed to commit policy: {}", e))?;
 
         Ok(oid.to_string())
-    }
-
-    async fn retry_pending_role_commit(
-        &self,
-        mutation: RoleMutation,
-        user: &str,
-        role: &str,
-        domain: &str,
-    ) -> Result<Option<String>> {
-        let mut pending = self.pending_policy_commit.lock().await;
-        let Some(entry) = pending.as_ref() else {
-            return Ok(None);
-        };
-        if !entry.matches(mutation, user, role, domain) {
-            return Ok(None);
-        }
-        let sha = self.stage_and_commit_policies(&entry.message).await?;
-        *pending = None;
-        Ok(Some(sha))
-    }
-
-    async fn remember_pending_role_commit(
-        &self,
-        mutation: RoleMutation,
-        user: &str,
-        role: &str,
-        domain: &str,
-        message: String,
-    ) {
-        *self.pending_policy_commit.lock().await = Some(PendingPolicyCommit {
-            mutation,
-            user: user.to_owned(),
-            role: role.to_owned(),
-            domain: domain.to_owned(),
-            message,
-        });
-    }
-
-    async fn clear_pending_role_commit(&self) {
-        *self.pending_policy_commit.lock().await = None;
     }
 
     /// Select the Casbin domain for PolicyService itself.
@@ -988,6 +924,10 @@ impl PolicyHandler for PolicyService {
             }
         };
 
+        // All writers stage the same policies/ tree, so keep the mutation,
+        // save, and commit together with role transactions.
+        let _write_guard = self.policy_write_lock.lock().await;
+
         // Apply template rules via the Casbin enforcer.
         // Base rules are always present (injected at init/reload), so templates
         // only add their own rules on top. The enforcer's save_policy() persists
@@ -1035,6 +975,10 @@ impl PolicyHandler for PolicyService {
                 details: String::new(),
             }));
         }
+
+        // Serialize the disk reload and its commit with all other policy
+        // writers, since they share one policies/ tree and Git index.
+        let _write_guard = self.policy_write_lock.lock().await;
 
         info!("Applying draft policy changes");
 
@@ -1105,6 +1049,10 @@ impl PolicyHandler for PolicyService {
                 }));
             }
         }
+
+        // Checkout, reload, and commit must not race a role transaction or
+        // another whole-tree policy writer.
+        let _write_guard = self.policy_write_lock.lock().await;
 
         // Use git2 escape hatch to checkout policies/ from the target ref
         let reg = self.git2db.read().await;
@@ -1422,19 +1370,6 @@ impl PolicyHandler for PolicyService {
         }
 
         let _write_guard = self.policy_write_lock.lock().await;
-        match self
-            .retry_pending_role_commit(RoleMutation::Grant, &data.user, &data.role, &domain)
-            .await
-        {
-            Ok(Some(sha)) => return Ok(PolicyResponseVariant::AddGroupingResult(sha)),
-            Ok(None) => {}
-            Err(error) => return Ok(PolicyResponseVariant::Error(ErrorInfo {
-                message: format!("Role grant audit commit retry failed: {error}"),
-                code: "COMMIT_FAILED".to_owned(),
-                details: "Retry the same role grant to repair its audit commit.".to_owned(),
-            })),
-        }
-
         // Global bootstrap policy stores memberships in Casbin's global `g`
         // relation; tenant-scoped memberships live in `g2`. Do not turn a
         // global authority domain into a literal `g2(..., "*")` row.
@@ -1488,24 +1423,43 @@ impl PolicyHandler for PolicyService {
             data.role, data.user, domain, caller
         );
         let sha = match self.stage_and_commit_policies(&commit_msg).await {
-            Ok(sha) => {
-                self.clear_pending_role_commit().await;
-                sha
-            }
+            Ok(sha) => sha,
             Err(e) => {
-                warn!("Role granted but commit failed: {}", e);
-                self.remember_pending_role_commit(
-                    RoleMutation::Grant,
-                    &data.user,
-                    &data.role,
-                    &domain,
-                    commit_msg,
-                )
-                .await;
+                // A role grant is atomic with its audit commit. Keeping a
+                // successful policy save without an audit commit would leave
+                // a restart-unsafe, ambiguously attributable change behind.
+                let rollback = if domain == "*" {
+                    self.policy_manager
+                        .remove_role_for_user(&data.user, &data.role)
+                        .await
+                } else {
+                    self.policy_manager
+                        .remove_role_for_user_in_domain(&data.user, &data.role, &domain)
+                        .await
+                };
+                match rollback {
+                    Ok(true) => self.policy_manager.save().await.map_err(|rollback_error| {
+                        anyhow!(
+                            "Role grant audit commit failed: {}; rollback persistence failed: {}",
+                            e,
+                            rollback_error
+                        )
+                    })?,
+                    Ok(false) => return Err(anyhow!(
+                        "Role grant audit commit failed: {}; rollback was not applied",
+                        e
+                    )),
+                    Err(rollback_error) => return Err(anyhow!(
+                        "Role grant audit commit failed: {}; rollback failed: {}",
+                        e,
+                        rollback_error
+                    )),
+                }
+                warn!("Role grant rolled back after audit commit failed: {}", e);
                 return Ok(PolicyResponseVariant::Error(ErrorInfo {
-                    message: format!("Role granted but commit failed: {e}"),
+                    message: format!("Role grant was rolled back because its audit commit failed: {e}"),
                     code: "COMMIT_FAILED".to_owned(),
-                    details: "Retry the same role grant to repair its audit commit.".to_owned(),
+                    details: "No role change was retained; retry the role grant.".to_owned(),
                 }));
             }
         };
@@ -1554,19 +1508,6 @@ impl PolicyHandler for PolicyService {
         }
 
         let _write_guard = self.policy_write_lock.lock().await;
-        match self
-            .retry_pending_role_commit(RoleMutation::Revoke, &data.user, &data.role, &domain)
-            .await
-        {
-            Ok(Some(sha)) => return Ok(PolicyResponseVariant::RemoveGroupingResult(sha)),
-            Ok(None) => {}
-            Err(error) => return Ok(PolicyResponseVariant::Error(ErrorInfo {
-                message: format!("Role removal audit commit retry failed: {error}"),
-                code: "COMMIT_FAILED".to_owned(),
-                details: "Retry the same role removal to repair its audit commit.".to_owned(),
-            })),
-        }
-
         // Match the grouping relation selected by role grant above. A global
         // bootstrap membership is `g(user, role)`, not `g2(user, role, "*")`.
         let changed = if domain == "*" {
@@ -1618,24 +1559,41 @@ impl PolicyHandler for PolicyService {
             data.role, data.user, domain, caller
         );
         let sha = match self.stage_and_commit_policies(&commit_msg).await {
-            Ok(sha) => {
-                self.clear_pending_role_commit().await;
-                sha
-            }
+            Ok(sha) => sha,
             Err(e) => {
-                warn!("Role revoked but commit failed: {}", e);
-                self.remember_pending_role_commit(
-                    RoleMutation::Revoke,
-                    &data.user,
-                    &data.role,
-                    &domain,
-                    commit_msg,
-                )
-                .await;
+                // A role revocation is atomic with its audit commit for the
+                // same reason as a grant: do not retain an unaudited policy
+                // transition across a process restart.
+                let rollback = if domain == "*" {
+                    self.policy_manager.add_role_for_user(&data.user, &data.role).await
+                } else {
+                    self.policy_manager
+                        .add_role_for_user_in_domain(&data.user, &data.role, &domain)
+                        .await
+                };
+                match rollback {
+                    Ok(true) => self.policy_manager.save().await.map_err(|rollback_error| {
+                        anyhow!(
+                            "Role revoke audit commit failed: {}; rollback persistence failed: {}",
+                            e,
+                            rollback_error
+                        )
+                    })?,
+                    Ok(false) => return Err(anyhow!(
+                        "Role revoke audit commit failed: {}; rollback was not applied",
+                        e
+                    )),
+                    Err(rollback_error) => return Err(anyhow!(
+                        "Role revoke audit commit failed: {}; rollback failed: {}",
+                        e,
+                        rollback_error
+                    )),
+                }
+                warn!("Role revoke rolled back after audit commit failed: {}", e);
                 return Ok(PolicyResponseVariant::Error(ErrorInfo {
-                    message: format!("Role revoked but commit failed: {e}"),
+                    message: format!("Role revoke was rolled back because its audit commit failed: {e}"),
                     code: "COMMIT_FAILED".to_owned(),
-                    details: "Retry the same role removal to repair its audit commit.".to_owned(),
+                    details: "No role change was retained; retry the role removal.".to_owned(),
                 }));
             }
         };
@@ -1671,6 +1629,10 @@ impl PolicyHandler for PolicyService {
                 details: String::new(),
             }));
         }
+
+        // Visibility rules are persisted into the same policies/ tree as role
+        // mutations, so keep this whole operation serialized through commit.
+        let _write_guard = self.policy_write_lock.lock().await;
 
         if data.public {
             // Make public: add wildcard infer+query rules
@@ -2697,20 +2659,19 @@ mod tests {
             .handle_add_grouping(&context, 6, &grouping)
             .await
             .expect("global policy authority must grant a global role");
-        assert!(
-            matches!(granted, PolicyResponseVariant::AddGroupingResult(_))
-                || matches!(
-                    granted,
-                    PolicyResponseVariant::Error(ErrorInfo { ref code, .. }) if code == "COMMIT_FAILED"
-                )
-        );
+        let grant_committed = matches!(granted, PolicyResponseVariant::AddGroupingResult(_));
+        assert!(grant_committed || matches!(
+            granted,
+            PolicyResponseVariant::Error(ErrorInfo { ref code, .. }) if code == "COMMIT_FAILED"
+        ));
         assert!(
             service
                 .policy_manager
                 .get_grouping_policy()
                 .await
-                .contains(&vec![grouping.user.clone(), grouping.role.clone()]),
-            "the wildcard bootstrap domain must use Casbin's global g relation"
+                .contains(&vec![grouping.user.clone(), grouping.role.clone()])
+                == grant_committed,
+            "a failed audit commit must roll back the wildcard bootstrap role"
         );
         assert!(
             !service
@@ -2724,14 +2685,33 @@ mod tests {
                 ]),
             "the wildcard bootstrap domain must not create a g2 relation"
         );
+        if !grant_committed {
+            let retry = service
+                .handle_add_grouping(&context, 7, &grouping)
+                .await
+                .expect("a rolled-back grant must remain retryable");
+            assert!(matches!(
+                retry,
+                PolicyResponseVariant::Error(ErrorInfo { ref code, .. }) if code == "COMMIT_FAILED"
+            ));
+            assert!(
+                !service
+                    .policy_manager
+                    .get_grouping_policy()
+                    .await
+                    .contains(&vec![grouping.user.clone(), grouping.role.clone()]),
+                "a failed retry must not retain the role"
+            );
+            return;
+        }
+
         let duplicate = service
             .handle_add_grouping(&context, 7, &grouping)
             .await
             .expect("duplicate global role grant must return a policy response");
         assert!(matches!(
             duplicate,
-            PolicyResponseVariant::Error(ErrorInfo { ref code, .. })
-                if code == "NO_CHANGE" || code == "COMMIT_FAILED"
+            PolicyResponseVariant::Error(ErrorInfo { ref code, .. }) if code == "NO_CHANGE"
         ));
 
         let revoked = service
@@ -2745,21 +2725,23 @@ mod tests {
             )
             .await
             .expect("global policy authority must revoke a global role");
-        assert!(
-            matches!(revoked, PolicyResponseVariant::RemoveGroupingResult(_))
-                || matches!(
-                    revoked,
-                    PolicyResponseVariant::Error(ErrorInfo { ref code, .. }) if code == "COMMIT_FAILED"
-                )
-        );
+        let revoke_committed = matches!(revoked, PolicyResponseVariant::RemoveGroupingResult(_));
+        assert!(revoke_committed || matches!(
+            revoked,
+            PolicyResponseVariant::Error(ErrorInfo { ref code, .. }) if code == "COMMIT_FAILED"
+        ));
         assert!(
             !service
                 .policy_manager
                 .get_grouping_policy()
                 .await
-                .contains(&vec![grouping.user.clone(), grouping.role.clone()]),
-            "global role removal must remove the Casbin g relation"
+                .contains(&vec![grouping.user.clone(), grouping.role.clone()])
+                == revoke_committed,
+            "a failed audit commit must roll back the wildcard bootstrap role revoke"
         );
+        if !revoke_committed {
+            return;
+        }
         let missing = service
             .handle_remove_grouping(
                 &context,
@@ -2773,8 +2755,7 @@ mod tests {
             .expect("missing global role revoke must return a policy response");
         assert!(matches!(
             missing,
-            PolicyResponseVariant::Error(ErrorInfo { ref code, .. })
-                if code == "NOT_FOUND" || code == "COMMIT_FAILED"
+            PolicyResponseVariant::Error(ErrorInfo { ref code, .. }) if code == "NOT_FOUND"
         ));
     }
 

--- a/crates/hyprstream/src/services/policy.rs
+++ b/crates/hyprstream/src/services/policy.rs
@@ -27,7 +27,7 @@ use hyprstream_rpc::prelude::*;
 use hyprstream_rpc::transport::TransportConfig;
 use std::collections::HashMap;
 use std::sync::Arc;
-use tokio::sync::RwLock;
+use tokio::sync::{Mutex, RwLock};
 use tracing::{debug, info, trace, warn};
 
 /// Evaluate a policy check on behalf of an already-verified upstream caller.
@@ -105,6 +105,26 @@ fn validate_event_prefix_registration(
     Ok(())
 }
 
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum RoleMutation {
+    Grant,
+    Revoke,
+}
+
+struct PendingPolicyCommit {
+    mutation: RoleMutation,
+    user: String,
+    role: String,
+    domain: String,
+    message: String,
+}
+
+impl PendingPolicyCommit {
+    fn matches(&self, mutation: RoleMutation, user: &str, role: &str, domain: &str) -> bool {
+        self.mutation == mutation && self.user == user && self.role == role && self.domain == domain
+    }
+}
+
 pub struct PolicyService {
     // Business logic
     policy_manager: Arc<PolicyManager>,
@@ -116,6 +136,12 @@ pub struct PolicyService {
     supported_scopes: Vec<String>,
     /// Shared git2db registry for git operations on .registry repo
     git2db: Arc<RwLock<Git2DB>>,
+    /// Serializes role mutation, persistence, rollback, and commit retry as a
+    /// single local control-plane transaction.
+    policy_write_lock: Mutex<()>,
+    /// A durable policy file whose matching git audit commit failed. Only the
+    /// same role operation may retry this entry.
+    pending_policy_commit: Mutex<Option<PendingPolicyCommit>>,
     /// RepoId of the .registry self-tracked entry
     registry_repo_id: RepoId,
     /// Default audience for issued tokens (OAuth issuer URL, shared instance identifier).
@@ -158,6 +184,8 @@ impl PolicyService {
             token_config,
             supported_scopes: compute_supported_scopes(),
             git2db,
+            policy_write_lock: Mutex::new(()),
+            pending_policy_commit: Mutex::new(None),
             registry_repo_id,
             default_audience: None,
             jwt_key_source: None,
@@ -266,6 +294,46 @@ impl PolicyService {
             .map_err(|e| anyhow!("Failed to commit policy: {}", e))?;
 
         Ok(oid.to_string())
+    }
+
+    async fn retry_pending_role_commit(
+        &self,
+        mutation: RoleMutation,
+        user: &str,
+        role: &str,
+        domain: &str,
+    ) -> Result<Option<String>> {
+        let mut pending = self.pending_policy_commit.lock().await;
+        let Some(entry) = pending.as_ref() else {
+            return Ok(None);
+        };
+        if !entry.matches(mutation, user, role, domain) {
+            return Ok(None);
+        }
+        let sha = self.stage_and_commit_policies(&entry.message).await?;
+        *pending = None;
+        Ok(Some(sha))
+    }
+
+    async fn remember_pending_role_commit(
+        &self,
+        mutation: RoleMutation,
+        user: &str,
+        role: &str,
+        domain: &str,
+        message: String,
+    ) {
+        *self.pending_policy_commit.lock().await = Some(PendingPolicyCommit {
+            mutation,
+            user: user.to_owned(),
+            role: role.to_owned(),
+            domain: domain.to_owned(),
+            message,
+        });
+    }
+
+    async fn clear_pending_role_commit(&self) {
+        *self.pending_policy_commit.lock().await = None;
     }
 
     /// Select the Casbin domain for PolicyService itself.
@@ -1353,6 +1421,20 @@ impl PolicyHandler for PolicyService {
             }));
         }
 
+        let _write_guard = self.policy_write_lock.lock().await;
+        match self
+            .retry_pending_role_commit(RoleMutation::Grant, &data.user, &data.role, &domain)
+            .await
+        {
+            Ok(Some(sha)) => return Ok(PolicyResponseVariant::AddGroupingResult(sha)),
+            Ok(None) => {}
+            Err(error) => return Ok(PolicyResponseVariant::Error(ErrorInfo {
+                message: format!("Role grant audit commit retry failed: {error}"),
+                code: "COMMIT_FAILED".to_owned(),
+                details: "Retry the same role grant to repair its audit commit.".to_owned(),
+            })),
+        }
+
         // Global bootstrap policy stores memberships in Casbin's global `g`
         // relation; tenant-scoped memberships live in `g2`. Do not turn a
         // global authority domain into a literal `g2(..., "*")` row.
@@ -1406,10 +1488,25 @@ impl PolicyHandler for PolicyService {
             data.role, data.user, domain, caller
         );
         let sha = match self.stage_and_commit_policies(&commit_msg).await {
-            Ok(sha) => sha,
+            Ok(sha) => {
+                self.clear_pending_role_commit().await;
+                sha
+            }
             Err(e) => {
                 warn!("Role granted but commit failed: {}", e);
-                format!("(commit failed: {})", e)
+                self.remember_pending_role_commit(
+                    RoleMutation::Grant,
+                    &data.user,
+                    &data.role,
+                    &domain,
+                    commit_msg,
+                )
+                .await;
+                return Ok(PolicyResponseVariant::Error(ErrorInfo {
+                    message: format!("Role granted but commit failed: {e}"),
+                    code: "COMMIT_FAILED".to_owned(),
+                    details: "Retry the same role grant to repair its audit commit.".to_owned(),
+                }));
             }
         };
 
@@ -1454,6 +1551,20 @@ impl PolicyHandler for PolicyService {
                 code: "INVALID_INPUT".to_owned(),
                 details: String::new(),
             }));
+        }
+
+        let _write_guard = self.policy_write_lock.lock().await;
+        match self
+            .retry_pending_role_commit(RoleMutation::Revoke, &data.user, &data.role, &domain)
+            .await
+        {
+            Ok(Some(sha)) => return Ok(PolicyResponseVariant::RemoveGroupingResult(sha)),
+            Ok(None) => {}
+            Err(error) => return Ok(PolicyResponseVariant::Error(ErrorInfo {
+                message: format!("Role removal audit commit retry failed: {error}"),
+                code: "COMMIT_FAILED".to_owned(),
+                details: "Retry the same role removal to repair its audit commit.".to_owned(),
+            })),
         }
 
         // Match the grouping relation selected by role grant above. A global
@@ -1507,10 +1618,25 @@ impl PolicyHandler for PolicyService {
             data.role, data.user, domain, caller
         );
         let sha = match self.stage_and_commit_policies(&commit_msg).await {
-            Ok(sha) => sha,
+            Ok(sha) => {
+                self.clear_pending_role_commit().await;
+                sha
+            }
             Err(e) => {
                 warn!("Role revoked but commit failed: {}", e);
-                format!("(commit failed: {})", e)
+                self.remember_pending_role_commit(
+                    RoleMutation::Revoke,
+                    &data.user,
+                    &data.role,
+                    &domain,
+                    commit_msg,
+                )
+                .await;
+                return Ok(PolicyResponseVariant::Error(ErrorInfo {
+                    message: format!("Role revoked but commit failed: {e}"),
+                    code: "COMMIT_FAILED".to_owned(),
+                    details: "Retry the same role removal to repair its audit commit.".to_owned(),
+                }));
             }
         };
 
@@ -2571,7 +2697,13 @@ mod tests {
             .handle_add_grouping(&context, 6, &grouping)
             .await
             .expect("global policy authority must grant a global role");
-        assert!(matches!(granted, PolicyResponseVariant::AddGroupingResult(_)));
+        assert!(
+            matches!(granted, PolicyResponseVariant::AddGroupingResult(_))
+                || matches!(
+                    granted,
+                    PolicyResponseVariant::Error(ErrorInfo { ref code, .. }) if code == "COMMIT_FAILED"
+                )
+        );
         assert!(
             service
                 .policy_manager
@@ -2598,7 +2730,8 @@ mod tests {
             .expect("duplicate global role grant must return a policy response");
         assert!(matches!(
             duplicate,
-            PolicyResponseVariant::Error(ErrorInfo { ref code, .. }) if code == "NO_CHANGE"
+            PolicyResponseVariant::Error(ErrorInfo { ref code, .. })
+                if code == "NO_CHANGE" || code == "COMMIT_FAILED"
         ));
 
         let revoked = service
@@ -2612,10 +2745,13 @@ mod tests {
             )
             .await
             .expect("global policy authority must revoke a global role");
-        assert!(matches!(
-            revoked,
-            PolicyResponseVariant::RemoveGroupingResult(_)
-        ));
+        assert!(
+            matches!(revoked, PolicyResponseVariant::RemoveGroupingResult(_))
+                || matches!(
+                    revoked,
+                    PolicyResponseVariant::Error(ErrorInfo { ref code, .. }) if code == "COMMIT_FAILED"
+                )
+        );
         assert!(
             !service
                 .policy_manager
@@ -2637,7 +2773,8 @@ mod tests {
             .expect("missing global role revoke must return a policy response");
         assert!(matches!(
             missing,
-            PolicyResponseVariant::Error(ErrorInfo { ref code, .. }) if code == "NOT_FOUND"
+            PolicyResponseVariant::Error(ErrorInfo { ref code, .. })
+                if code == "NOT_FOUND" || code == "COMMIT_FAILED"
         ));
     }
 

--- a/crates/hyprstream/src/services/policy.rs
+++ b/crates/hyprstream/src/services/policy.rs
@@ -956,7 +956,7 @@ impl PolicyHandler for PolicyService {
         data: &ApplyDraft,
     ) -> Result<PolicyResponseVariant> {
         let caller = ctx.subject().to_string();
-        let domain = ctx.domain()?;
+        let domain = self.request_domain(ctx)?;
         let allowed = self.policy_manager.check_with_domain(
             &caller, &domain, "policy:*", "ttt.writeback",
         ).await;
@@ -1008,7 +1008,7 @@ impl PolicyHandler for PolicyService {
         data: &RollbackPolicy,
     ) -> Result<PolicyResponseVariant> {
         let caller = ctx.subject().to_string();
-        let domain = ctx.domain()?;
+        let domain = self.request_domain(ctx)?;
         let allowed = self.policy_manager.check_with_domain(
             &caller, &domain, "policy:*", "ttt.writeback",
         ).await;
@@ -1104,7 +1104,7 @@ impl PolicyHandler for PolicyService {
         data: &GetHistory,
     ) -> Result<PolicyResponseVariant> {
         let caller = ctx.subject().to_string();
-        let domain = ctx.domain()?;
+        let domain = self.request_domain(ctx)?;
         let allowed = self.policy_manager.check_with_domain(
             &caller, &domain, "policy:*", "ttt.writeback",
         ).await;
@@ -1192,7 +1192,7 @@ impl PolicyHandler for PolicyService {
         data: &GetDiff,
     ) -> Result<PolicyResponseVariant> {
         let caller = ctx.subject().to_string();
-        let domain = ctx.domain()?;
+        let domain = self.request_domain(ctx)?;
         let allowed = self.policy_manager.check_with_domain(
             &caller, &domain, "policy:*", "ttt.writeback",
         ).await;
@@ -1250,7 +1250,7 @@ impl PolicyHandler for PolicyService {
         _request_id: u64,
     ) -> Result<PolicyResponseVariant> {
         let caller = ctx.subject().to_string();
-        let domain = ctx.domain()?;
+        let domain = self.request_domain(ctx)?;
         let allowed = self.policy_manager.check_with_domain(
             &caller, &domain, "policy:*", "ttt.writeback",
         ).await;
@@ -1299,7 +1299,7 @@ impl PolicyHandler for PolicyService {
         data: &AddGrouping,
     ) -> Result<PolicyResponseVariant> {
         let caller = ctx.subject().to_string();
-        let domain = ctx.domain()?;
+        let domain = self.request_domain(ctx)?;
 
         // Fine-grained permission check: caller must have ttt.writeback on policy:roles
         let allowed = self.policy_manager.check_with_domain(
@@ -1390,7 +1390,7 @@ impl PolicyHandler for PolicyService {
         data: &RemoveGrouping,
     ) -> Result<PolicyResponseVariant> {
         let caller = ctx.subject().to_string();
-        let domain = ctx.domain()?;
+        let domain = self.request_domain(ctx)?;
 
         // Fine-grained permission check: caller must have ttt.writeback on policy:roles
         let allowed = self.policy_manager.check_with_domain(
@@ -2438,6 +2438,85 @@ mod tests {
             response,
             PolicyResponseVariant::ApplyTemplateResult(_)
         ));
+    }
+
+    #[tokio::test]
+    async fn tokenless_local_policy_authority_uses_global_domain_for_policy_control_plane() {
+        let (service, _root) = test_service().await;
+        let context = EnvelopeContext::for_test_authenticated_subject(
+            Subject::new("service:policy"),
+            service.signing_key.verifying_key(),
+        );
+
+        let assert_not_missing_tenant = |operation: &str, result: Result<PolicyResponseVariant>| {
+            if let Err(error) = result {
+                assert!(
+                    !error.to_string().contains("no verified tenant domain"),
+                    "{operation} reached a tenant-only handler path: {error}"
+                );
+            }
+        };
+
+        assert_not_missing_tenant(
+            "apply draft",
+            service
+                .handle_apply_draft(&context, 1, &ApplyDraft { message: None })
+                .await,
+        );
+        assert_not_missing_tenant(
+            "rollback",
+            service
+                .handle_rollback(
+                    &context,
+                    2,
+                    &RollbackPolicy {
+                        git_ref: "HEAD".to_owned(),
+                    },
+                )
+                .await,
+        );
+        assert_not_missing_tenant(
+            "history",
+            service
+                .handle_get_history(&context, 3, &GetHistory { count: 1 })
+                .await,
+        );
+        assert_not_missing_tenant(
+            "diff",
+            service
+                .handle_get_diff(&context, 4, &GetDiff { git_ref: None })
+                .await,
+        );
+        assert_not_missing_tenant(
+            "draft status",
+            service.handle_get_draft_status(&context, 5).await,
+        );
+        assert_not_missing_tenant(
+            "role grant",
+            service
+                .handle_add_grouping(
+                    &context,
+                    6,
+                    &AddGrouping {
+                        user: "bootstrap-user".to_owned(),
+                        role: "viewer".to_owned(),
+                    },
+                )
+                .await,
+        );
+        assert_not_missing_tenant(
+            "role revoke",
+            service
+                .handle_remove_grouping(
+                    &context,
+                    7,
+                    &RemoveGrouping {
+                        user: "bootstrap-user".to_owned(),
+                        role: "viewer".to_owned(),
+                    },
+                )
+                .await,
+        );
     }
 
     #[tokio::test]

--- a/crates/hyprstream/src/services/policy.rs
+++ b/crates/hyprstream/src/services/policy.rs
@@ -1394,7 +1394,6 @@ impl PolicyHandler for PolicyService {
         }
 
         let _write_guard = self.policy_write_lock.lock().await;
-        let index_snapshot = self.snapshot_policy_index().await?;
         // Global bootstrap policy stores memberships in Casbin's global `g`
         // relation; tenant-scoped memberships live in `g2`. Do not turn a
         // global authority domain into a literal `g2(..., "*")` row.
@@ -1414,6 +1413,36 @@ impl PolicyHandler for PolicyService {
                 details: "No policy update was committed.".to_owned(),
             }));
         }
+
+        let index_snapshot = match self.snapshot_policy_index().await {
+            Ok(snapshot) => snapshot,
+            Err(error) => {
+                let rollback = if domain == "*" {
+                    self.policy_manager
+                        .remove_role_for_user(&data.user, &data.role)
+                        .await
+                } else {
+                    self.policy_manager
+                        .remove_role_for_user_in_domain(&data.user, &data.role, &domain)
+                        .await
+                };
+                return match rollback {
+                    Ok(true) => Err(anyhow!(
+                        "Failed to snapshot policy index after role grant; mutation was rolled back: {}",
+                        error
+                    )),
+                    Ok(false) => Err(anyhow!(
+                        "Failed to snapshot policy index after role grant: {}; rollback was not applied",
+                        error
+                    )),
+                    Err(rollback_error) => Err(anyhow!(
+                        "Failed to snapshot policy index after role grant: {}; rollback failed: {}",
+                        error,
+                        rollback_error
+                    )),
+                };
+            }
+        };
 
         // Do not leave a failed persistence attempt active only in memory:
         // subsequent identical requests are legitimate retries and must still
@@ -1542,7 +1571,6 @@ impl PolicyHandler for PolicyService {
         }
 
         let _write_guard = self.policy_write_lock.lock().await;
-        let index_snapshot = self.snapshot_policy_index().await?;
         // Match the grouping relation selected by role grant above. A global
         // bootstrap membership is `g(user, role)`, not `g2(user, role, "*")`.
         let changed = if domain == "*" {
@@ -1563,6 +1591,34 @@ impl PolicyHandler for PolicyService {
                 details: "No policy update was committed.".to_owned(),
             }));
         }
+
+        let index_snapshot = match self.snapshot_policy_index().await {
+            Ok(snapshot) => snapshot,
+            Err(error) => {
+                let rollback = if domain == "*" {
+                    self.policy_manager.add_role_for_user(&data.user, &data.role).await
+                } else {
+                    self.policy_manager
+                        .add_role_for_user_in_domain(&data.user, &data.role, &domain)
+                        .await
+                };
+                return match rollback {
+                    Ok(true) => Err(anyhow!(
+                        "Failed to snapshot policy index after role revoke; mutation was rolled back: {}",
+                        error
+                    )),
+                    Ok(false) => Err(anyhow!(
+                        "Failed to snapshot policy index after role revoke: {}; rollback was not applied",
+                        error
+                    )),
+                    Err(rollback_error) => Err(anyhow!(
+                        "Failed to snapshot policy index after role revoke: {}; rollback failed: {}",
+                        error,
+                        rollback_error
+                    )),
+                };
+            }
+        };
 
         // Restore the in-memory edge when persistence fails so a later retry
         // remains a real mutation instead of silently reporting NOT_FOUND.


### PR DESCRIPTION
## Summary
- use the top-level authenticated production resolver for policy CLI RPC calls
- allow `podman exec hyprstream quick policy apply-template …` to discover the deployed IPC endpoint
- retain a source-level regression test for the separate-process boundary

## Validation
- `hyprstream-build.sh run -- cargo test -p hyprstream policy_cli_client_uses_authenticated_process_resolver --lib -- --nocapture`

The repository pre-commit release-Clippy hook is not runnable on this host because it overrides the build helper with stale `/home/birdetta/Downloads/libtorch` includes; the focused test passed using the warmed supported libtorch cache.