### PR TITLE
feat(pds): add explicit public AT CBOR codec boundary

### DIFF
--- a/crates/hyprstream-pds/src/atproto_cbor.rs
+++ b/crates/hyprstream-pds/src/atproto_cbor.rs
@@ -488,6 +488,12 @@ mod tests {
             .map(|(_, data)| (Cid::from_dag_cbor(b"wrong label"), data.clone()))
             .collect::<Vec<_>>();
         assert!(build_public_record_proof_car(&commit, &proof, &mislabeled, &record).is_err());
+
+        let native_commit = Commit::sign(&unsigned, &signing);
+        assert!(
+            build_public_record_proof_car(&native_commit, &proof, &node_blocks, &record).is_err(),
+            "native-signed commits must not be emitted as public proof CARs"
+        );
     }
 
     #[test]

--- a/crates/hyprstream-pds/src/atproto_cbor.rs
+++ b/crates/hyprstream-pds/src/atproto_cbor.rs
@@ -459,6 +459,29 @@ mod tests {
             .iter()
             .any(|(cid, bytes)| *cid == commit.cid_atproto().unwrap()
                 && bytes == &commit.to_atproto_dag_cbor().unwrap()));
+
+        let empty = crate::mst::Proof { path: Vec::new() };
+        assert!(build_public_record_proof_car(&commit, &empty, &node_blocks, &record).is_err());
+
+        let wrong_unsigned = UnsignedCommit::new(
+            "did:web:tormentnexus.social",
+            Cid::from_dag_cbor(b"wrong public root"),
+            Tid::from_raw(9),
+            None,
+        );
+        let wrong_commit = Commit::sign_atproto(&wrong_unsigned, &signing).unwrap();
+        assert!(
+            build_public_record_proof_car(&wrong_commit, &proof, &node_blocks, &record).is_err()
+        );
+
+        // The record bytes/CID are identical, but its record key is different.
+        // A proof must remain bound to the collection/rkey path.
+        let wrong_record =
+            AtprotoRecord::new("app.bsky.feed.post", Tid::from_raw(9), post()).unwrap();
+        assert!(
+            build_public_record_proof_car(&commit, &proof, &node_blocks, &wrong_record).is_err()
+        );
+
         assert!(build_public_record_proof_car(&commit, &proof, &[], &record).is_err());
         let mislabeled = node_blocks
             .iter()

--- a/crates/hyprstream-pds/src/atproto_cbor.rs
+++ b/crates/hyprstream-pds/src/atproto_cbor.rs
@@ -13,7 +13,7 @@
 
 use std::cmp::Ordering;
 
-use anyhow::{Result, ensure};
+use anyhow::{ensure, Result};
 
 use crate::cid::Cid;
 use crate::dag_cbor::DagCbor;
