### PR TITLE
feat(bootstrap): admit provisioned service identities before network startup

### DIFF
--- a/crates/hyprstream-discovery/src/lib.rs
+++ b/crates/hyprstream-discovery/src/lib.rs
@@ -149,6 +149,7 @@ pub use plc_directory::{
     SignedPlcDirectoryGenesis,
 };
 pub use service::{
+    authenticate_local_deployment_registry,
     bootstrap_deployment_process, deployment_registry_verifier, resolve_and_authenticate_did_anchors,
     AuthorizationProvider, DiscoveryService, RecordCarData, RecordResolver, RegistryDeploymentVerifier,
     production_browser_currentness_verifier, production_browser_provisioning,

--- a/crates/hyprstream-discovery/src/service.rs
+++ b/crates/hyprstream-discovery/src/service.rs
@@ -1667,6 +1667,17 @@ pub fn deployment_registry_verifier() -> Result<RegistryDeploymentVerifier> {
         .ok_or_else(|| anyhow::anyhow!("deployment registry verifier is not installed"))
 }
 
+/// Authenticate the fixed, OS-owned deployment artifacts for an offline
+/// registry provisioning operation using the same role-specific trusted-file
+/// loader as startup. Returns verification-only evidence, not a raw-key
+/// authority constructor, and does not install a process resolver.
+pub fn authenticate_local_deployment_registry() -> Result<RegistryDeploymentVerifier> {
+    authenticate_registry_deployment_credentials(
+        load_trusted_registry_deployment_credentials()?,
+    )
+    .map(|identity| identity.verifier)
+}
+
 /// Non-cloneable proof privately minted from the fixed CA/JWT pair.
 struct AuthenticatedRegistryDeploymentIdentity {
     verifier: RegistryDeploymentVerifier,

--- a/crates/hyprstream/src/auth/identity_store.rs
+++ b/crates/hyprstream/src/auth/identity_store.rs
@@ -858,6 +858,24 @@ pub fn resolve_service_signing_key(
     }
 }
 
+/// Load a provisioned service identity without ever generating a replacement.
+pub fn load_existing_service_signing_key(
+    secrets_dir: &std::path::Path,
+    service_name: &str,
+    profile: SecretsProfile,
+) -> Result<SigningKey> {
+    validate_service_name(service_name)?;
+    let directory = match (profile, service_name) {
+        (_, "policy") | (SecretsProfile::PerServiceScoped, _) => secrets_dir.to_owned(),
+        (SecretsProfile::SharedDirectory, _) => secrets_dir.join(service_name),
+    };
+    let bytes = Zeroizing::new(read_secret(&directory, "signing-key")?
+        .ok_or_else(|| anyhow!("provisioned signing key is missing for service {service_name}"))?);
+    let seed = Zeroizing::new(<[u8; 32]>::try_from(bytes.as_slice())
+        .map_err(|_| anyhow!("service {service_name} signing-key must be 32 bytes"))?);
+    Ok(SigningKey::from_bytes(&seed))
+}
+
 // The `#atproto` commit-signing key is NOT loaded here. It is the *active* key
 // of the shared `Es256SigningKeyStore` (`auth::key_rotation`), the same P-256
 // key `oauth::did_document` publishes as the `#atproto` verification method —

--- a/crates/hyprstream/src/bin/main.rs
+++ b/crates/hyprstream/src/bin/main.rs
@@ -176,6 +176,14 @@ fn build_cli() -> ClapCommand {
                     .about("Initialize the checkpoint store for an explicitly provisioned fresh deployment"),
             )
             .subcommand(
+                ClapCommand::new("provision-services")
+                    .about("Admit existing local service identities before starting the registry")
+                    .arg(Arg::new("service").long("service").required(true)
+                        .action(clap::ArgAction::Append).value_delimiter(','))
+                    .arg(Arg::new("valid-for-seconds").long("valid-for-seconds")
+                        .value_parser(clap::value_parser!(i64)).default_value("86400")),
+            )
+            .subcommand(
                 ClapCommand::new("join")
                     .visible_alias("attach")
                     .about("Authorize and attach this host to one home PDS")
@@ -2367,6 +2375,15 @@ fn main() -> Result<()> {
                 println!("initialized empty deployment checkpoint store");
                 return Ok(());
             }
+            Some(("provision-services", provision_m)) => {
+                let services = provision_m.get_many::<String>("service")
+                    .context("service roster is required")?.cloned().collect::<Vec<_>>();
+                let lifetime = *provision_m.get_one::<i64>("valid-for-seconds")
+                    .context("service identity lifetime is required")?;
+                hyprstream_core::cli::deployment_bootstrap::provision_services(&services, lifetime)?;
+                println!("checkpoint-accepted service roster ready ({} services)", services.len());
+                return Ok(());
+            }
             Some(("join", join_m)) => {
                 let pds_url = join_m
                     .get_one::<String>("url")
@@ -2377,7 +2394,7 @@ fn main() -> Result<()> {
                     || hyprstream_core::cli::pds_handlers::handle_pds_join(&config, pds_url, scope),
                 );
             }
-            _ => anyhow::bail!("usage: hyprstream pds init-deployment-store | pds join <PDS_URL> [--scope <SCOPE>]"),
+            _ => anyhow::bail!("usage: hyprstream pds init-deployment-store | pds provision-services --service <NAMES> | pds join <PDS_URL> [--scope <SCOPE>]"),
         }
     }
 
