### PR TITLE
feat(cli): opt-in verified roster export for pds provision-services

### DIFF
--- a/crates/hyprstream/src/bin/main.rs
+++ b/crates/hyprstream/src/bin/main.rs
@@ -182,7 +182,10 @@ fn build_cli() -> ClapCommand {
                     .arg(Arg::new("service").long("service").required(true)
                         .action(clap::ArgAction::Append).value_delimiter(','))
                     .arg(Arg::new("valid-for-seconds").long("valid-for-seconds")
-                        .value_parser(clap::value_parser!(i64)).default_value("86400")),
+                        .value_parser(clap::value_parser!(i64)).default_value("86400"))
+                    .arg(Arg::new("roster-export").long("roster-export").value_name("PATH")
+                        .value_parser(clap::value_parser!(std::path::PathBuf))
+                        .help("Opt-in: atomically write a JSON manifest of the verified accepted roster (public fields only; not a trust root) to PATH. Behavior is unchanged when absent.")),
             )
             .subcommand(
                 ClapCommand::new("join")
@@ -2523,11 +2526,16 @@ fn main() -> Result<()> {
                     .context("service roster is required")?.cloned().collect::<Vec<_>>();
                 let lifetime = *provision_m.get_one::<i64>("valid-for-seconds")
                     .context("service identity lifetime is required")?;
+                let roster_export = provision_m.get_one::<std::path::PathBuf>("roster-export");
                 hyprstream_core::cli::deployment_bootstrap::provision_services(
                     &config,
                     &services,
                     lifetime,
+                    roster_export.map(std::path::PathBuf::as_path),
                 )?;
+                if let Some(path) = roster_export {
+                    println!("verified service roster manifest written to {}", path.display());
+                }
                 println!("checkpoint-accepted service roster ready ({} services)", services.len());
                 return Ok(());
             }
@@ -3809,9 +3817,21 @@ mod resolver_startup_controls {
         assert_eq!(provision.get_many::<String>("service").expect("roster")
             .map(String::as_str).collect::<Vec<_>>(), vec!["model", "event"]);
         assert_eq!(provision.get_one::<i64>("valid-for-seconds"), Some(&3600));
+        assert!(provision.get_one::<std::path::PathBuf>("roster-export").is_none());
         assert!(super::build_cli().try_get_matches_from([
             "hyprstream", "pds", "provision-services",
         ]).is_err());
+        let matches = super::build_cli().try_get_matches_from([
+            "hyprstream", "pds", "provision-services", "--service", "model",
+            "--roster-export", "/tmp/roster.json",
+        ]).expect("bootstrap CLI with roster export");
+        let provision = matches.subcommand_matches("pds").expect("pds")
+            .subcommand_matches("provision-services").expect("provision");
+        assert_eq!(
+            provision.get_one::<std::path::PathBuf>("roster-export")
+                .map(std::path::PathBuf::as_path),
+            Some(std::path::Path::new("/tmp/roster.json"))
+        );
     }
     const REFRESH_SCHEDULER_TURNS: usize = 32;
 

--- a/crates/hyprstream/src/cli/deployment_bootstrap.rs
+++ b/crates/hyprstream/src/cli/deployment_bootstrap.rs
@@ -9,18 +9,52 @@ use hyprstream_pds::at9p::{
 use hyprstream_pds::at9p_duplicity::AcceptedAt9pState;
 use hyprstream_pds::at9p_sign::{sign_capsule, sign_update_record};
 use hyprstream_rpc::crypto::pq::ml_dsa_sk_to_vk_bytes;
+use std::io::Write as _;
+use std::path::Path;
 use std::sync::Arc;
 
 use crate::auth::identity_store::{load_existing_service_signing_key, SecretsProfile};
 use crate::config::HyprConfig;
 use crate::services::discovery::{At9pStateIngest, PdsRecordStore};
 
+/// Machine-readable manifest schema emitted by `--roster-export`.
+const VERIFIED_ROSTER_SCHEMA: &str = "hyprstream/verified-service-roster@1";
+
+/// One public roster member projected from the checkpoint-verified accepted
+/// state read back from the store after admission. Contains no secret
+/// material: only the admitted DID, epoch, bounded validity, and the
+/// accepted-state head digest binding the entry to that exact state.
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize)]
+pub struct VerifiedServiceRosterEntry {
+    pub service: String,
+    pub did: String,
+    pub epoch: u64,
+    pub expires_at: String,
+    pub accepted_head_digest: String,
+}
+
+/// Public verified roster manifest. This document is not a trust root: it is a
+/// convenience projection for tooling, and the authenticated checkpoint store
+/// remains the authoritative source the values were verified against.
+#[derive(serde::Serialize)]
+struct VerifiedServiceRosterManifest {
+    schema: &'static str,
+    generated_at: String,
+    services: Vec<VerifiedServiceRosterEntry>,
+}
+
 /// Provision or renew a complete local service roster. The database writer
 /// lock excludes a running registry; callers must order this before services.
