### PR TITLE
Use runner cache and enforce Graviton guest artifacts

### DIFF
--- a/.github/scripts/graviton-build-test.sh
+++ b/.github/scripts/graviton-build-test.sh
@@ -17,6 +17,34 @@ export RUSTUP_HOME=/root/.rustup
 export SCCACHE_DIR="${PWD}/.sccache"
 mkdir -p "${SCCACHE_DIR}"
 
+# These are standalone workspaces, so Cargo's default target directory is
+# relative to each guest crate.  When the CI workflow supplies a shared target
+# directory, Cargo resolves a relative value from the crate's working
+# directory and an absolute value verbatim.  Keep that resolution in one
+# place so the artifacts we hand to the guest tests are the artifacts the
+# preceding Cargo commands actually produced.
+guest_target_dir() {
+  local crate_dir="$1"
+  if [[ -n "${CARGO_TARGET_DIR:-}" ]]; then
+    if [[ "${CARGO_TARGET_DIR}" = /* ]]; then
+      printf '%s\n' "${CARGO_TARGET_DIR}"
+    else
+      printf '%s/%s\n' "${crate_dir}" "${CARGO_TARGET_DIR}"
+    fi
+  else
+    printf '%s/target\n' "${crate_dir}"
+  fi
+}
+
+require_guest_artifact() {
+  local label="$1"
+  local artifact="$2"
+  if [[ ! -r "${artifact}" || ! -s "${artifact}" ]]; then
+    echo "${label} guest artifact is missing, unreadable, or empty: ${artifact}" >&2
+    return 1
+  fi
+}
+
 # Same-filesystem TMPDIR: the overlay_fsmount tests rename across layers, which
 # fails EXDEV (cross-device link) when temp dirs land on /tmp (tmpfs) while the
 # workspace is on another filesystem. Keep temp on the workspace fs.
@@ -76,8 +104,12 @@ run_phase "Python guest WASM build" bash -c \
   'cd crates/hyprstream-workers-python-guest && cargo build --release --target wasm32-unknown-unknown'
 run_phase "Wasmtime guest WASM build" bash -c \
   'cd crates/hyprstream-workers-wasmtime-fsguest && cargo build --release --target wasm32-wasip1'
-export HYPRSTREAM_PYGUEST_WASM="${PWD}/crates/hyprstream-workers-python-guest/target/wasm32-unknown-unknown/release/hyprstream_workers_python_guest.wasm"
-export HYPRSTREAM_FSGUEST_WASM="${PWD}/crates/hyprstream-workers-wasmtime-fsguest/target/wasm32-wasip1/release/hyprstream-workers-wasmtime-fsguest.wasm"
+PYTHON_GUEST_DIR="${PWD}/crates/hyprstream-workers-python-guest"
+FSGUEST_DIR="${PWD}/crates/hyprstream-workers-wasmtime-fsguest"
+export HYPRSTREAM_PYGUEST_WASM="$(guest_target_dir "${PYTHON_GUEST_DIR}")/wasm32-unknown-unknown/release/hyprstream_workers_python_guest.wasm"
+export HYPRSTREAM_FSGUEST_WASM="$(guest_target_dir "${FSGUEST_DIR}")/wasm32-wasip1/release/hyprstream-workers-wasmtime-fsguest.wasm"
+require_guest_artifact "Python" "${HYPRSTREAM_PYGUEST_WASM}"
+require_guest_artifact "Wasmtime" "${HYPRSTREAM_FSGUEST_WASM}"
 
 # nextest ci profile enforces the per-test slow-timeout from .config/nextest.toml;
 # fail-fast (the default) is what the merge gate wants.

--- a/.github/workflows/merge-gate-preflight.yml
+++ b/.github/workflows/merge-gate-preflight.yml
@@ -112,6 +112,26 @@ jobs:
     - name: Pull builder image
       run: podman pull "$BUILDER_IMAGE"
 
+    # Match the required Graviton gate's dedicated persistent Cargo target.
+    # Fail before the expensive container build if the runner did not mount the
+    # provisioned cache; never create a root-backed fallback on the workspace.
+    - name: Verify preflight Cargo cache mount
+      run: |
+        set -euo pipefail
+        echo "workspace filesystem"
+        df -h "$PWD"
+        df -i "$PWD"
+        if [[ ! -e /mnt/hypr-ci-cache ]]; then
+          echo "required cache path is absent: /mnt/hypr-ci-cache" >&2
+          exit 1
+        fi
+        echo "Cargo cache filesystem"
+        df -h /mnt/hypr-ci-cache
+        df -i /mnt/hypr-ci-cache
+        mountpoint -q /mnt/hypr-ci-cache
+        test -d /mnt/hypr-ci-cache/target/hyprstream
+        test -w /mnt/hypr-ci-cache/target/hyprstream
+
     # The browser-WASM phase runs inside graviton-build-test.sh as the non-root
     # ci user. Install Chromium and its matching driver while the container is
     # still root so the real browser test can execute instead of failing when
@@ -122,23 +142,30 @@ jobs:
 
     - name: Build + test (release, in rust-builder container)
       run: |
+        # The runner's IaC must label this existing cache container_file_t;
+        # do not relabel the whole cache with :Z or disable confinement.
         podman run --rm \
           -v "$PWD":/build:Z -w /build \
+          -v /mnt/hypr-ci-cache:/mnt/hypr-ci-cache \
           -e RUSTC_WRAPPER=sccache -e SCCACHE_BUCKET -e SCCACHE_REGION \
           -e SCCACHE_IDLE_TIMEOUT=0 \
           -e AWS_ACCESS_KEY_ID -e AWS_SECRET_ACCESS_KEY -e AWS_SESSION_TOKEN \
           -e AWS_REGION -e AWS_DEFAULT_REGION \
           -e LIBTORCH=/opt/libtorch -e LD_LIBRARY_PATH=/opt/libtorch/lib \
           -e LIBTORCH_BYPASS_VERSION_CHECK=1 -e OPENSSL_NO_VENDOR=1 \
+          -e CARGO_TARGET_DIR=/mnt/hypr-ci-cache/target/hyprstream \
           -e CARGO_INCREMENTAL=0 -e CARGO_TERM_COLOR=always \
           -e BROWSER_ATTEST_NONCE \
           "$BUILDER_IMAGE" \
           bash -euo pipefail -c '
             bash /build/.github/scripts/install-chromium.sh
+            test -d /mnt/hypr-ci-cache/target/hyprstream
+            test -w /mnt/hypr-ci-cache/target/hyprstream
             useradd -m ci
             chmod a+rx /root
             chmod -R a+rwX /root/.cargo /root/.rustup
             chown -R ci:ci /build
+            runuser -u ci -- test -w /mnt/hypr-ci-cache/target/hyprstream
             runuser -u ci -- bash -euo pipefail /build/.github/scripts/graviton-build-test.sh
           '
 

--- a/.github/workflows/merge-gate-preflight.yml
+++ b/.github/workflows/merge-gate-preflight.yml
@@ -154,7 +154,7 @@ jobs:
           -e LIBTORCH=/opt/libtorch -e LD_LIBRARY_PATH=/opt/libtorch/lib \
           -e LIBTORCH_BYPASS_VERSION_CHECK=1 -e OPENSSL_NO_VENDOR=1 \
           -e CARGO_TARGET_DIR=/mnt/hypr-ci-cache/target/hyprstream \
-          -e CARGO_INCREMENTAL=0 -e CARGO_TERM_COLOR=always \
+          -e CARGO_INCREMENTAL=0 -e CARGO_TERM_COLOR=always -e CI=true \
           -e BROWSER_ATTEST_NONCE \
           "$BUILDER_IMAGE" \
           bash -euo pipefail -c '

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -323,7 +323,7 @@ jobs:
           -e LIBTORCH=/opt/libtorch -e LD_LIBRARY_PATH=/opt/libtorch/lib \
           -e LIBTORCH_BYPASS_VERSION_CHECK=1 -e OPENSSL_NO_VENDOR=1 \
           -e CARGO_TARGET_DIR=/mnt/hypr-ci-cache/target/hyprstream \
-          -e CARGO_INCREMENTAL=0 -e CARGO_TERM_COLOR=always \
+          -e CARGO_INCREMENTAL=0 -e CARGO_TERM_COLOR=always -e CI=true \
           -e BROWSER_ATTEST_NONCE \
           "$BUILDER_IMAGE" \
           bash -euo pipefail -c '


### PR DESCRIPTION
## Problem
The Graviton required and preflight containers use a shared `CARGO_TARGET_DIR`, but the guest artifact paths in `graviton-build-test.sh` were crate-local. The guest helper guards could therefore see missing paths, and the containers did not explicitly forward `CI`.

## Change
- Resolve each standalone guest artifact from the actual Cargo target directory, honoring absolute and relative overrides and retaining the crate-local default when unset.
- Fail closed on missing, unreadable, or empty guest artifacts before nextest.
- Pass `CI=true` into both the required build and preflight containers so the existing CI guards execute.

The companion metal change in MR `fix/preflight-cache-labels` applies the existing SELinux cache labeling post-install template to the preflight runner. It must be reviewed and applied before a fresh preflight is used.

## Validation
- Exact changed artifact guard: missing and empty fixtures fail before the post-guard marker; valid fixture passes.
- Final local four-crate all-target nextest: 3357 passed, 8 skipped.
- Installed release Clippy hook passed on the corrected source.

Local validation cannot prove the arm64 runner mount, SELinux labeling, or hosted preflight execution. No hosted preflight was dispatched by this change.
