### PR TITLE
fix(tls): serve HTTPS alongside ACME challenges

### DIFF
--- a/crates/hyprstream/src/config/server.rs
+++ b/crates/hyprstream/src/config/server.rs
@@ -625,6 +625,17 @@ mod tests {
     #[test]
     fn mtls_client_verifier_is_not_wired() {
         let src = read_src("server/tls.rs");
+        assert_no_mtls_verifier(&src);
+    }
+
+    fn assert_no_mtls_verifier(src: &str) {
+        // rustls requires an explicit choice here. Disabling client auth is
+        // not an mTLS implementation; allow only that exact identifier.
+        let src = src
+            .split(|c: char| !c.is_alphanumeric() && c != '_')
+            .filter(|identifier| *identifier != "with_no_client_auth")
+            .collect::<Vec<_>>()
+            .join(" ");
         for needle in ["client_auth", "ClientCert", "client_ca"] {
             assert!(
                 !src.contains(needle),
@@ -633,5 +644,22 @@ mod tests {
                  authz model or remove the reference.",
             );
         }
+    }
+
+    #[test]
+    fn mtls_guard_allows_explicit_no_client_auth() {
+        assert_no_mtls_verifier("builder.with_no_client_auth().with_cert_resolver(resolver)");
+    }
+
+    #[test]
+    #[should_panic(expected = "mTLS client-cert verification")]
+    fn mtls_guard_rejects_client_verifier() {
+        assert_no_mtls_verifier("builder.with_client_cert_verifier(ClientCertVerifier)");
+    }
+
+    #[test]
+    #[should_panic(expected = "mTLS client-cert verification")]
+    fn mtls_guard_rejects_client_auth_even_alongside_no_auth() {
+        assert_no_mtls_verifier("builder.with_no_client_auth(); builder.with_client_auth_cert(cert)");
     }
 }

--- a/crates/hyprstream/src/config/server.rs
+++ b/crates/hyprstream/src/config/server.rs
@@ -636,7 +636,7 @@ mod tests {
             .filter(|identifier| *identifier != "with_no_client_auth")
             .collect::<Vec<_>>()
             .join(" ");
-        for needle in ["client_auth", "ClientCert", "client_ca"] {
+        for needle in ["client_auth", "client_cert", "ClientCert", "client_ca"] {
             assert!(
                 !src.contains(needle),
                 "server/tls.rs now references `{needle}`: mTLS client-cert verification is being \
@@ -654,7 +654,7 @@ mod tests {
     #[test]
     #[should_panic(expected = "mTLS client-cert verification")]
     fn mtls_guard_rejects_client_verifier() {
-        assert_no_mtls_verifier("builder.with_client_cert_verifier(ClientCertVerifier)");
+        assert_no_mtls_verifier("builder.with_client_cert_verifier(verifier)");
     }
 
     #[test]

--- a/crates/hyprstream/src/server/tls.rs
+++ b/crates/hyprstream/src/server/tls.rs
@@ -232,6 +232,7 @@ async fn init_acme_rustls_config(
         .map_err(|e| anyhow::anyhow!("cannot create ACME cache dir {:?}: {e}", cache_dir))?;
 
     let mut acme = AcmeConfig::new([domain])
+        .directory_lets_encrypt(true)
         .contact_push(contact)
         .cache_option(Some(rustls_acme::caches::DirCache::new(cache_dir)));
 
@@ -243,7 +244,7 @@ async fn init_acme_rustls_config(
         tls_config.acme_directory.as_deref().unwrap_or("Let's Encrypt"));
 
     let mut state = acme.state();
-    let rustls_server_config = state.challenge_rustls_config();
+    let rustls_server_config = acme_https_config(state.resolver());
 
     // Spawn the ACME event loop — handles challenge responses and renewals.
     tokio::spawn(async move {
@@ -262,7 +263,7 @@ async fn init_acme_rustls_config(
     });
 
     // Wrap the rustls ServerConfig in an axum-server RustlsConfig.
-    // rustls-acme updates the Arc<ServerConfig> in-place on renewal.
+    // rustls-acme updates the shared certificate resolver on renewal.
     let rustls_config = axum_server::tls_rustls::RustlsConfig::from_config(rustls_server_config);
     Ok(rustls_config)
 }
@@ -319,4 +320,97 @@ pub async fn serve_app(
 
     info!("{service_name} stopped");
     Ok(())
+}
+
+/// The shared listener must negotiate both HTTP and TLS-ALPN-01. The ACME
+/// resolver selects the challenge certificate only for an ACME ClientHello;
+/// ordinary clients receive the currently issued certificate.
+fn acme_https_config(
+    resolver: Arc<dyn rustls::server::ResolvesServerCert>,
+) -> Arc<rustls::ServerConfig> {
+    let mut config = rustls::ServerConfig::builder()
+        .with_no_client_auth()
+        .with_cert_resolver(resolver);
+    config.alpn_protocols = vec![b"h2".to_vec(), b"http/1.1".to_vec(), b"acme-tls/1".to_vec()];
+    Arc::new(config)
+}
+
+#[cfg(test)]
+mod acme_tests {
+    use super::*;
+    use rustls::pki_types::{PrivateKeyDer, PrivatePkcs8KeyDer, ServerName};
+    use std::io::Cursor;
+    use std::sync::atomic::{AtomicBool, Ordering};
+
+    #[derive(Debug)]
+    struct FixtureResolver {
+        key: Arc<rustls::sign::CertifiedKey>,
+        challenge_seen: AtomicBool,
+    }
+
+    impl rustls::server::ResolvesServerCert for FixtureResolver {
+        fn resolve(
+            &self,
+            hello: rustls::server::ClientHello<'_>,
+        ) -> Option<Arc<rustls::sign::CertifiedKey>> {
+            self.challenge_seen
+                .store(rustls_acme::is_tls_alpn_challenge(&hello), Ordering::SeqCst);
+            Some(self.key.clone())
+        }
+    }
+
+    /// Exercise the actual production config with real ClientHello negotiation.
+    /// Replacing its ALPN list with the old challenge-only list fails HTTP.
+    #[test]
+    fn acme_https_negotiates_http_and_challenge() -> anyhow::Result<()> {
+        hyprstream_rpc::transport::install_pq_crypto_provider()?;
+        let generated = rcgen::generate_simple_self_signed(vec!["localhost".to_owned()])?;
+        let cert = generated.cert.der().clone();
+        let private =
+            PrivateKeyDer::Pkcs8(PrivatePkcs8KeyDer::from(generated.key_pair.serialize_der()));
+        let provider = rustls::crypto::CryptoProvider::get_default()
+            .ok_or_else(|| anyhow::anyhow!("crypto provider missing"))?;
+        let key = Arc::new(rustls::sign::CertifiedKey::from_der(
+            vec![cert.clone()],
+            private,
+            provider,
+        )?);
+        for protocol in [b"h2".as_slice(), b"http/1.1", b"acme-tls/1"] {
+            let resolver = Arc::new(FixtureResolver {
+                key: key.clone(),
+                challenge_seen: AtomicBool::new(false),
+            });
+            let mut roots = rustls::RootCertStore::empty();
+            roots.add(cert.clone())?;
+            let mut client_config = rustls::ClientConfig::builder()
+                .with_root_certificates(roots)
+                .with_no_client_auth();
+            client_config.alpn_protocols = vec![protocol.to_vec()];
+            let mut client = rustls::ClientConnection::new(
+                Arc::new(client_config),
+                ServerName::try_from("localhost")?,
+            )?;
+            let mut server = rustls::ServerConnection::new(acme_https_config(resolver.clone()))?;
+            for _ in 0..16 {
+                let mut bytes = Vec::new();
+                client.write_tls(&mut bytes)?;
+                server.read_tls(&mut Cursor::new(bytes))?;
+                server.process_new_packets()?;
+                let mut bytes = Vec::new();
+                server.write_tls(&mut bytes)?;
+                client.read_tls(&mut Cursor::new(bytes))?;
+                client.process_new_packets()?;
+                if !client.is_handshaking() && !server.is_handshaking() {
+                    break;
+                }
+            }
+            assert!(!client.is_handshaking() && !server.is_handshaking());
+            assert_eq!(client.alpn_protocol(), Some(protocol));
+            assert_eq!(
+                resolver.challenge_seen.load(Ordering::SeqCst),
+                protocol == b"acme-tls/1"
+            );
+        }
+        Ok(())
+    }
 }


### PR DESCRIPTION
ACME listeners currently advertise only `acme-tls/1`, so HTTPS clients offering
`h2` or `http/1.1` cannot negotiate their application protocol even after a
certificate is available. Configure the shared listener for HTTP/2, HTTP/1.1,
and TLS-ALPN-01 using the ACME certificate resolver, which distinguishes
challenge ClientHellos from ordinary clients and updates certificates on renewal.

Explicitly select Let's Encrypt production as the default, matching the
documented Hyprstream configuration contract. rustls-acme itself defaults to
the staging CA. An explicit `acme_directory` continues to override this choice.

Validation: a local Rustls client/server handshake test negotiates each of the
three protocols and checks ACME challenge classification. The test passed
through shared BuildQ. This proves protocol negotiation; it does not claim
live certificate issuance or staging readiness.