+///
+/// `roster_export` is opt-in: when absent, behavior is unchanged. When given,
+/// a JSON manifest of only the verified readback public fields is written
+/// atomically (temporary file + rename); any member failure or unsafe output
+/// path fails the whole command without leaving partial or new output.
 pub fn provision_services(
     config: &HyprConfig,
     services: &[String],
     valid_for_seconds: i64,
+    roster_export: Option<&Path>,
 ) -> Result<()> {
     ensure!(
         (600..=86_400).contains(&valid_for_seconds),
@@ -84,16 +118,106 @@ pub fn provision_services(
         ));
     }
     // Verify every roster member, not just the first DID that clears the
-    // first-boot marker. No service starts while this writer is held.
+    // first-boot marker. No service starts while this writer is held. The
+    // manifest is built only from these verified readback states, never from
+    // the provisioned inputs.
     let now_text = Utc::now().to_rfc3339_opts(SecondsFormat::Secs, true);
+    let entries = build_verified_roster_entries(&store, &admitted, &now_text)?;
+    if let Some(path) = roster_export {
+        write_verified_roster_manifest(path, entries)?;
+        tracing::info!(path = %path.display(), "verified service roster manifest exported");
+    }
+    Ok(())
+}
+
+/// Re-read and re-verify every admitted member from the checkpoint store,
+/// projecting only public fields. Any missing, mismatched, expired, or
+/// unbound member fails the whole roster.
+fn build_verified_roster_entries(
+    store: &PdsRecordStore,
+    admitted: &[(&str, &SigningKey, AcceptedAt9pState)],
+    now_text: &str,
+) -> Result<Vec<VerifiedServiceRosterEntry>> {
+    let mut entries = Vec::with_capacity(admitted.len());
     for (name, key, state) in admitted {
         let verified = store
-            .accepted_at9p_state(&state.did, Some(&now_text))?
+            .accepted_at9p_state(&state.did, Some(now_text))?
             .context("provisioned service state disappeared")?;
         hyprstream_service::NativeServiceAnnouncement::from_accepted_state(name, key, &verified)?;
         tracing::info!(service = name, did = %verified.did, epoch = verified.epoch, "checkpoint-accepted service identity ready");
+        let expires_at = verified
+            .expires_at
+            .clone()
+            .context("verified accepted state lacks bounded expiry")?;
+        entries.push(VerifiedServiceRosterEntry {
+            service: (*name).to_owned(),
+            did: verified.did,
+            epoch: verified.epoch,
+            expires_at,
+            accepted_head_digest: hex::encode(verified.head_digest),
+        });
     }
-    Ok(())
+    Ok(entries)
+}
+
+/// Atomically write the verified roster manifest: serialize fully, write to a
+/// sibling temporary file (created exclusively), sync, then rename. A failure
+/// at any step removes the temporary file and never creates, truncates, or
+/// replaces the target path.
+fn write_verified_roster_manifest(
+    path: &Path,
+    services: Vec<VerifiedServiceRosterEntry>,
+) -> Result<()> {
+    ensure!(
+        !services.is_empty(),
+        "refusing to export an empty verified service roster"
+    );
+    ensure!(
+        !path.is_dir(),
+        "roster export path is a directory: {}",
+        path.display()
+    );
+    let file_name = path
+        .file_name()
+        .context("roster export path has no file name")?;
+    let parent = path
+        .parent()
+        .filter(|parent| !parent.as_os_str().is_empty())
+        .unwrap_or_else(|| Path::new("."));
+    ensure!(
+        parent.is_dir(),
+        "roster export parent directory does not exist: {}",
+        parent.display()
+    );
+    let temp = parent.join(format!(
+        ".{}.tmp-{}",
+        file_name.to_string_lossy(),
+        std::process::id()
+    ));
+    let manifest = VerifiedServiceRosterManifest {
+        schema: VERIFIED_ROSTER_SCHEMA,
+        generated_at: Utc::now().to_rfc3339_opts(SecondsFormat::Secs, true),
+        services,
+    };
+    let result = (|| -> Result<()> {
+        let bytes = serde_json::to_vec_pretty(&manifest)?;
+        let mut file = std::fs::OpenOptions::new()
+            .write(true)
+            .create_new(true)
+            .open(&temp)
+            .with_context(|| format!("create roster export temporary {}", temp.display()))?;
+        file.write_all(&bytes)?;
+        file.write_all(b"\n")?;
+        file.sync_all()?;
+        drop(file);
+        std::fs::rename(&temp, path)
+            .with_context(|| format!("publish roster export {}", path.display()))?;
+        Ok(())
+    })();
+    if result.is_err() {
+        let _ = std::fs::remove_file(&temp);
+    }
+    result
 }
 
 /// The command is dispatched after `main` has loaded and validated the
