### PR TITLE
feat: add authenticated native Event transport with MAC source scopes

### DIFF
--- a/crates/hyprstream-discovery/src/event_network_bootstrap_tests.rs
+++ b/crates/hyprstream-discovery/src/event_network_bootstrap_tests.rs
@@ -1,4 +1,6 @@
-//! Real signed admission/checkpoints and hybrid Iroh RPC, isolated from the
+//! MoQ-only Event reach through real signed checkpoints and Discovery Iroh RPC.
+//! Independent fixture, preserving the existing native bootstrap baseline.
+//! Isolated from the
 //! process-global test fixtures used by other transport tests.
 #![allow(clippy::unwrap_used, clippy::expect_used)]
 
@@ -51,11 +53,11 @@ fn announcement(state: &AcceptedAt9pState, name: &str, signer: &SigningKey, ca: 
 }
 
 #[test]
-fn required_network_bootstrap_real_checkpoint_and_iroh() -> Result<()> {
-    const CHILD: &str = "HYPRSTREAM_NATIVE_BOOTSTRAP_TEST_CHILD";
+fn event_network_reach_uses_signed_checkpoint_and_moq_capability() -> Result<()> {
+    const CHILD: &str = "HYPRSTREAM_EVENT_BOOTSTRAP_TEST_CHILD";
     if std::env::var_os(CHILD).is_none() {
         let status = std::process::Command::new(std::env::current_exe()?)
-            .args(["--exact", "service::network_bootstrap_tests::required_network_bootstrap_real_checkpoint_and_iroh", "--nocapture"])
+            .args(["--exact", "service::event_network_bootstrap_tests::event_network_reach_uses_signed_checkpoint_and_moq_capability", "--nocapture"])
             .env(CHILD, "1").status()?;
         anyhow::ensure!(status.success(), "isolated Iroh bootstrap regression failed");
         return Ok(());
@@ -79,11 +81,13 @@ async fn network_roundtrip() -> Result<()> {
     let policy = SigningKey::from_bytes(&[0x52; 32]);
     let model = SigningKey::from_bytes(&[0x53; 32]);
     let registry = SigningKey::from_bytes(&[0x54; 32]);
+    let event = SigningKey::from_bytes(&[0x55; 32]);
+    let event_state = admitted("event", &event)?;
     let discovery_state = admitted("discovery", &discovery)?;
     let policy_state = admitted("policy", &policy)?;
     let model_state = admitted("model", &model)?;
     let dir = tempfile::tempdir()?;
-    for state in [&discovery_state, &policy_state, &model_state] {
+    for state in [&discovery_state, &policy_state, &model_state, &event_state] {
         write_test_state(dir.path(), state, &registry)?;
     }
     let source = Arc::new(CheckpointedPdsAcceptedStateSource::open_test(dir.path(), registry.verifying_key())?
@@ -144,11 +148,14 @@ async fn network_roundtrip() -> Result<()> {
     let model_pq = hyprstream_rpc::crypto::pq::ml_dsa_vk_from_bytes(
         &hyprstream_rpc::crypto::pq::ml_dsa_sk_to_vk_bytes(&derive_mesh_mldsa_key(&model)))?;
     request_keys.bind(model.verifying_key().to_bytes(), &model_pq);
+    let event_pq = hyprstream_rpc::crypto::pq::ml_dsa_vk_from_bytes(
+        &hyprstream_rpc::crypto::pq::ml_dsa_sk_to_vk_bytes(&derive_mesh_mldsa_key(&event)))?;
+    request_keys.bind(event.verifying_key().to_bytes(), &event_pq);
     let _ = hyprstream_rpc::envelope::install_verify_config(hyprstream_rpc::envelope::EnvelopeVerifyConfig {
         policy: hyprstream_rpc::crypto::CryptoPolicy::Hybrid, pq_store: Some(Arc::new(request_keys)),
     });
     let discovery_client = crate::DiscoveryClient::new(Arc::new(ProductionRpcClient::new(
-        "discovery", "discovery", None, model.clone(), None, bootstrap_resolver,
+        "discovery", "discovery", None, model.clone(), None, bootstrap_resolver.clone(),
     )?));
     tokio::time::timeout(Duration::from_secs(10), discovery_client.announce(&announcement(&model_state, "model", &model, &policy))).await??;
     let resolver = DiscoveryServiceResolver {
@@ -159,6 +166,24 @@ async fn network_roundtrip() -> Result<()> {
     assert_eq!(resolved.service_did().as_str(), model_state.did);
     assert_eq!(resolved.response_verifying_key(), model.verifying_key());
     assert_eq!(resolved.request_kem_recipient.recipient.encode(), model_state.current.services[0].endpoint.request_kem.clone().unwrap());
+    // The Event barrier advertises only MoQ. Its authenticated Discovery
+    // announcement resolves under the required carrier profile, and cannot
+    // accidentally satisfy the RPC capability query used by ordinary services.
+    let event_carrier = derive_purpose_key(&event, "hyprstream-iroh-transport-v1");
+    let event_endpoint = IrohSubstrate::new(event_carrier.to_bytes(), RefuseHandler::new("reach fixture"), RefuseHandler::new("Event has no RPC")).await?;
+    let mut event_announcement = announcement(&event_state, "event", &event, &policy);
+    event_announcement.capabilities = vec!["hyprstream-moq/1".to_owned()];
+    let event_discovery_client = crate::DiscoveryClient::new(Arc::new(ProductionRpcClient::new(
+        "discovery", "discovery", None, event.clone(), None, bootstrap_resolver,
+    )?));
+    event_discovery_client.announce(&event_announcement).await?;
+    assert!(resolver.resolve_service(ServiceQuery::network("event")?).await.is_err());
+    let resolved_event = resolver.resolve_service(ServiceQuery::network_moq("event")?).await?;
+    resolver.ensure_current(&resolved_event).await?;
+    assert_eq!(resolved_event.service_did().as_str(), event_state.did);
+    assert!(matches!(resolved_event.transport().endpoint, hyprstream_rpc::transport::EndpointType::Iroh { node_id, .. }
+        if node_id == *event_endpoint.endpoint_id().as_bytes()));
+    event_endpoint.shutdown().await?;
     // Loss of the authenticated checkpoint is not repaired by a cached dial
     // or a fresh self heartbeat.
     let db = rocksdb::DB::open_for_read_only(&rocksdb::Options::default(), dir.path(), false)?;

--- a/crates/hyprstream-discovery/src/lib.rs
+++ b/crates/hyprstream-discovery/src/lib.rs
@@ -150,7 +150,7 @@ pub use plc_directory::{
 };
 pub use service::{
     authenticate_local_deployment_registry,
-    native_network_required,
+    native_network_required, production_moq_event_target, production_moql_accepted_state_authority,
     bootstrap_deployment_process, deployment_registry_verifier, resolve_and_authenticate_did_anchors,
     AuthorizationProvider, DiscoveryService, DiscoverySelfAnnouncer, RecordCarData, RecordResolver, RegistryDeploymentVerifier,
     production_browser_currentness_verifier, production_browser_provisioning,

--- a/crates/hyprstream-discovery/src/network_bootstrap_tests.rs
+++ b/crates/hyprstream-discovery/src/network_bootstrap_tests.rs
@@ -79,11 +79,13 @@ async fn network_roundtrip() -> Result<()> {
     let policy = SigningKey::from_bytes(&[0x52; 32]);
     let model = SigningKey::from_bytes(&[0x53; 32]);
     let registry = SigningKey::from_bytes(&[0x54; 32]);
+    let event = SigningKey::from_bytes(&[0x55; 32]);
+    let event_state = admitted("event", &event)?;
     let discovery_state = admitted("discovery", &discovery)?;
     let policy_state = admitted("policy", &policy)?;
     let model_state = admitted("model", &model)?;
     let dir = tempfile::tempdir()?;
-    for state in [&discovery_state, &policy_state, &model_state] {
+    for state in [&discovery_state, &policy_state, &model_state, &event_state] {
         write_test_state(dir.path(), state, &registry)?;
     }
     let source = Arc::new(CheckpointedPdsAcceptedStateSource::open_test(dir.path(), registry.verifying_key())?
@@ -144,11 +146,14 @@ async fn network_roundtrip() -> Result<()> {
     let model_pq = hyprstream_rpc::crypto::pq::ml_dsa_vk_from_bytes(
         &hyprstream_rpc::crypto::pq::ml_dsa_sk_to_vk_bytes(&derive_mesh_mldsa_key(&model)))?;
     request_keys.bind(model.verifying_key().to_bytes(), &model_pq);
+    let event_pq = hyprstream_rpc::crypto::pq::ml_dsa_vk_from_bytes(
+        &hyprstream_rpc::crypto::pq::ml_dsa_sk_to_vk_bytes(&derive_mesh_mldsa_key(&event)))?;
+    request_keys.bind(event.verifying_key().to_bytes(), &event_pq);
     let _ = hyprstream_rpc::envelope::install_verify_config(hyprstream_rpc::envelope::EnvelopeVerifyConfig {
         policy: hyprstream_rpc::crypto::CryptoPolicy::Hybrid, pq_store: Some(Arc::new(request_keys)),
     });
     let discovery_client = crate::DiscoveryClient::new(Arc::new(ProductionRpcClient::new(
-        "discovery", "discovery", None, model.clone(), None, bootstrap_resolver,
+        "discovery", "discovery", None, model.clone(), None, bootstrap_resolver.clone(),
     )?));
     tokio::time::timeout(Duration::from_secs(10), discovery_client.announce(&announcement(&model_state, "model", &model, &policy))).await??;
     let resolver = DiscoveryServiceResolver {
@@ -159,6 +164,24 @@ async fn network_roundtrip() -> Result<()> {
     assert_eq!(resolved.service_did().as_str(), model_state.did);
     assert_eq!(resolved.response_verifying_key(), model.verifying_key());
     assert_eq!(resolved.request_kem_recipient.recipient.encode(), model_state.current.services[0].endpoint.request_kem.clone().unwrap());
+    // The Event barrier advertises only MoQ. Its authenticated Discovery
+    // announcement resolves under the required carrier profile, and cannot
+    // accidentally satisfy the RPC capability query used by ordinary services.
+    let event_carrier = derive_purpose_key(&event, "hyprstream-iroh-transport-v1");
+    let event_endpoint = IrohSubstrate::new(event_carrier.to_bytes(), RefuseHandler::new("reach fixture"), RefuseHandler::new("Event has no RPC")).await?;
+    let mut event_announcement = announcement(&event_state, "event", &event, &policy);
+    event_announcement.capabilities = vec!["hyprstream-moq/1".to_owned()];
+    let event_discovery_client = crate::DiscoveryClient::new(Arc::new(ProductionRpcClient::new(
+        "discovery", "discovery", None, event.clone(), None, bootstrap_resolver,
+    )?));
+    event_discovery_client.announce(&event_announcement).await?;
+    assert!(resolver.resolve_service(ServiceQuery::network("event")?).await.is_err());
+    let resolved_event = resolver.resolve_service(ServiceQuery::network_moq("event")?).await?;
+    resolver.ensure_current(&resolved_event).await?;
+    assert_eq!(resolved_event.service_did().as_str(), event_state.did);
+    assert!(matches!(resolved_event.transport().endpoint, hyprstream_rpc::transport::EndpointType::Iroh { node_id, .. }
+        if node_id == *event_endpoint.endpoint_id().as_bytes()));
+    event_endpoint.shutdown().await?;
     // Loss of the authenticated checkpoint is not repaired by a cached dial
     // or a fresh self heartbeat.
     let db = rocksdb::DB::open_for_read_only(&rocksdb::Options::default(), dir.path(), false)?;

--- a/crates/hyprstream-discovery/src/service.rs
+++ b/crates/hyprstream-discovery/src/service.rs
@@ -33,7 +33,7 @@ use crate::placement_index::PlacementIndex;
 use crate::scheduling;
 use crate::state_store::{
     unix_millis_now, AnnouncedEndpoint, CachedEntityStatement, CachedEnvelopeKeyset,
-    DiscoveryState, DiscoveryStateStore, LiveAllocatable, MemoryStateStore, PutResult,
+    DiscoveryState, DiscoveryStateStore, LiveAllocatable, MemoryStateStore,
     ANNOUNCED_ENDPOINT_TTL,
 };
 
@@ -1836,6 +1836,44 @@ static PROCESS_BOOTSTRAP_CARRIER: std::sync::OnceLock<hyprstream_rpc::transport:
 /// Transport profile selected by authenticated process bootstrap.
 pub fn native_network_required() -> bool {
     PROCESS_NATIVE_NETWORK_REQUIRED.get().copied().unwrap_or(false)
+}
+
+/// Resolve native Event reach and its accepted-current server witness together.
+pub async fn production_moq_event_target() -> Result<(TransportConfig, hyprstream_rpc::stream_info::MoqlServerIdentity)> {
+    let resolver = PRODUCTION_RESOLVER.get().ok_or_else(|| anyhow::anyhow!("production resolver is not installed"))?;
+    let resolved = resolver.resolve_service_candidates(ServiceQuery::network_moq("event")?).await?
+        .into_iter().next().ok_or_else(|| anyhow::anyhow!("no native Event reach"))?;
+    resolver.ensure_current(&resolved).await?;
+    Ok((resolved.transport().clone(), hyprstream_rpc::stream_info::MoqlServerIdentity {
+        did: resolved.service_did().as_str().to_owned(),
+        epoch: resolved.evidence().accepted_state_epoch,
+        head_digest: resolved.evidence().accepted_state_digest.to_vec(),
+        expires_at_unix_ms: resolved.expires_at_unix_ms(),
+        ed25519: resolved.response_verifying_key().to_bytes(),
+        ml_dsa65: resolved.response_ml_dsa65().to_vec(),
+    }))
+}
+
+/// Project only bounded, valid checkpoint state into the MoQL authority.
+/// Every admission and live-session recheck rereads the pinned source.
+pub fn production_moql_accepted_state_authority() -> Result<Arc<dyn hyprstream_rpc::transport::moql_admission::AcceptedStateAuthority>> {
+    let source = PROCESS_ACCEPTED_STATE_SOURCE.get().cloned()
+        .ok_or_else(|| anyhow::anyhow!("production accepted-state authority is not installed"))?;
+    Ok(Arc::new(move |did: &str| {
+        use hyprstream_rpc::transport::moql_admission::{AcceptedIdentityState, AcceptedSubjectKey};
+        let state = source.accepted_state(did).ok().flatten()?;
+        let expires = chrono::DateTime::parse_from_rfc3339(state.expires_at.as_deref()?).ok()?.timestamp_millis();
+        let subject_keys = state.current.subject_keys.iter().map(|key| {
+            Some(AcceptedSubjectKey {
+                ed25519: key.ed25519_pub.as_slice().try_into().ok()?,
+                ml_dsa_65: (!key.mldsa65_pub.is_empty()).then(|| key.mldsa65_pub.clone())?,
+            })
+        }).collect::<Option<Vec<_>>>()?;
+        (!subject_keys.is_empty()).then_some(AcceptedIdentityState {
+            epoch: state.epoch, head_digest: state.head_digest, subject_keys,
+            expires_at_unix_ms: Some(expires),
+        })
+    }))
 }
 
 const DEPLOYMENT_CA_ROOT_PATH: &str = "/etc/hyprstream/trust/deployment-ca.hybrid";
@@ -3973,6 +4011,7 @@ impl ProductionRpcClient {
 #[doc(hidden)]
 pub mod test_fixtures {
     use super::*;
+    use crate::state_store::PutResult;
     use hyprstream_crypto::pq::ml_dsa_sk_to_vk_bytes;
     use hyprstream_pds::at9p::{
         CapsuleBody, HybridKeyPair, ServiceEndpoint, ServiceEntry, ServiceType,

--- a/crates/hyprstream-discovery/src/service.rs
+++ b/crates/hyprstream-discovery/src/service.rs
@@ -7,6 +7,10 @@
 #[path = "network_bootstrap_tests.rs"]
 mod network_bootstrap_tests;
 
+#[cfg(all(test, not(target_arch = "wasm32")))]
+#[path = "event_network_bootstrap_tests.rs"]
+mod event_network_bootstrap_tests;
+
 use async_trait::async_trait;
 use hyprstream_rpc::browser_provisioning::{
     BrowserCarrierProfile, BrowserCurrentnessVerifier, BrowserProvisioningDocument,

--- a/crates/hyprstream-rpc/src/events.rs
+++ b/crates/hyprstream-rpc/src/events.rs
@@ -306,7 +306,8 @@ pub trait EventAuthz: Send + Sync {
 
 static EVENT_AUTHZ: OnceLock<Arc<dyn EventAuthz>> = OnceLock::new();
 
-fn installed_event_authz() -> Option<Arc<dyn EventAuthz>> {
+/// Clone the process reference monitor for authenticated network Event sessions.
+pub fn installed_event_authz() -> Option<Arc<dyn EventAuthz>> {
     EVENT_AUTHZ.get().cloned()
 }
 
@@ -434,6 +435,19 @@ impl PublisherIdentity {
     }
 }
 
+/// The local Event caller selected by checkpoint-verified process bootstrap.
+/// This supplies an identity to MAC, never a clearance or authorization grant.
+static NETWORK_EVENT_IDENTITY: OnceLock<PublisherIdentity> = OnceLock::new();
+
+/// Bind Event publishers/subscribers before construction in a single-identity
+/// native process. A later service cannot silently replace that process identity.
+pub fn install_network_event_identity(proof: &crate::transport::moql_admission::MoqlAdmissionProof) -> Result<()> {
+    anyhow::ensure!(proof.did.starts_with("did:at9p:"), "native Event identity must be checkpointed did:at9p");
+    let installed = NETWORK_EVENT_IDENTITY.get_or_init(|| PublisherIdentity::verified(proof.did.clone()));
+    anyhow::ensure!(installed.did.as_ref() == Some(&proof.did), "Event process identity already bound to another DID");
+    Ok(())
+}
+
 impl Default for PublisherIdentity {
     fn default() -> Self {
         Self::anonymous()
@@ -524,7 +538,7 @@ impl EventPublisher {
             rekey_policy: RekeyPolicy::default(),
             // An omitted production installation is a hard deny at rest.
             authz: installed_event_authz().unwrap_or_else(|| Arc::new(DenyAllEventAuthz)),
-            publisher_identity: PublisherIdentity::anonymous(),
+            publisher_identity: NETWORK_EVENT_IDENTITY.get().cloned().unwrap_or_default(),
         })
     }
 
@@ -969,7 +983,8 @@ impl EventSubscriber {
             prefixes: Arc::new(RwLock::new(HashMap::new())),
             tenant: Arc::new(RwLock::new(None)),
             authz: installed_event_authz().unwrap_or_else(|| Arc::new(DenyAllEventAuthz)),
-            caller: Subject::anonymous(),
+            caller: NETWORK_EVENT_IDENTITY.get().and_then(|identity| identity.did.clone())
+                .map(Subject::new).unwrap_or_else(Subject::anonymous),
         })
     }
 

--- a/crates/hyprstream-rpc/src/moq_event.rs
+++ b/crates/hyprstream-rpc/src/moq_event.rs
@@ -462,6 +462,28 @@ pub fn ensure_event_client_origin(path: std::path::PathBuf) {
     connect_event_moq_uds_background(origin, path);
 }
 
+/// Install a client origin without opening any local socket.
+pub fn install_event_network_client_origin() -> Option<MoqEventOrigin> {
+    if global_moq_event_origin().is_some() { return None; }
+    let origin = MoqEventOrigin::new();
+    init_global_moq_event_origin(origin.clone()).then_some(origin)
+}
+
+/// One authenticated network link. Target identity must accompany a fresh
+/// checkpoint-resolved Iroh transport; callers re-resolve before reconnecting.
+pub async fn run_event_network_link(
+    origin: &MoqEventOrigin,
+    transport: &crate::transport::TransportConfig,
+    proof: &crate::transport::moql_admission::MoqlAdmissionProof,
+) -> Result<()> {
+    anyhow::ensure!(matches!(transport.endpoint, crate::transport::EndpointType::Iroh { .. }), "Event network link requires Iroh");
+    let stream = crate::dial::dial_stream_authenticated(transport, proof).await?;
+    let client = moq_net::Client::new().with_origin(origin.producer());
+    let session = stream.connect_moq(&client).await?;
+    let _ = session.closed().await;
+    anyhow::bail!("authenticated Event link closed")
+}
+
 /// Connect a local event origin to the event service's UDS plane (#275).
 ///
 /// Spawns a background task that connects a `moq_net::Client` (built with

--- a/crates/hyprstream-rpc/src/moq_stream.rs
+++ b/crates/hyprstream-rpc/src/moq_stream.rs
@@ -80,7 +80,8 @@ pub fn init_global_moq_admission_proof(
     GLOBAL_MOQ_ADMISSION_PROOF.set(proof).is_ok()
 }
 
-fn global_moq_admission_proof()
+/// Borrow the process proof for other authenticated native MoQ planes.
+pub fn global_moq_admission_proof()
 -> Option<&'static crate::transport::moql_admission::MoqlAdmissionProof> {
     GLOBAL_MOQ_ADMISSION_PROOF.get()
 }

--- a/crates/hyprstream-rpc/src/resolver.rs
+++ b/crates/hyprstream-rpc/src/resolver.rs
@@ -60,6 +60,11 @@ impl ServiceQuery {
         )
     }
 
+    /// Native MoQ-only capability query (the Event barrier has no RPC surface).
+    pub fn network_moq(service_name: impl Into<String>) -> anyhow::Result<Self> {
+        Self::new(service_name, ["hyprstream-moq/1".to_owned()], ResolverProfile::NativeIrohRequired, 3)
+    }
+
     /// Construct the explicit browser/public-edge query. Browser clients use
     /// WebTransport over QUIC; Iroh is deliberately not a browser carrier.
     pub fn browser(service_name: impl Into<String>) -> anyhow::Result<Self> {

--- a/crates/hyprstream-rpc/src/transport/iroh_moq.rs
+++ b/crates/hyprstream-rpc/src/transport/iroh_moq.rs
@@ -41,7 +41,6 @@ use web_transport_iroh::Session;
 use crate::moq_authz::{
     PeerIdentity, SharedSubscribeAuthorizer, SubscribeDecision, is_valid_tenant_segment,
     tenant_prefix,
-    tenant_scoped_consumer,
 };
 use crate::transport::moql_admission::MoqlAdmissionAuthenticator;
 
@@ -222,6 +221,7 @@ struct HandlerInner {
     /// Triggered by `ProtocolHandler::shutdown` so accept handlers stop
     /// waiting for `Session::closed()` and exit promptly.
     shutdown: CancellationToken,
+    event_authz: Option<Arc<dyn crate::events::EventAuthz>>,
 }
 
 impl std::fmt::Debug for IrohMoqProtocolHandler {
@@ -250,6 +250,7 @@ impl IrohMoqProtocolHandler {
                     super::rpc_session::DEFAULT_CONNECTION_LIMIT,
                 )),
                 shutdown: CancellationToken::new(),
+                event_authz: None,
             }),
         }
     }
@@ -280,6 +281,34 @@ impl IrohMoqProtocolHandler {
         self
     }
 
+    /// Serve only the fixed Event namespace, with independent MAC decisions
+    /// for each declared source and direction. No per-track callback is needed:
+    /// the session never receives an origin outside its authorized sources.
+    pub fn with_event_authz(mut self, authz: Arc<dyn crate::events::EventAuthz>) -> Self {
+        self.rebuild_inner(|i| i.event_authz = Some(authz));
+        self
+    }
+
+    async fn event_scopes(&self, peer: &PeerIdentity, tenant: &str, ingress: bool) -> (Vec<String>, Vec<String>) {
+        let mut subscribe = Vec::new();
+        let mut publish = Vec::new();
+        if let (Some(authz), Some(subject)) = (&self.inner.event_authz, &peer.subject) {
+            // Event has a fixed namespace. Other tenants cannot acquire local
+            // visibility, even if their policy happens to permit a source.
+            if tenant != "local" { return (subscribe, publish); }
+            let subject = crate::envelope::Subject::new(subject.clone());
+            // Source inventory only, not label policy. Missing policy rows and
+            // absent verified clearances continue to deny through EventAuthz.
+            // TODO(#1530): consume the generated Event source inventory.
+            for source in ["system", "worker", "model"] {
+                let path = format!("local/events/{source}");
+                if authz.can_subscribe(&subject, source).await { subscribe.push(path.clone()); }
+                if ingress && authz.can_publish(&subject, source).await { publish.push(path); }
+            }
+        }
+        (subscribe, publish)
+    }
+
     /// Mutate the inner config, cloning the shared `Arc<HandlerInner>` only when
     /// it is already shared (cloned handler) so builder calls compose without
     /// dropping previously-installed fields (authz / admission).
@@ -294,6 +323,7 @@ impl IrohMoqProtocolHandler {
                 authz: old.authz.clone(),
                 connection_limit: Arc::clone(&old.connection_limit),
                 shutdown: old.shutdown.clone(),
+                event_authz: old.event_authz.clone(),
             };
             f(&mut cloned);
             self.inner = Arc::new(cloned);
@@ -421,22 +451,28 @@ impl ProtocolHandler for IrohMoqProtocolHandler {
         // the peer a scoped writable origin. This keeps an ordinary subscriber
         // from colliding with a producer's broadcast names.
         let ingress_granted = self.inner.authz.authorizes_ingress(&peer, &tenant);
-        let server = if ingress_granted {
+        let event_scopes = self.event_scopes(&peer, &tenant, ingress_granted).await;
+        let server = if self.inner.event_authz.is_some() {
+            if event_scopes.0.is_empty() && event_scopes.1.is_empty() {
+                conn.close(0u32.into(), b"no authorized event sources");
+                return Ok(());
+            }
+            let read: Vec<_> = event_scopes.0.iter().map(|s| moq_net::Path::new(s)).collect();
+            let write: Vec<_> = event_scopes.1.iter().map(|s| moq_net::Path::new(s)).collect();
+            // Never scope with an empty list: library defaults must not turn
+            // deny into an unrestricted origin.
+            let consume = if write.is_empty() { None } else { self.inner.origin.producer.scope(&write) };
+            let publish = if read.is_empty() { None } else { self.inner.origin.consumer.scope(&read) };
+            Server::new().with_publish(publish).with_consume(consume)
+        } else if ingress_granted {
             let prefix = tenant_prefix(&tenant);
             let path = moq_net::Path::new(&prefix);
             let Some(scoped_origin) = self.inner.origin.producer.scope(&[path]) else {
-                tracing::debug!(%tenant, "iroh-moq: tenant has no visible relay scope");
                 return Ok(());
             };
-            tracing::debug!(
-                subject = %peer.subject.as_deref().unwrap_or("?"),
-                %tenant,
-                "iroh-moq: admitting explicitly authorized ingress"
-            );
             Server::new().with_origin(scoped_origin)
         } else {
-            let Some(scoped_consumer) = tenant_scoped_consumer(self.inner.origin.consumer(), &tenant) else {
-                tracing::debug!(%tenant, "iroh-moq: tenant has no visible subscriber scope");
+            let Some(scoped_consumer) = crate::moq_authz::tenant_scoped_consumer(self.inner.origin.consumer(), &tenant) else {
                 return Ok(());
             };
             Server::new().with_publish(scoped_consumer)
@@ -479,6 +515,12 @@ impl ProtocolHandler for IrohMoqProtocolHandler {
                             session_conn.close(0u32.into(), b"moql accepted state no longer current");
                             break;
                         }
+                    }
+                    if self.inner.event_authz.is_some()
+                        && self.event_scopes(&peer, &tenant, ingress_granted).await != event_scopes
+                    {
+                        session_conn.close(0u32.into(), b"event policy changed");
+                        break;
                     }
                     // Ingress is live deployment authority, not a one-time
                     // capability: a revoked grant must not keep announcing on

--- a/crates/hyprstream-rpc/tests/event_network.rs
+++ b/crates/hyprstream-rpc/tests/event_network.rs
@@ -1,0 +1,331 @@
+//! Real Iroh Event boundary: admission, explicit ingress, MAC source scope and revocation.
+#![allow(clippy::expect_used, clippy::unwrap_used)]
+use anyhow::{anyhow, Result};
+use ed25519_dalek::SigningKey;
+use hyprstream_rpc::auth::mac::*;
+use hyprstream_rpc::crypto::pq::{ml_dsa_sk_from_seed, ml_dsa_sk_to_vk_bytes};
+use hyprstream_rpc::envelope::Subject;
+use hyprstream_rpc::events::{EventAuthz, MacEventAuthz};
+use hyprstream_rpc::moq_authz::PeerIdentity;
+use hyprstream_rpc::moq_event::{MoqEventOrigin, EVENT_TRACK};
+use hyprstream_rpc::transport::iroh_moq::{IrohMoqProtocolHandler, MoqAuthzConfig, OriginShared};
+use hyprstream_rpc::transport::iroh_substrate::{IrohSubstrate, RefuseHandler, ALPN_MOQ_LITE};
+use hyprstream_rpc::transport::moql_admission::*;
+use moq_net::{Client, Track};
+use std::collections::HashMap;
+use std::sync::{
+    atomic::{AtomicBool, Ordering},
+    Arc,
+};
+use std::time::Duration;
+
+const WAIT: Duration = Duration::from_secs(5);
+
+// These labels/clearances are fixture policy only, never deployed defaults.
+struct Clearance;
+#[async_trait::async_trait]
+impl ClearanceSource for Clearance {
+    async fn clearance(&self, subject: &Subject) -> Option<SecurityContext> {
+        if subject.name() != Some("did:at9p:event-client") {
+            return None;
+        }
+        Some(SecurityContext::from_clearance(
+            fixture_label(),
+            VerifiedKeyMaterial::Classical,
+        ))
+    }
+}
+fn fixture_label() -> SecurityLabel {
+    SecurityLabel::new(Level::Public, Assurance::Classical, CompartmentSet::EMPTY)
+}
+struct Audit;
+impl MoqMacAuditSink for Audit {
+    fn record_deny(&self, _: &MoqMacAuditRecord) -> std::result::Result<(), String> {
+        Ok(())
+    }
+}
+struct Policy {
+    enabled: AtomicBool,
+    mac: MacEventAuthz,
+}
+#[async_trait::async_trait]
+impl EventAuthz for Policy {
+    async fn can_publish(&self, subject: &Subject, source: &str) -> bool {
+        self.enabled.load(Ordering::SeqCst) && self.mac.can_publish(subject, source).await
+    }
+    async fn can_subscribe(&self, subject: &Subject, source: &str) -> bool {
+        self.enabled.load(Ordering::SeqCst) && self.mac.can_subscribe(subject, source).await
+    }
+}
+
+struct Fixture {
+    server: IrohSubstrate,
+    origin: MoqEventOrigin,
+    proof: MoqlAdmissionProof,
+    policy: Arc<Policy>,
+    ingress: Arc<AtomicBool>,
+}
+
+impl Fixture {
+    async fn new(tenant: &str, ingress: bool, policy_enabled: bool) -> Result<Self> {
+        let client_ed = SigningKey::from_bytes(&[23; 32]);
+        let client_pq = ml_dsa_sk_from_seed(&[24; 32]);
+        let server_ed = SigningKey::from_bytes(&[25; 32]);
+        let server_pq = ml_dsa_sk_from_seed(&[26; 32]);
+        let did = "did:at9p:event-client".to_owned();
+        let server_did = "did:at9p:event-server".to_owned();
+        let expiry = hyprstream_rpc::envelope::current_timestamp() + 60_000;
+        let server_identity = hyprstream_rpc::stream_info::MoqlServerIdentity {
+            did: server_did.clone(),
+            epoch: 1,
+            head_digest: vec![9; 64],
+            expires_at_unix_ms: expiry,
+            ed25519: server_ed.verifying_key().to_bytes(),
+            ml_dsa65: ml_dsa_sk_to_vk_bytes(&server_pq),
+        };
+        let proof = MoqlAdmissionProof {
+            did: did.clone(),
+            ed25519: client_ed.clone(),
+            ml_dsa_65: client_pq.clone(),
+            expected_server: server_identity.clone(),
+        };
+        let states: HashMap<_, _> = [
+            (
+                did.clone(),
+                AcceptedIdentityState {
+                    epoch: 1,
+                    head_digest: [8; 64],
+                    subject_keys: vec![AcceptedSubjectKey {
+                        ed25519: client_ed.verifying_key().to_bytes(),
+                        ml_dsa_65: ml_dsa_sk_to_vk_bytes(&client_pq),
+                    }],
+                    expires_at_unix_ms: Some(expiry),
+                },
+            ),
+            (
+                server_did,
+                AcceptedIdentityState {
+                    epoch: 1,
+                    head_digest: [9; 64],
+                    subject_keys: vec![AcceptedSubjectKey {
+                        ed25519: server_ed.verifying_key().to_bytes(),
+                        ml_dsa_65: server_identity.ml_dsa65.clone(),
+                    }],
+                    expires_at_unix_ms: Some(expiry),
+                },
+            ),
+        ]
+        .into_iter()
+        .collect();
+        let secret: [u8; 32] = rand::random();
+        let carrier = *iroh::SecretKey::from_bytes(&secret).public().as_bytes();
+        let tenant = tenant.to_owned();
+        let admission = MoqlAdmissionAuthenticator::new(
+            Arc::new(move |did: &str| states.get(did).cloned()),
+            Arc::new(move |peer: &PeerIdentity| {
+                (peer.subject.as_deref() == Some(&did)).then(|| tenant.clone())
+            }),
+        )
+        .with_server_identity_and_carrier(
+            MoqlServerIdentityProof {
+                identity: server_identity,
+                ed25519: server_ed,
+                ml_dsa_65: server_pq,
+            },
+            carrier,
+        );
+        let origin = MoqEventOrigin::new();
+        let table = if policy_enabled {
+            MoqEventPolicyTable::build(
+                SUPPORTED_TRACK_POLICY_REVISION,
+                ["worker", "system"].map(|source| {
+                    MoqEventPolicyRow::new(MoqEventPlane::Event, source, fixture_label()).unwrap()
+                }),
+            )?
+        } else {
+            MoqEventPolicyTable::empty()
+        };
+        let policy = Arc::new(Policy {
+            enabled: AtomicBool::new(true),
+            mac: MacEventAuthz::new(MoqEventPep::new(
+                Arc::new(DeclaredTrackPolicyResolver::new(table)),
+                Arc::new(Clearance),
+                Arc::new(Audit),
+            )),
+        });
+        let ingress = Arc::new(AtomicBool::new(ingress));
+        let grant = ingress.clone();
+        let handler = IrohMoqProtocolHandler::with_origin(OriginShared::from_pair(
+            origin.producer(),
+            origin.consumer(),
+        ))
+        .with_event_authz(policy.clone())
+        .with_authz(
+            MoqAuthzConfig::default()
+                .with_admission(Arc::new(admission))
+                .with_ingress_authorizer(Arc::new(move |_: &PeerIdentity, _: &str| {
+                    grant.load(Ordering::SeqCst)
+                })),
+        );
+        let server = IrohSubstrate::new(secret, handler, RefuseHandler::new("MoQ only")).await?;
+        Ok(Self {
+            server,
+            origin,
+            proof,
+            policy,
+            ingress,
+        })
+    }
+
+    async fn connect(&self) -> Result<(IrohSubstrate, moq_net::Session, MoqEventOrigin)> {
+        let endpoint = IrohSubstrate::new(
+            rand::random(),
+            RefuseHandler::new("client"),
+            RefuseHandler::new("client"),
+        )
+        .await?;
+        let addr = iroh::EndpointAddr::from_parts(
+            self.server.endpoint_id(),
+            self.server
+                .endpoint()
+                .bound_sockets()
+                .into_iter()
+                .map(iroh::TransportAddr::Ip),
+        );
+        let conn = endpoint.connect(addr, ALPN_MOQ_LITE).await?;
+        prove_moql_admission(&conn, &self.proof, *endpoint.endpoint_id().as_bytes(), WAIT).await?;
+        let origin = MoqEventOrigin::new();
+        let session = tokio::time::timeout(
+            WAIT,
+            Client::new()
+                .with_origin(origin.producer())
+                .connect(web_transport_iroh::Session::raw(conn)),
+        )
+        .await??;
+        Ok((endpoint, session, origin))
+    }
+}
+
+async fn read_event(origin: &MoqEventOrigin, source: &str) -> Result<Vec<u8>> {
+    let path = format!("local/events/{source}");
+    let broadcast = tokio::time::timeout(WAIT, origin.consumer().announced_broadcast(&path))
+        .await?
+        .ok_or_else(|| anyhow!("missing Event broadcast"))?;
+    let mut track = broadcast.subscribe_track(&Track::new(EVENT_TRACK))?;
+    let mut group = tokio::time::timeout(WAIT, track.next_group())
+        .await??
+        .ok_or_else(|| anyhow!("missing group"))?;
+    let frame = tokio::time::timeout(WAIT, group.read_frame())
+        .await??
+        .ok_or_else(|| anyhow!("missing frame"))?;
+    Ok(frame.to_vec())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn authenticated_event_ingests_and_serves_declared_sources() -> Result<()> {
+    let fixture = Fixture::new("local", true, true).await?;
+    let mut publisher = fixture.origin.publisher("system")?;
+    publisher.publish_raw("system.event.ready", b"ready")?;
+    let (client, session, origin) = fixture.connect().await?;
+    assert!(read_event(&origin, "system").await?.ends_with(b"ready"));
+    let mut publisher = origin.publisher("worker")?;
+    publisher.publish_raw("worker.job.ready", b"ingested")?;
+    assert!(read_event(&fixture.origin, "worker")
+        .await?
+        .ends_with(b"ingested"));
+    // This source is absent from the server inventory, even though raw local
+    // MoqEventOrigin publishers themselves intentionally have no policy layer.
+    let mut unknown = origin.publisher("undeclared")?;
+    unknown.publish_raw("undeclared.job.ready", b"must not arrive")?;
+    assert!(tokio::time::timeout(
+        Duration::from_millis(300),
+        fixture
+            .origin
+            .consumer()
+            .announced_broadcast("local/events/undeclared")
+    )
+    .await
+    .is_err());
+    fixture.policy.enabled.store(false, Ordering::SeqCst);
+    let _ = tokio::time::timeout(WAIT, session.closed()).await?;
+    client.shutdown().await?;
+    fixture.server.shutdown().await?;
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn event_ingress_requires_separate_grant() -> Result<()> {
+    let fixture = Fixture::new("local", false, true).await?;
+    let mut publisher = fixture.origin.publisher("system")?;
+    publisher.publish_raw("system.event.ready", b"read-only")?;
+    let (client, _session, origin) = fixture.connect().await?;
+    assert!(read_event(&origin, "system").await?.ends_with(b"read-only"));
+    let mut publisher = origin.publisher("worker")?;
+    publisher.publish_raw("worker.job.ready", b"unauthorized")?;
+    assert!(tokio::time::timeout(
+        Duration::from_millis(300),
+        fixture
+            .origin
+            .consumer()
+            .announced_broadcast("local/events/worker")
+    )
+    .await
+    .is_err());
+    client.shutdown().await?;
+    fixture.server.shutdown().await?;
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn event_other_tenant_and_empty_policy_fail_closed() -> Result<()> {
+    for (tenant, enabled) in [("other", true), ("local", false)] {
+        let fixture = Fixture::new(tenant, true, enabled).await?;
+        if let Ok((client, session, _origin)) = fixture.connect().await {
+            let _ = tokio::time::timeout(WAIT, session.closed()).await?;
+            client.shutdown().await?;
+        }
+        fixture.server.shutdown().await?;
+    }
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn event_live_ingress_grant_revocation_closes_session() -> Result<()> {
+    let fixture = Fixture::new("local", true, true).await?;
+    let (client, session, _origin) = fixture.connect().await?;
+    fixture.ingress.store(false, Ordering::SeqCst);
+    let _ = tokio::time::timeout(WAIT, session.closed()).await?;
+    client.shutdown().await?;
+    fixture.server.shutdown().await?;
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn native_local_publishers_receive_checkpointed_identity_without_a_mac_grant() -> Result<()> {
+    let fixture = Fixture::new("local", true, true).await?;
+    hyprstream_rpc::moq_event::init_global_moq_event_origin(MoqEventOrigin::new());
+    // The fixture MAC recognizes only the actual client DID; anonymous source
+    // construction alone cannot publish, even with a declared worker row.
+    let anonymous =
+        hyprstream_rpc::events::EventPublisher::new("worker")?.with_authz(fixture.policy.clone());
+    assert!(anonymous
+        .publish_raw("worker.job.ready", b"anonymous")
+        .await
+        .is_err());
+    hyprstream_rpc::events::install_network_event_identity(&fixture.proof)?;
+    let publisher =
+        hyprstream_rpc::events::EventPublisher::new("worker")?.with_authz(fixture.policy.clone());
+    publisher
+        .publish_raw("worker.job.ready", b"identified")
+        .await?;
+    fixture.policy.enabled.store(false, Ordering::SeqCst);
+    assert!(publisher
+        .publish_raw("worker.job.ready", b"revoked")
+        .await
+        .is_err());
+    let mut other = fixture.proof.clone();
+    other.did = "did:at9p:other".to_owned();
+    assert!(hyprstream_rpc::events::install_network_event_identity(&other).is_err());
+    fixture.server.shutdown().await?;
+    Ok(())
+}

--- a/crates/hyprstream-service/src/service/factory.rs
+++ b/crates/hyprstream-service/src/service/factory.rs
@@ -269,7 +269,11 @@ impl NativeServiceAnnouncement {
         let recipient = hyprstream_rpc::node_identity::derive_mesh_kem_recipient(signer)?.public();
         let announcement = Self {
             service_did: did.clone(),
-            capabilities: vec!["hyprstream-rpc/1".to_owned(), "hyprstream-moq/1".to_owned()],
+            capabilities: if service_name == "event" {
+                vec!["hyprstream-moq/1".to_owned()]
+            } else {
+                vec!["hyprstream-rpc/1".to_owned(), "hyprstream-moq/1".to_owned()]
+            },
             accepted_state_digest: state.head_digest,
             accepted_state_epoch: state.epoch,
             accepted_state_expires_at_unix_ms: expires_at,
@@ -288,7 +292,8 @@ impl NativeServiceAnnouncement {
             "native announcement requires did:at9p identity"
         );
         anyhow::ensure!(
-            !service_name.is_empty() && self.capabilities.iter().any(|c| c == "hyprstream-rpc/1"),
+            !service_name.is_empty() && self.capabilities.iter().any(|c| c ==
+                if service_name == "event" { "hyprstream-moq/1" } else { "hyprstream-rpc/1" }),
             "native announcement lacks canonical service capability"
         );
         anyhow::ensure!(
@@ -554,6 +559,9 @@ pub struct ServiceContext {
     ca_ml_dsa_verifying_key: Option<hyprstream_rpc::crypto::pq::MlDsaVerifyingKey>,
 }
 
+/// Owned callback joining carrier binding to the signed announcement lifecycle.
+pub type NativeIrohAnnouncementCallback = Arc<dyn Fn(tokio_util::sync::CancellationToken, [u8; 32]) -> anyhow::Result<()> + Send + Sync>;
+
 impl ServiceContext {
     /// Return an accepted-state-bound admission proof for a service that was
     /// checkpoint-authorized for native network startup.
@@ -568,6 +576,25 @@ impl ServiceContext {
             })
             .transpose()
     }
+    /// Publication callback for a MoQ-only service which has no RPC loop.
+    pub fn native_iroh_announcement_callback(&self, service_name: &str) -> anyhow::Result<NativeIrohAnnouncementCallback> {
+        let shared = self.quic_shared.as_ref().ok_or_else(|| anyhow::anyhow!("native Event configuration missing"))?;
+        let publisher = shared.native_announcement_publisher.clone();
+        anyhow::ensure!(publisher.is_some(), "native announcement publisher missing");
+        let accepted = self.native_announcements.get(service_name).cloned();
+        anyhow::ensure!(accepted.is_some(), "native accepted announcement missing for {service_name}");
+        let signing_key = self.service_signing_key(service_name);
+        let trust = crate::service::trust_store::global_trust_store();
+        let jwt = trust.get(&signing_key.verifying_key()).and_then(|att| att.jwt);
+        let policy = trust.resolve_one("policy").ok_or_else(|| anyhow::anyhow!("policy key missing"))?;
+        let discovery = trust.resolve_one("discovery").ok_or_else(|| anyhow::anyhow!("discovery key missing"))?;
+        let service_name = service_name.to_owned();
+        Ok(Arc::new(move |cancellation, node_id| publish_native_announcement(
+            publisher.clone(), cancellation, service_name.clone(), NativeAnnouncementReach::Iroh { node_id },
+            signing_key.clone(), jwt.clone(), policy, discovery, accepted.clone(),
+        )))
+    }
+
     /// Create a new service context.
     pub fn new(
         signing_key: SigningKey,

--- a/crates/hyprstream/src/bin/main.rs
+++ b/crates/hyprstream/src/bin/main.rs
@@ -3114,6 +3114,11 @@ fn main() -> Result<()> {
                                                 .collect::<Result<Vec<_>>>()
                                         },
                                     )?;
+                                    // Event clients start before factories, so the process
+                                    // proof must be installed before any pre-factory dial.
+                                    if let Some(proof) = moq_admission_proof.clone() {
+                                        let _ = hyprstream_rpc::moq_stream::init_global_moq_admission_proof(proof);
+                                    }
                                     let discovery_transport = ctx.transport("discovery", SocketKind::Rep);
                                     let shared = hyprstream_service::QuicSharedConfig {
                                         cert_chain,
@@ -3404,9 +3409,7 @@ fn main() -> Result<()> {
                                     .iter()
                                     .any(|stage| stage.iter().any(|s| s == "event"));
                                 if !hosts_event_service {
-                                    hyprstream_rpc::moq_event::ensure_event_client_origin(
-                                        hyprstream_rpc::paths::event_socket(),
-                                    );
+                                    hyprstream_core::services::event_network::ensure_event_origin_for_profile()?;
                                 }
 
                                 for stage in &stages {

--- a/crates/hyprstream/src/cli/git_handlers.rs
+++ b/crates/hyprstream/src/cli/git_handlers.rs
@@ -10,8 +10,7 @@ use crate::runtime::GenerationRequest;
 use crate::services::generated::inference_client::ChatMessage;
 use crate::services::generated::model_client::ChatTemplateRequest;
 use hyprstream_rpc::events::EventSubscriber;
-use hyprstream_rpc::moq_event::ensure_event_client_origin;
-use hyprstream_rpc::paths;
+use crate::services::event_network::ensure_event_origin_for_profile;
 use crate::services::generated::registry_client::{
     BranchRequest, CheckoutRequest, CloneRequest, CreateWorktreeRequest,
     RemoveWorktreeRequest, UpdateRequest,
@@ -1522,7 +1521,7 @@ pub async fn handle_load(
     // plaintext-plane `AllowAllTerminalAuthz` and no group-key join is needed.
     if let Some(timeout_secs) = wait {
         println!("Waiting for model to load (timeout: {}s)...", timeout_secs);
-        ensure_event_client_origin(paths::event_socket());
+        ensure_event_origin_for_profile()?;
         let mut subscriber = EventSubscriber::new()?;
         subscriber.subscribe("model")?;
 
@@ -1632,6 +1631,9 @@ pub async fn handle_notify_command(
     use crate::cli::quick::NotifyCommand;
 
     match command {
+        NotifyCommand::Probe { timeout } => {
+            crate::services::event_network::probe_event_network(std::time::Duration::from_secs(timeout)).await
+        }
         NotifyCommand::Subscribe { pattern, json, timeout, count } => {
             handle_notify_subscribe(&pattern, json, timeout, count, signing_key).await
         }
@@ -1653,7 +1655,7 @@ async fn handle_notify_subscribe(
     // flip deferred to #555); the per-publish unlinkability of the old NotificationService
     // is consciously dropped per the epic's group-level-confidentiality decision.
     // notify subscribe is now a streaming subscribe (not a one-shot deliver).
-    ensure_event_client_origin(paths::event_socket());
+    ensure_event_origin_for_profile()?;
     let mut subscriber = EventSubscriber::new()?;
     subscriber.subscribe(pattern)?;
 

--- a/crates/hyprstream/src/cli/quick.rs
+++ b/crates/hyprstream/src/cli/quick.rs
@@ -421,6 +421,12 @@ pub enum WorktreeQuickCommand {
 /// Notification subcommands
 #[derive(Subcommand)]
 pub enum NotifyCommand {
+    /// Verify authenticated native Event access by receiving the system track.
+    Probe {
+        /// Maximum seconds for discovery, admission and authorized delivery.
+        #[arg(long, default_value = "10")]
+        timeout: u64,
+    },
     /// Subscribe to real-time events matching a scope pattern
     ///
     /// Opens an encrypted notification channel and prints events as they arrive.

--- a/crates/hyprstream/src/config/mod.rs
+++ b/crates/hyprstream/src/config/mod.rs
@@ -452,6 +452,14 @@ pub struct QuicConfig {
     #[serde(default)]
     pub native_network_profile: NativeNetworkProfile,
 
+    /// Explicit admitted DID to tenant bindings. Carrier IDs never select a tenant.
+    #[serde(default)]
+    pub moql_subject_tenants: std::collections::BTreeMap<String, String>,
+
+    /// Separate Event producer grants. Tenant membership alone grants no ingress.
+    #[serde(default)]
+    pub event_publishers: std::collections::BTreeSet<String>,
+
     /// #358: the producer-chosen moq RELAY this node rendezvouses through, as a
     /// dialable URI (`https://host:port` for the relay's WebTransport `/moq`
     /// endpoint, or an iroh node URI). Empty = direct-only (the baseline). When
@@ -473,6 +481,8 @@ impl Default for QuicConfig {
             key_path: String::new(),
             iroh: default_iroh_enabled(),
             native_network_profile: NativeNetworkProfile::Compatibility,
+            moql_subject_tenants: Default::default(),
+            event_publishers: Default::default(),
             relay: String::new(),
         }
     }

--- a/crates/hyprstream/src/services/event_network.rs
+++ b/crates/hyprstream/src/services/event_network.rs
@@ -1,0 +1,270 @@
+//! Native Event transport bootstrap. Identity admission and MAC are independent.
+use anyhow::{Context, Result};
+use hyprstream_rpc::transport::moql_admission::MoqlAdmissionProof;
+use std::sync::Arc;
+
+/// The fixed Event tree belongs only to the explicitly provisioned local tenant.
+pub fn require_event_tenant(
+    config: &crate::config::QuicConfig,
+    proof: &MoqlAdmissionProof,
+) -> Result<()> {
+    anyhow::ensure!(
+        config
+            .moql_subject_tenants
+            .get(&proof.did)
+            .is_some_and(|t| t == "local"),
+        "Event identity {} requires explicit quic.moql_subject_tenants binding to local",
+        proof.did
+    );
+    Ok(())
+}
+
+/// Initialize both CLI and service Event clients according to the deployment
+/// profile. Required mode never opens a UDS, including when credentials are absent.
+pub fn ensure_event_origin_for_profile() -> Result<()> {
+    let config = crate::config::HyprConfig::load()?;
+    if !config.quic.iroh_required() && !hyprstream_discovery::native_network_required() {
+        hyprstream_rpc::moq_event::ensure_event_client_origin(hyprstream_rpc::paths::event_socket());
+        return Ok(());
+    }
+    let proof = hyprstream_rpc::moq_stream::global_moq_admission_proof()
+        .context("native Event client requires an installed checkpointed admission proof")?
+        .clone();
+    require_event_tenant(&config.quic, &proof)?;
+    hyprstream_rpc::events::install_network_event_identity(&proof)?;
+    if let Some(origin) = hyprstream_rpc::moq_event::install_event_network_client_origin() {
+        tokio::spawn(async move {
+            loop {
+                let result: Result<()> = async {
+                    let (transport, identity) =
+                        hyprstream_discovery::production_moq_event_target().await?;
+                    let mut proof = proof.clone();
+                    proof.expected_server = identity;
+                    hyprstream_rpc::moq_event::run_event_network_link(&origin, &transport, &proof)
+                        .await
+                }
+                .await;
+                if let Err(error) = result {
+                    tracing::warn!(%error, "native Event link unavailable");
+                }
+                tokio::time::sleep(std::time::Duration::from_millis(500)).await;
+            }
+        });
+    }
+    Ok(())
+}
+
+/// Build the Event-owned admission authenticator and the independent explicit
+/// ingress grant. An absent MAC policy still denies every Event source.
+pub fn event_handler(
+    ctx: &hyprstream_service::ServiceContext,
+    origin: &hyprstream_rpc::moq_event::MoqEventOrigin,
+    node_id: [u8; 32],
+) -> Result<hyprstream_rpc::transport::iroh_moq::IrohMoqProtocolHandler> {
+    use hyprstream_rpc::transport::iroh_moq::{
+        IrohMoqProtocolHandler, MoqAuthzConfig, OriginShared,
+    };
+    use hyprstream_rpc::transport::moql_admission::{
+        MoqlAdmissionAuthenticator, MoqlServerIdentityProof,
+    };
+    let config = crate::config::HyprConfig::load()?;
+    let proof = ctx
+        .moql_admission_proof("event")?
+        .context("native Event server proof missing")?;
+    require_event_tenant(&config.quic, &proof)?;
+    hyprstream_rpc::events::install_network_event_identity(&proof)?;
+    let tenants = config.quic.moql_subject_tenants.clone();
+    let publishers = config.quic.event_publishers.clone();
+    let admission = MoqlAdmissionAuthenticator::new(
+        hyprstream_discovery::production_moql_accepted_state_authority()?,
+        Arc::new(move |peer| {
+            peer.subject
+                .as_ref()
+                .and_then(|did| tenants.get(did))
+                .cloned()
+        }),
+    );
+    admission.install_server_identity(
+        MoqlServerIdentityProof::from_local_admission_proof(&proof)?,
+        node_id,
+    )?;
+    let authz = hyprstream_rpc::events::installed_event_authz()
+        .context("Event MAC reference monitor missing")?;
+    Ok(IrohMoqProtocolHandler::with_origin(OriginShared::from_pair(
+        origin.producer(),
+        origin.consumer(),
+    ))
+    .with_event_authz(authz)
+    .with_authz(
+        MoqAuthzConfig::default()
+            .with_admission(Arc::new(admission))
+            .with_ingress_authorizer(Arc::new(
+                move |peer: &hyprstream_rpc::moq_authz::PeerIdentity, tenant: &str| {
+                    tenant == "local"
+                        && peer
+                            .subject
+                            .as_ref()
+                            .is_some_and(|did| publishers.contains(did))
+                },
+            )),
+    ))
+}
+
+/// Owns the Event carrier and announcement cancellation for the service lifetime.
+pub struct EventNetworkService {
+    secret: [u8; 32],
+    node_id: [u8; 32],
+    handler: hyprstream_rpc::transport::iroh_moq::IrohMoqProtocolHandler,
+    announce: hyprstream_service::service::factory::NativeIrohAnnouncementCallback,
+}
+
+impl EventNetworkService {
+    pub fn new(
+        ctx: &hyprstream_service::ServiceContext,
+        origin: &hyprstream_rpc::moq_event::MoqEventOrigin,
+    ) -> Result<Self> {
+        let key = hyprstream_rpc::node_identity::derive_purpose_key(
+            &ctx.service_signing_key("event"),
+            "hyprstream-iroh-transport-v1",
+        );
+        let node_id = key.verifying_key().to_bytes();
+        Ok(Self {
+            secret: key.to_bytes(),
+            node_id,
+            handler: event_handler(ctx, origin, node_id)?,
+            announce: ctx.native_iroh_announcement_callback("event")?,
+        })
+    }
+}
+
+impl hyprstream_rpc::service::Spawnable for EventNetworkService {
+    fn name(&self) -> &str {
+        "event"
+    }
+    fn registrations(
+        &self,
+    ) -> Vec<(
+        hyprstream_rpc::registry::SocketKind,
+        hyprstream_rpc::transport::TransportConfig,
+    )> {
+        vec![]
+    }
+    fn run(
+        self: Box<Self>,
+        shutdown: Arc<tokio::sync::Notify>,
+        on_ready: Option<tokio::sync::oneshot::Sender<()>>,
+    ) -> hyprstream_rpc::error::Result<()> {
+        use hyprstream_rpc::error::RpcError;
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .map_err(|e| RpcError::SpawnFailed(e.to_string()))?;
+        runtime.block_on(async move {
+            let substrate = hyprstream_rpc::transport::iroh_substrate::IrohSubstrate::new(
+                self.secret, self.handler,
+                hyprstream_rpc::transport::iroh_substrate::RefuseHandler::new("Event provides only authenticated moql"),
+            ).await.map_err(|e| RpcError::SpawnFailed(format!("native Event bind: {e}")))?;
+            let cancellation = tokio_util::sync::CancellationToken::new();
+            let _cancel_on_exit = cancellation.clone().drop_guard();
+            let announce_cancel = cancellation.clone();
+            let announce = self.announce;
+            let node_id = self.node_id;
+            let initial = tokio::select! {
+                biased;
+                _ = shutdown.notified() => Err(RpcError::SpawnFailed("Event stopped before announcement".into())),
+                result = tokio::task::spawn_blocking(move || announce(announce_cancel, node_id)) => {
+                    result.map_err(|e| RpcError::SpawnFailed(format!("Event announcement task: {e}")))
+                        .and_then(|r| r.map_err(|e| RpcError::SpawnFailed(format!("Event initial announcement: {e}"))))
+                }
+            };
+            if let Err(error) = initial {
+                cancellation.cancel();
+                let _ = substrate.shutdown().await;
+                return Err(error);
+            }
+            if let Some(ready) = on_ready { let _ = ready.send(()); }
+            let _ = hyprstream_rpc::notify::ready();
+            tokio::select! {
+                _ = shutdown.notified() => {},
+                _ = cancellation.cancelled() => {},
+                _ = async {
+                    while !substrate.router().is_shutdown() && !substrate.endpoint().is_closed() {
+                        tokio::time::sleep(std::time::Duration::from_secs(1)).await;
+                    }
+                } => {},
+            }
+            cancellation.cancel();
+            substrate.shutdown().await.map_err(|e| RpcError::SpawnFailed(format!("Event shutdown: {e}")))
+        })
+    }
+}
+
+/// Probe the native Event capability: authenticate to the freshly resolved
+/// carrier and receive an actual frame from the authorized system source.
+/// A carrier handshake alone, or a local retained Event, cannot satisfy it.
+pub async fn probe_event_network(timeout: std::time::Duration) -> Result<()> {
+    tokio::time::timeout(timeout, async {
+        let config = crate::config::HyprConfig::load()?;
+        anyhow::ensure!(config.quic.iroh_required() || hyprstream_discovery::native_network_required(), "Event network probe requires network-iroh-required");
+        let mut proof = hyprstream_rpc::moq_stream::global_moq_admission_proof()
+            .context("Event probe requires a checkpointed client proof")?.clone();
+        require_event_tenant(&config.quic, &proof)?;
+        let (transport, identity) = hyprstream_discovery::production_moq_event_target().await?;
+        proof.expected_server = identity;
+        let stream = hyprstream_rpc::dial::dial_stream_authenticated(&transport, &proof).await?;
+        let origin = hyprstream_rpc::moq_event::MoqEventOrigin::new();
+        // Subscriber-only: a health probe never announces or publishes.
+        let client = moq_net::Client::new().with_consume(origin.producer());
+        let session = stream.connect_moq(&client).await?;
+        let consumer = origin.consumer();
+        let evidence = async {
+            let broadcast = consumer.announced_broadcast("local/events/system").await.context("system Event source unavailable")?;
+            let mut track = broadcast.subscribe_track(&moq_net::Track::new(hyprstream_rpc::moq_event::EVENT_TRACK))?;
+            let mut group = track.next_group().await?.context("system Event track has no group")?;
+            group.read_frame().await?.context("system Event track has no frame")?;
+            Ok(())
+        };
+        tokio::select! {
+            result = evidence => result,
+            _ = session.closed() => anyhow::bail!("Event probe session closed before authorized track delivery"),
+        }
+    }).await.context("native Event capability probe timed out")?
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A required CLI/service initializer must reject absent proof before it
+    /// installs an origin or spawns a compatibility socket task. Isolate process
+    /// globals so this tests the real initializer without fixture order effects.
+    #[test]
+    fn required_event_client_missing_proof_has_no_local_fallback() -> Result<()> {
+        const CHILD: &str = "HYPRSTREAM_EVENT_REQUIRED_TEST_CHILD";
+        if std::env::var_os(CHILD).is_none() {
+            let status = std::process::Command::new(std::env::current_exe()?)
+                .args(["--exact", "services::event_network::tests::required_event_client_missing_proof_has_no_local_fallback", "--nocapture"])
+                .env(CHILD, "1")
+                .env("HYPRSTREAM__QUIC__NATIVE_NETWORK_PROFILE", "network-iroh-required")
+                .status()?;
+            anyhow::ensure!(
+                status.success(),
+                "required Event initializer isolation failed"
+            );
+            return Ok(());
+        }
+        anyhow::ensure!(hyprstream_rpc::moq_event::global_moq_event_origin().is_none());
+        let error = ensure_event_origin_for_profile()
+            .err()
+            .context("missing proof did not reject required Event initialization")?;
+        anyhow::ensure!(
+            error.to_string().contains("checkpointed admission proof"),
+            "unexpected error: {error}"
+        );
+        anyhow::ensure!(
+            hyprstream_rpc::moq_event::global_moq_event_origin().is_none(),
+            "required failure installed a local origin"
+        );
+        Ok(())
+    }
+}

--- a/crates/hyprstream/src/services/factories.rs
+++ b/crates/hyprstream/src/services/factories.rs
@@ -679,6 +679,10 @@ fn create_event_service(ctx: &ServiceContext) -> anyhow::Result<Box<dyn Spawnabl
     let origin = MoqEventOrigin::new();
     hyprstream_rpc::moq_event::init_global_moq_event_origin(origin.clone());
 
+    if ctx.iroh_required() {
+        return Ok(Box::new(super::event_network::EventNetworkService::new(ctx, &origin)?));
+    }
+
     // #275: serve the event-bus origin over the well-known cross-process UDS path
     // so OTHER service processes (worker, model, ...) can publish/subscribe events
     // to this shared bus. In the same-process (InprocManager) deployment every

--- a/crates/hyprstream/src/services/mod.rs
+++ b/crates/hyprstream/src/services/mod.rs
@@ -185,3 +185,6 @@ pub fn discovery_client_for_process(
 pub use mcp_service::{McpConfig, McpService};
 #[cfg(feature = "metrics")]
 pub use metrics::MetricsService;
+
+/// Authenticated Event transport and profile-aware initialization.
+pub mod event_network;

--- a/crates/hyprstream/src/services/oauth/browser_session.rs
+++ b/crates/hyprstream/src/services/oauth/browser_session.rs
@@ -379,6 +379,8 @@ mod tests {
             ..Default::default()
         };
         let quic = crate::config::QuicConfig {
+            event_publishers: Default::default(),
+            moql_subject_tenants: Default::default(),
             enabled: true,
             bind_addr: "127.0.0.1:4433".to_owned(),
             server_name: "pds.example.test".to_owned(),

--- a/crates/hyprstream/src/services/oauth/identity_registration.rs
+++ b/crates/hyprstream/src/services/oauth/identity_registration.rs
@@ -1744,6 +1744,8 @@ mod tests {
             ..AccountZoneConfig::default()
         };
         let quic = QuicConfig {
+            event_publishers: Default::default(),
+            moql_subject_tenants: Default::default(),
             enabled: true,
             bind_addr: "127.0.0.1:4433".to_owned(),
             server_name: "pds.example.test".to_owned(),

--- a/docs/network/event-plane.md
+++ b/docs/network/event-plane.md
@@ -1,0 +1,62 @@
+# Native Event plane
+
+With `quic.native_network_profile = "network-iroh-required"`, the Event
+service owns an Iroh substrate and publishes its initial signed Discovery
+announcement before reporting service readiness. Binding or announcement failure
+aborts startup. Shutdown cancels publication and closes the substrate. Event
+refuses RPC and advertises only `hyprstream-moq/1`; resolve it with
+`ServiceQuery::network_moq("event")`.
+
+Other services install their checkpoint-selected process proof before factories
+start. Their Event link resolves reach and server witness together, runs mutual
+hybrid MoQL admission, and reconnects through a fresh resolution after failure.
+The native Event initializer never opens a UDS. Compatibility mode retains the
+existing UDS behavior.
+
+## Independent authorization boundaries
+
+The deployment must explicitly map each admitted service/client DID to `local`
+in `quic.moql_subject_tenants`. The fixed Event namespace is `local/events`;
+other tenants cannot see or publish it. Carrier EndpointIds do not select tenants.
+
+A separate `quic.event_publishers` set grants the listed DIDs the ability to seek
+Event ingress. Membership in the tenant map does not imply that grant. On top of
+admission and ingress, the installed Event MAC reference monitor decides the
+allowed sources and directions. The carrier exposes only those source scopes.
+An empty policy table, absent verified clearance, or undeclared source denies.
+Current accepted state, ingress grants, and Event MAC scopes are rechecked while
+the session lives; loss/change of authority closes the connection.
+
+The temporary source inventory is `system`, `worker`, and `model`. It declares
+source names, **not security labels or clearances**. Per-OID publication paths
+are not exposed by this initial network port. Generated inventory integration
+is tracked by #1530 / #1505.
+
+Local plaintext Event publishers and subscribers receive the checkpoint-selected
+process DID before construction. This identity is an input to MAC; it does not
+create a verified subject context or authorize any operation. Explicit caller
+and publisher-identity overrides retain their existing behavior.
+
+## Probe and remaining activation requirements
+
+`hyprstream notify probe --timeout 10` requires the native profile, a provisioned
+checkpointed client proof, fresh Event resolution, mutual admission, and actual
+delivery on `local/events/system`'s `events` track. It uses a fresh subscriber
+origin, so a local retained broadcast cannot satisfy the probe. No Event RPC or
+UDS fallback is involved. A handshake alone is insufficient. The probe needs a
+live/retained system event; there is no periodic Event heartbeat in this port.
+
+This transport port does **not** activate production Event access:
+
+- Both production MAC policy tables remain empty until reviewed declared labels
+  are available. IdentityAware activation and signed policy/clearance provisioning
+  remain required; this change does not install system-low rows or FloorOnly
+  staging exceptions.
+- CLI `notify subscribe`, `notify probe`, and `load --wait` select the native path,
+  but CLI bootstrap still needs a legitimate checkpointed client proof. When that
+  proof is absent, initialization fails explicitly instead of using a service
+  identity or falling back to UDS.
+- The deployment must provision actual DID-to-tenant bindings and independent
+  ingress grants, then verify allowed and denied operations across hosts.
+- No live staging deployment, image publication, or cloud configuration is part
+  of this change. Transport tests do not establish staging readiness.


### PR DESCRIPTION
Required-native service processes currently use the Event UDS bridge, while the Event barrier binds no Iroh carrier or Discovery reach. Add an Event-owned authenticated Iroh substrate, cancelable signed announcement, checkpoint-backed target resolution, and explicit native client initialization before factories.

Event advertises only its MoQ capability. Its carrier independently enforces admitted DID-to-tenant bindings, explicit producer ingress grants, and MAC-authorized source scopes, with live authority rechecks. Local Event publishers/subscribers receive the checkpoint-selected process DID as MAC input. CLI Event entry points now honor the deployment profile; `notify probe` requires fresh admission and actual system-track delivery.

This remains a draft pending production activation dependencies: approved declared MAC rows and IdentityAware/signed clearance provisioning, legitimate CLI proof and Event PEP/verified subject-context bootstrap, and deployed cross-host evidence. Task-contract item 4 (production declared rows) and full declared-track health acceptance remain incomplete pending those approved identity-derived rows and activation. Both production tables remain empty and deny. No system-low policy or FloorOnly exception is introduced. Per-OID Event paths and periodic heartbeat production remain outside this initial port. See `docs/network/event-plane.md`.

Validation:
- BuildQ `cargo check --all-targets`: passed.
- BuildQ combined `cargo nextest run -p hyprstream -p hyprstream-rpc -p hyprstream-service -p hyprstream-discovery`: 3171 passed, 8 skipped.
- Five Event tests cover real-Iroh delivery, actual MAC table denial, tenant and ingress boundaries, live revocation, and local caller identity. Required-profile no-UDS failure and signed-checkpoint MoQ-only Event reach are also covered.
- Causal negative: removing the server Event scope filter made the undeclared-source assertion fail; restored implementation passes.
- Mandatory workspace release Clippy passed in the commit hook.

Refs #1494, #1505, #1530. Ports the stale Event design onto post-#1534 main; no cherry-pick or shared-branch rewrite.