@@ -268,11 +268,11 @@ mod tests {
     #![allow(clippy::unwrap_used, clippy::expect_used, clippy::indexing_slicing)]
 
     use super::*;
-    use crate::Cid;
     use crate::car::{build_public_record_proof_car, parse_car_v1_atproto};
     use crate::commit::{Commit, UnsignedCommit};
     use crate::mst::Node;
     use crate::tid::Tid;
+    use crate::Cid;
     use p256::ecdsa::SigningKey;
 
     fn post() -> DagCbor {
@@ -362,16 +362,14 @@ mod tests {
         }
         assert!(validate_nsid(&format!("com.{}.record", "a".repeat(64))).is_err());
         assert!(validate_nsid(&format!("com.example.{}", "a".repeat(64))).is_err());
-        assert!(
-            validate_nsid(&format!(
-                "{}.{}.{}.{}.record",
-                "a".repeat(63),
-                "b".repeat(63),
-                "c".repeat(63),
-                "d".repeat(63),
-            ))
-            .is_err()
-        );
+        assert!(validate_nsid(&format!(
+            "{}.{}.{}.{}.record",
+            "a".repeat(63),
+            "b".repeat(63),
+            "c".repeat(63),
+            "d".repeat(63),
+        ))
+        .is_err());
     }
 
     #[test]
@@ -454,17 +452,13 @@ mod tests {
         let car = build_public_record_proof_car(&commit, &proof, &node_blocks, &record).unwrap();
         let (roots, blocks) = parse_car_v1_atproto(&car).unwrap();
         assert_eq!(roots, vec![commit.cid_atproto().unwrap()]);
-        assert!(
-            blocks
-                .iter()
-                .any(|(cid, bytes)| *cid == record.cid() && bytes == record.bytes())
-        );
-        assert!(
-            blocks
-                .iter()
-                .any(|(cid, bytes)| *cid == commit.cid_atproto().unwrap()
-                    && bytes == &commit.to_atproto_dag_cbor().unwrap())
-        );
+        assert!(blocks
+            .iter()
+            .any(|(cid, bytes)| *cid == record.cid() && bytes == record.bytes()));
+        assert!(blocks
+            .iter()
+            .any(|(cid, bytes)| *cid == commit.cid_atproto().unwrap()
+                && bytes == &commit.to_atproto_dag_cbor().unwrap()));
 
         let empty = crate::mst::Proof { path: Vec::new() };
         assert!(build_public_record_proof_car(&commit, &empty, &node_blocks, &record).is_err());
@@ -509,6 +503,13 @@ mod tests {
         assert!(
             build_public_record_proof_car(&laundered, &proof, &node_blocks, &record).is_err(),
             "decoding canonical bytes must not launder native signature provenance"
+        );
+
+        let mut unsupported_unsigned = unsigned.clone();
+        unsupported_unsigned.version = 4;
+        assert!(
+            Commit::sign_atproto(&unsupported_unsigned, &signing).is_err(),
+            "public signing must reject unsupported commit versions"
         );
 
         let mut mutated_public_commit = commit.clone();

--- a/crates/hyprstream-pds/src/atproto_cbor.rs
+++ b/crates/hyprstream-pds/src/atproto_cbor.rs
@@ -459,6 +459,12 @@ mod tests {
             .iter()
             .any(|(cid, bytes)| *cid == commit.cid_atproto().unwrap()
                 && bytes == &commit.to_atproto_dag_cbor().unwrap()));
+        assert!(build_public_record_proof_car(&commit, &proof, &[], &record).is_err());
+        let mislabeled = node_blocks
+            .iter()
+            .map(|(_, data)| (Cid::from_dag_cbor(b"wrong label"), data.clone()))
+            .collect::<Vec<_>>();
+        assert!(build_public_record_proof_car(&commit, &proof, &mislabeled, &record).is_err());
     }
 
     #[test]

--- a/crates/hyprstream-pds/src/atproto_cbor.rs
+++ b/crates/hyprstream-pds/src/atproto_cbor.rs
@@ -1,0 +1,192 @@
+//! Explicit public AT Protocol CBOR boundary over the existing value type.
+//!
+//! Public DAG-CBOR orders text map keys by encoded bytes: UTF-8 byte length
+//! first, then lexical bytes. The existing native codec has a different order
+//! and is retained for already-signed artifacts. Neither decoder falls back to
+//! the other's order. This module does not change existing record, commit, MST
+//! or identity call sites, and does not establish public repository readiness.
+//!
+//! Integer-only AT data uses signed 64-bit integers. The public encoder checks
+//! this and validates map structure/depth before invoking the existing scalar
+//! writer. The decoder retains minimal-width, tag, UTF-8, duplicate-key and
+//! bounded-depth checks. Floats remain unsupported by the AT data model.
+
+use std::cmp::Ordering;
+
+use anyhow::{ensure, Result};
+
+use crate::dag_cbor::DagCbor;
+
+const MAX_DEPTH: usize = 128;
+
+fn key_order(a: &[u8], b: &[u8]) -> Ordering {
+    a.len().cmp(&b.len()).then_with(|| a.cmp(b))
+}
+
+/// Encode a value in the public AT Protocol format without mutating it.
+/// This is canonical serialization, not schema validation or authorization.
+pub fn encode(value: &DagCbor) -> Result<Vec<u8>> {
+    Ok(normalize(value, 0)?.encode())
+}
+
+/// Decode exactly one strictly canonical public AT Protocol value.
+/// No legacy/native ordering fallback is permitted.
+pub fn decode(bytes: &[u8]) -> Result<DagCbor> {
+    let value = DagCbor::decode_with_order(bytes, key_order)?;
+    // Enforce signed integer bounds and the same construction constraints as
+    // encode; byte-level canonicality has already been checked by the parser.
+    normalize(&value, 0)
+}
+
+fn normalize(value: &DagCbor, depth: usize) -> Result<DagCbor> {
+    ensure!(
+        depth <= MAX_DEPTH,
+        "ATProto CBOR nesting exceeds {MAX_DEPTH}"
+    );
+    Ok(match value {
+        DagCbor::Unsigned(n) => {
+            ensure!(
+                *n <= i64::MAX as u64,
+                "ATProto integer exceeds signed 64-bit range"
+            );
+            value.clone()
+        }
+        DagCbor::Negative(n) => {
+            ensure!(
+                *n >= i64::MIN as i128 && *n < 0,
+                "ATProto negative integer outside signed 64-bit range"
+            );
+            value.clone()
+        }
+        DagCbor::List(items) => DagCbor::List(
+            items
+                .iter()
+                .map(|item| normalize(item, depth + 1))
+                .collect::<Result<_>>()?,
+        ),
+        DagCbor::Map(pairs) => {
+            let mut normalized = Vec::with_capacity(pairs.len());
+            for (key, val) in pairs {
+                ensure!(depth < MAX_DEPTH, "ATProto CBOR map exceeds nesting limit");
+                let text = key.as_str()?;
+                normalized.push((text.to_owned(), normalize(val, depth + 1)?));
+            }
+            normalized.sort_by(|(a, _), (b, _)| key_order(a.as_bytes(), b.as_bytes()));
+            ensure!(
+                normalized.windows(2).all(|pair| pair[0].0 != pair[1].0),
+                "duplicate ATProto CBOR map key"
+            );
+            DagCbor::Map(
+                normalized
+                    .into_iter()
+                    .map(|(k, v)| (DagCbor::Text(k), v))
+                    .collect(),
+            )
+        }
+        _ => value.clone(),
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    #![allow(clippy::unwrap_used, clippy::expect_used, clippy::indexing_slicing)]
+
+    use super::*;
+    use crate::Cid;
+
+    fn post() -> DagCbor {
+        DagCbor::str_map([
+            ("$type", DagCbor::Text("app.bsky.feed.post".into())),
+            ("text", DagCbor::Text("Hello from Torment Nexus".into())),
+            (
+                "createdAt",
+                DagCbor::Text("2026-09-09T00:00:00.000Z".into()),
+            ),
+        ])
+    }
+
+    #[test]
+    fn public_post_matches_upstream_bytes_and_cid() {
+        // Generated independently with @atproto/lex-cbor 0.1.6 encode/cidForLex.
+        let upstream = hex::decode("a36474657874781848656c6c6f2066726f6d20546f726d656e74204e65787573652474797065726170702e62736b792e666565642e706f7374696372656174656441747818323032362d30392d30395430303a30303a30302e3030305a").unwrap();
+        let bytes = encode(&post()).unwrap();
+        assert_eq!(bytes, upstream);
+        assert_eq!(
+            Cid::from_dag_cbor(&bytes).to_string(),
+            "bafyreiaapk47b4fmdslcizkj5aj6ws6bmpmvfvjq3ryhx5qwgug6tldalm"
+        );
+        assert_eq!(encode(&decode(&bytes).unwrap()).unwrap(), bytes);
+    }
+
+    #[test]
+    fn native_bytes_and_strict_verifier_remain_separate() {
+        let value = DagCbor::str_map([("aa", DagCbor::Unsigned(1)), ("b", DagCbor::Unsigned(2))]);
+        let native = hex::decode("a262616101616202").unwrap();
+        let public = hex::decode("a261620262616101").unwrap();
+        assert_eq!(value.encode(), native);
+        assert_eq!(DagCbor::decode(&native).unwrap(), value);
+        assert_eq!(encode(&value).unwrap(), public);
+        assert!(DagCbor::decode(&public).is_err());
+        assert!(decode(&native).is_err());
+    }
+
+    #[test]
+    fn public_order_applies_to_nested_maps_and_utf8_byte_lengths() {
+        let inner = DagCbor::str_map([("é", DagCbor::Bool(true)), ("z", DagCbor::Bool(false))]);
+        let value = DagCbor::list([inner]);
+        assert_eq!(hex::encode(encode(&value).unwrap()), "81a2617af462c3a9f5");
+        assert_eq!(
+            encode(&decode(&encode(&value).unwrap()).unwrap()).unwrap(),
+            encode(&value).unwrap()
+        );
+    }
+
+    #[test]
+    fn malformed_construction_is_rejected_without_panic() {
+        for value in [
+            DagCbor::Negative(0),
+            DagCbor::Negative(i128::MIN),
+            DagCbor::Unsigned(u64::MAX),
+            DagCbor::Map(vec![(DagCbor::Bool(true), DagCbor::Null)]),
+            DagCbor::Map(vec![(DagCbor::Text("a".into()), DagCbor::Null); 2]),
+        ] {
+            assert!(encode(&value).is_err());
+        }
+    }
+
+    #[test]
+    fn decoder_retains_strictness_and_integer_bounds() {
+        for wire in [
+            "a2616101616102",     // duplicate keys
+            "1817",               // nonminimal integer
+            "00ff",               // trailing data
+            "9fff",               // indefinite array
+            "c000",               // unsupported tag
+            "61ff",               // invalid UTF-8
+            "1b8000000000000000", // outside signed integer range
+            "3b8000000000000000", // below signed integer range
+        ] {
+            assert!(decode(&hex::decode(wire).unwrap()).is_err(), "{wire}");
+        }
+    }
+
+    #[test]
+    fn links_and_signed_integer_extremes_round_trip() {
+        let value = DagCbor::list([
+            DagCbor::Link(Cid::from_raw(b"public blob")),
+            DagCbor::Unsigned(i64::MAX as u64),
+            DagCbor::Negative(i64::MIN as i128),
+        ]);
+        assert_eq!(decode(&encode(&value).unwrap()).unwrap(), value);
+    }
+
+    #[test]
+    fn excessive_nesting_is_rejected() {
+        let mut value = DagCbor::Null;
+        for _ in 0..130 {
+            value = DagCbor::list([value]);
+        }
+        assert!(encode(&value).is_err());
+        assert!(decode(&value.encode()).is_err());
+    }
+}

--- a/crates/hyprstream-pds/src/atproto_cbor.rs
+++ b/crates/hyprstream-pds/src/atproto_cbor.rs
@@ -15,9 +15,102 @@ use std::cmp::Ordering;
 
 use anyhow::{ensure, Result};
 
+use crate::cid::Cid;
 use crate::dag_cbor::DagCbor;
+use crate::tid::Tid;
 
 const MAX_DEPTH: usize = 128;
+
+/// A generic public AT Protocol repository record.
+///
+/// The value is retained as a typed DAG-CBOR value and its exact public bytes
+/// and CID are derived once at construction. This is deliberately independent
+/// of native `ModelRecord`: any supported collection can be stored without
+/// converting through a lossy JSON DTO. Construction validates the collection,
+/// TID record key, `$type` discriminator and canonical public bytes; it does
+/// not grant write authority or perform a full Lexicon validation.
+#[derive(Clone, Debug, PartialEq)]
+pub struct AtprotoRecord {
+    pub collection: String,
+    pub rkey: Tid,
+    pub value: DagCbor,
+    bytes: Vec<u8>,
+    cid: Cid,
+}
+
+impl AtprotoRecord {
+    pub fn new(collection: impl Into<String>, rkey: Tid, value: DagCbor) -> Result<Self> {
+        let collection = collection.into();
+        validate_nsid(&collection)?;
+        let type_value = value
+            .get("$type")
+            .ok_or_else(|| anyhow::anyhow!("AT record is missing $type"))?
+            .as_str()?;
+        ensure!(
+            type_value == collection,
+            "AT record $type does not match collection"
+        );
+        let bytes = encode(&value)?;
+        let cid = Cid::from_dag_cbor(&bytes);
+        Ok(Self {
+            collection,
+            rkey,
+            value,
+            bytes,
+            cid,
+        })
+    }
+
+    /// Reconstruct a record only when bytes are already strict public
+    /// canonical encoding. This check prevents a caller from changing the CID
+    /// by normalizing at a later boundary.
+    pub fn from_bytes(collection: impl Into<String>, rkey: Tid, bytes: &[u8]) -> Result<Self> {
+        let value = decode(bytes)?;
+        let record = Self::new(collection, rkey, value)?;
+        ensure!(record.bytes == bytes, "AT record bytes are not canonical");
+        Ok(record)
+    }
+
+    pub fn bytes(&self) -> &[u8] {
+        &self.bytes
+    }
+    pub fn cid(&self) -> Cid {
+        self.cid
+    }
+    pub fn uri(&self, did: &str) -> String {
+        format!("at://{did}/{}/{}", self.collection, self.rkey.encode())
+    }
+}
+
+fn validate_nsid(nsid: &str) -> Result<()> {
+    ensure!(
+        !nsid.is_empty() && nsid.len() <= 317,
+        "invalid AT collection NSID"
+    );
+    let mut segments = nsid.split('.');
+    let first = segments.next().unwrap_or_default();
+    ensure!(
+        !first.is_empty()
+            && first
+                .chars()
+                .all(|c| c.is_ascii_lowercase() || c.is_ascii_digit() || c == '-'),
+        "invalid NSID authority"
+    );
+    for segment in segments {
+        ensure!(
+            !segment.is_empty()
+                && segment
+                    .chars()
+                    .all(|c| c.is_ascii_alphanumeric() || c == '-'),
+            "invalid NSID segment"
+        );
+    }
+    ensure!(
+        nsid.contains('.'),
+        "AT collection NSID needs a domain hierarchy"
+    );
+    Ok(())
+}
 
 fn key_order(a: &[u8], b: &[u8]) -> Ordering {
     a.len().cmp(&b.len()).then_with(|| a.cmp(b))
@@ -92,7 +185,12 @@ mod tests {
     #![allow(clippy::unwrap_used, clippy::expect_used, clippy::indexing_slicing)]
 
     use super::*;
+    use crate::car::{build_public_record_proof_car, parse_car_v1_atproto};
+    use crate::commit::{Commit, UnsignedCommit};
+    use crate::mst::Node;
+    use crate::tid::Tid;
     use crate::Cid;
+    use p256::ecdsa::SigningKey;
 
     fn post() -> DagCbor {
         DagCbor::str_map([
@@ -178,6 +276,39 @@ mod tests {
             DagCbor::Negative(i64::MIN as i128),
         ]);
         assert_eq!(decode(&encode(&value).unwrap()).unwrap(), value);
+    }
+
+    #[test]
+    fn public_record_mst_commit_and_car_proof_round_trip() {
+        let rkey = Tid::from_raw(7);
+        let record = AtprotoRecord::new("app.bsky.feed.post", rkey, post()).unwrap();
+        let tree = Node::from_keyed_records(
+            &[(
+                format!("app.bsky.feed.post/{}", rkey.encode()),
+                record.cid(),
+            )]
+            .into_iter()
+            .collect(),
+        );
+        let (root_data, node_blocks) = tree.to_node_data_with_blocks_atproto().unwrap();
+        let root = root_data.cid_atproto().unwrap();
+        let unsigned =
+            UnsignedCommit::new("did:web:tormentnexus.social", root, Tid::from_raw(8), None);
+        let signing = SigningKey::from_bytes((&[7u8; 32]).into()).unwrap();
+        let commit = Commit::sign_atproto(&unsigned, &signing).unwrap();
+        commit.verify_atproto(signing.verifying_key()).unwrap();
+        let proof = tree.proof_atproto("app.bsky.feed.post", &rkey).unwrap();
+        proof.verify_atproto(&root, &record.cid()).unwrap();
+        let car = build_public_record_proof_car(&commit, &proof, &node_blocks, &record).unwrap();
+        let (roots, blocks) = parse_car_v1_atproto(&car).unwrap();
+        assert_eq!(roots, vec![commit.cid_atproto().unwrap()]);
+        assert!(blocks
+            .iter()
+            .any(|(cid, bytes)| *cid == record.cid() && bytes == record.bytes()));
+        assert!(blocks
+            .iter()
+            .any(|(cid, bytes)| *cid == commit.cid_atproto().unwrap()
+                && bytes == &commit.to_atproto_dag_cbor().unwrap()));
     }
 
     #[test]

--- a/crates/hyprstream-pds/src/atproto_cbor.rs
+++ b/crates/hyprstream-pds/src/atproto_cbor.rs
@@ -21,26 +21,78 @@ use crate::tid::Tid;
 
 const MAX_DEPTH: usize = 128;
 
+/// A validated AT Protocol record key.
+///
+/// Record keys are user-controlled path segments. They may be TIDs, literal
+/// values such as `self`, NSIDs, or any other value permitted by the baseline
+/// record-key syntax; they are not limited to the TID format.
+#[derive(Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+pub struct AtprotoRecordKey(String);
+
+impl AtprotoRecordKey {
+    pub fn new(value: impl Into<String>) -> Result<Self> {
+        let value = value.into();
+        ensure!(
+            (1..=512).contains(&value.len())
+                && value.is_ascii()
+                && value != "."
+                && value != ".."
+                && value.bytes().all(|c| {
+                    c.is_ascii_alphanumeric() || matches!(c, b'.' | b'-' | b'_' | b':' | b'~')
+                }),
+            "invalid AT record key"
+        );
+        Ok(Self(value))
+    }
+
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl From<Tid> for AtprotoRecordKey {
+    fn from(value: Tid) -> Self {
+        Self(value.encode())
+    }
+}
+
+impl From<&Tid> for AtprotoRecordKey {
+    fn from(value: &Tid) -> Self {
+        Self::from(*value)
+    }
+}
+
+impl From<&AtprotoRecordKey> for AtprotoRecordKey {
+    fn from(value: &AtprotoRecordKey) -> Self {
+        value.clone()
+    }
+}
+
 /// A generic public AT Protocol repository record.
 ///
 /// The value is retained as a typed DAG-CBOR value and its exact public bytes
 /// and CID are derived once at construction. This is deliberately independent
 /// of native `ModelRecord`: any supported collection can be stored without
 /// converting through a lossy JSON DTO. Construction validates the collection,
-/// TID record key, `$type` discriminator and canonical public bytes; it does
+/// general record key, `$type` discriminator and canonical public bytes; it does
 /// not grant write authority or perform a full Lexicon validation.
 #[derive(Clone, Debug, PartialEq)]
 pub struct AtprotoRecord {
     collection: String,
-    rkey: Tid,
+    rkey: AtprotoRecordKey,
     value: DagCbor,
     bytes: Vec<u8>,
     cid: Cid,
 }
 
 impl AtprotoRecord {
-    pub fn new(collection: impl Into<String>, rkey: Tid, value: DagCbor) -> Result<Self> {
+    pub fn new(
+        collection: impl Into<String>,
+        rkey: impl Into<AtprotoRecordKey>,
+        value: DagCbor,
+    ) -> Result<Self> {
         let collection = collection.into();
+        let rkey: AtprotoRecordKey = rkey.into();
         validate_nsid(&collection)?;
         let type_value = value
             .get("$type")
@@ -64,7 +116,11 @@ impl AtprotoRecord {
     /// Reconstruct a record only when bytes are already strict public
     /// canonical encoding. This check prevents a caller from changing the CID
     /// by normalizing at a later boundary.
-    pub fn from_bytes(collection: impl Into<String>, rkey: Tid, bytes: &[u8]) -> Result<Self> {
+    pub fn from_bytes(
+        collection: impl Into<String>,
+        rkey: impl Into<AtprotoRecordKey>,
+        bytes: &[u8],
+    ) -> Result<Self> {
         let value = decode(bytes)?;
         let record = Self::new(collection, rkey, value)?;
         ensure!(record.bytes == bytes, "AT record bytes are not canonical");
@@ -82,8 +138,8 @@ impl AtprotoRecord {
     }
 
     /// The validated record key.
-    pub fn rkey(&self) -> Tid {
-        self.rkey
+    pub fn rkey(&self) -> &AtprotoRecordKey {
+        &self.rkey
     }
 
     /// The validated record value.
@@ -95,7 +151,7 @@ impl AtprotoRecord {
         self.cid
     }
     pub fn uri(&self, did: &str) -> String {
-        format!("at://{did}/{}/{}", self.collection, self.rkey.encode())
+        format!("at://{did}/{}/{}", self.collection, self.rkey.as_str())
     }
 }
 
@@ -320,9 +376,30 @@ mod tests {
     fn record_identity_fields_are_immutable_after_construction() {
         let record = AtprotoRecord::new("app.bsky.feed.post", Tid::from_raw(7), post()).unwrap();
         assert_eq!(record.collection(), "app.bsky.feed.post");
-        assert_eq!(record.rkey(), Tid::from_raw(7));
+        assert_eq!(record.rkey().as_str(), Tid::from_raw(7).encode());
         assert_eq!(record.value(), &post());
         assert_eq!(record.cid(), Cid::from_dag_cbor(record.bytes()));
+    }
+
+    #[test]
+    fn literal_record_key_is_preserved_in_public_proof_path() {
+        let collection = "app.bsky.actor.profile";
+        let key = AtprotoRecordKey::new("self").unwrap();
+        let value = DagCbor::str_map([("$type", DagCbor::Text(collection.to_owned()))]);
+        let record = AtprotoRecord::new(collection, &key, value).unwrap();
+        let mut records = std::collections::BTreeMap::new();
+        records.insert(format!("{collection}/self"), record.cid());
+        let tree = Node::from_keyed_records(&records);
+        let proof = tree.proof_atproto(collection, &key).unwrap();
+        let root = tree
+            .to_node_data_with_blocks_atproto()
+            .unwrap()
+            .0
+            .cid_atproto()
+            .unwrap();
+        proof.verify_atproto(&root, &record.cid()).unwrap();
+        assert_eq!(record.rkey().as_str(), "self");
+        assert!(AtprotoRecordKey::new(".").is_err());
     }
 
     #[test]
@@ -370,7 +447,7 @@ mod tests {
         let signing = SigningKey::from_bytes((&[7u8; 32]).into()).unwrap();
         let commit = Commit::sign_atproto(&unsigned, &signing).unwrap();
         commit.verify_atproto(signing.verifying_key()).unwrap();
-        let proof = tree.proof_atproto("app.bsky.feed.post", &rkey).unwrap();
+        let proof = tree.proof_atproto("app.bsky.feed.post", rkey).unwrap();
         proof.verify_atproto(&root, &record.cid()).unwrap();
         let car = build_public_record_proof_car(&commit, &proof, &node_blocks, &record).unwrap();
         let (roots, blocks) = parse_car_v1_atproto(&car).unwrap();

--- a/crates/hyprstream-pds/src/atproto_cbor.rs
+++ b/crates/hyprstream-pds/src/atproto_cbor.rs
@@ -13,7 +13,7 @@
 
 use std::cmp::Ordering;
 
-use anyhow::{ensure, Result};
+use anyhow::{Result, ensure};
 
 use crate::cid::Cid;
 use crate::dag_cbor::DagCbor;
@@ -268,11 +268,11 @@ mod tests {
     #![allow(clippy::unwrap_used, clippy::expect_used, clippy::indexing_slicing)]
 
     use super::*;
+    use crate::Cid;
     use crate::car::{build_public_record_proof_car, parse_car_v1_atproto};
     use crate::commit::{Commit, UnsignedCommit};
     use crate::mst::Node;
     use crate::tid::Tid;
-    use crate::Cid;
     use p256::ecdsa::SigningKey;
 
     fn post() -> DagCbor {
@@ -362,14 +362,16 @@ mod tests {
         }
         assert!(validate_nsid(&format!("com.{}.record", "a".repeat(64))).is_err());
         assert!(validate_nsid(&format!("com.example.{}", "a".repeat(64))).is_err());
-        assert!(validate_nsid(&format!(
-            "{}.{}.{}.{}.record",
-            "a".repeat(63),
-            "b".repeat(63),
-            "c".repeat(63),
-            "d".repeat(63),
-        ))
-        .is_err());
+        assert!(
+            validate_nsid(&format!(
+                "{}.{}.{}.{}.record",
+                "a".repeat(63),
+                "b".repeat(63),
+                "c".repeat(63),
+                "d".repeat(63),
+            ))
+            .is_err()
+        );
     }
 
     #[test]
@@ -452,13 +454,17 @@ mod tests {
         let car = build_public_record_proof_car(&commit, &proof, &node_blocks, &record).unwrap();
         let (roots, blocks) = parse_car_v1_atproto(&car).unwrap();
         assert_eq!(roots, vec![commit.cid_atproto().unwrap()]);
-        assert!(blocks
-            .iter()
-            .any(|(cid, bytes)| *cid == record.cid() && bytes == record.bytes()));
-        assert!(blocks
-            .iter()
-            .any(|(cid, bytes)| *cid == commit.cid_atproto().unwrap()
-                && bytes == &commit.to_atproto_dag_cbor().unwrap()));
+        assert!(
+            blocks
+                .iter()
+                .any(|(cid, bytes)| *cid == record.cid() && bytes == record.bytes())
+        );
+        assert!(
+            blocks
+                .iter()
+                .any(|(cid, bytes)| *cid == commit.cid_atproto().unwrap()
+                    && bytes == &commit.to_atproto_dag_cbor().unwrap())
+        );
 
         let empty = crate::mst::Proof { path: Vec::new() };
         assert!(build_public_record_proof_car(&commit, &empty, &node_blocks, &record).is_err());
@@ -493,6 +499,32 @@ mod tests {
         assert!(
             build_public_record_proof_car(&native_commit, &proof, &node_blocks, &record).is_err(),
             "native-signed commits must not be emitted as public proof CARs"
+        );
+        let laundered = Commit::from_atproto_dag_cbor(
+            &native_commit
+                .to_atproto_dag_cbor()
+                .expect("native commit can be encoded for the negative test"),
+        )
+        .expect("canonical public shape must decode structurally");
+        assert!(
+            build_public_record_proof_car(&laundered, &proof, &node_blocks, &record).is_err(),
+            "decoding canonical bytes must not launder native signature provenance"
+        );
+
+        let mut mutated_public_commit = commit.clone();
+        mutated_public_commit.rev = Tid::from_raw(10);
+        assert!(
+            build_public_record_proof_car(&mutated_public_commit, &proof, &node_blocks, &record)
+                .is_err(),
+            "public CAR publication must reject a commit whose signed fields were mutated"
+        );
+
+        let mut mutated_public_signature = commit.clone();
+        mutated_public_signature.sig[0] ^= 1;
+        assert!(
+            build_public_record_proof_car(&mutated_public_signature, &proof, &node_blocks, &record)
+                .is_err(),
+            "public CAR publication must reject a mutated signature"
         );
     }
 

--- a/crates/hyprstream-pds/src/atproto_cbor.rs
+++ b/crates/hyprstream-pds/src/atproto_cbor.rs
@@ -31,9 +31,9 @@ const MAX_DEPTH: usize = 128;
 /// not grant write authority or perform a full Lexicon validation.
 #[derive(Clone, Debug, PartialEq)]
 pub struct AtprotoRecord {
-    pub collection: String,
-    pub rkey: Tid,
-    pub value: DagCbor,
+    collection: String,
+    rkey: Tid,
+    value: DagCbor,
     bytes: Vec<u8>,
     cid: Cid,
 }
@@ -74,6 +74,23 @@ impl AtprotoRecord {
     pub fn bytes(&self) -> &[u8] {
         &self.bytes
     }
+
+    /// The validated collection NSID. Record identity fields are immutable
+    /// after construction so this always agrees with `bytes()` and `cid()`.
+    pub fn collection(&self) -> &str {
+        &self.collection
+    }
+
+    /// The validated record key.
+    pub fn rkey(&self) -> Tid {
+        self.rkey
+    }
+
+    /// The validated record value.
+    pub fn value(&self) -> &DagCbor {
+        &self.value
+    }
+
     pub fn cid(&self) -> Cid {
         self.cid
     }
@@ -84,31 +101,41 @@ impl AtprotoRecord {
 
 fn validate_nsid(nsid: &str) -> Result<()> {
     ensure!(
-        !nsid.is_empty() && nsid.len() <= 317,
+        !nsid.is_empty() && nsid.len() <= 317 && nsid.is_ascii(),
         "invalid AT collection NSID"
     );
-    let mut segments = nsid.split('.');
-    let first = segments.next().unwrap_or_default();
+    let segments: Vec<&str> = nsid.split('.').collect();
     ensure!(
-        !first.is_empty()
-            && first
-                .chars()
-                .all(|c| c.is_ascii_lowercase() || c.is_ascii_digit() || c == '-'),
+        segments.len() >= 3,
+        "invalid NSID: authority and name required"
+    );
+
+    let name = segments.last().copied().unwrap_or_default();
+    ensure!(
+        (1..=63).contains(&name.len())
+            && name.as_bytes()[0].is_ascii_alphabetic()
+            && name.bytes().all(|c| c.is_ascii_alphanumeric()),
+        "invalid NSID name"
+    );
+
+    let authority = &segments[..segments.len() - 1];
+    let authority_len = nsid.len() - name.len() - 1;
+    ensure!(
+        authority.len() >= 2 && authority_len <= 253,
         "invalid NSID authority"
     );
-    for segment in segments {
+    for (index, segment) in authority.iter().enumerate() {
         ensure!(
-            !segment.is_empty()
+            (1..=63).contains(&segment.len())
                 && segment
-                    .chars()
-                    .all(|c| c.is_ascii_alphanumeric() || c == '-'),
+                    .bytes()
+                    .all(|c| c.is_ascii_alphanumeric() || c == b'-')
+                && segment.as_bytes()[0] != b'-'
+                && segment.as_bytes()[segment.len() - 1] != b'-'
+                && (index != 0 || segment.as_bytes()[0].is_ascii_alphabetic()),
             "invalid NSID segment"
         );
     }
-    ensure!(
-        nsid.contains('.'),
-        "AT collection NSID needs a domain hierarchy"
-    );
     Ok(())
 }
 
@@ -250,6 +277,52 @@ mod tests {
         ] {
             assert!(encode(&value).is_err());
         }
+    }
+
+    #[test]
+    fn nsid_validation_matches_at_protocol_syntax() {
+        for valid in [
+            "com.example.fooBar",
+            "net.users.bob.ping",
+            "a-0.b-1.c",
+            "a.b.c",
+            "cn.8.lex.stuff",
+        ] {
+            validate_nsid(valid).unwrap();
+        }
+        for invalid in [
+            "com.example",
+            "com.example.3",
+            "1.example.record",
+            "com.-example.record",
+            "com.example-.record",
+            "com.example.re-cord",
+            "com..example.record",
+            "com.example.",
+            "com.example.é",
+            "com.example.this_name_is_invalid",
+        ] {
+            assert!(validate_nsid(invalid).is_err(), "{invalid}");
+        }
+        assert!(validate_nsid(&format!("com.{}.record", "a".repeat(64))).is_err());
+        assert!(validate_nsid(&format!("com.example.{}", "a".repeat(64))).is_err());
+        assert!(validate_nsid(&format!(
+            "{}.{}.{}.{}.record",
+            "a".repeat(63),
+            "b".repeat(63),
+            "c".repeat(63),
+            "d".repeat(63),
+        ))
+        .is_err());
+    }
+
+    #[test]
+    fn record_identity_fields_are_immutable_after_construction() {
+        let record = AtprotoRecord::new("app.bsky.feed.post", Tid::from_raw(7), post()).unwrap();
+        assert_eq!(record.collection(), "app.bsky.feed.post");
+        assert_eq!(record.rkey(), Tid::from_raw(7));
+        assert_eq!(record.value(), &post());
+        assert_eq!(record.cid(), Cid::from_dag_cbor(record.bytes()));
     }
 
     #[test]

--- a/crates/hyprstream-pds/src/car.rs
+++ b/crates/hyprstream-pds/src/car.rs
@@ -26,6 +26,7 @@
 use anyhow::{anyhow, bail, ensure, Result};
 use p256::ecdsa::VerifyingKey;
 
+use crate::atproto_cbor::AtprotoRecord;
 use crate::cid::{read_uvarint, write_uvarint, Cid};
 use crate::commit::Commit;
 use crate::dag_cbor::DagCbor;
@@ -115,6 +116,56 @@ pub fn build_car_v1(roots: &[Cid], blocks: &[(Cid, Vec<u8>)]) -> Vec<u8> {
     out
 }
 
+/// Build a public AT Protocol CAR proof without changing the native CAR
+/// builder. Every block CID and byte payload is derived from the public
+/// canonical codec, including the CAR header.
+pub fn build_public_record_proof_car(
+    commit: &Commit,
+    path: &Proof,
+    node_blocks: &[(Cid, NodeData)],
+    record: &AtprotoRecord,
+) -> Result<Vec<u8>> {
+    let commit_cid = commit.cid_atproto()?;
+    let mut blocks = vec![(commit_cid, commit.to_atproto_dag_cbor()?)];
+    let path_cids: std::collections::BTreeSet<Cid> = path
+        .path
+        .iter()
+        .map(|step| match step {
+            crate::mst::ProofStep::FoundAt(d, _)
+            | crate::mst::ProofStep::ThroughEntry(d, _)
+            | crate::mst::ProofStep::LeftSubtree(d) => d.cid_atproto(),
+        })
+        .collect::<Result<_>>()?;
+    for (cid, data) in node_blocks {
+        if path_cids.contains(cid) {
+            blocks.push((*cid, data.encode_atproto()?));
+        }
+    }
+    blocks.push((record.cid(), record.bytes().to_vec()));
+    build_car_v1_atproto(&[commit_cid], &blocks)
+}
+
+/// Public AT Protocol CARv1 builder. The native builder remains unchanged.
+pub fn build_car_v1_atproto(roots: &[Cid], blocks: &[(Cid, Vec<u8>)]) -> Result<Vec<u8>> {
+    let header_value = DagCbor::str_map([
+        ("version", DagCbor::Unsigned(1)),
+        (
+            "roots",
+            DagCbor::List(roots.iter().copied().map(DagCbor::Link).collect()),
+        ),
+    ]);
+    let header_bytes = crate::atproto_cbor::encode(&header_value)?;
+    let mut out = Vec::new();
+    write_section(&mut out, &header_bytes);
+    for (cid, bytes) in blocks {
+        let mut section = Vec::with_capacity(cid.as_bytes().len() + bytes.len());
+        section.extend_from_slice(cid.as_bytes());
+        section.extend_from_slice(bytes);
+        write_section(&mut out, &section);
+    }
+    Ok(out)
+}
+
 fn write_section(out: &mut Vec<u8>, body: &[u8]) {
     write_uvarint(body.len() as u64, out);
     out.extend_from_slice(body);
@@ -153,6 +204,40 @@ pub fn parse_car_v1(input: &[u8]) -> Result<(Vec<Cid>, Vec<(Cid, Vec<u8>)>)> {
         let (cid, consumed) = parse_cid_prefix(body)?;
         let raw = body[consumed..].to_vec();
         blocks.push((cid, raw));
+    }
+    Ok((roots, blocks))
+}
+
+/// Parse a CAR whose header uses public AT canonical DAG-CBOR. Block framing is
+/// identical to [`parse_car_v1`]; callers decide how to decode each block.
+pub fn parse_car_v1_atproto(input: &[u8]) -> Result<(Vec<Cid>, Vec<(Cid, Vec<u8>)>)> {
+    let (header_body, mut cursor) = read_section(input, 0)?;
+    let header_val = crate::atproto_cbor::decode(header_body)?;
+    let version = header_val
+        .get("version")
+        .ok_or_else(|| anyhow!("CAR header missing 'version'"))?
+        .as_unsigned()?;
+    ensure!(
+        version == 1,
+        "only CARv1 is supported (got version {version})"
+    );
+    let roots_val = header_val
+        .get("roots")
+        .ok_or_else(|| anyhow!("CAR header missing 'roots'"))?
+        .as_list()?;
+    let roots = roots_val
+        .iter()
+        .map(|r| r.as_link())
+        .collect::<Result<Vec<_>>>()?
+        .into_iter()
+        .copied()
+        .collect();
+    let mut blocks = Vec::new();
+    while cursor < input.len() {
+        let (body, after) = read_section(input, cursor)?;
+        cursor = after;
+        let (cid, consumed) = parse_cid_prefix(body)?;
+        blocks.push((cid, body[consumed..].to_vec()));
     }
     Ok((roots, blocks))
 }

--- a/crates/hyprstream-pds/src/car.rs
+++ b/crates/hyprstream-pds/src/car.rs
@@ -125,6 +125,12 @@ pub fn build_public_record_proof_car(
     node_blocks: &[(Cid, NodeData)],
     record: &AtprotoRecord,
 ) -> Result<Vec<u8>> {
+    // Bind the supplied proof to both the signed commit root and this exact
+    // record before emitting any blocks. This rejects empty proofs and proofs
+    // copied from a different commit or record.
+    path.verify_atproto(&commit.data, &record.cid())?;
+    ensure_proof_record_key(path, record)?;
+
     let commit_cid = commit.cid_atproto()?;
     let mut blocks = vec![(commit_cid, commit.to_atproto_dag_cbor()?)];
     let path_cids: std::collections::BTreeSet<Cid> = path
@@ -156,6 +162,28 @@ pub fn build_public_record_proof_car(
     );
     blocks.push((record.cid(), record.bytes().to_vec()));
     build_car_v1_atproto(&[commit_cid], &blocks)
+}
+
+fn ensure_proof_record_key(path: &Proof, record: &AtprotoRecord) -> Result<()> {
+    let (data, index) = match path.path.last() {
+        Some(crate::mst::ProofStep::FoundAt(data, index)) => (data, *index),
+        _ => bail!("public MST proof has no terminal record entry"),
+    };
+    let mut key = Vec::new();
+    for entry in data.e.iter().take(index + 1) {
+        ensure!(
+            entry.p <= key.len(),
+            "public MST proof has an invalid key prefix length"
+        );
+        key.truncate(entry.p);
+        key.extend_from_slice(&entry.k);
+    }
+    let key = String::from_utf8(key).map_err(|_| anyhow!("public MST proof key is not UTF-8"))?;
+    ensure!(
+        key == format!("{}/{}", record.collection(), record.rkey().as_str()),
+        "public MST proof key does not match the supplied record"
+    );
+    Ok(())
 }
 
 /// Public AT Protocol CARv1 builder. The native builder remains unchanged.

--- a/crates/hyprstream-pds/src/car.rs
+++ b/crates/hyprstream-pds/src/car.rs
@@ -125,6 +125,7 @@ pub fn build_public_record_proof_car(
     node_blocks: &[(Cid, NodeData)],
     record: &AtprotoRecord,
 ) -> Result<Vec<u8>> {
+    commit.ensure_atproto_signature()?;
     // Bind the supplied proof to both the signed commit root and this exact
     // record before emitting any blocks. This rejects empty proofs and proofs
     // copied from a different commit or record.

--- a/crates/hyprstream-pds/src/car.rs
+++ b/crates/hyprstream-pds/src/car.rs
@@ -136,11 +136,24 @@ pub fn build_public_record_proof_car(
             | crate::mst::ProofStep::LeftSubtree(d) => d.cid_atproto(),
         })
         .collect::<Result<_>>()?;
+    let mut supplied_path_cids = std::collections::BTreeSet::new();
     for (cid, data) in node_blocks {
+        ensure!(
+            data.cid_atproto()? == *cid,
+            "public MST block is labeled with a CID that does not match its bytes"
+        );
         if path_cids.contains(cid) {
+            ensure!(
+                supplied_path_cids.insert(*cid),
+                "duplicate public MST block for proof path"
+            );
             blocks.push((*cid, data.encode_atproto()?));
         }
     }
+    ensure!(
+        supplied_path_cids.len() == path_cids.len(),
+        "public proof CAR is missing an MST path block"
+    );
     blocks.push((record.cid(), record.bytes().to_vec()));
     build_car_v1_atproto(&[commit_cid], &blocks)
 }

--- a/crates/hyprstream-pds/src/car.rs
+++ b/crates/hyprstream-pds/src/car.rs
@@ -271,11 +271,17 @@ fn parse_cid_prefix(body: &[u8]) -> Result<(Cid, usize)> {
         i += (body.len() - i) - rest.len();
         let (len, rest) = read_uvarint(&body[i..]).ok_or_else(|| anyhow!("truncated mh len"))?;
         i += (body.len() - i) - rest.len();
-        i += len as usize;
+        let digest_len = usize::try_from(len).map_err(|_| anyhow!("CID digest length overflow"))?;
+        let end = i
+            .checked_add(digest_len)
+            .ok_or_else(|| anyhow!("CID digest length overflow"))?;
+        ensure!(end <= body.len(), "truncated CID digest");
+        i = end;
         let cid = Cid::from_bytes(&body[..i])?;
         Ok((cid, i))
     } else if body[0] == 0x12 {
         // CIDv0 (sha2-256, 32 bytes): 34 bytes total.
+        ensure!(body.len() >= 34, "truncated CIDv0");
         let cid = Cid::from_bytes(&body[..34])?;
         Ok((cid, 34))
     } else {
@@ -501,5 +507,17 @@ mod tests {
         let (roots, blocks) = parse_car_v1(&car).expect("parse");
         assert_eq!(roots, vec![root]);
         assert!(blocks.is_empty());
+    }
+
+    #[test]
+    fn atproto_parser_rejects_truncated_cid_without_panicking() {
+        // A CIDv1 multihash advertises a 32-byte digest but the CAR section
+        // ends immediately after the length varint.
+        let malformed = hex::decode("11a265726f6f7473806776657273696f6e010401711220")
+            .expect("fixture is valid hex");
+        assert!(parse_car_v1_atproto(&malformed).is_err());
+
+        // The fixed-width CIDv0 form must receive the same bounds check.
+        assert!(parse_cid_prefix(&[0x12, 0x20]).is_err());
     }
 }

--- a/crates/hyprstream-pds/src/cid.rs
+++ b/crates/hyprstream-pds/src/cid.rs
@@ -152,7 +152,7 @@ impl Cid {
         let (code, rest) = read_uvarint(rest).ok_or_else(|| anyhow!("truncated multihash code"))?;
         let (len, rest) =
             read_uvarint(rest).ok_or_else(|| anyhow!("truncated multihash length"))?;
-        let len = len as usize;
+        let len = usize::try_from(len).map_err(|_| anyhow!("multihash length overflow"))?;
         if rest.len() != len {
             bail!(
                 "multihash length {len} does not match remaining {} bytes",
@@ -228,8 +228,18 @@ pub(crate) fn read_uvarint(input: &[u8]) -> Option<(u64, &[u8])> {
         if shift >= 64 {
             return None; // varint too long
         }
+        // The tenth byte contributes only the top bit of a u64. Reject
+        // payload bits which would overflow before shifting them in.
+        if shift == 63 && b & 0x7e != 0 {
+            return None;
+        }
         val |= ((b & 0x7f) as u64) << shift;
         if b & 0x80 == 0 {
+            // A terminating zero group after the first byte is an overlong
+            // representation (for example, `f1 00` for 0x71).
+            if i > 0 && b == 0 {
+                return None;
+            }
             return Some((val, &input[i + 1..]));
         }
         shift += 7;
@@ -324,5 +334,15 @@ mod tests {
             assert_eq!(parsed, val, "varint {val}");
             assert!(rest.is_empty(), "varint {val} had trailing bytes");
         }
+    }
+
+    #[test]
+    fn varint_rejects_overlong_and_overflow_encodings() {
+        assert!(read_uvarint(&[0xf1, 0x00]).is_none());
+        assert!(read_uvarint(&[0x80, 0x00]).is_none());
+
+        let mut overflow = vec![0xff; 9];
+        overflow.push(0x02);
+        assert!(read_uvarint(&overflow).is_none());
     }
 }

--- a/crates/hyprstream-pds/src/commit.rs
+++ b/crates/hyprstream-pds/src/commit.rs
@@ -25,8 +25,8 @@
 //! present-and-empty). The verifier re-encodes the unsigned form and checks the
 //! signature against the DID's published `#atproto` P-256 verifying key.
 
-use anyhow::{anyhow, bail, ensure, Result};
-use p256::ecdsa::{signature::Signer, Signature, SigningKey, VerifyingKey};
+use anyhow::{Result, anyhow, bail, ensure};
+use p256::ecdsa::{Signature, SigningKey, VerifyingKey, signature::Signer};
 use sha2::{Digest, Sha256};
 
 use crate::cid::Cid;
@@ -104,6 +104,10 @@ pub struct Commit {
     /// AT Protocol canonical-signature boundary. Native commits are never
     /// eligible for public CAR publication without an explicit conversion.
     atproto_signature: bool,
+    /// Canonical public bytes at the provenance boundary. Public fields are
+    /// intentionally retained for compatibility, so publication must also
+    /// detect any mutation after signing or decoding.
+    atproto_canonical_bytes: Option<Vec<u8>>,
 }
 
 impl Commit {
@@ -127,6 +131,7 @@ impl Commit {
             prev: unsigned.prev,
             sig: sig.to_vec(),
             atproto_signature: false,
+            atproto_canonical_bytes: None,
         }
     }
 
@@ -134,7 +139,7 @@ impl Commit {
     pub fn sign_atproto(unsigned: &UnsignedCommit, key: &SigningKey) -> Result<Self> {
         use p256::ecdsa::signature::Signer;
         let sig: Signature = key.sign(&unsigned.to_atproto_dag_cbor()?);
-        Ok(Commit {
+        let mut commit = Commit {
             did: unsigned.did.clone(),
             version: unsigned.version,
             data: unsigned.data,
@@ -142,7 +147,10 @@ impl Commit {
             prev: unsigned.prev,
             sig: sig.to_vec(),
             atproto_signature: true,
-        })
+            atproto_canonical_bytes: None,
+        };
+        commit.atproto_canonical_bytes = Some(commit.to_atproto_dag_cbor()?);
+        Ok(commit)
     }
 
     /// DAG-CBOR encode the (signed) commit. The `sig` field is a byte string.
@@ -212,10 +220,11 @@ impl Commit {
             commit.to_atproto_dag_cbor()?.as_slice() == bytes,
             "public commit bytes are not canonical"
         );
-        Ok(Commit {
-            atproto_signature: true,
-            ..commit
-        })
+        // Decoding canonical bytes proves only their shape and byte
+        // canonicality. It cannot prove that `sig` was produced over those
+        // bytes without the account's published verifying key, so decoded
+        // values remain untrusted until `verify_atproto_and_mark` succeeds.
+        Ok(commit)
     }
 
     fn validate_atproto_fields(value: &DagCbor) -> Result<()> {
@@ -279,6 +288,7 @@ impl Commit {
             prev,
             sig,
             atproto_signature: false,
+            atproto_canonical_bytes: None,
         })
     }
 
@@ -287,7 +297,29 @@ impl Commit {
             self.atproto_signature,
             "public CAR publication requires a commit signed with AT Protocol canonical bytes"
         );
+        let canonical = self
+            .atproto_canonical_bytes
+            .as_deref()
+            .ok_or_else(|| anyhow!("public signature provenance is missing canonical bytes"))?;
+        ensure!(
+            self.to_atproto_dag_cbor()?.as_slice() == canonical,
+            "public commit was mutated after its signature provenance was established"
+        );
         Ok(())
+    }
+
+    /// Verify a decoded public commit with the account's published
+    /// `#atproto` key and mark the value eligible for public CAR publication.
+    ///
+    /// Canonical decoding alone is not signature provenance: a native commit
+    /// can be re-encoded into the public shape, and its bytes remain perfectly
+    /// canonical. This explicit key-bound verification is therefore required
+    /// before a decoded value crosses the public publication boundary.
+    pub fn verify_atproto_and_mark(mut self, vk: &VerifyingKey) -> Result<Self> {
+        self.verify_atproto(vk)?;
+        self.atproto_signature = true;
+        self.atproto_canonical_bytes = Some(self.to_atproto_dag_cbor()?);
+        Ok(self)
     }
 
     /// The CID of this (signed) commit block.
@@ -708,6 +740,32 @@ mod tests {
             Commit::from_atproto_dag_cbor(&tampered).is_err(),
             "public decoder must reject a rev encoding that normalizes to a different byte form"
         );
+    }
+
+    #[test]
+    fn decoded_public_commit_requires_explicit_signature_verification() {
+        let (native, native_vk) = make_signed_commit();
+        let public_signing = SigningKey::random(&mut rand::rngs::OsRng);
+        let public =
+            Commit::sign_atproto(&native.unsigned(), &public_signing).expect("public signature");
+        let bytes = public
+            .to_atproto_dag_cbor()
+            .expect("canonical public bytes");
+        let decoded = Commit::from_atproto_dag_cbor(&bytes).expect("canonical decode");
+        assert!(
+            decoded.ensure_atproto_signature().is_err(),
+            "canonical decoding must not establish signature provenance"
+        );
+        assert!(
+            decoded.clone().verify_atproto_and_mark(&native_vk).is_err(),
+            "verification with the wrong key must not mark the commit"
+        );
+        let verified = decoded
+            .verify_atproto_and_mark(public_signing.verifying_key())
+            .expect("published key verifies public commit");
+        verified
+            .ensure_atproto_signature()
+            .expect("verified public commit is publishable");
     }
 
     #[test]

--- a/crates/hyprstream-pds/src/commit.rs
+++ b/crates/hyprstream-pds/src/commit.rs
@@ -197,7 +197,16 @@ impl Commit {
     pub fn from_atproto_dag_cbor(bytes: &[u8]) -> Result<Self> {
         let value = crate::atproto_cbor::decode(bytes)?;
         Self::validate_atproto_fields(&value)?;
-        Self::from_value(&value)
+        let commit = Self::from_value(&value)?;
+        // Public verification must bind the exact canonical block bytes. In
+        // particular, Tid::parse normalizes the final base32 bit; without
+        // this round-trip check, two distinct `rev` encodings could decode to
+        // one value and share signature verification.
+        ensure!(
+            commit.to_atproto_dag_cbor()?.as_slice() == bytes,
+            "public commit bytes are not canonical"
+        );
+        Ok(commit)
     }
 
     fn validate_atproto_fields(value: &DagCbor) -> Result<()> {
@@ -651,6 +660,35 @@ mod tests {
         assert!(
             Commit::from_atproto_dag_cbor(&bytes).is_err(),
             "public commits must reject unknown fields"
+        );
+    }
+
+    #[test]
+    fn public_commit_rejects_noncanonical_tid_rev_bytes() {
+        let (commit, _vk) = make_signed_commit();
+        let canonical = commit
+            .to_atproto_dag_cbor()
+            .expect("canonical public commit");
+        let mut value = crate::atproto_cbor::decode(&canonical).expect("decode public commit");
+        let mut fields = value.as_map().expect("commit map").to_vec();
+        let rev = fields
+            .iter_mut()
+            .find(|(key, _)| matches!(key, DagCbor::Text(name) if name == "rev"))
+            .expect("rev field");
+        let mut rev_text = rev.1.as_str().expect("rev text").to_owned();
+        let last = rev_text.pop().expect("tid digit");
+        let replacement = match last {
+            '2' => '3',
+            '3' => '2',
+            _ => panic!("test TID must end in 2 or 3, got {last}"),
+        };
+        rev_text.push(replacement);
+        rev.1 = DagCbor::Text(rev_text);
+        value = DagCbor::Map(fields);
+        let tampered = crate::atproto_cbor::encode(&value).expect("encode tampered commit");
+        assert!(
+            Commit::from_atproto_dag_cbor(&tampered).is_err(),
+            "public decoder must reject a rev encoding that normalizes to a different byte form"
         );
     }
 

--- a/crates/hyprstream-pds/src/commit.rs
+++ b/crates/hyprstream-pds/src/commit.rs
@@ -100,6 +100,10 @@ pub struct Commit {
     pub rev: Tid,
     pub prev: Option<Cid>,
     pub sig: Vec<u8>,
+    /// Whether this value was produced or decoded through the public
+    /// AT Protocol canonical-signature boundary. Native commits are never
+    /// eligible for public CAR publication without an explicit conversion.
+    atproto_signature: bool,
 }
 
 impl Commit {
@@ -122,6 +126,7 @@ impl Commit {
             rev: unsigned.rev,
             prev: unsigned.prev,
             sig: sig.to_vec(),
+            atproto_signature: false,
         }
     }
 
@@ -136,6 +141,7 @@ impl Commit {
             rev: unsigned.rev,
             prev: unsigned.prev,
             sig: sig.to_vec(),
+            atproto_signature: true,
         })
     }
 
@@ -206,7 +212,10 @@ impl Commit {
             commit.to_atproto_dag_cbor()?.as_slice() == bytes,
             "public commit bytes are not canonical"
         );
-        Ok(commit)
+        Ok(Commit {
+            atproto_signature: true,
+            ..commit
+        })
     }
 
     fn validate_atproto_fields(value: &DagCbor) -> Result<()> {
@@ -269,7 +278,16 @@ impl Commit {
             rev,
             prev,
             sig,
+            atproto_signature: false,
         })
+    }
+
+    pub(crate) fn ensure_atproto_signature(&self) -> Result<()> {
+        ensure!(
+            self.atproto_signature,
+            "public CAR publication requires a commit signed with AT Protocol canonical bytes"
+        );
+        Ok(())
     }
 
     /// The CID of this (signed) commit block.

--- a/crates/hyprstream-pds/src/commit.rs
+++ b/crates/hyprstream-pds/src/commit.rs
@@ -25,8 +25,8 @@
 //! present-and-empty). The verifier re-encodes the unsigned form and checks the
 //! signature against the DID's published `#atproto` P-256 verifying key.
 
-use anyhow::{Result, anyhow, bail, ensure};
-use p256::ecdsa::{Signature, SigningKey, VerifyingKey, signature::Signer};
+use anyhow::{anyhow, bail, ensure, Result};
+use p256::ecdsa::{signature::Signer, Signature, SigningKey, VerifyingKey};
 use sha2::{Digest, Sha256};
 
 use crate::cid::Cid;
@@ -138,6 +138,11 @@ impl Commit {
     /// Sign a commit using public AT Protocol canonical bytes.
     pub fn sign_atproto(unsigned: &UnsignedCommit, key: &SigningKey) -> Result<Self> {
         use p256::ecdsa::signature::Signer;
+        ensure!(
+            unsigned.version == COMMIT_VERSION,
+            "unsupported public commit version {} (expected {COMMIT_VERSION})",
+            unsigned.version
+        );
         let sig: Signature = key.sign(&unsigned.to_atproto_dag_cbor()?);
         let mut commit = Commit {
             did: unsigned.did.clone(),
@@ -297,6 +302,11 @@ impl Commit {
             self.atproto_signature,
             "public CAR publication requires a commit signed with AT Protocol canonical bytes"
         );
+        ensure!(
+            self.version == COMMIT_VERSION,
+            "unsupported public commit version {} (expected {COMMIT_VERSION})",
+            self.version
+        );
         let canonical = self
             .atproto_canonical_bytes
             .as_deref()
@@ -357,6 +367,11 @@ impl Commit {
 
     pub fn verify_atproto(&self, vk: &VerifyingKey) -> Result<()> {
         use p256::ecdsa::signature::Verifier;
+        ensure!(
+            self.version == COMMIT_VERSION,
+            "unsupported public commit version {} (expected {COMMIT_VERSION})",
+            self.version
+        );
         let signature = Signature::from_slice(&self.sig)
             .map_err(|e| anyhow::anyhow!("invalid ES256 signature bytes: {e}"))?;
         vk.verify(&self.unsigned().to_atproto_dag_cbor()?, &signature)

--- a/crates/hyprstream-pds/src/commit.rs
+++ b/crates/hyprstream-pds/src/commit.rs
@@ -195,7 +195,26 @@ impl Commit {
     }
 
     pub fn from_atproto_dag_cbor(bytes: &[u8]) -> Result<Self> {
-        Self::from_value(&crate::atproto_cbor::decode(bytes)?)
+        let value = crate::atproto_cbor::decode(bytes)?;
+        Self::validate_atproto_fields(&value)?;
+        Self::from_value(&value)
+    }
+
+    fn validate_atproto_fields(value: &DagCbor) -> Result<()> {
+        const FIELDS: &[&str] = &["did", "version", "data", "rev", "prev", "sig"];
+        let fields = value.as_map()?;
+        ensure!(
+            fields.len() == FIELDS.len(),
+            "public commit must contain exactly these fields: {FIELDS:?}"
+        );
+        for (key, _) in fields {
+            let key = key.as_str()?;
+            ensure!(
+                FIELDS.contains(&key),
+                "public commit has unknown field {key:?}"
+            );
+        }
+        Ok(())
     }
 
     pub fn from_value(value: &DagCbor) -> Result<Self> {
@@ -621,6 +640,18 @@ mod tests {
         let bytes = commit.to_dag_cbor();
         let back = Commit::from_dag_cbor(&bytes).expect("round-trip");
         assert_eq!(commit, back);
+    }
+
+    #[test]
+    fn public_commit_rejects_unknown_fields() {
+        let (commit, _vk) = make_signed_commit();
+        let mut fields = commit.to_value().as_map().unwrap().to_vec();
+        fields.push((DagCbor::Text("extra".into()), DagCbor::Null));
+        let bytes = crate::atproto_cbor::encode(&DagCbor::Map(fields)).unwrap();
+        assert!(
+            Commit::from_atproto_dag_cbor(&bytes).is_err(),
+            "public commits must reject unknown fields"
+        );
     }
 
     #[test]

--- a/crates/hyprstream-pds/src/commit.rs
+++ b/crates/hyprstream-pds/src/commit.rs
@@ -39,9 +39,10 @@ pub const COMMIT_VERSION: u64 = 3;
 /// An unsigned commit — the form that gets DAG-CBOR-encoded and signed.
 ///
 /// Field order matches atproto (`did`, `version`, `data`, `rev`, `prev`); the
-/// encoder re-sorts canonically (**pure lexicographic byte order**, RFC 7049
-/// §4.2.1 "core determinism" — not length-first) so the order here is only for
-/// readability. `version` is always [`COMMIT_VERSION`] = 3.
+/// existing native encoder re-sorts in its historical lexical text-key order.
+/// Public AT serialization is available through `to_atproto_dag_cbor` and uses
+/// encoded-key ordering without changing existing native bytes. `version` is
+/// always [`COMMIT_VERSION`] = 3.
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct UnsignedCommit {
     pub did: String,
@@ -65,6 +66,12 @@ impl UnsignedCommit {
     /// DAG-CBOR encode the unsigned commit (no `sig` field). This is what gets signed.
     pub fn to_dag_cbor(&self) -> Vec<u8> {
         self.to_value().encode()
+    }
+
+    /// Encode this commit's unsigned body using public AT Protocol ordering.
+    /// The native `to_dag_cbor` format is retained for existing artifacts.
+    pub fn to_atproto_dag_cbor(&self) -> Result<Vec<u8>> {
+        crate::atproto_cbor::encode(&self.to_value())
     }
 
     pub fn to_value(&self) -> DagCbor {
@@ -118,9 +125,28 @@ impl Commit {
         }
     }
 
+    /// Sign a commit using public AT Protocol canonical bytes.
+    pub fn sign_atproto(unsigned: &UnsignedCommit, key: &SigningKey) -> Result<Self> {
+        use p256::ecdsa::signature::Signer;
+        let sig: Signature = key.sign(&unsigned.to_atproto_dag_cbor()?);
+        Ok(Commit {
+            did: unsigned.did.clone(),
+            version: unsigned.version,
+            data: unsigned.data,
+            rev: unsigned.rev,
+            prev: unsigned.prev,
+            sig: sig.to_vec(),
+        })
+    }
+
     /// DAG-CBOR encode the (signed) commit. The `sig` field is a byte string.
     pub fn to_dag_cbor(&self) -> Vec<u8> {
         self.to_value().encode()
+    }
+
+    /// Encode the signed commit using public AT Protocol canonical bytes.
+    pub fn to_atproto_dag_cbor(&self) -> Result<Vec<u8>> {
+        crate::atproto_cbor::encode(&self.to_value())
     }
 
     pub fn to_value(&self) -> DagCbor {
@@ -166,6 +192,10 @@ impl Commit {
     pub fn from_dag_cbor(bytes: &[u8]) -> Result<Self> {
         let value = DagCbor::decode(bytes)?;
         Self::from_value(&value)
+    }
+
+    pub fn from_atproto_dag_cbor(bytes: &[u8]) -> Result<Self> {
+        Self::from_value(&crate::atproto_cbor::decode(bytes)?)
     }
 
     pub fn from_value(value: &DagCbor) -> Result<Self> {
@@ -219,6 +249,10 @@ impl Commit {
         Cid::from_dag_cbor(&self.to_dag_cbor())
     }
 
+    pub fn cid_atproto(&self) -> Result<Cid> {
+        Ok(Cid::from_dag_cbor(&self.to_atproto_dag_cbor()?))
+    }
+
     /// Verify the commit's signature against a `#atproto` P-256 verifying key.
     ///
     /// Re-encodes the unsigned commit, hashes with SHA-256, and verifies the
@@ -241,6 +275,14 @@ impl Commit {
             .map_err(|e| anyhow::anyhow!("invalid ES256 signature bytes: {e}"))?;
         vk.verify(&unsigned_bytes, &signature)
             .map_err(|e| anyhow::anyhow!("ES256 signature verification failed: {e}"))
+    }
+
+    pub fn verify_atproto(&self, vk: &VerifyingKey) -> Result<()> {
+        use p256::ecdsa::signature::Verifier;
+        let signature = Signature::from_slice(&self.sig)
+            .map_err(|e| anyhow::anyhow!("invalid ES256 signature bytes: {e}"))?;
+        vk.verify(&self.unsigned().to_atproto_dag_cbor()?, &signature)
+            .map_err(|e| anyhow::anyhow!("public ATProto ES256 signature verification failed: {e}"))
     }
 
     /// Verify against the bounded `#atproto` slot set currently published by a

--- a/crates/hyprstream-pds/src/dag_cbor.rs
+++ b/crates/hyprstream-pds/src/dag_cbor.rs
@@ -82,8 +82,9 @@ pub enum DagCbor {
     Text(String),
     /// Array (major 4), in given order.
     List(Vec<DagCbor>),
-    /// Map (major 5). Keys are stored in canonical (pure lexicographic byte)
-    /// sorted order at construction; encoding emits them as-is.
+    /// Map (major 5). Keys are stored in the existing native lexical text-byte
+    /// order at construction; public AT ordering is applied by
+    /// [`crate::atproto_cbor`] at its explicit boundary.
     Map(Vec<(DagCbor, DagCbor)>),
     /// CID link — encoded as CBOR tag 42.
     Link(Cid),
@@ -448,11 +449,11 @@ fn take<'a>(input: &'a [u8], cursor: &mut usize, n: usize) -> Result<&'a [u8]> {
     Ok(slice)
 }
 
-// ── canonical key ordering ──────────────────────────────────────────────────
+// ── native key ordering ──────────────────────────────────────────────────────
 
 /// Canonical comparison for a map key: returns the "canonical key" byte
 /// representation used both for sorting at construction and for verifying order
-/// at decode. DAG-CBOR map keys are text strings, so this is always UTF-8 bytes.
+/// at decode. Native map keys are text strings, so this is always UTF-8 bytes.
 fn canonical_key_of(key: &DagCbor) -> Vec<u8> {
     match key {
         DagCbor::Text(s) => s.as_bytes().to_vec(),

--- a/crates/hyprstream-pds/src/dag_cbor.rs
+++ b/crates/hyprstream-pds/src/dag_cbor.rs
@@ -1,4 +1,9 @@
-//! Deterministic DAG-CBOR encoding/decoding.
+//! Hyprstream's existing deterministic CBOR encoding/decoding.
+//!
+//! Compatibility note: this codec uses lexical text-key ordering. Public
+//! AT Protocol DAG-CBOR instead orders encoded keys (length first). Use
+//! [`crate::atproto_cbor`] for that explicit boundary. Existing native signed
+//! artifacts retain this codec; do not silently change their bytes or verifier.
 //!
 //! DAG-CBOR is a restricted subset of [CBOR (RFC 7049)](https://tools.ietf.org/html/rfc7049)
 //! with additional constraints so that a given value always produces the
@@ -8,11 +13,8 @@
 //!
 //! # Constraints enforced here
 //!
-//! 1. **Map keys are sorted** in pure lexicographic byte order
-//!    (RFC 7049 §4.2.1 "core determinism") — the convention atproto's
-//!    `@atproto/lex-cbor` (via `cborg`) uses. (NOT length-first-then-lex; that's
-//!    the older §3.9 "canonical CBOR" rule, which atproto rejects because it
-//!    would produce different bytes for the same record.)
+//! 1. **Map keys are sorted** in pure lexicographic text-byte order, preserving
+//!    the existing native format. This differs from public DAG-CBOR ordering.
 //! 2. **Integers use minimal encoding**: `u8` < 24 → one byte (major 0/1);
 //!    otherwise the smallest power-of-two width (1/2/4/8 bytes).
 //! 3. **No duplicate keys**: decoding rejects them.
@@ -185,13 +187,25 @@ impl DagCbor {
     /// sorted text keys, no duplicates, bounded recursion, and minimal integer
     /// and length widths on the wire.
     pub fn decode(input: &[u8]) -> Result<Self> {
+        Self::decode_with_order(input, canonical_key_cmp)
+    }
+
+    pub(crate) fn decode_with_order(
+        input: &[u8],
+        key_order: fn(&[u8], &[u8]) -> std::cmp::Ordering,
+    ) -> Result<Self> {
         let mut cursor = 0usize;
-        let val = Self::read(input, &mut cursor, 0)?;
+        let val = Self::read(input, &mut cursor, 0, key_order)?;
         ensure!(cursor == input.len(), "trailing bytes after DAG-CBOR value");
         Ok(val)
     }
 
-    fn read(input: &[u8], cursor: &mut usize, depth: usize) -> Result<Self> {
+    fn read(
+        input: &[u8],
+        cursor: &mut usize,
+        depth: usize,
+        key_order: fn(&[u8], &[u8]) -> std::cmp::Ordering,
+    ) -> Result<Self> {
         ensure!(
             depth <= MAX_RECURSION_DEPTH,
             "DepthLimitExceeded: DAG-CBOR nesting exceeds {MAX_RECURSION_DEPTH}"
@@ -240,7 +254,7 @@ impl DagCbor {
                 // untrusted and a huge value must not trigger a capacity panic.
                 let mut items = Vec::with_capacity(len.min(input.len().saturating_sub(*cursor)));
                 for _ in 0..len {
-                    items.push(Self::read(input, cursor, depth + 1)?);
+                    items.push(Self::read(input, cursor, depth + 1, key_order)?);
                 }
                 Ok(DagCbor::List(items))
             }
@@ -252,17 +266,17 @@ impl DagCbor {
                     Vec::with_capacity(len.min(input.len().saturating_sub(*cursor)));
                 let mut prev_key: Option<Vec<u8>> = None;
                 for _ in 0..len {
-                    let k = Self::read(input, cursor, depth + 1)?;
+                    let k = Self::read(input, cursor, depth + 1, key_order)?;
                     ensure!(
                         matches!(k, DagCbor::Text(_)),
                         "DAG-CBOR map key must be a text string"
                     );
-                    let v = Self::read(input, cursor, depth + 1)?;
+                    let v = Self::read(input, cursor, depth + 1, key_order)?;
                     // Enforce sorted + unique keys: compare against previous.
                     let key_bytes = canonical_key_of(&k);
                     if let Some(ref prev) = prev_key {
                         ensure!(
-                            canonical_key_cmp(prev, &key_bytes) == std::cmp::Ordering::Less,
+                            key_order(prev, &key_bytes) == std::cmp::Ordering::Less,
                             "DAG-CBOR map keys not in canonical order / duplicate"
                         );
                     }
@@ -446,10 +460,9 @@ fn canonical_key_of(key: &DagCbor) -> Vec<u8> {
     }
 }
 
-/// Compare two canonical keys: **pure lexicographic byte order** (RFC 7049
-/// §4.2.1 "core determinism"), which is what atproto's DAG-CBOR (`@atproto/lex-cbor`
-/// via `cborg`) uses. (Not length-first-then-lex — that's the older RFC 7049 §3.9
-/// "canonical CBOR" convention, which atproto does NOT use.)
+/// Preserve the existing native codec's lexical text-key ordering. Public
+/// AT Protocol ordering is separate in `atproto_cbor`; do not change this
+/// comparator without an explicit migration of native signed artifacts.
 fn canonical_key_cmp(a: &[u8], b: &[u8]) -> std::cmp::Ordering {
     a.cmp(b)
 }

--- a/crates/hyprstream-pds/src/lib.rs
+++ b/crates/hyprstream-pds/src/lib.rs
@@ -7,10 +7,13 @@
 //!
 //! # What this crate provides
 //!
-//! - **DAG-CBOR** deterministic encode/decode ([`dag_cbor`]) — canonical CBOR:
-//!   map keys sorted in **pure lexicographic byte order** (RFC 7049 §4.2.1 "core
-//!   determinism", the convention atproto's `@atproto/lex-cbor` uses), minimal-
-//!   length ints, no duplicate keys. CID links use CBOR tag 42 per the
+//! - **Existing native CBOR** deterministic encode/decode ([`dag_cbor`]):
+//!   map keys sorted in lexical text-byte order, minimal-length ints and no
+//!   duplicate keys. Public AT DAG-CBOR instead requires length-first key order;
+//!   [`atproto_cbor`] provides that explicit boundary without changing existing
+//!   native signed artifacts. Public repository call-site integration is still
+//!   required; the existing commit/MST APIs retain their existing bytes.
+//!   CID links use CBOR tag 42 per the
 //!   [DAG-CBOR spec](https://github.com/ipld/specs/blob/master/block-layer/codecs/dag-cbor.md).
 //!   The same record produces identical bytes → same CID every time.
 //! - **`ai.hyprstream.model` record** ([`record`]) — the confirmed 3-field
@@ -58,6 +61,7 @@ pub mod at9p_gate;
 pub mod at9p_login;
 pub mod at9p_resolver;
 pub mod at9p_sign;
+pub mod atproto_cbor;
 pub mod car;
 pub mod cid;
 pub mod commit;

--- a/crates/hyprstream-pds/src/mst.rs
+++ b/crates/hyprstream-pds/src/mst.rs
@@ -148,7 +148,28 @@ impl NodeData {
     }
 
     pub fn from_atproto_dag_cbor(bytes: &[u8]) -> Result<Self> {
-        Self::from_value(&crate::atproto_cbor::decode(bytes)?)
+        let value = crate::atproto_cbor::decode(bytes)?;
+        Self::reject_unknown_fields(&value, &["l", "e"], "MST node")?;
+        if let Some(entries) = value.get("e") {
+            for entry in entries.as_list()? {
+                Self::reject_unknown_fields(entry, &["p", "k", "v", "t"], "MST entry")?;
+            }
+        }
+        Self::from_value(&value)
+    }
+
+    /// Public DAG-CBOR nodes are a frozen wire shape.  Dropping an unknown
+    /// field would produce a different canonical encoding and therefore a
+    /// different CID, so reject it before projecting into [`NodeData`].
+    fn reject_unknown_fields(value: &DagCbor, allowed: &[&str], what: &str) -> Result<()> {
+        for (key, _) in value.as_map()? {
+            let key = match key {
+                DagCbor::Text(key) => key.as_str(),
+                _ => return Err(anyhow::anyhow!("{what} has a non-text field key")),
+            };
+            ensure!(allowed.contains(&key), "{what} has unknown field {key:?}");
+        }
+        Ok(())
     }
 
     pub fn to_value(&self) -> DagCbor {
@@ -908,6 +929,39 @@ mod tests {
         let (serialized, _) = native.to_node_data_with_blocks_atproto().unwrap();
         let (expected, _) = public.to_node_data_with_blocks_atproto_current().unwrap();
         assert_eq!(serialized, expected);
+    }
+
+    #[test]
+    fn public_mst_rejects_unknown_node_fields() {
+        let value = DagCbor::str_map([
+            ("e", DagCbor::List(Vec::new())),
+            ("l", DagCbor::Null),
+            ("future", DagCbor::Text("must-not-be-dropped".to_owned())),
+        ]);
+        let bytes = crate::atproto_cbor::encode(&value).expect("encode public node");
+        let error = NodeData::from_atproto_dag_cbor(&bytes).expect_err("unknown node field");
+        assert!(error.to_string().contains("unknown field"));
+    }
+
+    #[test]
+    fn public_mst_rejects_unknown_entry_fields() {
+        let cid = Cid::from_dag_cbor(b"record");
+        let value = DagCbor::str_map([
+            ("l", DagCbor::Null),
+            (
+                "e",
+                DagCbor::List(vec![DagCbor::str_map([
+                    ("p", DagCbor::Unsigned(0)),
+                    ("k", DagCbor::Bytes(b"app.bsky.feed.post/1".to_vec())),
+                    ("v", DagCbor::Link(cid)),
+                    ("t", DagCbor::Null),
+                    ("future", DagCbor::Bool(true)),
+                ])]),
+            ),
+        ]);
+        let bytes = crate::atproto_cbor::encode(&value).expect("encode public node");
+        let error = NodeData::from_atproto_dag_cbor(&bytes).expect_err("unknown entry field");
+        assert!(error.to_string().contains("unknown field"));
     }
 
     #[test]

--- a/crates/hyprstream-pds/src/mst.rs
+++ b/crates/hyprstream-pds/src/mst.rs
@@ -38,6 +38,7 @@ use std::collections::BTreeMap;
 
 use anyhow::{ensure, Result};
 
+use crate::atproto_cbor::AtprotoRecordKey;
 use crate::cid::Cid;
 use crate::dag_cbor::DagCbor;
 use crate::tid::Tid;
@@ -46,6 +47,10 @@ use crate::tid::Tid;
 /// `ai.hyprstream.model/3zztslq4be52u`. The MST orders by these UTF-8 bytes.
 fn record_key(collection: &str, rkey: Tid) -> String {
     format!("{collection}/{rkey}")
+}
+
+fn public_record_key(collection: &str, rkey: &AtprotoRecordKey) -> String {
+    format!("{collection}/{}", rkey.as_str())
 }
 
 /// Compute the MST level (height) of a record key: the number of trailing zero
@@ -438,8 +443,12 @@ impl Node {
     }
 
     /// Build an inclusion proof whose node CIDs use public AT serialization.
-    pub fn proof_atproto(&self, collection: &str, rkey: &Tid) -> Option<Proof> {
-        let target = record_key(collection, *rkey);
+    pub fn proof_atproto<K>(&self, collection: &str, rkey: K) -> Option<Proof>
+    where
+        K: Into<AtprotoRecordKey>,
+    {
+        let rkey: AtprotoRecordKey = rkey.into();
+        let target = public_record_key(collection, &rkey);
         let mut path = Vec::new();
         self.proof_rec_atproto(&target, &mut path).ok()?;
         Some(Proof { path })

--- a/crates/hyprstream-pds/src/mst.rs
+++ b/crates/hyprstream-pds/src/mst.rs
@@ -78,6 +78,26 @@ fn key_level(key: &str) -> u32 {
     zeros.min(31)
 }
 
+/// Compute the protocol MST layer for a public AT Protocol record key.
+///
+/// AT Protocol derives layers from the number of leading zero bits in the
+/// SHA-256 key hash, using two leading bits per layer. This is deliberately
+/// separate from the native tree's trailing-zero convention.
+fn atproto_key_level(key: &str) -> u32 {
+    use sha2::{Digest, Sha256};
+    let digest = Sha256::digest(key.as_bytes());
+    let mut leading = 0u32;
+    for &byte in digest.iter() {
+        if byte == 0 {
+            leading += 8;
+        } else {
+            leading += byte.leading_zeros();
+            break;
+        }
+    }
+    (leading / 2).min(31)
+}
+
 // (key_level is private; tests that need it live in this module and see it directly.)
 
 // ── TreeEntry / NodeData (the on-the-wire DAG-CBOR shapes) ──────────────────
@@ -264,14 +284,28 @@ impl Node {
     /// A directory walker enumerates a collection's records by filtering
     /// entries whose key starts with `"<collection>/"`.
     pub fn from_keyed_records(records: &BTreeMap<String, Cid>) -> Self {
+        Self::from_keyed_records_with_level(records, key_level)
+    }
+
+    /// Build an MST using the public AT Protocol layer function. The native
+    /// [`Self::from_keyed_records`] constructor remains unchanged for native
+    /// artifacts; callers producing public roots should use this constructor.
+    pub fn from_keyed_records_atproto(records: &BTreeMap<String, Cid>) -> Self {
+        Self::from_keyed_records_with_level(records, atproto_key_level)
+    }
+
+    fn from_keyed_records_with_level(
+        records: &BTreeMap<String, Cid>,
+        level_fn: fn(&str) -> u32,
+    ) -> Self {
         let keys: Vec<(String, Cid)> = records.iter().map(|(k, v)| (k.clone(), *v)).collect();
         if keys.is_empty() {
             return Node::empty();
         }
         // The root level is the maximum key level (so every key is at or below
         // the root). Building top-down from here keeps subtrees well-formed.
-        let max_level = keys.iter().map(|(k, _)| key_level(k)).max().unwrap_or(0);
-        Self::build_subtree(max_level, &keys)
+        let max_level = keys.iter().map(|(k, _)| level_fn(k)).max().unwrap_or(0);
+        Self::build_subtree(max_level, &keys, level_fn)
     }
 
     /// Recursively build a subtree at `level` from the given sorted
@@ -281,7 +315,7 @@ impl Node {
     /// - Keys with `key_level == level` become direct entries of this node.
     /// - Runs of keys with `key_level < level` become left (`l`) / right (`t`)
     ///   subtrees, each built at `level - 1`.
-    fn build_subtree(level: u32, keys: &[(String, Cid)]) -> Self {
+    fn build_subtree(level: u32, keys: &[(String, Cid)], level_fn: fn(&str) -> u32) -> Self {
         let mut node = Node {
             level,
             l: None,
@@ -300,13 +334,13 @@ impl Node {
         let mut have_anchor = false;
         let mut low_start: usize = 0;
         for (i, (k, _)) in keys.iter().enumerate() {
-            if key_level(k) == level {
+            if level_fn(k) == level {
                 // Flush the low-level run [low_start, i) as a subtree.
                 let run = &keys[low_start..i];
                 let subtree = if run.is_empty() {
                     None
                 } else {
-                    Some(Box::new(Self::build_subtree(level - 1, run)))
+                    Some(Box::new(Self::build_subtree(level - 1, run, level_fn)))
                 };
                 if !have_anchor {
                     node.l = subtree; // leading run → leftmost subtree
@@ -328,7 +362,7 @@ impl Node {
         // Trailing low-level run after the last anchor → that anchor's right subtree.
         let trailing = &keys[low_start..];
         if !trailing.is_empty() {
-            let subtree = Some(Box::new(Self::build_subtree(level - 1, trailing)));
+            let subtree = Some(Box::new(Self::build_subtree(level - 1, trailing, level_fn)));
             if let Some(last) = node.entries.last_mut() {
                 last.right = subtree;
             } else {
@@ -395,11 +429,32 @@ impl Node {
 
     /// Serialize this tree with public AT Protocol node ordering and CIDs.
     pub fn to_node_data_with_blocks_atproto(&self) -> Result<(NodeData, Vec<(Cid, NodeData)>)> {
+        // A native Node may have been built with the native layer function.
+        // Rebuild from its complete key set before public serialization so the
+        // resulting topology follows the AT Protocol layer rule.
+        let mut records = BTreeMap::new();
+        self.collect_keyed_records(&mut records);
+        Self::from_keyed_records_atproto(&records).to_node_data_with_blocks_atproto_current()
+    }
+
+    fn to_node_data_with_blocks_atproto_current(&self) -> Result<(NodeData, Vec<(Cid, NodeData)>)> {
         let mut blocks = Vec::new();
         let data = self.to_node_data_atproto_rec(&mut blocks)?;
         let cid = data.cid_atproto()?;
         blocks.push((cid, data.clone()));
         Ok((data, blocks))
+    }
+
+    fn collect_keyed_records(&self, records: &mut BTreeMap<String, Cid>) {
+        if let Some(left) = &self.l {
+            left.collect_keyed_records(records);
+        }
+        for entry in &self.entries {
+            records.insert(entry.key.clone(), entry.value);
+            if let Some(right) = &entry.right {
+                right.collect_keyed_records(records);
+            }
+        }
     }
 
     fn to_node_data_atproto_rec(&self, blocks: &mut Vec<(Cid, NodeData)>) -> Result<NodeData> {
@@ -449,8 +504,11 @@ impl Node {
     {
         let rkey: AtprotoRecordKey = rkey.into();
         let target = public_record_key(collection, &rkey);
+        let mut records = BTreeMap::new();
+        self.collect_keyed_records(&mut records);
+        let tree = Self::from_keyed_records_atproto(&records);
         let mut path = Vec::new();
-        self.proof_rec_atproto(&target, &mut path).ok()?;
+        tree.proof_rec_atproto(&target, &mut path).ok()?;
         Some(Proof { path })
     }
 
@@ -824,6 +882,32 @@ mod tests {
             found, keyed,
             "walked entries must match the input key set exactly"
         );
+    }
+
+    #[test]
+    fn public_mst_uses_protocol_layer_function() {
+        let keyed: BTreeMap<String, Cid> = (1..=32)
+            .map(|i| {
+                (
+                    format!("app.bsky.feed.post/{i:013}"),
+                    Cid::from_dag_cbor(format!("record-{i}").as_bytes()),
+                )
+            })
+            .collect();
+        let native = Node::from_keyed_records(&keyed);
+        let public = Node::from_keyed_records_atproto(&keyed);
+        let expected_level = keyed
+            .keys()
+            .map(|key| atproto_key_level(key))
+            .max()
+            .unwrap_or(0);
+        assert_eq!(public.level, expected_level);
+        assert_ne!(native.level, public.level);
+
+        // Public serialization must also rebuild a native tree's topology.
+        let (serialized, _) = native.to_node_data_with_blocks_atproto().unwrap();
+        let (expected, _) = public.to_node_data_with_blocks_atproto_current().unwrap();
+        assert_eq!(serialized, expected);
     }
 
     #[test]

--- a/crates/hyprstream-pds/src/mst.rs
+++ b/crates/hyprstream-pds/src/mst.rs
@@ -149,6 +149,14 @@ impl NodeData {
 
     pub fn from_atproto_dag_cbor(bytes: &[u8]) -> Result<Self> {
         let value = crate::atproto_cbor::decode(bytes)?;
+        // Keep the wire bytes tied to the value used for projection.  The
+        // public decoder is canonical today; retaining this explicit check
+        // prevents a future normalizer change from silently changing the MST
+        // node bytes and therefore its CID.
+        ensure!(
+            crate::atproto_cbor::encode(&value)? == bytes,
+            "ATProto MST bytes are not canonical"
+        );
         Self::reject_unknown_fields(&value, &["l", "e"], "MST node")?;
         if let Some(entries) = value.get("e") {
             for entry in entries.as_list()? {
@@ -962,6 +970,21 @@ mod tests {
         let bytes = crate::atproto_cbor::encode(&value).expect("encode public node");
         let error = NodeData::from_atproto_dag_cbor(&bytes).expect_err("unknown entry field");
         assert!(error.to_string().contains("unknown field"));
+    }
+
+    #[test]
+    fn public_mst_preserves_canonical_bytes_on_decode() {
+        let value = DagCbor::str_map([
+            ("l", DagCbor::Null),
+            ("e", DagCbor::List(Vec::new())),
+        ]);
+        let bytes = crate::atproto_cbor::encode(&value).expect("encode public node");
+        let node = NodeData::from_atproto_dag_cbor(&bytes).expect("decode public node");
+        assert_eq!(
+            crate::atproto_cbor::encode(&node.to_value()).expect("re-encode public node"),
+            bytes,
+            "public MST decode must preserve canonical bytes and CID"
+        );
     }
 
     #[test]

--- a/crates/hyprstream-pds/src/mst.rs
+++ b/crates/hyprstream-pds/src/mst.rs
@@ -112,6 +112,20 @@ impl NodeData {
         Cid::from_dag_cbor(&self.encode())
     }
 
+    /// Public AT Protocol serialization. The existing native format remains
+    /// the default for already-signed artifacts.
+    pub fn encode_atproto(&self) -> Result<Vec<u8>> {
+        crate::atproto_cbor::encode(&self.to_value())
+    }
+
+    pub fn cid_atproto(&self) -> Result<Cid> {
+        Ok(Cid::from_dag_cbor(&self.encode_atproto()?))
+    }
+
+    pub fn from_atproto_dag_cbor(bytes: &[u8]) -> Result<Self> {
+        Self::from_value(&crate::atproto_cbor::decode(bytes)?)
+    }
+
     pub fn to_value(&self) -> DagCbor {
         // atproto node shape: { l: Option<Link>, e: [{p,k,v,t}, ...] }
         let entries: Vec<DagCbor> = self
@@ -374,6 +388,97 @@ impl Node {
         blocks
     }
 
+    /// Serialize this tree with public AT Protocol node ordering and CIDs.
+    pub fn to_node_data_with_blocks_atproto(&self) -> Result<(NodeData, Vec<(Cid, NodeData)>)> {
+        let mut blocks = Vec::new();
+        let data = self.to_node_data_atproto_rec(&mut blocks)?;
+        let cid = data.cid_atproto()?;
+        blocks.push((cid, data.clone()));
+        Ok((data, blocks))
+    }
+
+    fn to_node_data_atproto_rec(&self, blocks: &mut Vec<(Cid, NodeData)>) -> Result<NodeData> {
+        let l = self
+            .l
+            .as_ref()
+            .map(|child| -> Result<Cid> {
+                let child_data = child.to_node_data_atproto_rec(blocks)?;
+                let cid = child_data.cid_atproto()?;
+                blocks.push((cid, child_data));
+                Ok(cid)
+            })
+            .transpose()?;
+        let mut entries = Vec::with_capacity(self.entries.len());
+        for (idx, entry) in self.entries.iter().enumerate() {
+            let p = shared_prefix_len(
+                self.entries
+                    .get(idx.wrapping_sub(1))
+                    .map(|e| e.key.as_str()),
+                &entry.key,
+            );
+            let k = entry.key.as_bytes()[p..].to_vec();
+            let t = entry
+                .right
+                .as_ref()
+                .map(|child| -> Result<Cid> {
+                    let child_data = child.to_node_data_atproto_rec(blocks)?;
+                    let cid = child_data.cid_atproto()?;
+                    blocks.push((cid, child_data));
+                    Ok(cid)
+                })
+                .transpose()?;
+            entries.push(TreeEntry {
+                p,
+                k,
+                v: entry.value,
+                t,
+            });
+        }
+        Ok(NodeData { l, e: entries })
+    }
+
+    /// Build an inclusion proof whose node CIDs use public AT serialization.
+    pub fn proof_atproto(&self, collection: &str, rkey: &Tid) -> Option<Proof> {
+        let target = record_key(collection, *rkey);
+        let mut path = Vec::new();
+        self.proof_rec_atproto(&target, &mut path).ok()?;
+        Some(Proof { path })
+    }
+
+    fn proof_rec_atproto(&self, target: &str, path: &mut Vec<ProofStep>) -> Result<()> {
+        let node_data = self.to_node_data_atproto_rec(&mut Vec::new())?;
+        if let Some(left) = &self.l {
+            let below_first = self
+                .entries
+                .first()
+                .map(|e| target < e.key.as_str())
+                .unwrap_or(true);
+            if below_first {
+                path.push(ProofStep::LeftSubtree(node_data));
+                return left.proof_rec_atproto(target, path);
+            }
+        }
+        for (i, entry) in self.entries.iter().enumerate() {
+            if entry.key == target {
+                path.push(ProofStep::FoundAt(node_data, i));
+                return Ok(());
+            }
+            let next_key = self.entries.get(i + 1).map(|e| e.key.as_str());
+            let in_range = match next_key {
+                Some(nk) => entry.key.as_str() < target && target < nk,
+                None => entry.key.as_str() < target,
+            };
+            if in_range {
+                if let Some(right) = &entry.right {
+                    path.push(ProofStep::ThroughEntry(node_data, i));
+                    return right.proof_rec_atproto(target, path);
+                }
+                return Err(anyhow::anyhow!("target is not present"));
+            }
+        }
+        Err(anyhow::anyhow!("target is not present"))
+    }
+
     /// Compute the MST path (inclusion proof) for `rkey`: the chain of
     /// `(NodeData, entry_index)` pairs from the root down to the entry whose
     /// key matches, plus the sibling-subtree CIDs needed to verify the chain.
@@ -459,6 +564,18 @@ impl Proof {
     /// (they asked for it), so we don't reconstruct it from prefix-compression —
     /// the value-CID check plus the CID chain is the load-bearing guarantee.
     pub fn verify(&self, root_cid: &Cid, record_cid: &Cid) -> Result<()> {
+        self.verify_with(root_cid, record_cid, |data| Ok(data.cid()))
+    }
+
+    /// Verify an inclusion proof using public AT Protocol node serialization.
+    pub fn verify_atproto(&self, root_cid: &Cid, record_cid: &Cid) -> Result<()> {
+        self.verify_with(root_cid, record_cid, NodeData::cid_atproto)
+    }
+
+    fn verify_with<F>(&self, root_cid: &Cid, record_cid: &Cid, cid_for: F) -> Result<()>
+    where
+        F: Fn(&NodeData) -> Result<Cid>,
+    {
         ensure!(!self.path.is_empty(), "empty MST proof");
         let mut expected_cid: Option<Cid> = None; // CID the *current* node must have
         let mut found_value: Option<Cid> = None;
@@ -470,7 +587,7 @@ impl Proof {
                 ProofStep::LeftSubtree(d) => (d, ProofKind::Left),
             };
             // Recompute this node's CID and verify against the expectation.
-            let node_cid = data.cid();
+            let node_cid = cid_for(data)?;
             if let Some(ref want) = expected_cid {
                 ensure!(
                     node_cid == *want,
@@ -694,7 +811,10 @@ mod tests {
             }
         }
         walk(tree.root_cid(), &block_map, &mut found);
-        assert_eq!(found, keyed, "walked entries must match the input key set exactly");
+        assert_eq!(
+            found, keyed,
+            "walked entries must match the input key set exactly"
+        );
     }
 
     #[test]

--- a/docs/atproto-cbor-interop.md
+++ b/docs/atproto-cbor-interop.md
@@ -1,0 +1,52 @@
+# Public AT encoding boundary
+
+The PDS `DagCbor` implementation historically sorts raw UTF-8 text keys
+lexicographically. Existing native capsule, operation and account artifacts use
+that implementation. Its previous comments incorrectly claimed this was the
+public AT encoding order.
+
+Public DAG-CBOR compares encoded text keys, including their length header; for
+text keys this is byte length first, followed by lexical bytes. See
+https://ipld.io/specs/codecs/dag-cbor/spec/#strictness.
+
+The additive `hyprstream_pds::atproto_cbor::{encode,decode}` boundary uses that
+public order. It shares scalar parsing and the existing value type, preserves
+strict parsing, and checks the signed-64-bit AT integer domain. The default
+native encoder and decoder retain their existing behavior. Neither decoder tries
+the alternate ordering after rejection.
+
+The interoperability vector in the unit test was independently generated with
+`@atproto/lex-cbor` 0.1.6:
+
+```javascript
+import {encode, cidForLex} from '@atproto/lex-cbor'
+const record = {
+  $type: 'app.bsky.feed.post',
+  text: 'Hello from Torment Nexus',
+  createdAt: '2026-09-09T00:00:00.000Z',
+}
+console.log(Buffer.from(encode(record)).toString('hex'))
+console.log((await cidForLex(record)).toString())
+```
+
+The expected CID is
+`bafyreiaapk47b4fmdslcizkj5aj6ws6bmpmvfvjq3ryhx5qwgug6tldalm`.
+The upstream wire map orders `text`, `$type`, `createdAt`. The test checks exact
+bytes and CID, rather than merely a round trip through our own implementation.
+Negative cases cover cross-format rejection, duplicate keys, nonminimal widths,
+invalid tags/UTF-8, trailing data, signed integer limits and excessive nesting.
+
+## Integration and migration gate
+
+This module is a serialization primitive, not a new authority, a schema validator
+or a public PDS rollout. Existing `Commit`, MST, CAR and record callers do not
+switch formats in this change. Public repository wiring must consistently use
+the public format for every relevant block, with independent signature/MST/CAR
+interop tests and a single-writer migration contract.
+
+Do not re-encode a stored native signed artifact, replace a native DID or broaden
+its canonical verifier to make public tests pass. Native security-critical data
+keeps its accepted bytes and verification policy. An exported public artifact
+gets its own bytes/CID and, where applicable, separately managed classical
+repository signature. Existing native/public mappings must record both identities
+explicitly; the encoding boundary cannot confer native authority on public input.


### PR DESCRIPTION
Public AT Protocol DAG-CBOR sorts encoded text keys by length and then bytes. The existing PDS codec sorts raw text bytes lexically; a standard app.bsky.feed.post consequently gets different bytes and a different CID from the upstream encoder. Changing that codec globally would also change native signed artifacts.

Add an explicit public `atproto_cbor` encode/decode boundary while retaining existing native behavior. The public path reuses scalar parsing and the existing value type, enforces signed 64-bit integers and strict canonical ordering, and never falls back to native ordering. Existing record, commit, MST, CAR and identity call sites retain their current encoding; this is a prerequisite for public repository integration, not a migration or readiness claim.

The upstream @atproto/lex-cbor 0.1.6 post vector checks exact bytes and CID. Tests also cover preserved native bytes, cross-format rejection, nested UTF-8 ordering, duplicate keys, invalid construction, malformed wire data, links, integer bounds and nesting limits.

Validation: 7 focused tests passed; the complete PDS suite passed (262 unit tests plus 6 integration tests, none ignored). Normal pre-commit workspace/all-target release Clippy runs through the shared BuildQ helper. No keys, crypto profiles, authority rules or live deployment are changed.

Stacked on #1602 to retain the lane's pinned schema contract. Merge base before tip after independent review and required checks. The public commit/MST/CAR call-site and migration gates remain outstanding, as do the existing staging and #1506 gates.