@@ -214,13 +338,16 @@ mod tests {
     #[test]
     fn deployment_bootstrap_rejects_invalid_roster_and_lifetime_before_credentials() {
         let config = HyprConfig::default();
-        assert!(provision_services(&config, &["model".to_owned()], 599).is_err());
-        assert!(provision_services(&config, &["model".to_owned()], 86401).is_err());
-        assert!(provision_services(&config, &[], 86400).is_err());
+        assert!(provision_services(&config, &["model".to_owned()], 599, None).is_err());
+        assert!(provision_services(&config, &["model".to_owned()], 86401, None).is_err());
+        assert!(provision_services(&config, &[], 86400, None).is_err());
         assert!(
-            provision_services(&config, &["model".to_owned(), "model".to_owned()], 86400).is_err()
+            provision_services(&config, &["model".to_owned(), "model".to_owned()], 86400, None)
+                .is_err()
         );
-        assert!(provision_services(&config, &["../not-a-service".to_owned()], 86400).is_err());
+        assert!(
+            provision_services(&config, &["../not-a-service".to_owned()], 86400, None).is_err()
+        );
     }
 
     #[test]
@@ -432,6 +559,191 @@ mod tests {
         assert_eq!(states.len(), 1);
         assert_eq!(states[0].did, did);
         assert_eq!(states[0].epoch, 0);
+        Ok(())
+    }
+
+    #[test]
+    fn deployment_bootstrap_roster_export_matches_verified_readback_not_inputs() -> Result<()> {
+        let (_dir, store, ingest, key) = fixture()?;
+        let now = Utc::now();
+        let now_text = now.to_rfc3339_opts(SecondsFormat::Secs, true);
+        let event_key = SigningKey::from_bytes(&[0x63; 32]);
+        let first = provision_one(&store, &ingest, "model", &key, now, 86400)?;
+        let event = provision_one(&store, &ingest, "event", &event_key, now, 86400)?;
+        let admitted = [
+            ("model", &key, first.clone()),
+            ("event", &event_key, event.clone()),
+        ];
+        let entries = build_verified_roster_entries(&store, &admitted, &now_text)?;
+        assert_eq!(entries.len(), 2);
+        // Every exported field equals an independent store readback of the
+        // accepted state, not the values handed to the provisioner.
+        let model_readback = store
+            .accepted_at9p_state(&first.did, Some(&now_text))?
+            .context("model readback")?;
+        assert_eq!(entries[0].service, "model");
+        assert_eq!(entries[0].did, model_readback.did);
+        assert_eq!(entries[0].epoch, model_readback.epoch);
+        assert_eq!(
+            entries[0].expires_at,
+            model_readback.expires_at.clone().context("model expiry")?
+        );
+        assert_eq!(
+            entries[0].accepted_head_digest,
+            hex::encode(model_readback.head_digest)
+        );
+        assert_eq!(entries[1].service, "event");
+        assert_eq!(entries[1].did, event.did);
+        assert_ne!(entries[0].did, entries[1].did);
+        // Provenance: after a real signed renewal advances the store, the
+        // rebuilt export tracks the new verified state even though the stale
+        // in-memory `first` value is still passed in as the admitted input.
+        let renewed = provision_one(
+            &store,
+            &ingest,
+            "model",
+            &key,
+            now + Duration::hours(13),
+            86400,
+        )?;
+        assert_eq!(renewed.epoch, first.epoch + 1);
+        let admitted = [
+            ("model", &key, first.clone()),
+            ("event", &event_key, event),
+        ];
+        let entries = build_verified_roster_entries(&store, &admitted, &now_text)?;
+        assert_eq!(entries[0].did, renewed.did);
+        assert_eq!(entries[0].epoch, renewed.epoch);
+        assert_eq!(
+            entries[0].accepted_head_digest,
+            hex::encode(renewed.head_digest)
+        );
+        assert_eq!(
+            entries[0].expires_at,
+            renewed.expires_at.clone().context("renewed expiry")?
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn deployment_bootstrap_roster_export_is_atomic_and_never_partial() -> Result<()> {
+        let (dir, store, ingest, key) = fixture()?;
+        let now = Utc::now();
+        let now_text = now.to_rfc3339_opts(SecondsFormat::Secs, true);
+        let first = provision_one(&store, &ingest, "model", &key, now, 86400)?;
+        let out_dir = tempfile::tempdir()?;
+        let target = out_dir.path().join("roster.json");
+        // A member whose key is not the accepted key fails the whole export;
+        // the target and any temporary sibling must not exist afterwards.
+        let wrong_key = SigningKey::from_bytes(&[0x65; 32]);
+        let admitted = [("model", &wrong_key, first.clone())];
+        let error = build_verified_roster_entries(&store, &admitted, &now_text)
+            .err()
+            .context("unaccepted key must fail roster verification")?;
+        assert!(error.to_string().contains("accepted current hybrid"));
+        let write_result = build_verified_roster_entries(&store, &admitted, &now_text)
+            .and_then(|entries| write_verified_roster_manifest(&target, entries));
+        assert!(write_result.is_err());
+        assert!(!target.exists());
+        assert!(std::fs::read_dir(out_dir.path())?.next().is_none());
+        // A failed renewal-time export leaves a previously published manifest
+        // byte-identical instead of clobbering it with partial content.
+        let good = [("model", &key, first.clone())];
+        let entries = build_verified_roster_entries(&store, &good, &now_text)?;
+        write_verified_roster_manifest(&target, entries)?;
+        let published = std::fs::read(&target)?;
+        let failed = build_verified_roster_entries(&store, &admitted, &now_text)
+            .and_then(|entries| write_verified_roster_manifest(&target, entries));
+        assert!(failed.is_err());
+        assert_eq!(std::fs::read(&target)?, published);
+        // Unsafe output targets fail without touching the store directory.
+        let entries = build_verified_roster_entries(&store, &good, &now_text)?;
+        assert!(write_verified_roster_manifest(dir.path(), entries.clone()).is_err());
+        assert!(
+            write_verified_roster_manifest(
+                &out_dir.path().join("missing-parent").join("roster.json"),
+                entries,
+            )
+            .is_err()
+        );
+        assert!(!out_dir.path().join("missing-parent").exists());
+        Ok(())
+    }
+
+    #[test]
+    fn deployment_bootstrap_roster_export_rejects_expired_and_unbounded_state() -> Result<()> {
+        let (_dir, store, ingest, key) = fixture()?;
+        let now = Utc::now();
+        let first = provision_one(&store, &ingest, "model", &key, now, 86400)?;
+        // Readback at a time beyond the bounded validity fails the export.
+        let later = (now + Duration::days(2)).to_rfc3339_opts(SecondsFormat::Secs, true);
+        let admitted = [("model", &key, first)];
+        let error = build_verified_roster_entries(&store, &admitted, &later)
+            .err()
+            .context("expired accepted state must fail roster export")?;
+        assert!(error.to_string().contains("expired"));
+        // A genesis-only accepted state has no bounded validity and is refused.
+        let genesis = SigningKey::from_bytes(&[0x67; 32]);
+        let pq = hyprstream_rpc::node_identity::derive_mesh_mldsa_key(&genesis);
+        let pair = HybridKeyPair::new(
+            genesis.verifying_key().to_bytes().to_vec(),
+            ml_dsa_sk_to_vk_bytes(&pq),
+        )?;
+        let endpoint = ServiceEndpoint::new(
+            Transport::Iroh,
+            format!("iroh://{}", hex::encode([0x68; 32])),
+        )?;
+        let service = ServiceEntry::new("#event", ServiceType::NinePExport, endpoint)?;
+        let body = CapsuleBody::new(vec![pair], vec![service])?;
+        let capsule = sign_capsule(body, &genesis, &pq)?;
+        let genesis_did = format!("did:at9p:{}", capsule.cid512()?);
+        let genesis_state =
+            ingest.ingest_genesis(&genesis_did, &capsule.to_dag_cbor()?)?;
+        assert_eq!(genesis_state.epoch, 0);
+        assert!(genesis_state.expires_at.is_none());
+        let now_text = now.to_rfc3339_opts(SecondsFormat::Secs, true);
+        let admitted = [("event", &genesis, genesis_state)];
+        let error = build_verified_roster_entries(&store, &admitted, &now_text)
+            .err()
+            .context("genesis-only state must fail roster export")?;
+        assert!(error.to_string().contains("no bounded production expiry"));
+        Ok(())
+    }
+
+    #[test]
+    fn deployment_bootstrap_roster_manifest_is_public_json_only() -> Result<()> {
+        let (_dir, store, ingest, key) = fixture()?;
+        let now = Utc::now();
+        let now_text = now.to_rfc3339_opts(SecondsFormat::Secs, true);
+        let first = provision_one(&store, &ingest, "model", &key, now, 86400)?;
+        let admitted = [("model", &key, first.clone())];
+        let entries = build_verified_roster_entries(&store, &admitted, &now_text)?;
+        let out_dir = tempfile::tempdir()?;
+        let target = out_dir.path().join("roster.json");
+        write_verified_roster_manifest(&target, entries)?;
+        let text = std::fs::read_to_string(&target)?;
+        let parsed: serde_json::Value = serde_json::from_str(&text)?;
+        assert_eq!(parsed["schema"], VERIFIED_ROSTER_SCHEMA);
+        let services = parsed["services"].as_array().context("services array")?;
+        assert_eq!(services.len(), 1);
+        assert_eq!(services[0]["service"], "model");
+        assert_eq!(services[0]["did"], first.did);
+        assert_eq!(
+            services[0]["epoch"],
+            serde_json::Value::from(first.epoch)
+        );
+        assert_eq!(
+            services[0]["expires_at"].as_str().context("expires_at")?,
+            first.expires_at.as_deref().context("first expiry")?
+        );
+        assert_eq!(
+            services[0]["accepted_head_digest"],
+            hex::encode(first.head_digest)
+        );
+        // The manifest must never leak private key material: neither the raw
+        // signing seed nor the derived ML-DSA secret appears in any form.
+        assert!(!text.contains(&hex::encode([0x62; 32])));
+        assert!(!text.contains("signing-key"));
         Ok(())
     }
 }

--- a/crates/hyprstream/src/cli/deployment_bootstrap.rs
+++ b/crates/hyprstream/src/cli/deployment_bootstrap.rs
@@ -162,8 +162,10 @@ fn build_verified_roster_entries(
 
 /// Atomically write the verified roster manifest: serialize fully, write to a
 /// sibling temporary file (created exclusively), sync, then rename. A failure
-/// at any step removes the temporary file and never creates, truncates, or
-/// replaces the target path.
+/// at any step never creates, truncates, or replaces the target path. Only a
+/// temporary file this invocation successfully created is ever removed; if
+/// exclusive creation fails because the predictable sibling already exists,
+/// that preexisting file belongs to someone else and is left untouched.
 fn write_verified_roster_manifest(
     path: &Path,
     services: Vec<VerifiedServiceRosterEntry>,
@@ -199,23 +201,39 @@ fn write_verified_roster_manifest(
         generated_at: Utc::now().to_rfc3339_opts(SecondsFormat::Secs, true),
         services,
     };
+    let bytes = serde_json::to_vec_pretty(&manifest)?;
+    // Ownership boundary: until the exclusive create succeeds, `temp` is not
+    // ours — a collision means a leftover from an interrupted earlier process
+    // (possibly with a reused PID) or another entry in the caller's directory,
+    // and must survive this failed invocation.
+    let file = std::fs::OpenOptions::new()
+        .write(true)
+        .create_new(true)
+        .open(&temp)
+        .with_context(|| format!("create roster export temporary {}", temp.display()))?;
+    publish_owned_roster_temp(file, &temp, path, &bytes)
+}
+
+/// Publish through a temporary file this invocation created exclusively. On
+/// any failure before the rename lands, only that owned file is removed;
+/// nothing else in the directory is touched.
+fn publish_owned_roster_temp(
+    mut file: std::fs::File,
+    temp: &Path,
+    path: &Path,
+    bytes: &[u8],
+) -> Result<()> {
     let result = (|| -> Result<()> {
-        let bytes = serde_json::to_vec_pretty(&manifest)?;
-        let mut file = std::fs::OpenOptions::new()
-            .write(true)
-            .create_new(true)
-            .open(&temp)
-            .with_context(|| format!("create roster export temporary {}", temp.display()))?;
-        file.write_all(&bytes)?;
+        file.write_all(bytes)?;
         file.write_all(b"\n")?;
         file.sync_all()?;
         drop(file);
-        std::fs::rename(&temp, path)
+        std::fs::rename(temp, path)
             .with_context(|| format!("publish roster export {}", path.display()))?;
         Ok(())
     })();
     if result.is_err() {
-        let _ = std::fs::remove_file(&temp);
+        let _ = std::fs::remove_file(temp);
     }
     result
 }
@@ -744,6 +762,107 @@ mod tests {
         // signing seed nor the derived ML-DSA secret appears in any form.
         assert!(!text.contains(&hex::encode([0x62; 32])));
         assert!(!text.contains("signing-key"));
+        Ok(())
+    }
+
+    /// The predictable sibling temp path of the current process, exactly as
+    /// `write_verified_roster_manifest` computes it.
+    fn roster_temp_sibling(target: &Path) -> Result<std::path::PathBuf> {
+        let file_name = target
+            .file_name()
+            .context("roster target has no file name")?;
+        Ok(target.with_file_name(format!(
+            ".{}.tmp-{}",
+            file_name.to_string_lossy(),
+            std::process::id()
+        )))
+    }
+
+    #[test]
+    fn deployment_bootstrap_roster_export_collision_preserves_foreign_sibling_and_target(
+    ) -> Result<()> {
+        let out_dir = tempfile::tempdir()?;
+        let target = out_dir.path().join("roster.json");
+        // A leftover from an interrupted earlier process (possibly a reused
+        // PID) occupies the predictable temp path, and an older published
+        // manifest occupies the target. The failed invocation must not delete
+        // or modify either: it never owned the sibling.
+        let foreign = roster_temp_sibling(&target)?;
+        std::fs::write(&foreign, b"interrupted earlier process")?;
+        std::fs::write(&target, b"previous good manifest")?;
+        let error = write_verified_roster_manifest(
+            &target,
+            vec![VerifiedServiceRosterEntry {
+                service: "model".to_owned(),
+                did: "did:at9p:collision".to_owned(),
+                epoch: 1,
+                expires_at: "2099-01-01T00:00:00Z".to_owned(),
+                accepted_head_digest: hex::encode([0x42; 64]),
+            }],
+        )
+        .err()
+        .context("temp collision must fail the export")?;
+        assert!(error.to_string().contains("create roster export temporary"));
+        assert_eq!(std::fs::read(&foreign)?, b"interrupted earlier process");
+        assert_eq!(std::fs::read(&target)?, b"previous good manifest");
+        Ok(())
+    }
+
+    #[test]
+    fn deployment_bootstrap_roster_export_failure_after_create_removes_only_owned_temp(
+    ) -> Result<()> {
+        let out_dir = tempfile::tempdir()?;
+        let target = out_dir.path().join("roster.json");
+        let temp = roster_temp_sibling(&target)?;
+        // Simulate ownership exactly as the writer acquires it, then fail the
+        // publication step: the rename destination's parent does not exist.
+        let owned = std::fs::OpenOptions::new()
+            .write(true)
+            .create_new(true)
+            .open(&temp)?;
+        let missing_target = out_dir.path().join("gone").join("roster.json");
+        let result = publish_owned_roster_temp(owned, &temp, &missing_target, b"{}");
+        assert!(result.is_err());
+        assert!(!temp.exists(), "owned temp must be removed after failure");
+        // An unrelated preexisting sibling entry is never cleanup scope.
+        let foreign = out_dir.path().join(".roster.json.tmp-foreign");
+        std::fs::write(&foreign, b"not ours")?;
+        let owned = std::fs::OpenOptions::new()
+            .write(true)
+            .create_new(true)
+            .open(&temp)?;
+        assert!(publish_owned_roster_temp(owned, &temp, &missing_target, b"{}").is_err());
+        assert!(!temp.exists());
+        assert_eq!(std::fs::read(&foreign)?, b"not ours");
+        // Success control: the owned path publishes and removes the temp.
+        let owned = std::fs::OpenOptions::new()
+            .write(true)
+            .create_new(true)
+            .open(&temp)?;
+        publish_owned_roster_temp(owned, &temp, &target, b"{\"ok\":true}")?;
+        assert!(!temp.exists());
+        assert_eq!(std::fs::read(&target)?, b"{\"ok\":true}\n");
+        Ok(())
+    }
+
+    #[test]
+    fn deployment_bootstrap_roster_export_success_control_publishes_atomically() -> Result<()> {
+        let (_dir, store, ingest, key) = fixture()?;
+        let now = Utc::now();
+        let now_text = now.to_rfc3339_opts(SecondsFormat::Secs, true);
+        let first = provision_one(&store, &ingest, "model", &key, now, 86400)?;
+        let admitted = [("model", &key, first.clone())];
+        let entries = build_verified_roster_entries(&store, &admitted, &now_text)?;
+        let out_dir = tempfile::tempdir()?;
+        let target = out_dir.path().join("roster.json");
+        write_verified_roster_manifest(&target, entries)?;
+        // Successful publication leaves exactly the target: no temp sibling.
+        let names = std::fs::read_dir(out_dir.path())?
+            .map(|entry| entry.map(|entry| entry.file_name()))
+            .collect::<std::io::Result<Vec<_>>>()?;
+        assert_eq!(names, [std::ffi::OsString::from("roster.json")]);
+        let parsed: serde_json::Value = serde_json::from_str(&std::fs::read_to_string(&target)?)?;
+        assert_eq!(parsed["services"][0]["did"], first.did);
         Ok(())
     }
 }

--- a/crates/hyprstream/src/services/oauth/required_consumer_tests.rs
+++ b/crates/hyprstream/src/services/oauth/required_consumer_tests.rs
@@ -122,6 +122,7 @@ fn required_oauth_runtime_clients_reach_policy_and_discovery_over_iroh() -> Resu
             "oauth".to_owned(),
         ],
         3600,
+        None,
     )?;
 
     // Match OAuthService::run: clients are created and used on its own


