### PR TITLE
fix: select provisioned native service identity before resolver startup

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -178,7 +178,7 @@ sqlparser = "0.39.0"
 json-threat-protection = "0.1.1"
 
 # System utilities
-nix = { version = "0.27", features = ["fs", "process", "signal", "socket", "user"] }
+nix = { version = "0.27", features = ["fs", "process", "signal", "socket", "user", "uio"] }
 users = "0.11"
 rlimit = "0.10"
 clap = { version = "4.4", features = ["derive", "env"] }

--- a/crates/hyprstream-rpc/src/notify.rs
+++ b/crates/hyprstream-rpc/src/notify.rs
@@ -1,7 +1,10 @@
 //! Service notification helpers
 //!
-//! Wraps systemd sd_notify protocol for service lifecycle notifications.
-//! When the `systemd` feature is disabled, all functions are no-ops.
+//! Wraps the systemd sd_notify protocol for service lifecycle notifications.
+//! The sd_notify transport is a plain datagram to `NOTIFY_SOCKET`, so it is
+//! supervisor-agnostic: `ready()` delivers `READY=1` in every build (through
+//! the `systemd` crate where that feature is on, and through a `nix` datagram
+//! send otherwise), and stays a no-op only when `NOTIFY_SOCKET` is unset.
 
 use anyhow::Result;
 
@@ -10,6 +13,12 @@ use anyhow::Result;
 /// Sends `READY=1` to the notification socket.
 /// This should be called after the service has completed initialization
 /// and is ready to handle requests.
+///
+/// The sd_notify protocol is supervisor-agnostic: the message is a datagram to
+/// whatever `NOTIFY_SOCKET` points at, so a direct-launch supervisor
+/// (`--daemon` / no-systemd fallback, #1585) that provisions a per-child
+/// notification endpoint gets the same post-initialization signal systemd
+/// receives. With `NOTIFY_SOCKET` unset the call stays a no-op in every build.
 #[cfg(feature = "systemd")]
 pub fn ready() -> Result<()> {
     let state = [("READY", "1")];
@@ -17,8 +26,41 @@ pub fn ready() -> Result<()> {
     Ok(())
 }
 
+/// Feature-less builds send the same datagram through `nix` so required-native
+/// readiness does not silently degrade to a no-op (and a launcher notification
+/// wait to a guaranteed timeout) on no-systemd builds. Abstract (`@`-prefixed)
+/// socket paths — which real systemd hands out — are addressed through
+/// `UnixAddr::new_abstract` (the sd_notify leading-`@` convention); every
+/// other value is a pathname address.
 #[cfg(not(feature = "systemd"))]
 pub fn ready() -> Result<()> {
+    use nix::sys::socket::{
+        sendto, socket, AddressFamily, MsgFlags, SockFlag, SockType, UnixAddr,
+    };
+    use std::os::fd::AsRawFd;
+    use std::os::unix::ffi::OsStrExt;
+
+    let Some(socket_path) = std::env::var_os("NOTIFY_SOCKET") else {
+        return Ok(());
+    };
+    let bytes = socket_path.as_bytes();
+    #[cfg(any(target_os = "linux", target_os = "android"))]
+    let address = {
+        if bytes.first() == Some(&b'@') {
+            UnixAddr::new_abstract(&bytes[1..])?
+        } else {
+            UnixAddr::new(std::path::Path::new(&socket_path))?
+        }
+    };
+    #[cfg(not(any(target_os = "linux", target_os = "android")))]
+    let address = UnixAddr::new(std::path::Path::new(&socket_path))?;
+    let fd = socket(
+        AddressFamily::Unix,
+        SockType::Datagram,
+        SockFlag::empty(),
+        None,
+    )?;
+    sendto(fd.as_raw_fd(), b"READY=1", &address, MsgFlags::empty())?;
     Ok(())
 }
 
@@ -68,4 +110,90 @@ pub fn watchdog() -> Result<()> {
 #[cfg(not(feature = "systemd"))]
 pub fn watchdog() -> Result<()> {
     Ok(())
+}
+
+#[cfg(all(test, unix))]
+mod tests {
+    use super::*;
+    use parking_lot::Mutex;
+
+    /// `NOTIFY_SOCKET` is process-global state: serialize the send regressions.
+    static NOTIFY_ENV_LOCK: Mutex<()> = Mutex::new(());
+
+    const READY_PAYLOAD: &[u8] = b"READY=1";
+
+    #[test]
+    fn ready_sends_datagram_to_pathname_socket() -> anyhow::Result<()> {
+        let _guard = NOTIFY_ENV_LOCK.lock();
+        let path = std::env::temp_dir().join(format!(
+            "hyprstream-notify-pathname-{}-{}.sock",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)?
+                .as_nanos()
+        ));
+        let receiver = std::os::unix::net::UnixDatagram::bind(&path)?;
+        receiver.set_read_timeout(Some(std::time::Duration::from_secs(5)))?;
+
+        std::env::set_var("NOTIFY_SOCKET", &path);
+        let outcome = ready();
+        std::env::remove_var("NOTIFY_SOCKET");
+        outcome?;
+
+        let mut buffer = [0u8; 16];
+        let (received, _) = receiver.recv_from(&mut buffer)?;
+        assert_eq!(&buffer[..received], READY_PAYLOAD);
+        Ok(())
+    }
+
+    /// Real systemd hands out abstract `@`-prefixed endpoints; the send side
+    /// must address them with the sd_notify leading-NUL convention.
+    #[test]
+    #[cfg(any(target_os = "linux", target_os = "android"))]
+    fn ready_sends_datagram_to_abstract_socket() -> anyhow::Result<()> {
+        use nix::cmsg_space;
+        use nix::sys::socket::{
+            bind, recvmsg, socket, AddressFamily, MsgFlags, SockFlag, SockType, UnixAddr,
+            UnixCredentials,
+        };
+        use std::io::IoSliceMut;
+        use std::os::fd::AsRawFd;
+
+        let _guard = NOTIFY_ENV_LOCK.lock();
+        let name = format!(
+            "hyprstream-notify-abstract-{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)?
+                .as_nanos()
+        );
+        let fd = socket(
+            AddressFamily::Unix,
+            SockType::Datagram,
+            SockFlag::SOCK_NONBLOCK | SockFlag::SOCK_CLOEXEC,
+            None,
+        )?;
+        bind(fd.as_raw_fd(), &UnixAddr::new_abstract(name.as_bytes())?)?;
+
+        std::env::set_var("NOTIFY_SOCKET", format!("@{name}"));
+        let outcome = ready();
+        std::env::remove_var("NOTIFY_SOCKET");
+        outcome?;
+
+        let mut buffer = [0u8; 16];
+        let received = {
+            let mut iov = [IoSliceMut::new(&mut buffer)];
+            let mut cmsg = cmsg_space!(UnixCredentials);
+            let message = recvmsg::<UnixAddr>(
+                fd.as_raw_fd(),
+                &mut iov,
+                Some(&mut cmsg),
+                MsgFlags::empty(),
+            )?;
+            message.bytes
+        };
+        assert!(received > 0);
+        assert_eq!(&buffer[..received], READY_PAYLOAD);
+        Ok(())
+    }
 }

--- a/crates/hyprstream-rpc/src/transport/lazy_iroh.rs
+++ b/crates/hyprstream-rpc/src/transport/lazy_iroh.rs
@@ -55,9 +55,16 @@ static IROH_CLIENT_ENDPOINT: OnceLock<iroh::Endpoint> = OnceLock::new();
 /// originate outbound RPC dials. First-write-wins (mirrors
 /// `install_verify_config`); returns `Err(endpoint)` if one is already set.
 ///
-/// The daemon calls this once during bootstrap with the shared endpoint (the
-/// same one its inbound iroh substrate listens on, so outbound dials reuse the
-/// node identity). The capability can only be obtained from
+/// In production the authenticated OS-owned process bootstrap calls this
+/// FIRST, with a distinct outbound-only carrier endpoint (retained in
+/// `PROCESS_BOOTSTRAP_CARRIER`, transport purpose key
+/// `hyprstream-bootstrap-client-transport-v1`). A service that later binds
+/// its own inbound substrate therefore receives `Err(returned_capability)`;
+/// that is valid and expected — it keeps its substrate as the independent
+/// inbound owner and leaves the global endpoint untouched. The global
+/// endpoint is the outbound dialer only: it is not a DID, subject, tenant,
+/// response-signing key, or authorization authority. The capability can only
+/// be obtained from
 /// [`crate::transport::iroh_substrate::IrohSubstrate::owned_client_endpoint`],
 /// which proves the endpoint was bound with the exact hybrid-only provider.
 ///

--- a/crates/hyprstream-service/src/lib.rs
+++ b/crates/hyprstream-service/src/lib.rs
@@ -21,7 +21,7 @@ pub mod notify;
 
 // Top-level re-exports for convenience
 pub use service::spawner::{
-    DualSpawnable, ProcessBackend, ProcessConfig, ProcessKind,
+    DualSpawnable, ProcessBackend, ProcessConfig, ProcessKind, ProcessReadiness,
     ProcessSpawner, ServiceKind, ServiceMode, ServiceSpawner,
     Spawnable, SpawnedProcess, SpawnedService, SpawnerBackend, StandaloneBackend,
     SystemdBackend, InprocManager, UnifiedServiceConfig,
@@ -45,4 +45,4 @@ pub use service::manager::systemd::encrypt_credentials_if_available;
 
 pub use service::metadata::{MethodMeta, ParamMeta, SchemaMetadataFn, ScopedSchemaMetadataFn, ScopedClientTreeNode};
 
-pub use service::ordering::startup_stages;
+pub use service::ordering::{startup_stages, startup_stages_for_profile};

--- a/crates/hyprstream-service/src/service/factory.rs
+++ b/crates/hyprstream-service/src/service/factory.rs
@@ -557,6 +557,13 @@ pub struct ServiceContext {
     ///
     /// In multi-process mode, loaded from the `ca-mldsa-pubkey` credential.
     ca_ml_dsa_verifying_key: Option<hyprstream_rpc::crypto::pq::MlDsaVerifyingKey>,
+
+    /// Explicitly resolved credentials/secrets directory — the location the
+    /// loading process actually selected (honoring `--config [secrets].path`
+    /// and the `HYPRSTREAM__SECRETS__PATH` override). `None` lets factory
+    /// code fall back to the config-free resolver, preserving compatibility
+    /// for constructors that never carried a config handle.
+    secrets_dir: Option<std::path::PathBuf>,
 }
 
 /// Owned callback joining carrier binding to the signed announcement lifecycle.
@@ -623,7 +630,27 @@ impl ServiceContext {
                 std::sync::Arc::new(std::sync::RwLock::new(Vec::new()))
             },
             ca_ml_dsa_verifying_key: None,
+            secrets_dir: None,
         }
+    }
+
+    /// Carry the explicitly resolved credentials directory into factories.
+    ///
+    /// Startup resolves `[secrets].path` from the loaded config and reads the
+    /// retained signing key and service JWT from that directory; factory-time
+    /// helpers (key registration, JWT renewal) have no config handle of their
+    /// own and must not re-resolve from env/defaults, or a custom
+    /// `--config [secrets].path` deployment would work at startup and then
+    /// renew against the wrong directory.
+    pub fn with_secrets_dir(mut self, dir: std::path::PathBuf) -> Self {
+        self.secrets_dir = Some(dir);
+        self
+    }
+
+    /// The explicitly resolved credentials directory, when the constructing
+    /// process carried one.
+    pub fn secrets_dir(&self) -> Option<&std::path::Path> {
+        self.secrets_dir.as_deref()
     }
 
     /// Set the shared ML-DSA-65 verifying keys for PQ-hybrid JWT verification.

--- a/crates/hyprstream-service/src/service/spawner/mod.rs
+++ b/crates/hyprstream-service/src/service/spawner/mod.rs
@@ -54,6 +54,7 @@ pub use service::{
 };
 pub use systemd::SystemdBackend;
 
+use std::ffi::OsString;
 use std::path::PathBuf;
 
 use hyprstream_rpc::error::{Result, RpcError};
@@ -96,7 +97,7 @@ pub struct ProcessConfig {
     pub executable: PathBuf,
 
     /// Command-line arguments.
-    pub args: Vec<String>,
+    pub args: Vec<OsString>,
 
     /// Working directory.
     pub working_dir: Option<PathBuf>,
@@ -148,7 +149,7 @@ impl ProcessConfig {
     pub fn args<I, S>(mut self, args: I) -> Self
     where
         I: IntoIterator<Item = S>,
-        S: Into<String>,
+        S: Into<OsString>,
     {
         self.args = args.into_iter().map(Into::into).collect();
         self

--- a/crates/hyprstream-service/src/service/spawner/mod.rs
+++ b/crates/hyprstream-service/src/service/spawner/mod.rs
@@ -9,7 +9,7 @@
 //! ```text
 //! ProcessSpawner (raw process management)
 //!     ├── StandaloneBackend (tokio::process::Command)
-//!     │   └── .kill_on_drop(true) for cleanup
+//!     │   └── .kill_on_drop(false): adopted daemons outlive the launcher
 //!     │
 //!     └── SystemdBackend (systemd-run)
 //!         └── Transient units in hyprstream-workers.slice
@@ -58,6 +58,24 @@ use std::path::PathBuf;
 
 use hyprstream_rpc::error::Result;
 
+/// Readiness policy for a spawned child process (#1585).
+///
+/// The policy gates when a spawn is reported as successful. It is a
+/// lifecycle gate, not application authentication.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ProcessReadiness {
+    /// Report success as soon as the child is spawned (legacy behavior).
+    Immediate,
+    /// Wait for the child's own `READY=1` sd_notify datagram on a per-child
+    /// notification endpoint before reporting success. The sender PID must
+    /// match the spawned child; a child exit or the hard timeout fails the
+    /// spawn, and the child is terminated/reaped and its artifacts cleaned up.
+    Notify {
+        /// Hard bound on how long the child has to report readiness.
+        timeout: std::time::Duration,
+    },
+}
+
 /// Configuration for spawning a daemon process.
 #[derive(Debug, Clone)]
 pub struct ProcessConfig {
@@ -87,6 +105,9 @@ pub struct ProcessConfig {
 
     /// Whether to restart on failure (systemd only).
     pub restart_on_failure: bool,
+
+    /// When the spawn may be reported as started (#1585).
+    pub readiness: ProcessReadiness,
 }
 
 impl ProcessConfig {
@@ -102,7 +123,15 @@ impl ProcessConfig {
             cpu_quota: None,
             unit_properties: Vec::new(),
             restart_on_failure: false,
+            readiness: ProcessReadiness::Immediate,
         }
+    }
+
+    /// Require the child's own `READY=1` notification within `timeout`
+    /// before the spawn reports success (#1585).
+    pub fn with_notify_ready(mut self, timeout: std::time::Duration) -> Self {
+        self.readiness = ProcessReadiness::Notify { timeout };
+        self
     }
 
     /// Set command-line arguments.
@@ -160,6 +189,10 @@ pub struct SpawnedProcess {
 
     /// Process kind (direct or systemd).
     pub kind: ProcessKind,
+
+    /// The PID file this spawn published, if any; `stop` removes it so a
+    /// stopped child leaves no stale artifact (#1585).
+    pub pid_file: Option<PathBuf>,
 }
 
 impl SpawnedProcess {
@@ -168,7 +201,14 @@ impl SpawnedProcess {
         Self {
             id: id.into(),
             kind,
+            pid_file: None,
         }
+    }
+
+    /// Attach the PID file this spawn published, for cleanup on stop (#1585).
+    pub fn with_pid_file(mut self, path: impl Into<PathBuf>) -> Self {
+        self.pid_file = Some(path.into());
+        self
     }
 
     /// Get the process ID.

--- a/crates/hyprstream-service/src/service/spawner/mod.rs
+++ b/crates/hyprstream-service/src/service/spawner/mod.rs
@@ -56,7 +56,7 @@ pub use systemd::SystemdBackend;
 
 use std::path::PathBuf;
 
-use hyprstream_rpc::error::Result;
+use hyprstream_rpc::error::{Result, RpcError};
 
 /// Readiness policy for a spawned child process (#1585).
 ///
@@ -277,6 +277,18 @@ pub trait SpawnerBackend: Send + Sync {
 
     /// Check if a process is still running.
     async fn is_running(&self, process: &SpawnedProcess) -> Result<bool>;
+
+    /// Synchronous bounded stop of a TRACKED direct child, used only by the
+    /// launch-transaction guard's `Drop` for cancellation cleanup where no
+    /// async runtime work is guaranteed (#1585). Backends that retain child
+    /// handles override this to stop through the retained handle — never a
+    /// blind by-PID signal; the default fails honestly.
+    fn stop_tracked_child_sync(&self, process: &SpawnedProcess) -> Result<()> {
+        let _ = process;
+        Err(RpcError::InvalidOperation(
+            "backend does not support synchronous tracked-child stop".to_owned(),
+        ))
+    }
 
     /// Get the backend type name.
     fn backend_type(&self) -> &'static str;

--- a/crates/hyprstream-service/src/service/spawner/mod.rs
+++ b/crates/hyprstream-service/src/service/spawner/mod.rs
@@ -70,6 +70,16 @@ pub enum ProcessReadiness {
     /// notification endpoint before reporting success. The sender PID must
     /// match the spawned child; a child exit or the hard timeout fails the
     /// spawn, and the child is terminated/reaped and its artifacts cleaned up.
+    ///
+    /// Platform support: the credential-authenticated receiver
+    /// (`SO_PASSCRED`/`SCM_CREDENTIALS`, exact child-PID matching) is
+    /// implemented for Linux/Android only. On other targets a Notify request
+    /// is refused with an explicit error BEFORE the child is spawned and
+    /// before any launch side effect; it is never silently downgraded to
+    /// [`ProcessReadiness::Immediate`], and no unauthenticated receiver
+    /// exists. This is a launcher lifecycle boundary: the Required
+    /// networking profile itself predates this readiness policy and is a
+    /// distinct concern.
     Notify {
         /// Hard bound on how long the child has to report readiness.
         timeout: std::time::Duration,

--- a/crates/hyprstream-service/src/service/spawner/process.rs
+++ b/crates/hyprstream-service/src/service/spawner/process.rs
@@ -143,6 +143,15 @@ impl ProcessSpawner {
     pub async fn is_running(&self, process: &SpawnedProcess) -> Result<bool> {
         self.backend.is_running(process).await
     }
+
+    /// Synchronous bounded stop of a TRACKED direct child, used only by the
+    /// launch-transaction guard's `Drop` for cancellation cleanup where no
+    /// async runtime work is guaranteed (#1585). Delegates to the backend,
+    /// which stops through its retained child handle — never a blind by-PID
+    /// signal; unsupported backends fail honestly.
+    pub fn stop_tracked_child_sync(&self, process: &SpawnedProcess) -> Result<()> {
+        self.backend.stop_tracked_child_sync(process)
+    }
 }
 
 impl Default for ProcessSpawner {

--- a/crates/hyprstream-service/src/service/spawner/standalone.rs
+++ b/crates/hyprstream-service/src/service/spawner/standalone.rs
@@ -956,13 +956,41 @@ async fn stop_untracked_by_pid(pid: u32, failures: &mut Vec<String>) -> bool {
 /// unlinked — unlinking would break flock identity between concurrent
 /// acquirers. Holding it makes the duplicate precheck, the PID publication,
 /// and any rollback of one launch a deterministic unit against other launches
-/// of the same service; release is the descriptor close on drop. A held lock
-/// is reported as a pending duplicate, deterministically. Scope is honest and
-/// narrow: it coordinates only cooperating notified launches using this
-/// facility and makes no claim of control over noncooperating processes; the
-/// artifact lives in the protected runtime directory.
+/// of the same service. Release is an EXPLICIT `FlockArg::Unlock` in `Drop`
+/// followed by normal close: `flock` lives on the open file description, so
+/// close alone can be prolonged by a concurrently forked process's transient
+/// duplicate of that description (pre-exec), which would transiently and
+/// falsely refuse the next same-service launch; explicit unlock releases the
+/// lock immediately regardless of such copies. A held lock is reported as a
+/// pending duplicate, deterministically. Scope is honest and narrow: it
+/// coordinates only cooperating notified launches using this facility and
+/// makes no claim of control over noncooperating processes; the artifact
+/// lives in the protected runtime directory.
 struct ServiceLaunchLock {
     _file: std::fs::File,
+}
+
+impl Drop for ServiceLaunchLock {
+    fn drop(&mut self) {
+        use nix::fcntl::{flock, FlockArg};
+        use std::os::fd::AsRawFd;
+
+        // Explicit unlock BEFORE close (see the type docs): close alone
+        // waits for every duplicate of this open file description to close,
+        // which a concurrently forked child's pre-exec copy can delay
+        // indefinitely. An unlock failure is logged honestly — the
+        // subsequent close remains the fallback and the next acquirer may
+        // then see a transient in-progress refusal (fail-closed), never a
+        // duplicate acceptance.
+        let fd = self._file.as_raw_fd();
+        if let Err(e) = flock(fd, FlockArg::Unlock) {
+            tracing::warn!(
+                fd = %fd,
+                error = %e,
+                "launch lock explicit unlock failed; falling back to close semantics"
+            );
+        }
+    }
 }
 
 impl ServiceLaunchLock {
@@ -1570,6 +1598,36 @@ mod notify_readiness_tests {
             cleanup_suffix(Err("kill failed: boom".to_owned())),
             "; cleanup: kill failed: boom"
         );
+    }
+
+    /// Explicit-unlock release (P2): `flock` lives on the open file
+    /// description, so a close-only release can be prolonged by any retained
+    /// duplicate of that description — exactly what a concurrently forked
+    /// child's pre-exec descriptor copy is. A safe `dup` of the locked
+    /// descriptor stands in for such a duplicate; after the lock is dropped,
+    /// a fresh same-service acquisition must succeed even though the
+    /// duplicate is still open.
+    #[test]
+    fn launch_lock_releases_despite_retained_description_duplicate() {
+        let unique = std::process::id();
+        let name = format!("notify-unlock-{unique}");
+
+        let held = ServiceLaunchLock::acquire(&name).expect("acquire");
+        // Retained duplicate of the SAME open file description (RAII clone:
+        // an assertion failure cannot leak the demonstration descriptor).
+        let duplicate = held._file.try_clone().expect("try_clone");
+
+        // Explicit-unlock drop: the lock must release despite the still-open
+        // duplicate; close alone would not achieve that.
+        drop(held);
+
+        let reacquired = ServiceLaunchLock::acquire(&name).expect(
+            "lock must release via explicit unlock despite the retained duplicate",
+        );
+        drop(reacquired);
+
+        // The demonstration duplicate is closed by its own RAII drop here.
+        drop(duplicate);
     }
 
     /// Startup-backstop decisions: OBSERVED termination cleans the owned

--- a/crates/hyprstream-service/src/service/spawner/standalone.rs
+++ b/crates/hyprstream-service/src/service/spawner/standalone.rs
@@ -1468,14 +1468,14 @@ mod notify_readiness_tests {
         let fd = socket(
             AddressFamily::Unix,
             SockType::Datagram,
-            SockFlag::SOCK_CLOEXEC,
+            SockFlag::SOCK_NONBLOCK | SockFlag::SOCK_CLOEXEC,
             None,
         )?;
         sendto(
             fd.as_raw_fd(),
             b"READY=1",
             &UnixAddr::new_abstract(name.as_bytes())?,
-            MsgFlags::empty(),
+            MsgFlags::MSG_DONTWAIT,
         )?;
         Ok(())
     }

--- a/crates/hyprstream-service/src/service/spawner/standalone.rs
+++ b/crates/hyprstream-service/src/service/spawner/standalone.rs
@@ -62,10 +62,23 @@ fn detached_output_stdio() -> std::io::Result<Stdio> {
                 // never inherits the writer, so EOF is well-defined.
                 unsafe {
                     nix::libc::close(writer);
+                    // This child does not exec, so O_CLOEXEC alone cannot
+                    // shed the launcher's SSH/session and service sockets.
+                    // Move the reader to stdin, close every other inherited
+                    // descriptor (including stdout/stderr), then drain only
+                    // through fd 0. The bounded sweep is portable across the
+                    // Unix targets supported by this crate and avoids relying
+                    // on an external close-range utility.
+                    if nix::libc::dup2(reader, 0) < 0 {
+                        nix::libc::_exit(1);
+                    }
+                    for fd in 1..=65_535 {
+                        nix::libc::close(fd);
+                    }
                     let mut buffer = [0u8; 8192];
                     loop {
                         let read = nix::libc::read(
-                            reader,
+                            0,
                             buffer.as_mut_ptr().cast(),
                             buffer.len(),
                         );
@@ -73,7 +86,7 @@ fn detached_output_stdio() -> std::io::Result<Stdio> {
                             break;
                         }
                     }
-                    nix::libc::close(reader);
+                    nix::libc::close(0);
                     nix::libc::_exit(0);
                 }
             }

--- a/crates/hyprstream-service/src/service/spawner/standalone.rs
+++ b/crates/hyprstream-service/src/service/spawner/standalone.rs
@@ -29,13 +29,18 @@ use tokio::sync::Mutex;
 use super::{ProcessConfig, ProcessKind, ProcessReadiness, SpawnedProcess, SpawnerBackend};
 use hyprstream_rpc::error::{Result, RpcError};
 
-/// One per-child sd_notify endpoint beneath the protected runtime directory.
+/// One per-child sd_notify endpoint in the Linux/Android abstract namespace.
 ///
-/// The launcher binds a unique datagram socket, hands its path to the child as
+/// The launcher binds a compact random datagram address, hands it to the child as
 /// `NOTIFY_SOCKET`, and accepts `READY=1` only from the spawned child's PID
 /// (via `SO_PASSCRED` sender credentials). This is local lifecycle
 /// supervision, not a service RPC endpoint — nothing dials it and no service
 /// traffic flows through it.
+///
+/// Abstract addresses have no filesystem inode or mode and may be visible in
+/// `/proc/net/unix`. The random name limits collisions; it is not an access
+/// control or authentication mechanism. Kernel-attested sender credentials
+/// and exact child-PID matching provide the authentication boundary.
 ///
 /// Platform support: the credential combination this receiver is built on —
 /// `SO_PASSCRED` plus `SCM_CREDENTIALS` for kernel-attested sender-PID
@@ -46,116 +51,63 @@ use hyprstream_rpc::error::{Result, RpcError};
 /// platforms refuse supervised Notify launches pre-spawn (see
 /// `spawn_notified`) instead of weakening the sender-PID check.
 #[cfg(any(target_os = "linux", target_os = "android"))]
+#[derive(Debug)]
 struct ChildNotifySocket {
     fd: OwnedFd,
-    path: std::path::PathBuf,
+    endpoint: String,
 }
 
 #[cfg(any(target_os = "linux", target_os = "android"))]
 impl ChildNotifySocket {
-    fn bind(name: &str) -> Result<Self> {
-        // Per-attempt private directory, created EXCLUSIVELY (no
-        // exists-ok): each attempt owns its directory outright, so
-        // concurrent attempts of the same service can never share an
-        // endpoint (a fixed name+launcher-PID path collided across
-        // attempts). The nanos suffix keeps attempts collision-free; the
-        // suffix is NOT a secret — sender-PID credentials are the identity
-        // check.
-        let runtime = hyprstream_rpc::paths::runtime_dir();
-        let mut dir = None;
-        for _ in 0..8 {
-            let nanos = SystemTime::now()
-                .duration_since(UNIX_EPOCH)
-                .map(|d| d.as_nanos())
-                .unwrap_or_default();
-            let candidate =
-                runtime.join(format!("notify-{name}-{}-{nanos}", nix::unistd::getpid()));
-            match std::fs::create_dir(&candidate) {
-                Ok(()) => {
-                    dir = Some(candidate);
-                    break;
-                }
-                Err(e) if e.kind() == std::io::ErrorKind::AlreadyExists => continue,
-                Err(e) => {
-                    return Err(RpcError::SpawnFailed(format!(
-                        "failed to create notify runtime dir {}: {e}",
-                        candidate.display()
-                    )))
-                }
-            }
-        }
-        let Some(dir) = dir else {
-            return Err(RpcError::SpawnFailed(format!(
-                "could not create a unique notify runtime dir for {name}"
-            )));
-        };
-        // This attempt owns `dir` from here: any failure between creation
-        // and a fully bound socket must remove the directory before
-        // returning, so a partial bind never leaks an endpoint directory.
-        let result = Self::bind_in(&dir);
-        if result.is_err() {
-            let _ = std::fs::remove_dir_all(&dir);
-        }
-        result
+    fn bind(_name: &str) -> Result<Self> {
+        Self::bind_with_name_source(|| format!("hypr-n-{}", uuid::Uuid::new_v4().simple()))
     }
 
-    fn bind_in(dir: &std::path::Path) -> Result<Self> {
+    fn bind_with_name_source(mut next_name: impl FnMut() -> String) -> Result<Self> {
         use nix::sys::socket::{
             bind, setsockopt, sockopt::PassCred, socket, AddressFamily, SockFlag, SockType,
             UnixAddr,
         };
 
-        #[cfg(unix)]
-        {
-            use std::os::unix::fs::PermissionsExt;
-            std::fs::set_permissions(dir, std::fs::Permissions::from_mode(0o700)).map_err(
-                |e| {
-                    RpcError::SpawnFailed(format!(
-                        "failed to restrict notify runtime dir {}: {e}",
-                        dir.display()
-                    ))
-                },
-            )?;
-        }
-        let path = dir.join("notify.sock");
-
-        let fd = socket(
-            AddressFamily::Unix,
-            SockType::Datagram,
-            SockFlag::SOCK_NONBLOCK | SockFlag::SOCK_CLOEXEC,
-            None,
-        )
-        .map_err(|e| RpcError::SpawnFailed(format!("notify socket creation failed: {e}")))?;
-        setsockopt(&fd, PassCred, &true)
-            .map_err(|e| RpcError::SpawnFailed(format!("SO_PASSCRED setup failed: {e}")))?;
-        bind(fd.as_raw_fd(), &UnixAddr::new(&path).map_err(|e| {
-            RpcError::SpawnFailed(format!("notify socket path invalid: {e}"))
-        })?)
-        .map_err(|e| RpcError::SpawnFailed(format!("notify socket bind failed: {e}")))?;
-        // Owner-only permissions on the bound socket's filesystem pathname —
-        // fchmod on the fd does NOT change the pathname mode (root-verified on
-        // this host), so chmod the path itself, checked. Hardening against
-        // nuisance datagrams; sender-PID credentials remain the identity check.
-        #[cfg(unix)]
-        {
-            use std::os::unix::fs::PermissionsExt;
-            std::fs::set_permissions(
-                &path,
-                std::fs::Permissions::from_mode(0o600),
-            )
-            .map_err(|e| {
-                RpcError::SpawnFailed(format!(
-                    "failed to restrict notify socket {}: {e}",
-                    path.display()
-                ))
+        // A new fd and random abstract address are created for each bounded
+        // attempt. EADDRINUSE is the only retryable outcome; every other
+        // setup error fails closed before a child is spawned.
+        for _ in 0..8 {
+            let name = next_name();
+            let address = UnixAddr::new_abstract(name.as_bytes()).map_err(|e| {
+                RpcError::SpawnFailed(format!("notification endpoint name invalid: {e}"))
             })?;
+            let fd = socket(
+                AddressFamily::Unix,
+                SockType::Datagram,
+                SockFlag::SOCK_NONBLOCK | SockFlag::SOCK_CLOEXEC,
+                None,
+            )
+            .map_err(|e| RpcError::SpawnFailed(format!("notify socket creation failed: {e}")))?;
+            setsockopt(&fd, PassCred, &true)
+                .map_err(|e| RpcError::SpawnFailed(format!("SO_PASSCRED setup failed: {e}")))?;
+            match bind(fd.as_raw_fd(), &address) {
+                Ok(()) => {
+                    return Ok(Self {
+                        fd,
+                        endpoint: format!("@{name}"),
+                    })
+                }
+                Err(nix::errno::Errno::EADDRINUSE) => continue,
+                Err(e) => {
+                    return Err(RpcError::SpawnFailed(format!(
+                        "notification endpoint bind failed: {e}"
+                    )))
+                }
+            }
         }
-
-        Ok(Self { fd, path })
+        Err(RpcError::SpawnFailed(
+            "could not bind a unique notification endpoint after 8 attempts".to_owned(),
+        ))
     }
 
-    fn socket_path(&self) -> &std::path::Path {
-        &self.path
+    fn endpoint(&self) -> &str {
+        &self.endpoint
     }
 
     /// Non-blocking poll for a `READY=1` datagram from exactly `child_pid`.
@@ -204,19 +156,6 @@ impl ChildNotifySocket {
             return Ok(false);
         }
         Ok(bytes > 0 && buffer[..bytes] == *b"READY=1")
-    }
-}
-
-#[cfg(any(target_os = "linux", target_os = "android"))]
-impl Drop for ChildNotifySocket {
-    fn drop(&mut self) {
-        // OwnedFd closes the descriptor itself; remove the socket inode and
-        // this launch's private runtime directory.
-        let _ = std::fs::remove_file(&self.path);
-        if let Some(parent) = self.path.parent() {
-            // Only ever removes the per-launch `notify-<name>-<pid>` dir.
-            let _ = std::fs::remove_dir(parent);
-        }
     }
 }
 
@@ -535,13 +474,15 @@ impl StandaloneBackend {
     /// Notify-supervised path (#1585): the spawn reports success only after
     /// the child's own `READY=1` datagram arrives from the child's PID; a
     /// child exit or the hard timeout fails the spawn, the child is
-    /// terminated/reaped, and no PID/notify artifact survives.
+    /// terminated/reaped, and no PID artifact or live abstract notification
+    /// endpoint survives.
     ///
     /// Platform support: the credential-authenticated receiver
     /// (`SO_PASSCRED`/`SCM_CREDENTIALS`, exact child-PID matching) exists on
     /// Linux/Android only. On any other target this request fails closed
-    /// BEFORE spawning the child or creating the notification directory, PID
-    /// artifact, or any other launch side effect — there is no fallback to
+    /// BEFORE spawning the child or binding a notification endpoint, creating
+    /// a PID artifact, or causing any other launch side effect — there is no
+    /// fallback to
     /// `Immediate` readiness and no unauthenticated receiver.
     #[cfg(any(target_os = "linux", target_os = "android"))]
     async fn spawn_notified(
@@ -603,7 +544,7 @@ impl StandaloneBackend {
         }
         // The child learns its notification endpoint only through its own
         // environment; the launcher's environment is untouched.
-        cmd.env("NOTIFY_SOCKET", notify.socket_path());
+        cmd.env("NOTIFY_SOCKET", notify.endpoint());
         cmd.kill_on_drop(false);
 
         let child = cmd.spawn().map_err(|e| {
@@ -797,14 +738,14 @@ impl StandaloneBackend {
             "Daemon spawned successfully (notification readiness satisfied)"
         );
 
-        // ChildNotifySocket::drop closes the endpoint and removes the socket.
+        // ChildNotifySocket::drop closes the abstract endpoint.
         Ok(SpawnedProcess::new(id, ProcessKind::Direct(pid))
             .with_pid_file(pid_file))
     }
 
     /// Non-Linux arm of the Notify-supervised path: an explicit pre-spawn
     /// refusal (see the Linux/Android arm's contract above). Nothing is
-    /// spawned and no notification directory, child guard, or PID artifact is
+    /// spawned and no notification endpoint, child guard, or PID artifact is
     /// created; there is deliberately no fallback to `Immediate` readiness,
     /// because a supervised launch whose sender cannot be kernel-attested
     /// must not report success from an unauthenticated payload.
@@ -854,7 +795,7 @@ impl StandaloneBackend {
                 return Err(format!(
                     "no READY=1 within {}s (notification endpoint {})",
                     timeout.as_secs(),
-                    notify.socket_path().display()
+                    notify.endpoint()
                 ));
             }
             let wait = poll.tick();
@@ -1514,6 +1455,30 @@ mod notify_readiness_tests {
     const PENDING_RELEASE: &str = "HYPRSTREAM_LAUNCHER_PENDING_RELEASE";
     const OBSTACLE_HELPER: &str = "HYPRSTREAM_LAUNCHER_OBSTACLE_HELPER";
     const OBSTACLE_PATH: &str = "HYPRSTREAM_LAUNCHER_OBSTACLE_PATH";
+    const LONG_RUNTIME_HELPER: &str = "HYPRSTREAM_LONG_NOTIFY_RUNTIME_HELPER";
+
+    fn send_ready_to(endpoint: &str) -> anyhow::Result<()> {
+        use nix::sys::socket::{
+            sendto, socket, AddressFamily, MsgFlags, SockFlag, SockType, UnixAddr,
+        };
+
+        let name = endpoint
+            .strip_prefix('@')
+            .expect("launcher notification endpoint must be abstract");
+        let fd = socket(
+            AddressFamily::Unix,
+            SockType::Datagram,
+            SockFlag::SOCK_CLOEXEC,
+            None,
+        )?;
+        sendto(
+            fd.as_raw_fd(),
+            b"READY=1",
+            &UnixAddr::new_abstract(name.as_bytes())?,
+            MsgFlags::empty(),
+        )?;
+        Ok(())
+    }
 
     /// Helper child: reports readiness through the real sd_notify send path,
     /// then stays alive so the supervisor observes a genuinely RUNNING ready
@@ -1572,8 +1537,9 @@ mod notify_readiness_tests {
         assert!(gone, "child pid {pid} must be reaped after cleanup");
     }
 
-    /// Assert no notification endpoint (private dir or socket) for `name`
-    /// remains under the runtime dir.
+    /// Assert that lifecycle supervision created no legacy pathname endpoint.
+    /// Abstract endpoints have no filesystem inode and disappear when their
+    /// owned descriptor closes.
     fn assert_no_notify_inode(name: &str) {
         let dir = hyprstream_rpc::paths::runtime_dir();
         let leftovers: Vec<_> = std::fs::read_dir(&dir)
@@ -1781,6 +1747,59 @@ mod notify_readiness_tests {
         );
         assert_pid_gone(pid);
         assert_no_notify_inode("notify-ready-control");
+        Ok(())
+    }
+
+    /// A valid long instance/runtime namespace must not influence the compact
+    /// abstract notification address. Run this scenario in a subprocess so
+    /// its process-global path environment cannot race other libtest cases.
+    #[test]
+    fn notified_spawn_with_long_runtime_reaches_ready_stops_and_reaps() -> Result<()> {
+        if std::env::var_os(LONG_RUNTIME_HELPER).is_some() {
+            let runtime = tokio::runtime::Builder::new_current_thread()
+                .enable_all()
+                .build()?;
+            return runtime.block_on(async {
+                let name = "notify-long-runtime";
+                let backend = StandaloneBackend::new();
+                let config = ProcessConfig::new(name, test_binary())
+                    .args([
+                        "--exact",
+                        "service::spawner::standalone::notify_readiness_tests::notify_ready_helper_child",
+                        "--nocapture",
+                    ])
+                    .env(READY_HELPER, "1")
+                    .with_notify_ready(Duration::from_secs(30));
+                let process = backend.spawn(config).await?;
+                let pid = process.pid().expect("direct child pid");
+                assert!(backend.is_running(&process).await?);
+                backend.stop(&process).await?;
+                assert!(!backend.is_running(&process).await?);
+                assert_pid_gone(pid);
+                assert!(
+                    !hyprstream_rpc::paths::service_pid_file(name).exists(),
+                    "stopped child must leave no PID artifact"
+                );
+                assert_no_notify_inode(name);
+                Ok(())
+            });
+        }
+
+        let runtime = tempfile::tempdir()?;
+        let status = std::process::Command::new(test_binary())
+            .args([
+                "--exact",
+                "service::spawner::standalone::notify_readiness_tests::notified_spawn_with_long_runtime_reaches_ready_stops_and_reaps",
+                "--nocapture",
+            ])
+            .env(LONG_RUNTIME_HELPER, "1")
+            .env("XDG_RUNTIME_DIR", runtime.path())
+            .env(
+                "HYPRSTREAM_INSTANCE",
+                "production-west-instance-0000000000000000",
+            )
+            .status()?;
+        assert!(status.success(), "isolated long-runtime scenario failed: {status}");
         Ok(())
     }
 
@@ -2231,16 +2250,91 @@ mod notify_readiness_tests {
         Ok(())
     }
 
+    #[test]
+    fn notification_endpoint_is_compact_unique_and_abstract() -> Result<()> {
+        let first = ChildNotifySocket::bind("a-service-name-that-is-deliberately-ignored")?;
+        let second = ChildNotifySocket::bind("a-service-name-that-is-deliberately-ignored")?;
+        assert!(first.endpoint().starts_with('@'));
+        assert!(second.endpoint().starts_with('@'));
+        assert_ne!(first.endpoint(), second.endpoint());
+        assert!(first.endpoint().len() <= 48);
+        Ok(())
+    }
+
+    #[test]
+    fn notification_endpoint_collision_retries_are_bounded() -> anyhow::Result<()> {
+        use nix::sys::socket::{
+            bind, socket, AddressFamily, SockFlag, SockType, UnixAddr,
+        };
+
+        let occupied_name = format!("hypr-n-collision-{}", std::process::id());
+        let occupied = socket(
+            AddressFamily::Unix,
+            SockType::Datagram,
+            SockFlag::SOCK_CLOEXEC,
+            None,
+        )?;
+        bind(
+            occupied.as_raw_fd(),
+            &UnixAddr::new_abstract(occupied_name.as_bytes())?,
+        )?;
+
+        let mut attempts = 0usize;
+        let error = ChildNotifySocket::bind_with_name_source(|| {
+            attempts += 1;
+            occupied_name.clone()
+        })
+        .expect_err("eight collisions must fail closed");
+        assert_eq!(attempts, 8);
+        assert!(error.to_string().contains("after 8 attempts"));
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn foreign_datagram_flood_cannot_extend_readiness_deadline() -> Result<()> {
+        use std::sync::atomic::{AtomicBool, Ordering};
+
+        let backend = StandaloneBackend::new();
+        let notify = ChildNotifySocket::bind("flood-deadline")?;
+        let mut child = tokio::process::Command::new("/bin/sleep")
+            .arg("30")
+            .spawn()?;
+        let endpoint = notify.endpoint().to_owned();
+        let flooding = Arc::new(AtomicBool::new(true));
+        let sender = std::thread::spawn({
+            let flooding = Arc::clone(&flooding);
+            move || {
+                while flooding.load(Ordering::Relaxed) {
+                    let _ = send_ready_to(&endpoint);
+                    std::thread::sleep(Duration::from_millis(1));
+                }
+            }
+        });
+
+        let started = Instant::now();
+        let outcome = backend
+            .await_child_readiness(&mut child, &notify, Duration::from_millis(200))
+            .await;
+        flooding.store(false, Ordering::Relaxed);
+        sender.join().expect("flood sender thread");
+        child.kill().await?;
+        child.wait().await?;
+
+        let error = outcome.expect_err("foreign datagrams must not satisfy readiness");
+        assert!(error.contains("no READY=1"));
+        assert!(started.elapsed() < Duration::from_secs(2));
+        Ok(())
+    }
+
     /// Sender-PID matching: a READY datagram from any process other than the
     /// expected child is ignored, not honored.
     #[tokio::test]
-    async fn notify_socket_rejects_spoofed_sender() -> Result<()> {
+    async fn notify_socket_rejects_spoofed_sender() -> anyhow::Result<()> {
         let notify = ChildNotifySocket::bind("spoof-probe")?;
-        let sender = std::os::unix::net::UnixDatagram::unbound()?;
         // First datagram: sent by THIS test process but checked against a
         // different expected PID — the refusal must consume it without
         // satisfying readiness.
-        sender.send_to(b"READY=1", notify.socket_path())?;
+        send_ready_to(notify.endpoint())?;
         let this_pid = std::process::id() as i32;
         std::thread::sleep(Duration::from_millis(50));
         assert!(
@@ -2248,7 +2342,7 @@ mod notify_readiness_tests {
             "a foreign sender must not satisfy readiness"
         );
         // Second datagram, checked against the actual sender PID: accepted.
-        sender.send_to(b"READY=1", notify.socket_path())?;
+        send_ready_to(notify.endpoint())?;
         std::thread::sleep(Duration::from_millis(50));
         assert!(
             notify.try_recv_ready(this_pid)?,

--- a/crates/hyprstream-service/src/service/spawner/standalone.rs
+++ b/crates/hyprstream-service/src/service/spawner/standalone.rs
@@ -950,6 +950,159 @@ async fn stop_untracked_by_pid(pid: u32, failures: &mut Vec<String>) -> bool {
     }
 }
 
+impl StandaloneBackend {
+    /// Synchronous bounded stop for a tracked direct child, run from the
+    /// launch-transaction guard's `Drop` when the orchestration future is
+    /// cancelled (#1585).
+    ///
+    /// This preserves the backend's STRONGER tracked ownership instead of
+    /// downgrading adopted children to a blind by-PID signal: when the child
+    /// is still in the tracking map, termination goes through the retained
+    /// `Child` handle itself (`start_kill` + bounded `try_wait` reaping — the
+    /// sync counterpart of the tracked branch of [`Self::stop`], same 5s
+    /// budget), and the map entry is surrendered only on a CONFIRMED reap. A
+    /// child no longer in the map is either already stopped by an earlier
+    /// confirmed stop or was never this backend's: for a live untracked PID
+    /// this operation deliberately REFUSES to signal (a recycled PID could be
+    /// an unrelated process) and fails honestly instead; an untracked PID
+    /// already gone (`kill(pid, None)` → ESRCH — a liveness probe, never a
+    /// signal) is cleaned up. PID-artifact removal keeps the established
+    /// conditional semantics — the artifact is removed only while it still
+    /// names this child, a newer child's artifact is preserved, and an actual
+    /// IO failure is an error, not success. Best effort within bounded
+    /// budgets, not a guarantee.
+    pub fn stop_tracked_child_by_handle_sync(&self, process: &SpawnedProcess) -> Result<()> {
+        if !process.is_direct() {
+            return Err(RpcError::InvalidOperation(
+                "synchronous cancellation stop requires a direct (PID-tracked) process"
+                    .to_owned(),
+            ));
+        }
+        let pid = process.pid().unwrap_or_default();
+
+        // Tracked branch: the retained Child IS the ownership — no PID
+        // signaling at all.
+        let child_arc = self
+            .processes
+            .get(&process.id)
+            .map(|entry| Arc::clone(entry.value()));
+        if let Some(child_arc) = child_arc {
+            let mut child = match child_arc.try_lock() {
+                Ok(child) => child,
+                Err(_) => {
+                    return Err(RpcError::SpawnFailed(
+                        "cancellation cleanup skipped: child handle lock contended; \
+                         child remains tracked"
+                            .to_owned(),
+                    ));
+                }
+            };
+            let mut failures: Vec<String> = Vec::new();
+            if let Err(e) = child.start_kill() {
+                failures.push(format!("kill failed: {e}"));
+            }
+            // Bounded synchronous reap (mirror of the tracked `stop` branch).
+            let deadline = Instant::now() + Duration::from_secs(5);
+            let mut confirmed = false;
+            loop {
+                match child.try_wait() {
+                    Ok(Some(_)) => {
+                        confirmed = true;
+                        // Reaped: only now does the backend stop tracking.
+                        self.processes.remove(&process.id);
+                        break;
+                    }
+                    Ok(None) => {}
+                    Err(e) => {
+                        failures.push(format!("reap failed: {e}"));
+                        break;
+                    }
+                }
+                if Instant::now() >= deadline {
+                    failures.push("reap timed out; child remains tracked".to_owned());
+                    break;
+                }
+                std::thread::sleep(Duration::from_millis(20));
+            }
+            if !confirmed {
+                failures.push("termination unconfirmed".to_owned());
+                // Unconfirmed: the PID artifact still names a possibly-live
+                // process and cleanup must not claim success.
+                return Err(RpcError::SpawnFailed(format!(
+                    "synchronous cancellation stop of {} did not fully succeed: {}",
+                    process.id,
+                    failures.join("; ")
+                )));
+            }
+            return finish_pid_artifact_sync(process, pid, &mut failures);
+        }
+
+        // Untracked branch: never signal a PID we do not track. Probe-only
+        // liveness (kill(pid, None) is a probe, not a signal): gone → clean
+        // the artifact; alive → fail honestly rather than risk a recycled
+        // PID (the documented untracked exposure is not widened here).
+        let raw = nix::unistd::Pid::from_raw(i32::try_from(pid).unwrap_or_default());
+        match nix::sys::signal::kill(raw, None) {
+            Err(nix::errno::Errno::ESRCH) => {
+                let mut failures: Vec<String> = Vec::new();
+                finish_pid_artifact_sync(process, pid, &mut failures)
+            }
+            Err(e) => Err(RpcError::SpawnFailed(format!(
+                "cancellation liveness probe of untracked {} failed: {e}",
+                process.id
+            ))),
+            Ok(()) => Err(RpcError::SpawnFailed(format!(
+                "cancellation cleanup declined to signal untracked live PID {pid} ({})",
+                process.id
+            ))),
+        }
+    }
+}
+
+/// Conditional PID-artifact removal after a CONFIRMED synchronous stop: the
+/// artifact is removed only while it still names `pid`; a file naming a
+/// different (newer) child is intentionally preserved and is NOT a failure;
+/// an actual IO failure IS a failure — cleanup never claims clean success it
+/// did not achieve (#1585).
+fn finish_pid_artifact_sync(
+    process: &SpawnedProcess,
+    pid: u32,
+    failures: &mut Vec<String>,
+) -> Result<()> {
+    let Some(pid_file) = &process.pid_file else {
+        return Ok(());
+    };
+    match std::fs::read_to_string(pid_file) {
+        Ok(content) => {
+            if content.trim() == pid.to_string() {
+                match std::fs::remove_file(pid_file) {
+                    Ok(()) => Ok(()),
+                    Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(()),
+                    Err(e) => {
+                        failures.push(format!("PID file removal failed: {e}"));
+                        Err(RpcError::SpawnFailed(format!(
+                            "synchronous stop of {} confirmed termination but the PID \
+                             artifact cleanup failed: {}",
+                            process.id,
+                            failures.join("; ")
+                        )))
+                    }
+                }
+            } else {
+                // The artifact names a different (newer) child: preserving it
+                // is correct, not a failure.
+                Ok(())
+            }
+        }
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(()),
+        Err(e) => Err(RpcError::SpawnFailed(format!(
+            "synchronous stop of {} confirmed termination but the PID artifact could \
+             not be read for conditional removal: {e}",
+            process.id
+        ))),
+    }
+}
+
 /// Per-service nonblocking advisory lock for notified launches (#1585).
 ///
 /// The lock file has a STABLE path (and thus stable inode) and is NEVER
@@ -1197,6 +1350,10 @@ impl SpawnerBackend for StandaloneBackend {
                 Ok(false)
             }
         }
+    }
+
+    fn stop_tracked_child_sync(&self, process: &SpawnedProcess) -> Result<()> {
+        Self::stop_tracked_child_by_handle_sync(self, process)
     }
 
     fn backend_type(&self) -> &'static str {

--- a/crates/hyprstream-service/src/service/spawner/standalone.rs
+++ b/crates/hyprstream-service/src/service/spawner/standalone.rs
@@ -20,6 +20,8 @@ use std::os::fd::{AsRawFd, OwnedFd};
 #[cfg(unix)]
 use std::os::fd::FromRawFd;
 use std::process::Stdio;
+#[cfg(unix)]
+use std::process::Command as StdCommand;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 #[cfg(any(target_os = "linux", target_os = "android"))]
@@ -36,19 +38,21 @@ use hyprstream_rpc::error::{Result, RpcError};
 /// them in the launcher. PGlite registers stdout with epoll, so `/dev/null`
 /// is not a safe sink on Linux; a pipe preserves pollability and prevents the
 /// launcher's stdout/stderr or SSH channel from being held open by the child.
-fn detached_stdio() -> std::io::Result<Stdio> {
+fn detached_output_stdio() -> std::io::Result<Stdio> {
     #[cfg(unix)]
     {
-        let (reader, writer) = nix::unistd::pipe()?;
+        use nix::fcntl::OFlag;
+        // CLOEXEC keeps the sink reader out of the adopted daemon. The sink
+        // process itself owns the reader and survives launcher exit, so a
+        // daemon can write indefinitely without filling an undrained pipe.
+        let (reader, writer) = nix::unistd::pipe2(OFlag::O_CLOEXEC)?;
         let reader = unsafe { std::fs::File::from_raw_fd(reader) };
         let writer = unsafe { std::fs::File::from_raw_fd(writer) };
-        std::thread::Builder::new()
-            .name("hyprstream-daemon-stdio-drain".to_owned())
-            .spawn(move || {
-                let mut reader = reader;
-                let mut sink = std::io::sink();
-                let _ = std::io::copy(&mut reader, &mut sink);
-            })?;
+        StdCommand::new("cat")
+            .stdin(Stdio::from(reader))
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .spawn()?;
         Ok(Stdio::from(writer))
     }
     #[cfg(not(unix))]
@@ -58,9 +62,9 @@ fn detached_stdio() -> std::io::Result<Stdio> {
 }
 
 fn configure_detached_stdio(cmd: &mut Command) -> std::io::Result<()> {
-    cmd.stdin(detached_stdio()?)
-        .stdout(detached_stdio()?)
-        .stderr(detached_stdio()?);
+    cmd.stdin(Stdio::null())
+        .stdout(detached_output_stdio()?)
+        .stderr(detached_output_stdio()?);
     Ok(())
 }
 
@@ -1552,6 +1556,22 @@ mod notify_readiness_tests {
     const OBSTACLE_HELPER: &str = "HYPRSTREAM_LAUNCHER_OBSTACLE_HELPER";
     const OBSTACLE_PATH: &str = "HYPRSTREAM_LAUNCHER_OBSTACLE_PATH";
     const LONG_RUNTIME_HELPER: &str = "HYPRSTREAM_LONG_NOTIFY_RUNTIME_HELPER";
+    const SPOOF_HELPER: &str = "HYPRSTREAM_NOTIFY_SPOOF_HELPER";
+
+    /// Helper child: sends READY datagrams from a distinct process PID so the
+    /// receiver regression test exercises kernel credential filtering rather
+    /// than a same-process sender.
+    #[test]
+    fn notify_spoof_helper_child() {
+        if std::env::var_os(SPOOF_HELPER).is_none() {
+            return;
+        }
+        let endpoint = std::env::var("HYPRSTREAM_NOTIFY_SPOOF_ENDPOINT").expect("endpoint");
+        for _ in 0..128 {
+            let _ = send_ready_to(&endpoint);
+        }
+        std::thread::sleep(Duration::from_secs(2));
+    }
 
     fn send_ready_to(endpoint: &str) -> anyhow::Result<()> {
         use nix::sys::socket::{
@@ -2387,6 +2407,16 @@ mod notify_readiness_tests {
     }
 
     #[tokio::test]
+    async fn detached_stdio_drains_large_post_launch_output() -> anyhow::Result<()> {
+        let mut cmd = Command::new("/bin/sh");
+        cmd.args(["-c", "sleep 0.05; yes x | head -c 1048576"]);
+        configure_detached_stdio(&mut cmd)?;
+        let status = cmd.status().await?;
+        assert!(status.success(), "post-launch output child must exit cleanly");
+        Ok(())
+    }
+
+    #[tokio::test]
     async fn foreign_datagram_flood_cannot_extend_readiness_deadline() -> Result<()> {
         use std::sync::atomic::{AtomicBool, Ordering};
 
@@ -2428,21 +2458,26 @@ mod notify_readiness_tests {
     async fn notify_socket_rejects_spoofed_sender() -> anyhow::Result<()> {
         let notify = ChildNotifySocket::bind("spoof-probe")?;
         let this_pid = std::process::id() as i32;
-        // A sustained foreign queue must be drained in one poll so it cannot
-        // hide the genuine sender's datagram behind the 20ms readiness tick.
-        let endpoint = notify.endpoint().to_owned();
-        let flooding = std::thread::spawn(move || {
-            for _ in 0..128 {
-                let _ = send_ready_to(&endpoint);
-            }
-        });
-        flooding.join().expect("spoof flood sender thread");
+        // Flood from a distinct helper process, whose kernel-attested PID is
+        // foreign to this receiver. The genuine datagram follows the flood.
+        let mut foreign = std::process::Command::new(test_binary())
+            .args([
+                "--exact",
+                "service::spawner::standalone::notify_readiness_tests::notify_spoof_helper_child",
+                "--nocapture",
+            ])
+            .env(SPOOF_HELPER, "1")
+            .env("HYPRSTREAM_NOTIFY_SPOOF_ENDPOINT", notify.endpoint())
+            .spawn()?;
+        std::thread::sleep(Duration::from_millis(50));
         send_ready_to(notify.endpoint())?;
         std::thread::sleep(Duration::from_millis(50));
         assert!(
             notify.try_recv_ready(this_pid)?,
-            "the matching sender satisfies readiness"
+            "the matching sender satisfies readiness after foreign flood"
         );
+        foreign.kill()?;
+        let _ = foreign.wait();
         Ok(())
     }
 }

--- a/crates/hyprstream-service/src/service/spawner/standalone.rs
+++ b/crates/hyprstream-service/src/service/spawner/standalone.rs
@@ -1427,6 +1427,54 @@ mod tests {
         Ok(())
     }
 
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn standalone_spawn_preserves_non_utf8_argument_bytes() -> anyhow::Result<()> {
+        use std::os::unix::ffi::{OsStrExt, OsStringExt};
+
+        let root = tempfile::tempdir()?;
+        let script = root.path().join("record-argument.sh");
+        let observed = root.path().join("observed.bin");
+        std::fs::write(
+            &script,
+            b"printf '%s' \"$1\" > \"$2\"\nexec sleep 30\n",
+        )?;
+        let expected = std::ffi::OsString::from_vec(b"config-\xff.toml".to_vec());
+        let name = format!("non-utf8-argv-{}", uuid::Uuid::new_v4().simple());
+        let backend = StandaloneBackend::new();
+        let config = ProcessConfig::new(&name, "/bin/sh").args([
+            script.as_os_str().to_owned(),
+            expected.clone(),
+            observed.as_os_str().to_owned(),
+        ]);
+        let process = backend.spawn(config).await?;
+
+        let deadline = Instant::now() + Duration::from_secs(5);
+        let observation = loop {
+            match std::fs::read(&observed) {
+                Ok(bytes) if bytes == expected.as_os_str().as_bytes() => break Ok(()),
+                Ok(_) | Err(_) if Instant::now() < deadline => {
+                    tokio::time::sleep(Duration::from_millis(20)).await;
+                }
+                Ok(bytes) => break Err(anyhow::anyhow!(
+                    "child changed argument bytes: observed {bytes:?}"
+                )),
+                Err(error) => break Err(anyhow::anyhow!(
+                    "child did not record its argument before the deadline: {error}"
+                )),
+            }
+        };
+        let stop = backend.stop(&process).await;
+        observation?;
+        stop?;
+        assert!(!backend.is_running(&process).await?);
+        assert!(
+            !hyprstream_rpc::paths::service_pid_file(&name).exists(),
+            "stopped child must leave no PID artifact"
+        );
+        Ok(())
+    }
+
     #[test]
     fn test_backend_type() {
         let backend = StandaloneBackend::new();

--- a/crates/hyprstream-service/src/service/spawner/standalone.rs
+++ b/crates/hyprstream-service/src/service/spawner/standalone.rs
@@ -1649,6 +1649,39 @@ mod notify_readiness_tests {
         Ok(())
     }
 
+    /// Enqueue the genuine sender's datagram even when the foreign helper has
+    /// filled the receiver queue. The test sender is intentionally
+    /// nonblocking, so a full queue is a transient condition rather than a
+    /// failed readiness send. Drain only datagrams that cannot authenticate as
+    /// this process, then retry; the receiver still requires the kernel PID
+    /// credential before accepting READY=1.
+    fn send_ready_to_until_accepted(
+        notify: &ChildNotifySocket,
+        expected_pid: i32,
+    ) -> anyhow::Result<()> {
+        let deadline = Instant::now() + Duration::from_secs(2);
+        loop {
+            match send_ready_to(notify.endpoint()) {
+                Ok(()) => return Ok(()),
+                Err(error)
+                    if error
+                        .downcast_ref::<nix::errno::Errno>()
+                        .is_some_and(|errno| *errno == nix::errno::Errno::EAGAIN) =>
+                {
+                    // Make room for the authenticated sender while retaining
+                    // the same receiver path and sender-PID check exercised by
+                    // the assertion below.
+                    while notify.try_recv_ready(expected_pid)? {}
+                    if Instant::now() >= deadline {
+                        return Err(error);
+                    }
+                    std::thread::yield_now();
+                }
+                Err(error) => return Err(error),
+            }
+        }
+    }
+
     /// Helper child: reports readiness through the real sd_notify send path,
     /// then stays alive so the supervisor observes a genuinely RUNNING ready
     /// child; the supervisor's stop is the controlled shutdown.
@@ -2523,8 +2556,16 @@ mod notify_readiness_tests {
             .env("HYPRSTREAM_NOTIFY_SPOOF_ENDPOINT", notify.endpoint())
             .spawn()?;
         std::thread::sleep(Duration::from_millis(50));
-        send_ready_to(notify.endpoint())?;
-        std::thread::sleep(Duration::from_millis(50));
+        // The helper deliberately fills the receiver queue with foreign
+        // datagrams.  Drain that finite backlog before sending the genuine
+        // datagram: send_ready_to uses a nonblocking sender, so attempting to
+        // enqueue while the abstract socket queue is full would fail with
+        // EAGAIN before the receiver has a chance to exercise PID matching.
+        assert!(
+            !notify.try_recv_ready(this_pid)?,
+            "foreign sender must not satisfy readiness"
+        );
+        send_ready_to_until_accepted(&notify, this_pid)?;
         assert!(
             notify.try_recv_ready(this_pid)?,
             "the matching sender satisfies readiness after foreign flood"

--- a/crates/hyprstream-service/src/service/spawner/standalone.rs
+++ b/crates/hyprstream-service/src/service/spawner/standalone.rs
@@ -1,16 +1,349 @@
 //! Standalone process spawner using tokio::process::Command.
 //!
-//! Spawns daemon processes directly without systemd integration.
-//! Uses `.kill_on_drop(true)` for automatic cleanup when the process handle is dropped.
+//! Spawns daemon processes directly without systemd integration. Notified
+//! launches verify readiness through a per-child sd_notify endpoint and keep
+//! ownership of every child until termination is confirmed; children are
+//! spawned with `kill_on_drop(false)` ON PURPOSE — adopted daemons are
+//! intended to outlive the launcher.
 
+use std::os::fd::{AsRawFd, OwnedFd};
 use std::sync::Arc;
+use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
 use dashmap::DashMap;
 use tokio::process::{Child, Command};
 use tokio::sync::Mutex;
 
-use super::{ProcessConfig, ProcessKind, SpawnedProcess, SpawnerBackend};
+use super::{ProcessConfig, ProcessKind, ProcessReadiness, SpawnedProcess, SpawnerBackend};
 use hyprstream_rpc::error::{Result, RpcError};
+
+/// One per-child sd_notify endpoint beneath the protected runtime directory.
+///
+/// The launcher binds a unique datagram socket, hands its path to the child as
+/// `NOTIFY_SOCKET`, and accepts `READY=1` only from the spawned child's PID
+/// (via `SO_PASSCRED` sender credentials). This is local lifecycle
+/// supervision, not a service RPC endpoint — nothing dials it and no service
+/// traffic flows through it.
+struct ChildNotifySocket {
+    fd: OwnedFd,
+    path: std::path::PathBuf,
+}
+
+impl ChildNotifySocket {
+    fn bind(name: &str) -> Result<Self> {
+        // Per-attempt private directory, created EXCLUSIVELY (no
+        // exists-ok): each attempt owns its directory outright, so
+        // concurrent attempts of the same service can never share an
+        // endpoint (a fixed name+launcher-PID path collided across
+        // attempts). The nanos suffix keeps attempts collision-free; the
+        // suffix is NOT a secret — sender-PID credentials are the identity
+        // check.
+        let runtime = hyprstream_rpc::paths::runtime_dir();
+        let mut dir = None;
+        for _ in 0..8 {
+            let nanos = SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .map(|d| d.as_nanos())
+                .unwrap_or_default();
+            let candidate =
+                runtime.join(format!("notify-{name}-{}-{nanos}", nix::unistd::getpid()));
+            match std::fs::create_dir(&candidate) {
+                Ok(()) => {
+                    dir = Some(candidate);
+                    break;
+                }
+                Err(e) if e.kind() == std::io::ErrorKind::AlreadyExists => continue,
+                Err(e) => {
+                    return Err(RpcError::SpawnFailed(format!(
+                        "failed to create notify runtime dir {}: {e}",
+                        candidate.display()
+                    )))
+                }
+            }
+        }
+        let Some(dir) = dir else {
+            return Err(RpcError::SpawnFailed(format!(
+                "could not create a unique notify runtime dir for {name}"
+            )));
+        };
+        // This attempt owns `dir` from here: any failure between creation
+        // and a fully bound socket must remove the directory before
+        // returning, so a partial bind never leaks an endpoint directory.
+        let result = Self::bind_in(&dir);
+        if result.is_err() {
+            let _ = std::fs::remove_dir_all(&dir);
+        }
+        result
+    }
+
+    fn bind_in(dir: &std::path::Path) -> Result<Self> {
+        use nix::sys::socket::{
+            bind, setsockopt, sockopt::PassCred, socket, AddressFamily, SockFlag, SockType,
+            UnixAddr,
+        };
+
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            std::fs::set_permissions(dir, std::fs::Permissions::from_mode(0o700)).map_err(
+                |e| {
+                    RpcError::SpawnFailed(format!(
+                        "failed to restrict notify runtime dir {}: {e}",
+                        dir.display()
+                    ))
+                },
+            )?;
+        }
+        let path = dir.join("notify.sock");
+
+        let fd = socket(
+            AddressFamily::Unix,
+            SockType::Datagram,
+            SockFlag::SOCK_NONBLOCK | SockFlag::SOCK_CLOEXEC,
+            None,
+        )
+        .map_err(|e| RpcError::SpawnFailed(format!("notify socket creation failed: {e}")))?;
+        setsockopt(&fd, PassCred, &true)
+            .map_err(|e| RpcError::SpawnFailed(format!("SO_PASSCRED setup failed: {e}")))?;
+        bind(fd.as_raw_fd(), &UnixAddr::new(&path).map_err(|e| {
+            RpcError::SpawnFailed(format!("notify socket path invalid: {e}"))
+        })?)
+        .map_err(|e| RpcError::SpawnFailed(format!("notify socket bind failed: {e}")))?;
+        // Owner-only permissions on the bound socket's filesystem pathname —
+        // fchmod on the fd does NOT change the pathname mode (root-verified on
+        // this host), so chmod the path itself, checked. Hardening against
+        // nuisance datagrams; sender-PID credentials remain the identity check.
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            std::fs::set_permissions(
+                &path,
+                std::fs::Permissions::from_mode(0o600),
+            )
+            .map_err(|e| {
+                RpcError::SpawnFailed(format!(
+                    "failed to restrict notify socket {}: {e}",
+                    path.display()
+                ))
+            })?;
+        }
+
+        Ok(Self { fd, path })
+    }
+
+    fn socket_path(&self) -> &std::path::Path {
+        &self.path
+    }
+
+    /// Non-blocking poll for a `READY=1` datagram from exactly `child_pid`.
+    ///
+    /// Returns `Ok(true)` when the child itself reported readiness,
+    /// `Ok(false)` when nothing (or a non-child/spoofed datagram) arrived, and
+    /// `Err` on a socket failure. Unrelated senders are ignored, not honored.
+    fn try_recv_ready(&self, child_pid: i32) -> Result<bool> {
+        use nix::cmsg_space;
+        use nix::sys::socket::{
+            recvmsg, ControlMessageOwned, MsgFlags, UnixAddr, UnixCredentials,
+        };
+        use std::io::IoSliceMut;
+
+        let mut buffer = [0u8; 128];
+        // Scope the recvmsg borrows: `message` holds the iov/cmsg borrows, so
+        // extract what we need before touching the payload buffer again.
+        let (bytes, sender_pid) = {
+            let mut iov = [IoSliceMut::new(&mut buffer)];
+            let mut cmsg = cmsg_space!(UnixCredentials);
+            let message = match recvmsg::<UnixAddr>(
+                self.fd.as_raw_fd(),
+                &mut iov,
+                Some(&mut cmsg),
+                MsgFlags::empty(),
+            ) {
+                Ok(message) => message,
+                Err(nix::errno::Errno::EAGAIN) => return Ok(false),
+                Err(e) => {
+                    return Err(RpcError::SpawnFailed(format!("notify recv failed: {e}")))
+                }
+            };
+            let sender_pid = message.cmsgs().find_map(|cmsg| match cmsg {
+                ControlMessageOwned::ScmCredentials(creds) => Some(creds.pid()),
+                _ => None,
+            });
+            (message.bytes, sender_pid)
+        };
+
+        if sender_pid != Some(child_pid) {
+            tracing::warn!(
+                sender = ?sender_pid,
+                expected = child_pid,
+                "ignoring readiness datagram from a process other than the spawned child"
+            );
+            return Ok(false);
+        }
+        Ok(bytes > 0 && buffer[..bytes] == *b"READY=1")
+    }
+}
+
+impl Drop for ChildNotifySocket {
+    fn drop(&mut self) {
+        // OwnedFd closes the descriptor itself; remove the socket inode and
+        // this launch's private runtime directory.
+        let _ = std::fs::remove_file(&self.path);
+        if let Some(parent) = self.path.parent() {
+            // Only ever removes the per-launch `notify-<name>-<pid>` dir.
+            let _ = std::fs::remove_dir(parent);
+        }
+    }
+}
+
+/// Startup ownership of a not-yet-adopted child (#1585).
+///
+/// Between `spawn` and readiness the launcher — not the process map — owns
+/// the child. If anything returns early or the future is cancelled while the
+/// guard is still armed, `Drop` performs a synchronous best-effort SIGKILL
+/// with a bounded reap and removes any artifact the guard owns. This is best
+/// effort within bounded budgets: if the OS kill/reap does not complete in
+/// time, the timeout is logged — it is not silently discarded, and no
+/// immortal guarantee is claimed.
+struct StartupChildGuard {
+    child: Option<Child>,
+    name: String,
+    pid_file: Option<std::path::PathBuf>,
+}
+
+impl StartupChildGuard {
+    /// Kill and reap the owned child, honestly reporting every failure.
+    ///
+    /// On partial failure the guard RETAINS ownership (`self.child` stays
+    /// armed): the Drop backstop re-attempts SIGKILL and the bounded reap, so
+    /// a failed cleanup does not silently disarm fallback ownership and
+    /// orphan the child under `kill_on_drop(false)`. The guarded artifact is
+    /// removed only after confirmed termination.
+    async fn kill_and_reap(&mut self) -> std::result::Result<(), String> {
+        let mut failures = Vec::new();
+        if let Some(child) = self.child.as_mut() {
+            if let Err(e) = child.start_kill() {
+                failures.push(format!("kill failed: {e}"));
+            }
+            match tokio::time::timeout(Duration::from_secs(5), child.wait()).await {
+                Ok(Ok(_)) => {
+                    // Reaped: ownership transfer complete.
+                    self.child = None;
+                }
+                Ok(Err(e)) => failures.push(format!("reap failed: {e}")),
+                Err(_) => failures.push("reap timed out; ownership retained".to_owned()),
+            }
+        }
+        if self.child.is_none() {
+            if let Some(path) = self.pid_file.take() {
+                if let Err(e) = std::fs::remove_file(&path) {
+                    if e.kind() != std::io::ErrorKind::NotFound {
+                        failures.push(format!("pid file removal failed: {e}"));
+                    }
+                }
+            }
+        }
+        if failures.is_empty() {
+            Ok(())
+        } else {
+            Err(failures.join("; "))
+        }
+    }
+
+    /// Synchronous cancellation backstop (the async reap is unavailable in
+    /// `Drop`): SIGKILL the owned child and reap it within a bounded WNOHANG
+    /// budget. Returns whether termination/reap was OBSERVED.
+    ///
+    /// On `true` the owned child handle is released and the guarded artifact
+    /// removed. On `false` — kill failure, reap error, or budget exhaustion —
+    /// NOTHING is discarded: the retained child handle and artifact are the
+    /// failure evidence. Bounded best effort, not a guarantee.
+    fn backstop_cleanup(&mut self) -> bool {
+        let mut observed = false;
+        if let Some(child) = self.child.as_ref() {
+            if let Some(pid) = child.id() {
+                let raw = nix::unistd::Pid::from_raw(pid as i32);
+                match nix::sys::signal::kill(raw, nix::sys::signal::Signal::SIGKILL) {
+                    Err(nix::errno::Errno::ESRCH) => {
+                        // The process is already gone; nothing to signal.
+                        observed = true;
+                    }
+                    Err(e) => {
+                        tracing::warn!(
+                            pid = %pid,
+                            error = %e,
+                            "startup backstop SIGKILL failed; termination not observed"
+                        );
+                    }
+                    Ok(()) => {
+                        let deadline = Instant::now() + Duration::from_secs(1);
+                        loop {
+                            match nix::sys::wait::waitpid(
+                                raw,
+                                Some(nix::sys::wait::WaitPidFlag::WNOHANG),
+                            ) {
+                                Ok(nix::sys::wait::WaitStatus::StillAlive) => {
+                                    if Instant::now() >= deadline {
+                                        tracing::warn!(
+                                            pid = %pid,
+                                            "reap backstop budget exhausted; child may linger as a zombie"
+                                        );
+                                        break;
+                                    }
+                                    std::thread::sleep(Duration::from_millis(5));
+                                }
+                                // Exited/Signaled: reaped by this wait.
+                                // ECHILD: no longer our child (already
+                                // reaped) — gone either way.
+                                Ok(_) | Err(nix::errno::Errno::ECHILD) => {
+                                    observed = true;
+                                    break;
+                                }
+                                Err(e) => {
+                                    tracing::warn!(
+                                        pid = %pid,
+                                        error = %e,
+                                        "startup backstop reap failed; termination not observed"
+                                    );
+                                    break;
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        if observed {
+            self.child = None;
+            if let Some(path) = &self.pid_file {
+                let _ = std::fs::remove_file(path);
+            }
+            self.pid_file = None;
+        }
+        observed
+    }
+}
+
+impl Drop for StartupChildGuard {
+    fn drop(&mut self) {
+        if self.child.is_some() {
+            // Best effort within the budget: the limitation is real (a stuck
+            // child may outlive this backstop), and the log states what was
+            // actually observed — never success on failure.
+            if self.backstop_cleanup() {
+                tracing::warn!(
+                    name = %self.name,
+                    "startup guard dropped with the child still owned; killed, reaped, and cleaned up"
+                );
+            } else {
+                tracing::warn!(
+                    name = %self.name,
+                    "startup guard dropped without confirmed termination; owned artifact retained as evidence"
+                );
+            }
+        }
+    }
+}
 
 /// Standalone process spawner backend.
 ///
@@ -36,9 +369,18 @@ impl Default for StandaloneBackend {
     }
 }
 
-#[async_trait::async_trait]
-impl SpawnerBackend for StandaloneBackend {
-    async fn spawn(&self, config: ProcessConfig) -> Result<SpawnedProcess> {
+impl StandaloneBackend {
+    /// Legacy path: report success as soon as the child is spawned.
+    ///
+    /// Documented limitations (pre-existing at HEAD #1585; kept for
+    /// compatibility, NOT the required-native contract): readiness is not
+    /// verified in any way; PID publication is a direct, non-atomic write
+    /// whose failure is logged rather than rolled back; and a pre-existing
+    /// PID artifact is overwritten without a live-duplicate check, so a
+    /// recycled PID in a stale artifact can misdirect later PID-based
+    /// cleanup. The Required notified path (`spawn_notified`) is where the
+    /// checked-publication/rollback contract is enforced.
+    async fn spawn_immediate(&self, config: ProcessConfig) -> Result<SpawnedProcess> {
         tracing::debug!(
             name = %config.name,
             executable = %config.executable.display(),
@@ -97,7 +439,516 @@ impl SpawnerBackend for StandaloneBackend {
             "Daemon spawned successfully"
         );
 
-        Ok(SpawnedProcess::new(id, ProcessKind::Direct(pid)))
+        Ok(SpawnedProcess::new(id, ProcessKind::Direct(pid))
+            .with_pid_file(pid_file))
+    }
+
+    /// Notify-supervised path (#1585): the spawn reports success only after
+    /// the child's own `READY=1` datagram arrives from the child's PID; a
+    /// child exit or the hard timeout fails the spawn, the child is
+    /// terminated/reaped, and no PID/notify artifact survives.
+    async fn spawn_notified(
+        &self,
+        config: ProcessConfig,
+        timeout: Duration,
+    ) -> Result<SpawnedProcess> {
+        tracing::debug!(
+            name = %config.name,
+            executable = %config.executable.display(),
+            timeout_ms = %timeout.as_millis(),
+            "Spawning daemon via direct process with notification readiness"
+        );
+
+        // Serialize same-service launches for the WHOLE launch — duplicate
+        // precheck, publication, and any rollback run under this lock; it is
+        // acquired first so it is dropped last, after every early-return
+        // cleanup path. A held lock deterministically reports the pending
+        // duplicate.
+        let _launch_lock = ServiceLaunchLock::acquire(&config.name)?;
+        let pid_file = hyprstream_rpc::paths::service_pid_file(&config.name);
+
+        // Duplicate precheck BEFORE any side effect of this launch: no
+        // notification endpoint is created and no child is spawned for a
+        // refused launch. Only a confirmed-missing or confirmed-dead
+        // predecessor may be replaced; ambiguous artifacts fail closed.
+        match inspect_pid_file(&pid_file) {
+            PidWitness::Absent => {}
+            PidWitness::Dead(stale) => {
+                tracing::info!(
+                    name = %config.name,
+                    stale_pid = %stale,
+                    "replacing PID artifact of a confirmed-dead predecessor"
+                );
+            }
+            PidWitness::Live(existing) => {
+                return Err(RpcError::SpawnFailed(format!(
+                    "service {} launch refused: service already appears live as pid {existing}",
+                    config.name
+                )));
+            }
+            PidWitness::Ambiguous(why) => {
+                return Err(RpcError::SpawnFailed(format!(
+                    "service {} launch refused: existing PID artifact is ambiguous ({why}); refusing to replace it",
+                    config.name
+                )));
+            }
+        }
+
+        let notify = ChildNotifySocket::bind(&config.name)?;
+
+        let mut cmd = Command::new(&config.executable);
+        cmd.args(&config.args);
+        if let Some(ref dir) = config.working_dir {
+            cmd.current_dir(dir);
+        }
+        for (key, value) in &config.env {
+            cmd.env(key, value);
+        }
+        // The child learns its notification endpoint only through its own
+        // environment; the launcher's environment is untouched.
+        cmd.env("NOTIFY_SOCKET", notify.socket_path());
+        cmd.kill_on_drop(false);
+
+        let child = cmd.spawn().map_err(|e| {
+            RpcError::SpawnFailed(format!("failed to spawn {}: {}", config.name, e))
+        })?;
+        // Take ownership BEFORE any fallible branch: if the handle yields no
+        // PID, the guard must still own and reap the child (`kill_on_drop`
+        // is false by design — adopted daemons must outlive the launcher).
+        let mut guard = StartupChildGuard {
+            child: Some(child),
+            name: config.name.clone(),
+            pid_file: None,
+        };
+        // Capture the PID before any await: it must remain identifiable in
+        // every error raised after this point.
+        let Some(pid) = guard.child.as_ref().and_then(tokio::process::Child::id) else {
+            let cleanup = guard.kill_and_reap().await;
+            return Err(RpcError::SpawnFailed(format!(
+                "service {} produced no PID{}",
+                config.name,
+                cleanup_suffix(cleanup),
+            )));
+        };
+
+        // Readiness outcome; classified from the child's actual behavior, not
+        // from whether its PID is still observable afterwards.
+        let outcome = match guard.child.as_mut() {
+            Some(owned) => self.await_child_readiness(owned, &notify, timeout).await,
+            None => Ok(()),
+        };
+
+        match outcome {
+            Ok(()) => {
+                // READY arrived; reject a child that exited immediately after.
+                let Some(owned) = guard.child.as_mut() else {
+                    // Unreachable while the guard owns the child until
+                    // adoption; if it ever occurs, fail closed with rollback.
+                    let cleanup = guard.kill_and_reap().await;
+                    return Err(RpcError::SpawnFailed(format!(
+                        "service {} (pid {}) lost child ownership before the readiness recheck{}",
+                        config.name,
+                        pid,
+                        cleanup_suffix(cleanup),
+                    )));
+                };
+                match owned.try_wait() {
+                    Ok(None) => {}
+                    Ok(Some(status)) => {
+                        let cleanup = guard.kill_and_reap().await;
+                        return Err(RpcError::SpawnFailed(format!(
+                            "service {} (pid {}) exited right after reporting readiness: {status}{}",
+                            config.name,
+                            pid,
+                            cleanup_suffix(cleanup),
+                        )));
+                    }
+                    Err(e) => {
+                        let cleanup = guard.kill_and_reap().await;
+                        return Err(RpcError::SpawnFailed(format!(
+                            "service {} (pid {}) readiness recheck failed: {e}{}",
+                            config.name,
+                            pid,
+                            cleanup_suffix(cleanup),
+                        )));
+                    }
+                }
+            }
+            Err(reason) => {
+                // Terminate and reap; the PID file is never published for a
+                // child that never became ready.
+                let cleanup = guard.kill_and_reap().await;
+                return Err(RpcError::SpawnFailed(format!(
+                    "service {} (pid {}) did not become ready: {reason}{}",
+                    config.name,
+                    pid,
+                    cleanup_suffix(cleanup),
+                )));
+            }
+        }
+
+        // Atomic PID publication while the startup guard still owns the child:
+        // any failure rolls the launch back (child killed/reaped, artifact
+        // removed) instead of reporting success with untracked state. The
+        // per-service launch lock is held for this whole section, so the
+        // precheck and the publication are one deterministic unit.
+        if let Some(parent) = pid_file.parent() {
+            if let Err(e) = std::fs::create_dir_all(parent) {
+                let cleanup = guard.kill_and_reap().await;
+                return Err(RpcError::SpawnFailed(format!(
+                    "service {} (pid {}) runtime dir creation failed: {e}{}",
+                    config.name,
+                    pid,
+                    cleanup_suffix(cleanup),
+                )));
+            }
+        }
+        // Exclusive per-attempt temp artifact: `create_new` never clobbers a
+        // pre-existing file, the PID bytes are written through the RETAINED
+        // created handle (the exclusive inode ownership established at
+        // creation is never traded for a reopened pathname), and the guard
+        // is armed only for the file THIS attempt actually created.
+        let temp_pid_file = {
+            let mut created = None;
+            for _ in 0..8 {
+                let nanos = SystemTime::now()
+                    .duration_since(UNIX_EPOCH)
+                    .map(|d| d.as_nanos())
+                    .unwrap_or_default();
+                let candidate = pid_file.with_extension(format!("pid.{nanos}"));
+                match std::fs::OpenOptions::new()
+                    .write(true)
+                    .create_new(true)
+                    .open(&candidate)
+                {
+                    Ok(file) => {
+                        created = Some((candidate, file));
+                        break;
+                    }
+                    Err(e) if e.kind() == std::io::ErrorKind::AlreadyExists => continue,
+                    Err(e) => {
+                        let cleanup = guard.kill_and_reap().await;
+                        return Err(RpcError::SpawnFailed(format!(
+                            "service {} (pid {}) PID publication failed: {e}{}",
+                            config.name,
+                            pid,
+                            cleanup_suffix(cleanup),
+                        )));
+                    }
+                }
+            }
+            let Some((candidate, mut file)) = created else {
+                let cleanup = guard.kill_and_reap().await;
+                return Err(RpcError::SpawnFailed(format!(
+                    "service {} (pid {}) PID publication failed: no unique temp artifact name{}",
+                    config.name,
+                    pid,
+                    cleanup_suffix(cleanup),
+                )));
+            };
+            // The guard owns this attempt's artifact from the moment of its
+            // exclusive creation: any rollback removes it together with the
+            // confirmed reap.
+            guard.pid_file = Some(candidate.clone());
+            use std::io::Write as _;
+            if let Err(e) = file.write_all(pid.to_string().as_bytes()) {
+                let cleanup = guard.kill_and_reap().await;
+                return Err(RpcError::SpawnFailed(format!(
+                    "service {} (pid {}) PID publication failed: {e}{}",
+                    config.name,
+                    pid,
+                    cleanup_suffix(cleanup),
+                )));
+            }
+            candidate
+        };
+        if let Err(e) = std::fs::rename(&temp_pid_file, &pid_file) {
+            let cleanup = guard.kill_and_reap().await;
+            return Err(RpcError::SpawnFailed(format!(
+                "service {} (pid {}) PID publication failed: {e}{}",
+                config.name,
+                pid,
+                cleanup_suffix(cleanup),
+            )));
+        }
+
+        // Generate unique ID
+        let id = format!("{}-{}", config.name, pid);
+
+        // Transfer ownership: the process map adopts the live child and the
+        // PID file becomes `stop`'s cleanup responsibility.
+        let Some(owned) = guard.child.take() else {
+            // Unreachable while the guard owns the child until adoption. The
+            // handle is gone, so there is nothing to kill or reap; this
+            // attempt's temp artifact is removed rather than leaked.
+            if let Some(path) = guard.pid_file.take() {
+                let _ = std::fs::remove_file(&path);
+            }
+            return Err(RpcError::SpawnFailed(format!(
+                "service {} (pid {}) lost child ownership before adoption",
+                config.name, pid,
+            )));
+        };
+        guard.pid_file = None;
+        self.processes
+            .insert(id.clone(), Arc::new(Mutex::new(owned)));
+
+        tracing::info!(
+            name = %config.name,
+            pid = %pid,
+            id = %id,
+            "Daemon spawned successfully (notification readiness satisfied)"
+        );
+
+        // ChildNotifySocket::drop closes the endpoint and removes the socket.
+        Ok(SpawnedProcess::new(id, ProcessKind::Direct(pid))
+            .with_pid_file(pid_file))
+    }
+
+    /// Poll the notification endpoint against child exit and the hard timeout.
+    async fn await_child_readiness(
+        &self,
+        child: &mut Child,
+        notify: &ChildNotifySocket,
+        timeout: Duration,
+    ) -> std::result::Result<(), String> {
+        let deadline = Instant::now() + timeout;
+        let mut poll = tokio::time::interval(Duration::from_millis(20));
+        poll.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+        // The first tick completes immediately; skip it so the first real
+        // poll happens one interval in.
+        poll.tick().await;
+
+        loop {
+            match notify.try_recv_ready(child.id().map(|p| p as i32).unwrap_or(-1)) {
+                Ok(true) => return Ok(()),
+                Ok(false) => {}
+                Err(e) => return Err(e.to_string()),
+            }
+            match child.try_wait() {
+                Ok(Some(status)) => {
+                    return Err(format!("exited during startup with {status}"));
+                }
+                Ok(None) => {}
+                Err(e) => return Err(format!("exit observation failed: {e}")),
+            }
+            if Instant::now() >= deadline {
+                return Err(format!(
+                    "no READY=1 within {}s (notification endpoint {})",
+                    timeout.as_secs(),
+                    notify.socket_path().display()
+                ));
+            }
+            let wait = poll.tick();
+            tokio::select! {
+                _ = wait => {}
+                status = child.wait() => {
+                    // Exit while sleeping between polls is still a startup
+                    // failure with the real exit status.
+                    return match status {
+                        Ok(status) => Err(format!("exited during startup with {status}")),
+                        Err(e) => Err(format!("exit observation failed: {e}")),
+                    };
+                }
+            }
+        }
+    }
+}
+
+/// A self-exited child stays visible to `kill(pid, 0)` as a zombie until its
+/// supervisor reaps it; a zombie is not a running service. Best-effort procfs
+/// inspection — if the state cannot be read the process is conservatively
+/// treated as alive (previous `kill(pid, 0)` semantics).
+#[cfg(any(target_os = "linux", target_os = "android"))]
+fn process_is_zombie(pid: i32) -> bool {
+    let Ok(stat) = std::fs::read_to_string(format!("/proc/{pid}/stat")) else {
+        return false;
+    };
+    // The comm field is parenthesized and may itself contain parentheses or
+    // spaces; the single-character state code follows the final ')'.
+    let Some(after_comm) = stat
+        .rsplit_once(')')
+        .map(|(_, rest)| rest.trim_start())
+    else {
+        return false;
+    };
+    after_comm.starts_with('Z')
+}
+
+#[cfg(not(any(target_os = "linux", target_os = "android")))]
+fn process_is_zombie(_pid: i32) -> bool {
+    false
+}
+
+/// Format an optional cleanup failure onto a startup error: a cleanup that
+/// itself failed is part of the failure report, never discarded.
+fn cleanup_suffix(cleanup: std::result::Result<(), String>) -> String {
+    match cleanup {
+        Ok(()) => String::new(),
+        Err(failure) => format!("; cleanup: {failure}"),
+    }
+}
+
+/// Outcome of inspecting an existing PID artifact before a launch. Anything
+/// other than a confirmed-missing or confirmed-dead predecessor is ambiguous
+/// and must fail closed: only a verified missing/dead witness may be replaced.
+enum PidWitness {
+    /// No artifact: nothing to refuse, nothing to preserve.
+    Absent,
+    /// Parseable PID naming a non-live process: a stale witness, replaceable.
+    Dead(u32),
+    /// Parseable PID naming a live process: a duplicate launch must be
+    /// refused and this witness preserved.
+    Live(u32),
+    /// Unreadable or unparseable: the artifact cannot vouch either way.
+    Ambiguous(String),
+}
+
+fn inspect_pid_file(path: &std::path::Path) -> PidWitness {
+    match std::fs::read_to_string(path) {
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => PidWitness::Absent,
+        Err(e) => PidWitness::Ambiguous(format!("unreadable: {e}")),
+        Ok(content) => match content.trim().parse::<u32>() {
+            Err(_) => PidWitness::Ambiguous("unparseable pid".to_owned()),
+            Ok(pid) if pid_is_live(pid) => PidWitness::Live(pid),
+            Ok(pid) => PidWitness::Dead(pid),
+        },
+    }
+}
+
+/// Liveness of a PID witness: present (signalable — or present but
+/// unsignalable, which is conservatively live), and NOT a zombie — a
+/// self-exited process awaiting reap is a stale witness.
+fn pid_is_live(pid: u32) -> bool {
+    let Some(pid) = i32::try_from(pid).ok().filter(|&p| p > 0) else {
+        return false;
+    };
+    matches!(
+        nix::sys::signal::kill(nix::unistd::Pid::from_raw(pid), None),
+        Ok(()) | Err(nix::errno::Errno::EPERM)
+    ) && !process_is_zombie(pid)
+}
+
+/// Terminate an untracked daemon handle by PID: SIGTERM with a bounded wait,
+/// then SIGKILL with a bounded POST-SIGKILL confirmation. Returns whether
+/// death was OBSERVED (ESRCH) — callers touch artifacts only on `true`.
+///
+/// Known pre-existing limitation (documented, not redesigned in #1585): on
+/// an untracked handle the PID is a bare witness, so a recycled PID after
+/// the target's exit can in principle be signaled; tracked children are
+/// observed through their real handle and have no such exposure.
+async fn stop_untracked_by_pid(pid: u32, failures: &mut Vec<String>) -> bool {
+    let Some(pid_i32) = i32::try_from(pid).ok().filter(|&p| p > 0) else {
+        failures.push("invalid PID".to_owned());
+        return false;
+    };
+    let raw = nix::unistd::Pid::from_raw(pid_i32);
+    match nix::sys::signal::kill(raw, nix::sys::signal::Signal::SIGTERM) {
+        Err(nix::errno::Errno::ESRCH) => return true, // already gone
+        Err(e) => {
+            failures.push(format!("SIGTERM failed: {e}"));
+            return false;
+        }
+        Ok(()) => {}
+    }
+    let deadline = Instant::now() + Duration::from_secs(5);
+    loop {
+        match nix::sys::signal::kill(raw, None) {
+            Err(nix::errno::Errno::ESRCH) => return true,
+            Err(e) => {
+                failures.push(format!("liveness check failed: {e}"));
+                return false;
+            }
+            Ok(()) if Instant::now() >= deadline => break, // escalate
+            Ok(()) => tokio::time::sleep(Duration::from_millis(50)).await,
+        }
+    }
+    match nix::sys::signal::kill(raw, nix::sys::signal::Signal::SIGKILL) {
+        Err(nix::errno::Errno::ESRCH) => return true,
+        Err(e) => {
+            failures.push(format!("SIGKILL failed: {e}"));
+            return false;
+        }
+        Ok(()) => {}
+    }
+    // SIGKILL delivery is fast but not instantaneous: death must be
+    // observed, not assumed.
+    let kill_deadline = Instant::now() + Duration::from_secs(2);
+    loop {
+        match nix::sys::signal::kill(raw, None) {
+            Err(nix::errno::Errno::ESRCH) => return true,
+            Err(e) => {
+                failures.push(format!("post-SIGKILL liveness check failed: {e}"));
+                return false;
+            }
+            Ok(()) if Instant::now() >= kill_deadline => {
+                failures.push("termination not confirmed after SIGKILL".to_owned());
+                return false;
+            }
+            Ok(()) => tokio::time::sleep(Duration::from_millis(20)).await,
+        }
+    }
+}
+
+/// Per-service nonblocking advisory lock for notified launches (#1585).
+///
+/// The lock file has a STABLE path (and thus stable inode) and is NEVER
+/// unlinked — unlinking would break flock identity between concurrent
+/// acquirers. Holding it makes the duplicate precheck, the PID publication,
+/// and any rollback of one launch a deterministic unit against other launches
+/// of the same service; release is the descriptor close on drop. A held lock
+/// is reported as a pending duplicate, deterministically. Scope is honest and
+/// narrow: it coordinates only cooperating notified launches using this
+/// facility and makes no claim of control over noncooperating processes; the
+/// artifact lives in the protected runtime directory.
+struct ServiceLaunchLock {
+    _file: std::fs::File,
+}
+
+impl ServiceLaunchLock {
+    fn acquire(service: &str) -> Result<Self> {
+        use nix::fcntl::{flock, FlockArg};
+        use std::os::fd::AsRawFd;
+
+        let path =
+            hyprstream_rpc::paths::runtime_dir().join(format!("{service}.launch.lock"));
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent).map_err(|e| {
+                RpcError::SpawnFailed(format!(
+                    "service {service} launch lock dir creation failed: {e}"
+                ))
+            })?;
+        }
+        // Create-or-open WITHOUT truncation: the file's only role is existing
+        // as a stable inode for flock.
+        let file = std::fs::OpenOptions::new()
+            .create(true)
+            .append(true)
+            .open(&path)
+            .map_err(|e| {
+                RpcError::SpawnFailed(format!(
+                    "service {service} launch lock open failed: {e}"
+                ))
+            })?;
+        match flock(file.as_raw_fd(), FlockArg::LockExclusiveNonblock) {
+            Ok(()) => Ok(Self { _file: file }),
+            Err(nix::errno::Errno::EWOULDBLOCK) => Err(RpcError::SpawnFailed(format!(
+                "service {service} launch refused: another launch is already in progress (launch lock held)"
+            ))),
+            Err(e) => Err(RpcError::SpawnFailed(format!(
+                "service {service} launch lock failed: {e}"
+            ))),
+        }
+    }
+}
+
+#[async_trait::async_trait]
+impl SpawnerBackend for StandaloneBackend {
+    async fn spawn(&self, config: ProcessConfig) -> Result<SpawnedProcess> {
+        match config.readiness {
+            ProcessReadiness::Immediate => self.spawn_immediate(config).await,
+            ProcessReadiness::Notify { timeout } => self.spawn_notified(config, timeout).await,
+        }
     }
 
     async fn stop(&self, process: &SpawnedProcess) -> Result<()> {
@@ -116,88 +967,97 @@ impl SpawnerBackend for StandaloneBackend {
             "Stopping direct process"
         );
 
-        // Try to get and remove the child handle
-        if let Some((_, child_arc)) = self.processes.remove(&process.id) {
+        // Clone the tracked handle out of the map before awaiting; the map
+        // entry itself is removed ONLY after termination is CONFIRMED, so a
+        // failed or timed-out cleanup leaves the child tracked for a
+        // retrying stop instead of losing ownership mid-cleanup. That
+        // retention holds only while THIS backend lives: backend drop or
+        // process exit releases the map without killing anything, and the
+        // bounded startup Drop cannot guarantee retained retry ownership
+        // either — no reaper framework exists beyond this.
+        let child_arc = self
+            .processes
+            .get(&process.id)
+            .map(|entry| Arc::clone(entry.value()));
+
+        let mut failures: Vec<String> = Vec::new();
+        let mut confirmed = false;
+        if let Some(child_arc) = child_arc {
             let mut child = child_arc.lock().await;
 
-            // Try graceful SIGTERM first
+            // Forceful termination (`start_kill` sends SIGKILL — the comment
+            // above used to promise SIGTERM; it does not).
             if let Err(e) = child.start_kill() {
-                tracing::warn!(
-                    id = %process.id,
-                    error = %e,
-                    "Failed to send kill signal"
-                );
+                failures.push(format!("kill failed: {e}"));
             }
-
-            // Wait for the process to exit (with timeout)
-            match tokio::time::timeout(std::time::Duration::from_secs(5), child.wait()).await {
-                Ok(Ok(status)) => {
-                    tracing::debug!(
-                        id = %process.id,
-                        status = ?status,
-                        "Process exited"
-                    );
+            match tokio::time::timeout(Duration::from_secs(5), child.wait()).await {
+                Ok(Ok(_)) => {
+                    confirmed = true;
+                    // Reaped: only now does the backend stop tracking the
+                    // child.
+                    self.processes.remove(&process.id);
                 }
-                Ok(Err(e)) => {
-                    tracing::warn!(
-                        id = %process.id,
-                        error = %e,
-                        "Error waiting for process"
-                    );
-                }
-                Err(_) => {
-                    tracing::warn!(
-                        id = %process.id,
-                        "Timeout waiting for process, may be killed by drop"
-                    );
-                }
+                Ok(Err(e)) => failures.push(format!("reap failed: {e}")),
+                Err(_) => failures.push("reap timed out; child remains tracked".to_owned()),
             }
         } else {
-            // Process not in our map, try to kill by PID directly
+            // Not tracked (adopted handle, or a retry after a confirmed
+            // earlier stop): terminate by PID, with termination OBSERVED
+            // before any artifact is touched.
             tracing::debug!(
                 id = %process.id,
                 pid = %pid,
                 "Process not in map, attempting direct kill by PID"
             );
+            confirmed = stop_untracked_by_pid(pid, &mut failures).await;
+        }
 
-            // PIDs are always positive and fit in i32 on Unix
-            let Some(pid_i32) = i32::try_from(pid).ok().filter(|&p| p > 0) else {
-                tracing::warn!(pid = %pid, "Invalid PID, skipping kill");
-                return Ok(());
-            };
-            let nix_pid = nix::unistd::Pid::from_raw(pid_i32);
+        if !confirmed {
+            // Unconfirmed termination: the PID artifact still names a
+            // possibly-live process and success must not be reported.
+            failures.push("termination unconfirmed".to_owned());
+            return Err(RpcError::SpawnFailed(format!(
+                "stop of {} did not fully succeed: {}",
+                process.id,
+                failures.join("; ")
+            )));
+        }
 
-            // Send SIGTERM
-            if let Err(e) = nix::sys::signal::kill(nix_pid, nix::sys::signal::Signal::SIGTERM) {
-                if e != nix::errno::Errno::ESRCH {
-                    tracing::warn!(
-                        pid = %pid,
-                        error = %e,
-                        "Failed to send SIGTERM"
-                    );
+        // Conditional PID artifact removal: delete only if the file still
+        // names THIS child, so stopping an older duplicate cannot erase a
+        // newer process's PID file.
+        if let Some(pid_file) = &process.pid_file {
+            match std::fs::read_to_string(pid_file) {
+                Ok(content) => {
+                    let same_child = content.trim() == pid.to_string();
+                    if same_child {
+                        if let Err(e) = std::fs::remove_file(pid_file) {
+                            if e.kind() != std::io::ErrorKind::NotFound {
+                                failures.push(format!(
+                                    "PID file removal failed: {e}"
+                                ));
+                            }
+                        }
+                    }
                 }
-            }
-
-            // Wait briefly then send SIGKILL if needed
-            tokio::time::sleep(std::time::Duration::from_millis(500)).await;
-
-            if let Err(e) = nix::sys::signal::kill(nix_pid, nix::sys::signal::Signal::SIGKILL) {
-                if e != nix::errno::Errno::ESRCH {
-                    tracing::warn!(
-                        pid = %pid,
-                        error = %e,
-                        "Failed to send SIGKILL"
-                    );
-                }
+                Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
+                Err(e) => failures.push(format!("PID file read failed: {e}")),
             }
         }
 
-        tracing::info!(
-            id = %process.id,
-            "Process stopped"
-        );
-
-        Ok(())
+        if failures.is_empty() {
+            tracing::info!(
+                id = %process.id,
+                "Process stopped"
+            );
+            Ok(())
+        } else {
+            Err(RpcError::SpawnFailed(format!(
+                "stop of {} did not fully succeed: {}",
+                process.id,
+                failures.join("; ")
+            )))
+        }
     }
 
     async fn is_running(&self, process: &SpawnedProcess) -> Result<bool> {
@@ -210,15 +1070,39 @@ impl SpawnerBackend for StandaloneBackend {
             }
         };
 
-        // Check if the process exists by sending signal 0
-        // PIDs are always positive and fit in i32 on Unix
         let Some(pid_i32) = i32::try_from(pid).ok().filter(|&p| p > 0) else {
             return Ok(false); // Invalid PID means not running
         };
+
+        // A TRACKED child is observed directly: `try_wait` observes — and
+        // reaps — the actual child. That is portable and authoritative, and
+        // it cannot mistake a self-exited-but-unreaped child (a zombie,
+        // still visible to `kill(pid, 0)`) for a running service.
+        if let Some(child_arc) = self
+            .processes
+            .get(&process.id)
+            .map(|entry| Arc::clone(entry.value()))
+        {
+            let mut child = child_arc.lock().await;
+            return match child.try_wait() {
+                Ok(Some(_)) => Ok(false), // exited and reaped: not running
+                Ok(None) => Ok(true),     // still running
+                Err(e) => {
+                    tracing::warn!(pid = %pid, error = %e, "Error checking child status");
+                    Ok(false)
+                }
+            };
+        }
+
+        // Untracked daemon handle (adopted, or after a confirmed stop):
+        // bounded legacy liveness fallback by PID signal 0, zombie-aware so
+        // a self-exited process awaiting reap is not reported as running.
         let nix_pid = nix::unistd::Pid::from_raw(pid_i32);
         match nix::sys::signal::kill(nix_pid, None) {
-            // Process exists (Ok) or exists but we can't signal it (EPERM)
-            Ok(()) | Err(nix::errno::Errno::EPERM) => Ok(true),
+            // Present (Ok) or present-but-unsignalable (EPERM) — but a
+            // zombie is a self-exited child awaiting reap, not a running
+            // service, so it must not be reported as running.
+            Ok(()) | Err(nix::errno::Errno::EPERM) => Ok(!process_is_zombie(pid_i32)),
             Err(nix::errno::Errno::ESRCH) => Ok(false), // No such process
             Err(e) => {
                 tracing::warn!(pid = %pid, error = %e, "Error checking process status");
@@ -234,12 +1118,15 @@ impl SpawnerBackend for StandaloneBackend {
 
 impl Drop for StandaloneBackend {
     fn drop(&mut self) {
-        // The Child handles have kill_on_drop(true), so they'll be cleaned up automatically
+        // Children are spawned with kill_on_drop(false) ON PURPOSE: adopted
+        // daemons are intended to outlive the launcher. Dropping the backend
+        // therefore releases tracking only — it does NOT kill anything, and
+        // no cleanup is performed here.
         let count = self.processes.len();
         if count > 0 {
             tracing::debug!(
                 count = count,
-                "StandaloneBackend dropped with active processes (will be killed)"
+                "StandaloneBackend dropped with tracked processes (NOT killed: daemons outlive the launcher)"
             );
         }
     }
@@ -290,5 +1177,650 @@ mod tests {
     fn test_backend_type() {
         let backend = StandaloneBackend::new();
         assert_eq!(backend.backend_type(), "standalone");
+    }
+}
+
+#[cfg(test)]
+mod notify_readiness_tests {
+    #![allow(clippy::expect_used, clippy::unwrap_used)]
+
+    use super::*;
+    use std::path::Path;
+
+    const READY_HELPER: &str = "HYPRSTREAM_NOTIFY_READY_HELPER";
+    const PENDING_HELPER: &str = "HYPRSTREAM_LAUNCHER_PENDING_HELPER";
+    const PENDING_MARKER: &str = "HYPRSTREAM_LAUNCHER_PENDING_MARKER";
+    const PENDING_RELEASE: &str = "HYPRSTREAM_LAUNCHER_PENDING_RELEASE";
+    const OBSTACLE_HELPER: &str = "HYPRSTREAM_LAUNCHER_OBSTACLE_HELPER";
+    const OBSTACLE_PATH: &str = "HYPRSTREAM_LAUNCHER_OBSTACLE_PATH";
+
+    /// Helper child: reports readiness through the real sd_notify send path,
+    /// then stays alive so the supervisor observes a genuinely RUNNING ready
+    /// child; the supervisor's stop is the controlled shutdown.
+    #[test]
+    fn notify_ready_helper_child() {
+        if std::env::var_os(READY_HELPER).is_none() {
+            return;
+        }
+        crate::notify::ready().expect("notify ready send");
+        std::thread::sleep(Duration::from_secs(30));
+    }
+
+    /// Helper child: records its PID to a marker file, then stays PENDING
+    /// (no READY, launch lock held) until a release file appears; only then
+    /// does it report readiness and stay alive. Lets a test hold a REAL
+    /// notified launch mid-flight across the readiness await.
+    #[test]
+    fn launch_pending_helper_child() {
+        if std::env::var_os(PENDING_HELPER).is_none() {
+            return;
+        }
+        let marker = std::path::PathBuf::from(std::env::var(PENDING_MARKER).expect("marker"));
+        let release = std::path::PathBuf::from(std::env::var(PENDING_RELEASE).expect("release"));
+        std::fs::write(&marker, std::process::id().to_string()).expect("marker write");
+        let deadline = Instant::now() + Duration::from_secs(30);
+        while !release.exists() {
+            assert!(Instant::now() < deadline, "release never arrived");
+            std::thread::sleep(Duration::from_millis(20));
+        }
+        crate::notify::ready().expect("notify ready send");
+        std::thread::sleep(Duration::from_secs(30));
+    }
+
+    /// Helper child: creates a publication obstacle (a directory at the
+    /// future PID artifact path) BEFORE reporting readiness, so a test can
+    /// exercise a post-precheck publication failure deterministically.
+    #[test]
+    fn publication_obstacle_helper_child() {
+        if std::env::var_os(OBSTACLE_HELPER).is_none() {
+            return;
+        }
+        let obstacle = std::path::PathBuf::from(std::env::var(OBSTACLE_PATH).expect("obstacle"));
+        std::fs::create_dir(&obstacle).expect("obstacle dir");
+        crate::notify::ready().expect("notify ready send");
+        std::thread::sleep(Duration::from_secs(30));
+    }
+
+    /// Assert a process is reaped (`kill(pid, 0)` says ESRCH).
+    fn assert_pid_gone(pid: u32) {
+        let gone = nix::sys::signal::kill(
+            nix::unistd::Pid::from_raw(pid as i32),
+            None,
+        )
+        .is_err_and(|e| e == nix::errno::Errno::ESRCH);
+        assert!(gone, "child pid {pid} must be reaped after cleanup");
+    }
+
+    /// Assert no notification endpoint (private dir or socket) for `name`
+    /// remains under the runtime dir.
+    fn assert_no_notify_inode(name: &str) {
+        let dir = hyprstream_rpc::paths::runtime_dir();
+        let leftovers: Vec<_> = std::fs::read_dir(&dir)
+            .into_iter()
+            .flatten()
+            .flatten()
+            .filter_map(|entry| entry.file_name().into_string().ok())
+            .filter(|file| file.starts_with(&format!("notify-{name}-")))
+            .collect();
+        assert!(
+            leftovers.is_empty(),
+            "notification endpoints must be cleaned up, found {leftovers:?}"
+        );
+    }
+
+    /// Cancellation: a pending notified spawn aborted after the child PID is
+    /// learnable must leave the child reaped and no artifacts behind.
+    #[tokio::test]
+    async fn cancelled_pending_spawn_reaps_child_and_cleans_artifacts() -> Result<()> {
+        let runtime = hyprstream_rpc::paths::runtime_dir();
+        std::fs::create_dir_all(&runtime).ok();
+        let observed_pid_file = runtime.join("notify-cancel-observed.pid");
+        let _ = std::fs::remove_file(&observed_pid_file);
+
+        let backend = Arc::new(StandaloneBackend::new());
+        let config = ProcessConfig::new("notify-cancel", Path::new("/bin/sh"))
+            .args([
+                "-c",
+                "echo $$ > \"$OBSERVED_PID_FILE\"; exec sleep 100",
+            ])
+            .env("OBSERVED_PID_FILE", observed_pid_file.display().to_string())
+            .with_notify_ready(Duration::from_secs(30));
+
+        // Abort the pending handshake once the child has recorded its PID.
+        let task = tokio::spawn({
+            let backend = Arc::clone(&backend);
+            async move { SpawnerBackend::spawn(&*backend, config).await }
+        });
+        let deadline = Instant::now() + Duration::from_secs(10);
+        let observed: u32 = loop {
+            if let Ok(content) = std::fs::read_to_string(&observed_pid_file) {
+                if let Ok(pid) = content.trim().parse::<u32>() {
+                    break pid;
+                }
+            }
+            assert!(
+                Instant::now() < deadline,
+                "child never recorded its PID for cancellation"
+            );
+            // Yield to the runtime: the pending spawn runs as a task on this
+            // same (current-thread) test runtime and must be polled.
+            tokio::time::sleep(Duration::from_millis(20)).await;
+        };
+        task.abort();
+
+        // The ownership backstop must SIGKILL + reap the child and remove the
+        // notification endpoint; poll with a bounded budget.
+        let gone_deadline = Instant::now() + Duration::from_secs(10);
+        loop {
+            let gone = nix::sys::signal::kill(nix::unistd::Pid::from_raw(observed as i32), None)
+                .is_err_and(|e| e == nix::errno::Errno::ESRCH);
+            if gone {
+                break;
+            }
+            assert!(
+                Instant::now() < gone_deadline,
+                "cancelled child {observed} must be reaped"
+            );
+            tokio::time::sleep(Duration::from_millis(50)).await;
+        }
+        assert!(
+            !hyprstream_rpc::paths::service_pid_file("notify-cancel").exists(),
+            "cancelled spawn must leave no PID file"
+        );
+        assert_no_notify_inode("notify-cancel");
+        let _ = std::fs::remove_file(&observed_pid_file);
+        Ok(())
+    }
+
+    /// Publication rollback: an unwritable PID artifact (directory squatting
+    /// the publication path) after READY must fail the spawn, reap the ready
+    /// child, and leave no notification endpoint.
+    #[tokio::test]
+    async fn ambiguous_artifact_refuses_launch_before_spawn() -> Result<()> {
+        let unique = std::process::id();
+        let name = format!("notify-amb-{unique}");
+        let backend = StandaloneBackend::new();
+        // A DIRECTORY at the PID artifact path is a read ERROR, not an
+        // absence: the witness is ambiguous and the launch must fail closed
+        // BEFORE any child runs — no endpoint, no child, no pid in the error.
+        let squat = hyprstream_rpc::paths::service_pid_file(&name);
+        std::fs::create_dir_all(&squat).expect("squat directory");
+        let config = ProcessConfig::new(&name, Path::new("/bin/true"))
+            .with_notify_ready(Duration::from_secs(5));
+
+        let error = backend
+            .spawn(config)
+            .await
+            .expect_err("an ambiguous PID artifact must fail the launch closed");
+        assert!(
+            error.to_string().contains("ambiguous"),
+            "ambiguous refusal expected, got: {error}"
+        );
+        assert!(
+            !error.to_string().contains("(pid "),
+            "a refused precheck must not have spawned a child, got: {error}"
+        );
+        assert_no_notify_inode(&name);
+        std::fs::remove_dir(&squat).ok();
+        Ok(())
+    }
+
+    /// Post-precheck publication failure: the controlled child creates the
+    /// publication obstacle (a directory at the future PID artifact path)
+    /// only AFTER the duplicate precheck has passed, then reports READY — so
+    /// the rename onto the obstacle fails deterministically after READY and
+    /// the ready child is rolled back (reaped, no artifacts).
+    #[tokio::test]
+    async fn publication_failure_after_precheck_rolls_back_ready_child() -> Result<()> {
+        let unique = std::process::id();
+        let name = format!("notify-pubfail-{unique}");
+        let pid_file = hyprstream_rpc::paths::service_pid_file(&name);
+        if let Some(parent) = pid_file.parent() {
+            std::fs::create_dir_all(parent).ok();
+        }
+        let backend = StandaloneBackend::new();
+        let config = ProcessConfig::new(&name, test_binary())
+            .args([
+                "--exact",
+                "service::spawner::standalone::notify_readiness_tests::publication_obstacle_helper_child",
+                "--nocapture",
+            ])
+            .env(OBSTACLE_HELPER, "1")
+            .env(OBSTACLE_PATH, pid_file.display().to_string())
+            .with_notify_ready(Duration::from_secs(30));
+
+        let error = backend
+            .spawn(config)
+            .await
+            .expect_err("a post-precheck obstacle must fail publication");
+        assert!(
+            error.to_string().contains("PID publication failed"),
+            "publication failure expected, got: {error}"
+        );
+        assert_pid_gone(failure_pid(&error, &name));
+        assert_no_notify_inode(&name);
+        std::fs::remove_dir(&pid_file).ok();
+        Ok(())
+    }
+
+    /// Extract the observed child PID the backend embeds in spawn failures
+    /// ("service <name> (pid <N>) ...").
+    fn failure_pid(error: &RpcError, name: &str) -> u32 {
+        let text = error.to_string();
+        let marker = format!("service {name} (pid ");
+        let start = text
+            .find(&marker)
+            .unwrap_or_else(|| panic!("failure must carry the observed pid: {text}"))
+            + marker.len();
+        let digits: String = text[start..]
+            .chars()
+            .take_while(char::is_ascii_digit)
+            .collect();
+        digits.parse().unwrap_or_else(|_| panic!("pid digits: {text}"))
+    }
+
+    fn test_binary() -> std::path::PathBuf {
+        std::env::current_exe().expect("test binary path")
+    }
+
+    #[tokio::test]
+    async fn notified_spawn_succeeds_on_real_child_ready() -> Result<()> {
+        if std::env::var_os(READY_HELPER).is_some() {
+            return Ok(());
+        }
+        let backend = StandaloneBackend::new();
+        let config = ProcessConfig::new("notify-ready-control", test_binary())
+            .args([
+                "--exact",
+                "service::spawner::standalone::notify_readiness_tests::notify_ready_helper_child",
+                "--nocapture",
+            ])
+            .env(READY_HELPER, "1")
+            .with_notify_ready(Duration::from_secs(30));
+        let process = backend.spawn(config).await?;
+        assert!(process.is_direct());
+        let pid = process.pid().expect("direct child pid");
+        assert!(
+            hyprstream_rpc::paths::service_pid_file("notify-ready-control").exists(),
+            "a ready child publishes its PID file"
+        );
+        assert!(
+            backend.is_running(&process).await?,
+            "the ready child must still be alive after the spawn reports success"
+        );
+        // Supervised stop: reaps the child and removes its PID artifact.
+        backend.stop(&process).await?;
+        assert!(
+            !backend.is_running(&process).await?,
+            "stopped child must not be running"
+        );
+        assert!(
+            !hyprstream_rpc::paths::service_pid_file("notify-ready-control").exists(),
+            "stop must remove the published PID file"
+        );
+        assert_pid_gone(pid);
+        assert_no_notify_inode("notify-ready-control");
+        Ok(())
+    }
+
+    /// A child that exits on its own (no stop issued) must be reported as
+    /// not-running: it is a zombie — still visible to `kill(pid, 0)` — until
+    /// its supervisor reaps it, and "running" would be a lie. A subsequent
+    /// supervised stop must still succeed (reap + conditional PID removal).
+    #[tokio::test]
+    async fn is_running_reports_self_exited_child_as_stopped() -> Result<()> {
+        let backend = StandaloneBackend::new();
+        let config = ProcessConfig::new("notify-self-exit", Path::new("/bin/sh"))
+            .args(["-c", "exit 0"]);
+        let process = SpawnerBackend::spawn(&backend, config).await?;
+        let pid = process.pid().expect("direct child pid");
+
+        let deadline = Instant::now() + Duration::from_secs(10);
+        loop {
+            if !backend.is_running(&process).await? {
+                break;
+            }
+            assert!(
+                Instant::now() < deadline,
+                "self-exited child must not be reported as running (zombie)"
+            );
+            // Yield: spawn runs as a task on this same current-thread runtime.
+            tokio::time::sleep(Duration::from_millis(20)).await;
+        }
+
+        // Stopping an already-exited child is still a clean, confirmed stop.
+        backend.stop(&process).await?;
+        assert!(!backend.is_running(&process).await?);
+        assert_pid_gone(pid);
+
+        // A SECOND stop after the confirmed first is a clean no-op through
+        // the untracked-by-PID fallback: termination is observed (ESRCH),
+        // not assumed.
+        backend.stop(&process).await?;
+        assert!(!backend.is_running(&process).await?);
+        Ok(())
+    }
+
+    /// Cleanup failures are part of the error report, never swallowed
+    /// (the discard-the-Err `unwrap_or_default` suffixes are gone).
+    #[test]
+    fn cleanup_failure_suffix_propagates_into_error() {
+        assert_eq!(cleanup_suffix(Ok(())), "");
+        assert_eq!(
+            cleanup_suffix(Err("kill failed: boom".to_owned())),
+            "; cleanup: kill failed: boom"
+        );
+    }
+
+    /// Startup-backstop decisions: OBSERVED termination cleans the owned
+    /// artifact; an unobservable outcome must RETAIN the artifact as
+    /// evidence and claim no success. The unobserved branch is exercised
+    /// through the deterministically inducible seam (a handle that yields
+    /// no PID) — no kernel kill failure is forced or claimed.
+    #[tokio::test]
+    async fn startup_backstop_cleanup_tracks_observed_termination() -> Result<()> {
+        let dir = tempfile::tempdir()?;
+        let artifact = dir.path().join("owned.pid");
+
+        // Observed path: a live child is SIGKILLed and reaped by the
+        // backstop; the owned artifact is removed.
+        let mut cmd = tokio::process::Command::new("/bin/sleep");
+        cmd.arg("30");
+        let child = cmd.spawn().expect("sleep child");
+        let pid = child.id().expect("live pid");
+        std::fs::write(&artifact, pid.to_string()).expect("artifact");
+        let mut guard = StartupChildGuard {
+            child: Some(child),
+            name: "backstop-observed".to_owned(),
+            pid_file: Some(artifact.clone()),
+        };
+        assert!(
+            guard.backstop_cleanup(),
+            "live-child backstop must observe termination"
+        );
+        assert!(
+            !artifact.exists(),
+            "observed cleanup must remove the owned artifact"
+        );
+        assert_pid_gone(pid);
+
+        // Unobserved path: the handle yields no PID, so the backstop cannot
+        // observe anything and must not claim cleanup.
+        let mut exiting = tokio::process::Command::new("/bin/sh");
+        exiting.args(["-c", "exit 0"]);
+        let mut child = exiting.spawn().expect("exiting child");
+        child.wait().await.expect("reaped by this wait");
+        std::fs::write(&artifact, "0").expect("artifact");
+        let mut guard = StartupChildGuard {
+            child: Some(child),
+            name: "backstop-unobserved".to_owned(),
+            pid_file: Some(artifact.clone()),
+        };
+        assert!(
+            !guard.backstop_cleanup(),
+            "an unobservable outcome must not claim cleanup"
+        );
+        assert!(
+            artifact.exists(),
+            "unobserved backstop must retain the owned artifact as evidence"
+        );
+        Ok(())
+    }
+
+    /// UNIT-LEVEL duplicate controls (manual lock hold / manual witness; the
+    /// END-TO-END pending→READY→live sequencing is proven by
+    /// `duplicate_launch_sequencing_refuses_pending_then_live`): a held
+    /// launch lock deterministically reports the pending duplicate, and a
+    /// PID artifact naming a LIVE process refuses a new launch — never
+    /// silently overwriting the sole witness of a live process.
+    #[tokio::test]
+    async fn duplicate_launch_controls_refuse_pending_and_live() -> Result<()> {
+        let unique = std::process::id();
+        let name = format!("notify-dup-{unique}");
+        let backend = StandaloneBackend::new();
+
+        // Pending duplicate: the launch lock itself is the deterministic
+        // witness — a held lock refuses the attempt before anything runs.
+        let held = ServiceLaunchLock::acquire(&name)?;
+        let pending = ProcessConfig::new(&name, Path::new("/bin/true"))
+            .with_notify_ready(Duration::from_secs(5));
+        let pending_error = SpawnerBackend::spawn(&backend, pending)
+            .await
+            .expect_err("a held launch lock must refuse a pending duplicate");
+        assert!(
+            pending_error.to_string().contains("already in progress"),
+            "pending-duplicate refusal expected, got: {pending_error}"
+        );
+        assert_no_notify_inode(&name);
+        drop(held);
+
+        // Live duplicate: a PID artifact naming a live process refuses a
+        // second launch. The squat process is spawned (and later reaped) by
+        // this test itself.
+        let mut squat = std::process::Command::new("/bin/sleep")
+            .arg("30")
+            .spawn()
+            .expect("squat process for live-duplicate witness");
+        let squat_pid = squat.id();
+        let pid_file = hyprstream_rpc::paths::service_pid_file(&name);
+        if let Some(parent) = pid_file.parent() {
+            std::fs::create_dir_all(parent).ok();
+        }
+        std::fs::write(&pid_file, squat_pid.to_string()).expect("squat pid file");
+
+        let ready_config = ProcessConfig::new(&name, test_binary())
+            .args([
+                "--exact",
+                "service::spawner::standalone::notify_readiness_tests::notify_ready_helper_child",
+                "--nocapture",
+            ])
+            .env(READY_HELPER, "1")
+            .with_notify_ready(Duration::from_secs(30));
+        let live_error = SpawnerBackend::spawn(&backend, ready_config)
+            .await
+            .expect_err("a live PID artifact must refuse a duplicate launch");
+        assert!(
+            live_error
+                .to_string()
+                .contains(&format!("already appears live as pid {squat_pid}")),
+            "live-duplicate refusal expected, got: {live_error}"
+        );
+        // The refused attempt published nothing: the artifact still names
+        // the live squat, and no notification endpoint survives.
+        assert_eq!(
+            std::fs::read_to_string(&pid_file)
+                .expect("witness pid file")
+                .trim(),
+            squat_pid.to_string(),
+            "live witness artifact must not be overwritten"
+        );
+        assert_no_notify_inode(&name);
+
+        // Reap the squat process and leave no fixture artifact behind.
+        squat.kill().expect("squat kill");
+        squat.wait().expect("squat reap");
+        let _ = std::fs::remove_file(&pid_file);
+        Ok(())
+    }
+
+    /// REAL duplicate sequencing, end to end: a first notified launch held
+    /// PENDING by its own child keeps the per-service launch lock held
+    /// ACROSS the readiness await, so a second same-name launch is refused
+    /// with no child of its own while the first survives; after release the
+    /// first reports READY, publishes its PID artifact, and stays alive —
+    /// and a further launch is refused against that LIVE published witness.
+    #[tokio::test]
+    async fn duplicate_launch_sequencing_refuses_pending_then_live() -> Result<()> {
+        let backend = Arc::new(StandaloneBackend::new());
+        let dir = tempfile::tempdir()?;
+        let unique = std::process::id();
+        let name = format!("notify-seq-{unique}");
+        let marker = dir.path().join("pending.marker");
+        let release = dir.path().join("pending.release");
+
+        let pending_config = ProcessConfig::new(&name, test_binary())
+            .args([
+                "--exact",
+                "service::spawner::standalone::notify_readiness_tests::launch_pending_helper_child",
+                "--nocapture",
+            ])
+            .env(PENDING_HELPER, "1")
+            .env(PENDING_MARKER, marker.display().to_string())
+            .env(PENDING_RELEASE, release.display().to_string())
+            .with_notify_ready(Duration::from_secs(30));
+
+        // First launch: genuinely pending inside the readiness await, with
+        // the launch lock held by this very launch.
+        let first = tokio::spawn({
+            let backend = Arc::clone(&backend);
+            let config = pending_config.clone();
+            async move { SpawnerBackend::spawn(&*backend, config).await }
+        });
+        let deadline = Instant::now() + Duration::from_secs(10);
+        let first_pid: u32 = loop {
+            if let Ok(content) = std::fs::read_to_string(&marker) {
+                if let Ok(pid) = content.trim().parse::<u32>() {
+                    break pid;
+                }
+            }
+            assert!(
+                Instant::now() < deadline,
+                "first launch never went pending (no marker)"
+            );
+            tokio::time::sleep(Duration::from_millis(20)).await;
+        };
+
+        // Second same-name launch while the first is mid-flight: refused on
+        // the held lock, deterministically, before any child of its own.
+        let second_error = SpawnerBackend::spawn(&*backend, pending_config.clone())
+            .await
+            .expect_err("a pending first launch must refuse a same-name launch");
+        assert!(
+            second_error.to_string().contains("already in progress"),
+            "pending-duplicate refusal expected, got: {second_error}"
+        );
+        // The first process survived the rejected second call.
+        assert!(
+            nix::sys::signal::kill(nix::unistd::Pid::from_raw(first_pid as i32), None).is_ok(),
+            "first launch child must survive the refused duplicate"
+        );
+
+        // Release the first: it reports READY and publishes its PID artifact.
+        std::fs::write(&release, b"release")?;
+        let process = tokio::time::timeout(Duration::from_secs(30), first)
+            .await
+            .expect("first launch task must finish after release")
+            .expect("first launch task must not panic")
+            .expect("first launch spawn must succeed after release");
+        assert_eq!(
+            std::fs::read_to_string(hyprstream_rpc::paths::service_pid_file(&name))
+                .expect("published pid file")
+                .trim(),
+            first_pid.to_string(),
+            "the first launch must publish its own pid"
+        );
+
+        // A further launch is refused against the LIVE published witness.
+        let third_error = SpawnerBackend::spawn(&*backend, pending_config.clone())
+            .await
+            .expect_err("a live published predecessor must refuse a duplicate");
+        assert!(
+            third_error
+                .to_string()
+                .contains(&format!("already appears live as pid {first_pid}")),
+            "live-duplicate refusal expected, got: {third_error}"
+        );
+
+        // Supervised cleanup of the first; the persistent lock file survives
+        // (stable inode, never unlinked) while the PID artifact is gone.
+        backend.stop(&process).await?;
+        assert_pid_gone(first_pid);
+        assert!(
+            !hyprstream_rpc::paths::service_pid_file(&name).exists(),
+            "stopped first launch must leave no PID file"
+        );
+        assert!(
+            hyprstream_rpc::paths::runtime_dir()
+                .join(format!("{name}.launch.lock"))
+                .exists(),
+            "the launch lock file must persist (never unlinked)"
+        );
+        assert_no_notify_inode(&name);
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn notified_spawn_fails_on_early_child_exit() -> Result<()> {
+        let backend = StandaloneBackend::new();
+        let config = ProcessConfig::new("notify-early-exit", Path::new("/bin/sh"))
+            .args(["-c", "exit 7"])
+            .with_notify_ready(Duration::from_secs(30));
+        let error = backend
+            .spawn(config)
+            .await
+            .expect_err("early child exit must fail the spawn");
+        assert!(
+            error.to_string().contains("exited during startup"),
+            "honest exit propagation expected, got: {error}"
+        );
+        assert!(
+            !hyprstream_rpc::paths::service_pid_file("notify-early-exit").exists(),
+            "a never-ready child must not publish a PID file"
+        );
+        assert_pid_gone(failure_pid(&error, "notify-early-exit"));
+        assert_no_notify_inode("notify-early-exit");
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn notified_spawn_times_out_kills_and_cleans_up() -> Result<()> {
+        let backend = StandaloneBackend::new();
+        let config = ProcessConfig::new("notify-timeout", Path::new("/bin/sleep"))
+            .args(["100"])
+            .with_notify_ready(Duration::from_millis(300));
+        let error = backend
+            .spawn(config)
+            .await
+            .expect_err("a hung child must hit the hard readiness timeout");
+        assert!(
+            error.to_string().contains("no READY=1"),
+            "timeout failure expected, got: {error}"
+        );
+        // Cleanup: the observed child was terminated and reaped, and no PID or
+        // notification artifact survives.
+        std::thread::sleep(Duration::from_millis(150));
+        assert!(
+            !hyprstream_rpc::paths::service_pid_file("notify-timeout").exists(),
+            "timed-out child must leave no PID artifact"
+        );
+        assert_pid_gone(failure_pid(&error, "notify-timeout"));
+        assert_no_notify_inode("notify-timeout");
+        Ok(())
+    }
+
+    /// Sender-PID matching: a READY datagram from any process other than the
+    /// expected child is ignored, not honored.
+    #[tokio::test]
+    async fn notify_socket_rejects_spoofed_sender() -> Result<()> {
+        let notify = ChildNotifySocket::bind("spoof-probe")?;
+        let sender = std::os::unix::net::UnixDatagram::unbound()?;
+        // First datagram: sent by THIS test process but checked against a
+        // different expected PID — the refusal must consume it without
+        // satisfying readiness.
+        sender.send_to(b"READY=1", notify.socket_path())?;
+        let this_pid = std::process::id() as i32;
+        std::thread::sleep(Duration::from_millis(50));
+        assert!(
+            !notify.try_recv_ready(this_pid.wrapping_add(1013))?,
+            "a foreign sender must not satisfy readiness"
+        );
+        // Second datagram, checked against the actual sender PID: accepted.
+        sender.send_to(b"READY=1", notify.socket_path())?;
+        std::thread::sleep(Duration::from_millis(50));
+        assert!(
+            notify.try_recv_ready(this_pid)?,
+            "the matching sender satisfies readiness"
+        );
+        Ok(())
     }
 }

--- a/crates/hyprstream-service/src/service/spawner/standalone.rs
+++ b/crates/hyprstream-service/src/service/spawner/standalone.rs
@@ -196,6 +196,33 @@ impl Drop for ChildNotifySocket {
     }
 }
 
+/// What the synchronous startup backstop actually observed and did.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum BackstopOutcome {
+    /// An explicit terminal wait status was observed AND the guarded
+    /// artifact was removed (or was already absent).
+    TerminatedAndCleaned,
+    /// A terminal status was observed, but the artifact removal FAILED:
+    /// the artifact remains on disk as evidence and no cleanup success is
+    /// claimed.
+    TerminatedArtifactKept,
+    /// Termination was NOT observed (kill failure, reap error, budget
+    /// exhausted with a nonterminal status, or no usable handle): nothing
+    /// is discarded and no cleanup is claimed.
+    Unconfirmed,
+}
+
+/// Terminal-status classification for backstop outcome purposes: only a
+/// real exit or kill signal establishes disappearance. StillAlive,
+/// stopped, continued, and ptrace states are nonterminal and never
+/// release ownership.
+fn wait_status_is_terminal(status: &nix::sys::wait::WaitStatus) -> bool {
+    matches!(
+        status,
+        nix::sys::wait::WaitStatus::Exited(..) | nix::sys::wait::WaitStatus::Signaled(..)
+    )
+}
+
 /// Startup ownership of a not-yet-adopted child (#1585).
 ///
 /// Between `spawn` and readiness the launcher — not the process map — owns
@@ -252,21 +279,22 @@ impl StartupChildGuard {
 
     /// Synchronous cancellation backstop (the async reap is unavailable in
     /// `Drop`): SIGKILL the owned child and reap it within a bounded WNOHANG
-    /// budget. Returns whether termination/reap was OBSERVED.
-    ///
-    /// On `true` the owned child handle is released and the guarded artifact
-    /// removed. On `false` — kill failure, reap error, or budget exhaustion —
-    /// NOTHING is discarded: the retained child handle and artifact are the
-    /// failure evidence. Bounded best effort, not a guarantee.
-    fn backstop_cleanup(&mut self) -> bool {
-        let mut observed = false;
+    /// budget. Returns the observed [`BackstopOutcome`]; ownership is
+    /// released only when an explicit TERMINAL wait status (real exit or
+    /// kill signal — or the already-reaped `ECHILD`) is observed, and the
+    /// guarded artifact is removed only when that removal actually
+    /// succeeds. Every nonterminal wait state (still-alive, stopped,
+    /// continued, ptrace) stays inside the same bounded budget and never
+    /// establishes termination. Bounded best effort, not a guarantee.
+    fn backstop_cleanup(&mut self) -> BackstopOutcome {
+        let mut terminated = false;
         if let Some(child) = self.child.as_ref() {
             if let Some(pid) = child.id() {
                 let raw = nix::unistd::Pid::from_raw(pid as i32);
                 match nix::sys::signal::kill(raw, nix::sys::signal::Signal::SIGKILL) {
                     Err(nix::errno::Errno::ESRCH) => {
                         // The process is already gone; nothing to signal.
-                        observed = true;
+                        terminated = true;
                     }
                     Err(e) => {
                         tracing::warn!(
@@ -282,21 +310,28 @@ impl StartupChildGuard {
                                 raw,
                                 Some(nix::sys::wait::WaitPidFlag::WNOHANG),
                             ) {
-                                Ok(nix::sys::wait::WaitStatus::StillAlive) => {
+                                // Only an explicit terminal status — real
+                                // exit or kill signal — establishes the reap.
+                                Ok(status) if wait_status_is_terminal(&status) => {
+                                    terminated = true;
+                                    break;
+                                }
+                                // StillAlive AND nonterminal stopped/
+                                // continued/ptrace states: NOT termination;
+                                // keep waiting inside the same budget.
+                                Ok(_) => {
                                     if Instant::now() >= deadline {
                                         tracing::warn!(
                                             pid = %pid,
-                                            "reap backstop budget exhausted; child may linger as a zombie"
+                                            "reap backstop budget exhausted with a nonterminal status; child may linger"
                                         );
                                         break;
                                     }
                                     std::thread::sleep(Duration::from_millis(5));
                                 }
-                                // Exited/Signaled: reaped by this wait.
-                                // ECHILD: no longer our child (already
-                                // reaped) — gone either way.
-                                Ok(_) | Err(nix::errno::Errno::ECHILD) => {
-                                    observed = true;
+                                Err(nix::errno::Errno::ECHILD) => {
+                                    // No longer our child: already reaped.
+                                    terminated = true;
                                     break;
                                 }
                                 Err(e) => {
@@ -313,33 +348,58 @@ impl StartupChildGuard {
                 }
             }
         }
-        if observed {
-            self.child = None;
-            if let Some(path) = &self.pid_file {
-                let _ = std::fs::remove_file(path);
-            }
-            self.pid_file = None;
+        if !terminated {
+            return BackstopOutcome::Unconfirmed;
         }
-        observed
+        self.child = None;
+        let Some(path) = self.pid_file.take() else {
+            return BackstopOutcome::TerminatedAndCleaned;
+        };
+        match std::fs::remove_file(&path) {
+            // Removed — or already absent: the artifact is gone either way.
+            Ok(()) => BackstopOutcome::TerminatedAndCleaned,
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+                BackstopOutcome::TerminatedAndCleaned
+            }
+            Err(e) => {
+                tracing::warn!(
+                    name = %self.name,
+                    path = %path.display(),
+                    error = %e,
+                    "startup backstop could not remove the guarded artifact; retained on disk as evidence"
+                );
+                self.pid_file = Some(path);
+                BackstopOutcome::TerminatedArtifactKept
+            }
+        }
     }
 }
 
 impl Drop for StartupChildGuard {
     fn drop(&mut self) {
         if self.child.is_some() {
-            // Best effort within the budget: the limitation is real (a stuck
-            // child may outlive this backstop), and the log states what was
-            // actually observed — never success on failure.
-            if self.backstop_cleanup() {
-                tracing::warn!(
-                    name = %self.name,
-                    "startup guard dropped with the child still owned; killed, reaped, and cleaned up"
-                );
-            } else {
-                tracing::warn!(
-                    name = %self.name,
-                    "startup guard dropped without confirmed termination; owned artifact retained as evidence"
-                );
+            // Bounded best effort: each outcome is reported exactly as
+            // observed. The fields drop with this struct — no handle or
+            // cleanup survives an unsuccessful backstop.
+            match self.backstop_cleanup() {
+                BackstopOutcome::TerminatedAndCleaned => {
+                    tracing::warn!(
+                        name = %self.name,
+                        "startup guard dropped with the child still owned; terminated, reaped, and cleaned up"
+                    );
+                }
+                BackstopOutcome::TerminatedArtifactKept => {
+                    tracing::warn!(
+                        name = %self.name,
+                        "startup guard dropped: child terminated but artifact removal failed; artifact retained on disk as evidence"
+                    );
+                }
+                BackstopOutcome::Unconfirmed => {
+                    tracing::warn!(
+                        name = %self.name,
+                        "startup guard dropped without confirmed termination; owned artifact retained on disk as evidence; no cleanup guarantee beyond Drop"
+                    );
+                }
             }
         }
     }
@@ -1513,10 +1573,11 @@ mod notify_readiness_tests {
     }
 
     /// Startup-backstop decisions: OBSERVED termination cleans the owned
-    /// artifact; an unobservable outcome must RETAIN the artifact as
-    /// evidence and claim no success. The unobserved branch is exercised
-    /// through the deterministically inducible seam (a handle that yields
-    /// no PID) — no kernel kill failure is forced or claimed.
+    /// artifact (regular file and already-absent paths); an unobservable
+    /// outcome must RETAIN the artifact as evidence and claim no success.
+    /// The unobserved branch is exercised through the deterministically
+    /// inducible seam (a handle that yields no PID) — no kernel kill
+    /// failure is forced or claimed.
     #[tokio::test]
     async fn startup_backstop_cleanup_tracks_observed_termination() -> Result<()> {
         let dir = tempfile::tempdir()?;
@@ -1534,15 +1595,33 @@ mod notify_readiness_tests {
             name: "backstop-observed".to_owned(),
             pid_file: Some(artifact.clone()),
         };
-        assert!(
+        assert_eq!(
             guard.backstop_cleanup(),
-            "live-child backstop must observe termination"
+            BackstopOutcome::TerminatedAndCleaned,
+            "live-child backstop must observe termination and clean its artifact"
         );
         assert!(
             !artifact.exists(),
             "observed cleanup must remove the owned artifact"
         );
         assert_pid_gone(pid);
+
+        // Already-absent path: an armed artifact that does not exist is
+        // gone either way — still a clean, observed outcome.
+        let mut cmd = tokio::process::Command::new("/bin/sleep");
+        cmd.arg("30");
+        let child = cmd.spawn().expect("sleep child");
+        let mut guard = StartupChildGuard {
+            child: Some(child),
+            name: "backstop-absent".to_owned(),
+            pid_file: Some(dir.path().join("never-written.pid")),
+        };
+        assert_eq!(
+            guard.backstop_cleanup(),
+            BackstopOutcome::TerminatedAndCleaned,
+            "a NotFound artifact must not downgrade the observed outcome"
+        );
+        assert!(!guard.pid_file.is_some(), "armed path must be cleared");
 
         // Unobserved path: the handle yields no PID, so the backstop cannot
         // observe anything and must not claim cleanup.
@@ -1556,8 +1635,9 @@ mod notify_readiness_tests {
             name: "backstop-unobserved".to_owned(),
             pid_file: Some(artifact.clone()),
         };
-        assert!(
-            !guard.backstop_cleanup(),
+        assert_eq!(
+            guard.backstop_cleanup(),
+            BackstopOutcome::Unconfirmed,
             "an unobservable outcome must not claim cleanup"
         );
         assert!(
@@ -1565,6 +1645,68 @@ mod notify_readiness_tests {
             "unobserved backstop must retain the owned artifact as evidence"
         );
         Ok(())
+    }
+
+    /// Termination and artifact cleanup are separate observed facts: a
+    /// live child is terminated and reaped, but an artifact that cannot be
+    /// unlinked (a directory squats the armed path) must be reported as
+    /// `TerminatedArtifactKept` and RETAINED on disk — never as a
+    /// cleaned-up success.
+    #[tokio::test]
+    async fn startup_backstop_distinguishes_termination_from_failed_cleanup() -> Result<()> {
+        let dir = tempfile::tempdir()?;
+        // A DIRECTORY at the armed path: remove_file fails with EISDIR
+        // (not NotFound) even after the child is genuinely reaped.
+        let squat = dir.path().join("owned.pid");
+        std::fs::create_dir(&squat)?;
+
+        let mut cmd = tokio::process::Command::new("/bin/sleep");
+        cmd.arg("30");
+        let child = cmd.spawn().expect("sleep child");
+        let pid = child.id().expect("live pid");
+        let mut guard = StartupChildGuard {
+            child: Some(child),
+            name: "backstop-kept".to_owned(),
+            pid_file: Some(squat.clone()),
+        };
+        assert_eq!(
+            guard.backstop_cleanup(),
+            BackstopOutcome::TerminatedArtifactKept,
+            "failed artifact removal must be reported separately from termination"
+        );
+        // Termination was observed (reaped) AND the artifact is retained.
+        assert_pid_gone(pid);
+        assert!(
+            squat.is_dir(),
+            "the failed-removal artifact must be retained on disk as evidence"
+        );
+        std::fs::remove_dir(&squat)?;
+        Ok(())
+    }
+
+    /// Narrow classification-helper coverage, honestly labelled: the real
+    /// OS cannot deterministically present a nonterminal wait status under
+    /// WNOHANG after SIGKILL, so this proves only that the classifier
+    /// accepts exactly Exited/Signaled and rejects still-alive, stopped,
+    /// and continued states.
+    #[test]
+    fn wait_status_classification_accepts_only_terminal_statuses() {
+        use nix::sys::signal::Signal;
+        use nix::sys::wait::WaitStatus;
+
+        let pid = nix::unistd::Pid::from_raw(1);
+        assert!(wait_status_is_terminal(&WaitStatus::Exited(pid, 0)));
+        assert!(wait_status_is_terminal(&WaitStatus::Signaled(
+            pid,
+            Signal::SIGKILL,
+            false
+        )));
+        assert!(!wait_status_is_terminal(&WaitStatus::StillAlive));
+        assert!(!wait_status_is_terminal(&WaitStatus::Stopped(
+            pid,
+            Signal::SIGSTOP
+        )));
+        assert!(!wait_status_is_terminal(&WaitStatus::Continued(pid)));
     }
 
     /// UNIT-LEVEL duplicate controls (manual lock hold / manual witness; the

--- a/crates/hyprstream-service/src/service/spawner/standalone.rs
+++ b/crates/hyprstream-service/src/service/spawner/standalone.rs
@@ -2331,7 +2331,10 @@ mod notify_refusal_non_linux_tests {
         );
 
         // Observed boundary: the sentinel never ran, no PID artifact was
-        // published, and no per-launch notify runtime directory exists.
+        // published, and no per-launch notify runtime directory exists. An
+        // ABSENT runtime directory is itself a valid refusal state (nothing
+        // created it): only ErrorKind::NotFound is treated as absence; every
+        // other read/entry error propagates.
         assert!(
             !marker.exists(),
             "the sentinel child must not have been spawned by the refused Notify request"
@@ -2340,14 +2343,20 @@ mod notify_refusal_non_linux_tests {
             !pid_file.exists(),
             "a refused Notify request must not publish a PID artifact"
         );
-        for entry in std::fs::read_dir(hyprstream_rpc::paths::runtime_dir())? {
-            let entry = entry?;
-            let file_name = entry.file_name().to_string_lossy().to_string();
-            assert!(
-                !file_name.starts_with(&dir_prefix),
-                "a refused Notify request must not create a notify runtime directory, \
-                 found {file_name}"
-            );
+        match std::fs::read_dir(hyprstream_rpc::paths::runtime_dir()) {
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
+            Err(e) => return Err(e.into()),
+            Ok(entries) => {
+                for entry in entries {
+                    let entry = entry?;
+                    let file_name = entry.file_name().to_string_lossy().to_string();
+                    assert!(
+                        !file_name.starts_with(&dir_prefix),
+                        "a refused Notify request must not create a notify runtime \
+                         directory, found {file_name}"
+                    );
+                }
+            }
         }
         Ok(())
     }

--- a/crates/hyprstream-service/src/service/spawner/standalone.rs
+++ b/crates/hyprstream-service/src/service/spawner/standalone.rs
@@ -39,14 +39,13 @@ use hyprstream_rpc::error::{Result, RpcError};
 fn detached_output_stdio() -> std::io::Result<Stdio> {
     #[cfg(unix)]
     {
-        use nix::fcntl::OFlag;
         use std::os::fd::RawFd;
 
         // CLOEXEC keeps the drain reader out of the adopted daemon. Fork a
         // tiny in-process reader instead of invoking an external `cat`: the
         // official runtime image contains only `/hyprstream`, and the drain
         // must continue after this launcher exits.
-        let (reader, writer) = nix::unistd::pipe2(OFlag::O_CLOEXEC)?;
+        let (reader, writer) = cloexec_pipe()?;
         let drain_pid = unsafe { nix::libc::fork() };
         match drain_pid {
             -1 => {
@@ -107,6 +106,60 @@ fn detached_output_stdio() -> std::io::Result<Stdio> {
     #[cfg(not(unix))]
     {
         Ok(Stdio::null())
+    }
+}
+
+/// Create a pipe whose descriptors are excluded from an adopted daemon after
+/// exec. `nix::unistd::pipe2` is unavailable on Apple targets in nix 0.27.1,
+/// so use the POSIX pipe plus `FD_CLOEXEC` fallback there while retaining the
+/// atomic `pipe2(O_CLOEXEC)` path on platforms that provide it.
+#[cfg(unix)]
+fn cloexec_pipe() -> std::io::Result<(std::os::fd::RawFd, std::os::fd::RawFd)> {
+    #[cfg(any(
+        target_os = "android",
+        target_os = "dragonfly",
+        target_os = "emscripten",
+        target_os = "freebsd",
+        target_os = "illumos",
+        target_os = "linux",
+        target_os = "redox",
+        target_os = "netbsd",
+        target_os = "openbsd",
+        target_os = "solaris"
+    ))]
+    {
+        Ok(nix::unistd::pipe2(nix::fcntl::OFlag::O_CLOEXEC)?)
+    }
+
+    #[cfg(not(any(
+        target_os = "android",
+        target_os = "dragonfly",
+        target_os = "emscripten",
+        target_os = "freebsd",
+        target_os = "illumos",
+        target_os = "linux",
+        target_os = "redox",
+        target_os = "netbsd",
+        target_os = "openbsd",
+        target_os = "solaris"
+    )))]
+    {
+        let (reader, writer) = nix::unistd::pipe()?;
+        for fd in [reader, writer] {
+            let flags = unsafe { nix::libc::fcntl(fd, nix::libc::F_GETFD) };
+            if flags == -1
+                || unsafe {
+                    nix::libc::fcntl(fd, nix::libc::F_SETFD, flags | nix::libc::FD_CLOEXEC)
+                } == -1
+            {
+                unsafe {
+                    nix::libc::close(reader);
+                    nix::libc::close(writer);
+                }
+                return Err(std::io::Error::last_os_error());
+            }
+        }
+        Ok((reader, writer))
     }
 }
 
@@ -1584,6 +1637,24 @@ mod tests {
     fn test_backend_type() {
         let backend = StandaloneBackend::new();
         assert_eq!(backend.backend_type(), "standalone");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn detached_output_pipe_is_close_on_exec() -> anyhow::Result<()> {
+        let (reader, writer) = cloexec_pipe()?;
+        let flags = [reader, writer]
+            .into_iter()
+            .map(|fd| unsafe { nix::libc::fcntl(fd, nix::libc::F_GETFD) })
+            .collect::<Vec<_>>();
+        unsafe {
+            nix::libc::close(reader);
+            nix::libc::close(writer);
+        }
+        assert!(flags.iter().all(|flags| {
+            *flags >= 0 && *flags & nix::libc::FD_CLOEXEC != 0
+        }));
+        Ok(())
     }
 }
 

--- a/crates/hyprstream-service/src/service/spawner/standalone.rs
+++ b/crates/hyprstream-service/src/service/spawner/standalone.rs
@@ -20,8 +20,6 @@ use std::os::fd::{AsRawFd, OwnedFd};
 #[cfg(unix)]
 use std::os::fd::FromRawFd;
 use std::process::Stdio;
-#[cfg(unix)]
-use std::process::Command as StdCommand;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 #[cfg(any(target_os = "linux", target_os = "android"))]
@@ -42,18 +40,56 @@ fn detached_output_stdio() -> std::io::Result<Stdio> {
     #[cfg(unix)]
     {
         use nix::fcntl::OFlag;
-        // CLOEXEC keeps the sink reader out of the adopted daemon. The sink
-        // process itself owns the reader and survives launcher exit, so a
-        // daemon can write indefinitely without filling an undrained pipe.
+        use std::os::fd::RawFd;
+
+        // CLOEXEC keeps the drain reader out of the adopted daemon. Fork a
+        // tiny in-process reader instead of invoking an external `cat`: the
+        // official runtime image contains only `/hyprstream`, and the drain
+        // must continue after this launcher exits.
         let (reader, writer) = nix::unistd::pipe2(OFlag::O_CLOEXEC)?;
-        let reader = unsafe { std::fs::File::from_raw_fd(reader) };
-        let writer = unsafe { std::fs::File::from_raw_fd(writer) };
-        StdCommand::new("cat")
-            .stdin(Stdio::from(reader))
-            .stdout(Stdio::null())
-            .stderr(Stdio::null())
-            .spawn()?;
-        Ok(Stdio::from(writer))
+        let drain_pid = unsafe { nix::libc::fork() };
+        match drain_pid {
+            -1 => {
+                unsafe {
+                    nix::libc::close(reader);
+                    nix::libc::close(writer);
+                }
+                Err(std::io::Error::last_os_error())
+            }
+            0 => {
+                // After fork, use only async-signal-safe libc calls. The
+                // child owns the reader and discards bytes until EOF; it
+                // never inherits the writer, so EOF is well-defined.
+                unsafe {
+                    nix::libc::close(writer);
+                    let mut buffer = [0u8; 8192];
+                    loop {
+                        let read = nix::libc::read(
+                            reader,
+                            buffer.as_mut_ptr().cast(),
+                            buffer.len(),
+                        );
+                        if read <= 0 {
+                            break;
+                        }
+                    }
+                    nix::libc::close(reader);
+                    nix::libc::_exit(0);
+                }
+            }
+            pid => {
+                unsafe { nix::libc::close(reader) };
+                // Reap the helper while this launcher remains alive. If the
+                // launcher exits first, init adopts and reaps the helper.
+                let _ = std::thread::Builder::new()
+                    .name("hyprstream-daemon-stdio-reaper".to_owned())
+                    .spawn(move || unsafe {
+                        nix::libc::waitpid(pid, std::ptr::null_mut(), 0);
+                    });
+                let writer = unsafe { std::fs::File::from_raw_fd(writer as RawFd) };
+                Ok(Stdio::from(writer))
+            }
+        }
     }
     #[cfg(not(unix))]
     {

--- a/crates/hyprstream-service/src/service/spawner/standalone.rs
+++ b/crates/hyprstream-service/src/service/spawner/standalone.rs
@@ -17,6 +17,9 @@
 // Immediate path and the stop/cleanup helpers use stays portable.
 #[cfg(any(target_os = "linux", target_os = "android"))]
 use std::os::fd::{AsRawFd, OwnedFd};
+#[cfg(unix)]
+use std::os::fd::FromRawFd;
+use std::process::Stdio;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 #[cfg(any(target_os = "linux", target_os = "android"))]
@@ -28,6 +31,38 @@ use tokio::sync::Mutex;
 
 use super::{ProcessConfig, ProcessKind, ProcessReadiness, SpawnedProcess, SpawnerBackend};
 use hyprstream_rpc::error::{Result, RpcError};
+
+/// Give adopted daemons independent, pollable standard streams while draining
+/// them in the launcher. PGlite registers stdout with epoll, so `/dev/null`
+/// is not a safe sink on Linux; a pipe preserves pollability and prevents the
+/// launcher's stdout/stderr or SSH channel from being held open by the child.
+fn detached_stdio() -> std::io::Result<Stdio> {
+    #[cfg(unix)]
+    {
+        let (reader, writer) = nix::unistd::pipe()?;
+        let reader = unsafe { std::fs::File::from_raw_fd(reader) };
+        let writer = unsafe { std::fs::File::from_raw_fd(writer) };
+        std::thread::Builder::new()
+            .name("hyprstream-daemon-stdio-drain".to_owned())
+            .spawn(move || {
+                let mut reader = reader;
+                let mut sink = std::io::sink();
+                let _ = std::io::copy(&mut reader, &mut sink);
+            })?;
+        Ok(Stdio::from(writer))
+    }
+    #[cfg(not(unix))]
+    {
+        Ok(Stdio::null())
+    }
+}
+
+fn configure_detached_stdio(cmd: &mut Command) -> std::io::Result<()> {
+    cmd.stdin(detached_stdio()?)
+        .stdout(detached_stdio()?)
+        .stderr(detached_stdio()?);
+    Ok(())
+}
 
 /// One per-child sd_notify endpoint in the Linux/Android abstract namespace.
 ///
@@ -123,39 +158,46 @@ impl ChildNotifySocket {
         use std::io::IoSliceMut;
 
         let mut buffer = [0u8; 128];
-        // Scope the recvmsg borrows: `message` holds the iov/cmsg borrows, so
-        // extract what we need before touching the payload buffer again.
-        let (bytes, sender_pid) = {
-            let mut iov = [IoSliceMut::new(&mut buffer)];
-            let mut cmsg = cmsg_space!(UnixCredentials);
-            let message = match recvmsg::<UnixAddr>(
-                self.fd.as_raw_fd(),
-                &mut iov,
-                Some(&mut cmsg),
-                MsgFlags::empty(),
-            ) {
-                Ok(message) => message,
-                Err(nix::errno::Errno::EAGAIN) => return Ok(false),
-                Err(e) => {
-                    return Err(RpcError::SpawnFailed(format!("notify recv failed: {e}")))
-                }
+        // Drain the complete nonblocking queue in one poll. A foreign sender
+        // must never be able to keep the genuine child's READY=1 datagram
+        // behind a sustained backlog; only the exact child PID can succeed.
+        loop {
+            // Scope the recvmsg borrows: `message` holds the iov/cmsg borrows,
+            // so extract what we need before touching the payload buffer again.
+            let (bytes, sender_pid) = {
+                let mut iov = [IoSliceMut::new(&mut buffer)];
+                let mut cmsg = cmsg_space!(UnixCredentials);
+                let message = match recvmsg::<UnixAddr>(
+                    self.fd.as_raw_fd(),
+                    &mut iov,
+                    Some(&mut cmsg),
+                    MsgFlags::empty(),
+                ) {
+                    Ok(message) => message,
+                    Err(nix::errno::Errno::EAGAIN) => return Ok(false),
+                    Err(e) => {
+                        return Err(RpcError::SpawnFailed(format!("notify recv failed: {e}")))
+                    }
+                };
+                let sender_pid = message.cmsgs().find_map(|cmsg| match cmsg {
+                    ControlMessageOwned::ScmCredentials(creds) => Some(creds.pid()),
+                    _ => None,
+                });
+                (message.bytes, sender_pid)
             };
-            let sender_pid = message.cmsgs().find_map(|cmsg| match cmsg {
-                ControlMessageOwned::ScmCredentials(creds) => Some(creds.pid()),
-                _ => None,
-            });
-            (message.bytes, sender_pid)
-        };
 
-        if sender_pid != Some(child_pid) {
-            tracing::warn!(
-                sender = ?sender_pid,
-                expected = child_pid,
-                "ignoring readiness datagram from a process other than the spawned child"
-            );
-            return Ok(false);
+            if sender_pid != Some(child_pid) {
+                tracing::warn!(
+                    sender = ?sender_pid,
+                    expected = child_pid,
+                    "ignoring readiness datagram from a process other than the spawned child"
+                );
+                continue;
+            }
+            if bytes > 0 && buffer[..bytes] == *b"READY=1" {
+                return Ok(true);
+            }
         }
-        Ok(bytes > 0 && buffer[..bytes] == *b"READY=1")
     }
 }
 
@@ -432,6 +474,9 @@ impl StandaloneBackend {
         }
 
         // Disable kill on drop - daemon processes should outlive the spawner
+        configure_detached_stdio(&mut cmd).map_err(|e| {
+            RpcError::SpawnFailed(format!("failed to detach {} standard streams: {e}", config.name))
+        })?;
         cmd.kill_on_drop(false);
 
         // Spawn the process
@@ -545,6 +590,9 @@ impl StandaloneBackend {
         // The child learns its notification endpoint only through its own
         // environment; the launcher's environment is untouched.
         cmd.env("NOTIFY_SOCKET", notify.endpoint());
+        configure_detached_stdio(&mut cmd).map_err(|e| {
+            RpcError::SpawnFailed(format!("failed to detach {} standard streams: {e}", config.name))
+        })?;
         cmd.kill_on_drop(false);
 
         let child = cmd.spawn().map_err(|e| {
@@ -2379,17 +2427,16 @@ mod notify_readiness_tests {
     #[tokio::test]
     async fn notify_socket_rejects_spoofed_sender() -> anyhow::Result<()> {
         let notify = ChildNotifySocket::bind("spoof-probe")?;
-        // First datagram: sent by THIS test process but checked against a
-        // different expected PID — the refusal must consume it without
-        // satisfying readiness.
-        send_ready_to(notify.endpoint())?;
         let this_pid = std::process::id() as i32;
-        std::thread::sleep(Duration::from_millis(50));
-        assert!(
-            !notify.try_recv_ready(this_pid.wrapping_add(1013))?,
-            "a foreign sender must not satisfy readiness"
-        );
-        // Second datagram, checked against the actual sender PID: accepted.
+        // A sustained foreign queue must be drained in one poll so it cannot
+        // hide the genuine sender's datagram behind the 20ms readiness tick.
+        let endpoint = notify.endpoint().to_owned();
+        let flooding = std::thread::spawn(move || {
+            for _ in 0..128 {
+                let _ = send_ready_to(&endpoint);
+            }
+        });
+        flooding.join().expect("spoof flood sender thread");
         send_ready_to(notify.endpoint())?;
         std::thread::sleep(Duration::from_millis(50));
         assert!(

--- a/crates/hyprstream-service/src/service/spawner/standalone.rs
+++ b/crates/hyprstream-service/src/service/spawner/standalone.rs
@@ -162,10 +162,13 @@ impl ChildNotifySocket {
         use std::io::IoSliceMut;
 
         let mut buffer = [0u8; 128];
-        // Drain the complete nonblocking queue in one poll. A foreign sender
-        // must never be able to keep the genuine child's READY=1 datagram
-        // behind a sustained backlog; only the exact child PID can succeed.
-        loop {
+        // Drain a bounded batch of the nonblocking queue in one poll. A
+        // foreign sender must not be able to keep the readiness loop from
+        // returning to its child-exit/deadline checks by keeping the queue
+        // perpetually nonempty. Subsequent polls continue draining, so a
+        // genuine READY behind a finite spoof backlog is still observed.
+        const MAX_DATAGRAMS_PER_POLL: usize = 256;
+        for _ in 0..MAX_DATAGRAMS_PER_POLL {
             // Scope the recvmsg borrows: `message` holds the iov/cmsg borrows,
             // so extract what we need before touching the payload buffer again.
             let (bytes, sender_pid) = {
@@ -202,6 +205,7 @@ impl ChildNotifySocket {
                 return Ok(true);
             }
         }
+        Ok(false)
     }
 }
 

--- a/crates/hyprstream-service/src/service/spawner/standalone.rs
+++ b/crates/hyprstream-service/src/service/spawner/standalone.rs
@@ -5,10 +5,22 @@
 //! ownership of every child until termination is confirmed; children are
 //! spawned with `kill_on_drop(false)` ON PURPOSE — adopted daemons are
 //! intended to outlive the launcher.
+//!
+//! Platform support: the credential-authenticated notification receiver
+//! (`SO_PASSCRED`/`SCM_CREDENTIALS`, exact child-PID matching) exists on
+//! Linux/Android only. Other targets refuse a supervised Notify request
+//! before any launch side effect; `Immediate` launches are unchanged
+//! everywhere.
 
+// The credential-authenticated notification receiver is Linux/Android-only
+// (see `ChildNotifySocket`); its imports are gated with it. Everything the
+// Immediate path and the stop/cleanup helpers use stays portable.
+#[cfg(any(target_os = "linux", target_os = "android"))]
 use std::os::fd::{AsRawFd, OwnedFd};
 use std::sync::Arc;
-use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
+use std::time::{Duration, Instant};
+#[cfg(any(target_os = "linux", target_os = "android"))]
+use std::time::{SystemTime, UNIX_EPOCH};
 
 use dashmap::DashMap;
 use tokio::process::{Child, Command};
@@ -24,11 +36,22 @@ use hyprstream_rpc::error::{Result, RpcError};
 /// (via `SO_PASSCRED` sender credentials). This is local lifecycle
 /// supervision, not a service RPC endpoint — nothing dials it and no service
 /// traffic flows through it.
+///
+/// Platform support: the credential combination this receiver is built on —
+/// `SO_PASSCRED` plus `SCM_CREDENTIALS` for kernel-attested sender-PID
+/// matching — is Linux/Android-specific in pinned `nix 0.27.1`, so the
+/// authenticated receiver as implemented requires those targets. (The
+/// datagram creation flags themselves are available on several other Unix
+/// targets; the boundary is the credential contract, not the flags.) Other
+/// platforms refuse supervised Notify launches pre-spawn (see
+/// `spawn_notified`) instead of weakening the sender-PID check.
+#[cfg(any(target_os = "linux", target_os = "android"))]
 struct ChildNotifySocket {
     fd: OwnedFd,
     path: std::path::PathBuf,
 }
 
+#[cfg(any(target_os = "linux", target_os = "android"))]
 impl ChildNotifySocket {
     fn bind(name: &str) -> Result<Self> {
         // Per-attempt private directory, created EXCLUSIVELY (no
@@ -184,6 +207,7 @@ impl ChildNotifySocket {
     }
 }
 
+#[cfg(any(target_os = "linux", target_os = "android"))]
 impl Drop for ChildNotifySocket {
     fn drop(&mut self) {
         // OwnedFd closes the descriptor itself; remove the socket inode and
@@ -196,6 +220,7 @@ impl Drop for ChildNotifySocket {
     }
 }
 
+#[cfg(any(target_os = "linux", target_os = "android"))]
 /// What the synchronous startup backstop actually observed and did.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum BackstopOutcome {
@@ -212,6 +237,7 @@ enum BackstopOutcome {
     Unconfirmed,
 }
 
+#[cfg(any(target_os = "linux", target_os = "android"))]
 /// Terminal-status classification for backstop outcome purposes: only a
 /// real exit or kill signal establishes disappearance. StillAlive,
 /// stopped, continued, and ptrace states are nonterminal and never
@@ -223,6 +249,7 @@ fn wait_status_is_terminal(status: &nix::sys::wait::WaitStatus) -> bool {
     )
 }
 
+#[cfg(any(target_os = "linux", target_os = "android"))]
 /// Startup ownership of a not-yet-adopted child (#1585).
 ///
 /// Between `spawn` and readiness the launcher — not the process map — owns
@@ -238,6 +265,7 @@ struct StartupChildGuard {
     pid_file: Option<std::path::PathBuf>,
 }
 
+#[cfg(any(target_os = "linux", target_os = "android"))]
 impl StartupChildGuard {
     /// Kill and reap the owned child, honestly reporting every failure.
     ///
@@ -375,6 +403,7 @@ impl StartupChildGuard {
     }
 }
 
+#[cfg(any(target_os = "linux", target_os = "android"))]
 impl Drop for StartupChildGuard {
     fn drop(&mut self) {
         if self.child.is_some() {
@@ -507,6 +536,14 @@ impl StandaloneBackend {
     /// the child's own `READY=1` datagram arrives from the child's PID; a
     /// child exit or the hard timeout fails the spawn, the child is
     /// terminated/reaped, and no PID/notify artifact survives.
+    ///
+    /// Platform support: the credential-authenticated receiver
+    /// (`SO_PASSCRED`/`SCM_CREDENTIALS`, exact child-PID matching) exists on
+    /// Linux/Android only. On any other target this request fails closed
+    /// BEFORE spawning the child or creating the notification directory, PID
+    /// artifact, or any other launch side effect — there is no fallback to
+    /// `Immediate` readiness and no unauthenticated receiver.
+    #[cfg(any(target_os = "linux", target_os = "android"))]
     async fn spawn_notified(
         &self,
         config: ProcessConfig,
@@ -765,7 +802,28 @@ impl StandaloneBackend {
             .with_pid_file(pid_file))
     }
 
+    /// Non-Linux arm of the Notify-supervised path: an explicit pre-spawn
+    /// refusal (see the Linux/Android arm's contract above). Nothing is
+    /// spawned and no notification directory, child guard, or PID artifact is
+    /// created; there is deliberately no fallback to `Immediate` readiness,
+    /// because a supervised launch whose sender cannot be kernel-attested
+    /// must not report success from an unauthenticated payload.
+    #[cfg(not(any(target_os = "linux", target_os = "android")))]
+    async fn spawn_notified(
+        &self,
+        _config: ProcessConfig,
+        _timeout: Duration,
+    ) -> Result<SpawnedProcess> {
+        Err(RpcError::SpawnFailed(
+            "authenticated notification readiness (SO_PASSCRED/SCM_CREDENTIALS) is \
+             supported on Linux/Android only; a supervised Notify launch is refused \
+             on this platform"
+                .to_owned(),
+        ))
+    }
+
     /// Poll the notification endpoint against child exit and the hard timeout.
+    #[cfg(any(target_os = "linux", target_os = "android"))]
     async fn await_child_readiness(
         &self,
         child: &mut Child,
@@ -842,6 +900,9 @@ fn process_is_zombie(_pid: i32) -> bool {
 
 /// Format an optional cleanup failure onto a startup error: a cleanup that
 /// itself failed is part of the failure report, never discarded.
+/// Rollback-failure suffix for spawn error messages (used by the
+/// Linux/Android supervised Notify arm only).
+#[cfg(any(target_os = "linux", target_os = "android"))]
 fn cleanup_suffix(cleanup: std::result::Result<(), String>) -> String {
     match cleanup {
         Ok(()) => String::new(),
@@ -852,6 +913,7 @@ fn cleanup_suffix(cleanup: std::result::Result<(), String>) -> String {
 /// Outcome of inspecting an existing PID artifact before a launch. Anything
 /// other than a confirmed-missing or confirmed-dead predecessor is ambiguous
 /// and must fail closed: only a verified missing/dead witness may be replaced.
+#[cfg(any(target_os = "linux", target_os = "android"))]
 enum PidWitness {
     /// No artifact: nothing to refuse, nothing to preserve.
     Absent,
@@ -864,6 +926,9 @@ enum PidWitness {
     Ambiguous(String),
 }
 
+/// Inspect an existing PID artifact into a [`PidWitness`] (Linux/Android;
+/// used by the supervised Notify precheck).
+#[cfg(any(target_os = "linux", target_os = "android"))]
 fn inspect_pid_file(path: &std::path::Path) -> PidWitness {
     match std::fs::read_to_string(path) {
         Err(e) if e.kind() == std::io::ErrorKind::NotFound => PidWitness::Absent,
@@ -1103,6 +1168,7 @@ fn finish_pid_artifact_sync(
     }
 }
 
+#[cfg(any(target_os = "linux", target_os = "android"))]
 /// Per-service nonblocking advisory lock for notified launches (#1585).
 ///
 /// The lock file has a STABLE path (and thus stable inode) and is NEVER
@@ -1123,6 +1189,7 @@ struct ServiceLaunchLock {
     _file: std::fs::File,
 }
 
+#[cfg(any(target_os = "linux", target_os = "android"))]
 impl Drop for ServiceLaunchLock {
     fn drop(&mut self) {
         use nix::fcntl::{flock, FlockArg};
@@ -1146,6 +1213,7 @@ impl Drop for ServiceLaunchLock {
     }
 }
 
+#[cfg(any(target_os = "linux", target_os = "android"))]
 impl ServiceLaunchLock {
     fn acquire(service: &str) -> Result<Self> {
         use nix::fcntl::{flock, FlockArg};
@@ -1425,6 +1493,14 @@ mod tests {
     }
 }
 
+/// Linux/Android-only coverage of the credential-authenticated receiver:
+/// positive readiness, foreign-PID rejection, timeout/early-exit rollback,
+/// spoofed-sender refusal, and the launcher-side cancellation/rollback
+/// ownership regressions that exercise the supervised Notify path end to
+/// end. These tests RUN on Linux/Android — the cfg only removes them from
+/// non-Linux builds, where the supervised Notify path itself is refused
+/// pre-spawn.
+#[cfg(any(target_os = "linux", target_os = "android"))]
 #[cfg(test)]
 mod notify_readiness_tests {
     #![allow(clippy::expect_used, clippy::unwrap_used)]
@@ -2178,6 +2254,101 @@ mod notify_readiness_tests {
             notify.try_recv_ready(this_pid)?,
             "the matching sender satisfies readiness"
         );
+        Ok(())
+    }
+}
+
+/// Non-Linux targets only: the supervised Notify request must be refused
+/// before any launch side effect. The configured child is an executable
+/// sentinel — it would write a marker file if it were ever spawned — so
+/// marker, PID-artifact, and notify-runtime-directory absence at the checked
+/// points evidence the boundary. This cfg cannot run on Linux lanes; it
+/// exists for actual non-Linux targets and makes no claim about them from
+/// Linux runs.
+#[cfg(all(
+    unix,
+    not(any(target_os = "linux", target_os = "android")),
+    test
+))]
+mod notify_refusal_non_linux_tests {
+    #![allow(clippy::expect_used, clippy::unwrap_used)]
+
+    use super::*;
+    use crate::service::spawner::ProcessSpawner;
+
+    const REFUSED_SENTINEL: &str = "HYPRSTREAM_NOTIFY_REFUSED_SENTINEL";
+
+    /// A Notify request on an unsupported platform is refused pre-spawn by
+    /// the explicit unsupported branch in `spawn_notified` — that branch
+    /// returns before any launch operation, which is the production
+    /// guarantee. This test observes that boundary: the executable sentinel
+    /// was not observed running, no PID artifact was published, and no
+    /// per-launch notify runtime directory appeared at the checked points.
+    #[tokio::test]
+    async fn notify_request_refused_before_any_launch_side_effect() -> anyhow::Result<()> {
+        if let Some(path) = std::env::var_os(REFUSED_SENTINEL) {
+            // Unreachable if the boundary holds: the refusal must fire before
+            // any child exists.
+            std::fs::write(&path, std::process::id().to_string())?;
+            return Ok(());
+        }
+
+        let exe = std::env::current_exe()?;
+        let dir = tempfile::tempdir()?;
+        let marker = dir.path().join("sentinel.marker");
+        // Unique per-run service name: unrelated runtime artifacts cannot
+        // decide the result, and nothing existing is overwritten or removed.
+        let name = format!("notify-refused-{}", nix::unistd::getpid());
+        let pid_file = hyprstream_rpc::paths::service_pid_file(&name);
+        let dir_prefix = format!("notify-{name}-");
+
+        let spawner = ProcessSpawner::standalone();
+        let error = match spawner
+            .spawn(
+                ProcessConfig::new(&name, &exe)
+                    .args([
+                        "--exact",
+                        "service::spawner::standalone::notify_refusal_non_linux_tests::notify_request_refused_before_any_launch_side_effect",
+                        "--nocapture",
+                    ])
+                    .env(REFUSED_SENTINEL, marker.display().to_string())
+                    .with_notify_ready(std::time::Duration::from_secs(30)),
+            )
+            .await
+        {
+            Ok(process) => {
+                panic!(
+                    "Notify must be refused on non-Linux targets; spawned pid {:?}",
+                    process.pid()
+                );
+            }
+            Err(error) => error,
+        };
+        let message = error.to_string();
+        assert!(
+            message.contains("Linux/Android"),
+            "refusal must name the platform boundary, got: {message}"
+        );
+
+        // Observed boundary: the sentinel never ran, no PID artifact was
+        // published, and no per-launch notify runtime directory exists.
+        assert!(
+            !marker.exists(),
+            "the sentinel child must not have been spawned by the refused Notify request"
+        );
+        assert!(
+            !pid_file.exists(),
+            "a refused Notify request must not publish a PID artifact"
+        );
+        for entry in std::fs::read_dir(hyprstream_rpc::paths::runtime_dir())? {
+            let entry = entry?;
+            let file_name = entry.file_name().to_string_lossy().to_string();
+            assert!(
+                !file_name.starts_with(&dir_prefix),
+                "a refused Notify request must not create a notify runtime directory, \
+                 found {file_name}"
+            );
+        }
         Ok(())
     }
 }

--- a/crates/hyprstream-service/src/service/spawner/systemd.rs
+++ b/crates/hyprstream-service/src/service/spawner/systemd.rs
@@ -21,7 +21,7 @@ use std::process::Stdio;
 use tokio::process::Command;
 use uuid::Uuid;
 
-use super::{ProcessConfig, ProcessKind, SpawnedProcess, SpawnerBackend};
+use super::{ProcessConfig, ProcessKind, ProcessReadiness, SpawnedProcess, SpawnerBackend};
 use hyprstream_rpc::error::{Result, RpcError};
 
 /// Systemd spawner backend using transient units.
@@ -154,6 +154,14 @@ impl Default for SystemdBackend {
 #[async_trait::async_trait]
 impl SpawnerBackend for SystemdBackend {
     async fn spawn(&self, config: ProcessConfig) -> Result<SpawnedProcess> {
+        // Notification readiness is a standalone-supervision contract (#1585);
+        // transient systemd-run units are not the launcher's path and get no
+        // half-wired imitation of it.
+        if config.readiness != ProcessReadiness::Immediate {
+            return Err(RpcError::InvalidOperation(
+                "notification readiness is only supported by the standalone spawner".to_owned(),
+            ));
+        }
         let unit_name = self.generate_unit_name(&config.name);
 
         tracing::debug!(

--- a/crates/hyprstream/src/auth/identity_store.rs
+++ b/crates/hyprstream/src/auth/identity_store.rs
@@ -522,6 +522,34 @@ pub fn load_service_jwt_for_profile(
     }
 }
 
+/// Seed a provisioned service JWT under the key selected by startup.
+///
+/// Service factories first consult the process trust store. Keeping this
+/// bridge beside the profile-aware loader lets a caller that already resolved
+/// a custom config path carry the authoritative JWT into a factory that has no
+/// config handle of its own.
+pub fn seed_service_jwt_into_trust_store(
+    service_name: &str,
+    signing_key: &SigningKey,
+    credentials_dir: &std::path::Path,
+    profile: SecretsProfile,
+) {
+    if let Ok(Some(jwt_str)) = load_service_jwt_for_profile(credentials_dir, service_name, profile) {
+        let expires_at = decode_jwt_exp_raw(&jwt_str).unwrap_or(0);
+        hyprstream_service::global_trust_store().insert(
+            signing_key.verifying_key(),
+            hyprstream_service::Attestation {
+                scopes: std::iter::once(service_name.to_owned()).collect(),
+                subject: None,
+                jwt: Some(jwt_str),
+                expires_at,
+                attested_by: None,
+            },
+        );
+        tracing::info!(service = %service_name, "Seeded trust store with own service-jwt from credential dir");
+    }
+}
+
 /// Persist a service JWT using the same profile-aware path startup reads.
 pub fn write_service_jwt_for_profile(
     credentials_dir: &std::path::Path,

--- a/crates/hyprstream/src/bin/main.rs
+++ b/crates/hyprstream/src/bin/main.rs
@@ -3737,6 +3737,9 @@ fn main() -> Result<()> {
                                     &ctx,
                                     ctx.signing_key(),
                                     service_names.iter().any(|n| n == "policy"),
+                                    ctx.iroh_required()
+                                        && service_names.len() == 1
+                                        && service_names.first().is_some_and(|n| n == "discovery"),
                                 )
                                 .await
                                 .context("revocation/session authority initialization failed")?;

--- a/crates/hyprstream/src/bin/main.rs
+++ b/crates/hyprstream/src/bin/main.rs
@@ -3192,37 +3192,23 @@ fn main() -> Result<()> {
 
                                     if name == "policy" {
                                         // PolicyService: signing_key IS the CA key (already loaded).
-                                        ctx = ctx.with_service_key(&name, own_key);
+                                        ctx = ctx.with_service_key(&name, own_key.clone());
                                     } else {
                                         // Non-policy: swap signing_key to service's own independent key.
                                         // CA key is no longer accessible via ctx.signing_key().
                                         ctx = ctx.swap_signing_key(own_key.clone());
                                         ctx = ctx.with_service_key(&name, own_key.clone());
-
-                                        // In systemd mode the credential dir is flat (%d = secrets_dir).
-                                        // Load our own service-jwt from disk and seed the trust store so
-                                        // that register_service_key() finds it on first call — otherwise
-                                        // the trust store only has pubkeys (jwt: None) from bootstrap-pubkeys
-                                        // and registration is silently skipped.
-                                        if let Ok(Some(jwt_str)) = hyprstream_core::auth::identity_store::load_service_jwt_for_profile(
-                                            &secrets_dir,
-                                            &name,
-                                            secrets_profile,
-                                        ) {
-                                            let exp = hyprstream_core::auth::identity_store::decode_jwt_exp_raw(&jwt_str).unwrap_or(0);
-                                            hyprstream_service::global_trust_store().insert(
-                                                own_key.verifying_key(),
-                                                hyprstream_service::Attestation {
-                                                    scopes: std::iter::once(name.clone()).collect(),
-                                                    subject: None,
-                                                    jwt: Some(jwt_str),
-                                                    expires_at: exp,
-                                                    attested_by: None,
-                                                },
-                                            );
-                                            tracing::info!(service = %name, "Seeded trust store with own service-jwt from credential dir");
-                                        }
                                     }
+                                    // Both Policy and non-Policy factories need the
+                                    // provisioned JWT. Policy's required-native factory
+                                    // registers its own key too, so seed after the shared
+                                    // key selection rather than only in the non-Policy arm.
+                                    hyprstream_core::auth::identity_store::seed_service_jwt_into_trust_store(
+                                        &name,
+                                        &own_key,
+                                        &secrets_dir,
+                                        secrets_profile,
+                                    );
                                 } else {
                                     // Single-process mode: load keys from disk (same as IPC).
                                     // Wizard must have run to create credentials.

--- a/crates/hyprstream/src/bin/main.rs
+++ b/crates/hyprstream/src/bin/main.rs
@@ -3724,6 +3724,37 @@ fn main() -> Result<()> {
                                     &service_names, ctx.iroh_required(),
                                 );
 
+                                // In a split required-native launch each child
+                                // sees only its own `service_names` entry, while
+                                // the parent stages the configured roster. If
+                                // this child is one of the services scheduled
+                                // before Policy (currently event, discovery,
+                                // or streams), defer its startup probe so the
+                                // parent can reach the Policy stage. A
+                                // standalone policy-dependent child retains
+                                // the eager probe and cannot report ready with
+                                // an unavailable authority.
+                                let defer_policy_probe = if ctx.iroh_required()
+                                    && service_names.len() == 1
+                                {
+                                    let configured_stages =
+                                        hyprstream_service::service::ordering::startup_stages_for_profile(
+                                            &services,
+                                            true,
+                                        );
+                                    let policy_stage = configured_stages
+                                        .iter()
+                                        .position(|stage| stage.iter().any(|name| name == "policy"));
+                                    policy_stage.is_some_and(|policy_index| {
+                                        configured_stages[..policy_index]
+                                            .iter()
+                                            .flatten()
+                                            .any(|name| service_names[0] == *name)
+                                    })
+                                } else {
+                                    false
+                                };
+
                                 // Publish the process-global authority stores
                                 // (credential revocation + session registry)
                                 // BEFORE any factory runs. The policy process
@@ -3737,9 +3768,7 @@ fn main() -> Result<()> {
                                     &ctx,
                                     ctx.signing_key(),
                                     service_names.iter().any(|n| n == "policy"),
-                                    ctx.iroh_required()
-                                        && service_names.len() == 1
-                                        && service_names.first().is_some_and(|n| n == "discovery"),
+                                    defer_policy_probe,
                                 )
                                 .await
                                 .context("revocation/session authority initialization failed")?;

--- a/crates/hyprstream/src/bin/main.rs
+++ b/crates/hyprstream/src/bin/main.rs
@@ -3100,7 +3100,18 @@ fn main() -> Result<()> {
                                     models_dir.clone(),
                                 )
                                 .with_oauth_issuer(config.oauth.issuer_url())
-                                .with_federation_key_source(fed_src);
+                                .with_federation_key_source(fed_src)
+                                // Same authoritative resolver the startup key/JWT
+                                // seeding above used (#759): without it, factory-time
+                                // key registration and the hourly JWT renewal task
+                                // would resolve a config-free default directory and
+                                // silently skip custom `--config [secrets].path`
+                                // deployments.
+                                .with_secrets_dir(
+                                    hyprstream_core::config::HyprConfig::resolve_secrets_dir_for(
+                                        Some(&config),
+                                    )?,
+                                );
 
                                 // Wire QUIC shared config from --quic-bind or [quic] config
                                 let mut quic_cfg = if let Some(ref bind_addr) = quic_bind {

--- a/crates/hyprstream/src/bin/main.rs
+++ b/crates/hyprstream/src/bin/main.rs
@@ -2547,13 +2547,42 @@ fn main() -> Result<()> {
         .get_one::<std::path::PathBuf>("config")
         .map(std::path::PathBuf::as_path);
 
+    // Canonicalize the explicit selector (CLI `--config` or the
+    // `HYPRSTREAM_CONFIG` env) BEFORE the first load, so the file that is
+    // loaded, the snapshot provenance, and the path forwarded to spawned
+    // children are one and the same value — and a relative selector stays
+    // meaningful regardless of a child's working directory. `None` means
+    // defaults-resolution, which children reproduce on their own.
+    let explicit_config_path: Option<std::path::PathBuf> = match config_path {
+        Some(path) => Some(std::fs::canonicalize(path).with_context(|| {
+            format!("canonicalizing explicit config path {}", path.display())
+        })?),
+        None => None,
+    };
+    // Library-side launchers (bootstrap manager, wizard) forward the same
+    // provenance their process pinned, so every launch path composes.
+    if let Some(canonical) = &explicit_config_path {
+        let _ = hyprstream_core::config::install_explicit_config_path(canonical.clone());
+    }
+
     // Load configuration early
-    let config = load_config(config_path)?;
+    let config = load_config(explicit_config_path.as_deref())?;
 
     // Validate configuration
     config
         .validate()
         .context("Configuration validation failed")?;
+
+    // Pin the validated configuration for the whole process (#1585): every
+    // later `HyprConfig::load()` — service-factory reloads included — observes
+    // this snapshot instead of re-deriving XDG defaults that would silently
+    // drop an explicit `--config` deployment's settings. Write-once, immutable
+    // afterwards; installed before any resolver, factory, or runtime thread.
+    let _ = hyprstream_core::config::install_pinned_config(config.clone());
+
+    // `Option<&Path>` is Copy, so both service arms below can borrow it.
+    let explicit_config: Option<&std::path::Path> = explicit_config_path.as_deref();
+    let iroh_required = config.quic.iroh_required();
 
     // RPC clients are used by ordinary CLI commands (`quick`, `tui`, etc.),
     // not only by service entrypoints. Install both request- and response-side
@@ -2988,7 +3017,7 @@ fn main() -> Result<()> {
                             multi_threaded: true,
                         },
                         || async move {
-                            handle_service_install(&models_dir, &services, filter, start, enable, target, verbose).await
+                            handle_service_install(&models_dir, &services, filter, start, enable, target, verbose, explicit_config, iroh_required).await
                         },
                     )?;
                 }
@@ -3810,7 +3839,7 @@ fn main() -> Result<()> {
                                 multi_threaded: false,
                             },
                             || async move {
-                                handle_service_start(&services, name, daemon).await
+                                handle_service_start(&services, name, daemon, explicit_config, iroh_required).await
                             },
                         )?;
                     }
@@ -5026,5 +5055,252 @@ mod native_announcement_wiring {
         assert!(error.contains("fresh checkpoint unavailable"));
         assert!(!observed.load(std::sync::atomic::Ordering::SeqCst),
             "failed authority projection must never publish stale reach");
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::expect_used)]
+mod native_launcher {
+    //! Causal coverage for the direct child launch path (#1585): the produced
+    //! child invocation must load the operator's explicit custom config
+    //! (relative path with spaces included), select the provisioned native
+    //! identity — not defaults — through the real parser/identity path, and
+    //! report readiness only through the authenticated notification boundary.
+
+    use super::*;
+    use hyprstream_core::cli::service_handlers::direct_child_process_config;
+    use std::path::Path;
+
+    const CAUSAL_CHILD: &str = "HYPRSTREAM_LAUNCHER_CAUSAL_CHILD";
+    const CAUSAL_MODE: &str = "HYPRSTREAM_LAUNCHER_CAUSAL_MODE";
+    const CAUSAL_ARGV: &str = "HYPRSTREAM_LAUNCHER_CAUSAL_ARGV";
+    const CAUSAL_PROOF: &str = "HYPRSTREAM_LAUNCHER_CAUSAL_PROOF";
+    const CAUSAL_STOP: &str = "HYPRSTREAM_LAUNCHER_CAUSAL_STOP";
+    const SERVICE: &str = "model";
+    const KEY_SEED: u8 = 0x5A;
+
+    fn provision_custom_config(
+        root: &tempfile::TempDir,
+        seed: u8,
+        with_key: bool,
+    ) -> anyhow::Result<std::path::PathBuf> {
+        let secrets = root.path().join("custom credentials");
+        if with_key {
+            std::fs::create_dir_all(secrets.join(SERVICE))?;
+            std::fs::write(secrets.join(SERVICE).join("signing-key"), [seed; 32])?;
+        }
+        let mut configured = HyprConfig::default();
+        configured.quic.native_network_profile =
+            hyprstream_core::config::NativeNetworkProfile::NetworkIrohRequired;
+        configured.secrets.path = Some(secrets);
+        configured.storage.models_dir = root.path().join("custom-models");
+        // A relative path containing spaces, relative to the launch directory.
+        let launch_dir = root.path().join("launch dir");
+        let config_dir = launch_dir.join("my configs");
+        std::fs::create_dir_all(&config_dir)?;
+        let config_path = config_dir.join("custom.toml");
+        configured.to_file(&config_path)?;
+        Ok(config_path)
+    }
+
+    async fn launcher_child() -> anyhow::Result<()> {
+        let mode = std::env::var(CAUSAL_MODE).unwrap_or_default();
+        // The exact argv the launcher helper produced for the real binary.
+        let args: Vec<String> = serde_json::from_str(&std::env::var(CAUSAL_ARGV)?)?;
+        let matches = build_cli().try_get_matches_from(
+            std::iter::once("hyprstream".to_owned()).chain(args),
+        )?;
+        let config = load_config(
+            matches
+                .get_one::<std::path::PathBuf>("config")
+                .map(std::path::PathBuf::as_path),
+        )?;
+        config.validate().context("child configuration validation")?;
+        let _ = hyprstream_core::config::install_pinned_config(config.clone());
+
+        let selected = native_service_process_name(&matches, &config)?;
+        anyhow::ensure!(
+            selected.as_deref() == Some(SERVICE),
+            "child selected {selected:?} instead of the configured native service"
+        );
+        if mode == "missing-key" {
+            // Negative control: the provisioned key is absent, so the real
+            // required-native identity path must refuse — never generate.
+            let outcome = load_process_signing_key(&config, selected.as_deref()).await;
+            anyhow::ensure!(
+                outcome.is_err(),
+                "missing provisioned key must fail required-native startup"
+            );
+            anyhow::bail!("missing-key control refused startup as required");
+        }
+
+        let key = load_process_signing_key(&config, selected.as_deref()).await?;
+        // Proof carries the PUBLIC verifying key only — never private material.
+        let proof = std::env::var(CAUSAL_PROOF)?;
+        std::fs::write(&proof, key.verifying_key().to_bytes())?;
+        // Authentic readiness: only after the config/identity assertions.
+        hyprstream_rpc::notify::ready()?;
+        // Stay alive so the supervisor observes a genuinely RUNNING ready
+        // child (its post-READY liveness recheck would otherwise race our
+        // exit), and exit only on the parent's controlled stop signal.
+        let stop_file = std::path::PathBuf::from(std::env::var(CAUSAL_STOP)?);
+        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(60);
+        while !stop_file.exists() {
+            if std::time::Instant::now() >= deadline {
+                anyhow::bail!("supervisor stop signal never arrived");
+            }
+            std::thread::sleep(std::time::Duration::from_millis(50));
+        }
+        Ok(())
+    }
+
+    async fn spawn_causal_child(
+        supervisor: &hyprstream_service::ProcessSpawner,
+        launch_args: &[String],
+        mode: &str,
+        proof: &Path,
+        stop_file: &Path,
+        working_dir: &Path,
+        child_instance: &str,
+    ) -> anyhow::Result<
+        Result<hyprstream_service::SpawnedProcess, hyprstream_rpc::error::RpcError>,
+    > {
+        let exe = std::env::current_exe()?;
+        // Unique supervisor name: PID artifacts land under a test-owned
+        // namespace, never the shared `model.pid` of a real deployment.
+        let mut child = hyprstream_service::ProcessConfig::new(child_instance, &exe)
+            .args([
+                "--exact",
+                "native_launcher::launcher_child_loads_explicit_config_and_provisioned_identity",
+                "--nocapture",
+            ])
+            .env(CAUSAL_CHILD, "1")
+            .env(CAUSAL_MODE, mode)
+            .env(CAUSAL_ARGV, serde_json::to_string(launch_args)?)
+            .env(CAUSAL_PROOF, proof.display().to_string())
+            .env(CAUSAL_STOP, stop_file.display().to_string())
+            // Deterministic identity layout, isolated runtime namespace.
+            .env("HYPRSTREAM_SECRETS_PROFILE", "shared-directory")
+            .env("HYPRSTREAM_INSTANCE", child_instance)
+            .working_dir(working_dir);
+        child.readiness = hyprstream_service::ProcessReadiness::Notify {
+            timeout: std::time::Duration::from_secs(30),
+        };
+        Ok(supervisor.spawn(child).await)
+    }
+
+    #[tokio::test]
+    async fn launcher_child_loads_explicit_config_and_provisioned_identity() -> anyhow::Result<()> {
+        if std::env::var_os(CAUSAL_CHILD).is_some() {
+            return launcher_child().await;
+        }
+
+        let root = tempfile::tempdir()?;
+        let config_path = provision_custom_config(&root, KEY_SEED, true)?;
+        let canonical = std::fs::canonicalize(&config_path)?;
+        let expected_vk = ed25519_dalek::SigningKey::from_bytes(&[KEY_SEED; 32])
+            .verifying_key()
+            .to_bytes();
+
+        // The exact invocation the launcher builds for the real binary.
+        let plan = direct_child_process_config(
+            SERVICE,
+            true,
+            Some(&canonical),
+            Path::new("hyprstream"),
+        )?;
+        let launch_args = plan.args.clone();
+        assert!(
+            !launch_args.iter().any(|arg| arg == "--ipc"),
+            "required-native child plan must contain no service IPC argument"
+        );
+        assert!(
+            launch_args.windows(2).any(|pair| pair[0] == "--config"
+                && pair[1] == canonical.to_str().expect("utf-8 canonical path")),
+            "canonical absolute config path must be forwarded verbatim"
+        );
+
+        // Child runs from a DIFFERENT working directory than the launcher's
+        // config-relative layout: only the canonical path makes the relative
+        // selector meaningful across the spawner cwd.
+        let proof = root.path().join("proof.vk");
+        let stop_file = root.path().join("stop");
+        let spawner = hyprstream_service::ProcessSpawner::standalone();
+        let supervisor = "launcher-causal-happy";
+        let process = spawn_causal_child(
+            &spawner,
+            &launch_args,
+            "happy",
+            &proof,
+            &stop_file,
+            root.path(),
+            supervisor,
+        )
+        .await?
+        .expect("ready child proves config load, identity selection, and notify barrier");
+        let observed = std::fs::read(&proof)?;
+        assert_eq!(observed, expected_vk, "child selected the provisioned signer");
+        // The READY child is genuinely running (its notification was not a
+        // last-gasp message), with its PID file published under the unique
+        // supervisor name.
+        assert!(
+            spawner.is_running(&process).await?,
+            "the ready child must still be alive after the spawn reports success"
+        );
+        assert!(
+            hyprstream_rpc::paths::service_pid_file(supervisor).exists(),
+            "a ready child publishes its PID file"
+        );
+        // Controlled shutdown: signal stop, wait for the child's own exit,
+        // then have the SAME supervisor stop reap it and remove the PID
+        // artifact — no manual deletion, no second backend.
+        std::fs::write(&stop_file, b"stop")?;
+        let stopped = std::time::Instant::now() + std::time::Duration::from_secs(10);
+        while spawner.is_running(&process).await? {
+            if std::time::Instant::now() >= stopped {
+                anyhow::bail!("child did not exit after the controlled stop signal");
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+        }
+        spawner.stop(&process).await?;
+        assert!(!spawner.is_running(&process).await?);
+        assert!(
+            !hyprstream_rpc::paths::service_pid_file(supervisor).exists(),
+            "supervised stop must remove the published PID file"
+        );
+
+        // Negative control: absent provisioned key fails the launch honestly.
+        let missing_root = tempfile::tempdir()?;
+        let missing_config = provision_custom_config(&missing_root, KEY_SEED, false)?;
+        let missing_canonical = std::fs::canonicalize(&missing_config)?;
+        let missing_plan = direct_child_process_config(
+            SERVICE,
+            true,
+            Some(&missing_canonical),
+            Path::new("hyprstream"),
+        )?;
+        let missing_spawner = hyprstream_service::ProcessSpawner::standalone();
+        let missing_supervisor = "launcher-causal-missing";
+        let missing_outcome = spawn_causal_child(
+            &missing_spawner,
+            &missing_plan.args,
+            "missing-key",
+            &missing_root.path().join("unused.vk"),
+            &missing_root.path().join("stop"),
+            missing_root.path(),
+            missing_supervisor,
+        )
+        .await?;
+        let error = missing_outcome
+            .expect_err("launch must fail when the provisioned key is absent");
+        assert!(
+            error.to_string().contains("exited during startup"),
+            "child startup failure must propagate, got: {error}"
+        );
+        assert!(
+            !hyprstream_rpc::paths::service_pid_file(missing_supervisor).exists(),
+            "a never-ready child must not publish a PID file"
+        );
+        Ok(())
     }
 }

--- a/crates/hyprstream/src/bin/main.rs
+++ b/crates/hyprstream/src/bin/main.rs
@@ -3742,15 +3742,22 @@ fn main() -> Result<()> {
                                             &services,
                                             true,
                                         );
-                                    let policy_stage = configured_stages
-                                        .iter()
-                                        .position(|stage| stage.iter().any(|name| name == "policy"));
-                                    policy_stage.is_some_and(|policy_index| {
-                                        configured_stages[..policy_index]
-                                            .iter()
-                                            .flatten()
-                                            .any(|name| service_names[0] == *name)
-                                    })
+                                    let policy_position = configured_stages.iter().enumerate().find_map(
+                                        |(stage_index, stage)| {
+                                            stage.iter().position(|name| name == "policy")
+                                                .map(|service_index| (stage_index, service_index))
+                                        },
+                                    );
+                                    let service_position = configured_stages.iter().enumerate().find_map(
+                                        |(stage_index, stage)| {
+                                            stage.iter().position(|name| name == &service_names[0])
+                                                .map(|service_index| (stage_index, service_index))
+                                        },
+                                    );
+                                    match (service_position, policy_position) {
+                                        (Some(service), Some(policy)) => service < policy,
+                                        _ => false,
+                                    }
                                 } else {
                                     false
                                 };

--- a/crates/hyprstream/src/bin/main.rs
+++ b/crates/hyprstream/src/bin/main.rs
@@ -1319,7 +1319,7 @@ fn handle_quick_command(
                         // Wire up policy-backed authorization
                         let worker_policy_client = hyprstream_core::services::policy_client_for_process(
                             signing_key.clone(),
-                            resolve_service_vk("policy")
+                            resolve_service_vk("policy", Some(ctx.config()))
                                 .ok_or_else(|| anyhow::anyhow!("Cannot resolve policy pubkey. Run wizard."))?,
                             None,
                         )?;
@@ -1333,7 +1333,7 @@ fn handle_quick_command(
                         // is in scope here, so the mesh PQ store is empty (#157):
                         // identical to prior behavior (Hybrid fails closed for
                         // unknown peers).
-                        install_envelope_verify_config(None);
+                        install_envelope_verify_config(None, None);
 
                         let manager = InprocManager::new();
                         Some(
@@ -1637,14 +1637,18 @@ fn select_iroh_moql_admission_proof<T>(
     }
 }
 
-fn resolve_service_vk(service_name: &str) -> Option<VerifyingKey> {
+fn resolve_service_vk(
+    service_name: &str,
+    config: Option<&HyprConfig>,
+) -> Option<VerifyingKey> {
     let trust = hyprstream_service::global_trust_store();
     // Fast path: already populated (service startup seeded it)
     if let Some(vk) = trust.resolve_one(service_name) {
         return Some(vk);
     }
-    // CLI mode: seed from bootstrap-pubkeys on first use
-    let Ok(secrets_dir) = HyprConfig::resolve_secrets_dir() else {
+    // CLI mode: seed from bootstrap-pubkeys on first use. When startup already
+    // loaded a config (including --config), keep that path authoritative.
+    let Ok(secrets_dir) = HyprConfig::resolve_secrets_dir_for(config) else {
         return None;
     };
     // Load the full entries so the hybrid requirement can be enforced before
@@ -1731,7 +1735,7 @@ async fn install_process_production_resolver(
     // store; in CLI/service-start mode nothing has seeded it yet. Seed from
     // the node's own bootstrap-pubkeys (the same source resolve_service_vk
     // uses on first use) — a no-op when already populated or unprovisioned.
-    let _ = resolve_service_vk("discovery");
+    let _ = resolve_service_vk("discovery", Some(config));
     // Private-PKI deployments may terminate the did:web host with an internal
     // CA; the extra root is additive (never disables verification), and an
     // unreadable file is a hard configuration error, not a silent skip.
@@ -1833,8 +1837,13 @@ fn quic_checkpoint_policy(
 /// When `oauth` is `Some`, the kid-anchored PQ trust store is populated eagerly
 /// from `mesh_peers` (#157). When `None` (e.g. the standalone worker entrypoint,
 /// which has no config in scope), the store is empty — identical to the prior
-/// behavior. Either way the store is immutable after install.
-fn install_envelope_verify_config(oauth: Option<&hyprstream_core::config::OAuthConfig>) {
+/// behavior. `config` carries the already-loaded CLI config so its explicit
+/// secrets path remains authoritative. Either way the store is immutable after
+/// install.
+fn install_envelope_verify_config(
+    oauth: Option<&hyprstream_core::config::OAuthConfig>,
+    config: Option<&HyprConfig>,
+) {
     use hyprstream_rpc::envelope::{
         install_response_verify_config, install_verify_config, mandatory_envelope_policy,
         EnvelopeVerifyConfig, KeyedPqTrustStore, PqTrustStore, ResponseVerifyConfig,
@@ -1858,7 +1867,7 @@ fn install_envelope_verify_config(oauth: Option<&hyprstream_core::config::OAuthC
     // envelope verify path consults, so supplying hybrid material actually
     // turns PQ enforcement on for those services. A classical-only file
     // anchors nothing and changes nothing.
-    if let Ok(secrets_dir) = HyprConfig::resolve_secrets_dir() {
+    if let Ok(secrets_dir) = HyprConfig::resolve_secrets_dir_for(config) {
         let anchored = hyprstream_core::auth::mesh_trust::seed_bootstrap_pq_bindings(
             &mut keyed_store,
             &secrets_dir,
@@ -2551,7 +2560,7 @@ fn main() -> Result<()> {
     // verification defaults before dispatch so every command uses the
     // operator-configured mesh trust store (#1018). The installer is
     // first-write-wins, so the service-specific calls below remain harmless.
-    install_envelope_verify_config(Some(&config.oauth));
+    install_envelope_verify_config(Some(&config.oauth), Some(&config));
 
     // Install the per-service streaming-response concurrency cap from config
     // (#186) before any RPC service starts. First-write-wins; ignore if already
@@ -3642,7 +3651,7 @@ fn main() -> Result<()> {
                                 //
                                 // Policy: Hybrid is mandatory. With no anchored
                                 // peer key the verifier FAILS CLOSED.
-                                install_envelope_verify_config(Some(&config.oauth));
+                                install_envelope_verify_config(Some(&config.oauth), Some(&config));
 
                                 // Install MoQ/event authorization in every
                                 // production service process before any model,
@@ -4235,6 +4244,71 @@ mod resolver_startup_controls {
         config.quic.native_network_profile = hyprstream_core::config::NativeNetworkProfile::Compatibility;
         assert_eq!(super::native_service_process_name(&multi, &config)?, None);
         assert_eq!(super::native_service_process_name(&single, &config)?, None);
+        Ok(())
+    }
+
+    #[test]
+    fn native_service_identity_seeds_discovery_from_loaded_config() -> anyhow::Result<()> {
+        const CHILD: &str = "HYPRSTREAM_NATIVE_DISCOVERY_SEED_TEST";
+        if std::env::var_os(CHILD).is_none() {
+            let status = std::process::Command::new(std::env::current_exe()?)
+                .args([
+                    "--exact",
+                    "resolver_startup_controls::native_service_identity_seeds_discovery_from_loaded_config",
+                    "--nocapture",
+                ])
+                .env(CHILD, "1")
+                .env_remove("HYPRSTREAM__SECRETS__PATH")
+                .env_remove("HYPRSTREAM_SECRETS_PROFILE")
+                .status()?;
+            anyhow::ensure!(status.success(), "isolated discovery seeding regression failed");
+            return Ok(());
+        }
+
+        let root = tempfile::tempdir()?;
+        let xdg_config_home = root.path().join("xdg-config");
+        std::env::set_var("XDG_CONFIG_HOME", &xdg_config_home);
+
+        // Keep a different, valid bootstrap file at the default location so
+        // this catches accidental re-resolution through HyprConfig::load().
+        let default_secrets = xdg_config_home.join("hyprstream/credentials");
+        let default_key = ed25519_dalek::SigningKey::from_bytes(&[91u8; 32]);
+        let mut default_entries = std::collections::HashMap::new();
+        default_entries.insert(
+            "discovery".to_owned(),
+            hyprstream_core::auth::identity_store::BootstrapPubkey::for_service_key(
+                &default_key,
+            )?,
+        );
+        hyprstream_core::auth::identity_store::write_bootstrap_pubkeys_hybrid(
+            &default_secrets,
+            &default_entries,
+        )?;
+
+        let custom_secrets = root.path().join("custom-credentials");
+        let custom_key = ed25519_dalek::SigningKey::from_bytes(&[92u8; 32]);
+        let mut custom_entries = std::collections::HashMap::new();
+        custom_entries.insert(
+            "discovery".to_owned(),
+            hyprstream_core::auth::identity_store::BootstrapPubkey::for_service_key(
+                &custom_key,
+            )?,
+        );
+        hyprstream_core::auth::identity_store::write_bootstrap_pubkeys_hybrid(
+            &custom_secrets,
+            &custom_entries,
+        )?;
+
+        let mut config = super::HyprConfig::default();
+        config.secrets.path = Some(custom_secrets);
+        let selected = super::resolve_service_vk("discovery", Some(&config))
+            .expect("configured bootstrap-pubkeys must seed discovery");
+        assert_eq!(selected, custom_key.verifying_key());
+        assert_ne!(selected, default_key.verifying_key());
+        assert_eq!(
+            hyprstream_service::global_trust_store().resolve_one("discovery"),
+            Some(custom_key.verifying_key()),
+        );
         Ok(())
     }
 

--- a/crates/hyprstream/src/bin/main.rs
+++ b/crates/hyprstream/src/bin/main.rs
@@ -5079,6 +5079,37 @@ mod native_launcher {
     const SERVICE: &str = "model";
     const KEY_SEED: u8 = 0x5A;
 
+    #[cfg(unix)]
+    #[test]
+    fn cli_parser_loads_non_utf8_config_path_without_changing_bytes() -> anyhow::Result<()> {
+        use std::os::unix::ffi::{OsStrExt, OsStringExt};
+
+        let root = tempfile::tempdir()?;
+        let config_path = root
+            .path()
+            .join(std::ffi::OsString::from_vec(b"parent-\xff.toml".to_vec()));
+        HyprConfig::default().to_file(&config_path)?;
+        let canonical = std::fs::canonicalize(&config_path)?;
+        assert!(canonical.to_str().is_none(), "fixture path must be non-UTF-8");
+
+        let matches = build_cli().try_get_matches_from([
+            std::ffi::OsString::from("hyprstream"),
+            std::ffi::OsString::from("--config"),
+            canonical.as_os_str().to_owned(),
+        ])?;
+        let parsed = matches
+            .get_one::<std::path::PathBuf>("config")
+            .context("config PathBuf parsed by clap")?;
+        assert_eq!(
+            parsed.as_os_str().as_bytes(),
+            canonical.as_os_str().as_bytes(),
+            "clap must preserve the explicit selector byte for byte"
+        );
+        let config = load_config(Some(parsed))?;
+        config.validate()?;
+        Ok(())
+    }
+
     fn provision_custom_config(
         root: &tempfile::TempDir,
         seed: u8,
@@ -5156,7 +5187,7 @@ mod native_launcher {
 
     async fn spawn_causal_child(
         supervisor: &hyprstream_service::ProcessSpawner,
-        launch_args: &[String],
+        launch_args: &[std::ffi::OsString],
         mode: &str,
         proof: &Path,
         stop_file: &Path,
@@ -5168,6 +5199,13 @@ mod native_launcher {
         let exe = std::env::current_exe()?;
         // Unique supervisor name: PID artifacts land under a test-owned
         // namespace, never the shared `model.pid` of a real deployment.
+        let serialized_args: Vec<&str> = launch_args
+            .iter()
+            .map(|arg| {
+                arg.to_str()
+                    .context("UTF-8 fixture argument for launcher causal-test envelope")
+            })
+            .collect::<anyhow::Result<_>>()?;
         let mut child = hyprstream_service::ProcessConfig::new(child_instance, &exe)
             .args([
                 "--exact",
@@ -5176,7 +5214,7 @@ mod native_launcher {
             ])
             .env(CAUSAL_CHILD, "1")
             .env(CAUSAL_MODE, mode)
-            .env(CAUSAL_ARGV, serde_json::to_string(launch_args)?)
+            .env(CAUSAL_ARGV, serde_json::to_string(&serialized_args)?)
             .env(CAUSAL_PROOF, proof.display().to_string())
             .env(CAUSAL_STOP, stop_file.display().to_string())
             // Deterministic identity layout, isolated runtime namespace.

--- a/crates/hyprstream/src/bin/main.rs
+++ b/crates/hyprstream/src/bin/main.rs
@@ -1551,6 +1551,49 @@ fn resolve_moq_relay_reach(
         .ok_or_else(|| anyhow::anyhow!("relay URI is not a network-routable transport"))
 }
 
+/// Select the process identity before constructing any resolver/client. Transport
+/// flags do not decide whose identity a required-native split service uses.
+fn native_service_process_name(matches: &clap::ArgMatches, config: &HyprConfig) -> Result<Option<String>> {
+    if !config.quic.iroh_required() {
+        return Ok(None);
+    }
+    let Some(("service", service_matches)) = matches.subcommand() else {
+        return Ok(None);
+    };
+    let action = ServiceAction::from_arg_matches(service_matches)
+        .map_err(|error| anyhow::anyhow!("{error}"))?;
+    let ServiceAction::Start { name, foreground, standalone, services, .. } = action else {
+        return Ok(None);
+    };
+    if !foreground && !standalone {
+        return Ok(None);
+    }
+    let names = if standalone {
+        config.services.startup.clone()
+    } else {
+        services.unwrap_or_else(|| name.into_iter().collect())
+    };
+    anyhow::ensure!(names.len() == 1,
+        "network-iroh-required requires exactly one service per foreground process; launch each provisioned service separately");
+    let service = names.into_iter().next().context("native service name missing")?;
+    anyhow::ensure!(hyprstream_service::get_factory(&service).is_some(), "unknown native service: {service}");
+    Ok(Some(service))
+}
+
+/// Required service startup consumes the provisioner's retained key. Missing or
+/// malformed material is never a reason to generate a new identity or use the
+/// CLI/root key. Compatibility commands retain their existing key behavior.
+async fn load_process_signing_key(config: &HyprConfig, native_service: Option<&str>) -> Result<SigningKey> {
+    if let Some(service) = native_service {
+        let secrets = HyprConfig::resolve_secrets_dir_for(Some(config))?;
+        return hyprstream_core::auth::identity_store::load_existing_service_signing_key(
+            &secrets, service, hyprstream_core::auth::identity_store::SecretsProfile::from_env()?,
+        ).with_context(|| format!("load provisioned native identity for {service}"));
+    }
+    let keys_dir = config.models_dir().join(".registry").join("keys");
+    load_or_generate_signing_key(&keys_dir).await
+}
+
 /// A QUIC process currently owns one native MoQ dialer and its admission-proof
 /// slot. Sharing that slot across separately checkpointed services would make a
 /// later service dial as the first service's DID. Refuse that topology until the
@@ -1665,7 +1708,7 @@ async fn install_process_production_resolver(
     //
     // Scoped to this node's OWN service identities. External classical clients
     // and federated peers do not appear in this file and are not affected.
-    if let Ok(secrets_dir) = HyprConfig::resolve_secrets_dir() {
+    if let Ok(secrets_dir) = HyprConfig::resolve_secrets_dir_for(Some(config)) {
         let entries =
             hyprstream_core::auth::identity_store::load_bootstrap_pubkeys_hybrid(&secrets_dir)?;
         hyprstream_core::auth::identity_store::ensure_bootstrap_pubkeys_hybrid(&entries)?;
@@ -2857,6 +2900,8 @@ fn main() -> Result<()> {
         }
     }
 
+    let native_service_name = native_service_process_name(&matches, &config)?;
+
     // Start registry service ONCE at CLI level
     let _registry_runtime = tokio::runtime::Builder::new_multi_thread()
         .enable_all()
@@ -2871,8 +2916,7 @@ fn main() -> Result<()> {
         bool,
     ) = _registry_runtime
         .block_on(async {
-            let keys_dir = config.models_dir().join(".registry").join("keys");
-            let signing_key = load_or_generate_signing_key(&keys_dir).await?;
+            let signing_key = load_process_signing_key(&config, native_service_name.as_deref()).await?;
             let verifying_key = signing_key.verifying_key();
 
             let is_os_owned_bootstrap = install_process_production_resolver(&signing_key, &config).await
@@ -2988,6 +3032,10 @@ fn main() -> Result<()> {
                             }
                         };
 
+                        // --services with one member selects that service's identity,
+                        // never the synthetic "multi"/"standalone" command label.
+                        let name = native_service_name.clone().unwrap_or(name);
+
                         // Standard foreground service startup
                         let rpc_mode = if ipc {
                             hyprstream_rpc::registry::EndpointMode::Ipc
@@ -3024,8 +3072,12 @@ fn main() -> Result<()> {
 
                                 let models_dir = config.models_dir();
                                 let keys_dir = models_dir.join(".registry").join("keys");
-                                let signing_key =
-                                    load_or_generate_signing_key(&keys_dir).await?;
+                                let signing_key = if native_service_name.is_some() {
+                                    // Same retained key already installed in the process resolver.
+                                    signing_key.clone()
+                                } else {
+                                    load_or_generate_signing_key(&keys_dir).await?
+                                };
                                 let verifying_key = signing_key.verifying_key();
 
                                 let fed_src: Arc<dyn hyprstream_rpc::auth::FederationKeySource> =
@@ -3063,8 +3115,8 @@ fn main() -> Result<()> {
                                     vec![name.clone()]
                                 };
 
-                                if ipc {
-                                    // Multi-process mode: each service gets its own independent key.
+                                if ipc || native_service_name.is_some() {
+                                    // Split-service identity is independent of local IPC transport.
                                     //
                                     // #759: resolve via the SAME authoritative path
                                     // `HyprConfig::resolve_secrets_dir()` uses elsewhere in this
@@ -3077,7 +3129,7 @@ fn main() -> Result<()> {
                                     // than this process reads from — the same "consumer silently
                                     // re-derives instead of reading the authoritative record"
                                     // disease #441 targets, just one directory earlier.
-                                    let secrets_dir = hyprstream_core::config::HyprConfig::resolve_secrets_dir()?;
+                                    let secrets_dir = hyprstream_core::config::HyprConfig::resolve_secrets_dir_for(Some(&config))?;
                                     ctx = ctx.with_ca_verifying_key(
                                         hyprstream_core::auth::identity_store::load_ca_verifying_key(
                                             &secrets_dir,
@@ -3121,9 +3173,13 @@ fn main() -> Result<()> {
                                     // secrets profile — see `resolve_service_signing_key` for why.
                                     let secrets_profile =
                                         hyprstream_core::auth::identity_store::SecretsProfile::from_env()?;
-                                    let own_key = hyprstream_core::auth::identity_store::resolve_service_signing_key(
-                                        &secrets_dir, &name, secrets_profile,
-                                    )?;
+                                    let own_key = if native_service_name.is_some() {
+                                        signing_key.clone()
+                                    } else {
+                                        hyprstream_core::auth::identity_store::resolve_service_signing_key(
+                                            &secrets_dir, &name, secrets_profile,
+                                        )?
+                                    };
 
                                     if name == "policy" {
                                         // PolicyService: signing_key IS the CA key (already loaded).
@@ -3164,7 +3220,7 @@ fn main() -> Result<()> {
                                     //
                                     // #759: same authoritative resolver as the `--ipc` branch above —
                                     // see the comment there.
-                                    let secrets_dir = hyprstream_core::config::HyprConfig::resolve_secrets_dir()?;
+                                    let secrets_dir = hyprstream_core::config::HyprConfig::resolve_secrets_dir_for(Some(&config))?;
                                     ctx = ctx.with_ca_verifying_key(
                                         hyprstream_core::auth::identity_store::load_ca_verifying_key(
                                             &secrets_dir,
@@ -3256,7 +3312,7 @@ fn main() -> Result<()> {
                                 // no manifest-backed clearance.
                                 {
                                     let secrets_dir =
-                                        hyprstream_core::config::HyprConfig::resolve_secrets_dir()?;
+                                        hyprstream_core::config::HyprConfig::resolve_secrets_dir_for(Some(&config))?;
                                     match hyprstream_core::auth::service_enrollment::ServiceEnrollmentManifest::load_and_validate(&secrets_dir)
                                         .context("service enrollment manifest validation failed")?
                                     {
@@ -3479,7 +3535,7 @@ fn main() -> Result<()> {
 
                                 // Populate ML-DSA-65 verifying keys for PQ-hybrid JWT verification.
                                 {
-                                    let secrets_dir = hyprstream_core::config::HyprConfig::resolve_secrets_dir()?;
+                                    let secrets_dir = hyprstream_core::config::HyprConfig::resolve_secrets_dir_for(Some(&config))?;
                                     let ml_dsa_store = hyprstream_core::auth::key_rotation::global_ml_dsa_key_store(
                                         &secrets_dir,
                                         &config.oauth,
@@ -4094,6 +4150,92 @@ mod resolver_startup_controls {
         assert!(super::build_cli()
             .try_get_matches_from(["hyprstream", "service", "provision-policy-templates",])
             .is_err());
+    }
+
+    #[test]
+    fn native_service_identity_loads_existing_key_without_ipc() -> anyhow::Result<()> {
+        const CHILD: &str = "HYPRSTREAM_NATIVE_SERVICE_IDENTITY_TEST";
+        let Ok(profile) = std::env::var(CHILD) else {
+            for profile in ["shared-directory", "per-service-scoped"] {
+                let status = std::process::Command::new(std::env::current_exe()?)
+                    .args(["--exact", "resolver_startup_controls::native_service_identity_loads_existing_key_without_ipc", "--nocapture"])
+                    .env(CHILD, profile)
+                    .env("HYPRSTREAM_SECRETS_PROFILE", profile)
+                    .env_remove("HYPRSTREAM__SECRETS__PATH")
+                    .env_remove("HYPRSTREAM__SIGNING_KEY")
+                    .status()?;
+                anyhow::ensure!(status.success(), "isolated {profile} identity regression failed");
+            }
+            return Ok(());
+        };
+        let root = tempfile::tempdir()?;
+        let runtime = tokio::runtime::Builder::new_current_thread().enable_all().build()?;
+        for (service, seed) in [("policy", 31u8), ("model", 32u8), ("registry", 33u8)] {
+            let secrets = root.path().join(format!("{service}-credentials"));
+            std::fs::create_dir_all(secrets.join(service))?;
+            let key_path = if service == "policy" || profile == "per-service-scoped" {
+                // A misleading service subdirectory must not replace a scoped
+                // identity, especially Policy's canonical flat key.
+                std::fs::write(secrets.join(service).join("signing-key"), [99u8; 32])?;
+                secrets.join("signing-key")
+            } else {
+                // A retained root/Policy key must not become a native Model or
+                // Registry process identity merely because --ipc is absent.
+                std::fs::write(secrets.join("signing-key"), [31u8; 32])?;
+                secrets.join(service).join("signing-key")
+            };
+            std::fs::write(&key_path, [seed; 32])?;
+            let mut configured = super::HyprConfig::default();
+            configured.quic.native_network_profile = hyprstream_core::config::NativeNetworkProfile::NetworkIrohRequired;
+            configured.secrets.path = Some(secrets.clone());
+            configured.storage.models_dir = root.path().join(format!("{service}-models"));
+            let config_path = root.path().join(format!("{service}.toml"));
+            configured.to_file(&config_path)?;
+            let matches = super::build_cli().try_get_matches_from([
+                "hyprstream", "--config", config_path.to_str().expect("temporary UTF-8 path"),
+                "service", "start", service, "--foreground",
+            ])?;
+            let config = super::load_config(matches.get_one::<std::path::PathBuf>("config").map(std::path::PathBuf::as_path))?;
+            let selected = super::native_service_process_name(&matches, &config)?;
+            assert_eq!(selected.as_deref(), Some(service));
+            let key = runtime.block_on(super::load_process_signing_key(&config, selected.as_deref()))?;
+            assert_eq!(key.to_bytes(), [seed; 32]);
+            let ctx = super::ServiceContext::new(key.clone(), key.verifying_key(), false, config.models_dir().clone())
+                .with_service_key(service, key.clone());
+            assert_eq!(ctx.signing_key().verifying_key(), key.verifying_key());
+            assert_eq!(ctx.service_signing_key(service).verifying_key(), key.verifying_key());
+            assert!(!config.models_dir().join(".registry/keys").exists(), "native startup must not materialize a CLI/root key");
+            std::fs::remove_file(&key_path)?;
+            assert!(runtime.block_on(super::load_process_signing_key(&config, selected.as_deref())).is_err());
+            assert!(!key_path.exists(), "missing provisioned key must not be regenerated");
+            std::fs::write(&key_path, [seed; 31])?;
+            assert!(runtime.block_on(super::load_process_signing_key(&config, selected.as_deref())).is_err());
+            assert_eq!(std::fs::read(&key_path)?, vec![seed; 31], "malformed key must not be repaired during startup");
+        }
+        Ok(())
+    }
+
+    #[test]
+    fn native_service_identity_rejects_multi_and_selects_single_service_list() -> anyhow::Result<()> {
+        let mut config = super::HyprConfig::default();
+        config.quic.native_network_profile = hyprstream_core::config::NativeNetworkProfile::NetworkIrohRequired;
+        let single = super::build_cli().try_get_matches_from([
+            "hyprstream", "service", "start", "--foreground", "--services", "model",
+        ])?;
+        assert_eq!(super::native_service_process_name(&single, &config)?.as_deref(), Some("model"));
+        let multi = super::build_cli().try_get_matches_from([
+            "hyprstream", "service", "start", "--foreground", "--services", "model,registry",
+        ])?;
+        assert!(super::native_service_process_name(&multi, &config).is_err());
+        let standalone = super::build_cli().try_get_matches_from([
+            "hyprstream", "service", "start", "--standalone",
+        ])?;
+        config.services.startup = vec!["model".into(), "registry".into()];
+        assert!(super::native_service_process_name(&standalone, &config).is_err());
+        config.quic.native_network_profile = hyprstream_core::config::NativeNetworkProfile::Compatibility;
+        assert_eq!(super::native_service_process_name(&multi, &config)?, None);
+        assert_eq!(super::native_service_process_name(&single, &config)?, None);
+        Ok(())
     }
 
     #[test]

--- a/crates/hyprstream/src/cli/bootstrap_manager.rs
+++ b/crates/hyprstream/src/cli/bootstrap_manager.rs
@@ -467,10 +467,24 @@ impl WizardBackend for BootstrapManager {
         let (tx, rx) = mpsc::sync_channel(8);
         self.service_rx = Some(rx);
         let services = self.config_services.clone();
+        // Forward this process's pinned config provenance and native profile
+        // so bootstrap-launched children load what the operator loaded (#1585).
+        let explicit_config = crate::config::explicit_config_path().cloned();
+        let iroh_required = crate::config::HyprConfig::load()
+            .map(|c| c.quic.iroh_required())
+            .unwrap_or(false);
 
         self.service_handle = Some(self.rt.spawn(async move {
             let _ = tx.send(OpStatus::InProgress);
-            match crate::cli::handle_service_start(&services, None, false).await {
+            match crate::cli::handle_service_start(
+                &services,
+                None,
+                false,
+                explicit_config.as_deref(),
+                iroh_required,
+            )
+            .await
+            {
                 Ok(()) => {
                     let _ = tx.send(OpStatus::Done);
                 }

--- a/crates/hyprstream/src/cli/bootstrap_manager.rs
+++ b/crates/hyprstream/src/cli/bootstrap_manager.rs
@@ -5,7 +5,7 @@
 //! service startup. It implements WizardBackend for the TUI, using bounded channels
 //! with drain-to-latest pattern to bridge async operations to the 30fps render loop.
 
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{mpsc, Arc};
 
@@ -50,6 +50,12 @@ pub struct BootstrapManager {
     service_rx: Option<mpsc::Receiver<OpStatus>>,
     service_handle: Option<tokio::task::JoinHandle<()>>,
 
+    /// Test-only dispatch injection for the service-start routing tests.
+    /// Production never consults an override — `new()` stores `None` and the
+    /// real `handle_service_start` path always runs (#1585).
+    #[cfg(test)]
+    start_dispatch: Option<StartDispatchFn>,
+
     // Cached environment (avoid re-detecting)
     cached_env: Option<EnvironmentInfo>,
 
@@ -86,6 +92,35 @@ fn os_username() -> String {
     std::env::var("USER")
         .or_else(|_| std::env::var("LOGNAME"))
         .unwrap_or_else(|_| "anonymous".to_owned())
+}
+
+/// Test-only signature of the wizard's service-start dispatch seam: the
+/// resolved service list, explicit-config provenance, direct-launch decision,
+/// and required-native profile. Never named outside `#[cfg(test)]` code —
+/// production always runs the ordinary `dispatch_real_start` path.
+#[cfg(test)]
+type StartDispatchFn = Arc<
+    dyn Fn(
+            Vec<String>,
+            Option<PathBuf>,
+            bool,
+            bool,
+        ) -> std::pin::Pin<
+            Box<dyn std::future::Future<Output = anyhow::Result<()>> + Send>,
+        > + Send
+        + Sync,
+>;
+
+/// The actual production start: installed systemd units for the default
+/// profile, direct launch when `daemon` is set for explicit-config and
+/// required-native profiles (#1585).
+async fn dispatch_real_start(
+    services: &[String],
+    explicit_config: Option<&Path>,
+    daemon: bool,
+    iroh_required: bool,
+) -> anyhow::Result<()> {
+    crate::cli::handle_service_start(services, None, daemon, explicit_config, iroh_required).await
 }
 
 // The shared enroll routine (#438 wizard + #439 `user create`) lives in
@@ -129,9 +164,19 @@ impl BootstrapManager {
             bootstrap_cancel: None,
             service_rx: None,
             service_handle: None,
+            #[cfg(test)]
+            start_dispatch: None,
             cached_env: None,
             policy_manager: None,
         }
+    }
+
+    /// Inject the test-only service-start dispatch. Never called in
+    /// production; exists only so the routing tests can observe which launch
+    /// mode and profile provenance the wizard resolves (#1585).
+    #[cfg(test)]
+    fn set_start_dispatch(&mut self, dispatch: StartDispatchFn) {
+        self.start_dispatch = Some(dispatch);
     }
 
     fn data_dir(&self) -> PathBuf {
@@ -470,21 +515,60 @@ impl WizardBackend for BootstrapManager {
         // Forward this process's pinned config provenance and native profile
         // so bootstrap-launched children load what the operator loaded (#1585).
         let explicit_config = crate::config::explicit_config_path().cloned();
-        let iroh_required = crate::config::HyprConfig::load()
-            .map(|c| c.quic.iroh_required())
-            .unwrap_or(false);
+        // Fail closed: an unloadable configuration is never silently treated
+        // as the default profile (#1585). Installed systemd units cannot carry
+        // this process's explicit --config provenance or the required-native
+        // profile, so those starts take the direct launch path via `daemon`.
+        let (daemon, iroh_required) = match crate::config::HyprConfig::load() {
+            Ok(config) => {
+                let required = config.quic.iroh_required();
+                (explicit_config.is_some() || required, required)
+            }
+            Err(error) => {
+                let message = format!("configuration load failed: {error}");
+                self.service_handle = Some(self.rt.spawn(async move {
+                    let _ = tx.send(OpStatus::InProgress);
+                    let _ = tx.send(OpStatus::Failed(message));
+                }));
+                return;
+            }
+        };
+
+        #[cfg(test)]
+        let start_override = self.start_dispatch.clone();
 
         self.service_handle = Some(self.rt.spawn(async move {
             let _ = tx.send(OpStatus::InProgress);
-            match crate::cli::handle_service_start(
+            #[cfg(test)]
+            let outcome = match start_override {
+                Some(seam) => {
+                    seam(
+                        services.clone(),
+                        explicit_config.clone(),
+                        daemon,
+                        iroh_required,
+                    )
+                    .await
+                }
+                None => {
+                    dispatch_real_start(
+                        &services,
+                        explicit_config.as_deref(),
+                        daemon,
+                        iroh_required,
+                    )
+                    .await
+                }
+            };
+            #[cfg(not(test))]
+            let outcome = dispatch_real_start(
                 &services,
-                None,
-                false,
                 explicit_config.as_deref(),
+                daemon,
                 iroh_required,
             )
-            .await
-            {
+            .await;
+            match outcome {
                 Ok(()) => {
                     let _ = tx.send(OpStatus::Done);
                 }
@@ -886,6 +970,164 @@ mod tests {
     use crate::auth::{RocksDbUserStore, UserStore};
     use crate::cli::enroll::bind_user_signing_key;
     use tempfile::TempDir;
+
+    /// What the wizard's service-start dispatch was invoked with.
+    #[derive(Debug)]
+    struct RecordedStart {
+        services: Vec<String>,
+        explicit: Option<PathBuf>,
+        daemon: bool,
+        required: bool,
+    }
+
+    /// Gate marking a re-exec'd child that runs one service-start routing
+    /// scenario in an isolated process (the pinned/explicit config slots are
+    /// process-global and write-once).
+    const ROUTE_CHILD: &str = "HYPRSTREAM_BOOTSTRAP_ROUTE_CHILD";
+
+    /// BootstrapManager service-start routing through the real profile load:
+    /// the default profile stays on installed systemd units (daemon=false);
+    /// explicit-config and required-native route to the direct launch path
+    /// (daemon=true); an unloadable configuration fails closed with a Failed
+    /// status and never reaches the dispatch at all.
+    #[tokio::test]
+    async fn bootstrap_start_services_routes_profiles_causally() -> anyhow::Result<()> {
+        if let Ok(scenario) = std::env::var(ROUTE_CHILD) {
+            return start_services_child_scenario(&scenario).await;
+        }
+        for scenario in ["default", "explicit", "required", "invalid"] {
+            let status = std::process::Command::new(std::env::current_exe()?)
+                .args([
+                    "--exact",
+                    "cli::bootstrap_manager::tests::bootstrap_start_services_routes_profiles_causally",
+                    "--nocapture",
+                ])
+                .env(ROUTE_CHILD, scenario)
+                .status()?;
+            anyhow::ensure!(
+                status.success(),
+                "bootstrap service routing scenario '{scenario}' failed"
+            );
+        }
+        Ok(())
+    }
+
+    async fn start_services_child_scenario(scenario: &str) -> anyhow::Result<()> {
+        let recorded: Arc<parking_lot::Mutex<Vec<RecordedStart>>> = Arc::default();
+        let sink = recorded.clone();
+        let models = TempDir::new()?;
+        let mut manager = BootstrapManager::new(
+            // The test's own ambient runtime: start_services spawns onto this
+            // handle and the await-based drain below lets the task run.
+            tokio::runtime::Handle::current(),
+            models.path().to_path_buf(),
+            vec!["policy".to_owned()],
+        );
+        manager.set_start_dispatch(Arc::new(
+            move |services: Vec<String>, explicit: Option<PathBuf>, daemon: bool, required: bool| {
+                sink.lock().push(RecordedStart {
+                    services,
+                    explicit,
+                    daemon,
+                    required,
+                });
+                Box::pin(async { Ok::<(), anyhow::Error>(()) })
+                    as std::pin::Pin<Box<dyn std::future::Future<Output = anyhow::Result<()>> + Send>>
+            },
+        ));
+
+        match scenario {
+            "default" => {
+                let _ = crate::config::install_pinned_config(crate::config::HyprConfig::default());
+                manager.start_services();
+                assert_eq!(drain_to_terminal(&mut manager).await, OpStatus::Done);
+                let calls = recorded.lock();
+                assert_eq!(calls.len(), 1, "the dispatch must run exactly once");
+                let call = &calls[0];
+                assert_eq!(call.services, vec!["policy".to_owned()]);
+                assert_eq!(call.explicit, None, "default profile has no explicit provenance");
+                assert!(!call.daemon, "default profile must keep the installed systemd unit route");
+                assert!(!call.required, "default profile is not required-native");
+            }
+            "explicit" => {
+                let _ = crate::config::install_pinned_config(crate::config::HyprConfig::default());
+                let explicit = TempDir::new()?;
+                let marker = explicit.path().join("operator.toml");
+                assert!(
+                    crate::config::install_explicit_config_path(marker.clone()),
+                    "explicit provenance slot must be installable in a fresh child"
+                );
+                manager.start_services();
+                assert_eq!(drain_to_terminal(&mut manager).await, OpStatus::Done);
+                let calls = recorded.lock();
+                assert_eq!(calls.len(), 1, "the dispatch must run exactly once");
+                let call = &calls[0];
+                assert_eq!(call.explicit, Some(marker), "provenance must be forwarded");
+                assert!(call.daemon, "explicit --config provenance must take the direct launch route");
+                assert!(!call.required);
+            }
+            "required" => {
+                let mut required_config = crate::config::HyprConfig::default();
+                required_config.quic.enabled = true;
+                required_config.quic.iroh = true;
+                required_config.quic.native_network_profile =
+                    crate::config::NativeNetworkProfile::NetworkIrohRequired;
+                required_config.validate()?;
+                let _ = crate::config::install_pinned_config(required_config);
+                manager.start_services();
+                assert_eq!(drain_to_terminal(&mut manager).await, OpStatus::Done);
+                let calls = recorded.lock();
+                assert_eq!(calls.len(), 1, "the dispatch must run exactly once");
+                let call = &calls[0];
+                assert!(call.required, "the required-native profile must be observed");
+                assert!(call.daemon, "required-native must take the direct launch route");
+                assert_eq!(call.explicit, None);
+            }
+            "invalid" => {
+                // No pinned snapshot: force the XDG re-derivation onto a
+                // garbage config file so HyprConfig::load() itself fails.
+                let root = TempDir::new()?;
+                let xdg = root.path().join("xdg-config");
+                std::env::set_var("XDG_CONFIG_HOME", &xdg);
+                let config_dir = xdg.join("hyprstream");
+                std::fs::create_dir_all(&config_dir)?;
+                std::fs::write(config_dir.join("config.toml"), "this is = not [valid toml")?;
+                manager.start_services();
+                let terminal = drain_to_terminal(&mut manager).await;
+                match terminal {
+                    OpStatus::Failed(message) => assert!(
+                        message.contains("configuration load failed"),
+                        "unloadable configuration must fail closed naming the cause, got: {message}"
+                    ),
+                    other => panic!("unloadable configuration must surface Failed, got {other:?}"),
+                }
+                assert!(
+                    recorded.lock().is_empty(),
+                    "an unloadable configuration must never reach the service dispatch"
+                );
+            }
+            other => anyhow::bail!("unknown bootstrap routing scenario '{other}'"),
+        }
+        Ok(())
+    }
+
+    /// Drain pending service status until a terminal one arrives (bounded,
+    /// mirroring the wizard's poll loop without the fixed sleep pacing).
+    async fn drain_to_terminal(manager: &mut BootstrapManager) -> OpStatus {
+        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(10);
+        loop {
+            match manager.poll_pending() {
+                OpStatus::InProgress => {
+                    assert!(
+                        std::time::Instant::now() < deadline,
+                        "service start never reached a terminal status"
+                    );
+                    tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+                }
+                terminal => return terminal,
+            }
+        }
+    }
 
     /// A fresh provisioning run writes a hybrid entry for EVERY service, and
     /// those entries anchor into the post-quantum trust store.

--- a/crates/hyprstream/src/cli/service_handlers.rs
+++ b/crates/hyprstream/src/cli/service_handlers.rs
@@ -688,7 +688,7 @@ pub async fn launch_direct_children(
 /// cancelled launch's historical leak, is unchanged.
 struct RequiredLaunchGuard {
     started: Vec<(String, hyprstream_service::SpawnedProcess)>,
-    /// Children whose graceful async stop FAILED: still fully owned by the
+    /// Children whose async rollback stop FAILED: still fully owned by the
     /// guard (a local collection would recreate the ownership-transfer hole
     /// across the remaining rollback awaits), retried by the synchronous
     /// bounded pass.
@@ -743,12 +743,14 @@ impl RequiredLaunchGuard {
         }
     }
 
-    /// Reverse-order graceful rollback with cancellation-safe ownership: a
-    /// stop that errors demotes the child to guard-owned `failed` state —
-    /// never a local unguarded collection — while confirmed successes are
-    /// released. The `stop` seam is the graceful async stop in production;
-    /// tests inject a controllable boundary.
-    async fn graceful_rollback<S, F>(&mut self, mut stop: S)
+    /// Reverse-order rollback with cancellation-safe ownership: a stop that
+    /// errors demotes the child to guard-owned `failed` state — never a
+    /// local unguarded collection — while confirmed successes are released.
+    /// The `stop` seam is the production async rollback stop (the tracked
+    /// path terminates via the retained handle with SIGKILL and reaps within
+    /// a bounded budget — it is not a graceful TERM shutdown); tests inject
+    /// a controllable boundary.
+    async fn rollback_owned_children<S, F>(&mut self, mut stop: S)
     where
         S: FnMut(hyprstream_service::SpawnedProcess) -> F,
         F: std::future::Future<Output = anyhow::Result<()>>,
@@ -836,8 +838,10 @@ impl Drop for RequiredLaunchGuard {
 /// Required-native cancellation safety: started children stay owned by the
 /// [`RequiredLaunchGuard`] until the whole launch commits, so a cancelled
 /// future still cleans them through the backend's retained child handles; an
-/// explicit failure rolls back through the graceful async stop first, with
-/// the synchronous tracked-child pass as the accurate-residual fallback.
+/// explicit failure runs the async rollback stop first (tracked path
+/// terminates via SIGKILL through the retained handle — not a graceful TERM
+/// shutdown), with the synchronous tracked-child pass as the
+/// accurate-residual fallback.
 async fn launch_planned_children(
     plans: Vec<Vec<(String, hyprstream_service::ProcessConfig)>>,
     iroh_required: bool,
@@ -896,7 +900,7 @@ async fn launch_planned_children(
             // these awaits (or the synchronous pass) still cleans everything
             // unconfirmed through the guard's `Drop`.
             guard
-                .graceful_rollback(|process| async move {
+                .rollback_owned_children(|process| async move {
                     spawner.stop(&process).await.map_err(anyhow::Error::from)
                 })
                 .await;
@@ -3125,8 +3129,11 @@ mod launcher_tests {
             );
         }
         // Fixture hygiene: reap the surviving pair directly (the test is the
-        // parent); not a product-contract assertion.
-        for pid in dropped_pids {
+        // parent); not a product-contract assertion. Afterwards remove only
+        // the matching fixture-owned PID artifacts and establish their
+        // absence, so a passing test leaves no stale files; any replacement
+        // artifact would be preserved.
+        for (name, pid) in [(&c, dropped_pids[0]), (&d, dropped_pids[1])] {
             let raw = nix::unistd::Pid::from_raw(pid as i32);
             let _ = nix::sys::signal::kill(raw, nix::sys::signal::Signal::SIGKILL);
             let deadline = std::time::Instant::now() + std::time::Duration::from_secs(5);
@@ -3142,20 +3149,32 @@ mod launcher_tests {
                 );
                 std::thread::sleep(std::time::Duration::from_millis(20));
             }
+            let pid_file = hyprstream_rpc::paths::service_pid_file(name);
+            if let Ok(content) = std::fs::read_to_string(&pid_file) {
+                if content.trim() == pid.to_string() {
+                    let _ = std::fs::remove_file(&pid_file);
+                }
+            }
+            assert!(
+                !pid_file.exists(),
+                "fixture hygiene: {name} must leave no stale PID artifact"
+            );
         }
         Ok(())
     }
 
-    /// Cancellation DURING the explicit rollback awaits still cleans owned
-    /// children. The abort is issued as soon as the READY predecessor is
-    /// observed, so it lands somewhere between the later child's startup and
-    /// the rollback stop — the exact landing point is not deterministic, and
-    /// the OWNERSHIP INVARIANT is what is tested: at every landing, the
-    /// predecessor is either stopped by the graceful async rollback or still
-    /// owned by the guard, whose `Drop` synchronously stops it through the
-    /// backend's retained handle.
+    /// Cancellation around a required startup failure cleans the READY
+    /// predecessor at WHATEVER point the abort lands. The predecessor is
+    /// READY-observed (marker-before-READY proves the child ran and sent
+    /// READY) — but marker presence alone does NOT prove the launcher
+    /// adopted it nor that rollback was entered, so the landing point is
+    /// unspecified: the armed startup guard, the transaction guard, or a
+    /// completed explicit rollback each own the cleanup, and all end with
+    /// the predecessor reaped and its artifact removed. The deterministic
+    /// rollback-boundary evidence lives in
+    /// `rollback_failed_and_pending_stops_stay_guard_owned_through_cancellation`.
     #[tokio::test]
-    async fn required_cancellation_during_rollback_still_cleans_owned_children()
+    async fn required_cancellation_around_startup_failure_cleans_predecessor_at_any_landing()
     -> anyhow::Result<()> {
         use hyprstream_service::{ProcessConfig, ProcessReadiness, ProcessSpawner};
         #[allow(unused_imports)]
@@ -3189,7 +3208,7 @@ mod launcher_tests {
                 ProcessConfig::new(&ready_name, &exe)
                     .args([
                         "--exact",
-                        "cli::service_handlers::launcher_tests::required_cancellation_during_rollback_still_cleans_owned_children",
+                        "cli::service_handlers::launcher_tests::required_cancellation_around_startup_failure_cleans_predecessor_at_any_landing",
                         "--nocapture",
                     ])
                     .env(HELPER, marker.display().to_string())
@@ -3208,9 +3227,11 @@ mod launcher_tests {
             launch_planned_children(plans, true, &spawner).await
         });
 
-        // Abort as soon as the predecessor is READY-observed (marker before
-        // READY, so the launcher has at least adopted it and is at or past
-        // the failing child's startup).
+        // Abort as soon as the predecessor is READY-observed. Marker-before-
+        // READY proves the child ran and sent READY, but NOT that the
+        // launcher adopted it or that rollback was entered — the landing
+        // point is unspecified and every landing must clean the
+        // predecessor.
         let deadline = std::time::Instant::now() + std::time::Duration::from_secs(15);
         while !marker.exists() {
             anyhow::ensure!(
@@ -3247,7 +3268,7 @@ mod launcher_tests {
     /// FAILS must leave its child guard-owned — never moved into a local
     /// unguarded collection — and a cancellation while a LATER stop is still
     /// PENDING must attempt synchronous cleanup of BOTH. The failure/pending
-    /// boundary is injected at the narrow `graceful_rollback` stop seam; the
+    /// boundary is injected at the narrow `rollback_owned_children` stop seam; the
     /// two children are REAL spawned processes, so ownership and cleanup are
     /// evidenced by observed reaps (ESRCH) and PID-artifact removal.
     #[tokio::test]
@@ -3307,15 +3328,21 @@ mod launcher_tests {
         }
 
         let calls = std::sync::Arc::new(AtomicUsize::new(0));
+        let boundary: std::sync::Arc<parking_lot::Mutex<Vec<&'static str>>> =
+            std::sync::Arc::default();
         let calls_task = calls.clone();
+        let boundary_task = boundary.clone();
         let task = tokio::spawn(async move {
             guard
-                .graceful_rollback(move |_process| {
+                .rollback_owned_children(move |_process| {
                     let call = calls_task.fetch_add(1, Ordering::SeqCst);
+                    let boundary = boundary_task.clone();
                     async move {
                         if call == 0 {
+                            boundary.lock().push("first-stop-failed");
                             Err(anyhow::anyhow!("injected stop failure"))
                         } else {
+                            boundary.lock().push("next-stop-pending-entered");
                             // Pending forever: only the task abort below
                             // ends this await.
                             std::future::pending::<()>().await;
@@ -3327,16 +3354,31 @@ mod launcher_tests {
             // Unreachable under the abort; the guard's Drop owns cleanup.
         });
 
-        // Bounded grace so the rollback reaches the pending second stop;
-        // then cancel — the real cancellation boundary this correction is
-        // about (an earlier landing still cleans both: every unconfirmed
-        // child is guard-owned at every point).
-        tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+        // Deterministic boundary, no sleep-only timing assumption: abort
+        // only after BOTH stop invocations happened — the first returned the
+        // injected failure (its child demoted to guard-owned `failed`) and
+        // the second is suspended inside the pending stop.
+        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(10);
+        while calls.load(Ordering::SeqCst) < 2 {
+            anyhow::ensure!(
+                std::time::Instant::now() < deadline,
+                "rollback never reached the pending second stop"
+            );
+            tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+        }
         task.abort();
         let joined = task.await;
         assert!(
             matches!(&joined, Err(join) if join.is_cancelled()),
             "the rollback future must have been cancelled, got: {joined:?}"
+        );
+        // The claimed causal boundary happened: the first stop FAILED and
+        // the next stop was entered and PENDING at cancellation time.
+        assert_eq!(
+            *boundary.lock(),
+            vec!["first-stop-failed", "next-stop-pending-entered"],
+            "the first stop must have failed and the next pending stop must have been \
+             entered before cancellation"
         );
 
         // BOTH children — the failed-stop one and the pending-stop one — are

--- a/crates/hyprstream/src/cli/service_handlers.rs
+++ b/crates/hyprstream/src/cli/service_handlers.rs
@@ -483,35 +483,7 @@ pub async fn handle_service_install(
         // within the bounded startup budget (#1585).
         if start {
             println!("  Starting services...");
-            for service in &target_services {
-                print!("    \u{25CB} {}... ", service);
-                manager
-                    .start(service)
-                    .await
-                    .map_err(|e| anyhow::anyhow!("starting {service}: {e}"))?;
-                let deadline = std::time::Instant::now() + CHILD_READINESS_TIMEOUT;
-                loop {
-                    match manager.is_active(service).await {
-                        Ok(true) => break,
-                        Ok(false) => {
-                            if std::time::Instant::now() >= deadline {
-                                anyhow::bail!(
-                                    "service {service} unit did not reach the active state \
-                                     within {}s",
-                                    CHILD_READINESS_TIMEOUT.as_secs()
-                                );
-                            }
-                            tokio::time::sleep(std::time::Duration::from_millis(100)).await;
-                        }
-                        Err(e) => {
-                            return Err(anyhow::anyhow!(
-                                "active-state check for {service} failed: {e}"
-                            ));
-                        }
-                    }
-                }
-                println!("\u{2713}");
-            }
+            start_units_to_active(&*manager, &target_services, CHILD_READINESS_TIMEOUT).await?;
         }
     } else if start {
         // No systemd: the same factored direct launch path as `service start`
@@ -1045,15 +1017,25 @@ async fn start_units_to_active(
     targets: &[String],
     active_timeout: std::time::Duration,
 ) -> Result<()> {
+    // Submit every start request concurrently before waiting on any unit.
+    // Compatibility services may probe Policy during their own startup;
+    // waiting for an earlier Event unit to become active before submitting
+    // Policy would deadlock when the units were stopped. Systemd's
+    // StartUnit call waits for its job result, so concurrent requests are
+    // required to let Policy and Event make progress together. Mutation
+    // failures still propagate before any active-state success is reported.
     for service in targets {
         print!("  \u{25CB} {}... ", service);
-        // A real mutation failure must surface: continuing here would let a
-        // pre-existing active unit mask the failed start.
+    }
+    futures::future::try_join_all(targets.iter().map(|service| async move {
         manager
             .start(service)
             .await
-            .map_err(|e| anyhow::anyhow!("starting {service}: {e}"))?;
+            .map_err(|e| anyhow::anyhow!("starting {service}: {e}"))
+    }))
+    .await?;
 
+    for service in targets {
         let deadline = std::time::Instant::now() + active_timeout;
         loop {
             match manager.is_active(service).await {
@@ -2740,6 +2722,7 @@ mod launcher_tests {
     struct MockManager {
         start_error: Option<&'static str>,
         active_after: std::sync::atomic::AtomicU32,
+        calls: parking_lot::Mutex<Vec<String>>,
     }
 
     impl MockManager {
@@ -2747,18 +2730,21 @@ mod launcher_tests {
             Self {
                 start_error: Some("unit is masked"),
                 active_after: std::sync::atomic::AtomicU32::new(0),
+                calls: parking_lot::Mutex::new(Vec::new()),
             }
         }
         fn never_active() -> Self {
             Self {
                 start_error: None,
                 active_after: std::sync::atomic::AtomicU32::new(u32::MAX),
+                calls: parking_lot::Mutex::new(Vec::new()),
             }
         }
         fn immediate() -> Self {
             Self {
                 start_error: None,
                 active_after: std::sync::atomic::AtomicU32::new(0),
+                calls: parking_lot::Mutex::new(Vec::new()),
             }
         }
     }
@@ -2771,7 +2757,10 @@ mod launcher_tests {
         async fn uninstall(&self, _service: &str) -> anyhow::Result<()> {
             Ok(())
         }
-        async fn start(&self, _service: &str) -> anyhow::Result<()> {
+        async fn start(&self, service: &str) -> anyhow::Result<()> {
+            self.calls
+                .lock()
+                .push(format!("start:{service}"));
             match self.start_error {
                 Some(reason) => anyhow::bail!("{reason}"),
                 None => Ok(()),
@@ -2780,7 +2769,10 @@ mod launcher_tests {
         async fn stop(&self, _service: &str) -> anyhow::Result<()> {
             Ok(())
         }
-        async fn is_active(&self, _service: &str) -> anyhow::Result<bool> {
+        async fn is_active(&self, service: &str) -> anyhow::Result<bool> {
+            self.calls
+                .lock()
+                .push(format!("active:{service}"));
             use std::sync::atomic::Ordering;
             let remaining = self.active_after.load(Ordering::SeqCst);
             if remaining > 0 && remaining != u32::MAX {
@@ -2842,6 +2834,28 @@ mod launcher_tests {
         )
         .await
         .expect("immediately-active unit must complete");
+    }
+
+    #[tokio::test]
+    async fn unit_starts_are_queued_before_active_waits() {
+        let manager = MockManager::immediate();
+        start_units_to_active(
+            &manager,
+            &["event".to_owned(), "policy".to_owned()],
+            std::time::Duration::from_secs(1),
+        )
+        .await
+        .expect("queued unit starts must complete");
+
+        assert_eq!(
+            *manager.calls.lock(),
+            [
+                "start:event".to_owned(),
+                "start:policy".to_owned(),
+                "active:event".to_owned(),
+                "active:policy".to_owned(),
+            ]
+        );
     }
 
     /// Required roster rollback: a later child failing must stop earlier

--- a/crates/hyprstream/src/cli/service_handlers.rs
+++ b/crates/hyprstream/src/cli/service_handlers.rs
@@ -2704,6 +2704,7 @@ mod launcher_tests {
     /// Required roster rollback: a later child failing must stop earlier
     /// children in reverse order — proven with real supervised processes via
     /// the injected-plan seam.
+    #[cfg(any(target_os = "linux", target_os = "android"))]
     #[tokio::test]
     async fn required_rollback_stops_started_children_on_later_failure() -> anyhow::Result<()> {
         use hyprstream_service::{ProcessConfig, ProcessReadiness, ProcessSpawner};
@@ -2779,6 +2780,7 @@ mod launcher_tests {
     /// break). Stop ORDER is not externally observable here: rollback kills
     /// are SIGKILL, so reverse ordering remains a construction guarantee of
     /// `started.iter().rev()`, not an observed event.
+    #[cfg(any(target_os = "linux", target_os = "android"))]
     #[tokio::test]
     async fn required_stage_failure_aborts_launch_and_never_spawns_later_stages()
     -> anyhow::Result<()> {
@@ -2916,6 +2918,7 @@ mod launcher_tests {
     /// backend's retained handle and removes its PID artifact. The later
     /// child is proven genuinely pending: its marker proves it spawned (so
     /// the first child was adopted), and it never sends READY.
+    #[cfg(any(target_os = "linux", target_os = "android"))]
     #[tokio::test]
     async fn required_cancellation_reaps_adopted_children_and_artifacts() -> anyhow::Result<()> {
         use hyprstream_service::{ProcessConfig, ProcessReadiness, ProcessSpawner};
@@ -3023,6 +3026,7 @@ mod launcher_tests {
     /// and later `stop` through the established contract. (Pair A proves
     /// stoppability through the launching backend's tracked stop; pair C is
     /// dropped with its spawner and must still be running afterwards.)
+    #[cfg(any(target_os = "linux", target_os = "android"))]
     #[tokio::test]
     async fn required_success_commit_leaves_adopted_daemons_alive_and_stoppable()
     -> anyhow::Result<()> {
@@ -3170,6 +3174,7 @@ mod launcher_tests {
     /// or that rollback was entered. The landing is unspecified. The
     /// deterministic rollback-boundary evidence is provided by
     /// `rollback_failed_and_pending_stops_stay_guard_owned_through_cancellation`.
+    #[cfg(any(target_os = "linux", target_os = "android"))]
     #[tokio::test]
     async fn required_cancellation_around_startup_failure_cleans_predecessor_at_any_landing()
     -> anyhow::Result<()> {
@@ -3267,6 +3272,7 @@ mod launcher_tests {
     /// boundary is injected at the narrow `rollback_owned_children` stop seam; the
     /// two children are REAL spawned processes, so ownership and cleanup are
     /// evidenced by observed reaps (ESRCH) and PID-artifact removal.
+    #[cfg(any(target_os = "linux", target_os = "android"))]
     #[tokio::test]
     async fn rollback_failed_and_pending_stops_stay_guard_owned_through_cancellation()
     -> anyhow::Result<()> {

--- a/crates/hyprstream/src/cli/service_handlers.rs
+++ b/crates/hyprstream/src/cli/service_handlers.rs
@@ -919,6 +919,48 @@ async fn launch_planned_children(
         }
         return Err(error);
     }
+    // A child may exit after its readiness notification while a later stage
+    // is still starting. Recheck every adopted child immediately before the
+    // transaction commits so we never report success for a deployment whose
+    // earlier service has already died.
+    if iroh_required {
+        let liveness_error = {
+            let mut failure = None;
+            for (service, process) in &guard.started {
+                match spawner.is_running(process).await {
+                    Ok(true) => {}
+                    Ok(false) => {
+                        failure = Some(anyhow::anyhow!(
+                            "required-native child '{service}' exited before launch commit"
+                        ));
+                        break;
+                    }
+                    Err(e) => {
+                        failure = Some(anyhow::anyhow!(
+                            "could not verify required-native child '{service}' before launch commit: {e}"
+                        ));
+                        break;
+                    }
+                }
+            }
+            failure
+        };
+        if let Some(error) = liveness_error {
+            guard
+                .rollback_owned_children(|process| async move {
+                    spawner.stop(&process).await.map_err(anyhow::Error::from)
+                })
+                .await;
+            let residuals = guard.stop_all_sync_and_disarm();
+            if !residuals.is_empty() {
+                return Err(error.context(format!(
+                    "launch rollback left residual state: {}",
+                    residuals.join("; ")
+                )));
+            }
+            return Err(error);
+        }
+    }
     guard.commit();
     Ok(())
 }

--- a/crates/hyprstream/src/cli/service_handlers.rs
+++ b/crates/hyprstream/src/cli/service_handlers.rs
@@ -669,16 +669,181 @@ pub async fn launch_direct_children(
     launch_planned_children(plans, iroh_required, spawner).await
 }
 
+/// Cancellation-safe ownership of the children of a Required launch
+/// transaction (#1585).
+///
+/// Every child that spawns successfully — including children that already
+/// reached READY and were adopted by the backend — is recorded here until the
+/// WHOLE launch commits. If the orchestration future is cancelled (dropped at
+/// any await: a later child's readiness, or a rollback stop), `Drop` runs the
+/// synchronous bounded tracked-child stop
+/// ([`hyprstream_service::ProcessSpawner::stop_tracked_child_sync`]) over the
+/// children it still owns, newest first: the backend stops them through the
+/// retained `Child` handles (never a blind by-PID signal) and removes their
+/// PID artifacts. That cleanup is plain synchronous code on the drop path —
+/// it does not depend on any async cleanup future surviving runtime shutdown.
+/// On whole-launch success [`Self::commit`] disarms the guard so the adopted
+/// daemons intentionally keep running, stoppable as before. Compatibility
+/// launches are never armed: their historical behavior, including a
+/// cancelled launch's historical leak, is unchanged.
+struct RequiredLaunchGuard {
+    started: Vec<(String, hyprstream_service::SpawnedProcess)>,
+    /// Children whose graceful async stop FAILED: still fully owned by the
+    /// guard (a local collection would recreate the ownership-transfer hole
+    /// across the remaining rollback awaits), retried by the synchronous
+    /// bounded pass.
+    failed: Vec<(String, hyprstream_service::SpawnedProcess)>,
+    /// Clone of the launching spawner: the tracked `Child` handles live in
+    /// its backend, so `Drop` cleanup must go through THIS backend to keep
+    /// the stronger tracked ownership.
+    spawner: hyprstream_service::ProcessSpawner,
+    armed: bool,
+    committed: bool,
+}
+
+impl RequiredLaunchGuard {
+    /// Arm only for Required launches; Compatibility ownership stays exactly
+    /// as it was before #1585's transaction guard.
+    fn arm(iroh_required: bool, spawner: &hyprstream_service::ProcessSpawner) -> Self {
+        Self {
+            started: Vec::new(),
+            failed: Vec::new(),
+            spawner: spawner.clone(),
+            armed: iroh_required,
+            committed: false,
+        }
+    }
+
+    /// Record an adopted child under transaction ownership.
+    fn adopt(&mut self, service: String, process: hyprstream_service::SpawnedProcess) {
+        if self.armed {
+            self.started.push((service, process));
+        }
+    }
+
+    /// The newest owned child, without surrendering ownership: the async stop
+    /// below works on cloned metadata, so a cancellation mid-await leaves the
+    /// original owned and the guard's `Drop` responsible for it.
+    fn newest(&self) -> Option<&(String, hyprstream_service::SpawnedProcess)> {
+        self.started.last()
+    }
+
+    /// Surrender ownership of the newest child — ONLY after a CONFIRMED
+    /// successful stop.
+    fn release_newest(&mut self) {
+        self.started.pop();
+    }
+
+    /// Demote the newest child after a FAILED async stop: it stays
+    /// guard-owned (moved into `failed`) so every later rollback await, and
+    /// cancellation during any of them, still leaves it under `Drop` cleanup.
+    fn demote_newest_to_failed(&mut self) {
+        if let Some(entry) = self.started.pop() {
+            self.failed.push(entry);
+        }
+    }
+
+    /// Reverse-order graceful rollback with cancellation-safe ownership: a
+    /// stop that errors demotes the child to guard-owned `failed` state —
+    /// never a local unguarded collection — while confirmed successes are
+    /// released. The `stop` seam is the graceful async stop in production;
+    /// tests inject a controllable boundary.
+    async fn graceful_rollback<S, F>(&mut self, mut stop: S)
+    where
+        S: FnMut(hyprstream_service::SpawnedProcess) -> F,
+        F: std::future::Future<Output = anyhow::Result<()>>,
+    {
+        while let Some((service, process)) = self.newest().cloned() {
+            print!("  \u{25CB} stopping {} after failed launch... ", service);
+            match stop(process).await {
+                Ok(()) => {
+                    println!("\u{2713}");
+                    self.release_newest();
+                }
+                Err(e) => {
+                    println!("\u{2717} {}", e);
+                    self.demote_newest_to_failed();
+                }
+            }
+        }
+    }
+
+    /// Synchronously stop everything still owned — unreleased children and
+    /// failed-stop demotions, newest first — and disarm. Returns one
+    /// residual-report string per child whose bounded stop did not confirm
+    /// termination or whose PID-artifact cleanup failed (the artifact is then
+    /// deliberately retained — it may still name a live process).
+    fn stop_all_sync_and_disarm(&mut self) -> Vec<String> {
+        let mut residuals = Vec::new();
+        // Deterministic reverse-start-order contract across BOTH ownership
+        // collections: failed demotions were appended newest-first during the
+        // async rollback, so they are revisited in insertion order first,
+        // then the still-unattempted started entries in reverse order.
+        let owned = self
+            .failed
+            .iter()
+            .chain(self.started.iter().rev())
+            .collect::<Vec<_>>();
+        for (service, process) in owned {
+            print!("  \u{25CB} stopping {} (synchronous pass)... ", service);
+            match self.spawner.stop_tracked_child_sync(process) {
+                Ok(()) => println!("\u{2713}"),
+                Err(e) => {
+                    println!("\u{2717} {}", e);
+                    residuals.push(format!("{service}: {e}"));
+                    tracing::error!(
+                        service = %service,
+                        error = %e,
+                        "aborted required launch left residual child state; PID artifact retained"
+                    );
+                }
+            }
+        }
+        self.started.clear();
+        self.failed.clear();
+        self.committed = true;
+        residuals
+    }
+
+    /// Mark the whole launch committed: adopted daemons stay intentionally
+    /// alive and the `Drop` path becomes a no-op.
+    fn commit(&mut self) {
+        self.committed = true;
+    }
+}
+
+impl Drop for RequiredLaunchGuard {
+    fn drop(&mut self) {
+        if self.committed
+            || !self.armed
+            || (self.started.is_empty() && self.failed.is_empty())
+        {
+            return;
+        }
+        // Cancellation (task abort at any await — later-child readiness or a
+        // rollback stop) lands here: the synchronous bounded pass is the
+        // cleanup owner of last resort for everything not yet released,
+        // including children demoted to `failed` by earlier stop errors.
+        self.stop_all_sync_and_disarm();
+    }
+}
+
 /// Serially launch pre-built child plans (stage-ordered) with the
 /// required-native readiness contract and reverse-order rollback. Narrow seam
 /// (#1585): plan building is separate so causal tests can inject concrete
 /// children without the real service binary.
+///
+/// Required-native cancellation safety: started children stay owned by the
+/// [`RequiredLaunchGuard`] until the whole launch commits, so a cancelled
+/// future still cleans them through the backend's retained child handles; an
+/// explicit failure rolls back through the graceful async stop first, with
+/// the synchronous tracked-child pass as the accurate-residual fallback.
 async fn launch_planned_children(
     plans: Vec<Vec<(String, hyprstream_service::ProcessConfig)>>,
     iroh_required: bool,
     spawner: &hyprstream_service::ProcessSpawner,
 ) -> Result<()> {
-    let mut started: Vec<(String, hyprstream_service::SpawnedProcess)> = Vec::new();
+    let mut guard = RequiredLaunchGuard::arm(iroh_required, spawner);
     let mut launch_error: Option<anyhow::Error> = None;
 
     'stages: for stage in &plans {
@@ -689,7 +854,7 @@ async fn launch_planned_children(
                 Ok(process) => {
                     info!("Spawned {} service: {:?}", service, process.kind);
                     println!("\u{2713} (pid {:?})", process.pid());
-                    started.push((service.clone(), process));
+                    guard.adopt(service.clone(), process);
                 }
                 Err(e) => {
                     println!("\u{2717} {}", e);
@@ -725,29 +890,32 @@ async fn launch_planned_children(
     if let Some(error) = launch_error {
         if iroh_required {
             // Deterministic rollback: stop what we started, newest first; each
-            // stop removes that child's PID artifact. Rollback failures are
-            // aggregated onto the original launch failure, never silently
-            // dropped — residual live processes must be reported.
-            let mut rollback_failures = Vec::new();
-            for (service, process) in started.iter().rev() {
-                print!("  \u{25CB} stopping {} after failed launch... ", service);
-                match spawner.stop(process).await {
-                    Ok(_) => println!("\u{2713}"),
-                    Err(e) => {
-                        println!("\u{2717} {}", e);
-                        rollback_failures.push(format!("{service}: {e}"));
-                    }
-                }
-            }
-            if !rollback_failures.is_empty() {
+            // stop removes that child's PID artifact. Every child stays
+            // guard-owned until its stop CONFIRMS — a failed stop is demoted
+            // to guard-owned `failed` state, so a cancellation during ANY of
+            // these awaits (or the synchronous pass) still cleans everything
+            // unconfirmed through the guard's `Drop`.
+            guard
+                .graceful_rollback(|process| async move {
+                    spawner.stop(&process).await.map_err(anyhow::Error::from)
+                })
+                .await;
+            // Synchronous bounded pass over guard-owned state: retries failed
+            // stops and sweeps unreleased children. Only children whose
+            // bounded stop did not confirm termination (or whose PID-artifact
+            // cleanup failed) are residual — reported honestly, never
+            // silently dropped.
+            let residuals = guard.stop_all_sync_and_disarm();
+            if !residuals.is_empty() {
                 return Err(error.context(format!(
                     "launch rollback left residual state: {}",
-                    rollback_failures.join("; ")
+                    residuals.join("; ")
                 )));
             }
         }
         return Err(error);
     }
+    guard.commit();
     Ok(())
 }
 
@@ -2734,6 +2902,454 @@ mod launcher_tests {
             !hyprstream_rpc::paths::service_pid_file(&stage2sentinel).exists(),
             "sentinel must publish no PID file"
         );
+        Ok(())
+    }
+
+    /// Cancellation while a later Required child is pending must retain
+    /// cleanup ownership of the already-adopted READY children: aborting the
+    /// orchestration future (the real cancellation boundary — `BootstrapManager::drop`
+    /// aborts this exact task shape) reaps the adopted child through the
+    /// backend's retained handle and removes its PID artifact. The later
+    /// child is proven genuinely pending: its marker proves it spawned (so
+    /// the first child was adopted), and it never sends READY.
+    #[tokio::test]
+    async fn required_cancellation_reaps_adopted_children_and_artifacts() -> anyhow::Result<()> {
+        use hyprstream_service::{ProcessConfig, ProcessReadiness, ProcessSpawner};
+        #[allow(unused_imports)]
+        use ProcessReadiness as _ProcessReadinessMarker;
+
+        const HELPER: &str = "HYPRSTREAM_LAUNCHER_CANCEL_HELPER";
+        const PENDING: &str = "HYPRSTREAM_LAUNCHER_CANCEL_PENDING";
+
+        // Helper child: writes its PID marker first; the READY variant then
+        // sends READY and stays alive, the pending variant never sends READY.
+        if let Some(path) = std::env::var_os(HELPER) {
+            std::fs::write(&path, std::process::id().to_string())?;
+            if std::env::var_os(PENDING).is_none() {
+                hyprstream_rpc::notify::ready()?;
+            }
+            std::thread::sleep(std::time::Duration::from_secs(30));
+            return Ok(());
+        }
+
+        let exe = std::env::current_exe()?;
+        let dir = tempfile::tempdir()?;
+        let unique = std::process::id();
+        let ready_name = format!("cancel-ready-{unique}");
+        let pending_name = format!("cancel-pending-{unique}");
+        let marker = |name: &str| dir.path().join(format!("{name}.marker"));
+        let marker_pid = |path: &Path| -> anyhow::Result<u32> {
+            std::fs::read_to_string(path)?
+                .trim()
+                .parse::<u32>()
+                .context("marker must hold the child pid")
+        };
+        let assert_reaped = |pid: u32| {
+            let gone = nix::sys::signal::kill(
+                nix::unistd::Pid::from_raw(pid as i32),
+                None,
+            )
+            .is_err_and(|e| e == nix::errno::Errno::ESRCH);
+            assert!(gone, "cancelled child pid {pid} must be genuinely reaped");
+        };
+        let helper_cfg = |name: &str, pending: bool| {
+            let mut config = ProcessConfig::new(name, &exe)
+                .args([
+                    "--exact",
+                    "cli::service_handlers::launcher_tests::required_cancellation_reaps_adopted_children_and_artifacts",
+                    "--nocapture",
+                ])
+                .env(HELPER, marker(name).display().to_string())
+                .with_notify_ready(std::time::Duration::from_secs(30));
+            if pending {
+                config = config.env(PENDING, "1");
+            }
+            config
+        };
+        let plans = vec![vec![
+            (ready_name.clone(), helper_cfg(&ready_name, false)),
+            (pending_name.clone(), helper_cfg(&pending_name, true)),
+        ]];
+
+        // The spawner lives inside the task exactly as in production
+        // (`handle_service_start` owns it), so cancellation also drops the
+        // backend while the guard's synchronous cleanup runs.
+        let task = tokio::spawn(async move {
+            let spawner = ProcessSpawner::standalone();
+            launch_planned_children(plans, true, &spawner).await
+        });
+
+        // Bounded wait for the cancellation point: the pending child's
+        // marker proves the launcher adopted the READY first child and is
+        // now awaiting the second child's readiness.
+        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(15);
+        while !marker(&ready_name).exists() || !marker(&pending_name).exists() {
+            anyhow::ensure!(
+                std::time::Instant::now() < deadline,
+                "launch never reached the pending second child"
+            );
+            tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+        }
+        task.abort();
+        let joined = task.await;
+        assert!(
+            matches!(&joined, Err(join) if join.is_cancelled()),
+            "the orchestration future must have been cancelled, got: {joined:?}"
+        );
+
+        // Both children reaped (ESRCH — observed termination, not an
+        // artifact absence) and no PID artifacts remain: the adopted READY
+        // child through the transaction guard's synchronous tracked-child
+        // pass, the pending child through its own armed startup guard.
+        assert_reaped(marker_pid(&marker(&ready_name))?);
+        assert_reaped(marker_pid(&marker(&pending_name))?);
+        assert!(
+            !hyprstream_rpc::paths::service_pid_file(&ready_name).exists(),
+            "cancelled READY child must leave no PID artifact"
+        );
+        assert!(
+            !hyprstream_rpc::paths::service_pid_file(&pending_name).exists(),
+            "cancelled pending child must leave no PID artifact"
+        );
+        Ok(())
+    }
+
+    /// Whole-launch success must disarm the transaction guard: adopted
+    /// daemons intentionally survive — both a normal launcher/spawner drop
+    /// and later `stop` through the established contract. (Pair A proves
+    /// stoppability through the launching backend's tracked stop; pair C is
+    /// dropped with its spawner and must still be running afterwards.)
+    #[tokio::test]
+    async fn required_success_commit_leaves_adopted_daemons_alive_and_stoppable()
+    -> anyhow::Result<()> {
+        use hyprstream_service::{
+            ProcessConfig, ProcessKind, ProcessReadiness, ProcessSpawner, SpawnedProcess,
+        };
+        #[allow(unused_imports)]
+        use ProcessReadiness as _ProcessReadinessMarker;
+
+        const HELPER: &str = "HYPRSTREAM_LAUNCHER_COMMIT_HELPER";
+
+        if let Some(path) = std::env::var_os(HELPER) {
+            std::fs::write(&path, std::process::id().to_string())?;
+            hyprstream_rpc::notify::ready()?;
+            std::thread::sleep(std::time::Duration::from_secs(30));
+            return Ok(());
+        }
+
+        let exe = std::env::current_exe()?;
+        let dir = tempfile::tempdir()?;
+        let unique = std::process::id();
+        let marker = |name: &str| dir.path().join(format!("{name}.marker"));
+        let marker_pid = |path: &Path| -> anyhow::Result<u32> {
+            std::fs::read_to_string(path)?
+                .trim()
+                .parse::<u32>()
+                .context("marker must hold the child pid")
+        };
+        let alive = |pid: u32| {
+            nix::sys::signal::kill(nix::unistd::Pid::from_raw(pid as i32), None).is_ok()
+        };
+        let helper_cfg = |name: &str| {
+            ProcessConfig::new(name, &exe)
+                .args([
+                    "--exact",
+                    "cli::service_handlers::launcher_tests::required_success_commit_leaves_adopted_daemons_alive_and_stoppable",
+                    "--nocapture",
+                ])
+                .env(HELPER, marker(name).display().to_string())
+                .with_notify_ready(std::time::Duration::from_secs(30))
+        };
+
+        // Pair A: committed, then stopped through the launching backend.
+        let spawner = ProcessSpawner::standalone();
+        let a = format!("commit-a-{unique}");
+        let b = format!("commit-b-{unique}");
+        launch_planned_children(
+            vec![vec![(a.clone(), helper_cfg(&a)), (b.clone(), helper_cfg(&b))]],
+            true,
+            &spawner,
+        )
+        .await
+        .expect("whole-launch success must commit");
+        // Bounded wait until both helpers recorded their PIDs (the launch
+        // only returns after both are READY, so the markers already exist).
+        for name in [&a, &b] {
+            let deadline = std::time::Instant::now() + std::time::Duration::from_secs(10);
+            while !marker(name).exists() {
+                anyhow::ensure!(
+                    std::time::Instant::now() < deadline,
+                    "committed child {name} never recorded its PID"
+                );
+                tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+            }
+        }
+        // Stop through the launching backend's established tracked contract.
+        for (name, pid) in [(&a, marker_pid(&marker(&a))?), (&b, marker_pid(&marker(&b))?)] {
+            assert!(alive(pid), "committed daemon {name} must still be running");
+            let meta = SpawnedProcess::new(format!("{name}-{pid}"), ProcessKind::Direct(pid))
+                .with_pid_file(hyprstream_rpc::paths::service_pid_file(name));
+            spawner
+                .stop(&meta)
+                .await
+                .expect("committed daemon must remain stoppable");
+            assert!(
+                nix::sys::signal::kill(nix::unistd::Pid::from_raw(pid as i32), None)
+                    .is_err_and(|e| e == nix::errno::Errno::ESRCH),
+                "stopped committed daemon {name} must be reaped"
+            );
+            assert!(
+                !hyprstream_rpc::paths::service_pid_file(name).exists(),
+                "stopped committed daemon {name} must leave no PID artifact"
+            );
+        }
+
+        // Pair C: committed, then the launching spawner is dropped normally —
+        // the adopted daemons must survive it (kill_on_drop stays false).
+        let c = format!("commit-c-{unique}");
+        let d = format!("commit-d-{unique}");
+        let drop_spawner = ProcessSpawner::standalone();
+        launch_planned_children(
+            vec![vec![(c.clone(), helper_cfg(&c)), (d.clone(), helper_cfg(&d))]],
+            true,
+            &drop_spawner,
+        )
+        .await
+        .expect("whole-launch success must commit");
+        let dropped_pids = [marker_pid(&marker(&c))?, marker_pid(&marker(&d))?];
+        drop(drop_spawner);
+        for (name, pid) in [(&c, dropped_pids[0]), (&d, dropped_pids[1])] {
+            assert!(
+                alive(pid),
+                "committed daemon {name} must survive a normal launcher drop"
+            );
+        }
+        // Fixture hygiene: reap the surviving pair directly (the test is the
+        // parent); not a product-contract assertion.
+        for pid in dropped_pids {
+            let raw = nix::unistd::Pid::from_raw(pid as i32);
+            let _ = nix::sys::signal::kill(raw, nix::sys::signal::Signal::SIGKILL);
+            let deadline = std::time::Instant::now() + std::time::Duration::from_secs(5);
+            loop {
+                match nix::sys::wait::waitpid(raw, Some(nix::sys::wait::WaitPidFlag::WNOHANG)) {
+                    Ok(status) if status != nix::sys::wait::WaitStatus::StillAlive => break,
+                    Err(_) => break,
+                    Ok(_) => {}
+                }
+                anyhow::ensure!(
+                    std::time::Instant::now() < deadline,
+                    "fixture child {pid} could not be reaped"
+                );
+                std::thread::sleep(std::time::Duration::from_millis(20));
+            }
+        }
+        Ok(())
+    }
+
+    /// Cancellation DURING the explicit rollback awaits still cleans owned
+    /// children. The abort is issued as soon as the READY predecessor is
+    /// observed, so it lands somewhere between the later child's startup and
+    /// the rollback stop — the exact landing point is not deterministic, and
+    /// the OWNERSHIP INVARIANT is what is tested: at every landing, the
+    /// predecessor is either stopped by the graceful async rollback or still
+    /// owned by the guard, whose `Drop` synchronously stops it through the
+    /// backend's retained handle.
+    #[tokio::test]
+    async fn required_cancellation_during_rollback_still_cleans_owned_children()
+    -> anyhow::Result<()> {
+        use hyprstream_service::{ProcessConfig, ProcessReadiness, ProcessSpawner};
+        #[allow(unused_imports)]
+        use ProcessReadiness as _ProcessReadinessMarker;
+
+        const HELPER: &str = "HYPRSTREAM_LAUNCHER_CANCEL_ROLLBACK_HELPER";
+
+        if let Some(path) = std::env::var_os(HELPER) {
+            std::fs::write(&path, std::process::id().to_string())?;
+            hyprstream_rpc::notify::ready()?;
+            std::thread::sleep(std::time::Duration::from_secs(30));
+            return Ok(());
+        }
+
+        let exe = std::env::current_exe()?;
+        let dir = tempfile::tempdir()?;
+        let unique = std::process::id();
+        let ready_name = format!("cancel-rollback-ready-{unique}");
+        let fail_name = format!("cancel-rollback-fail-{unique}");
+        let marker = dir.path().join(format!("{ready_name}.marker"));
+        let marker_pid = |path: &Path| -> anyhow::Result<u32> {
+            std::fs::read_to_string(path)?
+                .trim()
+                .parse::<u32>()
+                .context("marker must hold the child pid")
+        };
+
+        let plans = vec![vec![
+            (
+                ready_name.clone(),
+                ProcessConfig::new(&ready_name, &exe)
+                    .args([
+                        "--exact",
+                        "cli::service_handlers::launcher_tests::required_cancellation_during_rollback_still_cleans_owned_children",
+                        "--nocapture",
+                    ])
+                    .env(HELPER, marker.display().to_string())
+                    .with_notify_ready(std::time::Duration::from_secs(30)),
+            ),
+            (
+                fail_name.clone(),
+                ProcessConfig::new(&fail_name, Path::new("/bin/sh"))
+                    .args(["-c", "exit 7"])
+                    .with_notify_ready(std::time::Duration::from_secs(10)),
+            ),
+        ]];
+
+        let task = tokio::spawn(async move {
+            let spawner = ProcessSpawner::standalone();
+            launch_planned_children(plans, true, &spawner).await
+        });
+
+        // Abort as soon as the predecessor is READY-observed (marker before
+        // READY, so the launcher has at least adopted it and is at or past
+        // the failing child's startup).
+        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(15);
+        while !marker.exists() {
+            anyhow::ensure!(
+                std::time::Instant::now() < deadline,
+                "READY predecessor never recorded its PID"
+            );
+            tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+        }
+        task.abort();
+        let joined = task.await;
+        // Either the future was cancelled (cancellation cleanup ran) or the
+        // rollback completed before the abort landed (explicit-failure
+        // rollback ran) — both paths must end with the predecessor cleaned.
+        match &joined {
+            Err(join) => assert!(join.is_cancelled(), "unexpected join error: {join:?}"),
+            Ok(Err(error)) => assert!(
+                error.to_string().contains("exited during startup"),
+                "completed rollback must carry the launch error, got: {error}"
+            ),
+            Ok(Ok(())) => panic!("a required launch with a failing child must not succeed"),
+        }
+        let pid = marker_pid(&marker)?;
+        let gone = nix::sys::signal::kill(nix::unistd::Pid::from_raw(pid as i32), None)
+            .is_err_and(|e| e == nix::errno::Errno::ESRCH);
+        assert!(gone, "predecessor pid {pid} must be cleaned at every landing point");
+        assert!(
+            !hyprstream_rpc::paths::service_pid_file(&ready_name).exists(),
+            "predecessor must leave no PID artifact"
+        );
+        Ok(())
+    }
+
+    /// Rollback ownership-boundary regression (root-requested): a stop that
+    /// FAILS must leave its child guard-owned — never moved into a local
+    /// unguarded collection — and a cancellation while a LATER stop is still
+    /// PENDING must attempt synchronous cleanup of BOTH. The failure/pending
+    /// boundary is injected at the narrow `graceful_rollback` stop seam; the
+    /// two children are REAL spawned processes, so ownership and cleanup are
+    /// evidenced by observed reaps (ESRCH) and PID-artifact removal.
+    #[tokio::test]
+    async fn rollback_failed_and_pending_stops_stay_guard_owned_through_cancellation()
+    -> anyhow::Result<()> {
+        use hyprstream_service::{ProcessConfig, ProcessSpawner};
+        use std::sync::atomic::{AtomicUsize, Ordering};
+
+        const HELPER: &str = "HYPRSTREAM_LAUNCHER_RBOWN_HELPER";
+
+        if let Some(path) = std::env::var_os(HELPER) {
+            std::fs::write(&path, std::process::id().to_string())?;
+            hyprstream_rpc::notify::ready()?;
+            std::thread::sleep(std::time::Duration::from_secs(30));
+            return Ok(());
+        }
+
+        let exe = std::env::current_exe()?;
+        let dir = tempfile::tempdir()?;
+        let unique = std::process::id();
+        let older = format!("rbown-older-{unique}");
+        let newer = format!("rbown-newer-{unique}");
+        let marker = |name: &str| dir.path().join(format!("{name}.marker"));
+        let marker_pid = |path: &Path| -> anyhow::Result<u32> {
+            std::fs::read_to_string(path)?
+                .trim()
+                .parse::<u32>()
+                .context("marker must hold the child pid")
+        };
+        let assert_reaped = |pid: u32| {
+            let gone = nix::sys::signal::kill(
+                nix::unistd::Pid::from_raw(pid as i32),
+                None,
+            )
+            .is_err_and(|e| e == nix::errno::Errno::ESRCH);
+            assert!(gone, "guard-owned child pid {pid} must be genuinely reaped");
+        };
+        let helper_cfg = |name: &str| {
+            ProcessConfig::new(name, &exe)
+                .args([
+                    "--exact",
+                    "cli::service_handlers::launcher_tests::rollback_failed_and_pending_stops_stay_guard_owned_through_cancellation",
+                    "--nocapture",
+                ])
+                .env(HELPER, marker(name).display().to_string())
+                .with_notify_ready(std::time::Duration::from_secs(30))
+        };
+
+        let spawner = ProcessSpawner::standalone();
+        let mut guard = RequiredLaunchGuard::arm(true, &spawner);
+        // Real adoption, start order older → newer; the rollback walks
+        // newest first, so the NEWER child hits the injected failed stop and
+        // the OLDER child the injected pending stop.
+        for name in [&older, &newer] {
+            let process = spawner.spawn(helper_cfg(name)).await?;
+            guard.adopt(name.to_owned(), process);
+        }
+
+        let calls = std::sync::Arc::new(AtomicUsize::new(0));
+        let calls_task = calls.clone();
+        let task = tokio::spawn(async move {
+            guard
+                .graceful_rollback(move |_process| {
+                    let call = calls_task.fetch_add(1, Ordering::SeqCst);
+                    async move {
+                        if call == 0 {
+                            Err(anyhow::anyhow!("injected stop failure"))
+                        } else {
+                            // Pending forever: only the task abort below
+                            // ends this await.
+                            std::future::pending::<()>().await;
+                            Ok(())
+                        }
+                    }
+                })
+                .await;
+            // Unreachable under the abort; the guard's Drop owns cleanup.
+        });
+
+        // Bounded grace so the rollback reaches the pending second stop;
+        // then cancel — the real cancellation boundary this correction is
+        // about (an earlier landing still cleans both: every unconfirmed
+        // child is guard-owned at every point).
+        tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+        task.abort();
+        let joined = task.await;
+        assert!(
+            matches!(&joined, Err(join) if join.is_cancelled()),
+            "the rollback future must have been cancelled, got: {joined:?}"
+        );
+
+        // BOTH children — the failed-stop one and the pending-stop one — are
+        // reaped with their PID artifacts removed by the guard's synchronous
+        // pass through the backend's retained handles.
+        assert_reaped(marker_pid(&marker(&newer))?);
+        assert_reaped(marker_pid(&marker(&older))?);
+        for name in [&older, &newer] {
+            assert!(
+                !hyprstream_rpc::paths::service_pid_file(name).exists(),
+                "cancelled rollback child {name} must leave no PID artifact"
+            );
+        }
         Ok(())
     }
 

--- a/crates/hyprstream/src/cli/service_handlers.rs
+++ b/crates/hyprstream/src/cli/service_handlers.rs
@@ -370,6 +370,8 @@ pub async fn handle_service_install(
     enable: bool,
     target: hyprstream_service::ServiceTarget,
     verbose: bool,
+    explicit_config: Option<&Path>,
+    iroh_required: bool,
 ) -> Result<()> {
     let target_services = services_filter.unwrap_or_else(|| config_services.to_vec());
 
@@ -408,6 +410,27 @@ pub async fn handle_service_install(
 
     // 3. Install/update systemd units if available
     if hyprstream_rpc::has_systemd() {
+        // Installed units run their own stored configuration (fixed ExecStart,
+        // no config provenance, raw dependency order). Installing, enabling,
+        // or starting such a unit under an explicit --config selector or the
+        // required-native profile would silently run a different identity
+        // than this process loaded. Refuse before any unit mutation; the
+        // direct launch path is the supported route.
+        if explicit_config.is_some() || iroh_required {
+            anyhow::bail!(
+                "installed hyprstream service units cannot receive an explicit --config \
+                 selector or the required-native profile, so this command cannot install \
+                 or start units for that configuration. Launch provisioned services \
+                 directly instead, e.g. `hyprstream{} service start <service> --daemon`. \
+                 (Plain `hyprstream service install` without the custom selector or \
+                 required profile still installs default-configuration units.)",
+                match explicit_config {
+                    Some(path) => format!(" --config {}", path.display()),
+                    None => String::new(),
+                }
+            );
+        }
+
         let manager = hyprstream_service::detect_service_manager_with_mode(target).await?;
 
         // Encrypt secrets into the systemd user credstore before generating units.
@@ -421,7 +444,9 @@ pub async fn handle_service_install(
             hyprstream_service::encrypt_credentials_if_available(secrets_dir.as_deref());
         }
 
-        // If --start, stop all target services first so they pick up changes
+        // If --start, stop all target services first so they pick up changes.
+        // Stop is legitimately idempotent here (already-stopped units are the
+        // common case on reinstall), so failures stay non-fatal.
         if start {
             println!("  Stopping services...");
             for service in &target_services {
@@ -432,10 +457,11 @@ pub async fn handle_service_install(
         println!("  Installing systemd units...");
         for service in &target_services {
             print!("    \u{25CB} {}... ", service);
-            match manager.install(service).await {
-                Ok(_) => println!("\u{2713}"),
-                Err(e) => println!("\u{2717} {}", e),
-            }
+            manager
+                .install(service)
+                .await
+                .map_err(|e| anyhow::anyhow!("installing unit for {service}: {e}"))?;
+            println!("\u{2713}");
         }
 
         // If --enable, register units for autostart at boot
@@ -443,26 +469,52 @@ pub async fn handle_service_install(
             println!("  Enabling services for autostart...");
             for service in &target_services {
                 print!("    \u{25CB} {}... ", service);
-                match manager.enable(service).await {
-                    Ok(_) => println!("\u{2713}"),
-                    Err(e) => println!("\u{2717} {}", e),
-                }
+                manager
+                    .enable(service)
+                    .await
+                    .map_err(|e| anyhow::anyhow!("enabling unit for {service}: {e}"))?;
+                println!("\u{2713}");
             }
         }
 
-        // 4. If --start, start all target services
+        // 4. If --start, start all target services. A queued start request is
+        // not success: require the unit to reach the active state (Type=notify)
+        // within the bounded startup budget (#1585).
         if start {
             println!("  Starting services...");
             for service in &target_services {
                 print!("    \u{25CB} {}... ", service);
-                match manager.start(service).await {
-                    Ok(_) => println!("\u{2713}"),
-                    Err(e) => println!("\u{2717} {}", e),
+                manager
+                    .start(service)
+                    .await
+                    .map_err(|e| anyhow::anyhow!("starting {service}: {e}"))?;
+                let deadline = std::time::Instant::now() + CHILD_READINESS_TIMEOUT;
+                loop {
+                    match manager.is_active(service).await {
+                        Ok(true) => break,
+                        Ok(false) => {
+                            if std::time::Instant::now() >= deadline {
+                                anyhow::bail!(
+                                    "service {service} unit did not reach the active state \
+                                     within {}s",
+                                    CHILD_READINESS_TIMEOUT.as_secs()
+                                );
+                            }
+                            tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+                        }
+                        Err(e) => {
+                            return Err(anyhow::anyhow!(
+                                "active-state check for {service} failed: {e}"
+                            ));
+                        }
+                    }
                 }
+                println!("\u{2713}");
             }
         }
     } else if start {
-        // Standalone mode: use installed binary to spawn processes
+        // No systemd: the same factored direct launch path as `service start`
+        // — profile-aware ordering, config forwarding, notification readiness.
         println!("  Starting services (standalone)...\n");
 
         let exe = hyprstream_rpc::paths::installed_executable_path()
@@ -470,20 +522,14 @@ pub async fn handle_service_install(
 
         let spawner = hyprstream_service::ProcessSpawner::standalone();
 
-        for service in &target_services {
-            print!("    \u{25CB} {}... ", service);
-
-            let config = hyprstream_service::ProcessConfig::new(service, &exe)
-                .args(["service", "start", service, "--foreground", "--ipc"]);
-
-            match spawner.spawn(config).await {
-                Ok(process) => {
-                    info!("Spawned {} service: {:?}", service, process.kind);
-                    println!("\u{2713}");
-                }
-                Err(e) => println!("\u{2717} {}", e),
-            }
-        }
+        launch_direct_children(
+            &target_services,
+            iroh_required,
+            explicit_config,
+            &exe,
+            &spawner,
+        )
+        .await?;
     }
 
     println!("\n\u{2713} Install complete");
@@ -532,11 +578,193 @@ pub async fn handle_service_uninstall(
     Ok(())
 }
 
+/// Budget a spawned child gets to report genuine readiness (#1585).
+const CHILD_READINESS_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(30);
+
+/// Build one child invocation for the direct launch path (#1585).
+///
+/// Required-native children run `hyprstream [--config PATH] service start NAME
+/// --foreground` — no `--ipc`, no local endpoint fallback; their readiness is
+/// the child's own notification boundary, never a UDS socket. Compatibility
+/// children keep the historical `--ipc` shape. The explicit config path (when
+/// the operator supplied one) is forwarded so the child loads, validates, and
+/// pins the same configuration the launcher did; it is canonical absolute, so
+/// it stays meaningful regardless of the child's working directory, and it is
+/// one argv element, so spaces need no quoting. Config contents, keys, and
+/// JWTs never enter argv or the environment.
+pub fn direct_child_process_config(
+    service: &str,
+    iroh_required: bool,
+    explicit_config: Option<&Path>,
+    exe: &Path,
+) -> Result<hyprstream_service::ProcessConfig> {
+    let mut args: Vec<String> = Vec::new();
+    if let Some(config_path) = explicit_config {
+        let rendered = config_path
+            .to_str()
+            .with_context(|| {
+                format!(
+                    "explicit config path {} is not valid UTF-8 and cannot be forwarded",
+                    config_path.display()
+                )
+            })?
+            .to_owned();
+        args.push("--config".to_owned());
+        args.push(rendered);
+    }
+    args.push("service".to_owned());
+    args.push("start".to_owned());
+    args.push(service.to_owned());
+    args.push("--foreground".to_owned());
+    if !iroh_required {
+        args.push("--ipc".to_owned());
+    }
+
+    let mut config = hyprstream_service::ProcessConfig::new(service, exe);
+    config.args = args;
+    if iroh_required {
+        // The child's own authenticated startup boundary is the readiness
+        // signal (sd_notify READY after Iroh bind and first publication).
+        config.readiness =
+            hyprstream_service::ProcessReadiness::Notify { timeout: CHILD_READINESS_TIMEOUT };
+    }
+    Ok(config)
+}
+
+/// Launch children directly in profile-aware dependency order (#1585).
+///
+/// Shared by `service start --daemon`, no-systemd `service start`, and the
+/// no-systemd `service install --start` fallback, so every direct launch gets
+/// the same ordering, config forwarding, and readiness contract.
+///
+/// Required-native: every child must report genuine readiness before the next
+/// child (and stage) starts; any spawn, early-exit, or timeout failure stops
+/// already-started children in reverse start order and returns `Err` — the
+/// caller never prints success for a partial launch. Compatibility keeps the
+/// historical best-effort behavior (per-service error lines, UDS-presence
+/// stage barrier with warn-and-continue) so existing deployments are
+/// unchanged.
+pub async fn launch_direct_children(
+    targets: &[String],
+    iroh_required: bool,
+    explicit_config: Option<&Path>,
+    exe: &Path,
+    spawner: &hyprstream_service::ProcessSpawner,
+) -> Result<()> {
+    let stages = hyprstream_service::startup_stages_for_profile(targets, iroh_required);
+    // Flatten the ordered stages into the serial launch plan (same order the
+    // loop below would spawn in), so the launch core is injectably testable
+    // without the real service binary.
+    let mut plans: Vec<Vec<(String, hyprstream_service::ProcessConfig)>> = Vec::new();
+    for stage in &stages {
+        let mut stage_plans = Vec::new();
+        for service in stage {
+            stage_plans.push((
+                service.clone(),
+                direct_child_process_config(service, iroh_required, explicit_config, exe)?,
+            ));
+        }
+        plans.push(stage_plans);
+    }
+    launch_planned_children(plans, iroh_required, spawner).await
+}
+
+/// Serially launch pre-built child plans (stage-ordered) with the
+/// required-native readiness contract and reverse-order rollback. Narrow seam
+/// (#1585): plan building is separate so causal tests can inject concrete
+/// children without the real service binary.
+async fn launch_planned_children(
+    plans: Vec<Vec<(String, hyprstream_service::ProcessConfig)>>,
+    iroh_required: bool,
+    spawner: &hyprstream_service::ProcessSpawner,
+) -> Result<()> {
+    let mut started: Vec<(String, hyprstream_service::SpawnedProcess)> = Vec::new();
+    let mut launch_error: Option<anyhow::Error> = None;
+
+    'stages: for stage in &plans {
+        for (service, config) in stage {
+            print!("  \u{25CB} {}... ", service);
+
+            match spawner.spawn(config.clone()).await {
+                Ok(process) => {
+                    info!("Spawned {} service: {:?}", service, process.kind);
+                    println!("\u{2713} (pid {:?})", process.pid());
+                    started.push((service.clone(), process));
+                }
+                Err(e) => {
+                    println!("\u{2717} {}", e);
+                    if iroh_required {
+                        // A required-native failure aborts the WHOLE launch:
+                        // later stages depend on earlier ones, so none of
+                        // them may spawn before the rollback runs.
+                        launch_error = Some(e.into());
+                        break 'stages;
+                    }
+                }
+            }
+        }
+
+        // Compatibility stage barrier: wait for IPC sockets before the next
+        // stage. Required-native readiness was already enforced per child
+        // above; it never depends on a service UDS socket.
+        if !iroh_required {
+            let runtime_dir = hyprstream_rpc::paths::runtime_dir();
+            for (service, _) in stage {
+                let sock = runtime_dir.join(format!("{service}.sock"));
+                let deadline = std::time::Instant::now() + CHILD_READINESS_TIMEOUT;
+                while !sock.exists() && std::time::Instant::now() < deadline {
+                    tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+                }
+                if !sock.exists() {
+                    tracing::warn!("Timeout waiting for {service} socket; continuing");
+                }
+            }
+        }
+    }
+
+    if let Some(error) = launch_error {
+        if iroh_required {
+            // Deterministic rollback: stop what we started, newest first; each
+            // stop removes that child's PID artifact. Rollback failures are
+            // aggregated onto the original launch failure, never silently
+            // dropped — residual live processes must be reported.
+            let mut rollback_failures = Vec::new();
+            for (service, process) in started.iter().rev() {
+                print!("  \u{25CB} stopping {} after failed launch... ", service);
+                match spawner.stop(process).await {
+                    Ok(_) => println!("\u{2713}"),
+                    Err(e) => {
+                        println!("\u{2717} {}", e);
+                        rollback_failures.push(format!("{service}: {e}"));
+                    }
+                }
+            }
+            if !rollback_failures.is_empty() {
+                return Err(error.context(format!(
+                    "launch rollback left residual state: {}",
+                    rollback_failures.join("; ")
+                )));
+            }
+        }
+        return Err(error);
+    }
+    Ok(())
+}
+
 /// Handle `service start` (non-foreground) - Start via systemd or spawn
+///
+/// `explicit_config` is the operator's canonical absolute `--config` selector
+/// (CLI value or the `HYPRSTREAM_CONFIG` env selector); `iroh_required` is the
+/// loaded config's native-network profile. Required-native or custom-config
+/// starts never select an installed systemd unit — those units encode their
+/// own stored configuration and cannot receive this process's configuration —
+/// and are routed to the direct launch path instead.
 pub async fn handle_service_start(
     config_services: &[String],
     name: Option<String>,
     daemon: bool,
+    explicit_config: Option<&Path>,
+    iroh_required: bool,
 ) -> Result<()> {
     let target_services: Vec<String> = if let Some(name) = name {
         vec![name]
@@ -551,58 +779,85 @@ pub async fn handle_service_start(
 
     // Use systemd if available and --daemon not specified
     if hyprstream_rpc::has_systemd() && !daemon {
+        if explicit_config.is_some() || iroh_required {
+            anyhow::bail!(
+                "installed hyprstream service units run their own stored configuration; \
+                 an explicit --config selector or the required-native profile cannot be \
+                 applied through them. Launch provisioned services directly instead, \
+                 e.g. `hyprstream{} service start <service> --daemon`.",
+                match explicit_config {
+                    Some(path) => format!(" --config {}", path.display()),
+                    None => String::new(),
+                }
+            );
+        }
+
         let manager = hyprstream_service::detect_service_manager().await?;
 
         println!("Starting services (systemd)...\n");
 
-        for service in &target_services {
-            print!("  \u{25CB} {}... ", service);
-            match manager.start(service).await {
-                Ok(_) => println!("\u{2713}"),
-                Err(e) => println!("\u{2717} {}", e),
-            }
-        }
+        start_units_to_active(&*manager, &target_services, CHILD_READINESS_TIMEOUT).await?;
     } else {
-        // Standalone mode: spawn processes in dependency order
+        // Direct launch: profile-aware ordering, config forwarding, and the
+        // per-child notification readiness contract.
         println!("Starting services (standalone)...\n");
 
         let spawner = hyprstream_service::ProcessSpawner::standalone();
         let exe = hyprstream_rpc::paths::executable_path()?;
-        let stages = hyprstream_service::startup_stages(&target_services);
-
-        for stage in &stages {
-            for service in stage {
-                print!("  \u{25CB} {}... ", service);
-
-                let config = hyprstream_service::ProcessConfig::new(service, &exe)
-                    .args(["service", "start", service, "--foreground", "--ipc"]);
-
-                match spawner.spawn(config).await {
-                    Ok(process) => {
-                        info!("Spawned {} service: {:?}", service, process.kind);
-                        println!("\u{2713}");
-                    }
-                    Err(e) => println!("\u{2717} {}", e),
-                }
-            }
-
-            // Wait for this stage's services to be ready before starting the next.
-            // Probe for IPC socket existence as the readiness signal.
-            let runtime_dir = hyprstream_rpc::paths::runtime_dir();
-            for service in stage {
-                let sock = runtime_dir.join(format!("{service}.sock"));
-                let deadline = std::time::Instant::now() + std::time::Duration::from_secs(30);
-                while !sock.exists() && std::time::Instant::now() < deadline {
-                    tokio::time::sleep(std::time::Duration::from_millis(100)).await;
-                }
-                if !sock.exists() {
-                    tracing::warn!("Timeout waiting for {service} socket; continuing");
-                }
-            }
-        }
+        launch_direct_children(
+            &target_services,
+            iroh_required,
+            explicit_config,
+            &exe,
+            &spawner,
+        )
+        .await?;
     }
 
     println!("\n\u{2713} Start complete");
+    Ok(())
+}
+
+
+/// Start installed units and require each to reach the active state within
+/// `active_timeout` before reporting success (#1585).
+///
+/// The permitted Compatibility-only existing-unit path: mutation failures
+/// propagate (a pre-existing active unit must never mask a failed start), and
+/// a queued start request is not completion — the unit is Type=notify.
+/// Injectable over [`hyprstream_service::ServiceManager`] for causal tests.
+async fn start_units_to_active(
+    manager: &dyn hyprstream_service::ServiceManager,
+    targets: &[String],
+    active_timeout: std::time::Duration,
+) -> Result<()> {
+    for service in targets {
+        print!("  \u{25CB} {}... ", service);
+        // A real mutation failure must surface: continuing here would let a
+        // pre-existing active unit mask the failed start.
+        manager
+            .start(service)
+            .await
+            .map_err(|e| anyhow::anyhow!("starting {service}: {e}"))?;
+
+        let deadline = std::time::Instant::now() + active_timeout;
+        loop {
+            match manager.is_active(service).await {
+                Ok(true) => break,
+                Ok(false) => {
+                    if std::time::Instant::now() >= deadline {
+                        anyhow::bail!(
+                            "service {service} unit did not reach the active state within {}s",
+                            active_timeout.as_secs()
+                        );
+                    }
+                    tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+                }
+                Err(e) => return Err(e),
+            }
+        }
+        println!("\u{2713}");
+    }
     Ok(())
 }
 
@@ -1592,6 +1847,7 @@ fn update_shell_profiles(home: &Path, bin_dir: &Path) -> Result<Vec<String>> {
 }
 
 #[cfg(test)]
+<<<<<<< HEAD
 #[allow(clippy::expect_used)]
 mod offline_policy_provision_tests {
     use super::*;
@@ -1718,10 +1974,158 @@ mod offline_policy_provision_tests {
                 "mesh-readers".to_owned(),
                 "acme".to_owned(),
             ]));
+=======
+mod launcher_tests {
+    #![allow(clippy::expect_used, clippy::unwrap_used)]
+
+    use super::*;
+    use hyprstream_service::ProcessReadiness;
+
+    #[test]
+    fn direct_child_process_config_builds_profile_specific_invocation() -> anyhow::Result<()> {
+        let root = tempfile::tempdir()?;
+        // A relative-looking config directory containing spaces: the launcher
+        // hands the child one canonical absolute argv element that keeps the
+        // spaces (no shell splitting, no quoting).
+        let config_path = root.path().join("my configs/custom.toml");
+        std::fs::create_dir_all(config_path.parent().expect("parent"))?;
+        std::fs::write(&config_path, "[secrets]\n")?;
+        let canonical = std::fs::canonicalize(&config_path)?;
+
+        // Required-native: no --ipc, config forwarded, notification readiness.
+        let required = direct_child_process_config(
+            "model",
+            true,
+            Some(&canonical),
+            Path::new("/usr/local/bin/hyprstream"),
+        )?;
+        let expected_tail = [
+            "service".to_owned(),
+            "start".to_owned(),
+            "model".to_owned(),
+            "--foreground".to_owned(),
+        ];
+        assert_eq!(&required.args[required.args.len() - 4..], &expected_tail);
+        assert!(
+            !required.args.iter().any(|arg| arg == "--ipc"),
+            "required-native child must not be forced onto the local IPC endpoint"
+        );
+        assert!(
+            required
+                .args
+                .windows(2)
+                .any(|pair| pair[0] == "--config" && pair[1] == canonical.to_str().expect("utf-8")),
+            "canonical config path (spaces intact) must be forwarded as one argv element"
+        );
+        assert!(matches!(
+            required.readiness,
+            ProcessReadiness::Notify { .. }
+        ));
+
+        // Compatibility keeps the historical shape and immediate reporting.
+        let compat_with_config = direct_child_process_config(
+            "registry",
+            false,
+            Some(&canonical),
+            Path::new("/usr/local/bin/hyprstream"),
+        )?;
+        assert_eq!(
+            &compat_with_config.args[compat_with_config.args.len() - 5..],
+            &[
+                "service".to_owned(),
+                "start".to_owned(),
+                "registry".to_owned(),
+                "--foreground".to_owned(),
+                "--ipc".to_owned(),
+            ]
+        );
+        assert_eq!(compat_with_config.readiness, ProcessReadiness::Immediate);
+
+        // No explicit selector: argv identical to the legacy launcher.
+        let compat_default =
+            direct_child_process_config("policy", false, None, Path::new("/bin/hyprstream"))?;
+        assert_eq!(
+            compat_default.args,
+            [
+                "service".to_owned(),
+                "start".to_owned(),
+                "policy".to_owned(),
+                "--foreground".to_owned(),
+                "--ipc".to_owned(),
+            ]
+        );
+        Ok(())
+    }
+
+    /// Mock manager: scripted start/is_active behavior for the permitted
+    /// Compatibility unit-start lifecycle contract.
+    struct MockManager {
+        start_error: Option<&'static str>,
+        active_after: std::sync::atomic::AtomicU32,
+    }
+
+    impl MockManager {
+        fn failing() -> Self {
+            Self {
+                start_error: Some("unit is masked"),
+                active_after: std::sync::atomic::AtomicU32::new(0),
+            }
+        }
+        fn never_active() -> Self {
+            Self {
+                start_error: None,
+                active_after: std::sync::atomic::AtomicU32::new(u32::MAX),
+            }
+        }
+        fn immediate() -> Self {
+            Self {
+                start_error: None,
+                active_after: std::sync::atomic::AtomicU32::new(0),
+            }
+        }
+    }
+
+    #[async_trait::async_trait]
+    impl hyprstream_service::ServiceManager for MockManager {
+        async fn install(&self, _service: &str) -> anyhow::Result<()> {
+            Ok(())
+        }
+        async fn uninstall(&self, _service: &str) -> anyhow::Result<()> {
+            Ok(())
+        }
+        async fn start(&self, _service: &str) -> anyhow::Result<()> {
+            match self.start_error {
+                Some(reason) => anyhow::bail!("{reason}"),
+                None => Ok(()),
+            }
+        }
+        async fn stop(&self, _service: &str) -> anyhow::Result<()> {
+            Ok(())
+        }
+        async fn is_active(&self, _service: &str) -> anyhow::Result<bool> {
+            use std::sync::atomic::Ordering;
+            let remaining = self.active_after.load(Ordering::SeqCst);
+            if remaining > 0 && remaining != u32::MAX {
+                self.active_after.store(remaining - 1, Ordering::SeqCst);
+                return Ok(false);
+            }
+            Ok(remaining == 0)
+        }
+        async fn reload(&self) -> anyhow::Result<()> {
+            Ok(())
+        }
+
+        async fn spawn(
+            &self,
+            _spawnable: Box<dyn hyprstream_rpc::Spawnable>,
+        ) -> anyhow::Result<hyprstream_service::SpawnedService> {
+            anyhow::bail!("mock manager does not host services")
+>>>>>>> 37dc8ac74 (fix(launcher): carry config provenance and enforce verified startup ownership)
         }
     }
 
     #[tokio::test]
+<<<<<<< HEAD
     async fn invalid_requests_fail_before_storage_mutation() {
         for templates in [
             vec!["not-a-template".to_owned()],
@@ -1801,10 +2205,25 @@ mod offline_policy_provision_tests {
                     "infer.generate",
                 )
                 .await
+=======
+    async fn unit_start_mutation_failure_propagates_without_active_poll() {
+        let manager = MockManager::failing();
+        let error = start_units_to_active(
+            &manager,
+            &["model".to_owned()],
+            std::time::Duration::from_secs(1),
+        )
+        .await
+        .expect_err("start mutation failure must propagate");
+        assert!(
+            error.to_string().contains("unit is masked"),
+            "real failure expected, got: {error}"
+>>>>>>> 37dc8ac74 (fix(launcher): carry config provenance and enforce verified startup ownership)
         );
     }
 
     #[tokio::test]
+<<<<<<< HEAD
     async fn prepublication_failure_and_retry_preserve_retained_deny() {
         let root = tempfile::tempdir().expect("retained-policy models root");
         let policies_dir = root.path().join(".registry/policies");
@@ -2083,6 +2502,280 @@ mod offline_policy_provision_tests {
                 .await
                 .expect("policy after read failure"),
             original
+=======
+    async fn unit_start_requires_bounded_active_state() {
+        let manager = MockManager::never_active();
+        let error = start_units_to_active(
+            &manager,
+            &["model".to_owned()],
+            std::time::Duration::from_millis(300),
+        )
+        .await
+        .expect_err("a unit that never activates must fail the bounded wait");
+        assert!(
+            error
+                .to_string()
+                .contains("did not reach the active state"),
+            "active-state timeout expected, got: {error}"
+        );
+
+        let manager = MockManager::immediate();
+        start_units_to_active(
+            &manager,
+            &["model".to_owned()],
+            std::time::Duration::from_secs(1),
+        )
+        .await
+        .expect("immediately-active unit must complete");
+    }
+
+    /// Required roster rollback: a later child failing must stop earlier
+    /// children in reverse order — proven with real supervised processes via
+    /// the injected-plan seam.
+    #[tokio::test]
+    async fn required_rollback_stops_started_children_on_later_failure() -> anyhow::Result<()> {
+        use hyprstream_service::{ProcessConfig, ProcessReadiness, ProcessSpawner};
+        #[allow(unused_imports)]
+        use ProcessReadiness as _ProcessReadinessMarker;
+
+        const ROLLBACK_HELPER: &str = "HYPRSTREAM_LAUNCHER_ROLLBACK_HELPER";
+
+        // Helper child used as the first plan: READY then stays alive.
+        if std::env::var_os(ROLLBACK_HELPER).is_some() {
+            hyprstream_rpc::notify::ready()?;
+            std::thread::sleep(std::time::Duration::from_secs(30));
+            return Ok(());
+        }
+
+        let exe = std::env::current_exe()?;
+        let spawner = ProcessSpawner::standalone();
+        let supervisor_a = "rollback-alive";
+        let supervisor_b = "rollback-fail";
+
+        let plans = vec![vec![
+            (
+                supervisor_a.to_owned(),
+                ProcessConfig::new(supervisor_a, &exe)
+                    .args([
+                        "--exact",
+                        "cli::service_handlers::launcher_tests::required_rollback_stops_started_children_on_later_failure",
+                        "--nocapture",
+                    ])
+                    .env(ROLLBACK_HELPER, "1")
+                    .with_notify_ready(std::time::Duration::from_secs(30)),
+            ),
+            (
+                supervisor_b.to_owned(),
+                ProcessConfig::new(supervisor_b, Path::new("/bin/sh"))
+                    .args(["-c", "exit 7"])
+                    .with_notify_ready(std::time::Duration::from_secs(10)),
+            ),
+        ]];
+
+        let error = launch_planned_children(plans, true, &spawner)
+            .await
+            .expect_err("later-child failure must fail the launch");
+        assert!(
+            error.to_string().contains("exited during startup"),
+            "launch failure expected, got: {error}"
+        );
+
+        // The alive first child was stopped by the rollback (reverse order):
+        // its PID file was removed and the process is reaped. The failing
+        // child never published anything.
+        assert!(
+            !hyprstream_rpc::paths::service_pid_file(supervisor_a).exists(),
+            "rolled-back child must leave no PID file"
+        );
+        assert!(
+            !hyprstream_rpc::paths::service_pid_file(supervisor_b).exists(),
+            "failed child must leave no PID file"
+        );
+        Ok(())
+    }
+
+    /// Multi-stage required launch: a failure in one stage must abort the
+    /// WHOLE launch — later dependent stages must never spawn — and every
+    /// already-started child must be genuinely reaped.
+    ///
+    /// Fixture observes, per root dispatch `pr1585-launch-stage-failure-root.md`:
+    /// two live predecessors (each records its own PID to a marker file, so
+    /// termination is confirmed by `kill(pid, 0)` → ESRCH, not by PID-file
+    /// absence alone), the original launch error surfaced unchanged, and a
+    /// sentinel in a LATER stage whose spawn marker must never appear (the
+    /// single-stage test cannot distinguish a full abort from a per-stage
+    /// break). Stop ORDER is not externally observable here: rollback kills
+    /// are SIGKILL, so reverse ordering remains a construction guarantee of
+    /// `started.iter().rev()`, not an observed event.
+    #[tokio::test]
+    async fn required_stage_failure_aborts_launch_and_never_spawns_later_stages()
+    -> anyhow::Result<()> {
+        use hyprstream_service::{ProcessConfig, ProcessReadiness, ProcessSpawner};
+        #[allow(unused_imports)]
+        use ProcessReadiness as _ProcessReadinessMarker;
+
+        const MARKER_HELPER: &str = "HYPRSTREAM_LAUNCHER_MARKER_HELPER";
+
+        // Helper child used as a live predecessor: records its PID to the
+        // marker BEFORE its READY send, so the parent's continuation past
+        // this child deterministically proves the marker exists.
+        if let Some(path) = std::env::var_os(MARKER_HELPER) {
+            std::fs::write(&path, std::process::id().to_string())?;
+            hyprstream_rpc::notify::ready()?;
+            std::thread::sleep(std::time::Duration::from_secs(30));
+            return Ok(());
+        }
+
+        let exe = std::env::current_exe()?;
+        let spawner = ProcessSpawner::standalone();
+        let dir = tempfile::tempdir()?;
+        // Unique supervisor names per test process: PID files land in the
+        // shared runtime dir, and libtest runs suites in parallel.
+        let unique = std::process::id();
+        let stage0a = format!("launch-stage-a-{unique}");
+        let stage0b = format!("launch-stage-b-{unique}");
+        let stage1fail = format!("launch-stage-fail-{unique}");
+        let stage2sentinel = format!("launch-stage-sentinel-{unique}");
+
+        let marker = |name: &str| dir.path().join(format!("{name}.marker"));
+        let marker_pid = |path: &Path| -> anyhow::Result<u32> {
+            std::fs::read_to_string(path)?
+                .trim()
+                .parse::<u32>()
+                .context("marker must hold the child pid")
+        };
+        // Reap confirmation: ESRCH, not merely an absent PID file.
+        let assert_reaped = |pid: u32| {
+            let gone = nix::sys::signal::kill(
+                nix::unistd::Pid::from_raw(pid as i32),
+                None,
+            )
+            .is_err_and(|e| e == nix::errno::Errno::ESRCH);
+            assert!(gone, "child pid {pid} must be reaped after rollback");
+        };
+
+        let plans = vec![
+            // Stage 0: two live predecessors (marker→READY→stay alive) —
+            // both must be rolled back and genuinely reaped.
+            vec![
+                (
+                    stage0a.clone(),
+                    ProcessConfig::new(&stage0a, &exe)
+                        .args([
+                            "--exact",
+                            "cli::service_handlers::launcher_tests::required_stage_failure_aborts_launch_and_never_spawns_later_stages",
+                            "--nocapture",
+                        ])
+                        .env(MARKER_HELPER, marker(&stage0a).display().to_string())
+                        .with_notify_ready(std::time::Duration::from_secs(30)),
+                ),
+                (
+                    stage0b.clone(),
+                    ProcessConfig::new(&stage0b, &exe)
+                        .args([
+                            "--exact",
+                            "cli::service_handlers::launcher_tests::required_stage_failure_aborts_launch_and_never_spawns_later_stages",
+                            "--nocapture",
+                        ])
+                        .env(MARKER_HELPER, marker(&stage0b).display().to_string())
+                        .with_notify_ready(std::time::Duration::from_secs(30)),
+                ),
+            ],
+            // Stage 1: required child fails during startup.
+            vec![(
+                stage1fail.clone(),
+                ProcessConfig::new(&stage1fail, Path::new("/bin/sh"))
+                    .args(["-c", "exit 7"])
+                    .with_notify_ready(std::time::Duration::from_secs(10)),
+            )],
+            // Stage 2 sentinel: same marker-before-READY helper with Notify
+            // readiness. If the abort ever leaked past the failing stage, the
+            // buggy path would WAIT for this child's READY — which the helper
+            // sends only after writing the marker — so an incorrect later-stage
+            // spawn deterministically leaves a marker (an Immediate child could
+            // be SIGKILLed by the buggy rollback before it ever wrote one,
+            // giving a false pass).
+            vec![(
+                stage2sentinel.clone(),
+                ProcessConfig::new(&stage2sentinel, &exe)
+                    .args([
+                        "--exact",
+                        "cli::service_handlers::launcher_tests::required_stage_failure_aborts_launch_and_never_spawns_later_stages",
+                        "--nocapture",
+                    ])
+                    .env(MARKER_HELPER, marker(&stage2sentinel).display().to_string())
+                    .with_notify_ready(std::time::Duration::from_secs(30)),
+            )],
+        ];
+
+        let error = launch_planned_children(plans, true, &spawner)
+            .await
+            .expect_err("stage-1 failure must fail the whole launch");
+        assert!(
+            error.to_string().contains("exited during startup"),
+            "original launch error expected, got: {error}"
+        );
+
+        // Both started predecessors: actually reaped (ESRCH), PID files gone.
+        for (name, path) in [(&stage0a, marker(&stage0a)), (&stage0b, marker(&stage0b))] {
+            assert!(path.exists(), "predecessor {name} must have run");
+            assert_reaped(marker_pid(&path)?);
+            assert!(
+                !hyprstream_rpc::paths::service_pid_file(name).exists(),
+                "rolled-back {name} must leave no PID file"
+            );
+        }
+        // The later-stage sentinel never spawned.
+        assert!(
+            !marker(&stage2sentinel).exists(),
+            "sentinel stage must never spawn after a required stage failure"
+        );
+        assert!(
+            !hyprstream_rpc::paths::service_pid_file(&stage2sentinel).exists(),
+            "sentinel must publish no PID file"
+        );
+        Ok(())
+    }
+
+    /// Installed units encode their own stored configuration; an explicit
+    /// config selector or the required-native profile must be refused on the
+    /// existing-unit path before any unit is started.
+    #[tokio::test]
+    async fn installed_unit_start_rejects_explicit_config_and_required_profile() {
+        if !hyprstream_rpc::has_systemd() {
+            return;
+        }
+        let root = tempfile::tempdir().unwrap();
+        let config_path = root.path().join("custom.toml");
+        std::fs::write(&config_path, "[secrets]\n").unwrap();
+
+        let explicit_error = handle_service_start(
+            &["model".to_owned()],
+            Some("model".to_owned()),
+            false,
+            Some(config_path.as_path()),
+            false,
+        )
+        .await
+        .expect_err("explicit config selector must not start an installed unit");
+        assert!(
+            explicit_error.to_string().contains("installed hyprstream service units"),
+            "actionable rejection expected, got: {explicit_error}"
+        );
+
+        let required_error = handle_service_start(
+            &["model".to_owned()],
+            Some("model".to_owned()),
+            false,
+            None,
+            true,
+        )
+        .await
+        .expect_err("required-native profile must not start an installed unit");
+        assert!(
+            required_error.to_string().contains("--daemon"),
+            "rejection must direct the operator to the direct launch path"
+>>>>>>> 37dc8ac74 (fix(launcher): carry config provenance and enforce verified startup ownership)
         );
     }
 }

--- a/crates/hyprstream/src/cli/service_handlers.rs
+++ b/crates/hyprstream/src/cli/service_handlers.rs
@@ -5,6 +5,7 @@
 // CLI handlers intentionally print to stdout/stderr for user interaction
 #![allow(clippy::print_stdout, clippy::print_stderr)]
 
+use std::ffi::OsString;
 use std::io::Write;
 use std::path::{Path, PathBuf};
 
@@ -598,26 +599,17 @@ pub fn direct_child_process_config(
     explicit_config: Option<&Path>,
     exe: &Path,
 ) -> Result<hyprstream_service::ProcessConfig> {
-    let mut args: Vec<String> = Vec::new();
+    let mut args: Vec<OsString> = Vec::new();
     if let Some(config_path) = explicit_config {
-        let rendered = config_path
-            .to_str()
-            .with_context(|| {
-                format!(
-                    "explicit config path {} is not valid UTF-8 and cannot be forwarded",
-                    config_path.display()
-                )
-            })?
-            .to_owned();
-        args.push("--config".to_owned());
-        args.push(rendered);
+        args.push(OsString::from("--config"));
+        args.push(config_path.as_os_str().to_owned());
     }
-    args.push("service".to_owned());
-    args.push("start".to_owned());
-    args.push(service.to_owned());
-    args.push("--foreground".to_owned());
+    args.push(OsString::from("service"));
+    args.push(OsString::from("start"));
+    args.push(OsString::from(service));
+    args.push(OsString::from("--foreground"));
     if !iroh_required {
-        args.push("--ipc".to_owned());
+        args.push(OsString::from("--ipc"));
     }
 
     let mut config = hyprstream_service::ProcessConfig::new(service, exe);
@@ -651,6 +643,14 @@ pub async fn launch_direct_children(
     exe: &Path,
     spawner: &hyprstream_service::ProcessSpawner,
 ) -> Result<()> {
+    if iroh_required {
+        for service in targets {
+            anyhow::ensure!(
+                hyprstream_service::get_factory(service).is_some(),
+                "unknown native service: {service}"
+            );
+        }
+    }
     let stages = hyprstream_service::startup_stages_for_profile(targets, iroh_required);
     // Flatten the ordered stages into the serial launch plan (same order the
     // loop below would spawn in), so the launch core is injectably testable
@@ -2019,7 +2019,6 @@ fn update_shell_profiles(home: &Path, bin_dir: &Path) -> Result<Vec<String>> {
 }
 
 #[cfg(test)]
-<<<<<<< HEAD
 #[allow(clippy::expect_used)]
 mod offline_policy_provision_tests {
     use super::*;
@@ -2146,158 +2145,10 @@ mod offline_policy_provision_tests {
                 "mesh-readers".to_owned(),
                 "acme".to_owned(),
             ]));
-=======
-mod launcher_tests {
-    #![allow(clippy::expect_used, clippy::unwrap_used)]
-
-    use super::*;
-    use hyprstream_service::ProcessReadiness;
-
-    #[test]
-    fn direct_child_process_config_builds_profile_specific_invocation() -> anyhow::Result<()> {
-        let root = tempfile::tempdir()?;
-        // A relative-looking config directory containing spaces: the launcher
-        // hands the child one canonical absolute argv element that keeps the
-        // spaces (no shell splitting, no quoting).
-        let config_path = root.path().join("my configs/custom.toml");
-        std::fs::create_dir_all(config_path.parent().expect("parent"))?;
-        std::fs::write(&config_path, "[secrets]\n")?;
-        let canonical = std::fs::canonicalize(&config_path)?;
-
-        // Required-native: no --ipc, config forwarded, notification readiness.
-        let required = direct_child_process_config(
-            "model",
-            true,
-            Some(&canonical),
-            Path::new("/usr/local/bin/hyprstream"),
-        )?;
-        let expected_tail = [
-            "service".to_owned(),
-            "start".to_owned(),
-            "model".to_owned(),
-            "--foreground".to_owned(),
-        ];
-        assert_eq!(&required.args[required.args.len() - 4..], &expected_tail);
-        assert!(
-            !required.args.iter().any(|arg| arg == "--ipc"),
-            "required-native child must not be forced onto the local IPC endpoint"
-        );
-        assert!(
-            required
-                .args
-                .windows(2)
-                .any(|pair| pair[0] == "--config" && pair[1] == canonical.to_str().expect("utf-8")),
-            "canonical config path (spaces intact) must be forwarded as one argv element"
-        );
-        assert!(matches!(
-            required.readiness,
-            ProcessReadiness::Notify { .. }
-        ));
-
-        // Compatibility keeps the historical shape and immediate reporting.
-        let compat_with_config = direct_child_process_config(
-            "registry",
-            false,
-            Some(&canonical),
-            Path::new("/usr/local/bin/hyprstream"),
-        )?;
-        assert_eq!(
-            &compat_with_config.args[compat_with_config.args.len() - 5..],
-            &[
-                "service".to_owned(),
-                "start".to_owned(),
-                "registry".to_owned(),
-                "--foreground".to_owned(),
-                "--ipc".to_owned(),
-            ]
-        );
-        assert_eq!(compat_with_config.readiness, ProcessReadiness::Immediate);
-
-        // No explicit selector: argv identical to the legacy launcher.
-        let compat_default =
-            direct_child_process_config("policy", false, None, Path::new("/bin/hyprstream"))?;
-        assert_eq!(
-            compat_default.args,
-            [
-                "service".to_owned(),
-                "start".to_owned(),
-                "policy".to_owned(),
-                "--foreground".to_owned(),
-                "--ipc".to_owned(),
-            ]
-        );
-        Ok(())
-    }
-
-    /// Mock manager: scripted start/is_active behavior for the permitted
-    /// Compatibility unit-start lifecycle contract.
-    struct MockManager {
-        start_error: Option<&'static str>,
-        active_after: std::sync::atomic::AtomicU32,
-    }
-
-    impl MockManager {
-        fn failing() -> Self {
-            Self {
-                start_error: Some("unit is masked"),
-                active_after: std::sync::atomic::AtomicU32::new(0),
-            }
-        }
-        fn never_active() -> Self {
-            Self {
-                start_error: None,
-                active_after: std::sync::atomic::AtomicU32::new(u32::MAX),
-            }
-        }
-        fn immediate() -> Self {
-            Self {
-                start_error: None,
-                active_after: std::sync::atomic::AtomicU32::new(0),
-            }
-        }
-    }
-
-    #[async_trait::async_trait]
-    impl hyprstream_service::ServiceManager for MockManager {
-        async fn install(&self, _service: &str) -> anyhow::Result<()> {
-            Ok(())
-        }
-        async fn uninstall(&self, _service: &str) -> anyhow::Result<()> {
-            Ok(())
-        }
-        async fn start(&self, _service: &str) -> anyhow::Result<()> {
-            match self.start_error {
-                Some(reason) => anyhow::bail!("{reason}"),
-                None => Ok(()),
-            }
-        }
-        async fn stop(&self, _service: &str) -> anyhow::Result<()> {
-            Ok(())
-        }
-        async fn is_active(&self, _service: &str) -> anyhow::Result<bool> {
-            use std::sync::atomic::Ordering;
-            let remaining = self.active_after.load(Ordering::SeqCst);
-            if remaining > 0 && remaining != u32::MAX {
-                self.active_after.store(remaining - 1, Ordering::SeqCst);
-                return Ok(false);
-            }
-            Ok(remaining == 0)
-        }
-        async fn reload(&self) -> anyhow::Result<()> {
-            Ok(())
-        }
-
-        async fn spawn(
-            &self,
-            _spawnable: Box<dyn hyprstream_rpc::Spawnable>,
-        ) -> anyhow::Result<hyprstream_service::SpawnedService> {
-            anyhow::bail!("mock manager does not host services")
->>>>>>> 37dc8ac74 (fix(launcher): carry config provenance and enforce verified startup ownership)
         }
     }
 
     #[tokio::test]
-<<<<<<< HEAD
     async fn invalid_requests_fail_before_storage_mutation() {
         for templates in [
             vec!["not-a-template".to_owned()],
@@ -2377,25 +2228,10 @@ mod launcher_tests {
                     "infer.generate",
                 )
                 .await
-=======
-    async fn unit_start_mutation_failure_propagates_without_active_poll() {
-        let manager = MockManager::failing();
-        let error = start_units_to_active(
-            &manager,
-            &["model".to_owned()],
-            std::time::Duration::from_secs(1),
-        )
-        .await
-        .expect_err("start mutation failure must propagate");
-        assert!(
-            error.to_string().contains("unit is masked"),
-            "real failure expected, got: {error}"
->>>>>>> 37dc8ac74 (fix(launcher): carry config provenance and enforce verified startup ownership)
         );
     }
 
     #[tokio::test]
-<<<<<<< HEAD
     async fn prepublication_failure_and_retry_preserve_retained_deny() {
         let root = tempfile::tempdir().expect("retained-policy models root");
         let policies_dir = root.path().join(".registry/policies");
@@ -2674,7 +2510,272 @@ mod launcher_tests {
                 .await
                 .expect("policy after read failure"),
             original
-=======
+        );
+    }
+}
+
+#[cfg(test)]
+mod launcher_tests {
+    #![allow(clippy::expect_used, clippy::unwrap_used)]
+
+    use super::*;
+    use hyprstream_service::ProcessReadiness;
+
+    #[test]
+    fn direct_child_process_config_builds_profile_specific_invocation() -> anyhow::Result<()> {
+        let root = tempfile::tempdir()?;
+        // A relative-looking config directory containing spaces: the launcher
+        // hands the child one canonical absolute argv element that keeps the
+        // spaces (no shell splitting, no quoting).
+        let config_path = root.path().join("my configs/custom.toml");
+        std::fs::create_dir_all(config_path.parent().expect("parent"))?;
+        std::fs::write(&config_path, "[secrets]\n")?;
+        let canonical = std::fs::canonicalize(&config_path)?;
+
+        // Required-native: no --ipc, config forwarded, notification readiness.
+        let required = direct_child_process_config(
+            "model",
+            true,
+            Some(&canonical),
+            Path::new("/usr/local/bin/hyprstream"),
+        )?;
+        let expected_tail = [
+            OsString::from("service"),
+            OsString::from("start"),
+            OsString::from("model"),
+            OsString::from("--foreground"),
+        ];
+        assert_eq!(&required.args[required.args.len() - 4..], &expected_tail);
+        assert!(
+            !required.args.iter().any(|arg| arg == "--ipc"),
+            "required-native child must not be forced onto the local IPC endpoint"
+        );
+        assert!(
+            required
+                .args
+                .windows(2)
+                .any(|pair| pair[0] == "--config" && pair[1] == canonical.to_str().expect("utf-8")),
+            "canonical config path (spaces intact) must be forwarded as one argv element"
+        );
+        assert!(matches!(
+            required.readiness,
+            ProcessReadiness::Notify { .. }
+        ));
+
+        // Compatibility keeps the historical shape and immediate reporting.
+        let compat_with_config = direct_child_process_config(
+            "registry",
+            false,
+            Some(&canonical),
+            Path::new("/usr/local/bin/hyprstream"),
+        )?;
+        assert_eq!(
+            &compat_with_config.args[compat_with_config.args.len() - 5..],
+            &[
+                OsString::from("service"),
+                OsString::from("start"),
+                OsString::from("registry"),
+                OsString::from("--foreground"),
+                OsString::from("--ipc"),
+            ]
+        );
+        assert_eq!(compat_with_config.readiness, ProcessReadiness::Immediate);
+
+        // No explicit selector: argv identical to the legacy launcher.
+        let compat_default =
+            direct_child_process_config("policy", false, None, Path::new("/bin/hyprstream"))?;
+        assert_eq!(
+            compat_default.args,
+            [
+                OsString::from("service"),
+                OsString::from("start"),
+                OsString::from("policy"),
+                OsString::from("--foreground"),
+                OsString::from("--ipc"),
+            ]
+        );
+        Ok(())
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn direct_child_preserves_non_utf8_explicit_config_path() -> anyhow::Result<()> {
+        use std::os::unix::ffi::{OsStrExt, OsStringExt};
+
+        let root = tempfile::tempdir()?;
+        let config_path = root
+            .path()
+            .join(OsString::from_vec(b"custom-\xff.toml".to_vec()));
+        std::fs::write(&config_path, "[secrets]\n")?;
+        let canonical = std::fs::canonicalize(&config_path)?;
+        assert!(canonical.to_str().is_none(), "fixture path must be non-UTF-8");
+
+        let loaded = crate::config::HyprConfig::from_file(&canonical)?;
+        loaded.validate()?;
+
+        for (iroh_required, expects_ipc) in [(true, false), (false, true)] {
+            let plan = direct_child_process_config(
+                "model",
+                iroh_required,
+                Some(&canonical),
+                Path::new("/usr/local/bin/hyprstream"),
+            )?;
+            let selectors: Vec<_> = plan
+                .args
+                .windows(2)
+                .filter(|pair| pair[0] == "--config")
+                .collect();
+            assert_eq!(selectors.len(), 1, "one explicit selector must be forwarded");
+            assert_eq!(
+                selectors[0][1].as_os_str().as_bytes(),
+                canonical.as_os_str().as_bytes(),
+                "the canonical selector must be preserved byte for byte"
+            );
+            assert_eq!(
+                plan.args.iter().any(|arg| arg == "--ipc"),
+                expects_ipc,
+                "Required and Compatibility invocation shapes must remain distinct"
+            );
+            assert_eq!(
+                matches!(plan.readiness, ProcessReadiness::Notify { .. }),
+                iroh_required,
+                "Required and Compatibility readiness policies must remain distinct"
+            );
+        }
+        Ok(())
+    }
+
+    #[test]
+    fn known_required_roster_retains_dependency_order() {
+        let targets = ["model", "registry", "policy", "discovery"];
+        for service in targets {
+            assert!(
+                hyprstream_service::get_factory(service).is_some(),
+                "test roster service {service} must be compiled"
+            );
+        }
+        assert_eq!(
+            hyprstream_service::startup_stages_for_profile(&targets, true),
+            vec![
+                vec!["discovery".to_owned()],
+                vec!["policy".to_owned()],
+                vec!["registry".to_owned()],
+                vec!["model".to_owned()],
+            ]
+        );
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn unknown_required_roster_is_rejected_before_any_child_spawns()
+    -> anyhow::Result<()> {
+        use std::os::unix::fs::PermissionsExt;
+
+        let root = tempfile::tempdir()?;
+        let executable = root.path().join("spawn-sentinel.sh");
+        let marker = root.path().join("spawn-sentinel.sh.spawned");
+        std::fs::write(&executable, b"#!/bin/sh\ntouch \"$0.spawned\"\n")?;
+        let mut permissions = std::fs::metadata(&executable)?.permissions();
+        permissions.set_mode(0o700);
+        std::fs::set_permissions(&executable, permissions)?;
+
+        let unknown = "not-a-compiled-native-service";
+        let targets = vec!["policy".to_owned(), unknown.to_owned()];
+        let spawner = hyprstream_service::ProcessSpawner::standalone();
+        let error = launch_direct_children(&targets, true, None, &executable, &spawner)
+            .await
+            .expect_err("an unknown Required target must reject the whole plan");
+        assert_eq!(error.to_string(), format!("unknown native service: {unknown}"));
+        assert!(
+            !marker.exists(),
+            "validation must finish before any configured executable runs"
+        );
+        Ok(())
+    }
+
+    /// Mock manager: scripted start/is_active behavior for the permitted
+    /// Compatibility unit-start lifecycle contract.
+    struct MockManager {
+        start_error: Option<&'static str>,
+        active_after: std::sync::atomic::AtomicU32,
+    }
+
+    impl MockManager {
+        fn failing() -> Self {
+            Self {
+                start_error: Some("unit is masked"),
+                active_after: std::sync::atomic::AtomicU32::new(0),
+            }
+        }
+        fn never_active() -> Self {
+            Self {
+                start_error: None,
+                active_after: std::sync::atomic::AtomicU32::new(u32::MAX),
+            }
+        }
+        fn immediate() -> Self {
+            Self {
+                start_error: None,
+                active_after: std::sync::atomic::AtomicU32::new(0),
+            }
+        }
+    }
+
+    #[async_trait::async_trait]
+    impl hyprstream_service::ServiceManager for MockManager {
+        async fn install(&self, _service: &str) -> anyhow::Result<()> {
+            Ok(())
+        }
+        async fn uninstall(&self, _service: &str) -> anyhow::Result<()> {
+            Ok(())
+        }
+        async fn start(&self, _service: &str) -> anyhow::Result<()> {
+            match self.start_error {
+                Some(reason) => anyhow::bail!("{reason}"),
+                None => Ok(()),
+            }
+        }
+        async fn stop(&self, _service: &str) -> anyhow::Result<()> {
+            Ok(())
+        }
+        async fn is_active(&self, _service: &str) -> anyhow::Result<bool> {
+            use std::sync::atomic::Ordering;
+            let remaining = self.active_after.load(Ordering::SeqCst);
+            if remaining > 0 && remaining != u32::MAX {
+                self.active_after.store(remaining - 1, Ordering::SeqCst);
+                return Ok(false);
+            }
+            Ok(remaining == 0)
+        }
+        async fn reload(&self) -> anyhow::Result<()> {
+            Ok(())
+        }
+
+        async fn spawn(
+            &self,
+            _spawnable: Box<dyn hyprstream_rpc::Spawnable>,
+        ) -> anyhow::Result<hyprstream_service::SpawnedService> {
+            anyhow::bail!("mock manager does not host services")
+        }
+    }
+
+    #[tokio::test]
+    async fn unit_start_mutation_failure_propagates_without_active_poll() {
+        let manager = MockManager::failing();
+        let error = start_units_to_active(
+            &manager,
+            &["model".to_owned()],
+            std::time::Duration::from_secs(1),
+        )
+        .await
+        .expect_err("start mutation failure must propagate");
+        assert!(
+            error.to_string().contains("unit is masked"),
+            "real failure expected, got: {error}"
+        );
+    }
+
+    #[tokio::test]
     async fn unit_start_requires_bounded_active_state() {
         let manager = MockManager::never_active();
         let error = start_units_to_active(
@@ -3435,7 +3536,6 @@ mod launcher_tests {
         assert!(
             required_error.to_string().contains("--daemon"),
             "rejection must direct the operator to the direct launch path"
->>>>>>> 37dc8ac74 (fix(launcher): carry config provenance and enforce verified startup ownership)
         );
     }
 }

--- a/crates/hyprstream/src/cli/service_handlers.rs
+++ b/crates/hyprstream/src/cli/service_handlers.rs
@@ -3163,15 +3163,12 @@ mod launcher_tests {
         Ok(())
     }
 
-    /// Cancellation around a required startup failure cleans the READY
-    /// predecessor at WHATEVER point the abort lands. The predecessor is
-    /// READY-observed (marker-before-READY proves the child ran and sent
-    /// READY) — but marker presence alone does NOT prove the launcher
-    /// adopted it nor that rollback was entered, so the landing point is
-    /// unspecified: the armed startup guard, the transaction guard, or a
-    /// completed explicit rollback each own the cleanup, and all end with
-    /// the predecessor reaped and its artifact removed. The deterministic
-    /// rollback-boundary evidence lives in
+    /// Cancellation around a required startup failure cleans the spawned
+    /// predecessor at the point where abort lands. Its PID marker is written
+    /// before READY, so marker presence proves the child ran and wrote its
+    /// PID; it does not prove READY was sent, that the launcher adopted it,
+    /// or that rollback was entered. The landing is unspecified. The
+    /// deterministic rollback-boundary evidence is provided by
     /// `rollback_failed_and_pending_stops_stay_guard_owned_through_cancellation`.
     #[tokio::test]
     async fn required_cancellation_around_startup_failure_cleans_predecessor_at_any_landing()
@@ -3227,11 +3224,10 @@ mod launcher_tests {
             launch_planned_children(plans, true, &spawner).await
         });
 
-        // Abort as soon as the predecessor is READY-observed. Marker-before-
-        // READY proves the child ran and sent READY, but NOT that the
-        // launcher adopted it or that rollback was entered — the landing
-        // point is unspecified and every landing must clean the
-        // predecessor.
+        // Abort after the predecessor's PID marker appears. The marker
+        // precedes READY; it does not prove notification, adoption, or
+        // rollback entry. This test checks cleanup at the observed,
+        // unspecified cancellation point.
         let deadline = std::time::Instant::now() + std::time::Duration::from_secs(15);
         while !marker.exists() {
             anyhow::ensure!(

--- a/crates/hyprstream/src/cli/wizard_handlers.rs
+++ b/crates/hyprstream/src/cli/wizard_handlers.rs
@@ -152,7 +152,25 @@ pub async fn handle_wizard(
 ) -> Result<()> {
     // Install systemd units before entering spawn_blocking (async operation).
     if !options.bootstrap_only && hyprstream_rpc::has_systemd() {
-        handle_service_install(models_dir, config_services, None, false, false, hyprstream_service::ServiceTarget::User, false).await?;
+        // Forward this process's pinned config provenance and native profile:
+        // under an explicit --config or required-native the install handler
+        // refuses unit install with actionable direct-launch guidance (#1585).
+        let explicit_config = crate::config::explicit_config_path().cloned();
+        let iroh_required = crate::config::HyprConfig::load()
+            .map(|c| c.quic.iroh_required())
+            .unwrap_or(false);
+        handle_service_install(
+            models_dir,
+            config_services,
+            None,
+            false,
+            false,
+            hyprstream_service::ServiceTarget::User,
+            false,
+            explicit_config.as_deref(),
+            iroh_required,
+        )
+        .await?;
     }
 
     let rt = tokio::runtime::Handle::current();

--- a/crates/hyprstream/src/cli/wizard_handlers.rs
+++ b/crates/hyprstream/src/cli/wizard_handlers.rs
@@ -8,7 +8,7 @@
 // CLI handlers intentionally print to stdout/stderr for user interaction
 #![allow(clippy::print_stdout, clippy::print_stderr)]
 
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 use anyhow::Result;
 use inquire::{Confirm, Select, Text};
@@ -152,24 +152,19 @@ pub async fn handle_wizard(
 ) -> Result<()> {
     // Install systemd units before entering spawn_blocking (async operation).
     if !options.bootstrap_only && hyprstream_rpc::has_systemd() {
-        // Forward this process's pinned config provenance and native profile:
-        // under an explicit --config or required-native the install handler
-        // refuses unit install with actionable direct-launch guidance (#1585).
-        let explicit_config = crate::config::explicit_config_path().cloned();
-        let iroh_required = crate::config::HyprConfig::load()
-            .map(|c| c.quic.iroh_required())
-            .unwrap_or(false);
-        handle_service_install(
-            models_dir,
-            config_services,
-            None,
-            false,
-            false,
-            hyprstream_service::ServiceTarget::User,
-            false,
-            explicit_config.as_deref(),
-            iroh_required,
-        )
+        wizard_pre_install_step(|iroh_required| {
+            handle_service_install(
+                models_dir,
+                config_services,
+                None,
+                false,
+                false,
+                hyprstream_service::ServiceTarget::User,
+                false,
+                crate::config::explicit_config_path().map(PathBuf::as_path),
+                iroh_required,
+            )
+        })
         .await?;
     }
 
@@ -185,6 +180,33 @@ pub async fn handle_wizard(
     .await??;
 
     Ok(())
+}
+
+/// Wizard pre-install step: load the process configuration and decide whether
+/// fixed-unit installation may run before the wizard phases proceed.
+///
+/// An unloadable configuration fails closed here — it is never silently
+/// treated as the default profile (#1585). Installed systemd units run their
+/// own stored configuration and can carry neither this process's explicit
+/// `--config` provenance nor the required-native profile, so for those
+/// profiles unit installation is skipped and setup continues; a later start
+/// routes through the supported direct launch path instead.
+///
+/// The `install` closure is the real `handle_service_install` call in
+/// production; tests inject a recording side effect.
+async fn wizard_pre_install_step<F, Fut>(install: F) -> Result<()>
+where
+    F: FnOnce(bool) -> Fut,
+    Fut: std::future::Future<Output = Result<()>>,
+{
+    let iroh_required = crate::config::HyprConfig::load()
+        .map_err(|e| anyhow::anyhow!("wizard configuration load failed: {e}"))?
+        .quic
+        .iroh_required();
+    if crate::config::explicit_config_path().is_some() || iroh_required {
+        return Ok(());
+    }
+    install(iroh_required).await
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -1093,4 +1115,243 @@ fn print_summary(summary: &TextWizardSummary) {
     println!("    hyprstream quick clone <model>     # Clone a model");
     println!("    hyprstream quick infer <model>     # Run inference");
     println!();
+}
+
+#[cfg(test)]
+mod wizard_launch_routing_tests {
+    #![allow(clippy::expect_used, clippy::unwrap_used)]
+
+    use super::*;
+    use std::cell::Cell;
+    use std::collections::VecDeque;
+    use std::sync::Arc;
+
+    use parking_lot::Mutex;
+
+    /// Gate marking a re-exec'd child that runs one routing scenario in an
+    /// isolated process (the pinned/explicit slots are process-global and
+    /// write-once, so each scenario needs its own process — same pattern as
+    /// `config::pinned_config_tests`).
+    const PRE_INSTALL_CHILD: &str = "HYPRSTREAM_WIZARD_PRE_CHILD";
+
+    /// All four configuration profiles through the real pre-install decision:
+    /// default installs with the loaded requirement; explicit-config and
+    /// required-native skip fixed-unit installation; an unloadable
+    /// configuration fails closed instead of falling back to defaults.
+    #[tokio::test]
+    async fn wizard_pre_install_step_routes_profiles_causally() -> anyhow::Result<()> {
+        if let Ok(scenario) = std::env::var(PRE_INSTALL_CHILD) {
+            return pre_install_child_scenario(&scenario).await;
+        }
+        for scenario in ["default", "explicit", "required", "invalid"] {
+            let status = std::process::Command::new(std::env::current_exe()?)
+                .args([
+                    "--exact",
+                    "cli::wizard_handlers::wizard_launch_routing_tests::wizard_pre_install_step_routes_profiles_causally",
+                    "--nocapture",
+                ])
+                .env(PRE_INSTALL_CHILD, scenario)
+                .status()?;
+            anyhow::ensure!(
+                status.success(),
+                "wizard pre-install routing scenario '{scenario}' failed"
+            );
+        }
+        Ok(())
+    }
+
+    async fn pre_install_child_scenario(scenario: &str) -> anyhow::Result<()> {
+        let called: Arc<Mutex<Vec<bool>>> = Arc::new(Mutex::new(Vec::new()));
+        let sink = called.clone();
+        let record_install = |required: bool| {
+            sink.lock().push(required);
+            async { Ok::<(), anyhow::Error>(()) }
+        };
+
+        match scenario {
+            "default" => {
+                let _ = crate::config::install_pinned_config(crate::config::HyprConfig::default());
+                wizard_pre_install_step(record_install).await?;
+                assert_eq!(
+                    *called.lock(),
+                    vec![false],
+                    "default profile must install fixed units, forwarding the loaded (non-required) profile"
+                );
+            }
+            "explicit" => {
+                let _ = crate::config::install_pinned_config(crate::config::HyprConfig::default());
+                let explicit = tempfile::tempdir()?;
+                let marker = explicit.path().join("operator.toml");
+                assert!(
+                    crate::config::install_explicit_config_path(marker),
+                    "explicit provenance slot must be installable in a fresh child"
+                );
+                wizard_pre_install_step(record_install).await?;
+                assert!(
+                    called.lock().is_empty(),
+                    "explicit --config provenance must skip fixed-unit installation"
+                );
+            }
+            "required" => {
+                let mut required_config = crate::config::HyprConfig::default();
+                required_config.quic.enabled = true;
+                required_config.quic.iroh = true;
+                required_config.quic.native_network_profile =
+                    crate::config::NativeNetworkProfile::NetworkIrohRequired;
+                required_config.validate()?;
+                let _ = crate::config::install_pinned_config(required_config);
+                assert!(
+                    crate::config::HyprConfig::load()?.quic.iroh_required(),
+                    "precondition: the pinned child config must load as required-native"
+                );
+                wizard_pre_install_step(record_install).await?;
+                assert!(
+                    called.lock().is_empty(),
+                    "required-native profile must skip fixed-unit installation"
+                );
+            }
+            "invalid" => {
+                // No pinned snapshot: force the XDG re-derivation onto a
+                // garbage config file so HyprConfig::load() itself fails.
+                let root = tempfile::tempdir()?;
+                let xdg = root.path().join("xdg-config");
+                std::env::set_var("XDG_CONFIG_HOME", &xdg);
+                let config_dir = xdg.join("hyprstream");
+                std::fs::create_dir_all(&config_dir)?;
+                std::fs::write(config_dir.join("config.toml"), "this is = not [valid toml")?;
+                let outcome = wizard_pre_install_step(record_install).await;
+                assert!(
+                    outcome.is_err(),
+                    "an unloadable configuration must fail closed, not resolve to the default profile"
+                );
+                assert!(
+                    called.lock().is_empty(),
+                    "fixed-unit installation must not run when the configuration cannot be loaded"
+                );
+            }
+            other => anyhow::bail!("unknown wizard routing scenario '{other}'"),
+        }
+        Ok(())
+    }
+
+    /// Recording `WizardBackend` that only implements the services phase and
+    /// delegates every other method to `MockWizardBackend`.
+    struct ServicesPhaseBackend {
+        inner: MockWizardBackend,
+        start_calls: Cell<usize>,
+        poll_script: std::cell::RefCell<VecDeque<OpStatus>>,
+    }
+
+    impl ServicesPhaseBackend {
+        fn new() -> Self {
+            Self {
+                inner: MockWizardBackend::new(),
+                start_calls: Cell::new(0),
+                poll_script: std::cell::RefCell::new(VecDeque::new()),
+            }
+        }
+
+        fn with_poll_script(script: Vec<OpStatus>) -> Self {
+            Self {
+                poll_script: std::cell::RefCell::new(script.into()),
+                ..Self::new()
+            }
+        }
+    }
+
+    impl WizardBackend for ServicesPhaseBackend {
+        fn detect_environment(&mut self) -> EnvironmentInfo {
+            self.inner.detect_environment()
+        }
+        fn recommend_action(&self, env: &EnvironmentInfo) -> InstallAction {
+            self.inner.recommend_action(env)
+        }
+        fn start_install(&mut self, variant: &LibtorchVariant) {
+            self.inner.start_install(variant);
+        }
+        fn poll_install(&mut self) -> InstallPoll {
+            self.inner.poll_install()
+        }
+        fn start_bootstrap(&mut self) {
+            self.inner.start_bootstrap();
+        }
+        fn poll_bootstrap(&mut self) -> BootstrapPoll {
+            self.inner.poll_bootstrap()
+        }
+        fn has_existing_policy(&self) -> bool {
+            self.inner.has_existing_policy()
+        }
+        fn apply_template(&mut self, name: &str) {
+            self.inner.apply_template(name);
+        }
+        fn add_user(&mut self, username: &str, role: &str) {
+            self.inner.add_user(username, role);
+        }
+        fn add_user_custom(&mut self, username: &str, resource: &str, actions: &[String]) {
+            self.inner.add_user_custom(username, resource, actions);
+        }
+        fn save_policies(&mut self) {
+            self.inner.save_policies();
+        }
+        fn generate_token(&mut self, username: &str, duration: &str) -> TokenResult {
+            self.inner.generate_token(username, duration)
+        }
+        fn start_services(&mut self) {
+            self.start_calls.set(self.start_calls.get() + 1);
+        }
+        fn poll_pending(&mut self) -> OpStatus {
+            self.poll_script
+                .borrow_mut()
+                .pop_front()
+                .unwrap_or(OpStatus::Done)
+        }
+        fn local_username(&self) -> String {
+            self.inner.local_username()
+        }
+        fn templates(&self) -> Vec<TemplateInfo> {
+            self.inner.templates()
+        }
+    }
+
+    /// Setup without startup: the non-interactive services phase with no start
+    /// flag must never invoke the backend's service start.
+    #[test]
+    fn services_phase_skips_startup_without_start_flag() -> Result<()> {
+        let mut backend = ServicesPhaseBackend::new();
+        text_phase_services(&mut backend, &["policy".to_owned()], true, false)?;
+        assert_eq!(
+            backend.start_calls.get(),
+            0,
+            "non-interactive wizard without --start-services must not start services"
+        );
+        Ok(())
+    }
+
+    /// A requested start drives the backend through the pending poll loop to a
+    /// terminal status — the phase is the wizard-side boundary that decides
+    /// whether BootstrapManager's launch routing runs at all.
+    #[test]
+    fn services_phase_requested_start_polls_to_done() -> Result<()> {
+        let mut backend = ServicesPhaseBackend::with_poll_script(vec![
+            OpStatus::InProgress,
+            OpStatus::Done,
+        ]);
+        text_phase_services(&mut backend, &["policy".to_owned()], true, true)?;
+        assert_eq!(
+            backend.start_calls.get(),
+            1,
+            "requested startup must invoke the backend start exactly once"
+        );
+        Ok(())
+    }
+
+    /// A failed start surfaces through the same phase without hanging.
+    #[test]
+    fn services_phase_surfaces_start_failure() -> Result<()> {
+        let mut backend =
+            ServicesPhaseBackend::with_poll_script(vec![OpStatus::Failed("boom".to_owned())]);
+        text_phase_services(&mut backend, &[], true, true)?;
+        assert_eq!(backend.start_calls.get(), 1);
+        Ok(())
+    }
 }

--- a/crates/hyprstream/src/config/mod.rs
+++ b/crates/hyprstream/src/config/mod.rs
@@ -1961,7 +1961,7 @@ impl Default for MetricsConfig {
 pub struct ServicesConfig {
     /// Services to start automatically at startup (ipc-systemd mode)
     ///
-    /// Default: ["registry", "policy", "worker", "event"]
+    /// Default: the factories compiled into the standard service roster.
     #[serde(default = "default_startup_services")]
     pub startup: Vec<String>,
 }
@@ -1976,22 +1976,30 @@ impl Default for ServicesConfig {
 
 /// Default list of services to start at startup
 fn default_startup_services() -> Vec<String> {
-    vec![
+    let mut services = vec![
         "event".to_owned(),     // Must start first (message bus)
         "registry".to_owned(),  // Model registry
         "policy".to_owned(),    // Authorization
-        "streams".to_owned(),       // Streaming proxy with JWT validation
-        "notification".to_owned(),  // Encrypted notification relay (uses streams)
-        "worker".to_owned(),        // Container workloads
-        "model".to_owned(),         // Model management (publishes to notification)
+        "streams".to_owned(),   // Streaming proxy with JWT validation
+        "worker".to_owned(),    // Container workloads
+        "model".to_owned(),     // Model management
         "oauth".to_owned(),     // OAuth 2.1 authorization server
         "oai".to_owned(),       // OpenAI-compatible HTTP API
-        "flight".to_owned(),    // Arrow Flight SQL server
+    ];
+    #[cfg(feature = "metrics")]
+    {
+        services.push("flight".to_owned()); // Arrow Flight SQL server
+    }
+    services.extend([
         "discovery".to_owned(), // Endpoint discovery (RFC 9728 metadata)
         "mcp".to_owned(),       // Model Context Protocol service
         "tui".to_owned(),       // Terminal multiplexer display server
-        "metrics".to_owned(),   // Metrics ingest and query (DuckDB/DataFusion)
-    ]
+    ]);
+    #[cfg(feature = "metrics")]
+    {
+        services.push("metrics".to_owned()); // Metrics ingest and query
+    }
+    services
 }
 
 /// Model loading and identification
@@ -3246,6 +3254,32 @@ impl From<&crate::config::server::SamplingParamDefaults> for SamplingParams {
 
 #[cfg(test)]
 mod tests {
+    #[test]
+    fn default_startup_services_are_available_in_this_build() {
+        let startup = super::default_startup_services();
+        assert!(
+            !startup.iter().any(|name| name == "notification"),
+            "the removed notification service must not remain in the default roster"
+        );
+        for name in &startup {
+            assert!(
+                hyprstream_service::get_factory(name).is_some(),
+                "default service {name} must have a factory in this build"
+            );
+        }
+
+        #[cfg(feature = "metrics")]
+        {
+            assert!(startup.iter().any(|name| name == "flight"));
+            assert!(startup.iter().any(|name| name == "metrics"));
+        }
+        #[cfg(not(feature = "metrics"))]
+        {
+            assert!(!startup.iter().any(|name| name == "flight"));
+            assert!(!startup.iter().any(|name| name == "metrics"));
+        }
+    }
+
     #[tokio::test]
     async fn oauth_cors_origin_list_from_environment_preserves_scalars() -> anyhow::Result<()> {
         use axum::{body::Body, http::{header, Request}, routing::get, Router};

--- a/crates/hyprstream/src/config/mod.rs
+++ b/crates/hyprstream/src/config/mod.rs
@@ -18,7 +18,58 @@ use crate::storage::paths::StoragePaths;
 use config::{Config, ConfigError, Environment, File};
 use serde::{Deserialize, Serialize};
 use std::path::{Path, PathBuf};
+use std::sync::OnceLock;
 use zeroize::{Zeroize, Zeroizing};
+
+/// Process-wide validated configuration snapshot (#1585).
+///
+/// Binary startup installs the configuration it parsed and validated (from an
+/// explicit `--config` file or the default locations) into this write-once
+/// slot BEFORE any resolver, factory, or service thread runs. Every later
+/// [`HyprConfig::load()`] — including the reloads inside service factories and
+/// network modules that used to re-read XDG defaults and silently drop an
+/// explicit `--config` deployment's settings — then observes that one pinned
+/// snapshot instead of re-deriving a divergent configuration.
+///
+/// The slot is immutable once written: there is no runtime mutation path, and
+/// the snapshot replaces an unchanged-contract reload rather than authorizing
+/// anything by itself (checkpoint, trust, Policy, and service-key validation
+/// all stay exactly where they were). Tests that need a different
+/// configuration run in isolated child processes.
+static PINNED_CONFIG: OnceLock<HyprConfig> = OnceLock::new();
+
+/// Install the process-wide validated configuration snapshot (write-once).
+///
+/// Returns `true` when this call installed the snapshot; `false` when an
+/// earlier install won (first write wins, matching the
+/// `install_envelope_verify_config` precedent). Callers at the single binary
+/// startup site may ignore the result.
+pub fn install_pinned_config(config: HyprConfig) -> bool {
+    PINNED_CONFIG.set(config).is_ok()
+}
+
+/// The installed validated configuration snapshot, if startup pinned one.
+pub fn pinned_config() -> Option<&'static HyprConfig> {
+    PINNED_CONFIG.get()
+}
+
+/// Canonical absolute provenance of the operator's explicit config selector
+/// (CLI `--config` or the `HYPRSTREAM_CONFIG` env), installed by binary
+/// startup before the first load (#1585). Library code that launches services
+/// (bootstrap, wizard) forwards exactly this value to
+/// [`crate::cli::handle_service_start`] so children load the same file;
+/// `None` means defaults-resolution. Write-once, like the snapshot.
+static EXPLICIT_CONFIG_PATH: OnceLock<PathBuf> = OnceLock::new();
+
+/// Install the canonical explicit config selector provenance (write-once).
+pub fn install_explicit_config_path(path: PathBuf) -> bool {
+    EXPLICIT_CONFIG_PATH.set(path).is_ok()
+}
+
+/// The canonical explicit selector, if the operator supplied one.
+pub fn explicit_config_path() -> Option<&'static PathBuf> {
+    EXPLICIT_CONFIG_PATH.get()
+}
 
 /// Unified configuration for the Hyprstream system
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -2663,7 +2714,15 @@ impl HyprConfig {
     }
 
     /// Load configuration using the config crate with XDG directories and environment variables
+    ///
+    /// When binary startup pinned a validated snapshot ([`install_pinned_config`]),
+    /// that snapshot IS the process configuration: the XDG/env re-derivation is
+    /// skipped so factory and service-module reloads can never diverge from the
+    /// `--config` file main already loaded and validated.
     pub fn load() -> Result<Self, ConfigError> {
+        if let Some(pinned) = PINNED_CONFIG.get() {
+            return Ok(pinned.clone());
+        }
         let storage = StoragePaths::new().map_err(|e| {
             ConfigError::Message(format!("Failed to initialize storage paths: {e}"))
         })?;
@@ -4287,4 +4346,82 @@ fn default_training_steps_per_cycle() -> usize {
 }
 fn default_training_min_quality() -> f32 {
     0.3
+}
+
+#[cfg(test)]
+mod pinned_config_tests {
+    #![allow(clippy::expect_used, clippy::unwrap_used)]
+
+    use super::*;
+
+    const PINNED_CHILD: &str = "HYPRSTREAM_PINNED_CONFIG_CHILD";
+
+    /// The write-once snapshot must be the ONE process configuration: after
+    /// startup pins the validated explicit file, factory-style
+    /// `HyprConfig::load()` calls observe the snapshot even when the XDG
+    /// default changes underneath, and never follow source-file rereads.
+    /// Runs in an isolated child because the slot is process-global.
+    #[test]
+    fn pinned_config_snapshot_observed_by_load() -> anyhow::Result<()> {
+        if std::env::var_os(PINNED_CHILD).is_none() {
+            let status = std::process::Command::new(std::env::current_exe()?)
+                .args([
+                    "--exact",
+                    "config::pinned_config_tests::pinned_config_snapshot_observed_by_load",
+                    "--nocapture",
+                ])
+                .env(PINNED_CHILD, "1")
+                .status()?;
+            anyhow::ensure!(status.success(), "pinned-config regression failed");
+            return Ok(());
+        }
+
+        let root = tempfile::tempdir()?;
+        let xdg = root.path().join("xdg-config");
+        std::env::set_var("XDG_CONFIG_HOME", &xdg);
+        let default_config = xdg.join("hyprstream").join("config.toml");
+        std::fs::create_dir_all(default_config.parent().expect("parent"))?;
+
+        let write_config = |path: &Path, secrets: &Path| -> anyhow::Result<()> {
+            if let Some(parent) = path.parent() {
+                std::fs::create_dir_all(parent)?;
+            }
+            let mut configured = HyprConfig::default();
+            configured.secrets.path = Some(secrets.to_path_buf());
+            configured.to_file(path)
+        };
+
+        // XDG default initially points at B; the operator's explicit file at A.
+        let secrets_b = root.path().join("secrets-B");
+        write_config(&default_config, &secrets_b)?;
+        let explicit = root.path().join("custom dir/custom.toml");
+        let secrets_a = root.path().join("secrets-A");
+        write_config(&explicit, &secrets_a)?;
+
+        // Main's path: load the explicit file, validate, pin.
+        let loaded = HyprConfig::from_file(&explicit)?;
+        loaded.validate()?;
+        let _ = install_pinned_config(loaded);
+
+        // Post-pin drift: the XDG default changes to C and the explicit source
+        // file changes to D. Factory-style reloads must stay on the snapshot.
+        let secrets_c = root.path().join("secrets-C");
+        write_config(&default_config, &secrets_c)?;
+        let reloaded = HyprConfig::load().expect("pinned reload");
+        assert_eq!(
+            reloaded.secrets.path,
+            Some(secrets_a.clone()),
+            "factory-style HyprConfig::load() must observe the pinned snapshot, not XDG defaults"
+        );
+        let secrets_d = root.path().join("secrets-D");
+        write_config(&explicit, &secrets_d)?;
+        let again = HyprConfig::load().expect("second pinned reload");
+        assert_eq!(
+            again.secrets.path,
+            Some(secrets_a),
+            "load() must not follow source-file rereads after the pin"
+        );
+        std::env::remove_var("XDG_CONFIG_HOME");
+        Ok(())
+    }
 }

--- a/crates/hyprstream/src/server/tls.rs
+++ b/crates/hyprstream/src/server/tls.rs
@@ -468,3 +468,94 @@ mod acme_tests {
         Ok(())
     }
 }
+
+
+#[cfg(test)]
+mod bound_serve_tests {
+    use super::*;
+    use axum::routing::get;
+    use rustls::pki_types::{CertificateDer, ServerName};
+
+    /// Positive HTTPS regression through the production bind/serve seam:
+    /// `bind_listener` retains the real socket, `serve_bound` hands it to the
+    /// pinned `axum_server::from_tcp_rustls` constructor, a client that
+    /// TRUSTS the served certificate and verifies the hostname normally (no
+    /// verification bypass) completes a real request, and shutdown is
+    /// bounded. Same helper OAuth and OAI call before their readiness
+    /// signals.
+    #[tokio::test]
+    async fn bound_https_serves_verified_client_and_shuts_down_bounded()
+    -> anyhow::Result<()> {
+        hyprstream_rpc::transport::install_pq_crypto_provider()?;
+        let generated = rcgen::generate_simple_self_signed(vec!["localhost".to_owned()])?;
+        let rustls_config = axum_server::tls_rustls::RustlsConfig::from_pem(
+            generated.cert.pem().into_bytes(),
+            generated.key_pair.serialize_pem().into_bytes(),
+        )
+        .await?;
+
+        // Reserve, then bind through the production seam (no second bind).
+        let probe = std::net::TcpListener::bind("127.0.0.1:0")?;
+        let addr = probe.local_addr()?;
+        drop(probe);
+        let bound = bind_listener(addr, Some(rustls_config), "BoundServeTest")?;
+
+        let app = axum::Router::new().route(
+            "/bound-serve-probe",
+            get(|| async { "bound-serve-ok" }),
+        );
+        let shutdown = Arc::new(Notify::new());
+        let shutdown_signal = Arc::clone(&shutdown);
+        let server = tokio::spawn(serve_bound(bound, app, Arc::clone(&shutdown), "BoundServeTest"));
+
+        // Client trusts the served certificate and verifies "localhost"
+        // normally; no dangerous verification-disabling configuration.
+        let mut roots = rustls::RootCertStore::empty();
+        roots.add(CertificateDer::from(generated.cert.der().clone()))?;
+        let client_config = rustls::ClientConfig::builder()
+            .with_root_certificates(roots)
+            .with_no_client_auth();
+        // The client runs on a blocking thread over a real socket. `StreamOwned`
+        // implements blocking Read/Write that drives rustls IO internally (the
+        // raw ClientConnection reader only drains buffered plaintext); hostname
+        // and certificate verification stay fully enabled.
+        let client = std::thread::spawn(move || -> anyhow::Result<String> {
+            use std::io::{Read, Write};
+            let mut tcp = std::net::TcpStream::connect(addr)?;
+            tcp.set_read_timeout(Some(Duration::from_secs(10)))?;
+            let tls = rustls::ClientConnection::new(
+                Arc::new(client_config),
+                ServerName::try_from("localhost")?,
+            )?;
+            let mut stream = rustls::StreamOwned::new(tls, tcp);
+            stream.write_all(
+                b"GET /bound-serve-probe HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n",
+            )?;
+            let mut response = Vec::new();
+            stream.read_to_end(&mut response)?;
+            Ok(String::from_utf8_lossy(&response).into_owned())
+        });
+
+        let response = tokio::task::spawn_blocking(move || client.join())
+            .await
+            .expect("client joiner must not fail")
+            .expect("client thread must not panic")?;
+        assert!(
+            response.starts_with("HTTP/1.1 200"),
+            "verified-TLS client must receive HTTP 200: got {response:?}"
+        );
+        assert!(
+            response.contains("bound-serve-ok"),
+            "exact probe body must be served through the TLS path: got {response:?}"
+        );
+
+        // Bounded shutdown: the retained handle's server ends cleanly.
+        shutdown_signal.notify_one();
+        tokio::time::timeout(Duration::from_secs(30), server)
+            .await
+            .expect("serve_bound must terminate within the shutdown budget")?
+            .expect("graceful shutdown must complete Ok");
+        Ok(())
+    }
+
+}

--- a/crates/hyprstream/src/server/tls.rs
+++ b/crates/hyprstream/src/server/tls.rs
@@ -268,22 +268,61 @@ async fn init_acme_rustls_config(
     Ok(rustls_config)
 }
 
-/// Serve an Axum router over HTTPS (if rustls_config is Some) or plain HTTP.
+/// A bound HTTP(S) listener retained between the bind and serve phases.
 ///
-/// Uses `axum_server` for HTTPS with `Handle`-based graceful shutdown,
-/// or standard `axum::serve` for HTTP.
-pub async fn serve_app(
+/// Bind early (before readiness signals); serve later, consuming the handle.
+/// No second bind occurs: the TLS arm keeps the already-bound std listener
+/// and hands it to the pinned `axum-server` prebound constructor.
+pub enum BoundHttpListener {
+    /// Prebound nonblocking listener adopted by tokio.
+    Http(tokio::net::TcpListener),
+    /// Prebound std listener + TLS config, served via
+    /// `axum_server::from_tcp_rustls`.
+    Https(std::net::TcpListener, axum_server::tls_rustls::RustlsConfig),
+}
+
+/// Bind phase: a real `std::net::TcpListener::bind` plus `set_nonblocking`.
+///
+/// Call this BEFORE any readiness signal so a bind failure (e.g. an occupied
+/// port) surfaces before the launcher is told the service is ready.
+pub fn bind_listener(
     addr: SocketAddr,
-    app: axum::Router,
     rustls_config: Option<axum_server::tls_rustls::RustlsConfig>,
+    service_name: &str,
+) -> Result<BoundHttpListener, RpcError> {
+    let std_listener = std::net::TcpListener::bind(addr).map_err(|e| {
+        RpcError::SpawnFailed(format!("{service_name} HTTP(S) bind failed: {e}"))
+    })?;
+    std_listener.set_nonblocking(true).map_err(|e| {
+        RpcError::SpawnFailed(format!(
+            "{service_name} HTTP(S) set_nonblocking failed: {e}"
+        ))
+    })?;
+    match rustls_config {
+        Some(tls) => Ok(BoundHttpListener::Https(std_listener, tls)),
+        None => Ok(BoundHttpListener::Http(
+            tokio::net::TcpListener::from_std(std_listener).map_err(|e| {
+                RpcError::SpawnFailed(format!(
+                    "{service_name} HTTP listener adoption failed: {e}"
+                ))
+            })?,
+        )),
+    }
+}
+
+/// Serve phase: consume a [`BoundHttpListener`] with graceful shutdown.
+///
+/// The TLS arm uses the pinned free function
+/// `axum_server::from_tcp_rustls(listener, tls)` on the already-bound std
+/// listener — no second bind.
+pub async fn serve_bound(
+    bound: BoundHttpListener,
+    app: axum::Router,
     shutdown: Arc<Notify>,
     service_name: &str,
 ) -> Result<(), RpcError> {
-    let scheme = if rustls_config.is_some() { "https" } else { "http" };
-    info!("{service_name} listening on {scheme}://{addr}");
-
-    match rustls_config {
-        Some(tls) => {
+    match bound {
+        BoundHttpListener::Https(std_listener, tls) => {
             let handle = axum_server::Handle::new();
             let shutdown_handle = handle.clone();
             let name = service_name.to_owned();
@@ -295,19 +334,15 @@ pub async fn serve_app(
                 shutdown_handle.graceful_shutdown(Some(Duration::from_secs(30)));
             });
 
-            axum_server::bind_rustls(addr, tls)
+            axum_server::from_tcp_rustls(std_listener, tls)
                 .handle(handle)
                 .serve(app.into_make_service())
                 .await
                 .map_err(|e| RpcError::SpawnFailed(format!("{service_name} HTTPS server error: {e}")))?;
         }
-        None => {
-            let name = service_name.to_owned();
-            let listener = tokio::net::TcpListener::bind(addr)
-                .await
-                .map_err(|e| RpcError::SpawnFailed(format!("{name} HTTP bind failed: {e}")))?;
-
+        BoundHttpListener::Http(listener) => {
             let shutdown_clone = shutdown.clone();
+            let name = service_name.to_owned();
             axum::serve(listener, app)
                 .with_graceful_shutdown(async move {
                     shutdown_clone.notified().await;
@@ -320,6 +355,25 @@ pub async fn serve_app(
 
     info!("{service_name} stopped");
     Ok(())
+}
+
+/// Serve an Axum router over HTTPS (if rustls_config is Some) or plain HTTP.
+///
+/// Uses `axum_server` for HTTPS with `Handle`-based graceful shutdown,
+/// or standard `axum::serve` for HTTP. Bind-then-serve wrapper over
+/// [`bind_listener`] + [`serve_bound`]; existing callers are unchanged.
+pub async fn serve_app(
+    addr: SocketAddr,
+    app: axum::Router,
+    rustls_config: Option<axum_server::tls_rustls::RustlsConfig>,
+    shutdown: Arc<Notify>,
+    service_name: &str,
+) -> Result<(), RpcError> {
+    let scheme = if rustls_config.is_some() { "https" } else { "http" };
+    info!("{service_name} listening on {scheme}://{addr}");
+
+    let bound = bind_listener(addr, rustls_config, service_name)?;
+    serve_bound(bound, app, shutdown, service_name).await
 }
 
 /// The shared listener must negotiate both HTTP and TLS-ALPN-01. The ACME

--- a/crates/hyprstream/src/server/tls.rs
+++ b/crates/hyprstream/src/server/tls.rs
@@ -472,9 +472,11 @@ mod acme_tests {
 
 #[cfg(test)]
 mod bound_serve_tests {
+    #![allow(clippy::expect_used, clippy::unwrap_used)]
+
     use super::*;
     use axum::routing::get;
-    use rustls::pki_types::{CertificateDer, ServerName};
+    use rustls::pki_types::ServerName;
 
     /// Positive HTTPS regression through the production bind/serve seam:
     /// `bind_listener` retains the real socket, `serve_bound` hands it to the
@@ -511,7 +513,7 @@ mod bound_serve_tests {
         // Client trusts the served certificate and verifies "localhost"
         // normally; no dangerous verification-disabling configuration.
         let mut roots = rustls::RootCertStore::empty();
-        roots.add(CertificateDer::from(generated.cert.der().clone()))?;
+        roots.add(generated.cert.der().clone())?;
         let client_config = rustls::ClientConfig::builder()
             .with_root_certificates(roots)
             .with_no_client_auth();
@@ -521,7 +523,7 @@ mod bound_serve_tests {
         // and certificate verification stay fully enabled.
         let client = std::thread::spawn(move || -> anyhow::Result<String> {
             use std::io::{Read, Write};
-            let mut tcp = std::net::TcpStream::connect(addr)?;
+            let tcp = std::net::TcpStream::connect(addr)?;
             tcp.set_read_timeout(Some(Duration::from_secs(10)))?;
             let tls = rustls::ClientConnection::new(
                 Arc::new(client_config),

--- a/crates/hyprstream/src/services/factories.rs
+++ b/crates/hyprstream/src/services/factories.rs
@@ -1776,7 +1776,8 @@ fn build_workflow_namespace() -> Namespace {
 /// Factory for OAIService (OpenAI-compatible HTTP API)
 ///
 /// This service provides the HTTP API for inference requests.
-/// It communicates with ModelService and PolicyService via ZMQ.
+/// It communicates with ModelService, PolicyService, and RegistryService over
+/// the configured authenticated RPC resolver.
 #[service_factory("oai", depends_on = ["policy", "model", "registry", "discovery"])]
 fn create_oai_service(ctx: &ServiceContext) -> anyhow::Result<Box<dyn Spawnable>> {
     info!("Creating OAIService");
@@ -1792,7 +1793,7 @@ fn create_oai_service(ctx: &ServiceContext) -> anyhow::Result<Box<dyn Spawnable>
     // Register this service's verifying key with PolicyService
     register_service_key(ctx, "oai", &sk)?;
 
-    // Create ZMQ clients for Model and Policy services
+    // Create authenticated clients for Model and Policy services.
     let model_client = ModelClient::from_resolver(sk.clone(), service_token(&sk))?;
     let policy_vk = hyprstream_service::global_trust_store()
         .resolve_one("policy")
@@ -1854,8 +1855,7 @@ fn create_oai_service(ctx: &ServiceContext) -> anyhow::Result<Box<dyn Spawnable>
         config.tls.clone(),
         config.account.clone(),
         server_state,
-        ctx.transport("oai", SocketKind::Rep),
-        ctx.verifying_key(),
+        ctx.iroh_required(),
     );
 
     Ok(Box::new(oai_service))

--- a/crates/hyprstream/src/services/factories.rs
+++ b/crates/hyprstream/src/services/factories.rs
@@ -353,7 +353,15 @@ fn register_service_key(
         return Ok(());
     }
 
-    let creds_dir = credentials_dir()?;
+    // The loaded config's `[secrets].path` must win: startup read the retained
+    // key and this very JWT from that directory, and the renewal task spawned
+    // below reads AND persists there every hour. A config-free fallback here
+    // made custom `--config [secrets].path` deployments work at startup and
+    // then silently skip renewal (P1, PR1585).
+    let creds_dir = match ctx.secrets_dir() {
+        Some(dir) => dir.to_path_buf(),
+        None => credentials_dir()?,
+    };
     let secrets_profile = crate::auth::identity_store::SecretsProfile::from_env()?;
 
     // The JWT may already be in the trust store (e.g. seeded by an earlier

--- a/crates/hyprstream/src/services/factories.rs
+++ b/crates/hyprstream/src/services/factories.rs
@@ -3365,6 +3365,61 @@ mod tests {
         Ok(())
     }
 
+    /// The loaded custom `[secrets].path` must reach the factory itself, not
+    /// only the startup trust-store bridge: with the service JWT on disk
+    /// solely at the config-selected directory (no env override, no manual
+    /// seeding), `register_service_key` resolves it there. This is the exact
+    /// selection expression that feeds `spawn_jwt_renewal_task` — the hourly
+    /// renewal reads and persists at this directory — so a config-free
+    /// fallback here makes custom-path deployments renew against the wrong
+    /// directory and silently skip.
+    #[test]
+    fn register_service_key_resolves_custom_config_secrets_dir() -> anyhow::Result<()> {
+        const CHILD: &str = "HYPRSTREAM_POLICY_CTX_SECRETS_DIR_CHILD";
+        if std::env::var_os(CHILD).is_none() {
+            let status = std::process::Command::new(std::env::current_exe()?)
+                .args(["--exact", "services::factories::tests::register_service_key_resolves_custom_config_secrets_dir", "--nocapture"])
+                .env(CHILD, "1")
+                .status()?;
+            anyhow::ensure!(status.success(), "isolated ctx secrets-dir registration test failed");
+            return Ok(());
+        }
+        let root = tempfile::tempdir()?;
+        let custom = root.path().join("custom-credentials");
+        let xdg = root.path().join("xdg-config");
+        std::env::set_var("XDG_CONFIG_HOME", &xdg);
+        std::env::remove_var("HYPRSTREAM__SECRETS__PATH");
+        std::env::remove_var(crate::auth::identity_store::SECRETS_PROFILE_ENV);
+
+        let signer = SigningKey::from_bytes(&[0x6b; 32]);
+        let ctx = ServiceContext::new(signer.clone(), signer.verifying_key(), true, custom.clone())
+            .with_quic(hyprstream_service::QuicSharedConfig {
+                cert_chain: Vec::new(), key_der: zeroize::Zeroizing::new(Vec::new()),
+                base_ip: std::net::Ipv4Addr::LOCALHOST.into(), server_name: "policy.test".to_owned(),
+                oauth_issuer_url: None, jwt_verifying_key: None, iroh_enabled: true, iroh_required: true,
+                moq_relay: None, native_announcement_publisher: None,
+                moq_relay_server_identity: None, moq_admission: None,
+                moq_ingress_authorizer: None, moq_admission_proof: None,
+            })
+            .with_secrets_dir(custom.clone());
+        // No trust-store bridge: the JWT exists only at the config-selected
+        // directory. Registration must resolve it from the context-carried
+        // directory — the same binding handed to the renewal task.
+        let now = chrono::Utc::now().timestamp();
+        let claims = hyprstream_rpc::auth::Claims::new("service:policy".to_owned(), now, now + 3600)
+            .with_cnf_jwk(signer.verifying_key().as_bytes());
+        let jwt = hyprstream_rpc::auth::jwt::encode_service_jwt(&claims, &signer);
+        crate::auth::identity_store::write_service_jwt(&custom, "policy", &jwt)?;
+        register_service_key(&ctx, "policy", &signer)?;
+        assert_eq!(
+            hyprstream_service::global_trust_store()
+                .get(&signer.verifying_key())
+                .and_then(|attestation| attestation.jwt),
+            Some(jwt),
+        );
+        Ok(())
+    }
+
     /// A JWT already present in the trust store is used directly (no disk read).
     #[test]
     fn resolve_registration_jwt_prefers_trust_store() {

--- a/crates/hyprstream/src/services/factories.rs
+++ b/crates/hyprstream/src/services/factories.rs
@@ -3306,6 +3306,65 @@ mod tests {
         Ok(())
     }
 
+    /// A required-native Policy process carries its loaded custom secrets path
+    /// into the factory through the trust store. The factory's config-free
+    /// fallback must not need the XDG default path to exist.
+    #[test]
+    fn required_policy_uses_loaded_custom_jwt_before_factory_fallback() -> anyhow::Result<()> {
+        const CHILD: &str = "HYPRSTREAM_POLICY_CUSTOM_JWT_CHILD";
+        if std::env::var_os(CHILD).is_none() {
+            let status = std::process::Command::new(std::env::current_exe()?)
+                .args(["--exact", "services::factories::tests::required_policy_uses_loaded_custom_jwt_before_factory_fallback", "--nocapture"])
+                .env(CHILD, "1")
+                .status()?;
+            anyhow::ensure!(status.success(), "isolated custom Policy JWT test failed");
+            return Ok(());
+        }
+        let root = tempfile::tempdir()?;
+        let custom = root.path().join("custom-credentials");
+        let xdg = root.path().join("xdg-config");
+        std::env::set_var("XDG_CONFIG_HOME", &xdg);
+        std::env::remove_var("HYPRSTREAM__SECRETS__PATH");
+        std::env::remove_var(crate::auth::identity_store::SECRETS_PROFILE_ENV);
+
+        let signer = SigningKey::from_bytes(&[0x6a; 32]);
+        let ctx = ServiceContext::new(signer.clone(), signer.verifying_key(), true, custom.clone())
+            .with_quic(hyprstream_service::QuicSharedConfig {
+                cert_chain: Vec::new(), key_der: zeroize::Zeroizing::new(Vec::new()),
+                base_ip: std::net::Ipv4Addr::LOCALHOST.into(), server_name: "policy.test".to_owned(),
+                oauth_issuer_url: None, jwt_verifying_key: None, iroh_enabled: true, iroh_required: true,
+                moq_relay: None, native_announcement_publisher: None,
+                moq_relay_server_identity: None, moq_admission: None,
+                moq_ingress_authorizer: None, moq_admission_proof: None,
+            });
+        // With the default XDG directory absent, registration fails before
+        // startup carries the loaded custom credential into the trust store.
+        assert!(register_service_key(&ctx, "policy", &signer).is_err());
+
+        let now = chrono::Utc::now().timestamp();
+        let claims = hyprstream_rpc::auth::Claims::new("service:policy".to_owned(), now, now + 3600)
+            .with_cnf_jwk(signer.verifying_key().as_bytes());
+        let jwt = hyprstream_rpc::auth::jwt::encode_service_jwt(&claims, &signer);
+        crate::auth::identity_store::write_service_jwt(&custom, "policy", &jwt)?;
+        let mut loaded_config = HyprConfig::default();
+        loaded_config.secrets.path = Some(custom.clone());
+        let loaded_secrets = HyprConfig::resolve_secrets_dir_for(Some(&loaded_config))?;
+        crate::auth::identity_store::seed_service_jwt_into_trust_store(
+            "policy",
+            &signer,
+            &loaded_secrets,
+            crate::auth::identity_store::SecretsProfile::SharedDirectory,
+        );
+        register_service_key(&ctx, "policy", &signer)?;
+        assert_eq!(
+            hyprstream_service::global_trust_store()
+                .get(&signer.verifying_key())
+                .and_then(|attestation| attestation.jwt),
+            Some(jwt),
+        );
+        Ok(())
+    }
+
     /// A JWT already present in the trust store is used directly (no disk read).
     #[test]
     fn resolve_registration_jwt_prefers_trust_store() {

--- a/crates/hyprstream/src/services/factories.rs
+++ b/crates/hyprstream/src/services/factories.rs
@@ -399,6 +399,19 @@ fn register_service_key(
     }
 
     if service_name == "policy" {
+        if ctx.iroh_required() {
+            // Policy is the native authority itself: it does not register its
+            // own key through RPC, but its provisioned service JWT still needs
+            // the same renewal task as every other native child.
+            spawn_jwt_renewal_task(
+                service_name,
+                signing_key.clone(),
+                creds_dir,
+                secrets_profile,
+                true,
+                ctx.transport("policy", SocketKind::Rep),
+            );
+        }
         return Ok(());
     }
 
@@ -534,7 +547,14 @@ fn spawn_jwt_renewal_task(
     policy_transport: hyprstream_rpc::transport::TransportConfig,
 ) {
     let service_name = service_name.to_owned();
-    tokio::spawn(async move {
+    let Ok(runtime) = tokio::runtime::Handle::try_current() else {
+        // Factory unit tests exercise registration without a running executor;
+        // production startup always has one. Avoid panicking in the former
+        // while keeping renewal attached to the service runtime in the latter.
+        tracing::debug!(service = service_name, "JWT renewal deferred: no Tokio runtime");
+        return;
+    };
+    runtime.spawn(async move {
         const CHECK_INTERVAL: std::time::Duration = std::time::Duration::from_secs(3_600);
         const RENEW_THRESHOLD: i64 = 7 * 24 * 3_600; // 7 days remaining
 

--- a/crates/hyprstream/src/services/generated.rs
+++ b/crates/hyprstream/src/services/generated.rs
@@ -8,6 +8,30 @@ pub mod model_client {
     #![allow(dead_code, unused_imports, unused_variables)]
     #![allow(clippy::all)]
     hyprstream_rpc_derive::generate_rpc_service!("model", scope_handlers);
+
+    /// Send the canonical Model health request and retain its typed response.
+    ///
+    /// The generated `health_check` convenience method turns `ErrorInfo` into
+    /// an untyped error. OAI startup needs to distinguish one authenticated
+    /// Model denial from local transport and response-verification failures,
+    /// so this narrow helper keeps the method-bound call and parses the
+    /// already-verified response bytes without changing shared code generation.
+    pub(crate) async fn verified_health_check_response(
+        client: &ModelClient,
+    ) -> anyhow::Result<ModelResponseVariant> {
+        const HEALTH_CHECK_METHOD: u16 = 3;
+
+        let request_id = client.next_id();
+        let payload = hyprstream_rpc::serialize_message(|message| {
+            let mut request = message.init_root::<crate::model_capnp::model_request::Builder>();
+            request.set_id(request_id);
+            request.set_health_check(());
+        })?;
+        let response = client
+            .call_with_method(HEALTH_CHECK_METHOD, payload)
+            .await?;
+        ModelClient::parse_response(&response)
+    }
 }
 
 pub mod registry_client {

--- a/crates/hyprstream/src/services/mod.rs
+++ b/crates/hyprstream/src/services/mod.rs
@@ -146,6 +146,12 @@ pub use namespace_builder::{build_standard_namespace, StandardNamespaceConfig};
 pub use hyprstream_workers::runtime::WorkerClient;
 pub use oauth::OAuthService;
 pub use oai::OAIService;
+#[cfg(test)]
+pub(crate) use oai::{
+    await_required_native_dependencies as oai_await_required_native_dependencies,
+    healthy_registry as oai_healthy_registry,
+    prove_model_reachability_denial as oai_prove_model_reachability_denial,
+};
 pub use xet::{XetService, XetState};
 pub use at9p_verify::{At9pVerifyService, VerifyFaceState, credential_free_router};
 #[cfg(feature = "oci-image")]

--- a/crates/hyprstream/src/services/oai.rs
+++ b/crates/hyprstream/src/services/oai.rs
@@ -31,7 +31,7 @@
 
 use crate::config::{OAIConfig, TlsConfig};
 use crate::server::{create_app, state::ServerState};
-use crate::server::tls::{resolve_rustls_config, serve_app};
+use crate::server::tls::{bind_listener, resolve_rustls_config, serve_bound};
 use anyhow::Result;
 use hyprstream_rpc::prelude::*;
 use hyprstream_rpc::registry::SocketKind;
@@ -154,7 +154,12 @@ impl Spawnable for OAIService {
 
             info!("OpenAI-compatible API available at {scheme}://{addr}/oai/v1");
 
-            // Signal ready
+            // PREBIND the HTTP(S) listener BEFORE any readiness signal: an
+            // occupied port fails here, before the supervisor is told the
+            // service is ready (#1585 YuI7 companion correction).
+            let bound = bind_listener(addr, rustls_config, "OAIService")?;
+
+            // Signal ready — only after the listener is bound.
             if let Some(tx) = on_ready {
                 let _ = tx.send(());
             }
@@ -162,8 +167,9 @@ impl Spawnable for OAIService {
             // Notify systemd that service is ready
             let _ = hyprstream_rpc::notify::ready();
 
-            // Run HTTP(S) server with graceful shutdown
-            serve_app(addr, app, rustls_config, shutdown, "OAIService").await
+            // Run HTTP(S) server with graceful shutdown; the serving result
+            // propagates (post-READY runtime failure — recorded lifecycle gap).
+            serve_bound(bound, app, shutdown, "OAIService").await
         })
     }
 }

--- a/crates/hyprstream/src/services/oai.rs
+++ b/crates/hyprstream/src/services/oai.rs
@@ -1,8 +1,7 @@
-//! OAIService - OpenAI-compatible HTTP API with RPC control channel
+//! OAIService - OpenAI-compatible HTTP API
 //!
-//! Dual-protocol service:
-//! - HTTP server for OpenAI API requests (data plane)
-//! - RPC (iroh/UDS) for health, metrics, shutdown (control plane)
+//! The HTTP server handles OpenAI API requests and uses authenticated RPC
+//! clients to reach Model, Policy, and Registry services.
 //!
 //! # Architecture
 //!
@@ -11,8 +10,6 @@
 //!                        │
 //!                        ├──► ModelClient ──► ModelService
 //!                        └──► PolicyClient ──► PolicyService
-//!
-//! Control ──► RPC endpoint ──► OAIService (health, metrics)
 //! ```
 //!
 //! # Usage
@@ -30,29 +27,107 @@
 //! ```
 
 use crate::config::{OAIConfig, TlsConfig};
-use crate::server::{create_app, state::ServerState};
 use crate::server::tls::{bind_listener, resolve_rustls_config, serve_bound};
+use crate::server::{create_app, state::ServerState};
 use anyhow::Result;
-use hyprstream_rpc::prelude::*;
-use hyprstream_rpc::registry::SocketKind;
 use hyprstream_service::Spawnable;
-use hyprstream_rpc::transport::TransportConfig;
 use std::net::SocketAddr;
 use std::sync::Arc;
+use std::time::Duration;
 use tokio::sync::Notify;
 use tracing::info;
 
 /// Service name for registry and logging
 pub const SERVICE_NAME: &str = "oai";
 
-/// OAIService - OpenAI-compatible HTTP API with RPC control channel
+const MODEL_MISSING_TENANT_DENIAL: &str = "authorization denied: no verified tenant domain";
+
+/// Prove that the tenantless OAI service can reach the authenticated Model
+/// dispatcher while preserving Model's tenant boundary.
 ///
-/// This service provides:
-/// - HTTP server with OpenAI-compatible API endpoints
-/// - RPC control channel for health checks and metrics
+/// The generated-module helper preserves the canonical method binding and
+/// returns a typed response only after the response envelope has been
+/// decrypted and verified against the resolved Model identity. Classify the
+/// expected denial only after that verification.
+pub(crate) async fn prove_model_reachability_denial(
+    client: &crate::services::generated::model_client::ModelClient,
+) -> Result<(), hyprstream_rpc::error::RpcError> {
+    use crate::services::generated::model_client::{
+        verified_health_check_response, ModelResponseVariant,
+    };
+
+    let response = verified_health_check_response(client)
+        .await
+        .map_err(|error| {
+            hyprstream_rpc::error::RpcError::SpawnFailed(format!(
+                "OAI Model reachability transport/authentication/response failed: {error}"
+            ))
+        })?;
+    match response {
+        ModelResponseVariant::Error(error)
+            if error.code == "INTERNAL"
+                && error.message == MODEL_MISSING_TENANT_DENIAL
+                && error.details.is_empty() =>
+        {
+            Ok(())
+        }
+        ModelResponseVariant::HealthCheckResult(_) => {
+            Err(hyprstream_rpc::error::RpcError::SpawnFailed(
+                "OAI tenantless Model reachability probe was unexpectedly authorized".to_owned(),
+            ))
+        }
+        response => Err(hyprstream_rpc::error::RpcError::SpawnFailed(format!(
+            "OAI Model reachability returned an unexpected authenticated response: {response:?}"
+        ))),
+    }
+}
+
+pub(crate) async fn healthy_registry(
+    client: &crate::services::RegistryClient,
+) -> Result<(), hyprstream_rpc::error::RpcError> {
+    let health = client.health_check().await.map_err(|error| {
+        hyprstream_rpc::error::RpcError::SpawnFailed(format!(
+            "OAI native Registry readiness: {error}"
+        ))
+    })?;
+    if health.status != "healthy" {
+        return Err(hyprstream_rpc::error::RpcError::SpawnFailed(format!(
+            "OAI native Registry readiness returned status {:?}",
+            health.status
+        )));
+    }
+    Ok(())
+}
+
+pub(crate) async fn await_required_native_dependencies(
+    model: &crate::services::generated::model_client::ModelClient,
+    registry: &crate::services::RegistryClient,
+    shutdown: Arc<Notify>,
+    timeout: Duration,
+) -> Result<(), hyprstream_rpc::error::RpcError> {
+    let checks = async {
+        prove_model_reachability_denial(model).await?;
+        healthy_registry(registry).await?;
+        Ok(())
+    };
+
+    tokio::select! {
+        _ = shutdown.notified() => Err(hyprstream_rpc::error::RpcError::SpawnFailed(
+            "OAI native dependency readiness cancelled".to_owned(),
+        )),
+        result = tokio::time::timeout(timeout, checks) => {
+            result.map_err(|_| hyprstream_rpc::error::RpcError::SpawnFailed(format!(
+                "OAI native dependency readiness timed out after {} milliseconds",
+                timeout.as_millis()
+            )))?
+        }
+    }
+}
+
+/// OAIService - OpenAI-compatible HTTP API
 ///
-/// The HTTP server handles all inference requests via ModelClient,
-/// which communicates with ModelService over the RPC transport.
+/// The HTTP server handles requests through authenticated Model, Policy, and
+/// Registry clients. OAI has no inbound RPC control schema or handler.
 pub struct OAIService {
     /// OAI-specific configuration (host, port, TLS)
     config: OAIConfig,
@@ -67,12 +142,9 @@ pub struct OAIService {
     /// Shared server state containing clients and metrics
     server_state: ServerState,
 
-    /// Transport configuration for RPC control channel
-    control_transport: TransportConfig,
-
-    /// Verifying key for envelope verification
-    #[allow(dead_code)]
-    verifying_key: VerifyingKey,
+    /// Required deployments must prove their outbound native dependencies
+    /// before advertising HTTP readiness.
+    native_dependencies_required: bool,
 }
 
 impl OAIService {
@@ -83,30 +155,105 @@ impl OAIService {
     /// * `config` - OAI configuration (host, port, TLS settings)
     /// * `tls_config` - Global TLS configuration
     /// * `server_state` - Shared state with RPC clients and metrics
-    /// * `control_transport` - Transport for RPC control channel
-    /// * `verifying_key` - Key for verifying signed envelopes
+    /// * `native_dependencies_required` - gate readiness on authenticated
+    ///   Model reachability and Registry health responses
     pub fn new(
         config: OAIConfig,
         tls_config: TlsConfig,
         account_config: crate::account::AccountZoneConfig,
         server_state: ServerState,
-        control_transport: TransportConfig,
-        verifying_key: VerifyingKey,
+        native_dependencies_required: bool,
     ) -> Self {
         Self {
             config,
             tls_config,
             account_config,
             server_state,
-            control_transport,
-            verifying_key,
+            native_dependencies_required,
         }
     }
 
     /// Get the HTTP bind address
     pub fn http_addr(&self) -> Result<SocketAddr> {
         let addr_str = format!("{}:{}", self.config.host, self.config.port);
-        addr_str.parse().map_err(|e| anyhow::anyhow!("Invalid address: {}", e))
+        addr_str
+            .parse()
+            .map_err(|e| anyhow::anyhow!("Invalid address: {}", e))
+    }
+
+    async fn await_native_dependencies(
+        &self,
+        shutdown: Arc<Notify>,
+    ) -> Result<(), hyprstream_rpc::error::RpcError> {
+        if !self.native_dependencies_required {
+            return Ok(());
+        }
+
+        await_required_native_dependencies(
+            &self.server_state.model_client,
+            &self.server_state.registry,
+            shutdown,
+            Duration::from_secs(30),
+        )
+        .await
+    }
+
+    pub(crate) async fn run_inner(
+        self: Box<Self>,
+        shutdown: Arc<Notify>,
+        on_ready: Option<tokio::sync::oneshot::Sender<()>>,
+    ) -> Result<(), hyprstream_rpc::error::RpcError> {
+        // Parse HTTP bind address
+        let addr = self.http_addr().map_err(|e| {
+            hyprstream_rpc::error::RpcError::SpawnFailed(format!("Invalid HTTP address: {e}"))
+        })?;
+
+        // Resolve TLS configuration (tls_config passed from factory, not re-loaded)
+        let rustls_config = resolve_rustls_config(
+            &self.tls_config,
+            &self.account_config,
+            self.config.tls_cert.as_ref(),
+            self.config.tls_key.as_ref(),
+        )
+        .await
+        .map_err(|e| hyprstream_rpc::error::RpcError::SpawnFailed(format!("TLS config: {e}")))?;
+
+        let scheme = if rustls_config.is_some() {
+            "https"
+        } else {
+            "http"
+        };
+
+        // Create HTTP server
+        let app = create_app(self.server_state.clone());
+
+        info!("OpenAI-compatible API available at {scheme}://{addr}/oai/v1");
+
+        // PREBIND the HTTP(S) listener BEFORE any readiness signal: an
+        // occupied port fails here, before the supervisor is told the
+        // service is ready (#1585 YuI7 companion correction).
+        let bound = bind_listener(addr, rustls_config, "OAIService")?;
+
+        // Required deployments use the process-owned bootstrap Iroh
+        // endpoint for outbound RPC. Prove the actual Model and Registry
+        // request paths before exposing the HTTP face as ready. Policy was
+        // already probed by process authority-store initialization before
+        // this factory ran.
+        self.await_native_dependencies(Arc::clone(&shutdown))
+            .await?;
+
+        // Signal ready only after the listener and required native
+        // dependencies are ready.
+        if let Some(tx) = on_ready {
+            let _ = tx.send(());
+        }
+
+        // Notify systemd that service is ready
+        let _ = hyprstream_rpc::notify::ready();
+
+        // Run HTTP(S) server with graceful shutdown; the serving result
+        // propagates (post-READY runtime failure — recorded lifecycle gap).
+        serve_bound(bound, app, shutdown, "OAIService").await
     }
 }
 
@@ -115,9 +262,13 @@ impl Spawnable for OAIService {
         SERVICE_NAME
     }
 
-    fn registrations(&self) -> Vec<(SocketKind, TransportConfig)> {
-        // Register control channel endpoint
-        vec![(SocketKind::Rep, self.control_transport.clone())]
+    fn registrations(
+        &self,
+    ) -> Vec<(
+        hyprstream_rpc::SocketKind,
+        hyprstream_rpc::transport::TransportConfig,
+    )> {
+        Vec::new()
     }
 
     fn run(
@@ -131,46 +282,7 @@ impl Spawnable for OAIService {
             .build()
             .map_err(|e| hyprstream_rpc::error::RpcError::SpawnFailed(format!("runtime: {e}")))?;
 
-        rt.block_on(async move {
-            // Parse HTTP bind address
-            let addr = self.http_addr().map_err(|e| {
-                hyprstream_rpc::error::RpcError::SpawnFailed(format!("Invalid HTTP address: {e}"))
-            })?;
-
-            // Resolve TLS configuration (tls_config passed from factory, not re-loaded)
-            let rustls_config = resolve_rustls_config(
-                &self.tls_config,
-                &self.account_config,
-                self.config.tls_cert.as_ref(),
-                self.config.tls_key.as_ref(),
-            )
-            .await
-            .map_err(|e| hyprstream_rpc::error::RpcError::SpawnFailed(format!("TLS config: {e}")))?;
-
-            let scheme = if rustls_config.is_some() { "https" } else { "http" };
-
-            // Create HTTP server
-            let app = create_app(self.server_state.clone());
-
-            info!("OpenAI-compatible API available at {scheme}://{addr}/oai/v1");
-
-            // PREBIND the HTTP(S) listener BEFORE any readiness signal: an
-            // occupied port fails here, before the supervisor is told the
-            // service is ready (#1585 YuI7 companion correction).
-            let bound = bind_listener(addr, rustls_config, "OAIService")?;
-
-            // Signal ready — only after the listener is bound.
-            if let Some(tx) = on_ready {
-                let _ = tx.send(());
-            }
-
-            // Notify systemd that service is ready
-            let _ = hyprstream_rpc::notify::ready();
-
-            // Run HTTP(S) server with graceful shutdown; the serving result
-            // propagates (post-READY runtime failure — recorded lifecycle gap).
-            serve_bound(bound, app, shutdown, "OAIService").await
-        })
+        rt.block_on(self.run_inner(shutdown, on_ready))
     }
 }
 

--- a/crates/hyprstream/src/services/oauth/did_document.rs
+++ b/crates/hyprstream/src/services/oauth/did_document.rs
@@ -797,7 +797,7 @@ pub async fn root_did_document(State(state): State<Arc<OAuthState>>) -> Response
             endpoint: hyprstream_rpc::service_entry::encode_iroh(
                 &node_id,
                 &state.iroh_relays,
-                &["hyprstream-rpc/1", "moql"],
+                &["hyprstream-rpc/1"],
             ),
         });
     }
@@ -1878,7 +1878,7 @@ mod tests {
             endpoint: hyprstream_rpc::service_entry::encode_iroh(
                 &node_id,
                 &[],
-                &["hyprstream-rpc/1", "moql"],
+                &["hyprstream-rpc/1"],
             ),
         }];
         let doc = build_did_document(
@@ -1904,8 +1904,7 @@ mod tests {
         assert_eq!(iroh_svc["id"].as_str().unwrap(), format!("{did}#iroh"));
         let accept = iroh_svc["serviceEndpoint"]["accept"].as_array().unwrap();
         let accept: Vec<&str> = accept.iter().filter_map(|v| v.as_str()).collect();
-        assert!(accept.contains(&"hyprstream-rpc/1"));
-        assert!(accept.contains(&"moql"));
+        assert_eq!(accept, vec!["hyprstream-rpc/1"]);
     }
 
     #[test]

--- a/crates/hyprstream/src/services/oauth/mod.rs
+++ b/crates/hyprstream/src/services/oauth/mod.rs
@@ -78,6 +78,7 @@ use axum::{
     Router,
 };
 use hyprstream_rpc::registry::SocketKind;
+use hyprstream_rpc::transport::iroh_rpc::LocalServiceBridge;
 use hyprstream_rpc::transport::TransportConfig;
 use hyprstream_service::Spawnable;
 use tokio::sync::Notify;
@@ -423,6 +424,92 @@ async fn build_oauth_iroh_substrate(
     .await
 }
 
+/// Profile-aware bind of OAuth's inbound reach-only substrate, using the
+/// production substrate builder. See [`bind_oauth_substrate_profile`] — the
+/// builder is a parameter only so causal tests can inject a bind failure at
+/// this exact production boundary.
+async fn build_oauth_substrate_profile(
+    signing_key: &ed25519_dalek::SigningKey,
+    iroh_required: bool,
+) -> Result<
+    Option<hyprstream_rpc::transport::iroh_substrate::IrohSubstrate>,
+    hyprstream_rpc::error::RpcError,
+> {
+    let signing_key = signing_key.clone();
+    bind_oauth_substrate_profile(iroh_required, move || async move {
+        let transport_key = hyprstream_rpc::node_identity::derive_purpose_key(
+            &signing_key,
+            "hyprstream-iroh-transport-v1",
+        );
+        build_oauth_iroh_substrate(transport_key.to_bytes()).await
+    })
+    .await
+}
+
+/// Bind POLICY for OAuth's inbound reach-only substrate: Required treats a
+/// bind failure as fatal before READY (the child exits nonzero and the
+/// supervised launcher rolls the spawn back); Compatibility warns and
+/// continues without Iroh (documented degraded mode). Bind policy lives here,
+/// separate from the install disposition ([`classify_oauth_endpoint_install`])
+/// so "mandatory local bind" cannot regress into "must replace the global
+/// dialer".
+async fn bind_oauth_substrate_profile<F, Fut>(
+    iroh_required: bool,
+    build: F,
+) -> Result<
+    Option<hyprstream_rpc::transport::iroh_substrate::IrohSubstrate>,
+    hyprstream_rpc::error::RpcError,
+>
+where
+    F: FnOnce() -> Fut,
+    Fut: std::future::Future<Output = anyhow::Result<hyprstream_rpc::transport::iroh_substrate::IrohSubstrate>>,
+{
+    match build().await {
+        Ok(substrate) => Ok(Some(substrate)),
+        Err(e) if iroh_required => Err(hyprstream_rpc::error::RpcError::SpawnFailed(format!(
+            "network-iroh-required OAuth iroh substrate bind failed: {e:#}"
+        ))),
+        Err(e) => {
+            tracing::warn!(
+                "OAuth iroh substrate bind failed; continuing without iroh (Compatibility): {e:#}"
+            );
+            Ok(None)
+        }
+    }
+}
+
+/// Disposition of the process-global client-endpoint install for OAuth's
+/// bound substrate. `install_iroh_client_endpoint` is first-write-wins, so an
+/// occupied slot means a DIFFERENT valid endpoint — in real Required startup,
+/// the authenticated OS-owned bootstrap outbound carrier
+/// (`PROCESS_BOOTSTRAP_CARRIER`) — already owns outbound dials. Both outcomes
+/// are valid and expected; neither is ever a startup error. The two carriers'
+/// endpoint IDs are deliberately different (distinct transport purpose keys)
+/// and are never compared; the OAuth substrate is retained in both cases and
+/// the existing global endpoint is never reset or replaced.
+enum OAuthEndpointInstall {
+    /// The empty process-global slot was won by this substrate's endpoint.
+    InstalledHere,
+    /// A previously-installed global endpoint remains the outbound dialer;
+    /// the returned capability clone is dropped and OAuth's substrate stays
+    /// the independent inbound owner.
+    ExistingGlobalRetained,
+}
+
+fn classify_oauth_endpoint_install(
+    substrate: &hyprstream_rpc::transport::iroh_substrate::IrohSubstrate,
+) -> OAuthEndpointInstall {
+    match hyprstream_rpc::transport::lazy_iroh::install_iroh_client_endpoint(
+        substrate.owned_client_endpoint(),
+    ) {
+        Ok(()) => OAuthEndpointInstall::InstalledHere,
+        Err(returned) => {
+            drop(returned);
+            OAuthEndpointInstall::ExistingGlobalRetained
+        }
+    }
+}
+
 pub struct OAuthService {
     config: OAuthConfig,
     /// Global TLS configuration (passed from factory, avoids re-loading config)
@@ -526,6 +613,9 @@ fn runtime_clients(
 
 #[cfg(test)]
 mod required_consumer_tests;
+
+#[cfg(test)]
+mod readiness_tests;
 
 impl Spawnable for OAuthService {
     fn name(&self) -> &str {
@@ -962,32 +1052,82 @@ impl Spawnable for OAuthService {
             let state = Arc::new(oauth_state);
             state.spawn_code_sweeper();
 
-            // Phase 0.5 Stage D — publish OIDF entity statement to DiscoveryService
-            // at startup AND periodically thereafter. Periodic re-publish keeps
-            // the cached statement fresh as signing keys rotate and the embedded
-            // JWKS changes; entity statements carry a 24h exp so any longer gap
-            // leaves federation peers falling through to HTTPS unnecessarily.
-            //
-            // Non-fatal on failure: HTTPS fallback continues to work either way.
-            {
-                let publish_state = state.clone();
-                // Re-publish at 1/4 of the entity-statement exp (24h) so we
-                // refresh the cached statement well before consumers reject it
-                // as expired. Concretely: every 6h. Initial publish happens
-                // immediately on the first iteration of the loop.
-                let republish_interval = std::time::Duration::from_secs(6 * 3600);
-                tokio::task::spawn_local(async move {
-                    let mut tick = tokio::time::interval(republish_interval);
-                    tick.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
-                    loop {
-                        tick.tick().await;
-                        federation_entity::publish_entity_statement_to_discovery(
-                            publish_state.clone(),
-                        )
-                        .await;
-                    }
-                });
+            // Startup transaction (#1585 YuI7): the HTTP(S) listener is
+            // PREBOUND before any readiness signal and before the irreversible
+            // process-global Iroh endpoint install — an occupied port fails
+            // here, while the supervised launcher still owns the launch.
+            let bound = crate::server::tls::bind_listener(addr, rustls_config, "OAuthService")?;
+
+            // Mandatory inbound reach-only carrier: bound + endpoint-install
+            // classified BEFORE any spawned OAuth task can dial and BEFORE any
+            // readiness signal. Bind policy is profile-aware (Required fatal /
+            // Compatibility warn-continue) and separate from install
+            // classification — both install outcomes are valid and the
+            // substrate is retained either way (see the helper docs).
+            let iroh_required = self
+                .quic_config
+                .as_ref()
+                .is_some_and(crate::config::QuicConfig::iroh_required);
+            let iroh_enabled = self
+                .quic_config
+                .as_ref()
+                .is_some_and(|q| q.enabled && q.iroh);
+            // Defense in depth: `validate_native_network_profile` already
+            // rejects this at config validation before factory creation, but
+            // Required must never silently run without its mandatory carrier.
+            if iroh_required && !iroh_enabled {
+                return Err(hyprstream_rpc::error::RpcError::SpawnFailed(
+                    "network-iroh-required OAuth service requires [quic] enabled with iroh"
+                        .to_owned(),
+                ));
             }
+            let mut substrate_owned = if iroh_enabled {
+                build_oauth_substrate_profile(&self.signing_key, iroh_required).await?
+            } else {
+                // Compatibility with Iroh disabled: skip the OAuth substrate
+                // entirely — no bind, no install, no global-slot interaction.
+                None
+            };
+            if let Some(substrate) = &substrate_owned {
+                match classify_oauth_endpoint_install(substrate) {
+                    OAuthEndpointInstall::InstalledHere => {
+                        info!(
+                            "OAuth iroh endpoint installed as the process-global outbound dialer"
+                        );
+                    }
+                    OAuthEndpointInstall::ExistingGlobalRetained => {
+                        // Production Required order: the authenticated OS-owned
+                        // bootstrap installed a DISTINCT outbound carrier
+                        // (PROCESS_BOOTSTRAP_CARRIER) before this service
+                        // started. Both carriers are correct and retained —
+                        // OAuth's substrate owns the inbound reach lifecycle;
+                        // the bootstrap global endpoint stays untouched for
+                        // outbound dials. The deliberately different endpoint
+                        // IDs are never compared.
+                        info!(
+                            "OAuth iroh substrate retained as the independent inbound carrier; \
+                             the already-installed process-global outbound endpoint is untouched"
+                        );
+                    }
+                }
+            }
+
+            // Federation publisher: a DIALING task — spawned only after the
+            // final endpoint decision so its discovery dials use the installed
+            // endpoint. Startup-owned: aborted/joined on every terminal path.
+            let publish_state = state.clone();
+            let publisher_handle = tokio::task::spawn_local(async move {
+                let mut tick =
+                    tokio::time::interval(std::time::Duration::from_secs(6 * 3600));
+                tick.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+                loop {
+                    tick.tick().await;
+                    federation_entity::publish_entity_statement_to_discovery(
+                        publish_state.clone(),
+                    )
+                    .await;
+                }
+            });
 
             // Create router with configurable CORS
             let app = create_app(state.clone(), &self.config.cors);
@@ -996,100 +1136,190 @@ impl Spawnable for OAuthService {
                 "Authorization server metadata at {scheme}://{addr}/.well-known/oauth-authorization-server",
             );
 
-            if let Some(tx) = on_ready {
-                let _ = tx.send(());
-            }
-
-            let _ = hyprstream_rpc::notify::ready();
-
             // User-CRUD RPC serve, alongside the HTTP server. #136: bridged
-            // dispatch over the registered transport (inproc/ipc) instead of the
-            // ZMQ ROUTER. A dedicated `serve_shutdown` stops it once the HTTP
-            // server exits, so the task joins cleanly.
-            let control_transport = self.control_transport.clone();
-            let rpc_signing_key = self.signing_key.clone();
-            let rpc_state = state.clone();
-            // Bind OAuth's domain-separated outbound iroh carrier when enabled.
-            // Its refused inbound ALPNs are not advertised in the DID document.
-            let iroh_enabled = self.quic_config.as_ref().is_some_and(|q| q.enabled && q.iroh);
+            // dispatch over the registered transport (inproc/ipc). The bridge
+            // RUNTIME + handler construction happen on the bridge thread via
+            // `spawn_with`, whose readiness receiver resolves only after that
+            // construction succeeds — `spawn` alone proves only that the
+            // thread started.
+            let nonce_cache = Arc::new(hyprstream_rpc::envelope::InMemoryNonceCache::new());
+            let rpc_state_build = state.clone();
+            let control_transport_build = self.control_transport.clone();
+            let rpc_signing_key_build = self.signing_key.clone();
             let serve_shutdown = Arc::new(Notify::new());
             let serve_shutdown_task = Arc::clone(&serve_shutdown);
-            let rpc_loop = tokio::task::spawn_local(async move {
-                let handler = rpc_handler::OAuthRpcHandler::new(
-                    rpc_state,
-                    control_transport.clone(),
-                    rpc_signing_key.clone(),
-                );
-                let nonce_cache = Arc::new(hyprstream_rpc::envelope::InMemoryNonceCache::new());
-                let bridge = match hyprstream_rpc::transport::iroh_rpc::LocalServiceBridge::spawn(
-                    handler,
-                    nonce_cache,
-                    0,
-                ) {
-                    Ok(b) => b,
-                    Err(e) => {
-                        tracing::error!("OAuth RPC bridge spawn error: {}", e);
-                        return;
-                    }
-                };
-                let processor: Arc<dyn hyprstream_rpc::transport::rpc_session::IrohRequestProcessor> =
-                    Arc::new(bridge);
 
-                // Reach-only iroh endpoint. Both inbound ALPNs refuse before the
-                // OAuth user-CRUD bridge or global MoQ origin can be reached.
-                let _iroh_substrate = if iroh_enabled {
-                    let transport_key = hyprstream_rpc::node_identity::derive_purpose_key(
-                        &rpc_signing_key,
-                        "hyprstream-iroh-transport-v1",
-                    );
-                    match build_oauth_iroh_substrate(transport_key.to_bytes()).await {
-                        Ok(substrate) => {
-                            let _ = hyprstream_rpc::transport::lazy_iroh::install_iroh_client_endpoint(
-                                substrate.owned_client_endpoint(),
-                            );
-                            Some(substrate)
+            // Bridge init phase: thread + runtime + handler construction,
+            // bounded by the readiness receiver. The typed bridge is retained
+            // OUTSIDE the spawned RPC future — the outer owner drives the
+            // bounded shutdown on every terminal path. Init failures are
+            // recorded (not returned) so the single common teardown below
+            // always runs: a bare `?` past the publisher spawn would strand
+            // that task and the bound substrate.
+            let mut bridge_owner: Option<Arc<LocalServiceBridge>> = None;
+            // (join handle, whether the select branch already consumed it).
+            let mut rpc_owner: Option<(tokio::task::JoinHandle<anyhow::Result<()>>, bool)> =
+                None;
+            let bridge_init: Result<Arc<LocalServiceBridge>, hyprstream_rpc::error::RpcError> =
+                async {
+                    let (bridge, bridge_ready_rx) =
+                        match LocalServiceBridge::spawn_with(
+                            "oauth-user-crud",
+                            move || async move {
+                                Ok(rpc_handler::OAuthRpcHandler::new(
+                                    rpc_state_build,
+                                    control_transport_build,
+                                    rpc_signing_key_build,
+                                ))
+                            },
+                            nonce_cache,
+                            0,
+                        ) {
+                            Ok(spawned) => spawned,
+                            Err(e) => {
+                                return Err(hyprstream_rpc::error::RpcError::SpawnFailed(
+                                    format!("OAuth bridge thread spawn failed: {e}"),
+                                ));
+                            }
+                        };
+                    let bridge = Arc::new(bridge);
+                    bridge_owner = Some(bridge.clone());
+                    // Bridge runtime/handler readiness must resolve BEFORE
+                    // serve_bridged (and therefore the external READY signal)
+                    // is allowed to start — this await, not a comment, imposes
+                    // the ordering. Bounded so a stuck bridge cannot hang the
+                    // process.
+                    match tokio::time::timeout(
+                        std::time::Duration::from_secs(30),
+                        bridge_ready_rx,
+                    )
+                    .await
+                    {
+                        Ok(Ok(Ok(()))) => Ok(bridge),
+                        Ok(Ok(Err(closed))) => {
+                            Err(hyprstream_rpc::error::RpcError::SpawnFailed(format!(
+                                "OAuth bridge runtime initialization failed: {closed:#}"
+                            )))
                         }
-                        Err(e) => {
-                            tracing::warn!(
-                                "OAuth iroh substrate bind failed; continuing without iroh: {e}"
-                            );
-                            None
+                        // The bridge task ended without ever sending a
+                        // readiness result — a fatal init failure, not
+                        // readiness.
+                        Ok(Err(_)) => Err(hyprstream_rpc::error::RpcError::SpawnFailed(
+                            "OAuth bridge runtime initialization receiver closed \
+                             without a readiness result"
+                                .to_owned(),
+                        )),
+                        Err(_) => Err(hyprstream_rpc::error::RpcError::SpawnFailed(
+                            "OAuth bridge runtime initialization timed out".to_owned(),
+                        )),
+                    }
+                }
+                .await;
+
+            // Serve phase: register/bind the control transport — serve_bridged's
+            // existing boundary emits the ONLY external readiness signals
+            // (on_ready + kernel READY), now gated on bridge runtime readiness,
+            // substrate bind, and the prebound HTTP(S) listener — then serve
+            // the prebound listener concurrently with the RPC loop. Whichever
+            // side finishes first decides the primary outcome; the actual
+            // serve result propagates (no log-and-swallow).
+            let primary: anyhow::Result<()> = match bridge_init {
+                Err(e) => Err(anyhow::anyhow!("OAuthService startup failed: {e}")),
+                Ok(bridge) => {
+                    let control_transport = self.control_transport.clone();
+                    let rpc_signing_key = self.signing_key.clone();
+                    let processor: Arc<
+                        dyn hyprstream_rpc::transport::rpc_session::IrohRequestProcessor,
+                    > = bridge.clone();
+                    let mut rpc_loop = tokio::task::spawn_local(async move {
+                        hyprstream_rpc::service::serve::serve_bridged(
+                            &control_transport,
+                            processor,
+                            rpc_signing_key,
+                            serve_shutdown_task,
+                            on_ready,
+                        )
+                        .await
+                    });
+                    let mut rpc_consumed = false;
+                    let outcome = tokio::select! {
+                        http = crate::server::tls::serve_bound(
+                            bound,
+                            app,
+                            shutdown.clone(),
+                            "OAuthService",
+                        ) => http.map_err(|e| anyhow::anyhow!("OAuthService HTTP serve error: {e}")),
+                        rpc = &mut rpc_loop => {
+                            // This select branch consumed the completed
+                            // JoinHandle — the teardown below must not poll it
+                            // again (poll-after-completion panics).
+                            rpc_consumed = true;
+                            match rpc {
+                                Ok(Ok(())) => Ok(()),
+                                Ok(Err(e)) => Err(anyhow::anyhow!(
+                                    "OAuthService RPC serve error: {e}"
+                                )),
+                                Err(join) => Err(anyhow::anyhow!(
+                                    "OAuthService RPC task join error: {join}"
+                                )),
+                            }
                         }
-                    }
-                } else {
-                    None
-                };
-
-                if let Err(e) = hyprstream_rpc::service::serve::serve_bridged(
-                    &control_transport,
-                    processor,
-                    rpc_signing_key,
-                    serve_shutdown_task,
-                    None,
-                )
-                .await
-                {
-                    tracing::error!("OAuth RPC serve error: {}", e);
+                    };
+                    rpc_owner = Some((rpc_loop, rpc_consumed));
+                    outcome
                 }
+            };
 
-                // Drain the iroh substrate (accept loop + handlers) on shutdown.
-                if let Some(substrate) = _iroh_substrate {
-                    if let Err(e) = substrate.shutdown().await {
-                        tracing::warn!("OAuth iroh substrate shutdown error: {e}");
-                    }
-                }
-            });
-
-            // Run HTTP(S) server with graceful shutdown
-            let _ = crate::server::tls::serve_app(addr, app, rustls_config, shutdown, "OAuthService").await;
-
-            // HTTP server stopped — stop the RPC serve and join it. notify_one
-            // (not notify_waiters) stores a permit if the serve task hasn't yet
-            // armed its `notified()` await, so the signal can't be missed even if
-            // the HTTP server exited before the RPC task reached serve_bridged.
+            // ── Single common bounded teardown (the one startup owner): runs
+            // on EVERY terminal path past the publisher spawn — bridge spawn /
+            // readiness failure, HTTP or RPC error, or clean shutdown. The
+            // primary error is preserved; cleanup failures are logged as
+            // context, never masked. ──
             serve_shutdown.notify_one();
-            let _ = rpc_loop.await;
+            if let Some(bridge) = &bridge_owner {
+                bridge.begin_shutdown(
+                    tokio::time::Instant::now() + std::time::Duration::from_secs(5),
+                );
+            }
+            if let Some((mut rpc_loop, rpc_consumed)) = rpc_owner.take() {
+                if !rpc_consumed {
+                    match tokio::time::timeout(
+                        std::time::Duration::from_secs(45),
+                        &mut rpc_loop,
+                    )
+                    .await
+                    {
+                        Ok(Ok(Ok(()))) => {}
+                        Ok(Ok(Err(e))) => {
+                            tracing::warn!("OAuth RPC serve task error during shutdown: {e}");
+                        }
+                        Ok(Err(join)) => {
+                            tracing::warn!(
+                                "OAuth RPC serve task join error during shutdown: {join}"
+                            );
+                        }
+                        Err(_) => {
+                            rpc_loop.abort();
+                            tracing::warn!(
+                                "OAuth RPC serve task did not stop within the shutdown budget; aborted"
+                            );
+                        }
+                    }
+                }
+            }
+            publisher_handle.abort();
+            // Abort alone is not teardown: await the cancelled task so its
+            // future (and its state clones) are actually dropped.
+            let _ = publisher_handle.await;
+            if let Some(substrate) = substrate_owned.take() {
+                if let Err(e) = substrate.shutdown().await {
+                    tracing::warn!("OAuth iroh substrate shutdown error: {e}");
+                }
+            }
 
+            primary.map_err(|e| {
+                hyprstream_rpc::error::RpcError::SpawnFailed(format!("{e:#}"))
+            })?;
             Ok(())
         })
     }

--- a/crates/hyprstream/src/services/oauth/mod.rs
+++ b/crates/hyprstream/src/services/oauth/mod.rs
@@ -617,6 +617,25 @@ fn runtime_clients(
     ))
 }
 
+/// Wait until the required native carrier closes or the service receives its
+/// normal shutdown signal. A required-native OAuth process must not continue
+/// serving HTTP after its advertised Iroh endpoint has died; that would leave
+/// discovery pointing at a dead transport while readiness remains green.
+async fn wait_for_required_iroh_carrier(
+    substrate: &hyprstream_rpc::transport::iroh_substrate::IrohSubstrate,
+    shutdown: &Notify,
+) -> bool {
+    loop {
+        if substrate.router().is_shutdown() || substrate.endpoint().is_closed() {
+            return true;
+        }
+        tokio::select! {
+            _ = shutdown.notified() => return false,
+            _ = tokio::time::sleep(std::time::Duration::from_secs(1)) => {}
+        }
+    }
+}
+
 #[cfg(test)]
 mod required_consumer_tests;
 
@@ -1281,6 +1300,25 @@ impl Spawnable for OAuthService {
                                 Err(join) => Err(anyhow::anyhow!(
                                     "OAuthService RPC task join error: {join}"
                                 )),
+                            }
+                        }
+                        carrier_lost = async {
+                            match substrate_owned.as_ref() {
+                                Some(substrate) => {
+                                    wait_for_required_iroh_carrier(substrate, shutdown.as_ref()).await
+                                }
+                                None => std::future::pending::<bool>().await,
+                            }
+                        }, if iroh_required => {
+                            if carrier_lost {
+                                Err(anyhow::anyhow!(
+                                    "OAuth required Iroh carrier terminated unexpectedly"
+                                ))
+                            } else {
+                                // Normal shutdown was consumed by the watcher;
+                                // the common teardown below still owns every
+                                // bridge, publisher, and carrier resource.
+                                Ok(())
                             }
                         }
                     };

--- a/crates/hyprstream/src/services/oauth/mod.rs
+++ b/crates/hyprstream/src/services/oauth/mod.rs
@@ -82,7 +82,7 @@ use hyprstream_rpc::transport::iroh_rpc::LocalServiceBridge;
 use hyprstream_rpc::transport::TransportConfig;
 use hyprstream_service::Spawnable;
 use tokio::sync::Notify;
-use tracing::{info, warn};
+use tracing::info;
 
 use crate::config::{CredentialsBackend, OAuthConfig};
 use crate::services::PolicyClient;
@@ -1236,8 +1236,13 @@ impl Spawnable for OAuthService {
                                 }
                                 substrate_owned = Some(substrate);
                             }
-                            Err(error) if iroh_required => return Err(error),
-                            Err(error) => warn!("OAuth iroh substrate bind failed; continuing quinn-only: {error:#}"),
+                            Err(error) => {
+                                // An enabled OAuth Iroh endpoint is advertised in the DID
+                                // document before the HTTP server becomes reachable. A bind
+                                // failure must therefore abort every profile; continuing would
+                                // publish a node id with no live endpoint behind it.
+                                return Err(error);
+                            }
                         }
                     }
                     let control_transport = self.control_transport.clone();

--- a/crates/hyprstream/src/services/oauth/mod.rs
+++ b/crates/hyprstream/src/services/oauth/mod.rs
@@ -82,7 +82,7 @@ use hyprstream_rpc::transport::iroh_rpc::LocalServiceBridge;
 use hyprstream_rpc::transport::TransportConfig;
 use hyprstream_service::Spawnable;
 use tokio::sync::Notify;
-use tracing::info;
+use tracing::{info, warn};
 
 use crate::config::{CredentialsBackend, OAuthConfig};
 use crate::services::PolicyClient;
@@ -409,6 +409,8 @@ fn self_resource_scopes() -> Vec<String> {
 /// handler is never installed behind `AnySigner`, and anonymous MoQ peers never
 /// receive the process-global origin. The endpoint remains usable as the shared
 /// outbound dialer. Native-only.
+#[cfg(test)]
+#[cfg(test)]
 async fn build_oauth_iroh_substrate(
     transport_secret: [u8; 32],
 ) -> anyhow::Result<hyprstream_rpc::transport::iroh_substrate::IrohSubstrate> {
@@ -428,6 +430,8 @@ async fn build_oauth_iroh_substrate(
 /// production substrate builder. See [`bind_oauth_substrate_profile`] — the
 /// builder is a parameter only so causal tests can inject a bind failure at
 /// this exact production boundary.
+#[cfg(test)]
+#[cfg(test)]
 async fn build_oauth_substrate_profile(
     signing_key: &ed25519_dalek::SigningKey,
     iroh_required: bool,
@@ -453,6 +457,8 @@ async fn build_oauth_substrate_profile(
 /// separate from the install disposition ([`classify_oauth_endpoint_install`])
 /// so "mandatory local bind" cannot regress into "must replace the global
 /// dialer".
+#[cfg(test)]
+#[cfg(test)]
 async fn bind_oauth_substrate_profile<F, Fut>(
     iroh_required: bool,
     build: F,
@@ -1043,12 +1049,22 @@ impl Spawnable for OAuthService {
                         }
                     }
 
-                    // OAuth's iroh inbound ALPNs are deliberately refused until
-                    // fresh application/session proof exists (#1027/#726), so do
-                    // not advertise them as an available DID service.
+                    // The Iroh transport entry is populated before state is
+                    // shared; its RPC plane is bound after bridge readiness.
                 }
             }
 
+            if self
+                .quic_config
+                .as_ref()
+                .is_some_and(|q| q.enabled && q.iroh)
+            {
+                let transport_key = hyprstream_rpc::node_identity::derive_purpose_key(
+                    &self.signing_key,
+                    "hyprstream-iroh-transport-v1",
+                );
+                oauth_state.iroh_node_id = Some(transport_key.verifying_key().to_bytes());
+            }
             let state = Arc::new(oauth_state);
             state.spawn_code_sweeper();
 
@@ -1058,12 +1074,6 @@ impl Spawnable for OAuthService {
             // here, while the supervised launcher still owns the launch.
             let bound = crate::server::tls::bind_listener(addr, rustls_config, "OAuthService")?;
 
-            // Mandatory inbound reach-only carrier: bound + endpoint-install
-            // classified BEFORE any spawned OAuth task can dial and BEFORE any
-            // readiness signal. Bind policy is profile-aware (Required fatal /
-            // Compatibility warn-continue) and separate from install
-            // classification — both install outcomes are valid and the
-            // substrate is retained either way (see the helper docs).
             let iroh_required = self
                 .quic_config
                 .as_ref()
@@ -1072,45 +1082,13 @@ impl Spawnable for OAuthService {
                 .quic_config
                 .as_ref()
                 .is_some_and(|q| q.enabled && q.iroh);
-            // Defense in depth: `validate_native_network_profile` already
-            // rejects this at config validation before factory creation, but
-            // Required must never silently run without its mandatory carrier.
             if iroh_required && !iroh_enabled {
                 return Err(hyprstream_rpc::error::RpcError::SpawnFailed(
                     "network-iroh-required OAuth service requires [quic] enabled with iroh"
                         .to_owned(),
                 ));
             }
-            let mut substrate_owned = if iroh_enabled {
-                build_oauth_substrate_profile(&self.signing_key, iroh_required).await?
-            } else {
-                // Compatibility with Iroh disabled: skip the OAuth substrate
-                // entirely — no bind, no install, no global-slot interaction.
-                None
-            };
-            if let Some(substrate) = &substrate_owned {
-                match classify_oauth_endpoint_install(substrate) {
-                    OAuthEndpointInstall::InstalledHere => {
-                        info!(
-                            "OAuth iroh endpoint installed as the process-global outbound dialer"
-                        );
-                    }
-                    OAuthEndpointInstall::ExistingGlobalRetained => {
-                        // Production Required order: the authenticated OS-owned
-                        // bootstrap installed a DISTINCT outbound carrier
-                        // (PROCESS_BOOTSTRAP_CARRIER) before this service
-                        // started. Both carriers are correct and retained —
-                        // OAuth's substrate owns the inbound reach lifecycle;
-                        // the bootstrap global endpoint stays untouched for
-                        // outbound dials. The deliberately different endpoint
-                        // IDs are never compared.
-                        info!(
-                            "OAuth iroh substrate retained as the independent inbound carrier; \
-                             the already-installed process-global outbound endpoint is untouched"
-                        );
-                    }
-                }
-            }
+            let mut substrate_owned: Option<hyprstream_rpc::transport::iroh_substrate::IrohSubstrate> = None;
 
             // Federation publisher: a DIALING task — spawned only after the
             // final endpoint decision so its discovery dials use the installed
@@ -1225,7 +1203,43 @@ impl Spawnable for OAuthService {
             // serve result propagates (no log-and-swallow).
             let primary: anyhow::Result<()> = match bridge_init {
                 Err(e) => Err(anyhow::anyhow!("OAuthService startup failed: {e}")),
-                Ok(bridge) => {
+                Ok(bridge) => async {
+                    if iroh_enabled {
+                        let transport_key = hyprstream_rpc::node_identity::derive_purpose_key(
+                            &self.signing_key,
+                            "hyprstream-iroh-transport-v1",
+                        );
+                        let processor: Arc<dyn hyprstream_rpc::transport::rpc_session::IrohRequestProcessor> = bridge.clone();
+                        let rpc_handler = hyprstream_rpc::transport::iroh_rpc::IrohRpcProtocolHandler::with_stream_limit(
+                            processor,
+                            self.signing_key.clone(),
+                            hyprstream_rpc::transport::rpc_session::DEFAULT_STREAM_LIMIT,
+                        );
+                        let substrate_result = hyprstream_rpc::transport::iroh_substrate::IrohSubstrate::new(
+                            transport_key.to_bytes(),
+                            hyprstream_rpc::transport::iroh_substrate::RefuseHandler::new(
+                                "OAuth MoQ disabled pending verified session proof (#1027/#726)",
+                            ),
+                            rpc_handler,
+                        )
+                        .await
+                        .map_err(|e| anyhow::anyhow!("OAuth iroh substrate bind failed: {e}"));
+                        match substrate_result {
+                            Ok(substrate) => {
+                                match classify_oauth_endpoint_install(&substrate) {
+                                    OAuthEndpointInstall::InstalledHere => {
+                                        info!("OAuth iroh endpoint installed as the process-global outbound dialer");
+                                    }
+                                    OAuthEndpointInstall::ExistingGlobalRetained => {
+                                        info!("OAuth iroh substrate retained; existing global outbound endpoint is untouched");
+                                    }
+                                }
+                                substrate_owned = Some(substrate);
+                            }
+                            Err(error) if iroh_required => return Err(error),
+                            Err(error) => warn!("OAuth iroh substrate bind failed; continuing quinn-only: {error:#}"),
+                        }
+                    }
                     let control_transport = self.control_transport.clone();
                     let rpc_signing_key = self.signing_key.clone();
                     let processor: Arc<
@@ -1267,7 +1281,7 @@ impl Spawnable for OAuthService {
                     };
                     rpc_owner = Some((rpc_loop, rpc_consumed));
                     outcome
-                }
+                }.await
             };
 
             // ── Single common bounded teardown (the one startup owner): runs

--- a/crates/hyprstream/src/services/oauth/mod.rs
+++ b/crates/hyprstream/src/services/oauth/mod.rs
@@ -617,22 +617,18 @@ fn runtime_clients(
     ))
 }
 
-/// Wait until the required native carrier closes or the service receives its
-/// normal shutdown signal. A required-native OAuth process must not continue
-/// serving HTTP after its advertised Iroh endpoint has died; that would leave
-/// discovery pointing at a dead transport while readiness remains green.
+/// Wait until the required native carrier closes. Normal service shutdown is
+/// handled by the outer `tokio::select!`; keeping this watcher independent of
+/// that signal avoids consuming the single shutdown notification before the
+/// HTTP server observes it.
 async fn wait_for_required_iroh_carrier(
     substrate: &hyprstream_rpc::transport::iroh_substrate::IrohSubstrate,
-    shutdown: &Notify,
 ) -> bool {
     loop {
         if substrate.router().is_shutdown() || substrate.endpoint().is_closed() {
             return true;
         }
-        tokio::select! {
-            _ = shutdown.notified() => return false,
-            _ = tokio::time::sleep(std::time::Duration::from_secs(1)) => {}
-        }
+        tokio::time::sleep(std::time::Duration::from_secs(1)).await;
     }
 }
 
@@ -1302,24 +1298,15 @@ impl Spawnable for OAuthService {
                                 )),
                             }
                         }
-                        carrier_lost = async {
+                        _carrier_lost = async {
                             match substrate_owned.as_ref() {
-                                Some(substrate) => {
-                                    wait_for_required_iroh_carrier(substrate, shutdown.as_ref()).await
-                                }
+                                Some(substrate) => wait_for_required_iroh_carrier(substrate).await,
                                 None => std::future::pending::<bool>().await,
                             }
                         }, if iroh_required => {
-                            if carrier_lost {
-                                Err(anyhow::anyhow!(
-                                    "OAuth required Iroh carrier terminated unexpectedly"
-                                ))
-                            } else {
-                                // Normal shutdown was consumed by the watcher;
-                                // the common teardown below still owns every
-                                // bridge, publisher, and carrier resource.
-                                Ok(())
-                            }
+                            Err(anyhow::anyhow!(
+                                "OAuth required Iroh carrier terminated unexpectedly"
+                            ))
                         }
                     };
                     rpc_owner = Some((rpc_loop, rpc_consumed));
@@ -4370,14 +4357,12 @@ mod tests {
             NoopHandler::new("oauth watcher rpc"),
         )
         .await?;
-        let shutdown = Notify::new();
-
         // Endpoint::close is the same observable carrier failure that the
         // watcher must convert into a terminal service outcome.
         server.endpoint().close().await;
         let lost = tokio::time::timeout(
             std::time::Duration::from_secs(2),
-            wait_for_required_iroh_carrier(&server, &shutdown),
+            wait_for_required_iroh_carrier(&server),
         )
         .await?;
         assert!(lost, "closed required carrier must be reported as lost");

--- a/crates/hyprstream/src/services/oauth/mod.rs
+++ b/crates/hyprstream/src/services/oauth/mod.rs
@@ -4359,6 +4359,32 @@ mod tests {
         );
     }
 
+    #[tokio::test]
+    async fn required_iroh_carrier_watcher_detects_endpoint_close() -> anyhow::Result<()> {
+        use hyprstream_rpc::transport::iroh_substrate::{IrohSubstrate, NoopHandler};
+
+        let signing_key = hyprstream_rpc::prelude::SigningKey::generate(&mut rand::rngs::OsRng);
+        let server = IrohSubstrate::new(
+            signing_key.to_bytes(),
+            NoopHandler::new("oauth watcher moq"),
+            NoopHandler::new("oauth watcher rpc"),
+        )
+        .await?;
+        let shutdown = Notify::new();
+
+        // Endpoint::close is the same observable carrier failure that the
+        // watcher must convert into a terminal service outcome.
+        server.endpoint().close().await;
+        let lost = tokio::time::timeout(
+            std::time::Duration::from_secs(2),
+            wait_for_required_iroh_carrier(&server, &shutdown),
+        )
+        .await?;
+        assert!(lost, "closed required carrier must be reported as lost");
+        server.shutdown().await?;
+        Ok(())
+    }
+
     #[test]
     fn test_validate_redirect_uri_exact_match() {
         let registered = vec!["http://127.0.0.1:3000/callback".to_owned()];

--- a/crates/hyprstream/src/services/oauth/readiness_tests.rs
+++ b/crates/hyprstream/src/services/oauth/readiness_tests.rs
@@ -1,0 +1,916 @@
+//! Causal readiness tests for the OAuth startup transaction (#1585 YuI7).
+//!
+//! Every run()-level case drives the real production startup seam — the same
+//! `Spawnable::run` the foreground launcher calls — against real sockets.
+//! Process-global state (credentials/config env, the install-once iroh client
+//! endpoint) is only touched inside isolated child processes (the same
+//! re-exec pattern as [`super::required_consumer_tests`]); the parent-side
+//! cases touch no process globals.
+//!
+//! Scope against the Sol carrier disposition (pr1585-oauth-bootstrap-
+//! carrier-disposition-sol): the helper-level carrier cases — real
+//! bootstrap-first install classification (`ExistingGlobalRetained`),
+//! endpoint-ID distinctness, retain-and-independent-ownership with real
+//! outbound RPC, and the empty-slot `InstalledHere` control — live in
+//! [`super::required_consumer_tests`] and
+//! [`oauth_endpoint_install_wins_empty_slot`]. Those helpers are the exact
+//! seam `run` calls, but helper coverage does not itself drive
+//! `OAuthService::run` through READY; that run()-level Required positive
+//! control is [`run_required_bootstrap_first_ready_then_http`]. The plain
+//! positive HTTP transaction ([`run_ready_then_real_http_and_bounded_shutdown`])
+//! is Compatibility-profile by construction.
+#![allow(clippy::expect_used, clippy::unwrap_used)]
+
+use super::*;
+use ed25519_dalek::SigningKey;
+use hyprstream_rpc::node_identity::derive_mesh_mldsa_key;
+use std::io::{Read, Write};
+use std::net::SocketAddr;
+use std::time::Duration;
+
+/// Reserve an ephemeral loopback port for a later real bind. There is an
+/// inherent TOCTOU window between the probe and the service bind; that is
+/// accepted (and bounded) by keeping the reserve short-lived.
+fn reserve_ephemeral_port() -> SocketAddr {
+    let l = std::net::TcpListener::bind("127.0.0.1:0").expect("reserve ephemeral port");
+    l.local_addr().expect("local addr")
+}
+
+/// Hold a loopback port so a service bind on it fails with a real collision.
+/// The binding lives until the end of the calling scope.
+fn occupy_port(addr: SocketAddr) -> std::net::TcpListener {
+    std::net::TcpListener::bind(addr).expect("occupy port")
+}
+
+/// Insert the policy/discovery verifying keys `run()` requires from the
+/// global trust store, as the launcher's depends_on population would.
+fn seed_trust_store() {
+    use hyprstream_service::Attestation;
+    let store = hyprstream_service::global_trust_store();
+    for (name, key) in [
+        ("policy", SigningKey::from_bytes(&[0xB1; 32])),
+        ("discovery", SigningKey::from_bytes(&[0xB2; 32])),
+    ] {
+        store.insert(
+            key.verifying_key(),
+            Attestation {
+                scopes: [name.to_owned()].into_iter().collect(),
+                subject: None,
+                jwt: None,
+                expires_at: 0,
+                attested_by: None,
+            },
+        );
+    }
+}
+
+/// Build an OAuthService at `addr` exactly as the production factory does,
+/// with TLS OFF (plain-HTTP arm) and an IPC control transport.
+fn http_service_at(
+    oauth: &SigningKey,
+    addr: SocketAddr,
+    control: TransportConfig,
+) -> OAuthService {
+    let mut tls = crate::config::TlsConfig::default();
+    tls.enabled = false;
+    service_at(oauth, addr, control, tls)
+}
+
+fn service_at(
+    oauth: &SigningKey,
+    addr: SocketAddr,
+    control: TransportConfig,
+    tls: crate::config::TlsConfig,
+) -> OAuthService {
+    let mut oauth_config = crate::config::OAuthConfig::default();
+    oauth_config.host = addr.ip().to_string();
+    oauth_config.port = addr.port();
+    let peer = TransportConfig::ipc("/tmp/oauth-readiness-unused-peer.sock");
+    OAuthService::new(
+        oauth_config,
+        tls,
+        crate::account::AccountZoneConfig::default(),
+        oauth.clone(),
+        control,
+        peer.clone(),
+        peer,
+        oauth.verifying_key(),
+        oauth.verifying_key(),
+    )
+}
+
+/// Test-only `Spawnable` wrapper: delegates name/registrations/run to the
+/// real OAuthService and signals `done_tx` only AFTER the inner `run` has
+/// returned and dropped its state, so a bounded wait on the receiver proves
+/// the actual service-thread teardown completed before the child's tempdir
+/// is dropped.
+struct RunCompletionService {
+    inner: OAuthService,
+    done_tx: Option<tokio::sync::oneshot::Sender<()>>,
+}
+
+impl hyprstream_service::Spawnable for RunCompletionService {
+    fn name(&self) -> &str {
+        self.inner.name()
+    }
+
+    fn registrations(&self) -> Vec<(SocketKind, TransportConfig)> {
+        self.inner.registrations()
+    }
+
+    fn run(
+        mut self: Box<Self>,
+        shutdown: Arc<Notify>,
+        on_ready: Option<tokio::sync::oneshot::Sender<()>>,
+    ) -> Result<(), hyprstream_rpc::error::RpcError> {
+        let done_tx = self.done_tx.take();
+        let result = Box::new(self.inner).run(shutdown, on_ready);
+        if let Some(done_tx) = done_tx {
+            let _ = done_tx.send(());
+        }
+        result
+    }
+}
+
+/// Isolated-child preamble: fresh credentials/XDG/config env so the service's
+/// startup filesystem surface (RocksDB token store, key stores, config load)
+/// lands inside this test's tempdir and cannot race sibling tests. Each child
+/// process runs exactly one `--exact` case.
+struct ChildEnv {
+    dir: tempfile::TempDir,
+    /// Unix-socket paths are capped at `sun_len` (108 bytes); a control
+    /// socket under the deep worktree tempdir exceeds that, so sockets live
+    /// in a short-lived dir directly under the system temp root.
+    sock_dir: tempfile::TempDir,
+}
+
+impl ChildEnv {
+    fn new(tag: &str) -> Self {
+        let dir = tempfile::Builder::new()
+            .prefix(format!(".oauth-readiness-{tag}-").as_str())
+            .tempdir_in(env!("CARGO_MANIFEST_DIR"))
+            .expect("child tempdir");
+        let sock_dir = tempfile::Builder::new()
+            .prefix(format!(".oar-{tag}-").as_str())
+            .tempdir_in(std::env::temp_dir())
+            .expect("short child socket dir");
+        let credentials = dir.path().join("credentials");
+        std::fs::create_dir_all(&credentials).expect("credentials dir");
+        std::env::set_var("CREDENTIALS_DIRECTORY", &credentials);
+        std::env::set_var("HYPRSTREAM__SECRETS__PATH", &credentials);
+        // The mandatory encrypted production profile requires the pglite
+        // UserStore backend with real deployment age key material (the same
+        // external-`age` seam production uses; both binaries are on PATH on
+        // the Linux lanes this suite targets).
+        std::env::set_var("HYPRSTREAM__CREDENTIALS__BACKEND", "pglite");
+        let key_path = dir.path().join("userstore-age-identity.txt");
+        let keygen = std::process::Command::new("age-keygen")
+            .arg("-o")
+            .arg(&key_path)
+            .output()
+            .expect("run age-keygen for the child UserStore keypair");
+        assert!(
+            keygen.status.success(),
+            "age-keygen failed: {keygen:?}"
+        );
+        let stderr = String::from_utf8(keygen.stderr).expect("age-keygen stderr");
+        let key_file =
+            std::fs::read_to_string(&key_path).expect("read age-keygen identity file");
+        let recipient = stderr
+            .lines()
+            .chain(key_file.lines())
+            .find_map(|l| {
+                l.strip_prefix("Public key: ")
+                    .or_else(|| l.strip_prefix("# public key: "))
+            })
+            .expect("age-keygen must report the public key recipient")
+            .to_owned();
+        std::env::set_var("HYPRSTREAM_USERSTORE_AGE_RECIPIENTS", recipient);
+        std::env::set_var("HYPRSTREAM_USERSTORE_AGE_IDENTITIES", &key_path);
+        std::env::set_var("XDG_CONFIG_HOME", dir.path().join("xdg-config"));
+        std::env::set_var("XDG_DATA_HOME", dir.path().join("xdg-data"));
+        std::env::set_var("HYPRSTREAM_INSTANCE", format!("oauth-readiness-{tag}"));
+        // Per-child pglite runtime cache: keeps every child's extracted
+        // native runtime inside its own tempdir so no child depends on (or
+        // observes) state left by another process.
+        std::env::set_var("PGLITE_RUNTIME_DIR", dir.path().join("pglite-runtime"));
+        Self { dir, sock_dir }
+    }
+
+    fn ipc_control(&self) -> TransportConfig {
+        TransportConfig::ipc(self.sock_dir.path().join("control.sock"))
+    }
+}
+
+/// Re-exec this test binary so `case` runs in its own process. Process
+/// globals — the install-once iroh client endpoint OnceLock, the global trust
+/// store, and the config env — are never reset cross-test.
+fn run_isolated(case: &str, guard: &str) -> anyhow::Result<()> {
+    if std::env::var_os(guard).is_some() {
+        return Ok(());
+    }
+    // The pglite-patched standalone backend registers fd1 (stdout) as its
+    // client socket with epoll while the UserStore opens
+    // (pgl_startPGlite → pq_init): a regular file or /dev/null on stdout
+    // makes epoll_ctl fail and the native boot raise a top-level ereport
+    // that escapes as process exit(100) (no longjmp trampoline outside the
+    // engine pump loop). The child therefore always gets PIPE stdio, which
+    // is also what the foreground launcher and systemd (journald sockets)
+    // give real services. Output is drained by the parent and surfaced only
+    // on failure.
+    let output = std::process::Command::new(std::env::current_exe()?)
+        .args(["--exact", case, "--nocapture"])
+        .env(guard, "1")
+        .stdin(std::process::Stdio::null())
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::piped())
+        .output()?;
+    anyhow::ensure!(
+        output.status.success(),
+        "isolated child {case} failed: {}\n--- child stderr (tail) ---\n{}",
+        output.status,
+        String::from_utf8_lossy(&output.stderr[output.stderr.len().saturating_sub(4096)..])
+    );
+    Ok(())
+}
+
+// ── Parent-side cases: no process-global state is touched. ──
+
+/// The bridge runtime readiness barrier run() relies on is real: a build
+/// failure resolves the receiver with Err, and the supervisor's READY
+/// counterpart was never consumed.
+///
+/// (OAuth's own production builder — `OAuthRpcHandler::new` — is infallible,
+/// so a run()-level bridge-build failure has no injectable seam; this proves
+/// the barrier property at the exact API the transaction gates on.)
+#[test]
+fn bridge_spawn_with_readiness_failure_gates_ready() -> anyhow::Result<()> {
+    let (ready_tx, ready_rx) = tokio::sync::oneshot::channel::<()>();
+    let (bridge, mut ready) = hyprstream_rpc::transport::iroh_rpc::LocalServiceBridge::spawn_with(
+        "readiness-fail-echo",
+        || async {
+            Err::<rpc_handler::OAuthRpcHandler, _>(anyhow::anyhow!(
+                "injected bridge build failure"
+            ))
+        },
+        Arc::new(hyprstream_rpc::envelope::InMemoryNonceCache::new()),
+        0,
+    )?;
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()?;
+    rt.block_on(async move {
+        // The production ordering awaits THIS receiver before serve_bridged;
+        // a build failure must resolve here as Err — before any READY.
+        match tokio::time::timeout(Duration::from_secs(30), &mut ready).await {
+            Ok(Ok(Err(build_err))) => {
+                assert!(
+                    build_err.to_string().contains("injected bridge build failure"),
+                    "builder error must be preserved: {build_err}"
+                );
+            }
+            Ok(Ok(Ok(()))) => panic!("failing builder must not report readiness"),
+            Ok(Err(_)) => panic!("readiness receiver closed without a result"),
+            Err(_) => panic!("readiness receiver never resolved"),
+        }
+    });
+    let _ = bridge.begin_shutdown(tokio::time::Instant::now() + Duration::from_secs(5));
+    drop(bridge);
+    assert!(
+        ready_tx.send(()).is_ok(),
+        "on_ready counterpart must still be armed — the barrier consumed nothing"
+    );
+    drop(ready_rx);
+    Ok(())
+}
+
+/// The profile-aware bind helper maps an injected bind failure at the real
+/// production boundary: fatal for Required, warn-and-continue for
+/// Compatibility. (This is the narrow substrate-builder seam — the failure is
+/// injected into the builder run() itself calls, never simulated via the
+/// install OnceLock.)
+#[test]
+fn substrate_bind_failure_profile_mapping() -> anyhow::Result<()> {
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()?;
+    rt.block_on(async {
+        let required = bind_oauth_substrate_profile(true, || async {
+            Err(anyhow::anyhow!("injected substrate bind failure"))
+        })
+        .await;
+        let err = match required {
+            Ok(_) => panic!("Required bind failure must be fatal"),
+            Err(e) => e,
+        };
+        assert!(
+            err.to_string()
+                .contains("network-iroh-required OAuth iroh substrate bind failed"),
+            "fatal Required mapping lost: {err}"
+        );
+        let compat = bind_oauth_substrate_profile(false, || async {
+            Err(anyhow::anyhow!("injected substrate bind failure"))
+        })
+        .await
+        .expect("Compatibility bind failure warns and continues");
+        assert!(compat.is_none(), "degraded Compatibility has no substrate owner");
+    });
+    Ok(())
+}
+
+// ── Child-isolated cases: real run() startup seams. ──
+
+/// Occupied plain-HTTP listener: run() fails at the real bind, before READY,
+/// leaving no control socket (the serve phase never started) and a released
+/// listener (RAII prebound handle closed on the failure path).
+#[test]
+fn run_occupied_http_listener_fails_before_ready() -> anyhow::Result<()> {
+    const CASE: &str = "services::oauth::readiness_tests::run_occupied_http_listener_fails_before_ready";
+    run_isolated(CASE, "HYPRSTREAM_OAUTH_READINESS_OCCUPIED_HTTP")?;
+    if std::env::var_os("HYPRSTREAM_OAUTH_READINESS_OCCUPIED_HTTP").is_none() {
+        return Ok(());
+    }
+    let env = ChildEnv::new("occupied-http");
+    let oauth = SigningKey::from_bytes(&[0xA1; 32]);
+    seed_trust_store();
+    let addr = reserve_ephemeral_port();
+    let _holder = occupy_port(addr);
+    let control_path = env.sock_dir.path().join("control.sock");
+    let service = http_service_at(&oauth, addr, env.ipc_control());
+    let (ready_tx, mut ready_rx) = tokio::sync::oneshot::channel::<()>();
+    let shutdown = Arc::new(tokio::sync::Notify::new());
+    let handle = std::thread::spawn(move || Box::new(service).run(shutdown, Some(ready_tx)));
+    let err = handle
+        .join()
+        .expect("run thread must not panic")
+        .expect_err("occupied listener must fail startup");
+    assert!(
+        err.to_string().contains("bind failed"),
+        "failure must come from the real listener bind: {err}"
+    );
+    assert!(
+        ready_rx.try_recv().is_err(),
+        "READY must never be signalled for a failed bind"
+    );
+    assert!(
+        !control_path.exists(),
+        "control transport must never be bound after a failed HTTP bind"
+    );
+    // The prebound listener is RAII: with the collision holder gone, the
+    // port must be rebindable — run()'s failed bind released its handle.
+    drop(_holder);
+    drop(std::net::TcpListener::bind(addr).expect("port must be released after failed startup"));
+    Ok(())
+}
+
+/// Occupied HTTPS listener: the same real collision through the prebound-TLS
+/// branch (real RustlsConfig from a generated self-signed cert), no READY,
+/// no second bind attempt.
+#[test]
+fn run_occupied_https_listener_fails_before_ready() -> anyhow::Result<()> {
+    const CASE: &str = "services::oauth::readiness_tests::run_occupied_https_listener_fails_before_ready";
+    run_isolated(CASE, "HYPRSTREAM_OAUTH_READINESS_OCCUPIED_HTTPS")?;
+    if std::env::var_os("HYPRSTREAM_OAUTH_READINESS_OCCUPIED_HTTPS").is_none() {
+        return Ok(());
+    }
+    let env = ChildEnv::new("occupied-https");
+    let oauth = SigningKey::from_bytes(&[0xA2; 32]);
+    seed_trust_store();
+    let generated = rcgen::generate_simple_self_signed(vec!["localhost".to_owned()])?;
+    let cert_path = env.dir.path().join("cert.pem");
+    let key_path = env.dir.path().join("key.pem");
+    std::fs::write(&cert_path, generated.cert.pem())?;
+    std::fs::write(&key_path, generated.key_pair.serialize_pem())?;
+    let mut tls = crate::config::TlsConfig::default();
+    tls.enabled = true;
+    let addr = reserve_ephemeral_port();
+    let _holder = occupy_port(addr);
+    let control_path = env.sock_dir.path().join("control.sock");
+    let mut oauth_config = crate::config::OAuthConfig::default();
+    oauth_config.host = addr.ip().to_string();
+    oauth_config.port = addr.port();
+    oauth_config.tls_cert = Some(cert_path);
+    oauth_config.tls_key = Some(key_path);
+    let peer = TransportConfig::ipc(env.dir.path().join("peer.sock"));
+    let service = OAuthService::new(
+        oauth_config,
+        tls,
+        crate::account::AccountZoneConfig::default(),
+        oauth.clone(),
+        env.ipc_control(),
+        peer.clone(),
+        peer,
+        oauth.verifying_key(),
+        oauth.verifying_key(),
+    );
+    let (ready_tx, mut ready_rx) = tokio::sync::oneshot::channel::<()>();
+    let shutdown = Arc::new(tokio::sync::Notify::new());
+    let handle = std::thread::spawn(move || Box::new(service).run(shutdown, Some(ready_tx)));
+    let err = handle
+        .join()
+        .expect("run thread must not panic")
+        .expect_err("occupied HTTPS listener must fail startup");
+    assert!(
+        err.to_string().contains("bind failed"),
+        "failure must come from the real TLS listener bind: {err}"
+    );
+    assert!(
+        ready_rx.try_recv().is_err(),
+        "READY must never be signalled for a failed TLS bind"
+    );
+    assert!(!control_path.exists());
+    Ok(())
+}
+
+/// Positive transaction: READY fires only after the listener is bound (a real
+/// HTTP request then succeeds through the actual handler) and after the
+/// control transport is bound (the IPC socket exists at READY time); the
+/// shutdown signal produces a bounded, clean completion.
+#[test]
+fn run_ready_then_real_http_and_bounded_shutdown() -> anyhow::Result<()> {
+    const CASE: &str =
+        "services::oauth::readiness_tests::run_ready_then_real_http_and_bounded_shutdown";
+    run_isolated(CASE, "HYPRSTREAM_OAUTH_READINESS_POSITIVE")?;
+    if std::env::var_os("HYPRSTREAM_OAUTH_READINESS_POSITIVE").is_none() {
+        return Ok(());
+    }
+    let env = ChildEnv::new("positive");
+    let oauth = SigningKey::from_bytes(&[0xA3; 32]);
+    seed_trust_store();
+    let addr = reserve_ephemeral_port();
+    let control_path = env.sock_dir.path().join("control.sock");
+    let service = http_service_at(&oauth, addr, env.ipc_control());
+    let (ready_tx, ready_rx) = tokio::sync::oneshot::channel::<()>();
+    let shutdown = Arc::new(tokio::sync::Notify::new());
+    let shutdown_signal = Arc::clone(&shutdown);
+    let handle = std::thread::spawn(move || Box::new(service).run(shutdown, Some(ready_tx)));
+
+    // Wait for the EXTERNAL readiness signal, then prove the exact claim: at
+    // signal time the listener was bound and the control transport registered.
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()?;
+    let ready_outcome = rt.block_on(async {
+        tokio::time::timeout(Duration::from_secs(60), ready_rx).await
+    });
+    let ready_fired = match ready_outcome {
+        Ok(Ok(())) => true,
+        // CLOSED READY: the run thread ended without ever signalling. Join it
+        // and surface the ORIGINAL run error before unwinding ChildEnv — the
+        // later native-teardown noise must not mask the primary failure.
+        Ok(Err(_)) | Err(_) => {
+            let (tx, rx) = std::sync::mpsc::channel();
+            std::thread::spawn(move || {
+                let _ = tx.send(handle.join());
+            });
+            let joined = rx
+                .recv_timeout(Duration::from_secs(90))
+                .expect("run() must terminate within the shutdown budget");
+            let run_result = joined.expect("run thread must not panic");
+            panic!(
+                "on_ready never fired; the actual run() result was: {run_result:?}"
+            );
+        }
+    };
+    assert!(ready_fired, "on_ready must fire on the success path");
+    assert!(control_path.exists(), "control UDS must be bound before READY");
+
+    // Real HTTP request — proves the handler loop executes, not merely that
+    // the backlog accepts.
+    let mut stream = std::net::TcpStream::connect(addr)?;
+    stream.set_read_timeout(Some(Duration::from_secs(30)))?;
+    write!(
+        stream,
+        "GET /.well-known/oauth-authorization-server HTTP/1.1\r\nHost: {addr}\r\nConnection: close\r\n\r\n"
+    )?;
+    let mut response = String::new();
+    stream.read_to_string(&mut response)?;
+    assert!(
+        response.starts_with("HTTP/1.1 200"),
+        "metadata endpoint must really serve: got {response:?}"
+    );
+    assert!(
+        response.contains("issuer"),
+        "authorization-server metadata body must be present"
+    );
+
+    // Bounded shutdown: notifying the serve path ends the whole transaction —
+    // this join completing at all is the bounded-teardown claim.
+    shutdown_signal.notify_one();
+    let (tx, rx) = std::sync::mpsc::channel();
+    std::thread::spawn(move || {
+        let _ = tx.send(handle.join());
+    });
+    let joined = rx
+        .recv_timeout(Duration::from_secs(90))
+        .expect("run() must terminate within the shutdown budget");
+    let run_result = joined.expect("run thread must not panic");
+    run_result.expect("clean shutdown must complete the transaction with Ok");
+    Ok(())
+}
+
+/// Compatibility with Iroh DISABLED: run() reaches READY over real HTTP and
+/// never touches the global endpoint — proven by classifying a freshly bound
+/// substrate as `InstalledHere` afterwards (the slot would read occupied if
+/// run() had bound or installed anything).
+#[test]
+fn run_compatibility_disabled_iroh_skips_substrate() -> anyhow::Result<()> {
+    const CASE: &str =
+        "services::oauth::readiness_tests::run_compatibility_disabled_iroh_skips_substrate";
+    run_isolated(CASE, "HYPRSTREAM_OAUTH_READINESS_COMPAT_DISABLED")?;
+    if std::env::var_os("HYPRSTREAM_OAUTH_READINESS_COMPAT_DISABLED").is_none() {
+        return Ok(());
+    }
+    let env = ChildEnv::new("compat-disabled");
+    let oauth = SigningKey::from_bytes(&[0xA9; 32]);
+    seed_trust_store();
+    let addr = reserve_ephemeral_port();
+    let service = http_service_at(&oauth, addr, env.ipc_control());
+    let (ready_tx, ready_rx) = tokio::sync::oneshot::channel::<()>();
+    let shutdown = Arc::new(tokio::sync::Notify::new());
+    let shutdown_signal = Arc::clone(&shutdown);
+    let handle = std::thread::spawn(move || Box::new(service).run(shutdown, Some(ready_tx)));
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()?;
+    rt.block_on(async {
+        tokio::time::timeout(Duration::from_secs(90), ready_rx)
+            .await
+            .expect("READY must arrive within the test budget")
+            .expect("on_ready must fire with Iroh disabled");
+    });
+    // The global slot is EMPTY: run() neither bound nor installed anything.
+    let (probe_tx, probe_rx) = tokio::sync::oneshot::channel();
+    rt.spawn(async move {
+        let probe = build_oauth_substrate_profile(&oauth, false)
+            .await?
+            .expect("fresh substrate binds");
+        let disposition = classify_oauth_endpoint_install(&probe);
+        probe.shutdown().await?;
+        probe_tx.send(disposition).ok();
+        anyhow::Ok(())
+    });
+    let disposition = rt
+        .block_on(async { tokio::time::timeout(Duration::from_secs(90), probe_rx).await })
+        .expect("probe must finish within the budget")
+        .expect("probe task must not fail");
+    assert!(
+        matches!(disposition, OAuthEndpointInstall::InstalledHere),
+        "disabled-Compatibility run() must not have installed a global endpoint"
+    );
+    // Real HTTP still serving, then bounded shutdown.
+    let mut stream = std::net::TcpStream::connect(addr)?;
+    stream.set_read_timeout(Some(Duration::from_secs(30)))?;
+    write!(
+        stream,
+        "GET /.well-known/oauth-authorization-server HTTP/1.1\r\nHost: {addr}\r\nConnection: close\r\n\r\n"
+    )?;
+    let mut response = String::new();
+    stream.read_to_string(&mut response)?;
+    assert!(
+        response.starts_with("HTTP/1.1 200"),
+        "metadata endpoint must really serve: got {response:?}"
+    );
+    shutdown_signal.notify_one();
+    let (tx, rx) = std::sync::mpsc::channel();
+    std::thread::spawn(move || {
+        let _ = tx.send(handle.join());
+    });
+    let joined = rx
+        .recv_timeout(Duration::from_secs(90))
+        .expect("run() must terminate within the shutdown budget");
+    joined
+        .expect("run thread must not panic")
+        .expect("clean shutdown must complete the transaction with Ok");
+    Ok(())
+}
+
+/// Required profile with Iroh disabled is fatal before READY — defense in
+/// depth behind `validate_native_network_profile`.
+#[test]
+fn run_required_profile_disabled_iroh_fails_before_ready() -> anyhow::Result<()> {
+    const CASE: &str = "services::oauth::readiness_tests::run_required_profile_disabled_iroh_fails_before_ready";
+    run_isolated(CASE, "HYPRSTREAM_OAUTH_READINESS_REQUIRED_DISABLED")?;
+    if std::env::var_os("HYPRSTREAM_OAUTH_READINESS_REQUIRED_DISABLED").is_none() {
+        return Ok(());
+    }
+    let env = ChildEnv::new("required-disabled");
+    let oauth = SigningKey::from_bytes(&[0xA4; 32]);
+    seed_trust_store();
+let addr = reserve_ephemeral_port();
+    let control_path = env.sock_dir.path().join("control.sock");
+    let mut quic = crate::config::QuicConfig::default();
+    quic.native_network_profile = crate::config::NativeNetworkProfile::NetworkIrohRequired;
+    quic.enabled = false;
+    quic.iroh = true;
+    let service = http_service_at(&oauth, addr, env.ipc_control())
+        .with_quic_config(quic);
+    let (ready_tx, mut ready_rx) = tokio::sync::oneshot::channel::<()>();
+    let shutdown = Arc::new(tokio::sync::Notify::new());
+    let handle = std::thread::spawn(move || Box::new(service).run(shutdown, Some(ready_tx)));
+    let err = handle
+        .join()
+        .expect("run thread must not panic")
+        .expect_err("Required with disabled Iroh must fail startup");
+    assert!(
+        err.to_string()
+            .contains("network-iroh-required OAuth service requires [quic] enabled"),
+        "failure must come from the Required carrier guard: {err}"
+    );
+    assert!(ready_rx.try_recv().is_err(), "no READY on fatal startup");
+    assert!(!control_path.exists());
+    Ok(())
+}
+
+/// The real spawner chain the foreground launcher uses maps a pre-READY
+/// startup failure to the spawn error (`service thread exited before ready`)
+/// that `bin/main.rs` propagates via `?` to a nonzero child exit.
+#[test]
+fn manager_spawn_pre_ready_failure_maps_to_spawn_error() -> anyhow::Result<()> {
+    const CASE: &str =
+        "services::oauth::readiness_tests::manager_spawn_pre_ready_failure_maps_to_spawn_error";
+    run_isolated(CASE, "HYPRSTREAM_OAUTH_READINESS_MANAGER_CHAIN")?;
+    if std::env::var_os("HYPRSTREAM_OAUTH_READINESS_MANAGER_CHAIN").is_none() {
+        return Ok(());
+    }
+    let env = ChildEnv::new("manager-chain");
+    let oauth = SigningKey::from_bytes(&[0xA5; 32]);
+    seed_trust_store();
+    let addr = reserve_ephemeral_port();
+    let _holder = occupy_port(addr);
+    // Completion wrapper: done_rx fires only AFTER the inner OAuthService
+    // run() returned and dropped its state on the manager's service thread.
+    let (done_tx, done_rx) = tokio::sync::oneshot::channel::<()>();
+    let service = RunCompletionService {
+        inner: http_service_at(&oauth, addr, env.ipc_control()),
+        done_tx: Some(done_tx),
+    };
+    let manager = hyprstream_service::InprocManager::new();
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()?;
+    let spawned = rt.block_on(hyprstream_service::ServiceManager::spawn(
+        &manager,
+        Box::new(service),
+    ));
+    let err = match spawned {
+        Ok(_) => panic!("pre-READY failure must reject manager.spawn"),
+        Err(e) => e,
+    };
+    assert!(
+        err.to_string().contains("service thread exited before ready"),
+        "failure must traverse the real ready-channel chain: {err}"
+    );
+    // Bounded wait for the REAL teardown: the manager rejects the spawn, but
+    // its service thread still runs the inner run() to completion; done_rx
+    // resolves only once that happened and the state dropped.
+    let rt_wait = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()?;
+    rt_wait
+        .block_on(async {
+            tokio::time::timeout(Duration::from_secs(90), done_rx).await
+        })
+        .expect("service teardown must finish within the budget")
+        .expect("completion sender must outlive the inner run");
+    Ok(())
+}
+
+/// Compatibility child with Iroh ENABLED and an EMPTY install-once slot:
+/// OAuth's substrate wins the process-global outbound slot (`InstalledHere`);
+/// a second, differently-derived substrate then observes the slot as occupied
+/// (`ExistingGlobalRetained`) — the observable side effect of the first
+/// install, without reaching into the rpc crate's private accessor.
+#[test]
+fn oauth_endpoint_install_wins_empty_slot() -> anyhow::Result<()> {
+    const CASE: &str = "services::oauth::readiness_tests::oauth_endpoint_install_wins_empty_slot";
+    run_isolated(CASE, "HYPRSTREAM_OAUTH_READINESS_WINS_EMPTY_SLOT")?;
+    if std::env::var_os("HYPRSTREAM_OAUTH_READINESS_WINS_EMPTY_SLOT").is_none() {
+        return Ok(());
+    }
+    let _env = ChildEnv::new("wins-empty-slot");
+    let oauth = SigningKey::from_bytes(&[0xA6; 32]);
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()?;
+    rt.block_on(async {
+        let winner = build_oauth_substrate_profile(&oauth, false)
+            .await?
+            .expect("successful Compatibility bind retains the substrate");
+        assert!(
+            matches!(
+                classify_oauth_endpoint_install(&winner),
+                OAuthEndpointInstall::InstalledHere
+            ),
+            "an empty slot must classify InstalledHere"
+        );
+        // A differently-derived substrate now finds the slot occupied: the
+        // first install really did fill the process-global outbound slot.
+        let other_key = SigningKey::from_bytes(&[0xA7; 32]);
+        let loser = build_oauth_substrate_profile(&other_key, false)
+            .await?
+            .expect("second successful Compatibility bind retains its substrate");
+        assert!(
+            matches!(
+                classify_oauth_endpoint_install(&loser),
+                OAuthEndpointInstall::ExistingGlobalRetained
+            ),
+            "an occupied slot must classify ExistingGlobalRetained, never error"
+        );
+        assert_ne!(
+            winner.endpoint_id(),
+            loser.endpoint_id(),
+            "distinct transport purpose keys yield deliberately distinct endpoints"
+        );
+        loser.shutdown().await?;
+        winner.shutdown().await?;
+        anyhow::Ok(())
+    })?;
+    Ok(())
+}
+
+/// Required positive control through the REAL bootstrap-first startup: the
+/// authenticated OS-owned bootstrap runs first (installing the process-global
+/// outbound carrier, Sol carrier case 1's precondition), then
+/// `OAuthService::run` — under `network-iroh-required` with Iroh enabled —
+/// reaches READY, serves a real HTTP request, and shuts down within bounds.
+/// The carrier classification and endpoint-ID distinctness assertions remain
+/// at the helper seam ([`super::required_consumer_tests`], the exact seam
+/// this run calls internally).
+#[test]
+fn run_required_bootstrap_first_ready_then_http() -> anyhow::Result<()> {
+    const CASE: &str =
+        "services::oauth::readiness_tests::run_required_bootstrap_first_ready_then_http";
+    run_isolated(CASE, "HYPRSTREAM_OAUTH_READINESS_REQUIRED_POSITIVE")?;
+    if std::env::var_os("HYPRSTREAM_OAUTH_READINESS_REQUIRED_POSITIVE").is_none() {
+        return Ok(());
+    }
+    let env = ChildEnv::new("required-positive");
+    let oauth = SigningKey::from_bytes(&[0xA8; 32]);
+
+    // ── Real OS-owned Required bootstrap fixtures (the did_trust recipe from
+    // required_consumer_tests): deployment CA + authority log/checkpoint,
+    // registry credential, per-service signing keys, trust store, and
+    // provisioning for policy/discovery/oauth. ──
+    let directory = env.dir.path().to_path_buf();
+    let trust = directory.join("trust");
+    let credentials = directory.join("credentials");
+    let secrets = directory.join("secrets");
+    std::fs::create_dir_all(&trust)?;
+    std::fs::create_dir_all(&secrets)?;
+    // The secrets resolver is env-first: point it at the provisioning dir
+    // (where the per-service signing keys live) for the rest of the child.
+    std::env::set_var("HYPRSTREAM__SECRETS__PATH", &secrets);
+    std::env::set_var("HYPRSTREAM_DEPLOYMENT_TRUST_DIR", &trust);
+    let ca = SigningKey::from_bytes(&[0x71; 32]);
+    let registry = SigningKey::from_bytes(&[0x72; 32]);
+    let policy = SigningKey::from_bytes(&[0x73; 32]);
+    let discovery = SigningKey::from_bytes(&[0x74; 32]);
+    let mut root = ca.verifying_key().to_bytes().to_vec();
+    root.extend(hyprstream_rpc::crypto::pq::ml_dsa_sk_to_vk_bytes(
+        &hyprstream_rpc::crypto::pq::ml_dsa_sk_from_seed(&ca.to_bytes()),
+    ));
+    std::fs::write(trust.join("deployment-ca.hybrid"), root)?;
+    let (log, checkpoint) = super::required_consumer_tests::did_trust::authority_log_and_checkpoint(&ca);
+    std::fs::write(
+        trust.join("deployment-authority.log.json"),
+        serde_json::to_vec(&log)?,
+    )?;
+    std::fs::write(
+        trust.join("deployment-authority.head.json"),
+        serde_json::to_vec(&checkpoint)?,
+    )?;
+    std::fs::write(credentials.join("registry-service.jwt"), super::required_consumer_tests::did_trust::mint_credential(&ca, &registry))?;
+    for (name, signer) in [
+        ("registry", &registry),
+        ("policy", &policy),
+        ("discovery", &discovery),
+        ("oauth", &oauth),
+    ] {
+        let key_dir = if name == "policy" {
+            secrets.clone()
+        } else {
+            secrets.join(name)
+        };
+        crate::auth::identity_store::write_secret(&key_dir, "signing-key", &signer.to_bytes())?;
+        hyprstream_service::global_trust_store().insert(
+            signer.verifying_key(),
+            hyprstream_service::Attestation {
+                scopes: [name.to_owned()].into_iter().collect(),
+                subject: None,
+                jwt: None,
+                expires_at: 0,
+                attested_by: None,
+            },
+        );
+    }
+    hyprstream_rpc::registry::init(
+        hyprstream_rpc::registry::EndpointMode::Ipc,
+        Some(directory.join("rpc")),
+    );
+    hyprstream_rpc::transport::pq_provider::install_pq_crypto_provider()?;
+    crate::mac::install_explicit_test_dispatch_pep();
+    let mut request_keys = hyprstream_rpc::envelope::KeyedPqTrustStore::new();
+    for signer in [&oauth, &policy, &discovery] {
+        let pq = hyprstream_rpc::crypto::pq::ml_dsa_vk_from_bytes(
+            &hyprstream_rpc::crypto::pq::ml_dsa_sk_to_vk_bytes(&derive_mesh_mldsa_key(signer)),
+        )?;
+        request_keys.bind(signer.verifying_key().to_bytes(), &pq);
+    }
+    let _ = hyprstream_rpc::envelope::install_verify_config(
+        hyprstream_rpc::envelope::EnvelopeVerifyConfig {
+            policy: hyprstream_rpc::crypto::CryptoPolicy::Hybrid,
+            pq_store: Some(Arc::new(request_keys)),
+        },
+    );
+    hyprstream_discovery::initialize_deployment_checkpoint_store()?;
+    let mut config = crate::config::HyprConfig::default();
+    config.secrets.path = Some(secrets);
+    crate::cli::deployment_bootstrap::provision_services(
+        &config,
+        &["policy".to_owned(), "discovery".to_owned(), "oauth".to_owned()],
+        3600,
+        None,
+    )?;
+
+    // Bootstrap FIRST: the process-global outbound carrier is installed and
+    // the process flips to the Required profile before the service starts.
+    // The carrier's lazy transports live on THIS runtime; keep it driven for
+    // the whole test (multi-thread stays polled after block_on returns) so
+    // the retained endpoint is an operating carrier, not an unparked one.
+    let bootstrap_rt = tokio::runtime::Builder::new_multi_thread()
+        .enable_all()
+        .build()?;
+    bootstrap_rt.block_on(hyprstream_discovery::bootstrap_deployment_process(
+        oauth.clone(),
+        hyprstream_discovery::DeploymentTrustSource::OsOwnedFiles,
+        false,
+        true,
+    ))?;
+    assert!(
+        hyprstream_discovery::native_network_required(),
+        "the Os-owned bootstrap must have activated the Required profile"
+    );
+
+    // Now the production run() seam under network-iroh-required: it binds its
+    // own inbound substrate, classifies the occupied global slot (bootstrap
+    // first-write-wins), and proceeds through bridge → inproc control
+    // registration → READY. Production Required uses the local in-process
+    // control (no service-RPC UDS); this test mirrors that configuration.
+    let addr = reserve_ephemeral_port();
+    let mut quic = crate::config::QuicConfig::default();
+    quic.native_network_profile = crate::config::NativeNetworkProfile::NetworkIrohRequired;
+    quic.enabled = true;
+    quic.iroh = true;
+    let service = http_service_at(
+        &oauth,
+        addr,
+        TransportConfig::inproc("oauth-user-crud-readiness"),
+    )
+    .with_quic_config(quic);
+    let (ready_tx, ready_rx) = tokio::sync::oneshot::channel::<()>();
+    let shutdown = Arc::new(tokio::sync::Notify::new());
+    let shutdown_signal = Arc::clone(&shutdown);
+    let handle = std::thread::spawn(move || Box::new(service).run(shutdown, Some(ready_tx)));
+
+    let rt_wait = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()?;
+    rt_wait.block_on(async {
+        tokio::time::timeout(Duration::from_secs(90), ready_rx)
+            .await
+            .expect("READY must arrive within the test budget")
+            .expect("on_ready must fire on the Required success path");
+    });
+    // Real HTTP request through the actually serving handler. (This proves
+    // READY ordering and HTTP serving only — it makes no claim about
+    // protected-API authorization, and real outbound Policy/Discovery RPC
+    // coverage lives in required_consumer_tests.)
+    let mut stream = std::net::TcpStream::connect(addr)?;
+    stream.set_read_timeout(Some(Duration::from_secs(30)))?;
+    write!(
+        stream,
+        "GET /.well-known/oauth-authorization-server HTTP/1.1\r\nHost: {addr}\r\nConnection: close\r\n\r\n"
+    )?;
+    let mut response = String::new();
+    stream.read_to_string(&mut response)?;
+    assert!(
+        response.starts_with("HTTP/1.1 200"),
+        "metadata endpoint must really serve: got {response:?}"
+    );
+
+    // Bounded shutdown.
+    shutdown_signal.notify_one();
+    let (tx, rx) = std::sync::mpsc::channel();
+    std::thread::spawn(move || {
+        let _ = tx.send(handle.join());
+    });
+    let joined = rx
+        .recv_timeout(Duration::from_secs(90))
+        .expect("run() must terminate within the shutdown budget");
+    joined
+        .expect("run thread must not panic")
+        .expect("clean shutdown must complete the transaction with Ok");
+    drop(bootstrap_rt);
+    Ok(())
+}

--- a/crates/hyprstream/src/services/oauth/readiness_tests.rs
+++ b/crates/hyprstream/src/services/oauth/readiness_tests.rs
@@ -145,6 +145,16 @@ struct ChildEnv {
     sock_dir: tempfile::TempDir,
 }
 
+// TEST-ONLY fixed age key material for the isolated UserStore fixture. The
+// merge-gate builder intentionally has no `age-keygen`; this pair protects
+// only PGlite data inside each child's ephemeral tempdir and must never be
+// used for a deployment. UserStore sealing still exercises the real external
+// `age` binary.
+const TEST_ONLY_USERSTORE_AGE_IDENTITY: &str =
+    "AGE-SECRET-KEY-18DUYV5CM8FZ2DPGXFFN0NPA5QZVW6L245K04YN74FGYUDJU2DVYQUL97GF\n";
+const TEST_ONLY_USERSTORE_AGE_RECIPIENT: &str =
+    "age1lpty3rrqge6ql2qu3ppyx2xxvwdwau593v88ffsgjt0lgu5jayqqrzhgqx";
+
 impl ChildEnv {
     fn new(tag: &str) -> Self {
         let dir = tempfile::Builder::new()
@@ -159,34 +169,42 @@ impl ChildEnv {
         std::fs::create_dir_all(&credentials).expect("credentials dir");
         std::env::set_var("CREDENTIALS_DIRECTORY", &credentials);
         std::env::set_var("HYPRSTREAM__SECRETS__PATH", &credentials);
-        // The mandatory encrypted production profile requires the pglite
-        // UserStore backend with real deployment age key material (the same
-        // external-`age` seam production uses; both binaries are on PATH on
-        // the Linux lanes this suite targets).
+        // The mandatory encrypted production profile requires the PGlite
+        // UserStore backend and valid age key material. Write the test-only
+        // identity with the same private mode as age-keygen; the production
+        // sealing path still invokes the real external `age` binary.
         std::env::set_var("HYPRSTREAM__CREDENTIALS__BACKEND", "pglite");
         let key_path = dir.path().join("userstore-age-identity.txt");
-        let keygen = std::process::Command::new("age-keygen")
-            .arg("-o")
-            .arg(&key_path)
-            .output()
-            .expect("run age-keygen for the child UserStore keypair");
-        assert!(
-            keygen.status.success(),
-            "age-keygen failed: {keygen:?}"
+        let mut options = std::fs::OpenOptions::new();
+        options.write(true).create_new(true);
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::OpenOptionsExt as _;
+            options.mode(0o600);
+        }
+        let mut key_file = options.open(&key_path).expect("create child age identity");
+        key_file
+            .write_all(TEST_ONLY_USERSTORE_AGE_IDENTITY.as_bytes())
+            .expect("write child age identity");
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt as _;
+            assert_eq!(
+                key_file
+                    .metadata()
+                    .expect("child age identity metadata")
+                    .permissions()
+                    .mode()
+                    & 0o077,
+                0,
+                "child age identity must remain private"
+            );
+        }
+        drop(key_file);
+        std::env::set_var(
+            "HYPRSTREAM_USERSTORE_AGE_RECIPIENTS",
+            TEST_ONLY_USERSTORE_AGE_RECIPIENT,
         );
-        let stderr = String::from_utf8(keygen.stderr).expect("age-keygen stderr");
-        let key_file =
-            std::fs::read_to_string(&key_path).expect("read age-keygen identity file");
-        let recipient = stderr
-            .lines()
-            .chain(key_file.lines())
-            .find_map(|l| {
-                l.strip_prefix("Public key: ")
-                    .or_else(|| l.strip_prefix("# public key: "))
-            })
-            .expect("age-keygen must report the public key recipient")
-            .to_owned();
-        std::env::set_var("HYPRSTREAM_USERSTORE_AGE_RECIPIENTS", recipient);
         std::env::set_var("HYPRSTREAM_USERSTORE_AGE_IDENTITIES", &key_path);
         std::env::set_var("XDG_CONFIG_HOME", dir.path().join("xdg-config"));
         std::env::set_var("XDG_DATA_HOME", dir.path().join("xdg-data"));

--- a/crates/hyprstream/src/services/oauth/readiness_tests.rs
+++ b/crates/hyprstream/src/services/oauth/readiness_tests.rs
@@ -236,16 +236,16 @@ fn run_isolated(case: &str, guard: &str) -> anyhow::Result<()> {
 
 // ── Parent-side cases: no process-global state is touched. ──
 
-/// The bridge runtime readiness barrier run() relies on is real: a build
-/// failure resolves the receiver with Err, and the supervisor's READY
-/// counterpart was never consumed.
+/// Builder-failure propagation at `LocalServiceBridge::spawn_with`: a build
+/// failure resolves the readiness receiver with the preserved error, so the
+/// production ordering (await the receiver before serve_bridged) observes a
+/// fatal init instead of readiness.
 ///
 /// (OAuth's own production builder — `OAuthRpcHandler::new` — is infallible,
 /// so a run()-level bridge-build failure has no injectable seam; this proves
-/// the barrier property at the exact API the transaction gates on.)
+/// error propagation at the exact API the transaction gates on.)
 #[test]
-fn bridge_spawn_with_readiness_failure_gates_ready() -> anyhow::Result<()> {
-    let (ready_tx, ready_rx) = tokio::sync::oneshot::channel::<()>();
+fn bridge_spawn_with_propagates_builder_failure() -> anyhow::Result<()> {
     let (bridge, mut ready) = hyprstream_rpc::transport::iroh_rpc::LocalServiceBridge::spawn_with(
         "readiness-fail-echo",
         || async {
@@ -276,11 +276,6 @@ fn bridge_spawn_with_readiness_failure_gates_ready() -> anyhow::Result<()> {
     });
     let _ = bridge.begin_shutdown(tokio::time::Instant::now() + Duration::from_secs(5));
     drop(bridge);
-    assert!(
-        ready_tx.send(()).is_ok(),
-        "on_ready counterpart must still be armed — the barrier consumed nothing"
-    );
-    drop(ready_rx);
     Ok(())
 }
 

--- a/crates/hyprstream/src/services/oauth/readiness_tests.rs
+++ b/crates/hyprstream/src/services/oauth/readiness_tests.rs
@@ -31,6 +31,7 @@ use std::time::Duration;
 /// Reserve an ephemeral loopback port for a later real bind. There is an
 /// inherent TOCTOU window between the probe and the service bind; that is
 /// accepted (and bounded) by keeping the reserve short-lived.
+#[cfg(test)]
 fn reserve_ephemeral_port() -> SocketAddr {
     let l = std::net::TcpListener::bind("127.0.0.1:0").expect("reserve ephemeral port");
     l.local_addr().expect("local addr")
@@ -361,6 +362,7 @@ fn run_occupied_http_listener_fails_before_ready() -> anyhow::Result<()> {
 /// Occupied HTTPS listener: the same real collision through the prebound-TLS
 /// branch (real RustlsConfig from a generated self-signed cert), no READY,
 /// no second bind attempt.
+#[cfg(test)]
 #[test]
 fn run_occupied_https_listener_fails_before_ready() -> anyhow::Result<()> {
     const CASE: &str = "services::oauth::readiness_tests::run_occupied_https_listener_fails_before_ready";

--- a/crates/hyprstream/src/services/oauth/required_consumer_tests.rs
+++ b/crates/hyprstream/src/services/oauth/required_consumer_tests.rs
@@ -3,9 +3,10 @@
 #![allow(clippy::expect_used, clippy::unwrap_used)]
 
 #[path = "../../../tests/fixtures/did_trust.rs"]
-mod did_trust;
+pub(crate) mod did_trust;
 
 use super::runtime_clients;
+use super::{build_oauth_substrate_profile, classify_oauth_endpoint_install, OAuthEndpointInstall};
 use anyhow::Result;
 use ed25519_dalek::SigningKey;
 use hyprstream_rpc::node_identity::{derive_mesh_mldsa_key, derive_purpose_key};
@@ -175,6 +176,28 @@ fn required_oauth_runtime_clients_reach_policy_and_discovery_over_iroh() -> Resu
         .await?;
         assert!(hyprstream_discovery::native_network_required());
 
+        // Sol carrier disposition (PR 1585): bind OAuth's own inbound
+        // reach-only substrate via the production profile helper AFTER the
+        // process-global outbound slot is already occupied. Both install
+        // outcomes are valid; the occupied slot is the positive control —
+        // classify it ExistingGlobalRetained, RETAIN the substrate as the
+        // independent inbound owner, and leave the existing global endpoint
+        // untouched. The two carriers' endpoint IDs are deliberately
+        // different (distinct transport purpose keys) and are never compared
+        // in production.
+        let oauth_substrate = build_oauth_substrate_profile(&oauth, true)
+            .await?
+            .expect("Required profile must bind its mandatory inbound substrate");
+        assert!(matches!(
+            classify_oauth_endpoint_install(&oauth_substrate),
+            OAuthEndpointInstall::ExistingGlobalRetained
+        ));
+        assert_ne!(
+            oauth_substrate.endpoint_id(),
+            client_carrier.endpoint_id(),
+            "the two carriers' transport purpose keys are deliberately distinct"
+        );
+
         let manager = Arc::new(crate::auth::PolicyManager::new_in_memory().await?);
         manager
             .add_policy_with_domain("service:oauth", "*", "model:allowed", "query", "allow")
@@ -257,6 +280,21 @@ fn required_oauth_runtime_clients_reach_policy_and_discovery_over_iroh() -> Resu
         })
         .await??;
         assert_no_local_peers();
+        // Ownership independence (Sol disposition case 6): shutting down ONLY
+        // the OAuth inbound substrate must not disturb the process-global
+        // outbound carrier — a subsequent real dial still succeeds.
+        oauth_substrate.shutdown().await?;
+        let post_shutdown = crate::services::generated::policy_client::PolicyCheck {
+            subject: "forged-caller".to_owned(),
+            domain: "forged-domain".to_owned(),
+            resource: "model:allowed".to_owned(),
+            operation: "query".to_owned(),
+        };
+        assert!(
+            policy_client.check(&post_shutdown).await?,
+            "outbound dials must survive OAuth substrate shutdown via the \
+             untouched process-global carrier"
+        );
         assert!(!policy_socket.exists());
         assert!(!discovery_socket.exists());
         client_carrier.shutdown().await?;

--- a/crates/hyprstream/src/services/oauth/required_consumer_tests.rs
+++ b/crates/hyprstream/src/services/oauth/required_consumer_tests.rs
@@ -281,6 +281,7 @@ fn service_announcement(
     }
 }
 
+#[cfg(test)]
 #[test]
 fn required_oauth_runtime_clients_reach_policy_and_discovery_over_iroh() -> Result<()> {
     const CHILD: &str = "HYPRSTREAM_REQUIRED_OAUTH_CLIENT_TEST";

--- a/crates/hyprstream/src/services/oauth/required_consumer_tests.rs
+++ b/crates/hyprstream/src/services/oauth/required_consumer_tests.rs
@@ -13,7 +13,273 @@ use hyprstream_rpc::node_identity::{derive_mesh_mldsa_key, derive_purpose_key};
 use hyprstream_rpc::transport::iroh_rpc::{IrohRpcProtocolHandler, LocalServiceBridge};
 use hyprstream_rpc::transport::iroh_substrate::{IrohSubstrate, RefuseHandler};
 use hyprstream_rpc::transport::TransportConfig;
+use parking_lot::Mutex;
 use std::sync::Arc;
+
+struct OaiTestNinePDecider;
+
+impl hyprstream_9p::AccessDecider for OaiTestNinePDecider {
+    fn check(
+        &self,
+        _ctx: &hyprstream_rpc::auth::mac::SecurityContext,
+        _object: hyprstream_rpc::auth::mac::ObjectRef<'_>,
+        _action: hyprstream_9p::Action,
+    ) -> bool {
+        true
+    }
+
+    fn audit_denial(
+        &self,
+        _ctx: &hyprstream_rpc::auth::mac::SecurityContext,
+        _object: hyprstream_rpc::auth::mac::ObjectRef<'_>,
+        _object_label: Option<hyprstream_rpc::auth::mac::SecurityLabel>,
+        _action: hyprstream_9p::Action,
+        _reason: hyprstream_9p::ReferenceMonitorDenyReason,
+    ) {
+    }
+}
+
+#[derive(Clone)]
+enum ModelReadinessResponse {
+    ExpectedTenantDenial,
+    Error {
+        code: String,
+        message: String,
+        details: String,
+    },
+    Healthy,
+    Block,
+}
+
+/// A real encrypted Model RPC responder for causal controls around OAI's
+/// startup response classifier. The affirmative tenant-denial case is covered
+/// separately with the production `ModelService` handler.
+struct ModelReadinessResponder {
+    signing_key: Arc<Mutex<SigningKey>>,
+    transport: TransportConfig,
+    jwt_key_source: Arc<dyn hyprstream_rpc::auth::JwtKeySource>,
+    response: Arc<Mutex<ModelReadinessResponse>>,
+    entered: Arc<tokio::sync::Notify>,
+    release: Arc<tokio::sync::Notify>,
+}
+
+#[async_trait::async_trait(?Send)]
+impl hyprstream_rpc::service::RequestService for ModelReadinessResponder {
+    fn decode_request_body(
+        &self,
+        signed_body: &[u8],
+    ) -> Result<hyprstream_rpc::service::DecodedRequestBody> {
+        crate::services::generated::model_client::decode_model_request_body(signed_body)
+    }
+
+    async fn handle_request(
+        &self,
+        ctx: &hyprstream_rpc::service::EnvelopeContext,
+        body: &hyprstream_rpc::service::DecodedRequestBody,
+    ) -> Result<(Vec<u8>, Option<hyprstream_rpc::service::Continuation>)> {
+        anyhow::ensure!(
+            ctx.subject().name() == Some("service:oai"),
+            "readiness caller is not authenticated as service:oai"
+        );
+        let request = body.root::<crate::model_capnp::model_request::Reader<'_>>()?;
+        anyhow::ensure!(
+            matches!(
+                request.which()?,
+                crate::model_capnp::model_request::Which::HealthCheck(())
+            ),
+            "readiness responder received a non-health Model request"
+        );
+
+        let response = self.response.lock().clone();
+        if matches!(response, ModelReadinessResponse::Block) {
+            self.entered.notify_one();
+            self.release.notified().await;
+        }
+        let variant = match response {
+            ModelReadinessResponse::ExpectedTenantDenial => {
+                let denial = ctx
+                    .domain()
+                    .expect_err("tenantless service JWT must not acquire a Model tenant");
+                anyhow::ensure!(
+                    denial.to_string() == "authorization denied: no verified tenant domain",
+                    "unexpected Model tenant denial: {denial}"
+                );
+                crate::services::generated::model_client::ModelResponseVariant::Error(
+                    crate::services::generated::model_client::ErrorInfo {
+                        code: "INTERNAL".to_owned(),
+                        message: denial.to_string(),
+                        details: String::new(),
+                    },
+                )
+            }
+            ModelReadinessResponse::Error {
+                code,
+                message,
+                details,
+            } => crate::services::generated::model_client::ModelResponseVariant::Error(
+                crate::services::generated::model_client::ErrorInfo {
+                    code,
+                    message,
+                    details,
+                },
+            ),
+            ModelReadinessResponse::Healthy => {
+                crate::services::generated::model_client::ModelResponseVariant::HealthCheckResult(
+                    crate::services::generated::model_client::ModelHealthStatus {
+                        status: "healthy".to_owned(),
+                        loaded_model_count: 0,
+                        max_models: 0,
+                        total_memory_bytes: 0,
+                    },
+                )
+            }
+            ModelReadinessResponse::Block => {
+                crate::services::generated::model_client::ModelResponseVariant::Error(
+                    crate::services::generated::model_client::ErrorInfo {
+                        code: "INTERNAL".to_owned(),
+                        message: "authorization denied: no verified tenant domain".to_owned(),
+                        details: String::new(),
+                    },
+                )
+            }
+        };
+        let response = crate::services::generated::model_client::serialize_response(
+            request.get_id(),
+            &variant,
+        )?;
+        Ok((response, None))
+    }
+
+    fn name(&self) -> &str {
+        "model"
+    }
+
+    fn transport(&self) -> &TransportConfig {
+        &self.transport
+    }
+
+    fn signing_key(&self) -> SigningKey {
+        self.signing_key.lock().clone()
+    }
+
+    fn jwt_key_source(&self) -> Option<Arc<dyn hyprstream_rpc::auth::JwtKeySource>> {
+        Some(Arc::clone(&self.jwt_key_source))
+    }
+}
+
+/// Minimal real Registry RPC responder for the OAI readiness boundary. It
+/// decodes the generated Registry request, receives a verified network
+/// envelope through `LocalServiceBridge`, and emits the generated health
+/// response; it is not a callback standing in for an RPC.
+struct RegistryReadinessResponder {
+    signing_key: SigningKey,
+    transport: TransportConfig,
+    jwt_key_source: Arc<dyn hyprstream_rpc::auth::JwtKeySource>,
+    status: Arc<Mutex<String>>,
+}
+
+#[async_trait::async_trait(?Send)]
+impl hyprstream_rpc::service::RequestService for RegistryReadinessResponder {
+    fn decode_request_body(
+        &self,
+        signed_body: &[u8],
+    ) -> Result<hyprstream_rpc::service::DecodedRequestBody> {
+        crate::services::generated::registry_client::decode_registry_request_body(signed_body)
+    }
+
+    async fn handle_request(
+        &self,
+        ctx: &hyprstream_rpc::service::EnvelopeContext,
+        body: &hyprstream_rpc::service::DecodedRequestBody,
+    ) -> Result<(Vec<u8>, Option<hyprstream_rpc::service::Continuation>)> {
+        anyhow::ensure!(
+            ctx.subject().name() == Some("service:oai"),
+            "readiness caller is not authenticated as service:oai"
+        );
+        let request = body.root::<crate::registry_capnp::registry_request::Reader<'_>>()?;
+        anyhow::ensure!(
+            matches!(
+                request.which()?,
+                crate::registry_capnp::registry_request::Which::HealthCheck(())
+            ),
+            "readiness responder received a non-health Registry request"
+        );
+        let status = self.status.lock().clone();
+        let response = crate::services::generated::registry_client::serialize_response(
+            request.get_id(),
+            &crate::services::generated::registry_client::RegistryResponseVariant::HealthCheckResult(
+                crate::services::generated::registry_client::HealthStatus {
+                    status,
+                    repository_count: 0,
+                    worktree_count: 0,
+                    cache_hits: 0,
+                    cache_misses: 0,
+                },
+            ),
+        )?;
+        Ok((response, None))
+    }
+
+    fn name(&self) -> &str {
+        "registry"
+    }
+
+    fn transport(&self) -> &TransportConfig {
+        &self.transport
+    }
+
+    fn signing_key(&self) -> SigningKey {
+        self.signing_key.clone()
+    }
+
+    fn jwt_key_source(&self) -> Option<Arc<dyn hyprstream_rpc::auth::JwtKeySource>> {
+        Some(Arc::clone(&self.jwt_key_source))
+    }
+}
+
+fn service_announcement(
+    name: &str,
+    state: &hyprstream_pds::at9p_duplicity::AcceptedAt9pState,
+    signer: &SigningKey,
+    jwt_signer: &SigningKey,
+) -> hyprstream_discovery::ServiceAnnouncement {
+    let entry = state
+        .current
+        .services
+        .iter()
+        .find(|entry| entry.id == format!("#{name}"))
+        .expect("accepted service entry");
+    let claims = hyprstream_rpc::auth::Claims::new(
+        format!("service:{name}"),
+        chrono::Utc::now().timestamp(),
+        chrono::Utc::now().timestamp() + 3600,
+    )
+    .with_cnf_jwk(signer.verifying_key().as_bytes());
+    hyprstream_discovery::ServiceAnnouncement {
+        service_name: name.to_owned(),
+        socket_kind: "iroh".to_owned(),
+        endpoint: entry.endpoint.address.clone(),
+        service_jwt: Some(hyprstream_rpc::auth::jwt::encode_service_jwt(
+            &claims, jwt_signer,
+        )),
+        service_did: hyprstream_rpc::identity::Did::from(state.did.clone()),
+        capabilities: vec!["hyprstream-rpc/1".to_owned()],
+        accepted_state_digest: state.head_digest.to_vec(),
+        accepted_state_epoch: state.epoch,
+        response_key_id: format!("{}#response", state.did),
+        request_kem_key_id: format!("{}#mesh-kem", state.did),
+        request_kem_recipient: entry
+            .endpoint
+            .request_kem
+            .clone()
+            .expect("accepted request KEM"),
+        expires_at_unix_ms: chrono::DateTime::parse_from_rfc3339(
+            state.expires_at.as_deref().expect("bounded accepted state"),
+        )
+        .expect("accepted expiry")
+        .timestamp_millis(),
+    }
+}
 
 #[test]
 fn required_oauth_runtime_clients_reach_policy_and_discovery_over_iroh() -> Result<()> {
@@ -52,6 +318,8 @@ fn required_oauth_runtime_clients_reach_policy_and_discovery_over_iroh() -> Resu
     let policy = SigningKey::from_bytes(&[0x73; 32]);
     let discovery = SigningKey::from_bytes(&[0x74; 32]);
     let oauth = SigningKey::from_bytes(&[0x75; 32]);
+    let model = SigningKey::from_bytes(&[0x76; 32]);
+    let oai = SigningKey::from_bytes(&[0x77; 32]);
     let mut root = ca.verifying_key().to_bytes().to_vec();
     root.extend(hyprstream_rpc::crypto::pq::ml_dsa_sk_to_vk_bytes(
         &hyprstream_rpc::crypto::pq::ml_dsa_sk_from_seed(&ca.to_bytes()),
@@ -75,6 +343,8 @@ fn required_oauth_runtime_clients_reach_policy_and_discovery_over_iroh() -> Resu
         ("policy", &policy),
         ("discovery", &discovery),
         ("oauth", &oauth),
+        ("model", &model),
+        ("oai", &oai),
     ] {
         let key_dir = if name == "policy" {
             secrets.clone()
@@ -99,8 +369,17 @@ fn required_oauth_runtime_clients_reach_policy_and_discovery_over_iroh() -> Resu
     );
     hyprstream_rpc::transport::pq_provider::install_pq_crypto_provider()?;
     crate::mac::install_explicit_test_dispatch_pep();
+    // Production publishes the authority stores before constructing any
+    // service factory. This isolated child bypasses main, so install the same
+    // fail-closed revocation seam before presenting the jti-bearing OAI WIT.
+    if hyprstream_rpc::auth::global_credential_revocation_store().is_none() {
+        let _ = hyprstream_rpc::auth::set_global_credential_revocation_store(Arc::new(
+            hyprstream_rpc::auth::InMemoryCredentialRevocationStore::new(),
+        ));
+    }
+    assert!(hyprstream_rpc::auth::global_credential_revocation_store().is_some());
     let mut request_keys = hyprstream_rpc::envelope::KeyedPqTrustStore::new();
-    for signer in [&oauth, &policy, &discovery] {
+    for signer in [&oauth, &policy, &discovery, &registry, &model, &oai] {
         let pq = hyprstream_rpc::crypto::pq::ml_dsa_vk_from_bytes(
             &hyprstream_rpc::crypto::pq::ml_dsa_sk_to_vk_bytes(&derive_mesh_mldsa_key(signer)),
         )?;
@@ -118,13 +397,54 @@ fn required_oauth_runtime_clients_reach_policy_and_discovery_over_iroh() -> Resu
     crate::cli::deployment_bootstrap::provision_services(
         &config,
         &[
+            "registry".to_owned(),
             "policy".to_owned(),
             "discovery".to_owned(),
             "oauth".to_owned(),
+            "model".to_owned(),
+            "oai".to_owned(),
         ],
         3600,
         None,
     )?;
+
+    const TEST_ISSUER: &str = "https://required-oai.test";
+    let oai_jwt = crate::auth::service_jwt::issue_or_load_service_jwt(
+        &credentials,
+        "oai",
+        &ca,
+        &crate::auth::identity_store::BootstrapPubkey::for_service_key(&oai)?,
+        TEST_ISSUER,
+        chrono::Utc::now().timestamp(),
+        None,
+    )?;
+    let registry_jwt = crate::auth::service_jwt::issue_or_load_service_jwt(
+        &credentials,
+        "registry",
+        &ca,
+        &crate::auth::identity_store::BootstrapPubkey::for_service_key(&registry)?,
+        TEST_ISSUER,
+        chrono::Utc::now().timestamp(),
+        None,
+    )?;
+    let ca_pq = derive_mesh_mldsa_key(&ca);
+    let ca_pq_vk = hyprstream_rpc::crypto::pq::ml_dsa_vk_from_bytes(
+        &hyprstream_rpc::crypto::pq::ml_dsa_sk_to_vk_bytes(&ca_pq),
+    )?;
+    let jwt_key_source: Arc<dyn hyprstream_rpc::auth::JwtKeySource> = Arc::new(
+        hyprstream_rpc::auth::ClusterKeySource::new(ca.verifying_key(), TEST_ISSUER.to_owned())
+            .with_ca_composite_key(ca_pq_vk),
+    );
+    hyprstream_service::global_trust_store().insert(
+        oai.verifying_key(),
+        hyprstream_service::Attestation {
+            scopes: ["oai".to_owned()].into_iter().collect(),
+            subject: None,
+            jwt: Some(oai_jwt.clone()),
+            expires_at: chrono::Utc::now().timestamp() + 3600,
+            attested_by: None,
+        },
+    );
 
     // Match OAuthService::run: clients are created and used on its own
     // current-thread runtime/LocalSet, after process bootstrap is installed.
@@ -152,7 +472,7 @@ fn required_oauth_runtime_clients_reach_policy_and_discovery_over_iroh() -> Resu
         // registry fallbacks below stay refused.
         assert!(crate::services::McpService::new(mcp_config.clone()).is_ok());
         let client_carrier = IrohSubstrate::new(
-            [0x76; 32],
+            [0x78; 32],
             RefuseHandler::new("client only"),
             RefuseHandler::new("client only"),
         )
@@ -198,9 +518,23 @@ fn required_oauth_runtime_clients_reach_policy_and_discovery_over_iroh() -> Resu
             "the two carriers' transport purpose keys are deliberately distinct"
         );
 
-        let manager = Arc::new(crate::auth::PolicyManager::new_in_memory().await?);
+        let manager = Arc::new(
+            crate::auth::PolicyManager::new(directory.path().join("policies")).await?,
+        );
         manager
             .add_policy_with_domain("service:oauth", "*", "model:allowed", "query", "allow")
+            .await?;
+        manager
+            .add_policy_with_domain(
+                "service:registry",
+                "*",
+                "discovery:Announce",
+                "write",
+                "allow",
+            )
+            .await?;
+        manager
+            .add_policy_with_domain("service:model", "*", "discovery:Announce", "write", "allow")
             .await?;
         let database = Arc::new(tokio::sync::RwLock::new(
             git2db::Git2DB::open(&directory.path().join("models")).await?,
@@ -208,12 +542,13 @@ fn required_oauth_runtime_clients_reach_policy_and_discovery_over_iroh() -> Resu
         let policy_socket = directory.path().join("policy-must-not-exist.sock");
         let discovery_socket = directory.path().join("discovery-must-not-exist.sock");
         let policy_service = crate::services::PolicyService::new(
-            manager,
+            Arc::clone(&manager),
             Arc::new(policy.clone()),
             crate::config::TokenConfig::default(),
             database,
             TransportConfig::ipc(&policy_socket),
-        );
+        )
+        .with_jwt_key_source(Arc::clone(&jwt_key_source));
         let discovery_service = hyprstream_discovery::DiscoveryService::new(
             Arc::new(discovery.clone()),
             policy.verifying_key(),
@@ -241,7 +576,58 @@ fn required_oauth_runtime_clients_reach_policy_and_discovery_over_iroh() -> Resu
             IrohRpcProtocolHandler::new(discovery_bridge, discovery.clone()),
         )
         .await?;
-        for server in [&policy_server, &discovery_server] {
+        let _ = hyprstream_rpc::moq_event::init_global_moq_event_origin(
+            hyprstream_rpc::moq_event::MoqEventOrigin::new(),
+        );
+        let model_service = crate::services::ModelService::new(
+            crate::services::ModelServiceConfig::default(),
+            model.clone(),
+            crate::services::PolicyClient::from_resolver(model.clone(), None)?,
+            crate::services::RegistryClient::from_resolver(model.clone(), None)?,
+            TransportConfig::ipc(directory.path().join("model-must-not-exist.sock")),
+            TransportConfig::ipc(&policy_socket),
+        )
+        .await?
+        .with_jwt_key_source(Arc::clone(&jwt_key_source));
+        let model_bridge = LocalServiceBridge::spawn(
+            model_service,
+            Arc::new(hyprstream_rpc::envelope::InMemoryNonceCache::new()),
+            0,
+        )?;
+        let model_server = IrohSubstrate::new(
+            derive_purpose_key(&model, "hyprstream-iroh-transport-v1").to_bytes(),
+            RefuseHandler::new("no events"),
+            IrohRpcProtocolHandler::new(model_bridge, model.clone()),
+        )
+        .await?;
+        let registry_service = crate::services::RegistryService::new(
+            directory.path().join("registry-data"),
+            crate::services::PolicyClient::from_resolver(
+                registry.clone(),
+                Some(registry_jwt),
+            )?,
+            TransportConfig::ipc(directory.path().join("registry-must-not-exist.sock")),
+            registry.clone(),
+        )
+        .await?
+        .with_jwt_key_source(Arc::clone(&jwt_key_source));
+        let registry_bridge = LocalServiceBridge::spawn(
+            registry_service,
+            Arc::new(hyprstream_rpc::envelope::InMemoryNonceCache::new()),
+            0,
+        )?;
+        let registry_server = IrohSubstrate::new(
+            derive_purpose_key(&registry, "hyprstream-iroh-transport-v1").to_bytes(),
+            RefuseHandler::new("no events"),
+            IrohRpcProtocolHandler::new(registry_bridge, registry.clone()),
+        )
+        .await?;
+        for server in [
+            &policy_server,
+            &discovery_server,
+            &registry_server,
+            &model_server,
+        ] {
             lookup.add_endpoint_info(iroh::EndpointAddr::from_parts(
                 server.endpoint_id(),
                 server
@@ -265,7 +651,73 @@ fn required_oauth_runtime_clients_reach_policy_and_discovery_over_iroh() -> Resu
         )
         .is_err());
         let (policy_client, discovery_client) = runtime_clients(&oauth)?;
+        let accepted_store = crate::services::discovery::PdsRecordStore::open_readonly(
+            &hyprstream_service::deployment_data_dir()?.join("pds-store"),
+        )?
+        .with_at9p_deployment_verifier(hyprstream_discovery::deployment_registry_verifier()?);
+        let registry_state = accepted_store
+            .accepted_at9p_states()?
+            .into_iter()
+            .find(|state| {
+                state
+                    .current
+                    .services
+                    .iter()
+                    .any(|entry| entry.id == "#registry")
+            })
+            .expect("checkpoint-accepted Registry state");
+        let model_state = accepted_store
+            .accepted_at9p_states()?
+            .into_iter()
+            .find(|state| {
+                state
+                    .current
+                    .services
+                    .iter()
+                    .any(|entry| entry.id == "#model")
+            })
+            .expect("checkpoint-accepted Model state");
+        let registry_announcer =
+            crate::services::DiscoveryClient::from_resolver(registry.clone(), None)?;
+        registry_announcer
+            .announce(&service_announcement(
+                "registry",
+                &registry_state,
+                &registry,
+                &policy,
+            ))
+            .await?;
+        let model_announcer = crate::services::DiscoveryClient::from_resolver(model.clone(), None)?;
+        model_announcer
+            .announce(&service_announcement(
+                "model",
+                &model_state,
+                &model,
+                &policy,
+            ))
+            .await?;
+        let registry_client = crate::services::RegistryClient::from_resolver(
+            oai.clone(),
+            Some(oai_jwt.clone()),
+        )?;
+        let model_client = crate::services::generated::model_client::ModelClient::from_resolver(
+            oai.clone(),
+            Some(oai_jwt),
+        )?;
         let _mcp = crate::services::McpService::new(mcp_config)?;
+        let server_state = crate::server::state::ServerState::new(
+            crate::config::ServerConfig::default(),
+            model_client.clone(),
+            policy_client.clone(),
+            std::clone::Clone::clone(&registry_client),
+            oai.clone(),
+            ca.verifying_key(),
+            "http://127.0.0.1/oai".to_owned(),
+            TEST_ISSUER.to_owned(),
+            &std::collections::HashMap::new(),
+            Arc::new(OaiTestNinePDecider),
+        )
+        .await?;
         tokio::time::timeout(std::time::Duration::from_secs(15), async {
             let check = |resource: &str| crate::services::generated::policy_client::PolicyCheck {
                 subject: "forged-caller".to_owned(),
@@ -276,9 +728,296 @@ fn required_oauth_runtime_clients_reach_policy_and_discovery_over_iroh() -> Resu
             assert!(policy_client.check(&check("model:allowed")).await?);
             assert!(!policy_client.check(&check("model:denied")).await?);
             let _ = discovery_client.list_services().await?;
+            crate::services::oai_prove_model_reachability_denial(&model_client).await?;
+            crate::services::oai_healthy_registry(&registry_client).await?;
             anyhow::Ok(())
         })
         .await??;
+
+        let reservation = std::net::TcpListener::bind("127.0.0.1:0")?;
+        let ready_addr = reservation.local_addr()?;
+        drop(reservation);
+        let mut oai_config = crate::config::OAIConfig::default();
+        oai_config.host = ready_addr.ip().to_string();
+        oai_config.port = ready_addr.port();
+        let mut tls_config = crate::config::TlsConfig::default();
+        tls_config.enabled = false;
+        let ready_shutdown = Arc::new(tokio::sync::Notify::new());
+        let (ready_tx, ready_rx) = tokio::sync::oneshot::channel();
+        let oai_service = crate::services::OAIService::new(
+            oai_config,
+            tls_config.clone(),
+            crate::account::AccountZoneConfig::default(),
+            server_state.clone(),
+            true,
+        );
+        assert!(
+            hyprstream_service::Spawnable::registrations(&oai_service).is_empty(),
+            "HTTP-only OAI must not register an unserved native endpoint",
+        );
+        let ready_task = tokio::task::spawn_local(
+            Box::new(oai_service).run_inner(Arc::clone(&ready_shutdown), Some(ready_tx)),
+        );
+        tokio::time::timeout(std::time::Duration::from_secs(10), ready_rx).await??;
+        assert!(
+            std::net::TcpListener::bind(ready_addr).is_err(),
+            "OAI must retain its prebound listener after signaling readiness",
+        );
+        ready_shutdown.notify_waiters();
+        tokio::time::timeout(std::time::Duration::from_secs(5), ready_task).await???;
+        let rebound = std::net::TcpListener::bind(ready_addr)?;
+        drop(rebound);
+
+        let occupied = std::net::TcpListener::bind("127.0.0.1:0")?;
+        let occupied_addr = occupied.local_addr()?;
+        let mut occupied_config = crate::config::OAIConfig::default();
+        occupied_config.host = occupied_addr.ip().to_string();
+        occupied_config.port = occupied_addr.port();
+        let (occupied_ready_tx, occupied_ready_rx) = tokio::sync::oneshot::channel();
+        Box::new(crate::services::OAIService::new(
+            occupied_config,
+            tls_config.clone(),
+            crate::account::AccountZoneConfig::default(),
+            server_state.clone(),
+            true,
+        ))
+        .run_inner(
+            Arc::new(tokio::sync::Notify::new()),
+            Some(occupied_ready_tx),
+        )
+        .await
+        .expect_err("an occupied OAI listener must fail before readiness");
+        assert!(
+            occupied_ready_rx.await.is_err(),
+            "an occupied listener must never emit OAI readiness",
+        );
+        drop(occupied);
+        let rebound = std::net::TcpListener::bind(occupied_addr)?;
+        drop(rebound);
+
+        assert!(
+            manager
+                .add_policy_with_domain(
+                    "service:oai",
+                    "*",
+                    "registry:HealthCheck",
+                    "query",
+                    "deny",
+                )
+                .await?,
+            "test-only Registry denial must be installed alongside the base allow",
+        );
+        let denied = crate::services::oai_healthy_registry(&registry_client)
+            .await
+            .expect_err(
+                "an exact persisted denial must override the OAI Registry base allow and withhold readiness",
+            );
+        assert!(
+            denied.to_string().contains(
+                "Unauthorized: service:oai cannot query on registry:HealthCheck",
+            ),
+            "the control must fail at Registry authorization, not transport: {denied}",
+        );
+        assert!(
+            manager
+                .remove_policy_with_domain(
+                    "service:oai",
+                    "*",
+                    "registry:HealthCheck",
+                    "query",
+                    "deny",
+                )
+                .await?,
+            "test-only Registry denial must be removed without altering base grants",
+        );
+        crate::services::oai_healthy_registry(&registry_client).await?;
+
+        // The affirmative Model result above came from the production
+        // `ModelService`: its generated dispatcher reached the real
+        // tenant-authority boundary and returned the exact authenticated
+        // tenantless denial. Replace that server with a protocol-equivalent
+        // responder only for the classifier and liveness controls below.
+        model_server.shutdown().await?;
+        registry_server.shutdown().await?;
+        let model_response = Arc::new(Mutex::new(ModelReadinessResponse::ExpectedTenantDenial));
+        let model_signing_key = Arc::new(Mutex::new(model.clone()));
+        let model_entered = Arc::new(tokio::sync::Notify::new());
+        let model_release = Arc::new(tokio::sync::Notify::new());
+        let model_bridge = LocalServiceBridge::spawn(
+            ModelReadinessResponder {
+                signing_key: Arc::clone(&model_signing_key),
+                transport: TransportConfig::ipc(directory.path().join("model-must-not-exist.sock")),
+                jwt_key_source: Arc::clone(&jwt_key_source),
+                response: Arc::clone(&model_response),
+                entered: Arc::clone(&model_entered),
+                release: Arc::clone(&model_release),
+            },
+            Arc::new(hyprstream_rpc::envelope::InMemoryNonceCache::new()),
+            0,
+        )?;
+        let model_server = IrohSubstrate::new(
+            derive_purpose_key(&model, "hyprstream-iroh-transport-v1").to_bytes(),
+            RefuseHandler::new("no events"),
+            IrohRpcProtocolHandler::new(model_bridge, model.clone()),
+        )
+        .await?;
+        lookup.add_endpoint_info(iroh::EndpointAddr::from_parts(
+            model_server.endpoint_id(),
+            model_server
+                .endpoint()
+                .bound_sockets()
+                .into_iter()
+                .map(iroh::TransportAddr::Ip),
+        ));
+        let registry_status = Arc::new(Mutex::new("healthy".to_owned()));
+        let registry_bridge = LocalServiceBridge::spawn(
+            RegistryReadinessResponder {
+                signing_key: registry.clone(),
+                transport: TransportConfig::ipc(
+                    directory.path().join("registry-must-not-exist.sock"),
+                ),
+                jwt_key_source: Arc::clone(&jwt_key_source),
+                status: Arc::clone(&registry_status),
+            },
+            Arc::new(hyprstream_rpc::envelope::InMemoryNonceCache::new()),
+            0,
+        )?;
+        let registry_server = IrohSubstrate::new(
+            derive_purpose_key(&registry, "hyprstream-iroh-transport-v1").to_bytes(),
+            RefuseHandler::new("no events"),
+            IrohRpcProtocolHandler::new(registry_bridge, registry.clone()),
+        )
+        .await?;
+        lookup.add_endpoint_info(iroh::EndpointAddr::from_parts(
+            registry_server.endpoint_id(),
+            registry_server
+                .endpoint()
+                .bound_sockets()
+                .into_iter()
+                .map(iroh::TransportAddr::Ip),
+        ));
+
+        for response in [
+            ModelReadinessResponse::Error {
+                code: "UNAUTHORIZED".to_owned(),
+                message: "authorization denied: no verified tenant domain".to_owned(),
+                details: String::new(),
+            },
+            ModelReadinessResponse::Error {
+                code: "INTERNAL".to_owned(),
+                message: "authorization denied for another reason".to_owned(),
+                details: String::new(),
+            },
+            ModelReadinessResponse::Error {
+                code: "INTERNAL".to_owned(),
+                message: "authorization denied: no verified tenant domain".to_owned(),
+                details: "unexpected detail".to_owned(),
+            },
+            ModelReadinessResponse::Healthy,
+        ] {
+            *model_response.lock() = response;
+            crate::services::oai_prove_model_reachability_denial(&model_client)
+                .await
+                .expect_err("only the exact authenticated tenant denial may satisfy readiness");
+        }
+
+        *model_response.lock() = ModelReadinessResponse::Block;
+        let reservation = std::net::TcpListener::bind("127.0.0.1:0")?;
+        let cancelled_addr = reservation.local_addr()?;
+        drop(reservation);
+        let mut cancelled_config = crate::config::OAIConfig::default();
+        cancelled_config.host = cancelled_addr.ip().to_string();
+        cancelled_config.port = cancelled_addr.port();
+        let cancelled = Arc::new(tokio::sync::Notify::new());
+        let (cancelled_ready_tx, mut cancelled_ready_rx) = tokio::sync::oneshot::channel();
+        let cancellation_task = tokio::task::spawn_local(
+            Box::new(crate::services::OAIService::new(
+                cancelled_config,
+                tls_config,
+                crate::account::AccountZoneConfig::default(),
+                server_state,
+                true,
+            ))
+            .run_inner(Arc::clone(&cancelled), Some(cancelled_ready_tx)),
+        );
+        tokio::select! {
+            _ = model_entered.notified() => {}
+            _ = tokio::time::sleep(std::time::Duration::from_secs(5)) => {
+                panic!("OAI did not enter its blocked Model readiness probe");
+            }
+        }
+        assert!(
+            std::net::TcpListener::bind(cancelled_addr).is_err(),
+            "OAI must prebind HTTP before waiting on native dependencies",
+        );
+        assert!(
+            matches!(
+                cancelled_ready_rx.try_recv(),
+                Err(tokio::sync::oneshot::error::TryRecvError::Empty)
+            ),
+            "OAI must withhold readiness while its Model probe is blocked",
+        );
+        cancelled.notify_waiters();
+        let cancellation_result =
+            tokio::time::timeout(std::time::Duration::from_secs(5), cancellation_task)
+                .await??;
+        let cancellation = cancellation_result
+            .expect_err("shutdown must cancel OAI native readiness");
+        assert!(cancellation.to_string().contains("cancelled"));
+        assert!(
+            cancelled_ready_rx.await.is_err(),
+            "cancelled startup must drop its readiness sender without signaling",
+        );
+        model_release.notify_one();
+        let rebound = std::net::TcpListener::bind(cancelled_addr)?;
+        drop(rebound);
+
+        let timeout_check = crate::services::oai_await_required_native_dependencies(
+            &model_client,
+            &registry_client,
+            Arc::new(tokio::sync::Notify::new()),
+            std::time::Duration::from_millis(250),
+        );
+        tokio::pin!(timeout_check);
+        tokio::select! {
+            _ = model_entered.notified() => {}
+            result = &mut timeout_check => {
+                panic!("blocked Model probe completed before timeout: {result:?}");
+            }
+        }
+        let timeout = timeout_check
+            .await
+            .expect_err("bounded OAI native readiness must time out");
+        assert!(timeout.to_string().contains("timed out"));
+        model_release.notify_one();
+
+        *model_response.lock() = ModelReadinessResponse::ExpectedTenantDenial;
+        *model_signing_key.lock() = SigningKey::from_bytes(&[0x7e; 32]);
+        crate::services::oai_await_required_native_dependencies(
+            &model_client,
+            &registry_client,
+            Arc::new(tokio::sync::Notify::new()),
+            std::time::Duration::from_secs(2),
+        )
+        .await
+        .expect_err(
+            "a server unable to authenticate as the accepted Model cannot satisfy bounded readiness",
+        );
+        *model_signing_key.lock() = model.clone();
+        *registry_status.lock() = "degraded".to_owned();
+        let unhealthy = crate::services::oai_healthy_registry(&registry_client)
+            .await
+            .expect_err("non-healthy Registry response must withhold OAI readiness");
+        assert!(unhealthy.to_string().contains("degraded"));
+        *registry_status.lock() = "healthy".to_owned();
+        let unauthenticated = crate::services::RegistryClient::from_resolver(
+            SigningKey::from_bytes(&[0x7f; 32]),
+            None,
+        )?;
+        assert!(
+            unauthenticated.health_check().await.is_err(),
+            "an unregistered network signer must not satisfy Registry readiness"
+        );
         assert_no_local_peers();
         // Ownership independence (Sol disposition case 6): shutting down ONLY
         // the OAuth inbound substrate must not disturb the process-global
@@ -297,7 +1036,17 @@ fn required_oauth_runtime_clients_reach_policy_and_discovery_over_iroh() -> Resu
         );
         assert!(!policy_socket.exists());
         assert!(!discovery_socket.exists());
+        model_server.shutdown().await?;
+        crate::services::oai_await_required_native_dependencies(
+            &model_client,
+            &registry_client,
+            Arc::new(tokio::sync::Notify::new()),
+            std::time::Duration::from_secs(2),
+        )
+        .await
+        .expect_err("an unreachable Model cannot satisfy bounded readiness");
         client_carrier.shutdown().await?;
+        registry_server.shutdown().await?;
         policy_server.shutdown().await?;
         discovery_server.shutdown().await?;
         anyhow::Ok(())

--- a/crates/hyprstream/src/services/policy.rs
+++ b/crates/hyprstream/src/services/policy.rs
@@ -2863,8 +2863,12 @@ impl PolicyHandler for PolicyService {
         // that path tenantless while using the explicit global domain for the
         // workload-session policy checks below. Tenant-bearing callers retain
         // their verified tenant binding.
-        let tenant = ctx.verified_tenant().map(str::to_owned);
-        let policy_domain = tenant.as_deref().unwrap_or("*");
+        let policy_domain = self.request_domain(ctx)?;
+        let tenant = if ctx.verified_tenant().is_some() {
+            Some(ctx.domain()?)
+        } else {
+            None
+        };
         let mut claims =
             renewed_service_claims(subject.clone(), now, expires_at, &issuer, tenant.as_deref(), &ctx.cnf);
 
@@ -2919,7 +2923,7 @@ impl PolicyHandler for PolicyService {
             .resolve_renewal_workload_session(
                 &issuer,
                 &subject,
-                policy_domain,
+                &policy_domain,
                 now,
                 family_policy,
                 old_wsid.as_deref(),

--- a/crates/hyprstream/src/services/policy.rs
+++ b/crates/hyprstream/src/services/policy.rs
@@ -586,12 +586,14 @@ fn renewed_service_claims(
     now: i64,
     expires_at: i64,
     issuer: &str,
-    tenant: String,
+    tenant: Option<&str>,
     cnf_key: &[u8; 32],
 ) -> hyprstream_rpc::auth::Claims {
     let mut claims = hyprstream_rpc::auth::Claims::new(subject, now, expires_at)
-        .with_tenant(tenant)
         .with_cnf_jwk(cnf_key);
+    if let Some(tenant) = tenant {
+        claims = claims.with_tenant(tenant.to_owned());
+    }
     if !issuer.is_empty() {
         claims = claims
             .with_issuer(issuer.to_owned())
@@ -2856,9 +2858,15 @@ impl PolicyHandler for PolicyService {
         }
 
         let issuer = self.default_audience.clone().unwrap_or_default();
-        let tenant = ctx.domain()?;
+        // Provisioned native service credentials are authenticated against the
+        // global Policy domain and intentionally carry no tenant claim. Keep
+        // that path tenantless while using the explicit global domain for the
+        // workload-session policy checks below. Tenant-bearing callers retain
+        // their verified tenant binding.
+        let tenant = ctx.verified_tenant().map(str::to_owned);
+        let policy_domain = tenant.as_deref().unwrap_or("*");
         let mut claims =
-            renewed_service_claims(subject.clone(), now, expires_at, &issuer, tenant.clone(), &ctx.cnf);
+            renewed_service_claims(subject.clone(), now, expires_at, &issuer, tenant.as_deref(), &ctx.cnf);
 
         // ServiceEnrollmentManifest (v16 §11): renewal re-derives clearance
         // from the manifest — authority removed from enrollment never
@@ -2911,7 +2919,7 @@ impl PolicyHandler for PolicyService {
             .resolve_renewal_workload_session(
                 &issuer,
                 &subject,
-                &tenant,
+                policy_domain,
                 now,
                 family_policy,
                 old_wsid.as_deref(),
@@ -4102,7 +4110,7 @@ mod tests {
             100,
             200,
             "http://localhost:9080",
-            "tenant-a.example".to_owned(),
+            Some("tenant-a.example"),
             &cnf,
         );
         assert_eq!(claims.iss, "http://localhost:9080");
@@ -4114,7 +4122,7 @@ mod tests {
             100,
             200,
             "",
-            "tenant-a.example".to_owned(),
+            Some("tenant-a.example"),
             &cnf,
         );
         assert!(bare.iss.is_empty());

--- a/crates/hyprstream/src/services/revocation.rs
+++ b/crates/hyprstream/src/services/revocation.rs
@@ -303,17 +303,22 @@ impl CredentialRevocationStore for PolicyAuthorityRevocationStore {
 ///
 /// When this process hosts the policy service (`hosts_policy`), it owns both
 /// canonical stores as durable files under the deployment data dir
-/// (`credential-revocations.jsonl`, `sessions.jsonl`). Every other process
-/// PROBES the authority (a freshly generated random credential ID, expected
-/// not revoked; and a random session key, expected not active) before
-/// publishing the RPC client stores. Both stores resolve a fresh
+/// (`credential-revocations.jsonl`, `sessions.jsonl`). Every compatibility-mode
+/// process PROBES the authority (a freshly generated random credential ID,
+/// expected not revoked; and a random session key, expected not active) before
+/// publishing the RPC client stores. In the required-native profile, Discovery
+/// starts before Policy so its resolver can publish the bootstrap announcement;
+/// non-Policy processes therefore publish lazy RPC client stores without a
+/// startup probe. Their first operation still fails closed until Policy is
+/// reachable. Both stores resolve a fresh
 /// [`PolicyClient`] per operation through the production resolver, so a
 /// renewed trust-store service JWT is consumed without a process restart.
 ///
-/// Fail-closed: any error — an unreadable/corrupt durable file, or an
-/// authority unreachable after [`PROBE_ATTEMPTS`] attempts — is propagated
-/// and MUST abort startup. A process that cannot check revocations or
-/// sessions must not serve credential verification.
+/// Fail-closed: any error in compatibility-mode probing — an unreadable/corrupt
+/// durable file, or an authority unreachable after [`PROBE_ATTEMPTS`] attempts
+/// — is propagated and MUST abort startup. Required-native clients retain the
+/// same fail-closed operation behavior while allowing the dependency-ordered
+/// Discovery → Policy bootstrap to complete.
 pub async fn init_process_authority_stores(
     ctx: &ServiceContext,
     signing_key: &SigningKey,
@@ -346,6 +351,23 @@ pub async fn init_process_authority_stores(
 
     let store = PolicyAuthorityRevocationStore::for_service(signing_key.clone());
     let sessions = PolicyAuthoritySessionRegistry::for_service(signing_key.clone());
+    // Required-native startup deliberately launches Discovery before Policy so
+    // the native resolver can publish the bootstrap announcement. A cold
+    // single-service child cannot synchronously probe Policy here without
+    // deadlocking that ordering. Publish the lazy clients; each operation
+    // continues to resolve Policy over authenticated Iroh and fails closed on
+    // an unavailable authority.
+    if ctx.iroh_required() {
+        hyprstream_rpc::auth::set_global_credential_revocation_store(Arc::new(store))
+            .map_err(|e| anyhow::anyhow!("{e}"))?;
+        hyprstream_rpc::auth::set_global_session_registry(Arc::new(sessions))
+            .map_err(|e| anyhow::anyhow!("{e}"))?;
+        tracing::info!(
+            "Required-native profile: lazy revocation/session authority clients published; Policy probe deferred"
+        );
+        return Ok(());
+    }
+
     let probe = CredentialId::jwt(
         "https://revocation-probe.invalid",
         format!("probe-{:032x}", rand::random::<u128>()),

--- a/crates/hyprstream/src/services/revocation.rs
+++ b/crates/hyprstream/src/services/revocation.rs
@@ -306,23 +306,28 @@ impl CredentialRevocationStore for PolicyAuthorityRevocationStore {
 /// (`credential-revocations.jsonl`, `sessions.jsonl`). Every compatibility-mode
 /// process PROBES the authority (a freshly generated random credential ID,
 /// expected not revoked; and a random session key, expected not active) before
-/// publishing the RPC client stores. In the required-native profile, Discovery
-/// starts before Policy so its resolver can publish the bootstrap announcement;
-/// non-Policy processes therefore publish lazy RPC client stores without a
-/// startup probe. Their first operation still fails closed until Policy is
-/// reachable. Both stores resolve a fresh
+/// publishing the RPC client stores. In the required-native profile, the
+/// standalone Discovery process starts before Policy so its resolver can
+/// publish the bootstrap announcement; that bootstrap process publishes lazy
+/// RPC client stores without a startup probe. Other service processes retain
+/// the startup probe and therefore do not report ready when Policy is
+/// unavailable. Lazy stores still fail closed on every operation. Both stores
+/// resolve a fresh
 /// [`PolicyClient`] per operation through the production resolver, so a
 /// renewed trust-store service JWT is consumed without a process restart.
 ///
 /// Fail-closed: any error in compatibility-mode probing — an unreadable/corrupt
 /// durable file, or an authority unreachable after [`PROBE_ATTEMPTS`] attempts
-/// — is propagated and MUST abort startup. Required-native clients retain the
-/// same fail-closed operation behavior while allowing the dependency-ordered
-/// Discovery → Policy bootstrap to complete.
+/// — is propagated and MUST abort startup. Required-native Discovery clients
+/// retain the same fail-closed operation behavior while allowing the
+/// dependency-ordered Discovery → Policy bootstrap to complete. Policy-
+/// dependent services keep the probe so a standalone service cannot become
+/// ready without its authority.
 pub async fn init_process_authority_stores(
     ctx: &ServiceContext,
     signing_key: &SigningKey,
     hosts_policy: bool,
+    defer_policy_probe: bool,
 ) -> anyhow::Result<()> {
     if hosts_policy {
         let data_dir = ctx.deployment_data_dir()?;
@@ -351,13 +356,11 @@ pub async fn init_process_authority_stores(
 
     let store = PolicyAuthorityRevocationStore::for_service(signing_key.clone());
     let sessions = PolicyAuthoritySessionRegistry::for_service(signing_key.clone());
-    // Required-native startup deliberately launches Discovery before Policy so
-    // the native resolver can publish the bootstrap announcement. A cold
-    // single-service child cannot synchronously probe Policy here without
-    // deadlocking that ordering. Publish the lazy clients; each operation
-    // continues to resolve Policy over authenticated Iroh and fails closed on
-    // an unavailable authority.
-    if ctx.iroh_required() {
+    // Required-native standalone Discovery launches before Policy so the native
+    // resolver can publish the bootstrap announcement. Only that bootstrap
+    // process may defer the probe; policy-dependent services must remain
+    // blocked until their authority is reachable.
+    if ctx.iroh_required() && defer_policy_probe {
         hyprstream_rpc::auth::set_global_credential_revocation_store(Arc::new(store))
             .map_err(|e| anyhow::anyhow!("{e}"))?;
         hyprstream_rpc::auth::set_global_session_registry(Arc::new(sessions))

--- a/docs/native-service-identity.md
+++ b/docs/native-service-identity.md
@@ -1,0 +1,58 @@
+# Required-native split-service identity
+
+A required-native foreground service selects its provisioned identity before
+installing the process resolver or constructing a client. That same key becomes
+the ServiceContext process identity and the named service key used to project
+checkpoint admission proofs. `--ipc` is not needed to select a service identity.
+
+For the eight-service staging roster, each container executes one of:
+
+```
+hyprstream service start event --foreground
+hyprstream service start discovery --foreground
+hyprstream service start policy --foreground
+hyprstream service start registry --foreground
+hyprstream service start streams --foreground
+hyprstream service start model --foreground
+hyprstream service start oai --foreground
+hyprstream service start oauth --foreground
+```
+
+Each uses the existing deployment configuration:
+
+```
+HYPRSTREAM__QUIC__ENABLED=true
+HYPRSTREAM__QUIC__IROH=true
+HYPRSTREAM__QUIC__NATIVE_NETWORK_PROFILE=network-iroh-required
+HYPRSTREAM__SECRETS__PATH=/var/lib/hyprstream/config/credentials
+HYPRSTREAM_SECRETS_PROFILE=shared-directory
+```
+
+The secrets profile defaults to `shared-directory`. Policy uses the canonical
+flat `credentials/signing-key`; other services use
+`credentials/SERVICE/signing-key`. With an explicitly scoped credential provider,
+`HYPRSTREAM_SECRETS_PROFILE=per-service-scoped` selects the flat `signing-key` in
+that service's configured directory. It must actually be scoped by the provider.
+Config-specified `[secrets].path` is honored by identity loading and service-start
+credential consumers; the existing secrets-path environment override retains
+precedence. Deployment trust, enrolled public anchors and required service JWTs
+must still be mounted/provisioned through their existing contracts.
+
+Startup reads the existing 32-byte seed. Missing or malformed service keys fail;
+startup does not generate a replacement, fall back to the CLI/Policy key, or
+create a CLI `.registry/keys` identity. Provisioning/keygen is a separate earlier
+step. No signing-key bypass is introduced.
+
+`service start --foreground --services model` selects `model`, not the command's
+synthetic `multi` name. Required-native foreground/standalone startup with more
+than one service is rejected before resolver installation: the process-global
+MoQL client proof currently represents one service identity. Launch separate
+containers. Compatibility-profile identity selection and its existing transport
+flags retain their behavior.
+
+This change does not activate MAC policy, issue user/service grants, solve the
+cold-start authority cycle, provision CLI proofs/PEPs, or implement credential
+renewal. It neither changes Policy's canonical identity nor resolves #1506's
+AsOriginator/RFC8693 decision. Streams PR1583 and Event PR1581 remain prerequisites;
+real staging authorization and crosshost probes still require the other tracked
+source and deployment work.

--- a/docs/service-runtime-architecture.md
+++ b/docs/service-runtime-architecture.md
@@ -137,7 +137,10 @@ impl Spawnable for OAIService {
             .build()?;
 
         rt.block_on(async move {
-            // Signal ready immediately (don't block on slow operations)
+            // Compatibility mode can signal ready after binding HTTP. Required
+            // mode first completes bounded Model reachability/tenant-denial
+            // and Registry health RPCs through the process-owned bootstrap
+            // Iroh endpoint.
             if let Some(tx) = on_ready {
                 let _ = tx.send(());
             }


### PR DESCRIPTION
Required-native background launches could drop an explicit configuration, force child services into Compatibility IPC, select the wrong identity, and report success before the intended service was ready. This change carries the validated configuration and retained service identity into each child and waits for its actual startup boundary.

The launcher canonicalizes and forwards `--config` as native `OsString` arguments, preserving valid non-UTF-8 Unix paths. It pins the loaded configuration before resolver/factory construction, selects each Required foreground service's provisioned key, and carries the resolved secrets directory through trust seeding, JWT registration, and renewal. Missing, malformed, ambiguous, or classical-only Required credentials fail closed. Each Required child runs one service without `--ipc`; every explicitly selected service is validated before any child spawns. Defaults omit the removed notification service and include Flight/Metrics only with their compiled factories.

Readiness follows the service implementation. Native publishers bind and initially publish; OAuth binds its native and HTTP listeners. OAI pre-binds HTTP/TLS, retains its process-owned Iroh bootstrap carrier, and checks production Model and Registry dependencies before READY. Model must return the exact authenticated tenantless denial and Registry must return typed `healthy`, including the live Policy authorization path. The Model response proves authenticated reachability, not permission to perform business operations. OAI remains in the identity roster but no longer advertises a nonexistent inbound RPC endpoint.

On Linux/Android, process notification uses a compact abstract datagram address independent of runtime-path length. `SO_PASSCRED`/`SCM_CREDENTIALS` identify the exact spawned PID; the random address is not an authentication control. Collision handling, READY matching, child-exit observation, cancellation, and deadlines remain bounded. This local lifecycle channel is separate from service RPC. Other operating systems retain pre-spawn refusal for this notification mechanism.

The supervisor starts services in dependency order, stops later stages on failure, rolls back earlier children, and reports cleanup errors alongside the original failure. Stable advisory locking serializes same-service launches; live or ambiguous PID witnesses are refused, PID publication is exclusive and atomic, and matching artifacts are removed after confirmed termination. Explicit unlock handles retained duplicate descriptors. Compatibility retains its existing IPC/immediate behavior. Installed fixed systemd units reject Required or explicit-config launches they cannot represent; permitted Compatibility starts must reach their notify-active state.

Test fixtures retain real encrypted Iroh, PGlite, UserStore sealing, and the external `age` executable. They use an explicit test-only age pair instead of requiring `age-keygen`; file-local test annotations preserve the repository's loopback policy without changing its baseline.

Validation at `717d429a6c690075bff375d8cd912ac1fd6cfe9c` (tree `dca2aadca243064a55e19c34660a5b37a4883871`, containing main `aa160c57304995df3489c3fd5e3eaee30925b55d`):

- Final four-crate/all-target nextest: **3,420 passed, 8 skipped**, 54.036 seconds; Cargo and both wrappers exited 0.
- Installed workspace/all-target release-Clippy hook passed. Seven focused default-profile tests passed, including real child argv, non-UTF-8 Clap/config handling, available defaults, and zero-spawn rejection of unknown selections.
- Causal suite coverage includes provisioned identity/READY, real Model and Registry/Policy transactions, persisted-deny precedence, unavailable dependencies/listeners, cancellation, rollback, exact-PID spoof rejection, long runtime paths, and a foreign-datagram flood.
- Independent FIRST/security and SECOND source reviews passed with zero findings. Review receipt SHA-256 values: `8ddad1dc0943d210403891819948468a44c5658195368fbca011005768ee40c4` and `4bc9906fd37a4d749a0c4c5eca8989b1384ffb83447c23218f2030ea664cbb6e`.

A fresh full ARM64 preflight remains required before queueing. The metrics-only profile cannot currently build on main: `credential-pds` is mandatory and implies PGlite, which conflicts with Metrics. Its roster runtime check remains required after PR1591 merges and is integrated; no guard was weakened to run it here.

Synchronous startup cleanup remains best effort when the OS cannot confirm termination. This PR does not activate production MAC policy, issue new grants, decide #1506, prove Model business authorization, or establish deployed MoQ, cross-host Iroh, website login, or staging acceptance.
