### PR TITLE
build: add canonical RPM staging runtime container

### DIFF
--- a/Containerfile.rpm
+++ b/Containerfile.rpm
@@ -1,0 +1,36 @@
+# CPU staging runtime built from the canonical FerruleOS RPM, not Cargo.
+# Use the same pinned Hummingbird baseline as the canonical RPM install gate.
+# This is an application container: no bootc switch and no host OS migration.
+FROM quay.io/hummingbird-community/bootc-os@sha256:4285846e3980533f156217181718360e971dd4e8b889cf75c47fce71728785b0
+USER 0:0
+ARG SOURCE_COMMIT
+ARG RPM_SHA256
+ARG RPM_ARCH=x86_64
+COPY hyprstream.rpm /tmp/hyprstream.rpm
+RUN set -eu; \
+    test "${#SOURCE_COMMIT}" = 40; \
+    test "${#RPM_SHA256}" = 64; \
+    case "$SOURCE_COMMIT$RPM_SHA256" in *[!0-9a-f]*) exit 1;; esac; \
+    case "$RPM_ARCH" in x86_64|aarch64) ;; *) exit 1;; esac; \
+    test "$(uname -m)" = "$RPM_ARCH"; \
+    printf '%s  /tmp/hyprstream.rpm\n' "$RPM_SHA256" | sha256sum --check -; \
+    test "$(rpm -qp --queryformat '%{ARCH}' /tmp/hyprstream.rpm)" = "$RPM_ARCH"; \
+    rpm -qp --provides /tmp/hyprstream.rpm | grep -Fx "bundled(hyprstream-source) = $SOURCE_COMMIT"; \
+    dnf -y --setopt=install_weak_deps=False install /tmp/hyprstream.rpm; \
+    rpm -qf /usr/bin/hyprstream; \
+    /usr/bin/hyprstream --version; \
+    ln -s /usr/bin/hyprstream /hyprstream; \
+    dnf clean all; \
+    rm -f /tmp/hyprstream.rpm; \
+    getent group 65532 >/dev/null || groupadd --gid 65532 hyprstream
+RUN getent passwd 65532 >/dev/null || \
+    useradd --uid 65532 --gid 65532 --no-create-home \
+      --home-dir /var/lib/hyprstream --shell /sbin/nologin hyprstream
+LABEL org.opencontainers.image.source="https://github.com/hyprstream/hyprstream" \
+      org.opencontainers.image.revision="${SOURCE_COMMIT}" \
+      ai.hyprstream.rpm.sha256="${RPM_SHA256}" \
+      ai.hyprstream.rpm.arch="${RPM_ARCH}"
+ENV HOME=/var/lib/hyprstream RUST_LOG=info
+USER 65532:65532
+ENTRYPOINT ["/hyprstream"]
+CMD ["--help"]

--- a/docs/rpm-runtime-container.md
+++ b/docs/rpm-runtime-container.md
@@ -1,0 +1,47 @@
+# RPM-based staging application container
+
+`Containerfile.rpm` installs the canonical FerruleOS CPU RPM into the same pinned
+Hummingbird baseline used by the RPM pipeline's build/install gate. It runs
+Hyprstream as UID/GID 65532 and keeps `/hyprstream` as an entrypoint alias for
+existing Quadlets. The RPM database and private libtorch runtime remain intact.
+It does not compile Cargo, migrate the Rocky host, boot systemd in the container,
+or require SSH/SSM. The existing multi-backend `Dockerfile` is unchanged.
+
+Request the canonical RPM pipeline on its protected main with
+`HYPRSTREAM_SOURCE_REF=<full reviewed source SHA>`. Both architecture jobs consume
+the same `hyprstream-source-input` artifact; `latest` is discovery only and must
+be resolved before a deployment pin is selected.
+
+Before preparing an image, record the successful canonical GitLab pipeline and
+build job IDs, verify their source-input artifact equals the intended source,
+and obtain the matching Hummingbird RPM over the authenticated job-artifact API.
+Do not substitute a Rawhide compatibility artifact or a legacy mutable `latest`
+package. Record its SHA-256. A hash calculated from an arbitrary download alone
+does not prove its origin. The helper checks the bytes, architecture and embedded
+source provide; the caller supplies the pipeline provenance.
+
+Prepare a new, minimal build context (requires host `rpm`):
+
+```sh
+bash scripts/prepare-rpm-runtime.sh \
+  /path/to/canonical.rpm "$RPM_SHA256" "$SOURCE_COMMIT" x86_64 /path/to/new-context
+podman build --file /path/to/new-context/Containerfile \
+  --build-arg SOURCE_COMMIT="$SOURCE_COMMIT" \
+  --build-arg RPM_SHA256="$RPM_SHA256" --build-arg RPM_ARCH=x86_64 \
+  --tag localhost/hyprstream-rpm-staging /path/to/new-context
+podman run --rm --network=none localhost/hyprstream-rpm-staging --version
+```
+
+Build natively on the selected architecture; use `aarch64` for ARM. The image
+build repeats artifact hash, architecture and embedded source checks, installs
+through DNF with ordinary repository verification, and runs the actual installed
+binary. It does not weaken GPG settings or label unsigned metadata as signed.
+
+The application revision and RPM hash are OCI labels. After runtime validation,
+publish through the authorized image path and pin the resulting OCI digest in
+staging, recording source/RPM/pipeline/image provenance together. Never deploy a
+mutable image tag or claim a tiny preparation fixture proves application startup.
+
+`bash scripts/test-prepare-rpm-runtime.sh` checks preparation against a tiny real
+RPM. The actual RPM container build, unprivileged smoke test and deployment remain
+separate required gates.