### PR DESCRIPTION
## Summary

Adds an opt-in `--roster-export PATH` flag to `hyprstream pds provision-services` that writes a machine-readable JSON manifest (`hyprstream/verified-service-roster@1`) of the **verified** accepted service roster, so IaC (staging network templates) can consume actual accepted service DIDs and epoch/lifetime instead of deriving DIDs from raw keys or scraping logs.

Each manifest entry contains only public fields projected from the checkpoint-verified accepted-state readback: exact service name, admitted `did:at9p` DID, epoch, bounded expiry, and the accepted-state head digest binding the entry to that exact state. No seeds, JWTs, or private key material are ever emitted.

## Provenance and failure semantics

- Every admitted member is re-read through `PdsRecordStore::accepted_at9p_state(did, Some(now))` (freshness enforced) and re-bound via `NativeServiceAnnouncement::from_accepted_state` (service present in the exact accepted state, signer is an accepted current hybrid response key, epoch > 0, unexpired) before anything is serialized. Exported values come from that readback, never from CLI inputs.
- Any member failure — invalid identity, missing/expired authority, unbounded genesis-only state — fails the whole export.
- The manifest is fully serialized, written to an exclusive sibling temp file (`.<name>.tmp-<pid>`, `create_new`), synced, and atomically renamed. A failed invocation never creates, truncates, or replaces the target path, and no temporary file is left behind.
- Default behavior is unchanged: without `--roster-export` nothing is written.

