### PR TITLE
fix(ci): publish after manual exact-SHA Rust validation

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -38,7 +38,7 @@ jobs:
         set -euo pipefail
         runs="$(
           gh api \
-            "repos/${REPOSITORY}/actions/runs?head_sha=${EXPECTED_SHA}&event=merge_group&per_page=100"
+            "repos/${REPOSITORY}/actions/runs?head_sha=${EXPECTED_SHA}&per_page=100"
         )"
         matches="$(
           jq \

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -2,7 +2,9 @@ name: Build Docker Images
 
 on:
   # Merge-queue candidates pass the Rust gate before GitHub lands their exact
-  # SHA on main. Publish that landed SHA directly; Rust intentionally has no
+  # SHA on main. An administrator queue landing can instead be followed by an
+  # operator-requested, exact-SHA `workflow_dispatch` Rust validation. Publish
+  # only after either full-validation path succeeds; Rust intentionally has no
   # duplicate push-to-main run (#1331).
   push:
     branches: [ "main" ]
@@ -26,7 +28,7 @@ jobs:
       actions: read
       contents: read
     steps:
-    - name: Verify protected-main Rust gate
+    - name: Verify exact-main Rust validation
       if: github.ref == 'refs/heads/main'
       env:
         EXPECTED_SHA: ${{ github.sha }}
@@ -46,7 +48,7 @@ jobs:
               select(
                 .name == "Rust" and
                 .path == ".github/workflows/rust.yml" and
-                .event == "merge_group" and
+                (.event == "merge_group" or .event == "workflow_dispatch") and
                 .head_sha == $sha and
                 .conclusion == "success"
               )
@@ -54,7 +56,7 @@ jobs:
             <<< "$runs"
         )"
         if [ "$matches" -lt 1 ]; then
-          echo "::error::refusing to publish ${EXPECTED_SHA}: no successful Rust merge-group gate found"
+          echo "::error::refusing to publish ${EXPECTED_SHA}: no successful exact-SHA Rust validation found"
           exit 1
         fi
 


### PR DESCRIPTION
Restores immutable image publication when a reviewed administrator merge-queue landing has no `merge_group` event. The publisher still requires a successful full Rust workflow for the exact main SHA; it additionally accepts the documented operator `workflow_dispatch` validation path.