--- a/scripts/prepare-rpm-runtime.sh
+++ b/scripts/prepare-rpm-runtime.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+# Prepare a minimal OCI context from a pinned canonical CI RPM artifact.
+# The caller records the successful GitLab job/pipeline and verifies its source
+# input artifact first; hashing an arbitrary RPM does not authenticate its origin.
+# Arguments: RPM file, expected RPM SHA256, source SHA, RPM arch, output dir.
+set -Eeuo pipefail
+if [ "$#" -ne 5 ]; then
+  echo 'usage: prepare-rpm-runtime.sh RPM_FILE RPM_SHA256 SOURCE_SHA RPM_ARCH OUTPUT_DIR' >&2
+  exit 2
+fi
+rpm_file=$1 rpm_sha=$2 source_sha=$3 rpm_arch=$4 output_dir=$5
+[[ "$rpm_sha" =~ ^[0-9a-f]{64}$ ]] || exit 2
+[[ "$source_sha" =~ ^[0-9a-f]{40}$ ]] || exit 2
+case "$rpm_arch" in x86_64|aarch64) ;; *) exit 2;; esac
+[ -f "$rpm_file" ] || { echo 'RPM file not found' >&2; exit 2; }
+printf '%s  %s\n' "$rpm_sha" "$rpm_file" | sha256sum --check -
+test "$(rpm -qp --queryformat '%{ARCH}' "$rpm_file")" = "$rpm_arch"
+rpm -qp --provides "$rpm_file" | grep -Fx "bundled(hyprstream-source) = $source_sha"
+[ ! -e "$output_dir" ] || { echo 'output directory must not exist' >&2; exit 2; }
+mkdir -m 0700 -p "$output_dir"
+cp -- "$rpm_file" "$output_dir/hyprstream.rpm"
+printf '%s  %s/hyprstream.rpm\n' "$rpm_sha" "$output_dir" | sha256sum --check -
+test "$(rpm -qp --queryformat '%{ARCH}' "$output_dir/hyprstream.rpm")" = "$rpm_arch"
+rpm -qp --provides "$output_dir/hyprstream.rpm" | grep -Fx "bundled(hyprstream-source) = $source_sha"
+printf '%s\n' "$rpm_sha" >"$output_dir/rpm.sha256"
+cp "$(dirname "${BASH_SOURCE[0]}")/../Containerfile.rpm" "$output_dir/Containerfile"

