### PR TITLE
fix: bound required Policy initial Iroh publication wait

### DIFF
--- a/crates/hyprstream-rpc/src/transport/lazy_iroh.rs
+++ b/crates/hyprstream-rpc/src/transport/lazy_iroh.rs
@@ -40,6 +40,19 @@ use crate::transport::iroh_substrate::{ALPN_HYPRSTREAM_RPC, OwnedIrohClientEndpo
 use crate::transport::iroh_transport::{IrohPendingStream, IrohPublishStub, IrohTransport};
 use crate::transport_traits::Transport;
 
+/// Availability failures before a request is dispatched. This deliberately
+/// excludes malformed addresses, missing client setup, peer authentication,
+/// ALPN rejection, and all errors after connection establishment.
+#[derive(Debug, thiserror::Error)]
+pub enum IrohPeerUnavailable {
+    #[error("iroh connect timed out")]
+    ConnectTimeout,
+    #[error("iroh peer is in reconnect backoff")]
+    ReconnectBackoff,
+    #[error("iroh peer address discovery is not available yet")]
+    AddressDiscovery(#[source] iroh::endpoint::ConnectError),
+}
+
 /// Default per-request deadline when the caller passes `None`.
 const DEFAULT_TIMEOUT: Duration = Duration::from_secs(30);
 
@@ -97,6 +110,9 @@ pub struct LazyIrohTransport {
     relay_url: Option<String>,
     /// Cached session + reconnect backoff (#156).
     state: Mutex<LazyState<IrohTransport>>,
+    /// Accessed only while holding `state`: a later backoff must not turn a
+    /// prior authentication/configuration rejection into availability.
+    availability_backoff: std::sync::atomic::AtomicBool,
     /// Test-only dial endpoint override.
     ///
     /// Production always dials from the process-global install-once endpoint
@@ -125,6 +141,7 @@ impl LazyIrohTransport {
             direct_addrs,
             relay_url,
             state: Mutex::new(LazyState::default()),
+            availability_backoff: std::sync::atomic::AtomicBool::new(false),
             #[cfg(test)]
             endpoint_override: None,
         }
@@ -145,6 +162,7 @@ impl LazyIrohTransport {
             direct_addrs,
             relay_url,
             state: Mutex::new(LazyState::default()),
+            availability_backoff: std::sync::atomic::AtomicBool::new(false),
             endpoint_override: Some(endpoint),
         }
     }
@@ -184,9 +202,11 @@ impl LazyIrohTransport {
             return Ok(transport.clone());
         }
         if let Some(remaining) = guard.backoff.cooldown_remaining() {
-            return Err(anyhow!(
-                "iroh peer is in reconnect backoff — retry in {remaining:.1?}"
-            ));
+            return if self.availability_backoff.load(std::sync::atomic::Ordering::Relaxed) {
+                Err(IrohPeerUnavailable::ReconnectBackoff.into())
+            } else {
+                Err(anyhow!("iroh peer is in reconnect backoff — retry in {remaining:.1?}"))
+            };
         }
         let endpoint = self.dial_endpoint().ok_or_else(|| {
             anyhow!(
@@ -203,14 +223,28 @@ impl LazyIrohTransport {
         {
             Err(_) => {
                 guard.backoff.record_failure();
-                Err(anyhow!("iroh connect timed out after {CONNECT_TIMEOUT:?}"))
+                self.availability_backoff.store(true, std::sync::atomic::Ordering::Relaxed);
+                Err(IrohPeerUnavailable::ConnectTimeout.into())
             }
             Ok(Err(e)) => {
                 guard.backoff.record_failure();
-                Err(anyhow!("iroh connect: {e}"))
+                let unavailable = matches!(
+                    &e,
+                    iroh::endpoint::ConnectError::Connect {
+                        source: iroh::endpoint::ConnectWithOptsError::NoAddress { .. },
+                        ..
+                    }
+                );
+                self.availability_backoff.store(unavailable, std::sync::atomic::Ordering::Relaxed);
+                if unavailable {
+                    Err(IrohPeerUnavailable::AddressDiscovery(e).into())
+                } else {
+                    Err(anyhow::Error::new(e).context("iroh connect"))
+                }
             }
             Ok(Ok(conn)) => {
                 guard.backoff.record_success();
+                self.availability_backoff.store(false, std::sync::atomic::Ordering::Relaxed);
                 let transport = IrohTransport::new(conn);
                 guard.cached = Some(transport.clone());
                 Ok(transport)
@@ -224,6 +258,7 @@ impl LazyIrohTransport {
         let mut guard = self.state.lock().await;
         guard.cached = None;
         guard.backoff.record_failure();
+        self.availability_backoff.store(false, std::sync::atomic::Ordering::Relaxed);
     }
 }
 
@@ -279,6 +314,26 @@ mod tests {
         let mut k = [0u8; 32];
         rand::thread_rng().fill_bytes(&mut k);
         k
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn lazy_iroh_absent_peer_is_typed_availability_before_dispatch() {
+        let client = IrohSubstrate::new_test(
+            fresh_key(), NoopHandler::new("client moq"), NoopHandler::new("client rpc"),
+        ).await.unwrap();
+        let peer = ed25519_dalek::SigningKey::from_bytes(&fresh_key()).verifying_key().to_bytes();
+        // Minimal test carrier has neither a relay nor address lookup. No
+        // server exists, so these bytes can never have reached a handler.
+        let transport = LazyIrohTransport::new_with_endpoint(peer, vec![], None, client.endpoint().clone());
+        let error = transport.send(b"not-dispatched".to_vec(), Some(100)).await.unwrap_err();
+        assert!(crate::transport_traits::is_pre_dispatch_transport_error(&error));
+        assert!(error.chain().any(|cause| cause.downcast_ref::<IrohPeerUnavailable>().is_some()));
+        assert!(transport.state.lock().await.cached.is_none());
+        // Backoff preserves its explicit availability provenance.
+        let error = transport.send(b"still-not-dispatched".to_vec(), Some(100)).await.unwrap_err();
+        assert!(error.chain().any(|cause| matches!(cause.downcast_ref::<IrohPeerUnavailable>(), Some(IrohPeerUnavailable::ReconnectBackoff))));
+        drop(transport);
+        client.shutdown().await.unwrap();
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
@@ -354,8 +409,13 @@ mod tests {
         let res = tokio::time::timeout(Duration::from_secs(8), t.send(b"x".to_vec(), Some(3_000)))
             .await
             .expect("send must complete (with an error) — wrong identity should reject, not hang");
-        assert!(res.is_err(), "dialing a server's address under a wrong EndpointId must fail");
+        let error = res.expect_err("dialing a server's address under a wrong EndpointId must fail");
+        assert!(!error.chain().any(|cause| cause.downcast_ref::<IrohPeerUnavailable>().is_some()),
+            "a peer-identity handshake rejection must not become retryable availability");
         assert!(t.state.lock().await.cached.is_none(), "a failed handshake caches nothing");
+        let backoff_error = t.send(b"x".to_vec(), Some(3_000)).await.expect_err("rejection backoff");
+        assert!(!backoff_error.chain().any(|cause| cause.downcast_ref::<IrohPeerUnavailable>().is_some()),
+            "backoff must retain the prior permanent failure classification");
 
         // As above, release the transport's endpoint clone before cleanly
         // draining every substrate owned by this test.

--- a/crates/hyprstream/src/bin/main.rs
+++ b/crates/hyprstream/src/bin/main.rs
@@ -177,6 +177,12 @@ fn build_cli() -> ClapCommand {
                     .about("Initialize the checkpoint store for an explicitly provisioned fresh deployment"),
             )
             .subcommand(
+                ClapCommand::new("inspect-services")
+                    .about("Read existing checkpoint-verified service identities as public JSON without provisioning or renewal")
+                    .arg(Arg::new("service").long("service").required(true)
+                        .action(clap::ArgAction::Append).value_delimiter(',')),
+            )
+            .subcommand(
                 ClapCommand::new("provision-services")
                     .about("Admit existing local service identities before starting the registry")
                     .arg(Arg::new("service").long("service").required(true)
@@ -2267,6 +2273,19 @@ fn main() -> Result<()> {
         .validate()
         .context("Configuration validation failed")?;
 
+    // Read-only accepted-state inspection must precede tracing (which may
+    // create log files), endpoint/runtime initialization and all bootstrap/key
+    // generation paths. Buffer the complete verified roster before stdout.
+    if let Some(("pds", pds)) = matches.subcommand() {
+        if let Some(("inspect-services", inspect)) = pds.subcommand() {
+            let services = inspect.get_many::<String>("service")
+                .context("service roster is required")?.cloned().collect::<Vec<_>>();
+            let bytes = hyprstream_core::cli::deployment_bootstrap::inspect_services(&config, &services)?;
+            std::io::Write::write_all(&mut std::io::stdout().lock(), &bytes)?;
+            return Ok(());
+        }
+    }
+
     // RPC clients are used by ordinary CLI commands (`quick`, `tui`, etc.),
     // not only by service entrypoints. Install both request- and response-side
     // verification defaults before dispatch so every command uses the
@@ -3809,6 +3828,22 @@ fn main() -> Result<()> {
 #[cfg(test)]
 #[allow(clippy::expect_used)]
 mod resolver_startup_controls {
+    #[test]
+    fn readonly_roster_cli_requires_services_and_has_no_mutation_options() {
+        let matches = super::build_cli().try_get_matches_from([
+            "hyprstream", "pds", "inspect-services", "--service", "model,event",
+        ]).expect("read-only roster CLI");
+        let inspect = matches.subcommand_matches("pds").expect("pds")
+            .subcommand_matches("inspect-services").expect("inspect");
+        assert_eq!(inspect.get_many::<String>("service").expect("services")
+            .map(String::as_str).collect::<Vec<_>>(), vec!["model", "event"]);
+        for args in [
+            vec!["hyprstream", "pds", "inspect-services"],
+            vec!["hyprstream", "pds", "inspect-services", "--service", "model", "--valid-for-seconds", "86400"],
+            vec!["hyprstream", "pds", "inspect-services", "--service", "model", "--roster-export", "out.json"],
+        ] { assert!(super::build_cli().try_get_matches_from(args).is_err()); }
+    }
+
     #[test]
     fn deployment_bootstrap_cli_requires_roster_and_parses_lifetime() {
         let matches = super::build_cli().try_get_matches_from([

--- a/crates/hyprstream/src/bin/main.rs
+++ b/crates/hyprstream/src/bin/main.rs
@@ -1319,7 +1319,7 @@ fn handle_quick_command(
                         // Wire up policy-backed authorization
                         let worker_policy_client = hyprstream_core::services::policy_client_for_process(
                             signing_key.clone(),
-                            resolve_service_vk("policy")
+                            resolve_service_vk("policy", Some(ctx.config()))
                                 .ok_or_else(|| anyhow::anyhow!("Cannot resolve policy pubkey. Run wizard."))?,
                             None,
                         )?;
@@ -1333,7 +1333,7 @@ fn handle_quick_command(
                         // is in scope here, so the mesh PQ store is empty (#157):
                         // identical to prior behavior (Hybrid fails closed for
                         // unknown peers).
-                        install_envelope_verify_config(None);
+                        install_envelope_verify_config(None, None);
 
                         let manager = InprocManager::new();
                         Some(
@@ -1637,14 +1637,18 @@ fn select_iroh_moql_admission_proof<T>(
     }
 }
 
-fn resolve_service_vk(service_name: &str) -> Option<VerifyingKey> {
+fn resolve_service_vk(
+    service_name: &str,
+    config: Option<&HyprConfig>,
+) -> Option<VerifyingKey> {
     let trust = hyprstream_service::global_trust_store();
     // Fast path: already populated (service startup seeded it)
     if let Some(vk) = trust.resolve_one(service_name) {
         return Some(vk);
     }
-    // CLI mode: seed from bootstrap-pubkeys on first use
-    let Ok(secrets_dir) = HyprConfig::resolve_secrets_dir() else {
+    // CLI mode: seed from bootstrap-pubkeys on first use. When startup already
+    // loaded a config (including --config), keep that path authoritative.
+    let Ok(secrets_dir) = HyprConfig::resolve_secrets_dir_for(config) else {
         return None;
     };
     // Load the full entries so the hybrid requirement can be enforced before
@@ -1731,7 +1735,7 @@ async fn install_process_production_resolver(
     // store; in CLI/service-start mode nothing has seeded it yet. Seed from
     // the node's own bootstrap-pubkeys (the same source resolve_service_vk
     // uses on first use) — a no-op when already populated or unprovisioned.
-    let _ = resolve_service_vk("discovery");
+    let _ = resolve_service_vk("discovery", Some(config));
     // Private-PKI deployments may terminate the did:web host with an internal
     // CA; the extra root is additive (never disables verification), and an
     // unreadable file is a hard configuration error, not a silent skip.
@@ -1833,8 +1837,13 @@ fn quic_checkpoint_policy(
 /// When `oauth` is `Some`, the kid-anchored PQ trust store is populated eagerly
 /// from `mesh_peers` (#157). When `None` (e.g. the standalone worker entrypoint,
 /// which has no config in scope), the store is empty — identical to the prior
-/// behavior. Either way the store is immutable after install.
-fn install_envelope_verify_config(oauth: Option<&hyprstream_core::config::OAuthConfig>) {
+/// behavior. `config` carries the already-loaded CLI config so its explicit
+/// secrets path remains authoritative. Either way the store is immutable after
+/// install.
+fn install_envelope_verify_config(
+    oauth: Option<&hyprstream_core::config::OAuthConfig>,
+    config: Option<&HyprConfig>,
+) {
     use hyprstream_rpc::envelope::{
         install_response_verify_config, install_verify_config, mandatory_envelope_policy,
         EnvelopeVerifyConfig, KeyedPqTrustStore, PqTrustStore, ResponseVerifyConfig,
@@ -1858,7 +1867,7 @@ fn install_envelope_verify_config(oauth: Option<&hyprstream_core::config::OAuthC
     // envelope verify path consults, so supplying hybrid material actually
     // turns PQ enforcement on for those services. A classical-only file
     // anchors nothing and changes nothing.
-    if let Ok(secrets_dir) = HyprConfig::resolve_secrets_dir() {
+    if let Ok(secrets_dir) = HyprConfig::resolve_secrets_dir_for(config) {
         let anchored = hyprstream_core::auth::mesh_trust::seed_bootstrap_pq_bindings(
             &mut keyed_store,
             &secrets_dir,
@@ -2551,7 +2560,7 @@ fn main() -> Result<()> {
     // verification defaults before dispatch so every command uses the
     // operator-configured mesh trust store (#1018). The installer is
     // first-write-wins, so the service-specific calls below remain harmless.
-    install_envelope_verify_config(Some(&config.oauth));
+    install_envelope_verify_config(Some(&config.oauth), Some(&config));
 
     // Install the per-service streaming-response concurrency cap from config
     // (#186) before any RPC service starts. First-write-wins; ignore if already
@@ -3618,7 +3627,7 @@ fn main() -> Result<()> {
                                 //
                                 // Policy: Hybrid is mandatory. With no anchored
                                 // peer key the verifier FAILS CLOSED.
-                                install_envelope_verify_config(Some(&config.oauth));
+                                install_envelope_verify_config(Some(&config.oauth), Some(&config));
 
                                 // Install MoQ/event authorization in every
                                 // production service process before any model,
@@ -4170,6 +4179,71 @@ mod resolver_startup_controls {
         config.quic.native_network_profile = hyprstream_core::config::NativeNetworkProfile::Compatibility;
         assert_eq!(super::native_service_process_name(&multi, &config)?, None);
         assert_eq!(super::native_service_process_name(&single, &config)?, None);
+        Ok(())
+    }
+
+    #[test]
+    fn native_service_identity_seeds_discovery_from_loaded_config() -> anyhow::Result<()> {
+        const CHILD: &str = "HYPRSTREAM_NATIVE_DISCOVERY_SEED_TEST";
+        if std::env::var_os(CHILD).is_none() {
+            let status = std::process::Command::new(std::env::current_exe()?)
+                .args([
+                    "--exact",
+                    "resolver_startup_controls::native_service_identity_seeds_discovery_from_loaded_config",
+                    "--nocapture",
+                ])
+                .env(CHILD, "1")
+                .env_remove("HYPRSTREAM__SECRETS__PATH")
+                .env_remove("HYPRSTREAM_SECRETS_PROFILE")
+                .status()?;
+            anyhow::ensure!(status.success(), "isolated discovery seeding regression failed");
+            return Ok(());
+        }
+
+        let root = tempfile::tempdir()?;
+        let xdg_config_home = root.path().join("xdg-config");
+        std::env::set_var("XDG_CONFIG_HOME", &xdg_config_home);
+
+        // Keep a different, valid bootstrap file at the default location so
+        // this catches accidental re-resolution through HyprConfig::load().
+        let default_secrets = xdg_config_home.join("hyprstream/credentials");
+        let default_key = ed25519_dalek::SigningKey::from_bytes(&[91u8; 32]);
+        let mut default_entries = std::collections::HashMap::new();
+        default_entries.insert(
+            "discovery".to_owned(),
+            hyprstream_core::auth::identity_store::BootstrapPubkey::for_service_key(
+                &default_key,
+            )?,
+        );
+        hyprstream_core::auth::identity_store::write_bootstrap_pubkeys_hybrid(
+            &default_secrets,
+            &default_entries,
+        )?;
+
+        let custom_secrets = root.path().join("custom-credentials");
+        let custom_key = ed25519_dalek::SigningKey::from_bytes(&[92u8; 32]);
+        let mut custom_entries = std::collections::HashMap::new();
+        custom_entries.insert(
+            "discovery".to_owned(),
+            hyprstream_core::auth::identity_store::BootstrapPubkey::for_service_key(
+                &custom_key,
+            )?,
+        );
+        hyprstream_core::auth::identity_store::write_bootstrap_pubkeys_hybrid(
+            &custom_secrets,
+            &custom_entries,
+        )?;
+
+        let mut config = super::HyprConfig::default();
+        config.secrets.path = Some(custom_secrets);
+        let selected = super::resolve_service_vk("discovery", Some(&config))
+            .expect("configured bootstrap-pubkeys must seed discovery");
+        assert_eq!(selected, custom_key.verifying_key());
+        assert_ne!(selected, default_key.verifying_key());
+        assert_eq!(
+            hyprstream_service::global_trust_store().resolve_one("discovery"),
+            Some(custom_key.verifying_key()),
+        );
         Ok(())
     }
 

--- a/crates/hyprstream/src/bin/main.rs
+++ b/crates/hyprstream/src/bin/main.rs
@@ -2044,6 +2044,46 @@ where
     result
 }
 
+/// Policy must serve authority probes while Discovery starts, but is not READY
+/// until Discovery accepts its announcement. Only typed pre-dispatch Iroh
+/// unavailability can keep that initial publication pending.
+const POLICY_INITIAL_PUBLICATION_BUDGET: std::time::Duration = std::time::Duration::from_secs(120);
+const POLICY_INITIAL_PUBLICATION_RETRY: std::time::Duration = std::time::Duration::from_millis(500);
+
+async fn wait_for_policy_initial_publication<F, Fut>(
+    cancellation: &tokio_util::sync::CancellationToken,
+    budget: std::time::Duration,
+    mut attempt: F,
+) -> anyhow::Result<()>
+where
+    F: FnMut() -> Fut,
+    Fut: std::future::Future<Output = anyhow::Result<()>>,
+{
+    let deadline = tokio::time::Instant::now() + budget;
+    loop {
+        let result = tokio::select! {
+            biased;
+            _ = cancellation.cancelled() => anyhow::bail!("Policy initial publication cancelled"),
+            _ = tokio::time::sleep_until(deadline) => anyhow::bail!("Policy initial publication deadline exceeded"),
+            result = async { attempt().await } => result,
+        };
+        match result {
+            Ok(()) => return Ok(()),
+            Err(error) if hyprstream_rpc::transport_traits::is_pre_dispatch_transport_error(&error)
+                && error.chain().any(|cause| cause.downcast_ref::<hyprstream_rpc::transport::lazy_iroh::IrohPeerUnavailable>().is_some()) => {
+                tracing::info!(%error, "Policy awaiting Discovery initial publication");
+            }
+            Err(error) => return Err(error),
+        }
+        tokio::select! {
+            biased;
+            _ = cancellation.cancelled() => anyhow::bail!("Policy initial publication cancelled"),
+            _ = tokio::time::sleep_until(deadline) => anyhow::bail!("Policy initial publication deadline exceeded"),
+            _ = tokio::time::sleep(POLICY_INITIAL_PUBLICATION_RETRY) => {}
+        }
+    }
+}
+
 /// Spawn the native-announcement refresh loop on its own current-thread Tokio
 /// runtime and return a channel for the first announcement result.
 ///
@@ -3176,6 +3216,52 @@ fn main() -> Result<()> {
                                                                 return;
                                                             }
                                                         };
+                                                        if service_name == "policy"
+                                                            && hyprstream_discovery::native_network_required()
+                                                            && matches!(request.reach, hyprstream_service::NativeAnnouncementReach::Iroh { .. })
+                                                        {
+                                                            let cancellation = request.cancellation.clone();
+                                                            let initial = wait_for_policy_initial_publication(
+                                                                &cancellation,
+                                                                POLICY_INITIAL_PUBLICATION_BUDGET,
+                                                                || {
+                                                                    // Re-read signed current state and the exact service
+                                                                    // key's credential on every attempt, before any dial.
+                                                                    let announcement = hyprstream_core::services::factories::current_native_announcement(&mut request);
+                                                                    let client = &client;
+                                                                    async move {
+                                                                        let announcement = announcement?;
+                                                                        let jwt_expiry = announcement.service_jwt.as_deref()
+                                                                            .and_then(hyprstream_core::auth::identity_store::decode_jwt_exp_raw)
+                                                                            .and_then(|seconds| seconds.checked_mul(1_000))
+                                                                            .context("Policy initial announcement requires a bounded service JWT")?;
+                                                                        let expiry = announcement.expires_at_unix_ms.min(jwt_expiry);
+                                                                        let remaining = expiry.saturating_sub(chrono::Utc::now().timestamp_millis());
+                                                                        anyhow::ensure!(remaining > 0, "Policy initial announcement authority expired");
+                                                                        let duration = std::time::Duration::from_millis(u64::try_from(remaining)?);
+                                                                        tokio::time::timeout(duration, client.announce(&announcement)).await
+                                                                            .context("Policy initial announcement authority expired during publication")??;
+                                                                        anyhow::ensure!(chrono::Utc::now().timestamp_millis() < expiry,
+                                                                            "Policy initial announcement authority expired before readiness");
+                                                                        Ok(())
+                                                                    }
+                                                                },
+                                                            ).await;
+                                                            // Report only success or terminal failure, never a
+                                                            // transient availability error. The spawner's existing
+                                                            // bind/publication READY and cancellation gates remain.
+                                                            if let Some(tx) = announce_tx.as_ref() {
+                                                                if let Some(tx) = tx.lock().take() {
+                                                                    let _ = tx.send(initial.as_ref().map(|_| ()).map_err(ToString::to_string));
+                                                                }
+                                                            }
+                                                            if initial.is_err() { return; }
+                                                            tokio::select! {
+                                                                biased;
+                                                                _ = cancellation.cancelled() => return,
+                                                                _ = tokio::time::sleep(std::time::Duration::from_secs(25)) => {}
+                                                            }
+                                                        }
                                                         let _completion = refresh_native_announcement(
                                                             &service_name,
                                                             &socket_kind,
@@ -3801,6 +3887,95 @@ fn main() -> Result<()> {
 #[cfg(test)]
 #[allow(clippy::expect_used)]
 mod resolver_startup_controls {
+    fn unavailable_policy_publication() -> anyhow::Error {
+        hyprstream_rpc::transport_traits::PreDispatchTransportError::new(
+            hyprstream_rpc::transport::lazy_iroh::IrohPeerUnavailable::ConnectTimeout.into(),
+        ).into()
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn policy_initial_publication_retries_only_typed_availability_and_reprojects() {
+        let cancellation = tokio_util::sync::CancellationToken::new();
+        let mut projections = 0;
+        let start = tokio::time::Instant::now();
+        super::wait_for_policy_initial_publication(&cancellation, std::time::Duration::from_secs(120), || {
+            projections += 1;
+            let generation = projections;
+            async move {
+                if generation < 3 { Err(unavailable_policy_publication()) } else { Ok(()) }
+            }
+        }).await.expect("late Discovery should allow Policy to publish");
+        assert_eq!(projections, 3, "every retry must request fresh authority material");
+        assert_eq!(start.elapsed(), std::time::Duration::from_secs(1));
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn policy_initial_publication_permanent_error_after_availability_is_terminal() {
+        let cancellation = tokio_util::sync::CancellationToken::new();
+        // These are intentionally untyped security/projection errors. Even
+        // availability-looking text must never select the retry path.
+        for terminal in ["expired current authority", "revoked service JWT", "iroh connect timed out"] {
+            let mut attempts = 0;
+            let error = super::wait_for_policy_initial_publication(&cancellation, std::time::Duration::from_secs(120), || {
+                attempts += 1;
+                let first = attempts == 1;
+                async move {
+                    if first { Err(unavailable_policy_publication()) } else { anyhow::bail!(terminal) }
+                }
+            }).await.expect_err("security failures must be terminal");
+            assert_eq!(error.to_string(), terminal);
+            assert_eq!(attempts, 2);
+        }
+        let mut attempts = 0;
+        let error = super::wait_for_policy_initial_publication(&cancellation, std::time::Duration::from_secs(120), || {
+            attempts += 1;
+            async {
+                Err(hyprstream_rpc::transport_traits::PreDispatchTransportError::new(
+                    anyhow::anyhow!("missing Iroh client endpoint"),
+                ).into())
+            }
+        }).await.expect_err("pre-dispatch alone is not an availability proof");
+        assert_eq!(attempts, 1);
+        assert!(error.to_string().contains("missing Iroh client endpoint"));
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn policy_initial_publication_deadline_bounds_retries_and_inflight_call() {
+        let cancellation = tokio_util::sync::CancellationToken::new();
+        let start = tokio::time::Instant::now();
+        let error = super::wait_for_policy_initial_publication(&cancellation, std::time::Duration::from_secs(2), || async {
+            Err(unavailable_policy_publication())
+        }).await.expect_err("absent Discovery cannot keep startup pending forever");
+        assert!(error.to_string().contains("deadline exceeded"));
+        assert_eq!(start.elapsed(), std::time::Duration::from_secs(2));
+        let start = tokio::time::Instant::now();
+        let error = super::wait_for_policy_initial_publication(&cancellation, std::time::Duration::from_secs(2), std::future::pending).await
+            .expect_err("deadline also interrupts a stalled RPC");
+        assert!(error.to_string().contains("deadline exceeded"));
+        assert_eq!(start.elapsed(), std::time::Duration::from_secs(2));
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn policy_initial_publication_cancellation_precedes_success() {
+        let cancellation = tokio_util::sync::CancellationToken::new();
+        cancellation.cancel();
+        let mut called = false;
+        super::wait_for_policy_initial_publication(&cancellation, std::time::Duration::from_secs(120), || {
+            called = true;
+            async { Ok(()) }
+        }).await.expect_err("cancelled startup cannot publish or become ready");
+        assert!(!called);
+        let cancellation = tokio_util::sync::CancellationToken::new();
+        let cancel = cancellation.clone();
+        let cancel_task = tokio::spawn(async move {
+            tokio::time::sleep(std::time::Duration::from_secs(1)).await;
+            cancel.cancel();
+        });
+        super::wait_for_policy_initial_publication(&cancellation, std::time::Duration::from_secs(120), std::future::pending).await
+            .expect_err("shutdown interrupts an in-flight publication");
+        cancel_task.await.expect("canceller");
+    }
+
     #[test]
     fn deployment_bootstrap_cli_requires_roster_and_parses_lifetime() {
         let matches = super::build_cli().try_get_matches_from([

--- a/crates/hyprstream/src/bin/main.rs
+++ b/crates/hyprstream/src/bin/main.rs
@@ -1548,6 +1548,49 @@ fn resolve_moq_relay_reach(
         .ok_or_else(|| anyhow::anyhow!("relay URI is not a network-routable transport"))
 }
 
+/// Select the process identity before constructing any resolver/client. Transport
+/// flags do not decide whose identity a required-native split service uses.
+fn native_service_process_name(matches: &clap::ArgMatches, config: &HyprConfig) -> Result<Option<String>> {
+    if !config.quic.iroh_required() {
+        return Ok(None);
+    }
+    let Some(("service", service_matches)) = matches.subcommand() else {
+        return Ok(None);
+    };
+    let action = ServiceAction::from_arg_matches(service_matches)
+        .map_err(|error| anyhow::anyhow!("{error}"))?;
+    let ServiceAction::Start { name, foreground, standalone, services, .. } = action else {
+        return Ok(None);
+    };
+    if !foreground && !standalone {
+        return Ok(None);
+    }
+    let names = if standalone {
+        config.services.startup.clone()
+    } else {
+        services.unwrap_or_else(|| name.into_iter().collect())
+    };
+    anyhow::ensure!(names.len() == 1,
+        "network-iroh-required requires exactly one service per foreground process; launch each provisioned service separately");
+    let service = names.into_iter().next().context("native service name missing")?;
+    anyhow::ensure!(hyprstream_service::get_factory(&service).is_some(), "unknown native service: {service}");
+    Ok(Some(service))
+}
+
+/// Required service startup consumes the provisioner's retained key. Missing or
+/// malformed material is never a reason to generate a new identity or use the
+/// CLI/root key. Compatibility commands retain their existing key behavior.
+async fn load_process_signing_key(config: &HyprConfig, native_service: Option<&str>) -> Result<SigningKey> {
+    if let Some(service) = native_service {
+        let secrets = HyprConfig::resolve_secrets_dir_for(Some(config))?;
+        return hyprstream_core::auth::identity_store::load_existing_service_signing_key(
+            &secrets, service, hyprstream_core::auth::identity_store::SecretsProfile::from_env()?,
+        ).with_context(|| format!("load provisioned native identity for {service}"));
+    }
+    let keys_dir = config.models_dir().join(".registry").join("keys");
+    load_or_generate_signing_key(&keys_dir).await
+}
+
 /// A QUIC process currently owns one native MoQ dialer and its admission-proof
 /// slot. Sharing that slot across separately checkpointed services would make a
 /// later service dial as the first service's DID. Refuse that topology until the
@@ -1662,7 +1705,7 @@ async fn install_process_production_resolver(
     //
     // Scoped to this node's OWN service identities. External classical clients
     // and federated peers do not appear in this file and are not affected.
-    if let Ok(secrets_dir) = HyprConfig::resolve_secrets_dir() {
+    if let Ok(secrets_dir) = HyprConfig::resolve_secrets_dir_for(Some(config)) {
         let entries =
             hyprstream_core::auth::identity_store::load_bootstrap_pubkeys_hybrid(&secrets_dir)?;
         hyprstream_core::auth::identity_store::ensure_bootstrap_pubkeys_hybrid(&entries)?;
@@ -2592,6 +2635,8 @@ fn main() -> Result<()> {
         }
     }
 
+    let native_service_name = native_service_process_name(&matches, &config)?;
+
     // Start registry service ONCE at CLI level
     let _registry_runtime = tokio::runtime::Builder::new_multi_thread()
         .enable_all()
@@ -2606,8 +2651,7 @@ fn main() -> Result<()> {
         bool,
     ) = _registry_runtime
         .block_on(async {
-            let keys_dir = config.models_dir().join(".registry").join("keys");
-            let signing_key = load_or_generate_signing_key(&keys_dir).await?;
+            let signing_key = load_process_signing_key(&config, native_service_name.as_deref()).await?;
             let verifying_key = signing_key.verifying_key();
 
             let is_os_owned_bootstrap = install_process_production_resolver(&signing_key, &config).await
@@ -2723,6 +2767,10 @@ fn main() -> Result<()> {
                             }
                         };
 
+                        // --services with one member selects that service's identity,
+                        // never the synthetic "multi"/"standalone" command label.
+                        let name = native_service_name.clone().unwrap_or(name);
+
                         // Standard foreground service startup
                         let rpc_mode = if ipc {
                             hyprstream_rpc::registry::EndpointMode::Ipc
@@ -2759,8 +2807,12 @@ fn main() -> Result<()> {
 
                                 let models_dir = config.models_dir();
                                 let keys_dir = models_dir.join(".registry").join("keys");
-                                let signing_key =
-                                    load_or_generate_signing_key(&keys_dir).await?;
+                                let signing_key = if native_service_name.is_some() {
+                                    // Same retained key already installed in the process resolver.
+                                    signing_key.clone()
+                                } else {
+                                    load_or_generate_signing_key(&keys_dir).await?
+                                };
                                 let verifying_key = signing_key.verifying_key();
 
                                 let fed_src: Arc<dyn hyprstream_rpc::auth::FederationKeySource> =
@@ -2798,8 +2850,8 @@ fn main() -> Result<()> {
                                     vec![name.clone()]
                                 };
 
-                                if ipc {
-                                    // Multi-process mode: each service gets its own independent key.
+                                if ipc || native_service_name.is_some() {
+                                    // Split-service identity is independent of local IPC transport.
                                     //
                                     // #759: resolve via the SAME authoritative path
                                     // `HyprConfig::resolve_secrets_dir()` uses elsewhere in this
@@ -2812,7 +2864,7 @@ fn main() -> Result<()> {
                                     // than this process reads from — the same "consumer silently
                                     // re-derives instead of reading the authoritative record"
                                     // disease #441 targets, just one directory earlier.
-                                    let secrets_dir = hyprstream_core::config::HyprConfig::resolve_secrets_dir()?;
+                                    let secrets_dir = hyprstream_core::config::HyprConfig::resolve_secrets_dir_for(Some(&config))?;
                                     ctx = ctx.with_ca_verifying_key(
                                         hyprstream_core::auth::identity_store::load_ca_verifying_key(
                                             &secrets_dir,
@@ -2856,9 +2908,13 @@ fn main() -> Result<()> {
                                     // secrets profile — see `resolve_service_signing_key` for why.
                                     let secrets_profile =
                                         hyprstream_core::auth::identity_store::SecretsProfile::from_env()?;
-                                    let own_key = hyprstream_core::auth::identity_store::resolve_service_signing_key(
-                                        &secrets_dir, &name, secrets_profile,
-                                    )?;
+                                    let own_key = if native_service_name.is_some() {
+                                        signing_key.clone()
+                                    } else {
+                                        hyprstream_core::auth::identity_store::resolve_service_signing_key(
+                                            &secrets_dir, &name, secrets_profile,
+                                        )?
+                                    };
 
                                     if name == "policy" {
                                         // PolicyService: signing_key IS the CA key (already loaded).
@@ -2899,7 +2955,7 @@ fn main() -> Result<()> {
                                     //
                                     // #759: same authoritative resolver as the `--ipc` branch above —
                                     // see the comment there.
-                                    let secrets_dir = hyprstream_core::config::HyprConfig::resolve_secrets_dir()?;
+                                    let secrets_dir = hyprstream_core::config::HyprConfig::resolve_secrets_dir_for(Some(&config))?;
                                     ctx = ctx.with_ca_verifying_key(
                                         hyprstream_core::auth::identity_store::load_ca_verifying_key(
                                             &secrets_dir,
@@ -2991,7 +3047,7 @@ fn main() -> Result<()> {
                                 // no manifest-backed clearance.
                                 {
                                     let secrets_dir =
-                                        hyprstream_core::config::HyprConfig::resolve_secrets_dir()?;
+                                        hyprstream_core::config::HyprConfig::resolve_secrets_dir_for(Some(&config))?;
                                     match hyprstream_core::auth::service_enrollment::ServiceEnrollmentManifest::load_and_validate(&secrets_dir)
                                         .context("service enrollment manifest validation failed")?
                                     {
@@ -3226,7 +3282,7 @@ fn main() -> Result<()> {
 
                                 // Populate ML-DSA-65 verifying keys for PQ-hybrid JWT verification.
                                 {
-                                    let secrets_dir = hyprstream_core::config::HyprConfig::resolve_secrets_dir()?;
+                                    let secrets_dir = hyprstream_core::config::HyprConfig::resolve_secrets_dir_for(Some(&config))?;
                                     let ml_dsa_store = hyprstream_core::auth::key_rotation::global_ml_dsa_key_store(
                                         &secrets_dir,
                                         &config.oauth,
@@ -3802,6 +3858,92 @@ fn main() -> Result<()> {
 #[cfg(test)]
 #[allow(clippy::expect_used)]
 mod resolver_startup_controls {
+    #[test]
+    fn native_service_identity_loads_existing_key_without_ipc() -> anyhow::Result<()> {
+        const CHILD: &str = "HYPRSTREAM_NATIVE_SERVICE_IDENTITY_TEST";
+        let Ok(profile) = std::env::var(CHILD) else {
+            for profile in ["shared-directory", "per-service-scoped"] {
+                let status = std::process::Command::new(std::env::current_exe()?)
+                    .args(["--exact", "resolver_startup_controls::native_service_identity_loads_existing_key_without_ipc", "--nocapture"])
+                    .env(CHILD, profile)
+                    .env("HYPRSTREAM_SECRETS_PROFILE", profile)
+                    .env_remove("HYPRSTREAM__SECRETS__PATH")
+                    .env_remove("HYPRSTREAM__SIGNING_KEY")
+                    .status()?;
+                anyhow::ensure!(status.success(), "isolated {profile} identity regression failed");
+            }
+            return Ok(());
+        };
+        let root = tempfile::tempdir()?;
+        let runtime = tokio::runtime::Builder::new_current_thread().enable_all().build()?;
+        for (service, seed) in [("policy", 31u8), ("model", 32u8), ("registry", 33u8)] {
+            let secrets = root.path().join(format!("{service}-credentials"));
+            std::fs::create_dir_all(secrets.join(service))?;
+            let key_path = if service == "policy" || profile == "per-service-scoped" {
+                // A misleading service subdirectory must not replace a scoped
+                // identity, especially Policy's canonical flat key.
+                std::fs::write(secrets.join(service).join("signing-key"), [99u8; 32])?;
+                secrets.join("signing-key")
+            } else {
+                // A retained root/Policy key must not become a native Model or
+                // Registry process identity merely because --ipc is absent.
+                std::fs::write(secrets.join("signing-key"), [31u8; 32])?;
+                secrets.join(service).join("signing-key")
+            };
+            std::fs::write(&key_path, [seed; 32])?;
+            let mut configured = super::HyprConfig::default();
+            configured.quic.native_network_profile = hyprstream_core::config::NativeNetworkProfile::NetworkIrohRequired;
+            configured.secrets.path = Some(secrets.clone());
+            configured.storage.models_dir = root.path().join(format!("{service}-models"));
+            let config_path = root.path().join(format!("{service}.toml"));
+            configured.to_file(&config_path)?;
+            let matches = super::build_cli().try_get_matches_from([
+                "hyprstream", "--config", config_path.to_str().expect("temporary UTF-8 path"),
+                "service", "start", service, "--foreground",
+            ])?;
+            let config = super::load_config(matches.get_one::<std::path::PathBuf>("config").map(std::path::PathBuf::as_path))?;
+            let selected = super::native_service_process_name(&matches, &config)?;
+            assert_eq!(selected.as_deref(), Some(service));
+            let key = runtime.block_on(super::load_process_signing_key(&config, selected.as_deref()))?;
+            assert_eq!(key.to_bytes(), [seed; 32]);
+            let ctx = super::ServiceContext::new(key.clone(), key.verifying_key(), false, config.models_dir().clone())
+                .with_service_key(service, key.clone());
+            assert_eq!(ctx.signing_key().verifying_key(), key.verifying_key());
+            assert_eq!(ctx.service_signing_key(service).verifying_key(), key.verifying_key());
+            assert!(!config.models_dir().join(".registry/keys").exists(), "native startup must not materialize a CLI/root key");
+            std::fs::remove_file(&key_path)?;
+            assert!(runtime.block_on(super::load_process_signing_key(&config, selected.as_deref())).is_err());
+            assert!(!key_path.exists(), "missing provisioned key must not be regenerated");
+            std::fs::write(&key_path, [seed; 31])?;
+            assert!(runtime.block_on(super::load_process_signing_key(&config, selected.as_deref())).is_err());
+            assert_eq!(std::fs::read(&key_path)?, vec![seed; 31], "malformed key must not be repaired during startup");
+        }
+        Ok(())
+    }
+
+    #[test]
+    fn native_service_identity_rejects_multi_and_selects_single_service_list() -> anyhow::Result<()> {
+        let mut config = super::HyprConfig::default();
+        config.quic.native_network_profile = hyprstream_core::config::NativeNetworkProfile::NetworkIrohRequired;
+        let single = super::build_cli().try_get_matches_from([
+            "hyprstream", "service", "start", "--foreground", "--services", "model",
+        ])?;
+        assert_eq!(super::native_service_process_name(&single, &config)?.as_deref(), Some("model"));
+        let multi = super::build_cli().try_get_matches_from([
+            "hyprstream", "service", "start", "--foreground", "--services", "model,registry",
+        ])?;
+        assert!(super::native_service_process_name(&multi, &config).is_err());
+        let standalone = super::build_cli().try_get_matches_from([
+            "hyprstream", "service", "start", "--standalone",
+        ])?;
+        config.services.startup = vec!["model".into(), "registry".into()];
+        assert!(super::native_service_process_name(&standalone, &config).is_err());
+        config.quic.native_network_profile = hyprstream_core::config::NativeNetworkProfile::Compatibility;
+        assert_eq!(super::native_service_process_name(&multi, &config)?, None);
+        assert_eq!(super::native_service_process_name(&single, &config)?, None);
+        Ok(())
+    }
+
     #[test]
     fn deployment_bootstrap_cli_requires_roster_and_parses_lifetime() {
         let matches = super::build_cli().try_get_matches_from([

--- a/crates/hyprstream/src/cli/deployment_bootstrap.rs
+++ b/crates/hyprstream/src/cli/deployment_bootstrap.rs
@@ -60,15 +60,7 @@ pub fn provision_services(
         (600..=86_400).contains(&valid_for_seconds),
         "service identity lifetime must be 600..86400 seconds"
     );
-    ensure!(!services.is_empty(), "at least one service is required");
-    let mut unique = std::collections::HashSet::new();
-    for name in services {
-        ensure!(unique.insert(name), "duplicate service in bootstrap roster");
-        ensure!(
-            hyprstream_service::get_factory(name).is_some(),
-            "unknown service in bootstrap roster: {name}"
-        );
-    }
+    validate_service_roster(services)?;
     let verifier = hyprstream_discovery::authenticate_local_deployment_registry()?;
     let secrets = provisioning_secrets_dir(config)?;
     let acceptance =
@@ -128,6 +120,76 @@ pub fn provision_services(
         tracing::info!(path = %path.display(), "verified service roster manifest exported");
     }
     Ok(())
+}
+
+/// Read the current accepted roster without acquiring a writer or admitting
+/// state. Returns a complete public JSON document only after every member has
+/// passed the existing deployment/checkpoint/key-binding/freshness validators.
+/// The caller emits these buffered bytes; no output or store is written here.
+pub fn inspect_services(config: &HyprConfig, services: &[String]) -> Result<Vec<u8>> {
+    validate_service_roster(services)?;
+    let verifier = hyprstream_discovery::authenticate_local_deployment_registry()?;
+    let secrets = provisioning_secrets_dir(config)?;
+    let keys = load_roster_keys(&secrets, services)?;
+    let directory = hyprstream_service::deployment_data_dir()?.join("pds-store");
+    let store = PdsRecordStore::open_readonly(&directory)?
+        .with_at9p_deployment_verifier(verifier);
+    inspect_verified_roster(&store, &keys, &Utc::now().to_rfc3339_opts(SecondsFormat::Secs, true))
+}
+
+fn validate_service_roster(services: &[String]) -> Result<()> {
+    ensure!(!services.is_empty(), "at least one service is required");
+    let mut unique = std::collections::HashSet::new();
+    for name in services {
+        ensure!(unique.insert(name), "duplicate service in bootstrap roster");
+        ensure!(
+            hyprstream_service::get_factory(name).is_some(),
+            "unknown service in bootstrap roster: {name}"
+        );
+    }
+    Ok(())
+}
+
+fn load_roster_keys(secrets: &Path, services: &[String]) -> Result<Vec<(String, SigningKey)>> {
+    services.iter().map(|name| {
+        load_existing_service_signing_key(secrets, name, SecretsProfile::SharedDirectory)
+            .map(|key| (name.clone(), key))
+    }).collect()
+}
+
+fn inspect_verified_roster(
+    store: &PdsRecordStore,
+    keys: &[(String, SigningKey)],
+    now_text: &str,
+) -> Result<Vec<u8>> {
+    // Enumerate through the authenticated checkpoint path, never deserialize
+    // raw DB bytes or use an editable prior export as authority. Missing or
+    // ambiguous service IDs cannot silently become first boot or a new DID.
+    let states = store.accepted_at9p_states()?;
+    let mut admitted = Vec::with_capacity(keys.len());
+    for (name, key) in keys {
+        let service_id = format!("#{name}");
+        let mut matching = states.iter().filter(|state| {
+            state.current.services.iter().any(|service| service.id == service_id)
+        });
+        let state = matching.next().with_context(|| format!("no accepted identity for service {name}"))?;
+        ensure!(matching.next().is_none(), "multiple accepted identities match service {name}");
+        admitted.push((name.as_str(), key, state.clone()));
+    }
+    let entries = build_verified_roster_entries(store, &admitted, now_text)?;
+    let mut bytes = serialize_verified_roster_manifest(entries)?;
+    bytes.push(b'\n');
+    Ok(bytes)
+}
+
+fn serialize_verified_roster_manifest(services: Vec<VerifiedServiceRosterEntry>) -> Result<Vec<u8>> {
+    ensure!(!services.is_empty(), "refusing to export an empty verified service roster");
+    let manifest = VerifiedServiceRosterManifest {
+        schema: VERIFIED_ROSTER_SCHEMA,
+        generated_at: Utc::now().to_rfc3339_opts(SecondsFormat::Secs, true),
+        services,
+    };
+    Ok(serde_json::to_vec_pretty(&manifest)?)
 }
 
 /// Re-read and re-verify every admitted member from the checkpoint store,
@@ -196,12 +258,7 @@ fn write_verified_roster_manifest(
         file_name.to_string_lossy(),
         std::process::id()
     ));
-    let manifest = VerifiedServiceRosterManifest {
-        schema: VERIFIED_ROSTER_SCHEMA,
-        generated_at: Utc::now().to_rfc3339_opts(SecondsFormat::Secs, true),
-        services,
-    };
-    let bytes = serde_json::to_vec_pretty(&manifest)?;
+    let bytes = serialize_verified_roster_manifest(services)?;
     // Ownership boundary: until the exclusive create succeeds, `temp` is not
     // ours — a collision means a leftover from an interrupted earlier process
     // (possibly with a reused PID) or another entry in the caller's directory,
@@ -352,6 +409,134 @@ fn provision_one(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    // Inventory contents and names (including directories) without relying on
+    // atime, which a read may legitimately update at the filesystem layer.
+    fn filesystem_contents(root: &Path) -> Result<std::collections::BTreeMap<std::path::PathBuf, Option<Vec<u8>>>> {
+        fn visit(root: &Path, dir: &Path, out: &mut std::collections::BTreeMap<std::path::PathBuf, Option<Vec<u8>>>) -> Result<()> {
+            for entry in std::fs::read_dir(dir)? {
+                let entry = entry?;
+                let path = entry.path();
+                let relative = path.strip_prefix(root)?.to_path_buf();
+                if entry.file_type()?.is_dir() {
+                    out.insert(relative, None);
+                    visit(root, &path, out)?;
+                } else {
+                    out.insert(relative, Some(std::fs::read(path)?));
+                }
+            }
+            Ok(())
+        }
+        let mut out = std::collections::BTreeMap::new();
+        visit(root, root, &mut out)?;
+        Ok(out)
+    }
+
+    #[test]
+    fn readonly_roster_reads_verified_state_without_changing_store_or_keys() -> Result<()> {
+        let (dir, store, ingest, model) = fixture()?;
+        let event = SigningKey::from_bytes(&[0x63; 32]);
+        let now = Utc::now();
+        let accepted_model = provision_one(&store, &ingest, "model", &model, now, 86400)?;
+        let accepted_event = provision_one(&store, &ingest, "event", &event, now, 86400)?;
+        let credentials = dir.path().join("retained-credentials");
+        crate::auth::identity_store::write_secret(&credentials.join("model"), "signing-key", &model.to_bytes())?;
+        crate::auth::identity_store::write_secret(&credentials.join("event"), "signing-key", &event.to_bytes())?;
+        drop(ingest);
+        drop(store);
+        let before = filesystem_contents(dir.path())?;
+        let keys = load_roster_keys(&credentials, &["model".into(), "event".into()])?;
+        let readonly = PdsRecordStore::open_readonly(dir.path())?
+            .with_at9p_acceptance_identity(SigningKey::from_bytes(&[0x61; 32]).verifying_key());
+        let bytes = inspect_verified_roster(&readonly, &keys, &now.to_rfc3339_opts(SecondsFormat::Secs, true))?;
+        let document: serde_json::Value = serde_json::from_slice(&bytes)?;
+        assert_eq!(document["schema"], VERIFIED_ROSTER_SCHEMA);
+        assert_eq!(document["services"].as_array().context("services")?.len(), 2);
+        for (index, state) in [accepted_model, accepted_event].iter().enumerate() {
+            assert_eq!(document["services"][index]["did"], state.did);
+            assert_eq!(document["services"][index]["epoch"], state.epoch);
+            assert_eq!(document["services"][index]["accepted_head_digest"], hex::encode(state.head_digest));
+            assert_eq!(document["services"][index]["expires_at"], state.expires_at.as_deref().context("expiry")?);
+        }
+        assert!(!String::from_utf8(bytes)?.contains(&hex::encode(model.to_bytes())));
+        assert_eq!(filesystem_contents(dir.path())?, before);
+        Ok(())
+    }
+
+    #[test]
+    fn readonly_roster_failure_preserves_state_and_never_initializes_missing_input() -> Result<()> {
+        let missing_root = tempfile::tempdir()?;
+        let before = filesystem_contents(missing_root.path())?;
+        assert!(PdsRecordStore::open_readonly(&missing_root.path().join("missing-store")).is_err());
+        assert!(load_roster_keys(missing_root.path(), &["model".into()]).is_err());
+        assert_eq!(filesystem_contents(missing_root.path())?, before);
+        let empty = missing_root.path().join("empty-store");
+        std::fs::create_dir(&empty)?;
+        let before = filesystem_contents(missing_root.path())?;
+        assert!(PdsRecordStore::open_readonly(&empty).is_err());
+        assert_eq!(filesystem_contents(missing_root.path())?, before);
+        std::fs::write(empty.join("CURRENT"), b"invalid current manifest")?;
+        let before = filesystem_contents(missing_root.path())?;
+        assert!(PdsRecordStore::open_readonly(&empty).is_err());
+        assert_eq!(filesystem_contents(missing_root.path())?, before);
+
+        let (dir, store, ingest, key) = fixture()?;
+        let now = Utc::now();
+        provision_one(&store, &ingest, "model", &key, now, 86400)?;
+        drop(ingest);
+        drop(store);
+        let before = filesystem_contents(dir.path())?;
+        let readonly = PdsRecordStore::open_readonly(dir.path())?
+            .with_at9p_acceptance_identity(SigningKey::from_bytes(&[0x61; 32]).verifying_key());
+        // A successful first member cannot produce a partial JSON result when
+        // a later requested service is missing or its retained key mismatches.
+        assert!(inspect_verified_roster(&readonly, &[("model".into(), key.clone()), ("event".into(), key.clone())], &now.to_rfc3339_opts(SecondsFormat::Secs, true)).is_err());
+        assert!(inspect_verified_roster(&readonly, &[("model".into(), SigningKey::from_bytes(&[0x77; 32]))], &now.to_rfc3339_opts(SecondsFormat::Secs, true)).is_err());
+        assert!(inspect_verified_roster(&readonly, &[("model".into(), key.clone())], &(now + Duration::hours(25)).to_rfc3339_opts(SecondsFormat::Secs, true)).is_err());
+        let wrong_verifier = PdsRecordStore::open_readonly(dir.path())?
+            .with_at9p_acceptance_identity(SigningKey::from_bytes(&[0x78; 32]).verifying_key());
+        assert!(inspect_verified_roster(&wrong_verifier, &[("model".into(), key)], &now.to_rfc3339_opts(SecondsFormat::Secs, true)).is_err());
+        assert_eq!(filesystem_contents(dir.path())?, before);
+        Ok(())
+    }
+
+    #[test]
+    fn readonly_roster_rejects_corrupt_checkpoint_and_preserves_failure_evidence() -> Result<()> {
+        let (dir, store, ingest, key) = fixture()?;
+        let now = Utc::now();
+        let accepted = provision_one(&store, &ingest, "model", &key, now, 86400)?;
+        drop(ingest);
+        drop(store);
+        // Tamper only in fixture setup, then close the writer before capturing
+        // the failed reader's complete on-disk before/after evidence.
+        let db = rocksdb::DB::open(&rocksdb::Options::default(), dir.path())?;
+        db.put(format!("at9p-checkpoint\0{}", accepted.subject_cid512), b"invalid checkpoint")?;
+        drop(db);
+        let before = filesystem_contents(dir.path())?;
+        let readonly = PdsRecordStore::open_readonly(dir.path())?
+            .with_at9p_acceptance_identity(SigningKey::from_bytes(&[0x61; 32]).verifying_key());
+        assert!(inspect_verified_roster(&readonly, &[("model".into(), key)], &now.to_rfc3339_opts(SecondsFormat::Secs, true)).is_err());
+        assert_eq!(filesystem_contents(dir.path())?, before);
+        Ok(())
+    }
+
+    #[test]
+    fn readonly_roster_rejects_empty_first_boot_store_without_consuming_marker() -> Result<()> {
+        let dir = tempfile::tempdir()?;
+        let store = PdsRecordStore::open(dir.path())?;
+        store.mark_first_boot()?;
+        drop(store);
+        let before = filesystem_contents(dir.path())?;
+        let readonly = PdsRecordStore::open_readonly(dir.path())?
+            .with_at9p_acceptance_identity(SigningKey::from_bytes(&[0x61; 32]).verifying_key());
+        assert!(inspect_verified_roster(&readonly, &[("model".into(), SigningKey::from_bytes(&[0x62; 32]))], &Utc::now().to_rfc3339_opts(SecondsFormat::Secs, true)).is_err());
+        assert!(readonly.first_boot_pending()?);
+        assert_eq!(filesystem_contents(dir.path())?, before);
+        assert!(validate_service_roster(&[]).is_err());
+        assert!(validate_service_roster(&["model".into(), "model".into()]).is_err());
+        assert!(validate_service_roster(&["unknown-service".into()]).is_err());
+        Ok(())
+    }
 
     #[test]
     fn deployment_bootstrap_rejects_invalid_roster_and_lifetime_before_credentials() {

--- a/crates/hyprstream/src/services/discovery.rs
+++ b/crates/hyprstream/src/services/discovery.rs
@@ -267,6 +267,12 @@ impl PdsRecordStore {
     /// (surfacing a missing/corrupt store at startup) but does not hold the
     /// handle — see the type-level docs. The resolver holds **no signing key**.
     pub fn open_readonly(path: &Path) -> AnyResult<Self> {
+        // RocksDB's read-only open can create a missing directory before it
+        // discovers that no database exists. A resolver/inspection read must
+        // not turn missing retained state into a newly initialized path.
+        let metadata = std::fs::metadata(path)
+            .with_context(|| format!("PDS read-only store directory is unavailable: {path:?}"))?;
+        anyhow::ensure!(metadata.is_dir(), "PDS read-only store path is not a directory: {path:?}");
         let opts = readonly_opts();
         let _probe = rocksdb::DB::open_for_read_only(&opts, path, false)
             .with_context(|| format!("failed to open PDS record store (ro) at {path:?}"))?;
@@ -2294,6 +2300,22 @@ mod pds_store_tests {
             "the advanced commit must link the previous commit"
         );
         assert!(second.rev > first.rev, "rev must strictly advance");
+    }
+
+    #[test]
+    fn readonly_roster_store_open_never_creates_missing_directories() -> AnyResult<()> {
+        let root = tempfile::tempdir()?;
+        for path in [root.path().join("missing"), root.path().join("absent-parent/nested/store")] {
+            assert!(PdsRecordStore::open_readonly(&path).is_err());
+            assert!(!path.exists());
+            assert_eq!(std::fs::read_dir(root.path())?.count(), 0);
+        }
+        let file = root.path().join("not-a-directory");
+        std::fs::write(&file, b"preserve existing bytes")?;
+        assert!(PdsRecordStore::open_readonly(&file).is_err());
+        assert_eq!(std::fs::read(&file)?, b"preserve existing bytes");
+        assert_eq!(std::fs::read_dir(root.path())?.count(), 1);
+        Ok(())
     }
 
     #[test]

--- a/docs/native-service-identity.md
+++ b/docs/native-service-identity.md
@@ -1,0 +1,58 @@
+# Required-native split-service identity
+
+A required-native foreground service selects its provisioned identity before
+installing the process resolver or constructing a client. That same key becomes
+the ServiceContext process identity and the named service key used to project
+checkpoint admission proofs. `--ipc` is not needed to select a service identity.
+
+For the eight-service staging roster, each container executes one of:
+
+```
+hyprstream service start event --foreground
+hyprstream service start discovery --foreground
+hyprstream service start policy --foreground
+hyprstream service start registry --foreground
+hyprstream service start streams --foreground
+hyprstream service start model --foreground
+hyprstream service start oai --foreground
+hyprstream service start oauth --foreground
+```
+
+Each uses the existing deployment configuration:
+
+```
+HYPRSTREAM__QUIC__ENABLED=true
+HYPRSTREAM__QUIC__IROH=true
+HYPRSTREAM__QUIC__NATIVE_NETWORK_PROFILE=network-iroh-required
+HYPRSTREAM__SECRETS__PATH=/var/lib/hyprstream/config/credentials
+HYPRSTREAM_SECRETS_PROFILE=shared-directory
+```
+
+The secrets profile defaults to `shared-directory`. Policy uses the canonical
+flat `credentials/signing-key`; other services use
+`credentials/SERVICE/signing-key`. With an explicitly scoped credential provider,
+`HYPRSTREAM_SECRETS_PROFILE=per-service-scoped` selects the flat `signing-key` in
+that service's configured directory. It must actually be scoped by the provider.
+Config-specified `[secrets].path` is honored by identity loading and service-start
+credential consumers; the existing secrets-path environment override retains
+precedence. Deployment trust, enrolled public anchors and required service JWTs
+must still be mounted/provisioned through their existing contracts.
+
+Startup reads the existing 32-byte seed. Missing or malformed service keys fail;
+startup does not generate a replacement, fall back to the CLI/Policy key, or
+create a CLI `.registry/keys` identity. Provisioning/keygen is a separate earlier
+step. No signing-key bypass is introduced.
+
+`service start --foreground --services model` selects `model`, not the command's
+synthetic `multi` name. Required-native foreground/standalone startup with more
+than one service is rejected before resolver installation: the process-global
+MoQL client proof currently represents one service identity. Launch separate
+containers. Compatibility-profile identity selection and its existing transport
+flags retain their behavior.
+
+This change does not activate MAC policy, issue user/service grants, solve the
+cold-start authority cycle, provision CLI proofs/PEPs, or implement credential
+renewal. It neither changes Policy's canonical identity nor resolves #1506's
+AsOriginator/RFC8693 decision. Streams PR1583 and Event PR1581 remain prerequisites;
+real staging authorization and crosshost probes still require the other tracked
+source and deployment work.

--- a/docs/readonly-accepted-roster.md
+++ b/docs/readonly-accepted-roster.md
@@ -1,0 +1,45 @@
+# Read-only accepted service roster
+
+`hyprstream pds inspect-services --service event,discovery,policy,registry,streams,model,oai,oauth`
+
+This OS-owned local inspection command reads existing accepted service state and
+emits one complete `hyprstream/verified-service-roster@1` JSON document to stdout.
+It uses the same public schema as `pds provision-services --roster-export`, with
+service name, DID, epoch, expiry and accepted head digest. All requested members
+must verify before any document bytes are emitted. Errors return nonzero without
+a document; diagnostics go to stderr. A stdout I/O error can still interrupt a
+write, so consumers must require successful exit and a complete valid document.
+
+The existing deployment trust loader authenticates the OS-owned hybrid deployment
+CA, authority log/checkpoint and current Registry credential. The accepted-state
+store opens read-only at the existing deployment path (`models/.registry/pds-store`
+beneath the deployment data directory; `/var/lib/hyprstream/models/.registry/pds-store`
+with `XDG_DATA_HOME=/var/lib`). Missing or invalid stores fail without initialization.
+The command never opens the writer, ingest WAL, provisioner, renewal, genesis,
+checkpoint advance or key-generation paths.
+
+Retained service signing keys are still required to reuse the existing hybrid
+service-key binding validator. The selected config `[secrets].path` and existing
+`HYPRSTREAM__SECRETS__PATH` override resolve that directory. As with the offline
+provisioner, it uses the shared-directory profile: Policy's canonical flat key,
+other services' `SERVICE/signing-key`. It does not generate missing keys, sign
+successors or print secret material. Existing trusted-artifact path and ownership
+requirements, Registry JWT validity and accepted-state freshness remain mandatory.
+
+Missing, ambiguous, invalid, expired or genesis-only roster members fail the whole
+read. Checkpoint/signature failures are never interpreted as absent state or first
+boot. A fresh `generated_at` records inspection time, not renewal; unchanged
+accepted epochs, digests and expiries remain unchanged in the output.
+
+The early dispatch precedes logging initialization, local endpoint initialization,
+service bootstrap and ordinary CLI signing-key/resolver startup. No output-file
+option exists: capture stdout using a caller-owned temporary file and publish it
+only after successful exit. Redirecting directly over an old good file truncates
+it in the shell before verification and is not failure-preserving publication.
+
+This is verified local readback, not a remote trust root, caller credential,
+client-admission mechanism or service-readiness probe. It can inspect beside a
+live writer through existing read-only RocksDB handles, but it does not lock out
+concurrent renewal or promise an all-roster transaction snapshot. Maintenance must
+still own its existing exclusion and compare accepted heads/epochs/expiry before
+mutation; live-service readiness still requires authenticated network probes.

--- a/docs/service-identity-bootstrap.md
+++ b/docs/service-identity-bootstrap.md
@@ -60,6 +60,32 @@ processes retain their own credentials; Policy loads its provisioned service
 JWT without an RPC to itself. Required Policy clients and the policy CLI resolve
 over Iroh. The required service loop does not bind a local RPC socket.
 
+In a split required-profile deployment, start Policy and Discovery concurrently
+once offline provisioning and key generation finish. Policy must not be ordered
+`After=Discovery` (nor Discovery after Policy readiness): Discovery probes the
+canonical Policy revocation/session stores before its factory can bind. Policy's
+Iroh handler binds before its announcement wait, so it can answer authenticated
+probes while Discovery starts. No authority store is bypassed or replaced.
+
+Only required Iroh Policy startup retries initial announcement availability
+failures. The wait has a 120-second monotonic deadline and 500ms retry delay;
+each connect retains the transport's existing 10-second timeout. Every retry
+reprojects current signed state and the current service credential, and each
+publication is additionally bounded by that credential and identity's expiry.
+Only typed pre-dispatch address-discovery, connect-timeout and backoff failures
+retry. Authentication/authorization rejection and invalid local authority are
+terminal. A deadline, cancellation or failure never signals READY. Successful
+initial publication is followed by the existing 25-second refresh cadence.
+Set these bootstrap units' `TimeoutStartSec` above the application wait plus
+startup allowance (180 seconds is the intended staging contract). This requires
+a concurrent launch contract in deployment units, not a readiness-order cycle.
+
+The pinned bootstrap MAC table does not yet declare the Policy revocation/session
+probe leaves or Discovery announcement. The reviewed generated inventory and
+its production MAC consumer must provide these declarations before a complete
+isolated-process IdentityAware startup can succeed. Publication retry does not
+supply policy labels, widen activation or replace the #1506 human decision.
+
 Compatibility clients permit validated QUIC or Iroh reach; browser provisioning
 retains its explicit WebTransport profile. Systemd notification sockets carry
 lifecycle signals only. Event/Streams MoQL networking and deployment unit wiring


### PR DESCRIPTION
Required Iroh Policy startup currently aborts on its first Discovery announcement failure. With separate processes starting together, that can kill Policy before Discovery completes its revocation/session authority probes. Keep Policy bound and its initial publication pending for up to 120 seconds, retrying only typed pre-dispatch Iroh availability failures every 500ms. Current accepted identity and JWT are reprojected for each attempt; their expiry bounds the call. Security failures, cancellation and deadline expiry remain terminal, and READY still requires successful publication.

Deployment must launch Policy and Discovery concurrently after provisioning and key generation, with an adequate TimeoutStartSec (intended contract: 180s). Revocation initialization and durable authority ownership are unchanged. This draft is stacked on the frozen Event transport branch.

Full isolated-process IdentityAware READY acceptance remains pending reviewed MAC inventory integration: current production MAC tables lack Policy revocation/session probe and Discovery announcement labels. PR1530 adds the Discovery annotation but predates both probe leaves and does not install a generated MAC label consumer. This PR adds no permissive rows or fixture policy and does not change #1506.

Validation through the shared BuildQ lease:

- Focused initial-publication tests: 4 passed.
- Real loopback Iroh transport tests: 4 passed, including absent-peer availability and wrong-identity rejection.
- Four-package `cargo check --all-targets`: passed.
- Final combined four-package `cargo nextest run --all-targets`: 3176 passed, 8 skipped.
- Required foreground workspace/all-targets release Clippy hook: passed (60s).

The two-process production READY test remains pending the explicit MAC dependency above; existing permit-fixture integration results are not claimed as that acceptance evidence.
