### PR TITLE
Draft: Bind native arm64 images to source revision

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -323,6 +323,8 @@ jobs:
         TAGS: ${{ steps.meta.outputs.tags }}
       run: |
         set -euo pipefail
+        revision=$(git rev-parse HEAD)
+        test "$revision" = "$GITHUB_SHA"
         mkdir -p "$PODMAN_ROOT" "$PODMAN_RUNROOT"
         # Turn the newline-separated tag list into repeated `-t` args.
         tag_args=()
@@ -340,9 +342,16 @@ jobs:
         podman --root "$PODMAN_ROOT" --runroot "$PODMAN_RUNROOT" build \
           --target runtime \
           --build-arg VARIANT=cpu-arm64 \
+          --label "org.opencontainers.image.revision=$revision" \
           "${tag_args[@]}" \
           -f Dockerfile \
           .
+        # Staging pins the arm64 child digest only after checking this label.
+        # Refuse publication if the built image does not identify our source.
+        built_revision=$(podman --root "$PODMAN_ROOT" --runroot "$PODMAN_RUNROOT" \
+          image inspect --format '{{ index .Config.Labels "org.opencontainers.image.revision" }}' \
+          "${tag_args[1]}")
+        test "$built_revision" = "$revision"
 
     - name: Push image tags
       if: github.event_name != 'pull_request'


### PR DESCRIPTION
The native arm64 image job did not bind and verify its triggering source revision in the built image. Require checked-out `HEAD` to equal `GITHUB_SHA`, set `org.opencontainers.image.revision` on the runtime image, and inspect that label before pushing.

Integrated onto main `d2f3b279` as `bfdebe817f60bb8e6a16effc9716558729fa8c48`. The nine-line workflow change is unchanged from its reviewed predecessor.

Validation: four causal command-boundary cases passed; installed release Clippy passed; final local four-crate all-target nextest passed **3,361 tests, 8 skipped**. The earlier authority-fixture failure is preserved in the evidence and resolved by integration of merged PR1594.

Actual ARM image publication and OCI index/child-digest/source-label readback remain deployment gates. This change alone does not establish staging readiness.
