### PR TITLE
Scope the ARM Metrics release build to its production binary

### DIFF
--- a/.github/scripts/graviton-build-test.sh
+++ b/.github/scripts/graviton-build-test.sh
@@ -101,7 +101,7 @@ run_phase "native release build" cargo build --release
 # marker and without PGlite. Exercise both its production binary and typed
 # handler tests in the required merge/preflight path; the default build above
 # cannot compile this mutually exclusive profile.
-run_phase "Metrics release build" cargo build --locked --release --no-default-features --features metrics
+run_phase "Metrics release build" cargo build -p hyprstream --bin hyprstream --locked --release --no-default-features --features metrics
 run_phase "Metrics typed handler tests" cargo test -p hyprstream --locked --lib --no-default-features --features metrics services::metrics::tests::
 
 # wasm guest artifacts for the sandbox/mount tests (deny-on-missing-guest guard).


### PR DESCRIPTION
The ARM Metrics release phase currently selects the virtual workspace, although it is intended to build the standalone Hyprstream Metrics binary. Select `-p hyprstream --bin hyprstream` explicitly while retaining the locked release Metrics profile.

The default workspace release build, full nextest and doctests, typed Metrics handler tests, and browser/guest checks remain unchanged. Local validation passed: installed release Clippy and four-crate all-target nextest (3,361 passed, 8 skipped). Actual ARM execution remains the required merge-group gate; timing savings have not yet been measured.