--- a/scripts/test-prepare-rpm-runtime.sh
+++ b/scripts/test-prepare-rpm-runtime.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+# Tiny real RPM fixture tests preparation, not application/container execution.
+set -Eeuo pipefail
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+work="$(mktemp -d)"
+trap 'rm -rf -- "$work"' EXIT
+arch="$(uname -m)"
+case "$arch" in x86_64) wrong_arch=aarch64;; aarch64) wrong_arch=x86_64;; *) exit 2;; esac
+source_sha=1111111111111111111111111111111111111111
+mkdir -p "$work"/{BUILD,BUILDROOT,RPMS,SOURCES,SPECS,SRPMS}
+cat >"$work/SPECS/fixture.spec" <<EOF
+Name: hyprstream-runtime-fixture
+Version: 1
+Release: 1
+Summary: Runtime preparation fixture only
+License: MIT
+BuildArch: $arch
+Provides: bundled(hyprstream-source) = $source_sha
+%description
+No application payload; validates RPM metadata handling.
+%install
+mkdir -p %{buildroot}/usr/share/hyprstream-runtime-fixture
+echo fixture > %{buildroot}/usr/share/hyprstream-runtime-fixture/value
+%files
+/usr/share/hyprstream-runtime-fixture/value
+EOF
+rpmbuild --define "_topdir $work" -bb "$work/SPECS/fixture.spec" >"$work/build.log" 2>&1
+rpm_file="$work/RPMS/$arch/hyprstream-runtime-fixture-1-1.$arch.rpm"
+rpm_sha="$(sha256sum "$rpm_file" | cut -d' ' -f1)"
+prepare="$script_dir/prepare-rpm-runtime.sh"
+bash "$prepare" "$rpm_file" "$rpm_sha" "$source_sha" "$arch" "$work/context" >/dev/null
+cmp "$rpm_file" "$work/context/hyprstream.rpm"
+cmp "$script_dir/../Containerfile.rpm" "$work/context/Containerfile"
+test "$(<"$work/context/rpm.sha256")" = "$rpm_sha"
+reject() {
+  if bash "$prepare" "$@" >/dev/null 2>&1; then echo 'expected preparation rejection' >&2; exit 1; fi
+}
+reject "$rpm_file" "z${rpm_sha:1}" "$source_sha" "$arch" "$work/bad-hex"
+reject "$rpm_file" 0000000000000000000000000000000000000000000000000000000000000000 "$source_sha" "$arch" "$work/wrong-hash"
+reject "$rpm_file" "$rpm_sha" 2222222222222222222222222222222222222222 "$arch" "$work/wrong-source"
+reject "$rpm_file" "$rpm_sha" "$source_sha" "$wrong_arch" "$work/wrong-arch"
+reject "$rpm_file" "$rpm_sha" "$source_sha" "$arch" "$work/context"
+test ! -e "$work/wrong-hash"
+test ! -e "$work/bad-hex"
+test ! -e "$work/wrong-source"
+test ! -e "$work/wrong-arch"
+echo 'prepare-rpm-runtime: PASS (real RPM metadata/hash/source/arch checks; existing context preserved)'


### PR DESCRIPTION
## Outcome

Add the RPM-based staging application container requested for delivery. The
existing multi-backend Cargo Dockerfile stays unchanged; this CPU runtime installs
the canonical FerruleOS RPM on the same digest-pinned Hummingbird baseline used
by its RPM install gate. No Rocky host migration, SSH/SSM or bootc activation.

The image retains the installed RPM database/private libtorch, runs as65532,
preserves `/hyprstream` for existing Quadlets and records source/RPM hash labels.
The minimal context helper verifies SHA256, native architecture and the RPM's
embedded source provide. Its caller must first verify the successful canonical
GitLab job/source-input provenance; hashing an arbitrary download is not origin
authentication. Normal DNF verification is preserved; no GPG-check weakening.

## Validation

- Tiny real-RPM preparation suite PASS: matching artifact/source/arch accepted;
  wrong hash/source/architecture and existing output context rejected.
- Shell syntax and diff checks PASS.
- Required foreground workspace/all-target release Clippy hook PASS,56.24s.
- Exact pinned Hummingbird base pulled; offline container confirms RPM/DNF/account
  tools and matchingx86_64 architecture. This is not application runtime proof.

## Remaining gate

Draft until independent Sol review and an actual canonical RPM container build
plus unprivileged smoke test. Latest successful canonical RPM pipeline2818202932
has expired build artifacts and contains oldsource3b02baf; do not substitute its
legacy mutable package or claim it includes current staging repairs. Final image
must be built from the reviewed integrated source and pinned by its OCI digest.