@@ -3564,6 +3581,21 @@ fn main() -> Result<()> {
 #[cfg(test)]
 #[allow(clippy::expect_used)]
 mod resolver_startup_controls {
+    #[test]
+    fn deployment_bootstrap_cli_requires_roster_and_parses_lifetime() {
+        let matches = super::build_cli().try_get_matches_from([
+            "hyprstream", "pds", "provision-services", "--service", "model,event",
+            "--valid-for-seconds", "3600",
+        ]).expect("bootstrap CLI");
+        let pds = matches.subcommand_matches("pds").expect("pds");
+        let provision = pds.subcommand_matches("provision-services").expect("provision");
+        assert_eq!(provision.get_many::<String>("service").expect("roster")
+            .map(String::as_str).collect::<Vec<_>>(), vec!["model", "event"]);
+        assert_eq!(provision.get_one::<i64>("valid-for-seconds"), Some(&3600));
+        assert!(super::build_cli().try_get_matches_from([
+            "hyprstream", "pds", "provision-services",
+        ]).is_err());
+    }
     const REFRESH_SCHEDULER_TURNS: usize = 32;
 
     async fn assert_publication_ready(

--- a/crates/hyprstream/src/bin/main.rs
+++ b/crates/hyprstream/src/bin/main.rs
@@ -2380,7 +2380,11 @@ fn main() -> Result<()> {
                     .context("service roster is required")?.cloned().collect::<Vec<_>>();
                 let lifetime = *provision_m.get_one::<i64>("valid-for-seconds")
                     .context("service identity lifetime is required")?;
-                hyprstream_core::cli::deployment_bootstrap::provision_services(&services, lifetime)?;
+                hyprstream_core::cli::deployment_bootstrap::provision_services(
+                    &config,
+                    &services,
+                    lifetime,
+                )?;
                 println!("checkpoint-accepted service roster ready ({} services)", services.len());
                 return Ok(());
             }

--- a/crates/hyprstream/src/cli/deployment_bootstrap.rs
+++ b/crates/hyprstream/src/cli/deployment_bootstrap.rs
@@ -1,0 +1,373 @@
+//! Offline service identity admission before network services start.
+
+use anyhow::{ensure, Context, Result};
+use chrono::{DateTime, Duration, SecondsFormat, Utc};
+use ed25519_dalek::SigningKey;
+use hyprstream_pds::at9p::{
+    CapsuleBody, HybridKeyPair, ServiceEndpoint, ServiceEntry, ServiceType, Transport,
+};
+use hyprstream_pds::at9p_duplicity::AcceptedAt9pState;
+use hyprstream_pds::at9p_sign::{sign_capsule, sign_update_record};
+use hyprstream_rpc::crypto::pq::ml_dsa_sk_to_vk_bytes;
+use std::sync::Arc;
+
+use crate::auth::identity_store::{load_existing_service_signing_key, SecretsProfile};
+use crate::services::discovery::{At9pStateIngest, PdsRecordStore};
+
+/// Provision or renew a complete local service roster. The database writer
+/// lock excludes a running registry; callers must order this before services.
+pub fn provision_services(services: &[String], valid_for_seconds: i64) -> Result<()> {
+    ensure!(
+        (600..=86_400).contains(&valid_for_seconds),
+        "service identity lifetime must be 600..86400 seconds"
+    );
+    ensure!(!services.is_empty(), "at least one service is required");
+    let mut unique = std::collections::HashSet::new();
+    for name in services {
+        ensure!(unique.insert(name), "duplicate service in bootstrap roster");
+        ensure!(
+            hyprstream_service::get_factory(name).is_some(),
+            "unknown service in bootstrap roster: {name}"
+        );
+    }
+    let verifier = hyprstream_discovery::authenticate_local_deployment_registry()?;
+    let secrets = crate::config::HyprConfig::resolve_secrets_dir()?;
+    let acceptance =
+        load_existing_service_signing_key(&secrets, "registry", SecretsProfile::SharedDirectory)?;
+    ensure!(
+        verifier.matches(&acceptance.verifying_key()),
+        "registry signing key does not match authenticated deployment credential"
+    );
+    // Load the entire roster before writing any state; missing keys are errors,
+    // never a reason to silently generate a replacement service identity.
+    let keys = services
+        .iter()
+        .map(|name| {
+            load_existing_service_signing_key(&secrets, name, SecretsProfile::SharedDirectory)
+                .map(|key| (name, key))
+        })
+        .collect::<Result<Vec<_>>>()?;
+    let directory = hyprstream_service::deployment_data_dir()?.join("pds-store");
+    let probe =
+        PdsRecordStore::open_readonly(&directory)?.with_at9p_deployment_verifier(verifier.clone());
+    ensure!(
+        probe.first_boot_pending()? || !probe.accepted_at9p_states()?.is_empty(),
+        "empty unmarked checkpoint store requires explicit initialization or recovery"
+    );
+    drop(probe);
+    let store =
+        Arc::new(PdsRecordStore::open(&directory)?.with_at9p_deployment_verifier(verifier.clone()));
+    let audit = hyprstream_rpc::node_identity::derive_purpose_key(
+        &acceptance,
+        "hyprstream-at9p-audit-ed25519-v1",
+    );
+    let audit_pq = hyprstream_rpc::node_identity::derive_mesh_mldsa_key(&audit);
+    let ingest = At9pStateIngest::open(
+        Arc::clone(&store),
+        &directory.join("at9p-duplicity.wal"),
+        acceptance,
+        audit,
+        audit_pq,
+    )?;
+    let now = Utc::now();
+    let mut admitted = Vec::new();
+    for (name, key) in &keys {
+        admitted.push((
+            name.as_str(),
+            key,
+            provision_one(&store, &ingest, name, key, now, valid_for_seconds)?,
+        ));
+    }
+    // Verify every roster member, not just the first DID that clears the
+    // first-boot marker. No service starts while this writer is held.
+    let now_text = Utc::now().to_rfc3339_opts(SecondsFormat::Secs, true);
+    for (name, key, state) in admitted {
+        let verified = store
+            .accepted_at9p_state(&state.did, Some(&now_text))?
+            .context("provisioned service state disappeared")?;
+        hyprstream_service::NativeServiceAnnouncement::from_accepted_state(name, key, &verified)?;
+        tracing::info!(service = name, did = %verified.did, epoch = verified.epoch, "checkpoint-accepted service identity ready");
+    }
+    Ok(())
+}
+
+fn provision_one(
+    store: &PdsRecordStore,
+    ingest: &At9pStateIngest,
+    service_name: &str,
+    signer: &SigningKey,
+    now: DateTime<Utc>,
+    valid_for_seconds: i64,
+) -> Result<AcceptedAt9pState> {
+    let service_id = format!("#{service_name}");
+    let pq = hyprstream_rpc::node_identity::derive_mesh_mldsa_key(signer);
+    let hybrid = HybridKeyPair::new(
+        signer.verifying_key().to_bytes().to_vec(),
+        ml_dsa_sk_to_vk_bytes(&pq),
+    )?;
+    let commitment = hybrid.commitment_digest();
+    let carrier =
+        hyprstream_rpc::node_identity::derive_purpose_key(signer, "hyprstream-iroh-transport-v1");
+    let endpoint = ServiceEndpoint::new(
+        Transport::Iroh,
+        format!("iroh://{}", hex::encode(carrier.verifying_key().to_bytes())),
+    )?;
+    let service = ServiceEntry::new(&service_id, ServiceType::NinePExport, endpoint)?;
+    let states = store.accepted_at9p_states()?;
+    let mut matching = states.into_iter().filter(|state| {
+        state
+            .current
+            .services
+            .iter()
+            .any(|entry| entry.id == service_id)
+            && state
+                .current
+                .subject_keys
+                .iter()
+                .any(|key| key.ed25519_pub == hybrid.ed25519_pub)
+    });
+    let existing = matching.next();
+    ensure!(
+        matching.next().is_none(),
+        "multiple accepted identities match service {service_name}"
+    );
+    let state = match existing {
+        Some(state) => {
+            ensure!(
+                state.current.subject_keys.contains(&hybrid),
+                "accepted service hybrid key does not match the provisioned signer"
+            );
+            state
+        }
+        None => {
+            let mut body = CapsuleBody::new(vec![hybrid.clone()], vec![service.clone()])?;
+            body.next_key_commitments = vec![commitment];
+            let genesis = sign_capsule(body, signer, &pq)?;
+            let bytes = genesis.to_dag_cbor()?;
+            let did = format!("did:at9p:{}", genesis.cid512()?);
+            ingest.ingest_genesis(&did, &bytes)?
+        }
+    };
+    let renew_after = now + Duration::seconds(valid_for_seconds / 2);
+    if state.epoch > 0
+        && state.current.services.iter().any(|entry| entry == &service)
+        && state
+            .expires_at
+            .as_deref()
+            .map(DateTime::parse_from_rfc3339)
+            .transpose()?
+            .is_some_and(|expiry| expiry >= renew_after)
+    {
+        return Ok(state);
+    }
+    ensure!(
+        !state.terminal,
+        "service {service_name} identity has no authorized successor"
+    );
+    ensure!(
+        state.current.next_key_commitments.contains(&commitment),
+        "provisioned service key is not committed for the next update"
+    );
+    // Preserve every other subject key, service entry and future commitment.
+    let mut body = state.current.clone();
+    let entry = body
+        .services
+        .iter_mut()
+        .find(|entry| entry.id == service_id)
+        .context("accepted service entry disappeared")?;
+    *entry = service;
+    let expires =
+        (now + Duration::seconds(valid_for_seconds)).to_rfc3339_opts(SecondsFormat::Secs, true);
+    let update = sign_update_record(
+        state.subject_cid512.clone(),
+        state
+            .epoch
+            .checked_add(1)
+            .context("service identity epoch exhausted")?,
+        state.head_digest,
+        body,
+        expires,
+        signer,
+        &pq,
+    )?;
+    ingest.ingest_successor(
+        &state.did,
+        &update.to_dag_cbor()?,
+        &now.to_rfc3339_opts(SecondsFormat::Secs, true),
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn deployment_bootstrap_rejects_invalid_roster_and_lifetime_before_credentials() {
+        assert!(provision_services(&["model".to_owned()], 599).is_err());
+        assert!(provision_services(&["model".to_owned()], 86401).is_err());
+        assert!(provision_services(&[], 86400).is_err());
+        assert!(provision_services(&["model".to_owned(), "model".to_owned()], 86400).is_err());
+        assert!(provision_services(&["../not-a-service".to_owned()], 86400).is_err());
+    }
+
+    fn fixture() -> Result<(
+        tempfile::TempDir,
+        Arc<PdsRecordStore>,
+        At9pStateIngest,
+        SigningKey,
+    )> {
+        let dir = tempfile::tempdir()?;
+        let acceptance = SigningKey::from_bytes(&[0x61; 32]);
+        let store = Arc::new(
+            PdsRecordStore::open(dir.path())?
+                .with_at9p_acceptance_identity(acceptance.verifying_key()),
+        );
+        let audit = hyprstream_rpc::node_identity::derive_purpose_key(
+            &acceptance,
+            "hyprstream-at9p-audit-ed25519-v1",
+        );
+        let pq = hyprstream_rpc::node_identity::derive_mesh_mldsa_key(&audit);
+        let ingest = At9pStateIngest::open(
+            Arc::clone(&store),
+            &dir.path().join("audit.wal"),
+            acceptance,
+            audit,
+            pq,
+        )?;
+        Ok((dir, store, ingest, SigningKey::from_bytes(&[0x62; 32])))
+    }
+
+    #[test]
+    fn deployment_bootstrap_admits_bounded_successor_and_reuses_identity() -> Result<()> {
+        let (_dir, store, ingest, key) = fixture()?;
+        let now = Utc::now();
+        let first = provision_one(&store, &ingest, "model", &key, now, 86400)?;
+        assert_eq!(first.epoch, 1);
+        assert!(!first.terminal);
+        hyprstream_service::NativeServiceAnnouncement::from_accepted_state("model", &key, &first)?;
+        let retry = provision_one(
+            &store,
+            &ingest,
+            "model",
+            &key,
+            now + Duration::minutes(1),
+            86400,
+        )?;
+        assert_eq!(retry.did, first.did);
+        assert_eq!(retry.head_digest, first.head_digest);
+        let renewed = provision_one(
+            &store,
+            &ingest,
+            "model",
+            &key,
+            now + Duration::hours(13),
+            86400,
+        )?;
+        assert_eq!(renewed.did, first.did);
+        assert_eq!(renewed.epoch, 2);
+        assert_ne!(renewed.head_digest, first.head_digest);
+        assert_eq!(store.accepted_at9p_states()?.len(), 1);
+        Ok(())
+    }
+
+    #[test]
+    fn deployment_bootstrap_resumes_after_genesis_only_partial_progress() -> Result<()> {
+        let (_dir, store, ingest, key) = fixture()?;
+        let now = Utc::now();
+        // Deliberately invalid internal update lifetime simulates interruption
+        // after durable genesis; the public command rejects this input earlier.
+        assert!(provision_one(&store, &ingest, "model", &key, now, -1).is_err());
+        let states = store.accepted_at9p_states()?;
+        assert_eq!(states.len(), 1);
+        assert_eq!(states[0].epoch, 0);
+        let resumed = provision_one(&store, &ingest, "model", &key, now, 86400)?;
+        assert_eq!(resumed.did, states[0].did);
+        assert_eq!(resumed.epoch, 1);
+        Ok(())
+    }
+
+    #[test]
+    fn deployment_bootstrap_checkpoint_survives_reopen_and_covers_roster() -> Result<()> {
+        let (dir, store, ingest, key) = fixture()?;
+        let now = Utc::now();
+        let first = provision_one(&store, &ingest, "model", &key, now, 86400)?;
+        let second_key = SigningKey::from_bytes(&[0x63; 32]);
+        let second = provision_one(&store, &ingest, "event", &second_key, now, 86400)?;
+        assert_ne!(first.did, second.did);
+        drop(ingest);
+        drop(store);
+        let reopened = PdsRecordStore::open_readonly(dir.path())?
+            .with_at9p_acceptance_identity(SigningKey::from_bytes(&[0x61; 32]).verifying_key());
+        let states = reopened.accepted_at9p_states()?;
+        assert_eq!(states.len(), 2);
+        assert!(states.iter().all(|state| state.epoch == 1));
+        let wrong = PdsRecordStore::open_readonly(dir.path())?
+            .with_at9p_acceptance_identity(SigningKey::from_bytes(&[0x64; 32]).verifying_key());
+        assert!(wrong.accepted_at9p_states().is_err());
+        Ok(())
+    }
+
+    #[test]
+    fn deployment_bootstrap_never_generates_missing_service_keys() -> Result<()> {
+        let dir = tempfile::tempdir()?;
+        assert!(load_existing_service_signing_key(
+            dir.path(),
+            "model",
+            SecretsProfile::SharedDirectory
+        )
+        .is_err());
+        assert!(load_existing_service_signing_key(
+            dir.path(),
+            "policy",
+            SecretsProfile::SharedDirectory
+        )
+        .is_err());
+        assert!(!dir.path().join("model").exists());
+        assert!(!dir.path().join("signing-key").exists());
+        let model_dir = dir.path().join("model");
+        crate::auth::identity_store::write_secret(&model_dir, "signing-key", &[0x65; 32])?;
+        let loaded = load_existing_service_signing_key(
+            dir.path(),
+            "model",
+            SecretsProfile::SharedDirectory,
+        )?;
+        assert_eq!(
+            loaded.verifying_key(),
+            SigningKey::from_bytes(&[0x65; 32]).verifying_key()
+        );
+        assert!(load_existing_service_signing_key(
+            dir.path(),
+            "../model",
+            SecretsProfile::SharedDirectory
+        )
+        .is_err());
+        Ok(())
+    }
+
+    #[test]
+    fn deployment_bootstrap_rejects_existing_hybrid_mismatch_without_replacing_did() -> Result<()> {
+        let (_dir, store, ingest, key) = fixture()?;
+        let other_pq = hyprstream_rpc::node_identity::derive_mesh_mldsa_key(
+            &SigningKey::from_bytes(&[0x66; 32]),
+        );
+        let hybrid = HybridKeyPair::new(
+            key.verifying_key().to_bytes().to_vec(),
+            ml_dsa_sk_to_vk_bytes(&other_pq),
+        )?;
+        let endpoint = ServiceEndpoint::new(
+            Transport::Iroh,
+            format!("iroh://{}", hex::encode([0x67; 32])),
+        )?;
+        let service = ServiceEntry::new("#model", ServiceType::NinePExport, endpoint)?;
+        let body = CapsuleBody::new(vec![hybrid], vec![service])?;
+        let genesis = sign_capsule(body, &key, &other_pq)?;
+        let did = format!("did:at9p:{}", genesis.cid512()?);
+        ingest.ingest_genesis(&did, &genesis.to_dag_cbor()?)?;
+        assert!(provision_one(&store, &ingest, "model", &key, Utc::now(), 86400).is_err());
+        let states = store.accepted_at9p_states()?;
+        assert_eq!(states.len(), 1);
+        assert_eq!(states[0].did, did);
+        assert_eq!(states[0].epoch, 0);
+        Ok(())
+    }
+}

--- a/crates/hyprstream/src/cli/deployment_bootstrap.rs
+++ b/crates/hyprstream/src/cli/deployment_bootstrap.rs
@@ -12,11 +12,16 @@ use hyprstream_rpc::crypto::pq::ml_dsa_sk_to_vk_bytes;
 use std::sync::Arc;
 
 use crate::auth::identity_store::{load_existing_service_signing_key, SecretsProfile};
+use crate::config::HyprConfig;
 use crate::services::discovery::{At9pStateIngest, PdsRecordStore};
 
 /// Provision or renew a complete local service roster. The database writer
 /// lock excludes a running registry; callers must order this before services.
-pub fn provision_services(services: &[String], valid_for_seconds: i64) -> Result<()> {
+pub fn provision_services(
+    config: &HyprConfig,
+    services: &[String],
+    valid_for_seconds: i64,
+) -> Result<()> {
     ensure!(
         (600..=86_400).contains(&valid_for_seconds),
         "service identity lifetime must be 600..86400 seconds"
@@ -31,7 +36,7 @@ pub fn provision_services(services: &[String], valid_for_seconds: i64) -> Result
         );
     }
     let verifier = hyprstream_discovery::authenticate_local_deployment_registry()?;
-    let secrets = crate::config::HyprConfig::resolve_secrets_dir()?;
+    let secrets = provisioning_secrets_dir(config)?;
     let acceptance =
         load_existing_service_signing_key(&secrets, "registry", SecretsProfile::SharedDirectory)?;
     ensure!(
@@ -89,6 +94,13 @@ pub fn provision_services(services: &[String], valid_for_seconds: i64) -> Result
         tracing::info!(service = name, did = %verified.did, epoch = verified.epoch, "checkpoint-accepted service identity ready");
     }
     Ok(())
+}
+
+/// The command is dispatched after `main` has loaded and validated the
+/// operator-selected configuration. Reusing that exact value keeps an explicit
+/// `--config` `[secrets].path` authoritative rather than reloading defaults.
+fn provisioning_secrets_dir(config: &HyprConfig) -> Result<std::path::PathBuf> {
+    HyprConfig::resolve_secrets_dir_for(Some(config))
 }
 
 fn provision_one(
@@ -203,11 +215,23 @@ mod tests {
 
     #[test]
     fn deployment_bootstrap_rejects_invalid_roster_and_lifetime_before_credentials() {
-        assert!(provision_services(&["model".to_owned()], 599).is_err());
-        assert!(provision_services(&["model".to_owned()], 86401).is_err());
-        assert!(provision_services(&[], 86400).is_err());
-        assert!(provision_services(&["model".to_owned(), "model".to_owned()], 86400).is_err());
-        assert!(provision_services(&["../not-a-service".to_owned()], 86400).is_err());
+        let config = HyprConfig::default();
+        assert!(provision_services(&config, &["model".to_owned()], 599).is_err());
+        assert!(provision_services(&config, &["model".to_owned()], 86401).is_err());
+        assert!(provision_services(&config, &[], 86400).is_err());
+        assert!(
+            provision_services(&config, &["model".to_owned(), "model".to_owned()], 86400).is_err()
+        );
+        assert!(provision_services(&config, &["../not-a-service".to_owned()], 86400).is_err());
+    }
+
+    #[test]
+    fn deployment_bootstrap_uses_loaded_config_for_secrets_dir() -> Result<()> {
+        let mut config = HyprConfig::default();
+        let custom_secrets = tempfile::tempdir()?.path().join("custom-secrets");
+        config.secrets.path = Some(custom_secrets.clone());
+        assert_eq!(provisioning_secrets_dir(&config)?, custom_secrets);
+        Ok(())
     }
 
     fn fixture() -> Result<(

--- a/crates/hyprstream/src/cli/mod.rs
+++ b/crates/hyprstream/src/cli/mod.rs
@@ -15,6 +15,7 @@ pub mod gpu_detect;
 pub mod handlers;
 pub mod policy_handlers;
 pub mod pds_handlers;
+pub mod deployment_bootstrap;
 pub mod quick;
 pub mod bootstrap_manager;
 pub mod remote_handlers;

--- a/crates/hyprstream/src/services/factories.rs
+++ b/crates/hyprstream/src/services/factories.rs
@@ -170,6 +170,20 @@ pub fn classify_pds_store_for_quic(ctx: &ServiceContext) -> anyhow::Result<PdsBo
     )
 }
 
+fn accepted_state_matches_service(
+    state: &hyprstream_pds::at9p_duplicity::AcceptedAt9pState,
+    service_name: &str,
+    verifying_key: &[u8; 32],
+) -> bool {
+    let service_id = format!("#{service_name}");
+    state.current.services.iter().any(|entry| entry.id == service_id)
+        && state
+            .current
+            .subject_keys
+            .iter()
+            .any(|key| key.ed25519_pub.as_slice() == verifying_key)
+}
+
 /// Populate every ordinary network service announcement from a fresh
 /// checkpoint-verifying PDS read. Missing or ambiguous state fails startup
 /// before any QUIC service can bind and advertise an incomplete bundle.
@@ -187,16 +201,7 @@ pub fn with_checkpointed_native_announcements(
     {
         let signer = ctx.service_signing_key(service_name);
         let mut matching = states.iter().filter(|state| {
-            state
-                .current
-                .services
-                .iter()
-                .any(|entry| entry.id == *service_name)
-                && state
-                    .current
-                    .subject_keys
-                    .iter()
-                    .any(|key| key.ed25519_pub.as_slice() == signer.verifying_key().as_bytes())
+            accepted_state_matches_service(state, service_name, signer.verifying_key().as_bytes())
         });
         let state = matching.next().ok_or_else(|| {
             anyhow::anyhow!(
@@ -2793,6 +2798,51 @@ fn compute_tls_endorsement(
 #[allow(clippy::unwrap_used, clippy::expect_used)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn checkpointed_service_selection_uses_canonical_id_and_current_signer() {
+        use hyprstream_pds::at9p::{
+            CapsuleBody, HybridKeyPair, ServiceEndpoint, ServiceEntry, ServiceType, Transport,
+        };
+        use hyprstream_pds::at9p_duplicity::AcceptedAt9pState;
+        use hyprstream_pds::at9p_gate::verify_genesis_capsule;
+        use hyprstream_pds::at9p_sign::sign_capsule;
+        use hyprstream_rpc::crypto::pq::ml_dsa_sk_to_vk_bytes;
+
+        let signer = ed25519_dalek::SigningKey::from_bytes(&[0x71; 32]);
+        let pq = hyprstream_rpc::node_identity::derive_mesh_mldsa_key(&signer);
+        let key = HybridKeyPair::new(
+            signer.verifying_key().to_bytes().to_vec(),
+            ml_dsa_sk_to_vk_bytes(&pq),
+        )
+        .unwrap();
+        let endpoint = ServiceEndpoint::new(
+            Transport::Iroh,
+            format!("iroh://{}", hex::encode([0x72; 32])),
+        )
+        .unwrap();
+        let service = ServiceEntry::new("#model", ServiceType::NinePExport, endpoint).unwrap();
+        let body = CapsuleBody::new(vec![key], vec![service]).unwrap();
+        let genesis = sign_capsule(body, &signer, &pq).unwrap();
+        let verified = verify_genesis_capsule(
+            &genesis.cid512().unwrap(),
+            &genesis.to_dag_cbor().unwrap(),
+        )
+        .unwrap();
+        let state = AcceptedAt9pState::from_verified_genesis(&verified).unwrap();
+        let key = signer.verifying_key().to_bytes();
+        assert!(accepted_state_matches_service(&state, "model", &key));
+        assert!(!accepted_state_matches_service(&state, "#model", &key));
+        assert!(!accepted_state_matches_service(&state, "registry", &key));
+        assert!(!accepted_state_matches_service(&state, "model", &[0x73; 32]));
+        // Selection does not weaken the separate bounded-successor gate.
+        let error = hyprstream_service::NativeServiceAnnouncement::from_accepted_state(
+            "model", &signer, &state,
+        )
+        .err()
+        .expect("genesis alone cannot authorize a production announcement");
+        assert!(error.to_string().contains("bounded production expiry"));
+    }
 
     #[test]
     fn native_deployment_chain_has_no_local_policy_bootstrap() {

--- a/docs/service-identity-bootstrap.md
+++ b/docs/service-identity-bootstrap.md
@@ -1,0 +1,46 @@
+# Offline service identity bootstrap
+
+Before starting separate network service containers, initialize the deployment
+checkpoint store, provision the intended service keys through the existing
+credential workflow, and admit their identities:
+
+```sh
+hyprstream pds init-deployment-store
+hyprstream pds provision-services \
+  --service registry,policy,discovery,event,model,streams,oai,oauth \
+  --valid-for-seconds 86400
+```
+
+The command is for an OS-owned deployment with existing, authenticated public
+CA/authority/checkpoint files and a current registry deployment JWT. It uses
+the configured shared credentials directory: Policy uses its root signing key;
+other services use their service subdirectories. Missing keys are errors. The
+registry signing key must match the authenticated deployment credential.
+
+Run the command before the registry opens the store. It takes the normal sole
+writer lock and uses the same guarded genesis/successor admission and atomic
+checkpoint writer as the registry RPC. It does not insert synthetic identity
+records, clear security history, weaken signature checks, or start a network
+listener. It verifies the full requested roster before reporting success.
+
+Each identity advertises its canonical `#service` entry and the Iroh carrier
+address derived from that service's existing key. The address is not used as
+application identity. Genesis commits the existing hybrid signer for the first
+successor; that successor has a bounded expiry and retains future commitments.
+
+Retries reuse checkpoint-verified identities, including a genesis accepted
+before an interrupted first-successor operation. A live matching identity is
+left unchanged while at least half the requested lifetime remains. Otherwise,
+the command advances the existing chain through the guard and preserves other
+current keys, service entries and commitments. Ambiguous matching identities,
+uncommitted signers, renewal of terminal identities and invalid checkpoints fail closed.
+
+The default lifetime is 24 hours; accepted values are 600–86400 seconds. This
+command does not install an automatic renewal timer. Operators must renew
+before expiry, either through the authorized live registry successor-ingest
+RPC or in a maintenance window with the registry stopped. Identity provisioning
+alone does not implement Discovery's network startup or the Iroh event runtime;
+those remain required before declaring the networked deployment ready.
+
+Normal output includes only service names, public DIDs, epochs and completion
+counts. Private key bytes and credential token contents are never printed.


### PR DESCRIPTION
## Summary

Adds the missing offline `pds provision-services` command for service identities
before separate network containers start. Uses existing provisioned keys and
authenticated OS-owned deployment artifacts, then the registry's guarded
genesis/successor admission and atomic checkpoint writer. No synthetic state,
new key generation, resolver installation, or network listener.

- Full explicit service roster, canonical service IDs and key-derived Iroh
  carrier addresses (addresses are not application authority).
- Bounded successor expiry; retry reuses accepted identity, including recovery
  after genesis-only partial progress. Renewal preserves authorized commitments.
- Verify the full roster before success; reject missing keys, ambiguous state,
  mismatched hybrid keys and invalid acceptance checkpoints.
- Normal output contains only service names, public DIDs, epochs and counts.

Stacks on C2 #1543. Also contains the canonical-ID fix already cherry-picked
and independently passed in C1 #1540; that overlap will be reconciled on refresh.

## Validation

Shared hyprstream-build/BuildQ, cached CUDA130 libtorch, no private targets:

- `cargo check -p hyprstream --lib --bin hyprstream`: PASS.
- Final `cargo test -p hyprstream --lib deployment_bootstrap_`: PASS, 6 tests
  covering validation, existing-key loading, interrupted bootstrap, retry and
  renewal, persisted roster/foreign checkpoint rejection, and hybrid mismatch.
- CLI parsing regression: PASS.
- Existing Discovery production-authority API inventory regression: PASS.
- Required workspace/all-target release Clippy pre-commit hook: PASS.
- New module rustfmt and `git diff --check`: PASS.

## Limits and deployment work

Default identity lifetime is 24 hours (allowed600–86400 seconds). This command
does not install an automatic renewal timer; use authorized live registry
successor ingestion or an offline maintenance renewal before expiry.
It requires the registry to be stopped while holding the sole writer lock.

This is a bootstrap prerequisite, not a claim of complete networked staging.
Discovery network bootstrap/self-announcement, event Iroh runtime/admission,
and Metal startup/health wiring remain separate implementation work.
No AWS, image pin, or deployment change was made. Independent Sol review required.
