### PR TITLE
feat: serve native Streams over authenticated Iroh

### DIFF
--- a/crates/hyprstream-rpc/src/moq_stream.rs
+++ b/crates/hyprstream-rpc/src/moq_stream.rs
@@ -358,6 +358,10 @@ pub fn serve_moq_uds_background(origin: MoqStreamOrigin, path: PathBuf) {
     use crate::transport::uds_session::{PLANE_MOQ, accept_uds};
     use moq_net::Server as MoqServer;
 
+    if native_iroh_required() {
+        tracing::error!("network-iroh-required refuses a local MoQ socket server");
+        return;
+    }
     // Remove stale socket from a previous run (best-effort).
     let _ = std::fs::remove_file(&path);
 
@@ -1080,7 +1084,7 @@ impl MoqStreamHandle {
         // local moq UDS plane when the StreamInfo carries no dialable reach —
         // never the other way around (see method docs; #275).
         let has_dialable_reach = reach.iter().any(|d| reach_to_transport_config(d).is_some());
-        if has_dialable_reach {
+        if has_dialable_reach || native_iroh_required() {
             tokio::spawn(moq_stream_handle_task_networked(
                 reach,
                 broadcast_path.clone(),
@@ -1143,7 +1147,7 @@ impl MoqStreamHandle {
         let (tx, rx) =
             tokio::sync::mpsc::channel::<anyhow::Result<crate::streaming::StreamPayload>>(64);
         let has_dialable_reach = reach.iter().any(|d| reach_to_transport_config(d).is_some());
-        if has_dialable_reach {
+        if has_dialable_reach || native_iroh_required() {
             tokio::spawn(moq_stream_handle_task_networked(
                 reach,
                 broadcast_path.clone(),
@@ -1237,6 +1241,10 @@ async fn moq_stream_handle_task(
     use crate::transport::uds_session::{PLANE_MOQ, connect_uds};
     use moq_net::{Client as MoqClient, Origin, Track};
 
+    if native_iroh_required() {
+        let _ = tx.send(Err(anyhow!("network-iroh-required refuses a local MoQ socket client"))).await;
+        return;
+    }
     let session = match connect_uds(&uds_path, PLANE_MOQ).await {
         Ok(s) => s,
         Err(e) => {
@@ -1484,12 +1492,25 @@ pub struct MoqReachConnection {
     _session: moq_net::Session,
 }
 
+/// Monotonic process transport policy installed by native deployment bootstrap.
+static NATIVE_IROH_REQUIRED: std::sync::atomic::AtomicBool = std::sync::atomic::AtomicBool::new(false);
+
+/// Require native Iroh; later compatibility callers cannot reopen fallbacks.
+pub fn require_native_iroh() {
+    NATIVE_IROH_REQUIRED.store(true, std::sync::atomic::Ordering::Release);
+}
+
+pub fn native_iroh_required() -> bool {
+    NATIVE_IROH_REQUIRED.load(std::sync::atomic::Ordering::Acquire)
+}
+
 /// Resolve a producer's reach into a live moq subscriber connection (#356).
 ///
 /// This is the **single** reach→connection resolver shared by every networked
 /// subscriber (the inference [`MoqStreamHandle::networked`] task and the CLI
 /// model-load / `notify subscribe` consumers). It enforces one transport policy
-/// in one place:
+/// in one place. A required native process accepts only Iroh and never takes
+/// the compatibility QUIC/UDS alternatives below:
 ///
 ///   1. **Networked first** — dial the first dialable `Destination` in `reach`
 ///      (the producer's wire-advertised QUIC/`/moq` endpoint) via
@@ -1523,9 +1544,19 @@ pub async fn connect_moq_reach_with_server_identity(
     reach: &[crate::stream_info::Destination],
     server_identity: &crate::stream_info::MoqlServerIdentity,
 ) -> Result<MoqReachConnection> {
+    connect_moq_reach_for_profile(reach, server_identity, native_iroh_required()).await
+}
+
+/// Explicit policy seam. Required mode admits only Iroh destinations.
+pub async fn connect_moq_reach_for_profile(
+    reach: &[crate::stream_info::Destination],
+    server_identity: &crate::stream_info::MoqlServerIdentity,
+    iroh_required: bool,
+) -> Result<MoqReachConnection> {
     use crate::transport::uds_session::{PLANE_MOQ, connect_uds};
     use moq_net::{Client as MoqClient, Origin};
 
+    let iroh_required = iroh_required || native_iroh_required();
     let client_origin = Origin::random().produce();
     let consumer = client_origin.consume();
     let moq_client = MoqClient::new().with_consume(client_origin);
@@ -1537,6 +1568,9 @@ pub async fn connect_moq_reach_with_server_identity(
         let Some(cfg) = reach_to_transport_config(dest) else {
             continue;
         };
+        if iroh_required && !matches!(cfg.endpoint, crate::transport::EndpointType::Iroh { .. }) {
+            continue;
+        }
         had_dialable_network_reach = true;
         let dial = match (&cfg.endpoint, global_moq_admission_proof()) {
             (crate::transport::EndpointType::Iroh { .. }, Some(proof)) => {
@@ -1589,6 +1623,9 @@ pub async fn connect_moq_reach_with_server_identity(
     // A producer-advertised network endpoint is authoritative. In particular,
     // an authenticated Iroh rejection must not silently cross into this
     // process's local plane: that could subscribe to an unrelated producer.
+    if iroh_required && !had_dialable_network_reach {
+        return Err(anyhow!("network-iroh-required: no dialable Iroh stream reach; refusing QUIC/local fallback"));
+    }
     if had_dialable_network_reach {
         return Err(anyhow!(
             "all dialable network reaches failed; refusing local moq UDS fallback{}",
@@ -1882,6 +1919,10 @@ pub async fn run_relay_announce_link(
     };
     let cfg = reach_to_transport_config(&dest)
         .ok_or_else(|| anyhow!("relay reach is not a dialable network transport"))?;
+
+    if native_iroh_required() && !matches!(cfg.endpoint, crate::transport::EndpointType::Iroh { .. }) {
+        return Err(anyhow!("network-iroh-required rejects non-Iroh stream relay"));
+    }
 
     // #504 item 3 — relay-capability gate (fail-closed): do NOT announce this
     // node's origin (broadcast track names / `broadcastPath`, traffic patterns)
@@ -3071,6 +3112,21 @@ mod tests {
                 cert_hashes: vec![vec![0u8; 32]],
             }),
             moql_server_identity: Default::default(),
+        }
+    }
+
+    #[tokio::test]
+    async fn required_stream_reach_rejects_empty_and_browser_only_without_dial() {
+        let identity = crate::stream_info::MoqlServerIdentity::default();
+        for reach in [vec![], vec![crate::stream_info::Destination {
+            role: crate::stream_info::Role::Direct,
+            transport: crate::stream_info::TransportConfig::Quic(crate::stream_info::QuicReach {
+                addr: "127.0.0.1:9".into(), server_name: "localhost".into(), cert_hashes: vec![],
+            }), moql_server_identity: Default::default(),
+        }]] {
+            let result = tokio::time::timeout(std::time::Duration::from_millis(200),
+                connect_moq_reach_for_profile(&reach, &identity, true)).await.unwrap();
+            assert!(result.err().unwrap().to_string().contains("no dialable Iroh stream reach"));
         }
     }
 

--- a/crates/hyprstream-rpc/src/transport/moql_admission.rs
+++ b/crates/hyprstream-rpc/src/transport/moql_admission.rs
@@ -764,6 +764,12 @@ impl MoqlAdmissionAuthenticator {
         }
     }
 
+    /// Share live authority, isolating each service's carrier identity and replay cache.
+    pub fn for_server(&self) -> Self {
+        Self::new(Arc::clone(&self.authority), Arc::clone(&self.tenant_resolver))
+            .with_timeout(self.timeout)
+    }
+
     /// Install the local accepted-state identity that signs server confirmation
     /// frames. A bare authenticator remains useful for unit decision tests but
     /// cannot admit a network tunnel.

--- a/crates/hyprstream-service/src/service/factory.rs
+++ b/crates/hyprstream-service/src/service/factory.rs
@@ -269,7 +269,7 @@ impl NativeServiceAnnouncement {
         let recipient = hyprstream_rpc::node_identity::derive_mesh_kem_recipient(signer)?.public();
         let announcement = Self {
             service_did: did.clone(),
-            capabilities: if service_name == "event" {
+            capabilities: if matches!(service_name, "event" | "streams") {
                 vec!["hyprstream-moq/1".to_owned()]
             } else {
                 vec!["hyprstream-rpc/1".to_owned(), "hyprstream-moq/1".to_owned()]
@@ -293,7 +293,7 @@ impl NativeServiceAnnouncement {
         );
         anyhow::ensure!(
             !service_name.is_empty() && self.capabilities.iter().any(|c| c ==
-                if service_name == "event" { "hyprstream-moq/1" } else { "hyprstream-rpc/1" }),
+                if matches!(service_name, "event" | "streams") { "hyprstream-moq/1" } else { "hyprstream-rpc/1" }),
             "native announcement lacks canonical service capability"
         );
         anyhow::ensure!(
@@ -426,7 +426,7 @@ impl QuicSharedConfig {
             moq_relay_server_identity: self.moq_relay_server_identity.clone(),
             // #1027: thread the daemon-owned moql admission authenticator
             // through so the spawner installs it on the iroh `moql` handler.
-            moq_admission: self.moq_admission.clone(),
+            moq_admission: self.moq_admission.as_ref().map(|admission| Arc::new(admission.for_server())),
             moq_ingress_authorizer: self.moq_ingress_authorizer.clone(),
             moq_admission_proof: self.moq_admission_proof.clone(),
         }

--- a/crates/hyprstream-service/src/service/spawner/service.rs
+++ b/crates/hyprstream-service/src/service/spawner/service.rs
@@ -31,6 +31,22 @@ fn production_moq_authz(
         .with_ingress_authorizer_option(ingress_authorizer)
 }
 
+/// Native producer reach and channel must refer to the same service-owned tree.
+fn producer_moq_origin(
+    required: bool,
+    relay: Option<hyprstream_rpc::moq_stream::MoqStreamOrigin>,
+    has_producer: bool,
+) -> Option<hyprstream_rpc::moq_stream::MoqStreamOrigin> {
+    relay.or_else(|| {
+        if required {
+            has_producer.then(|| hyprstream_rpc::moq_stream::MoqStreamOrigin::standalone()
+                .with_prefix(hyprstream_rpc::moq_stream::DEFAULT_PREFIX).build())
+        } else {
+            hyprstream_rpc::moq_stream::global_moq_origin().cloned()
+        }
+    })
+}
+
 // Re-export Spawnable trait from hyprstream-rpc (where it's defined so
 // types in that crate can implement it without circular deps).
 pub use hyprstream_rpc::service::Spawnable;
@@ -248,12 +264,11 @@ impl<S: RequestService + Send + Sync + 'static> Spawnable for UnifiedServiceConf
                         .with_prefix(hyprstream_rpc::moq_stream::DEFAULT_PREFIX)
                         .build()
                 });
+                // Native producers serve only their own stream channel origin.
+                let moq_origin = producer_moq_origin(qc.iroh_required, relay_origin.clone(), moq_origin_handle.is_some());
                 if let Some(handle) = &moq_origin_handle {
-                    *handle.write() = relay_origin.clone();
+                    *handle.write() = moq_origin.clone();
                 }
-                let moq_origin = relay_origin
-                    .clone()
-                    .or_else(|| hyprstream_rpc::moq_stream::global_moq_origin().cloned());
 
                 let mut rpc_server = hyprstream_rpc::transport::quinn_transport::QuinnRpcServer::with_capacity(
                     wt_server,
@@ -352,6 +367,11 @@ impl<S: RequestService + Send + Sync + 'static> Spawnable for UnifiedServiceConf
                 // Link a relay only to this service's scoped origin. The shared
                 // process origin would leak other services' broadcasts into it.
                 if let Some(relay) = qc.moq_relay.take() {
+                    if qc.iroh_required && !matches!(relay, hyprstream_rpc::stream_info::TransportConfig::Iroh(_)) {
+                        return Err(hyprstream_rpc::error::RpcError::SpawnFailed(
+                            "network-iroh-required rejects non-Iroh stream relay".into(),
+                        ));
+                    }
                     if let Some(origin) = relay_origin {
                         hyprstream_rpc::moq_stream::serve_origin_to_relay_background(
                             origin.producer().clone(),
@@ -1159,6 +1179,20 @@ mod tests {
     use hyprstream_rpc::crypto::generate_signing_keypair;
     use hyprstream_rpc::prelude::SigningKey;
     use hyprstream_rpc::service::RequestService;
+
+    #[tokio::test]
+    async fn native_producer_origins_do_not_expose_sibling_tracks() -> AnyhowResult<()> {
+        let first = producer_moq_origin(true, None, true).ok_or_else(|| anyhow!("native producer origin missing"))?;
+        let second = producer_moq_origin(true, None, true).ok_or_else(|| anyhow!("native producer origin missing"))?;
+        let _broadcast = first.producer().create_broadcast("local/streams/first").ok_or_else(|| anyhow!("first broadcast missing"))?;
+        assert!(first.consumer().announced_broadcast("local/streams/first").await.is_some());
+        assert!(tokio::time::timeout(std::time::Duration::from_millis(100),
+            second.consumer().announced_broadcast("local/streams/first")).await.is_err());
+        assert!(producer_moq_origin(true, None, false).is_none());
+        let relayed = producer_moq_origin(true, Some(first), true).ok_or_else(|| anyhow!("relay origin missing"))?;
+        assert!(relayed.consumer().announced_broadcast("local/streams/first").await.is_some());
+        Ok(())
+    }
 
     #[test]
     fn production_moq_handler_preserves_explicit_ingress_and_defaults_to_denial() {

--- a/crates/hyprstream/src/bin/main.rs
+++ b/crates/hyprstream/src/bin/main.rs
@@ -1728,6 +1728,9 @@ async fn install_process_production_resolver(
              has no remote-Discovery story and would silently ignore this flag"
         );
     }
+    if config.quic.iroh_required() {
+        hyprstream_rpc::moq_stream::require_native_iroh();
+    }
     hyprstream_discovery::bootstrap_deployment_process(
         signing_key.clone(),
         trust_source,
@@ -3136,12 +3139,10 @@ fn main() -> Result<()> {
                                         // verified resolver result; the URI alone is reachability,
                                         // never an application identity.
                                         moq_relay_server_identity: None,
-                                        // #1027: no moql admission material is provisioned at
-                                        // daemon bootstrap yet; the accept path stays in its
-                                        // fail-closed anonymous posture until a deployment
-                                        // installs an authenticator here.
-                                        moq_admission: None,
-                                        moq_ingress_authorizer: None,
+                                        moq_admission: if moq_admission_proof.is_some() {
+                                            Some(hyprstream_core::services::stream_network::production_stream_admission(&qc)?)
+                                        } else { None },
+                                        moq_ingress_authorizer: Some(hyprstream_core::services::stream_network::stream_ingress_authorizer(&qc)),
                                         moq_admission_proof,
                                         native_announcement_publisher: Some(std::sync::Arc::new(
                                             move |request: hyprstream_service::NativeAnnouncementRequest| {

--- a/crates/hyprstream/src/config/mod.rs
+++ b/crates/hyprstream/src/config/mod.rs
@@ -460,6 +460,11 @@ pub struct QuicConfig {
     #[serde(default)]
     pub event_publishers: std::collections::BTreeSet<String>,
 
+    /// Explicit remote Streams ingress, separate from Event permissions.
+    /// Empty leaves admitted peers read-only.
+    #[serde(default)]
+    pub stream_publishers: std::collections::BTreeSet<String>,
+
     /// #358: the producer-chosen moq RELAY this node rendezvouses through, as a
     /// dialable URI (`https://host:port` for the relay's WebTransport `/moq`
     /// endpoint, or an iroh node URI). Empty = direct-only (the baseline). When
@@ -483,6 +488,7 @@ impl Default for QuicConfig {
             native_network_profile: NativeNetworkProfile::Compatibility,
             moql_subject_tenants: Default::default(),
             event_publishers: Default::default(),
+            stream_publishers: Default::default(),
             relay: String::new(),
         }
     }

--- a/crates/hyprstream/src/services/factories.rs
+++ b/crates/hyprstream/src/services/factories.rs
@@ -1080,7 +1080,7 @@ fn create_registry_service(ctx: &ServiceContext) -> anyhow::Result<Box<dyn Spawn
     // RegistryService publishes clone-progress streams via StreamChannel::run_stream
     // (which fails loudly if no moq origin is registered in this process).
     // Initialize this process's local moq plane. Idempotent.
-    init_local_moq_stream_plane("registry");
+    init_local_moq_stream_plane("registry", ctx.iroh_required());
 
     let config = load_config();
     let sk = ctx.service_signing_key("registry");
@@ -1209,8 +1209,8 @@ fn create_registry_service(ctx: &ServiceContext) -> anyhow::Result<Box<dyn Spawn
 /// service, and stream-publisher services such as `tui`/`notification`/`registry`/
 /// `metrics`/`model`) needs its OWN moq plane in-process: the process-global
 /// [`MoqStreamOrigin`] that `StreamChannel::publisher()` appends into, plus a
-/// per-PID UDS moq server so a co-located client can connect directly to the
-/// path returned in the publisher's response.
+/// compatibility per-PID UDS server. Native required profiles initialize the
+/// process plane without sockets; each publisher is served by its own Iroh origin.
 ///
 /// In a multi-process (systemd one-process-per-service) deployment, only the
 /// `streams` factory used to do this, so other publisher processes had a `None`
@@ -1222,7 +1222,10 @@ fn create_registry_service(ctx: &ServiceContext) -> anyhow::Result<Box<dyn Spawn
 /// without double-initializing the origin or double-serving the UDS. This lets
 /// it compose with the `streams` factory and with multiple publisher factories
 /// co-located in one process.
-fn init_local_moq_stream_plane(service_name: &str) {
+fn init_local_moq_stream_plane(service_name: &str, iroh_required: bool) {
+    if iroh_required {
+        hyprstream_rpc::moq_stream::require_native_iroh();
+    }
     // Guard: a moq origin already exists in this process — nothing to do.
     if hyprstream_rpc::moq_stream::global_moq_origin().is_some() {
         return;
@@ -1252,6 +1255,10 @@ fn init_local_moq_stream_plane(service_name: &str) {
         return;
     }
 
+    // Native publishers are served by their service-owned Iroh handler.
+    if hyprstream_rpc::moq_stream::native_iroh_required() {
+        return;
+    }
     let moq_uds_path = {
         let dir = std::env::temp_dir().join(format!("hyprstream-{}", std::process::id()));
         let _ = std::fs::create_dir_all(&dir);
@@ -1267,15 +1274,17 @@ fn init_local_moq_stream_plane(service_name: &str) {
 
 /// Factory for the moq stream origin (#138 N4 — ZMQ StreamService removed).
 ///
-/// Builds the process-global `MoqStreamOrigin`, registers it, and starts the
-/// UDS moq server so cross-process subscribers (e.g. `tui attach`) can
-/// subscribe over moq without any ZMQ sockets.
+/// Compatibility serves a local UDS plane. Required native mode owns an
+/// authenticated Iroh rendezvous origin and announces only its MoQ capability.
 #[service_factory("streams")]
-fn create_streams_service(_ctx: &ServiceContext) -> anyhow::Result<Box<dyn Spawnable>> {
+fn create_streams_service(ctx: &ServiceContext) -> anyhow::Result<Box<dyn Spawnable>> {
     info!("Creating moq stream origin (ZMQ StreamService removed)");
 
-    init_local_moq_stream_plane("streams");
+    init_local_moq_stream_plane("streams", ctx.iroh_required());
 
+    if ctx.iroh_required() {
+        return Ok(Box::new(crate::services::stream_network::StreamsNetworkService::new(ctx)?));
+    }
     Ok(Box::new(MoqStreamBarrierService::new()))
 }
 
@@ -1340,7 +1349,7 @@ fn create_model_service(ctx: &ServiceContext) -> anyhow::Result<Box<dyn Spawnabl
     // ModelService spawns InferenceService instances in-process, which publish
     // generation streams via StreamChannel::run_stream (fails loudly without a
     // moq origin). Initialize this process's local moq plane. Idempotent.
-    init_local_moq_stream_plane("model");
+    init_local_moq_stream_plane("model", ctx.iroh_required());
 
     use crate::services::{ModelService, ModelServiceConfig};
 
@@ -2614,7 +2623,7 @@ fn create_tui_service(ctx: &ServiceContext) -> anyhow::Result<Box<dyn Spawnable>
     // StreamChannel::publisher(), and returns its per-PID moq UDS path to the
     // client. In a per-process deployment this process has no moq plane unless
     // we initialize one here. Idempotent — no-op if already set.
-    init_local_moq_stream_plane("tui");
+    init_local_moq_stream_plane("tui", ctx.iroh_required());
 
     let config = load_config();
     let tui_config = &config.tui;
@@ -2897,7 +2906,7 @@ fn create_metrics_service(ctx: &ServiceContext) -> anyhow::Result<Box<dyn Spawna
     // MetricsService publishes query-result streams via StreamChannel::run_stream
     // (fails loudly without a moq origin). Initialize this process's local moq
     // plane. Idempotent.
-    init_local_moq_stream_plane("metrics");
+    init_local_moq_stream_plane("metrics", ctx.iroh_required());
 
     use crate::services::MetricsService;
     use hyprstream_metrics::query::QueryOrchestrator;
@@ -3380,6 +3389,24 @@ mod tests {
         assert!(result.is_err());
     }
 
+    #[test]
+    fn required_stream_initializer_never_serves_uds() -> anyhow::Result<()> {
+        const CHILD: &str = "HYPRSTREAM_NATIVE_STREAM_INIT_TEST";
+        if std::env::var_os(CHILD).is_none() {
+            let status = std::process::Command::new(std::env::current_exe()?)
+                .args(["--exact", "services::factories::tests::required_stream_initializer_never_serves_uds", "--nocapture"])
+                .env(CHILD, "1").status()?;
+            anyhow::ensure!(status.success(), "isolated native stream initializer failed");
+            return Ok(());
+        }
+        init_local_moq_stream_plane("model", true);
+        init_local_moq_stream_plane("registry", false);
+        assert!(hyprstream_rpc::moq_stream::global_moq_origin().is_some());
+        assert!(hyprstream_rpc::moq_stream::global_moq_uds_path().is_none());
+        assert!(hyprstream_rpc::moq_stream::native_iroh_required());
+        Ok(())
+    }
+
     /// `init_local_moq_stream_plane` sets both process-global moq state
     /// (`global_moq_origin` + `global_moq_uds_path`) and is idempotent: a second
     /// call is a no-op and must not panic (composes with the streams factory and
@@ -3394,7 +3421,7 @@ mod tests {
         use hyprstream_rpc::moq_stream::{global_moq_origin, global_moq_uds_path};
 
         // First call (or pre-set by another test) → plane is initialized.
-        init_local_moq_stream_plane("test");
+        init_local_moq_stream_plane("test", false);
         assert!(
             global_moq_origin().is_some(),
             "origin must be set after init_local_moq_stream_plane",
@@ -3407,7 +3434,7 @@ mod tests {
         let path_after_first = uds.map(std::path::Path::to_path_buf);
 
         // Second call must be a no-op (idempotent) — no panic, no change.
-        init_local_moq_stream_plane("test");
+        init_local_moq_stream_plane("test", false);
         assert!(global_moq_origin().is_some());
         assert_eq!(
             global_moq_uds_path().map(std::path::Path::to_path_buf),

--- a/crates/hyprstream/src/services/mod.rs
+++ b/crates/hyprstream/src/services/mod.rs
@@ -188,3 +188,6 @@ pub use metrics::MetricsService;
 
 /// Authenticated Event transport and profile-aware initialization.
 pub mod event_network;
+
+/// Native producer/Streams carrier admission and lifecycle.
+pub mod stream_network;

--- a/crates/hyprstream/src/services/oauth/browser_session.rs
+++ b/crates/hyprstream/src/services/oauth/browser_session.rs
@@ -380,6 +380,7 @@ mod tests {
         };
         let quic = crate::config::QuicConfig {
             event_publishers: Default::default(),
+            stream_publishers: Default::default(),
             moql_subject_tenants: Default::default(),
             enabled: true,
             bind_addr: "127.0.0.1:4433".to_owned(),

--- a/crates/hyprstream/src/services/oauth/identity_registration.rs
+++ b/crates/hyprstream/src/services/oauth/identity_registration.rs
@@ -1745,6 +1745,7 @@ mod tests {
         };
         let quic = QuicConfig {
             event_publishers: Default::default(),
+            stream_publishers: Default::default(),
             moql_subject_tenants: Default::default(),
             enabled: true,
             bind_addr: "127.0.0.1:4433".to_owned(),

--- a/crates/hyprstream/src/services/stream_network.rs
+++ b/crates/hyprstream/src/services/stream_network.rs
@@ -1,0 +1,500 @@
+//! Native Streams origins. Carrier admission is independent of stream payload
+//! authentication and MAC authorization performed by the producing RPC service.
+use crate::config::QuicConfig;
+use anyhow::{Context, Result};
+use hyprstream_rpc::transport::iroh_moq::{MoqAuthzConfig, SharedIngressAuthorizer};
+use hyprstream_rpc::transport::moql_admission::MoqlAdmissionAuthenticator;
+use std::sync::Arc;
+
+/// Current accepted identity and explicit tenant assignment, never carrier identity.
+pub fn production_stream_admission(config: &QuicConfig) -> Result<Arc<MoqlAdmissionAuthenticator>> {
+    Ok(stream_admission(
+        config,
+        hyprstream_discovery::production_moql_accepted_state_authority()?,
+    ))
+}
+
+fn stream_admission(
+    config: &QuicConfig,
+    authority: Arc<dyn hyprstream_rpc::transport::moql_admission::AcceptedStateAuthority>,
+) -> Arc<MoqlAdmissionAuthenticator> {
+    let tenants = config.moql_subject_tenants.clone();
+    Arc::new(MoqlAdmissionAuthenticator::new(
+        authority,
+        Arc::new(move |peer| {
+            peer.subject
+                .as_ref()
+                .and_then(|did| tenants.get(did))
+                .cloned()
+        }),
+    ))
+}
+
+/// Tenant admission never grants publishing. Configuration is immutable for the
+/// process lifetime; removing a roster row requires a service reload/restart.
+/// Accepted-state/key revocation is rechecked live by the admission authority.
+pub fn stream_ingress_authorizer(config: &QuicConfig) -> SharedIngressAuthorizer {
+    let publishers = config.stream_publishers.clone();
+    let tenants = config.moql_subject_tenants.clone();
+    Arc::new(
+        move |peer: &hyprstream_rpc::moq_authz::PeerIdentity, tenant: &str| {
+            peer.subject.as_ref().is_some_and(|did| {
+                publishers.contains(did) && tenants.get(did).is_some_and(|bound| bound == tenant)
+            })
+        },
+    )
+}
+
+fn stream_handler(
+    config: &QuicConfig,
+    origin: &hyprstream_rpc::moq_stream::MoqStreamOrigin,
+    admission: Arc<MoqlAdmissionAuthenticator>,
+) -> hyprstream_rpc::transport::iroh_moq::IrohMoqProtocolHandler {
+    use hyprstream_rpc::transport::iroh_moq::{IrohMoqProtocolHandler, OriginShared};
+    IrohMoqProtocolHandler::with_origin(OriginShared::from_pair(
+        origin.producer().clone(),
+        origin.consumer().clone(),
+    ))
+    .with_authz(
+        MoqAuthzConfig::default()
+            .with_admission(admission)
+            .with_ingress_authorizer(stream_ingress_authorizer(config)),
+    )
+}
+
+/// Owns an independent rendezvous origin. It advertises transport capability,
+/// never ownership of tracks living on Registry/Model/TUI producer endpoints.
+pub struct StreamsNetworkService {
+    secret: [u8; 32],
+    node_id: [u8; 32],
+    handler: hyprstream_rpc::transport::iroh_moq::IrohMoqProtocolHandler,
+    announce: hyprstream_service::service::factory::NativeIrohAnnouncementCallback,
+}
+
+impl StreamsNetworkService {
+    pub fn new(ctx: &hyprstream_service::ServiceContext) -> Result<Self> {
+        let config = crate::config::HyprConfig::load()?;
+        let proof = ctx
+            .moql_admission_proof("streams")?
+            .context("native Streams server proof missing")?;
+        anyhow::ensure!(
+            config
+                .quic
+                .moql_subject_tenants
+                .get(&proof.did)
+                .is_some_and(|tenant| tenant == "local"),
+            "native Streams server requires explicit admitted DID binding to local tenant"
+        );
+        let key = hyprstream_rpc::node_identity::derive_purpose_key(
+            &ctx.service_signing_key("streams"),
+            "hyprstream-iroh-transport-v1",
+        );
+        let node_id = key.verifying_key().to_bytes();
+        let admission = production_stream_admission(&config.quic)?;
+        admission.install_server_identity(
+            hyprstream_rpc::transport::moql_admission::MoqlServerIdentityProof::from_local_admission_proof(&proof)?, node_id)?;
+        let origin = hyprstream_rpc::moq_stream::MoqStreamOrigin::standalone()
+            .with_prefix(hyprstream_rpc::moq_stream::DEFAULT_PREFIX)
+            .build();
+        Ok(Self {
+            secret: key.to_bytes(),
+            node_id,
+            handler: stream_handler(&config.quic, &origin, admission),
+            announce: ctx.native_iroh_announcement_callback("streams")?,
+        })
+    }
+}
+
+impl hyprstream_rpc::service::Spawnable for StreamsNetworkService {
+    fn name(&self) -> &str {
+        "streams"
+    }
+    fn registrations(
+        &self,
+    ) -> Vec<(
+        hyprstream_rpc::registry::SocketKind,
+        hyprstream_rpc::transport::TransportConfig,
+    )> {
+        vec![]
+    }
+    fn run(
+        self: Box<Self>,
+        shutdown: Arc<tokio::sync::Notify>,
+        on_ready: Option<tokio::sync::oneshot::Sender<()>>,
+    ) -> hyprstream_rpc::error::Result<()> {
+        use hyprstream_rpc::error::RpcError;
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .map_err(|e| RpcError::SpawnFailed(e.to_string()))?;
+        runtime.block_on(async move {
+            let substrate = hyprstream_rpc::transport::iroh_substrate::IrohSubstrate::new(
+                self.secret, self.handler,
+                hyprstream_rpc::transport::iroh_substrate::RefuseHandler::new("Streams provides only authenticated moql"),
+            ).await.map_err(|e| RpcError::SpawnFailed(format!("native Streams bind: {e}")))?;
+            let cancellation = tokio_util::sync::CancellationToken::new();
+            let _cancel_on_exit = cancellation.clone().drop_guard();
+            let announce_cancel = cancellation.clone();
+            let announce = self.announce;
+            let node_id = self.node_id;
+            let initial = tokio::select! {
+                biased;
+                _ = shutdown.notified() => Err(RpcError::SpawnFailed("Streams stopped before announcement".into())),
+                result = tokio::task::spawn_blocking(move || announce(announce_cancel, node_id)) => {
+                    result.map_err(|e| RpcError::SpawnFailed(format!("Streams announcement task: {e}")))
+                        .and_then(|r| r.map_err(|e| RpcError::SpawnFailed(format!("Streams initial announcement: {e}"))))
+                }
+            };
+            if let Err(error) = initial {
+                cancellation.cancel();
+                let _ = substrate.shutdown().await;
+                return Err(error);
+            }
+            if let Some(ready) = on_ready { let _ = ready.send(()); }
+            let _ = hyprstream_rpc::notify::ready();
+            tokio::select! {
+                _ = shutdown.notified() => {},
+                _ = cancellation.cancelled() => {},
+                _ = async {
+                    while !substrate.router().is_shutdown() && !substrate.endpoint().is_closed() {
+                        tokio::time::sleep(std::time::Duration::from_secs(1)).await;
+                    }
+                } => {},
+            }
+            cancellation.cancel();
+            substrate.shutdown().await.map_err(|e| RpcError::SpawnFailed(format!("Streams shutdown: {e}")))
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ed25519_dalek::SigningKey;
+    use hyprstream_rpc::crypto::pq::{ml_dsa_sk_from_seed, ml_dsa_sk_to_vk_bytes};
+    use hyprstream_rpc::transport::iroh_substrate::{IrohSubstrate, RefuseHandler, ALPN_MOQ_LITE};
+    use hyprstream_rpc::transport::moql_admission::{
+        prove_moql_admission, AcceptedIdentityState, AcceptedSubjectKey, MoqlAdmissionProof,
+        MoqlServerIdentityProof,
+    };
+    use moq_net::{Client, Group, Origin, Track};
+    use std::time::Duration;
+
+    fn identity(name: &str, seed: u8) -> (MoqlAdmissionProof, AcceptedIdentityState) {
+        let ed25519 = SigningKey::from_bytes(&[seed; 32]);
+        let ml_dsa_65 = ml_dsa_sk_from_seed(&[seed; 32]);
+        let expires_at_unix_ms = hyprstream_rpc::envelope::current_timestamp() + 60_000;
+        let state = AcceptedIdentityState {
+            epoch: 1,
+            head_digest: [seed; 64],
+            expires_at_unix_ms: Some(expires_at_unix_ms),
+            subject_keys: vec![AcceptedSubjectKey {
+                ed25519: ed25519.verifying_key().to_bytes(),
+                ml_dsa_65: ml_dsa_sk_to_vk_bytes(&ml_dsa_65),
+            }],
+        };
+        let expected_server = hyprstream_rpc::stream_info::MoqlServerIdentity {
+            did: format!("did:at9p:{name}"),
+            epoch: 1,
+            head_digest: state.head_digest.to_vec(),
+            expires_at_unix_ms,
+            ed25519: ed25519.verifying_key().to_bytes(),
+            ml_dsa65: ml_dsa_sk_to_vk_bytes(&ml_dsa_65),
+        };
+        (
+            MoqlAdmissionProof {
+                did: expected_server.did.clone(),
+                ed25519,
+                ml_dsa_65,
+                expected_server,
+            },
+            state,
+        )
+    }
+
+    fn direct(server: &IrohSubstrate) -> iroh::EndpointAddr {
+        iroh::EndpointAddr::from_parts(
+            server.endpoint_id(),
+            server
+                .endpoint()
+                .bound_sockets()
+                .into_iter()
+                .map(iroh::TransportAddr::Ip),
+        )
+    }
+
+    async fn peer(seed: u8) -> Result<IrohSubstrate> {
+        IrohSubstrate::new(
+            [seed; 32],
+            RefuseHandler::new("no moq"),
+            RefuseHandler::new("no rpc"),
+        )
+        .await
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn streams_readiness_requires_announcement_and_shutdown_cancels_it() -> Result<()> {
+        use hyprstream_rpc::service::Spawnable;
+        for fail_announcement in [true, false] {
+            let secret = [if fail_announcement { 71 } else { 72 }; 32];
+            let node_id = *iroh::SecretKey::from_bytes(&secret).public().as_bytes();
+            let observed = Arc::new(parking_lot::Mutex::new(None));
+            let callback_observed = Arc::clone(&observed);
+            let service = StreamsNetworkService {
+                secret,
+                node_id,
+                handler: hyprstream_rpc::transport::iroh_moq::IrohMoqProtocolHandler::new(),
+                announce: Arc::new(move |cancel, actual| {
+                    assert_eq!(actual, node_id);
+                    *callback_observed.lock() = Some(cancel);
+                    anyhow::ensure!(!fail_announcement, "fixture announcement refusal");
+                    Ok(())
+                }),
+            };
+            let shutdown = Arc::new(tokio::sync::Notify::new());
+            let (ready_tx, ready_rx) = tokio::sync::oneshot::channel();
+            let stop = Arc::clone(&shutdown);
+            let task =
+                tokio::task::spawn_blocking(move || Box::new(service).run(stop, Some(ready_tx)));
+            let ready = tokio::time::timeout(Duration::from_secs(5), ready_rx).await?;
+            if fail_announcement {
+                assert!(ready.is_err());
+                assert!(task.await?.is_err());
+            } else {
+                assert!(ready.is_ok());
+                shutdown.notify_one();
+                tokio::time::timeout(Duration::from_secs(5), task).await???;
+            }
+            assert!(observed
+                .lock()
+                .as_ref()
+                .is_some_and(tokio_util::sync::CancellationToken::is_cancelled));
+        }
+        Ok(())
+    }
+
+    /// Exercises the exact production stream handler and config-to-authority
+    /// wiring, using independent real Iroh peers and mutable accepted state.
+    /// Fixture identity acceptance grants no Event labels or production policy.
+    #[test]
+    fn native_stream_payload_tenant_ingress_and_currentness() -> Result<()> {
+        const CHILD: &str = "HYPRSTREAM_NATIVE_STREAM_PAYLOAD_TEST";
+        if std::env::var_os(CHILD).is_none() {
+            let status = std::process::Command::new(std::env::current_exe()?)
+                .args(["--exact", "services::stream_network::tests::native_stream_payload_tenant_ingress_and_currentness", "--nocapture"])
+                .env(CHILD, "1").status()?;
+            anyhow::ensure!(
+                status.success(),
+                "isolated native stream payload regression failed"
+            );
+            return Ok(());
+        }
+        tokio::runtime::Builder::new_multi_thread()
+            .worker_threads(2)
+            .enable_all()
+            .build()?
+            .block_on(stream_roundtrip())
+    }
+
+    async fn stream_roundtrip() -> Result<()> {
+        let (server_proof, server_state) = identity("streams", 61);
+        let (mut publisher, publisher_state) = identity("publisher", 62);
+        let (mut reader, reader_state) = identity("reader", 63);
+        let (mut other, other_state) = identity("other", 64);
+        let server_identity = server_proof.expected_server.clone();
+        for proof in [&mut publisher, &mut reader, &mut other] {
+            proof.expected_server = server_identity.clone();
+        }
+        let states = Arc::new(parking_lot::RwLock::new(std::collections::BTreeMap::from(
+            [
+                (server_proof.did.clone(), server_state),
+                (publisher.did.clone(), publisher_state),
+                (reader.did.clone(), reader_state),
+                (other.did.clone(), other_state),
+            ],
+        )));
+        let authority = Arc::clone(&states);
+        let mut config = QuicConfig::default();
+        config.moql_subject_tenants = std::collections::BTreeMap::from([
+            (server_proof.did.clone(), "local".into()),
+            (publisher.did.clone(), "local".into()),
+            (reader.did.clone(), "local".into()),
+            (other.did.clone(), "other".into()),
+        ]);
+        config.stream_publishers.insert(publisher.did.clone());
+        config.stream_publishers.insert(other.did.clone());
+        // An Event ingress row must never authorize stream injection.
+        config.event_publishers.insert(reader.did.clone());
+        let admission = stream_admission(
+            &config,
+            Arc::new(move |did: &str| authority.read().get(did).cloned()),
+        );
+        let secret = [65; 32];
+        admission.install_server_identity(
+            MoqlServerIdentityProof::from_local_admission_proof(&server_proof)?,
+            *iroh::SecretKey::from_bytes(&secret).public().as_bytes(),
+        )?;
+        let origin = hyprstream_rpc::moq_stream::MoqStreamOrigin::standalone().build();
+        let server = IrohSubstrate::new(
+            secret,
+            stream_handler(&config, &origin, admission),
+            RefuseHandler::new("streams no rpc"),
+        )
+        .await?;
+        let writer = peer(66).await?;
+        let subscriber = peer(67).await?;
+        let outsider = peer(68).await?;
+        let writer_conn = writer.connect(direct(&server), ALPN_MOQ_LITE).await?;
+        prove_moql_admission(
+            &writer_conn,
+            &publisher,
+            *writer.endpoint_id().as_bytes(),
+            Duration::from_secs(2),
+        )
+        .await?;
+        let write_origin = Origin::random().produce();
+        let writer_session = Client::new()
+            .with_origin(write_origin.clone())
+            .connect(web_transport_iroh::Session::raw(writer_conn.clone()))
+            .await?;
+        let reader_conn = subscriber.connect(direct(&server), ALPN_MOQ_LITE).await?;
+        prove_moql_admission(
+            &reader_conn,
+            &reader,
+            *subscriber.endpoint_id().as_bytes(),
+            Duration::from_secs(2),
+        )
+        .await?;
+        let read_origin = Origin::random().produce();
+        let read_consumer = read_origin.consume();
+        let reader_session = Client::new()
+            .with_origin(read_origin.clone())
+            .with_consume(read_origin.clone())
+            .connect(web_transport_iroh::Session::raw(reader_conn))
+            .await?;
+        let other_conn = outsider.connect(direct(&server), ALPN_MOQ_LITE).await?;
+        prove_moql_admission(
+            &other_conn,
+            &other,
+            *outsider.endpoint_id().as_bytes(),
+            Duration::from_secs(2),
+        )
+        .await?;
+        let other_origin = Origin::random().produce();
+        let other_consumer = other_origin.consume();
+        let other_session = Client::new()
+            .with_origin(other_origin.clone())
+            .with_consume(other_origin.clone())
+            .connect(web_transport_iroh::Session::raw(other_conn))
+            .await?;
+        // Exercise the production required-profile reach dialer too, with the
+        // authenticated producer witness and an independently provisioned peer.
+        let lookup = iroh::address_lookup::memory::MemoryLookup::new();
+        lookup.add_endpoint_info(direct(&server));
+        subscriber.endpoint().address_lookup()?.add(lookup);
+        assert!(
+            hyprstream_rpc::transport::lazy_iroh::install_iroh_client_endpoint(
+                subscriber.owned_client_endpoint()
+            )
+            .is_ok()
+        );
+        assert!(hyprstream_rpc::moq_stream::init_global_moq_admission_proof(
+            reader.clone()
+        ));
+        hyprstream_rpc::moq_stream::require_native_iroh();
+        let reach = hyprstream_rpc::moq_stream::ProducerReachConfig {
+            iroh_node_id: Some(*server.endpoint_id().as_bytes()),
+            moql_server_identity: Some(server_identity.clone()),
+            ..Default::default()
+        }
+        .reach();
+        let network_reader = tokio::time::timeout(
+            Duration::from_secs(3),
+            hyprstream_rpc::moq_stream::connect_moq_reach_for_profile(
+                &reach,
+                &server_identity,
+                true,
+            ),
+        )
+        .await??;
+        let name = "local/streams/authorized-payload";
+        let mut broadcast = write_origin
+            .create_broadcast(name)
+            .context("writer broadcast")?;
+        let mut track = broadcast.create_track(Track::new("tokens"))?;
+        let mut group = track.create_group(Group::from(0u64))?;
+        group.write_frame(bytes::Bytes::from_static(b"producer-owned frame"))?;
+        drop(group);
+        let received = tokio::time::timeout(
+            Duration::from_secs(3),
+            read_consumer.announced_broadcast(name),
+        )
+        .await?
+        .context("reader announcement")?;
+        let received_track = received.subscribe_track(&Track::new("tokens"))?;
+        let mut received_group =
+            tokio::time::timeout(Duration::from_secs(3), received_track.get_group(0))
+                .await??
+                .context("payload group")?;
+        assert_eq!(
+            received_group.read_frame().await?,
+            Some(bytes::Bytes::from_static(b"producer-owned frame"))
+        );
+        let network_broadcast = tokio::time::timeout(
+            Duration::from_secs(3),
+            network_reader.consumer.announced_broadcast(name),
+        )
+        .await?
+        .context("required-profile reader announcement")?;
+        let network_track = network_broadcast.subscribe_track(&Track::new("tokens"))?;
+        let mut network_group =
+            tokio::time::timeout(Duration::from_secs(3), network_track.get_group(0))
+                .await??
+                .context("required-profile group")?;
+        assert_eq!(
+            network_group.read_frame().await?,
+            Some(bytes::Bytes::from_static(b"producer-owned frame"))
+        );
+        let _injected = read_origin
+            .create_broadcast("local/streams/reader-injected")
+            .context("reader injection")?;
+        let _cross = other_origin
+            .create_broadcast("local/streams/cross-tenant")
+            .context("cross tenant injection")?;
+        for denied in [
+            "local/streams/reader-injected",
+            "local/streams/cross-tenant",
+        ] {
+            assert!(tokio::time::timeout(
+                Duration::from_millis(250),
+                origin.consumer().announced_broadcast(denied)
+            )
+            .await
+            .is_err());
+        }
+        assert!(tokio::time::timeout(
+            Duration::from_millis(250),
+            other_consumer.announced_broadcast(name)
+        )
+        .await
+        .is_err());
+        // Advancing authoritative state revokes an already writable session.
+        states.write().remove(&publisher.did);
+        tokio::time::timeout(Duration::from_secs(3), writer_conn.closed()).await?;
+        let rejected = writer.connect(direct(&server), ALPN_MOQ_LITE).await?;
+        assert!(prove_moql_admission(
+            &rejected,
+            &publisher,
+            *writer.endpoint_id().as_bytes(),
+            Duration::from_secs(2)
+        )
+        .await
+        .is_err());
+        drop((writer_session, reader_session, other_session));
+        writer.shutdown().await?;
+        subscriber.shutdown().await?;
+        outsider.shutdown().await?;
+        server.shutdown().await?;
+        Ok(())
+    }
+}

--- a/docs/streams-native-network.md
+++ b/docs/streams-native-network.md
@@ -1,0 +1,70 @@
+# Native Streams deployment contract
+
+This change stacks on Event PR1581. Set `quic.enabled=true`, `quic.iroh=true`,
+and `quic.native_network_profile="network-iroh-required"`. Required native
+processes neither serve nor dial local MoQ sockets, and native reach/relay
+selection rejects browser QUIC alternatives. The compatibility/browser paths
+remain available when this profile is not selected.
+
+Registry, Model, TUI, and Metrics keep service-owned publisher origins attached
+to the same native handler and signed stream reach their responses advertise.
+The separate `streams` service owns an independent authenticated Iroh rendezvous
+origin. Its signed announcement claims only `hyprstream-moq/1`, not RPC or the
+tracks hosted by other producer services. Readiness follows successful carrier
+bind and initial signed announcement; cancellation shuts down both publication
+and the carrier. A listener being ready is not proof of authorized payload access.
+
+Every native server uses the production live accepted-state authority and an
+explicit `quic.moql_subject_tenants` DID-to-tenant map. Each server receives an
+independent confirmation identity/replay cache; carrier addresses never select
+application identity. Existing accepted-state expiry/rotation/removal checks
+remain active throughout a session.
+
+`quic.stream_publishers` is a distinct explicit DID set, default empty. It grants
+remote stream ingress only for the same DID's configured tenant. Tenant membership
+alone leaves a peer read-only, and `event_publishers` grants no Streams ingress.
+The map and roster are process configuration: changes require restart/reload;
+accepted-state revocation is live. Populate them from verified provisioning
+artifacts and an approved ingress roster, never invented DIDs or labels. The
+central Streams service's own admitted DID requires an explicit `local` binding.
+
+This transport does not grant MAC clearance. Existing producing RPC authorization,
+per-recipient stream key provisioning, payload authentication/encryption and epoch
+controls remain separate. No Event label table or permissive MAC policy is added.
+IdentityAware production activation, approved policy rows, and fresh CLI identity/
+proof/PEP provisioning remain deployment prerequisites. There is no fabricated
+Streams health/probe CLI. Event's existing command is spelled:
+
+```
+hyprstream quick notify probe --timeout 10
+```
+
+It requires the separate legitimate CLI proof and Event authorization bootstrap.
+
+## Inference ownership boundary
+
+`ModelService` constructs `InferenceServiceConfig` with its own reach/origin
+handles (`model.rs`, `with_stream_plane`), so those inference publishers use the
+Model endpoint updated here. The inference runner's distinct Iroh endpoint serves
+RPC and explicitly refuses MoQ; it is not advertised as the Model stream origin.
+
+A separately deployed standalone inference process (`owns_stream_plane` plus its
+custom `serve_inference_bridged` QUIC configuration) still has only a QUIC streaming
+bridge. That separate path is unchanged and is not native Streams acceptance.
+The normal eight-service staging roster uses Model-owned inference creation;
+a standalone inference deployment requires its own bounded transport work.
+
+## Verification boundary
+
+The causal test uses the production config-to-admission/ingress/handler path,
+independent real Iroh producer/subscriber peers, and the required-profile reach
+dialer to carry an actual frame. It checks that Event ingress does not authorize
+stream injection, another tenant cannot inject/read that frame, and removing an
+accepted publisher closes its active session and denies reconnect. Other tests
+cover no-reach/browser-only rejection, socket-free initialization, producer-origin
+isolation, and announcement/readiness/shutdown ordering. Existing transport,
+stream epoch, admission, relay and compatibility suites remain intact.
+
+These are transport implementation results. Crosshost deployment acceptance still
+requires actual provisioned identities, approved policy, fixed cold-start authority
+ordering, a reviewed image, and real authenticated runtime probes.


### PR DESCRIPTION
Required-native deployments still started local Streams sockets, the central Streams service was a readiness barrier without a network carrier, and native stream clients could fall back to UDS or browser QUIC. This change serves Streams through authenticated Iroh, isolates producer-owned origins, wires production admission and explicit Streams ingress, and makes required-profile reach selection fail closed to Iroh.

Stacked on #1581 (`feat/network-event-plane`). The central service advertises only its MoQ capability and waits for its signed initial announcement before READY. `quic.stream_publishers` defaults empty and is separate from Event ingress; tenant membership does not grant publishing. No MAC labels, grants or bypass policies are introduced.

Validation: five focused regressions passed, including actual payload through the production required-profile dialer, tenant/ingress/currentness denial, publisher isolation, no-UDS startup and announcement/shutdown ordering. Full final-source nextest across hyprstream, hyprstream-rpc, hyprstream-service and hyprstream-discovery: **3176 passed, 8 skipped**. `cargo check --all-targets` passed. All validation and normal commit hooks use BuildQ.

Deployment remains gated on approved IdentityAware policy/activation, real CLI identity/proof/PEP provisioning, cold-start authority ordering, and reviewed IaC/image deployment. No standalone inference streaming fix or full staging readiness is claimed: normal Model-owned inference inherits the Model origin, while the separate standalone inference QUIC bridge remains separate work. See `docs/streams-native-network.md` for the exact boundary and configuration contract.