## Safe consumer contract

The manifest is **not** a new trust root. The authenticated checkpoint store (deployment trust bundle + accepted at9p state) remains authoritative; the manifest is a convenience projection for tooling, valid only as long as the recorded epochs/expiries it mirrors. It grants no policy, clearance, or enrollment expansion.

## Tests

- `deployment_bootstrap_roster_export_matches_verified_readback_not_inputs`: exported fields equal an independent store readback; after a real signed renewal advances the store, a rebuilt export tracks the new epoch/head/expiry even when stale in-memory admitted values are passed in (provenance).
- `deployment_bootstrap_roster_export_is_atomic_and_never_partial`: unaccepted-key member fails the whole export with no target and no temp leftovers; a previously published manifest stays byte-identical after a failed run; directory/missing-parent targets are refused.
- `deployment_bootstrap_roster_export_rejects_expired_and_unbounded_state`: expired readback and genesis-only (unbounded) states fail the export.
- `deployment_bootstrap_roster_manifest_is_public_json_only`: exact JSON content matches verified state; no private key material appears.
- CLI parse coverage for the new flag in `main.rs`.

Validation (BuildQ): focused tests 13/13 + CLI parse 1/1, `cargo clippy -p hyprstream --all-targets -- -D warnings` clean, `cargo check --all-targets` clean, final combined nextest results in the linked fleet report.

Draft: main.rs argument-dispatch adjacency to the active PR1518 repair is intentional-minimal (one arg + three dispatch lines); coordination via the fleet report.