### PR TITLE
feat(xrpc): gate standard createRecord on native auth

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6926,6 +6926,7 @@ dependencies = [
  "jsonwebtoken 10.3.0",
  "k256",
  "keyring",
+ "language-tags",
  "libc",
  "listenfd",
  "log",
@@ -6994,6 +6995,8 @@ dependencies = [
  "tracing-opentelemetry",
  "tracing-subscriber",
  "tui-logger",
+ "unicode-segmentation",
+ "uriparse",
  "url",
  "urlencoding",
  "users",
@@ -9059,6 +9062,12 @@ dependencies = [
  "libc",
  "thiserror 2.0.18",
 ]
+
+[[package]]
+name = "language-tags"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4345964bb142484797b161f473a503a434de77149dd8c7427788c6e13379388"
 
 [[package]]
 name = "lazy_static"
@@ -17276,6 +17285,16 @@ dependencies = [
  "serde_json",
  "url",
  "webpki-roots 0.26.11",
+]
+
+[[package]]
+name = "uriparse"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0200d0fc04d809396c2ad43f3c95da3582a2556eba8d453c1087f4120ee352ff"
+dependencies = [
+ "fnv",
+ "lazy_static",
 ]
 
 [[package]]

--- a/Dockerfile
+++ b/Dockerfile
@@ -310,6 +310,8 @@ WORKDIR /build
 COPY Cargo.toml ./
 COPY Cargo.lock ./
 COPY crates ./crates
+# Compile-time include_str! inputs for the pinned AT Protocol schema validator.
+COPY lexicons/upstream/atproto ./lexicons/upstream/atproto
 
 ENV LIBTORCH=/opt/libtorch
 ENV LD_LIBRARY_PATH=/opt/libtorch/lib

--- a/crates/hyprstream-pds/src/commit.rs
+++ b/crates/hyprstream-pds/src/commit.rs
@@ -218,9 +218,8 @@ impl Commit {
         Self::validate_atproto_fields(&value)?;
         let commit = Self::from_value(&value)?;
         // Public verification must bind the exact canonical block bytes. In
-        // particular, Tid::parse normalizes the final base32 bit; without
-        // this round-trip check, two distinct `rev` encodings could decode to
-        // one value and share signature verification.
+        // particular, decoding and re-encoding the revision must preserve
+        // its exact text; no alternate field encoding may share verification.
         ensure!(
             commit.to_atproto_dag_cbor()?.as_slice() == bytes,
             "public commit bytes are not canonical"
@@ -729,32 +728,43 @@ mod tests {
     }
 
     #[test]
-    fn public_commit_rejects_noncanonical_tid_rev_bytes() {
-        let (commit, _vk) = make_signed_commit();
-        let canonical = commit
-            .to_atproto_dag_cbor()
-            .expect("canonical public commit");
-        let mut value = crate::atproto_cbor::decode(&canonical).expect("decode public commit");
-        let mut fields = value.as_map().expect("commit map").to_vec();
+    fn public_commit_preserves_odd_tid_revisions_and_rejects_changed_signature_input() {
+        let key = SigningKey::random(&mut rand::rngs::OsRng);
+        let unsigned = UnsignedCommit::new(
+            "did:web:alice.example.com",
+            Cid::from_dag_cbor(b"root"),
+            Tid::parse("3jzfcijpj2z2a").unwrap(),
+            None,
+        );
+        let commit = Commit::sign_atproto(&unsigned, &key).unwrap();
+        let mut fields = commit.to_value().as_map().unwrap().to_vec();
         let rev = fields
             .iter_mut()
             .find(|(key, _)| matches!(key, DagCbor::Text(name) if name == "rev"))
-            .expect("rev field");
-        let mut rev_text = rev.1.as_str().expect("rev text").to_owned();
-        let last = rev_text.pop().expect("tid digit");
-        let replacement = match last {
-            '2' => '3',
-            '3' => '2',
-            _ => panic!("test TID must end in 2 or 3, got {last}"),
-        };
-        rev_text.push(replacement);
-        rev.1 = DagCbor::Text(rev_text);
-        value = DagCbor::Map(fields);
-        let tampered = crate::atproto_cbor::encode(&value).expect("encode tampered commit");
-        assert!(
-            Commit::from_atproto_dag_cbor(&tampered).is_err(),
-            "public decoder must reject a rev encoding that normalizes to a different byte form"
-        );
+            .unwrap();
+        rev.1 = DagCbor::Text("3jzfcijpj2z2b".into());
+        let changed = crate::atproto_cbor::encode(&DagCbor::Map(fields.clone())).unwrap();
+        let decoded = Commit::from_atproto_dag_cbor(&changed).unwrap();
+        assert_eq!(decoded.rev.encode(), "3jzfcijpj2z2b");
+        assert_eq!(decoded.to_atproto_dag_cbor().unwrap(), changed);
+        assert!(decoded.verify_atproto(key.verifying_key()).is_err());
+        let signed_odd = Commit::sign_atproto(&decoded.unsigned(), &key).unwrap();
+        Commit::from_atproto_dag_cbor(&signed_odd.to_atproto_dag_cbor().unwrap())
+            .unwrap()
+            .verify_atproto(key.verifying_key())
+            .unwrap();
+        for invalid in ["kjzfcijpj2z2a", "3JZFCIJPJ2Z2B"] {
+            let mut fields = fields.clone();
+            fields
+                .iter_mut()
+                .find(|(key, _)| matches!(key, DagCbor::Text(name) if name == "rev"))
+                .unwrap()
+                .1 = DagCbor::Text(invalid.into());
+            assert!(Commit::from_atproto_dag_cbor(
+                &crate::atproto_cbor::encode(&DagCbor::Map(fields)).unwrap()
+            )
+            .is_err());
+        }
     }
 
     #[test]

--- a/crates/hyprstream-pds/src/tid.rs
+++ b/crates/hyprstream-pds/src/tid.rs
@@ -1,24 +1,22 @@
 //! atproto TID (Timestamp Identifier) — lexicographically-sortable record keys.
 //!
-//! A TID is a 13-character base32-sorted string encoding a 64-bit integer whose
-//! high 53 bits are a microsecond timestamp and low 10 bits are a per-actor
-//! "clock id" (random, to break ties within the same microsecond). Because the
-//! base32 alphabet is sorted (`2..7`, then `a..z`) and the timestamp occupies
-//! the high bits, string comparison of TIDs matches chronological order — which
-//! is exactly what the MST relies on to keep record keys in order.
+//! A TID is a 13-character base32-sortable integer. A timestamp constructor
+//! packs 53 microsecond-timestamp bits above a 10-bit per-actor clock id.
+//! The sorted alphabet makes string order agree with numeric order.
 //!
 //! # Format
 //!
-//! The 64-bit integer is big-endian base32-encoded with the 13-symbol alphabet
-//! `234567abcdefghijklmnopqrstuvwxyz` (RFC 4648 base32 without padding, but
-//! using lowercase). The leading bit is always 0 (the timestamp is capped at
-//! 2^53), giving 53 bits of timestamp headroom until ~2242 CE.
+//! The alphabet is `234567abcdefghijklmnopqrstuvwxyz` (32 symbols). The raw
+//! 64-bit integer is represented by 13 radix-32 digits, with a zero 65th bit
+//! at the LEFT. Thus the first digit is restricted to `2..7` or `a..j`, while
+//! the final digit carries all five low bits. This is integer encoding, not
+//! byte-oriented base32 with right-side padding bits.
 
 use std::fmt;
 
 use anyhow::{bail, Result};
 
-/// The 13-symbol TID base32 alphabet (sorted: '2' < ... < 'z').
+/// The 32-symbol TID base32 alphabet (sorted: '2' < ... < 'z').
 const TID_ALPHABET: &[u8; 32] = b"234567abcdefghijklmnopqrstuvwxyz";
 const TID_LEN: usize = 13;
 
@@ -69,22 +67,14 @@ impl Tid {
     /// (Named `encode` rather than `to_string` to avoid shadowing the
     /// `ToString` blanket impl that `Display` would otherwise recurse through.)
     pub fn encode(self) -> String {
-        // 13 base32 symbols carry 65 bits. The 64-bit TID value occupies the
-        // low 64 bits of that 65-bit space; the top (65th) bit is always 0
-        // (the timestamp is capped at 2^53, so bit 63 is 0 in practice too).
-        // We emit big-endian, 5 bits per symbol, MSB first: symbol 0 carries
-        // bits [64..60], symbol 1 carries bits [59..55], …, symbol 12 carries
-        // bits [4..0].
-        //
-        // Concretely: shift the value left by 1 to place it in a 65-bit field,
-        // then extract 5-bit groups from the top.
-        let val65 = (self.0 as u128) << 1; // 65-bit quantity (top bit 0)
+        // Zero-extend the raw integer on the left: digits carry bits
+        // [64..60], [59..55], ..., [4..0]. Never shift the value left.
         let mut out = vec![TID_ALPHABET[0]; TID_LEN];
         for (i, slot) in out.iter_mut().enumerate() {
             // Symbol i carries bits [64-5i .. 60-5i] of the 65-bit field.
-            // Extract by shifting the *upper* bit position down to 0.
+            // Shift the group's least significant bit down to bit zero.
             let shift = 60 - 5 * i;
-            let idx = ((val65 >> shift) & 0x1f) as usize;
+            let idx = ((self.0 >> shift) & 0x1f) as usize;
             *slot = TID_ALPHABET[idx];
         }
         // TID_ALPHABET is ASCII, so from_utf8 is infallible in practice; use
@@ -102,20 +92,21 @@ impl Tid {
         if s.len() != TID_LEN {
             bail!("TID must be {TID_LEN} chars, got {}", s.len());
         }
-        // Inverse of encode: accumulate 13 symbols × 5 bits = 65 bits into a
-        // u128 (big-endian), then drop the top padding bit and take the low 64.
-        let mut val65: u128 = 0;
-        for &byte in s.as_bytes().iter() {
-            let idx = match TID_ALPHABET.iter().position(|&a| a == byte) {
-                Some(i) => i as u128,
+        let mut value = 0u64;
+        for (position, &byte) in s.as_bytes().iter().enumerate() {
+            let digit = match TID_ALPHABET.iter().position(|&a| a == byte) {
+                Some(i) => i as u64,
                 None => bail!("invalid TID char {byte:?}"),
             };
-            val65 = val65
-                .checked_shl(5)
+            if position == 0 && digit >= 16 {
+                bail!("TID leading digit exceeds the 64-bit range");
+            }
+            value = value
+                .checked_mul(32)
+                .and_then(|value| value.checked_add(digit))
                 .ok_or_else(|| anyhow::anyhow!("TID overflow"))?;
-            val65 |= idx;
         }
-        Ok(Tid((val65 >> 1) as u64))
+        Ok(Tid(value))
     }
 }
 
@@ -136,8 +127,58 @@ mod tests {
     use super::*;
 
     #[test]
+    fn tid_raw_integer_vectors_cover_low_bits_and_full_range() {
+        for (raw, text) in [
+            (0, "2222222222222"),
+            (1, "2222222222223"),
+            (31, "222222222222z"),
+            (32, "2222222222232"),
+            (1u64 << 60, "3222222222222"),
+            ((1u64 << 63) - 1, "bzzzzzzzzzzzz"),
+            (1u64 << 63, "c222222222222"),
+            (u64::MAX, "jzzzzzzzzzzzz"),
+        ] {
+            assert_eq!(Tid::from_raw(raw).encode(), text);
+            assert_eq!(Tid::parse(text).unwrap().to_raw(), raw);
+        }
+        let maximum_timestamp = Tid::from_micros((1u64 << 53) - 1, 1023);
+        assert_eq!(maximum_timestamp.to_raw(), (1u64 << 63) - 1);
+        assert_eq!(maximum_timestamp.encode(), "bzzzzzzzzzzzz");
+    }
+
+    #[test]
+    fn tid_preserves_every_final_digit_and_valid_odd_low_bit() {
+        let even = Tid::parse("3jzfcijpj2z2a").unwrap();
+        let odd = Tid::parse("3jzfcijpj2z2b").unwrap();
+        assert_eq!(odd.to_raw(), even.to_raw() + 1);
+        assert_eq!(odd.encode(), "3jzfcijpj2z2b");
+        for &digit in TID_ALPHABET {
+            let text = format!("3jzfcijpj2z2{}", digit as char);
+            assert_eq!(Tid::parse(&text).unwrap().encode(), text);
+        }
+    }
+
+    #[test]
+    fn tid_rejects_out_of_range_leading_digits_and_noncanonical_text() {
+        for (index, &digit) in TID_ALPHABET.iter().enumerate() {
+            let text = format!("{}jzfcijpj2z2a", digit as char);
+            assert_eq!(Tid::parse(&text).is_ok(), index < 16, "{text}");
+        }
+        for text in [
+            "kjzfcijpj2z2a",
+            "KJZFCIJPJ2Z2A",
+            "3JZFCIJPJ2Z2B",
+            "3jzfcijpj2z2b=",
+            "3jzfcijpj2z2",
+            "3jzfcijpj2z21",
+        ] {
+            assert!(Tid::parse(text).is_err(), "{text}");
+        }
+    }
+
+    #[test]
     fn tid_string_round_trip() {
-        for raw in [0u64, 1, 0x1234_5678, 0x7fff_ffff_ffff] {
+        for raw in [0u64, 1, 0x1234_5678, 0x7fff_ffff_ffff, 1u64 << 63, u64::MAX] {
             let tid = Tid::from_raw(raw);
             let s = tid.encode();
             assert_eq!(s.len(), TID_LEN, "tid {raw}");

--- a/crates/hyprstream/Cargo.toml
+++ b/crates/hyprstream/Cargo.toml
@@ -97,6 +97,10 @@ bincode.workspace = true
 tokio-stream.workspace = true
 hex.workspace = true
 chrono.workspace = true
+# Lexicon string constraints: grapheme clusters, BCP47 and RFC3986 syntax.
+unicode-segmentation = "=1.12.0"
+language-tags = "0.3.2"
+uriparse = "0.6.4"
 async-stream.workspace = true
 anyhow.workspace = true
 sha2.workspace = true  # SHA256 validation for LFS files

--- a/crates/hyprstream/src/services/discovery.rs
+++ b/crates/hyprstream/src/services/discovery.rs
@@ -508,7 +508,14 @@ impl PdsRecordStore {
         let d = sha2::Sha256::digest(repo_id.as_bytes());
         let micros = u64::from_be_bytes([d[0], d[1], d[2], d[3], d[4], d[5], d[6], d[7]]);
         let clock_id = u16::from_be_bytes([d[8], d[9]]);
-        Tid::from_micros(micros, clock_id)
+        // Preserve the spelling already stored in RocksDB and signed into
+        // native MSTs before the public TID codec correction. The old codec
+        // encoded this 63-bit hash as base32(raw << 1). Lift the derivation
+        // into the corrected integer representation, rather than changing
+        // existing keys or teaching the public parser an ambiguous format.
+        // from_micros always leaves bit 63 clear, so this shift cannot lose
+        // entropy or exceed the public TID's 64-bit range.
+        Tid::from_raw(Tid::from_micros(micros, clock_id).to_raw() << 1)
     }
 
     /// Load the full record set + signed commit for `did`, or `None` if the
@@ -2673,6 +2680,116 @@ mod pds_store_tests {
                 publisher.publish_record(bad, "repo-a", SAMPLE_OID).is_err(),
                 "collection {bad:?} must be rejected"
             );
+        }
+    }
+
+    // Frozen spellings from the pre-correction base32(raw << 1) codec.
+    // In particular repo-a exercises bit 63 of the corrected representation.
+    const LEGACY_RKEYS: [(&str, &str); 3] = [
+        ("repo-a", "i4pvpmy7trq2g"),
+        ("repo-b", "42al4ks2j6lfu"),
+        ("name-a", "65wkrauzdcfsw"),
+    ];
+
+    #[test]
+    fn tid_for_repo_preserves_legacy_storage_spelling() {
+        for (id, spelling) in LEGACY_RKEYS {
+            let tid = PdsRecordStore::tid_for_repo(id);
+            assert_eq!(tid.encode(), spelling);
+            assert_eq!(Tid::parse(spelling).unwrap(), tid);
+            assert_eq!(tid.to_raw() & 1, 0);
+        }
+        assert!(PdsRecordStore::tid_for_repo("repo-a").to_raw() > i64::MAX as u64);
+    }
+
+    #[test]
+    fn legacy_store_upgrade_preserves_keys_and_republishes_without_duplicates() {
+        let dir = tempfile::tempdir().unwrap();
+        let sk = SigningKey::random(&mut rand::rngs::OsRng);
+        let vk = *sk.verifying_key();
+        let collections = [COLLECTION_NSID, COLLECTION_NSID, NAME_COLLECTION];
+        let record = ModelRecord::new(
+            format!("at://{DID}"),
+            git_oid_to_cid_string(SAMPLE_OID).unwrap(),
+            "2026-07-19T00:00:00.000Z",
+        )
+        .unwrap();
+        // Seed the pre-upgrade wire/disk representation directly: no current
+        // tid_for_repo, record_key, or build_tree helper can mask a regression.
+        let mut keyed = BTreeMap::new();
+        let mut expected_keys = std::collections::BTreeSet::new();
+        let legacy_commit = {
+            let db = rocksdb::DB::open_default(dir.path()).unwrap();
+            let mut batch = rocksdb::WriteBatch::default();
+            for ((_, spelling), collection) in LEGACY_RKEYS.iter().zip(collections) {
+                let key = format!("rk\0{DID}\0{collection}\0{spelling}").into_bytes();
+                batch.put(&key, record.to_dag_cbor());
+                expected_keys.insert(key);
+                keyed.insert(format!("{collection}/{spelling}"), record.cid());
+            }
+            let root = Node::from_keyed_records(&keyed).root_cid();
+            // Parsing the old on-wire revision preserves its exact signed
+            // bytes even though the codec's internal raw representation changed.
+            let commit = Commit::sign(
+                &UnsignedCommit::new(
+                    DID.to_owned(),
+                    root,
+                    Tid::parse("3jzfcijpj2z2a").unwrap(),
+                    None,
+                ),
+                &sk,
+            );
+            batch.put(format!("commit\0{DID}"), commit.to_dag_cbor());
+            db.write(batch).unwrap();
+            commit
+        };
+        let mut previous = legacy_commit.cid();
+        for oid in [SAMPLE_OID_2, SAMPLE_OID] {
+            let store = Arc::new(PdsRecordStore::open(dir.path()).unwrap());
+            let loaded = store.load_repo(DID).unwrap().unwrap();
+            assert_eq!(loaded.commit.cid(), previous);
+            assert_eq!(loaded.records.len(), LEGACY_RKEYS.len());
+            assert_eq!(
+                PdsRecordStore::build_tree(&loaded.records).root_cid(),
+                loaded.commit.data
+            );
+            loaded.commit.verify(&vk).unwrap();
+            for ((id, _), collection) in LEGACY_RKEYS.iter().zip(collections) {
+                resolve_and_verify(&store, &vk, collection, id);
+            }
+            let publisher =
+                PdsPublisher::new(store.clone(), DID.to_owned(), test_es256_store(sk.clone()));
+            for ((id, spelling), collection) in LEGACY_RKEYS.iter().zip(collections) {
+                publisher.publish_record(collection, id, oid).unwrap();
+                let repo = store.load_repo(DID).unwrap().unwrap();
+                assert_eq!(repo.records.len(), LEGACY_RKEYS.len());
+                assert_eq!(repo.commit.prev, Some(previous));
+                assert_eq!(
+                    repo.records[&(collection.to_owned(), Tid::parse(spelling).unwrap())]
+                        .current_oid,
+                    git_oid_to_cid_string(oid).unwrap()
+                );
+                resolve_and_verify(&store, &vk, collection, id);
+                previous = repo.commit.cid();
+            }
+            let RecordBacking::ReadWrite(db) = &store.backing else {
+                unreachable!()
+            };
+            let actual_keys: std::collections::BTreeSet<_> = db
+                .prefix_iterator(record_prefix(DID))
+                .map(|entry| entry.unwrap().0.to_vec())
+                .take_while(|key| key.starts_with(&record_prefix(DID)))
+                .collect();
+            assert_eq!(
+                actual_keys, expected_keys,
+                "upgrade must overwrite the original keys"
+            );
+            drop(publisher);
+            drop(store);
+            let readonly = Arc::new(PdsRecordStore::open_readonly(dir.path()).unwrap());
+            for ((id, _), collection) in LEGACY_RKEYS.iter().zip(collections) {
+                resolve_and_verify(&readonly, &vk, collection, id);
+            }
         }
     }
 

--- a/crates/hyprstream/src/services/oauth/mod.rs
+++ b/crates/hyprstream/src/services/oauth/mod.rs
@@ -224,7 +224,7 @@ pub fn create_app(state: Arc<OAuthState>, cors_config: &crate::config::CorsConfi
             auth::require_global_service_authority,
         ));
 
-    let protected_router = Router::new()
+    let protected_routes = Router::new()
         .route(
             xrpc::GET_SERVICE_AUTH_PATH,
             get(xrpc::get_service_auth),
@@ -240,7 +240,13 @@ pub fn create_app(state: Arc<OAuthState>, cors_config: &crate::config::CorsConfi
             get(userinfo::userinfo).post(userinfo::userinfo),
         )
         .merge(authority_router)
-        .layer(axum::middleware::from_fn_with_state(
+        .merge(if state.public_repo_writer.is_some() {
+            xrpc::xrpc_write_routes()
+        } else {
+            Router::new()
+        });
+
+    let protected_router = protected_routes.layer(axum::middleware::from_fn_with_state(
             Arc::clone(&state),
             auth::require_bearer_token,
         ));

--- a/crates/hyprstream/src/services/oauth/state.rs
+++ b/crates/hyprstream/src/services/oauth/state.rs
@@ -2260,7 +2260,7 @@ pub fn canonical_issuer_origin(issuer_url: &str) -> Option<String> {
 /// while a non-default port is retained and its domain-segment separator is
 /// encoded as `%3A`. IPv6 is rejected until client and server share one
 /// canonical DID representation for it.
-fn atproto_service_did_for_origin(issuer_url: &str) -> Option<String> {
+pub(super) fn atproto_service_did_for_origin(issuer_url: &str) -> Option<String> {
     let url = url::Url::parse(issuer_url).ok()?;
     if !matches!(url.scheme(), "http" | "https")
         || !url.username().is_empty()

--- a/crates/hyprstream/src/services/oauth/state.rs
+++ b/crates/hyprstream/src/services/oauth/state.rs
@@ -1165,6 +1165,9 @@ pub struct OAuthState {
     /// by the write path (#910) and tests; the read endpoints consult it
     /// directly. Default-empty so existing construction sites need no change.
     pub xrpc_repos: Arc<super::xrpc::XrpcRepoStore>,
+    /// Optional native-authorized public repository writer. No public write
+    /// routes are mounted while this is absent.
+    pub public_repo_writer: Option<Arc<crate::services::public_repo::PublicRepoWriter>>,
     /// When `true`, the XRPC read-slice routes (`/xrpc/…`) are mounted on the
     /// OAuth router (#1112). Copied from `OAuthConfig::xrpc_read_slice`.
     pub xrpc_read_slice: bool,
@@ -1358,6 +1361,7 @@ impl OAuthState {
             ),
             sessions: super::session::SessionStore::default(),
             xrpc_repos: Arc::new(super::xrpc::XrpcRepoStore::new()),
+            public_repo_writer: None,
             xrpc_read_slice: config.xrpc_read_slice,
             deployment_well_known_dir: config.deployment_well_known_dir.clone(),
             rsa_encoding_key: None,
@@ -1424,6 +1428,16 @@ impl OAuthState {
         store: Arc<hyprstream_pds_service::AccountRecordStore>,
     ) -> Self {
         self.hosted_account_store = Some(store);
+        self
+    }
+
+    /// Install the explicit native-authorized public repository writer. This
+    /// opt-in is required before standard XRPC repository writes are exposed.
+    pub fn with_public_repo_writer(
+        mut self,
+        writer: Arc<crate::services::public_repo::PublicRepoWriter>,
+    ) -> Self {
+        self.public_repo_writer = Some(writer);
         self
     }
 

--- a/crates/hyprstream/src/services/oauth/xrpc.rs
+++ b/crates/hyprstream/src/services/oauth/xrpc.rs
@@ -2152,6 +2152,14 @@ mod tests {
                 ("/record/facets/0/index/byteStart", json!(-1)),
                 ("/record/facets/0/features/0/did", json!("did::private")),
                 (
+                    "/record/facets/0/features/0/did",
+                    json!("did:key:zExample%"),
+                ),
+                (
+                    "/record/reply/root/uri",
+                    json!("at://did:key:zExample%/app.bsky.feed.post/key"),
+                ),
+                (
                     "/record/facets/0/features/1/uri",
                     json!("https://example.com/invalid space"),
                 ),

--- a/crates/hyprstream/src/services/oauth/xrpc.rs
+++ b/crates/hyprstream/src/services/oauth/xrpc.rs
@@ -80,6 +80,8 @@ const MAX_SERVICE_AUTH_PARAMETER_BYTES: usize = 2_048;
 /// Each request streams the entire repo; bounding concurrency prevents
 /// memory/CPU exhaustion from parallel full-repo exports.
 pub const GET_REPO_CONCURRENCY: usize = 4;
+/// Snapshot/encoding work has its own bound; slow CAR bodies cannot hold it.
+const DURABLE_SNAPSHOT_CONCURRENCY: usize = 4;
 
 // ─────────────────────────────────────────────────────────────────────────────
 // RepoSnapshot + XrpcRepoStore
@@ -180,6 +182,7 @@ impl RepoSnapshot {
 pub struct XrpcRepoStore {
     by_did: RwLock<BTreeMap<String, Arc<RepoSnapshot>>>,
     get_repo_sema: Arc<Semaphore>,
+    snapshot_work_sema: Arc<Semaphore>,
 }
 
 impl Default for XrpcRepoStore {
@@ -187,6 +190,7 @@ impl Default for XrpcRepoStore {
         Self {
             by_did: RwLock::new(BTreeMap::new()),
             get_repo_sema: Arc::new(Semaphore::new(GET_REPO_CONCURRENCY)),
+            snapshot_work_sema: Arc::new(Semaphore::new(DURABLE_SNAPSHOT_CONCURRENCY)),
         }
     }
 }
@@ -226,6 +230,15 @@ impl XrpcRepoStore {
             return None; // ambiguous — refuse
         }
         Some(Arc::clone(first))
+    }
+
+    /// Bound durable snapshot/encoding work independently of response bodies.
+    /// Move ownership into the blocking task so cancellation cannot release
+    /// admission while that work is still running.
+    async fn acquire_snapshot_work_owned(
+        &self,
+    ) -> Result<OwnedSemaphorePermit, tokio::sync::AcquireError> {
+        self.snapshot_work_sema.clone().acquire_owned().await
     }
 
     /// Acquire an **owned** concurrency permit for full-CAR export. The permit
@@ -1869,6 +1882,22 @@ mod tests {
         Router,
         String,
     ) {
+        let (dir, store, gate, app, token, _) =
+            build_write_input_fixture_with_admission(did, issuer_url).await;
+        (dir, store, gate, app, token)
+    }
+
+    async fn build_write_input_fixture_with_admission(
+        did: &str,
+        issuer_url: &str,
+    ) -> (
+        tempfile::TempDir,
+        Arc<crate::services::public_repo::PublicRepoStore>,
+        Arc<WriteInputGate>,
+        Router,
+        String,
+        Arc<XrpcRepoStore>,
+    ) {
         if hyprstream_rpc::auth::global_credential_revocation_store().is_none() {
             let _ = hyprstream_rpc::auth::set_global_credential_revocation_store(Arc::new(
                 hyprstream_rpc::auth::InMemoryCredentialRevocationStore::new(),
@@ -1901,8 +1930,9 @@ mod tests {
             .with_scope(Some("atproto".to_owned()))
             .with_jti();
         let token = hyprstream_rpc::auth::jwt::encode(&claims, &signing_key);
+        let reads = state.xrpc_repos.clone();
         let app = build_production_app_from_state(state).await;
-        (dir, store, gate, app, token)
+        (dir, store, gate, app, token, reads)
     }
 
     fn write_input(id: u64) -> Value {
@@ -1954,7 +1984,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn router_all_durable_reads_share_export_admission() {
+    async fn router_point_reads_remain_available_with_four_held_car_bodies() {
         let (_dir, _store, _gate, app, token) = build_write_input_fixture().await;
         let created = app
             .clone()
@@ -1977,10 +2007,73 @@ mod tests {
                     .unwrap(),
             );
         }
+        assert!(held
+            .iter()
+            .all(|response| response.status() == StatusCode::OK));
+        // Waiting exports must acquire body admission before snapshot work.
+        let mut queued_exports = Vec::new();
+        for _ in 0..DURABLE_SNAPSHOT_CONCURRENCY {
+            let app = app.clone();
+            queued_exports.push(tokio::spawn(async move {
+                app.oneshot(read_request(
+                    "/xrpc/com.atproto.sync.getRepo?did=did:web:pub.example.com",
+                ))
+                .await
+                .unwrap()
+            }));
+        }
+        assert!(
+            tokio::time::timeout(std::time::Duration::from_millis(50), &mut queued_exports[0])
+                .await
+                .is_err()
+        );
         let mut pending = Vec::new();
         for uri in [
             format!("/xrpc/com.atproto.repo.getRecord?repo=pub.example.com&collection=app.bsky.feed.post&rkey={}", Tid::from_raw(7).encode()),
             "/xrpc/com.atproto.repo.describeRepo?repo=pub.example.com".to_owned(),
+        ] {
+            let app = app.clone();
+            pending.push(tokio::spawn(async move { app.oneshot(read_request(&uri)).await.unwrap() }));
+        }
+        for request in pending {
+            let response = tokio::time::timeout(std::time::Duration::from_secs(2), request)
+                .await
+                .unwrap()
+                .unwrap();
+            assert_eq!(response.status(), StatusCode::OK);
+        }
+        assert_eq!(held.len(), GET_REPO_CONCURRENCY);
+        for export in queued_exports {
+            export.abort();
+        }
+    }
+
+    #[tokio::test]
+    async fn router_snapshot_work_admission_bounds_every_durable_reader() {
+        let (_dir, _store, _gate, app, token, reads) = build_write_input_fixture_with_admission(
+            "did:web:pub.example.com",
+            "https://h.example.com",
+        )
+        .await;
+        let created = app
+            .clone()
+            .oneshot(write_http_request(
+                &token,
+                &write_input(7),
+                HeaderMap::new(),
+            ))
+            .await
+            .unwrap();
+        assert_eq!(created.status(), StatusCode::OK);
+        let mut held = Vec::new();
+        for _ in 0..DURABLE_SNAPSHOT_CONCURRENCY {
+            held.push(reads.acquire_snapshot_work_owned().await.unwrap());
+        }
+        let mut pending = Vec::new();
+        for uri in [
+            format!("/xrpc/com.atproto.repo.getRecord?repo=pub.example.com&collection=app.bsky.feed.post&rkey={}", Tid::from_raw(7).encode()),
+            "/xrpc/com.atproto.repo.describeRepo?repo=pub.example.com".to_owned(),
+            "/xrpc/com.atproto.sync.getRepo?did=did:web:pub.example.com".to_owned(),
         ] {
             let app = app.clone();
             pending.push(tokio::spawn(async move { app.oneshot(read_request(&uri)).await.unwrap() }));
@@ -1993,13 +2086,26 @@ mod tests {
             );
         }
         drop(held.pop());
+        let mut responses = Vec::new();
         for request in pending {
             let response = tokio::time::timeout(std::time::Duration::from_secs(2), request)
                 .await
                 .unwrap()
                 .unwrap();
             assert_eq!(response.status(), StatusCode::OK);
+            responses.push(response);
         }
+        // CAR body retains only export admission, not snapshot-work admission.
+        assert_eq!(reads.snapshot_work_sema.available_permits(), 1);
+        assert_eq!(
+            reads.get_repo_sema.available_permits(),
+            GET_REPO_CONCURRENCY - 1
+        );
+        drop(responses);
+        assert_eq!(
+            reads.get_repo_sema.available_permits(),
+            GET_REPO_CONCURRENCY
+        );
     }
 
     #[tokio::test]

--- a/crates/hyprstream/src/services/oauth/xrpc.rs
+++ b/crates/hyprstream/src/services/oauth/xrpc.rs
@@ -1023,6 +1023,16 @@ pub async fn create_record(
             "OAuth identity binding is invalid",
         );
     }
+    // The protected router has verified the matching proof, ath, nonce, and
+    // replay state for bound tokens. Unbound Bearer tokens remain valid for
+    // other OAuth routes, but cannot authorize this atproto write endpoint.
+    if claims.cnf_jkt().is_none() {
+        return xrpc_error(
+            StatusCode::UNAUTHORIZED,
+            errors::INVALID_REQUEST,
+            "a DPoP-bound OAuth access token is required",
+        );
+    }
     let input: Value = match serde_json::from_slice(&body) {
         Ok(value) => value,
         Err(_) => {
@@ -1862,12 +1872,59 @@ mod tests {
         }
     }
 
+    #[derive(Clone)]
+    struct WriteAccess {
+        token: String,
+        claims: hyprstream_rpc::auth::Claims,
+        key: SigningKey,
+        htu: String,
+        nonce: String,
+    }
+
+    impl WriteAccess {
+        fn proof_payload(&self) -> Value {
+            use sha2::{Digest as _, Sha256};
+            json!({
+                "jti": uuid::Uuid::new_v4().to_string(),
+                "htm": "POST",
+                "htu": self.htu,
+                "iat": chrono::Utc::now().timestamp(),
+                "ath": URL_SAFE_NO_PAD.encode(Sha256::digest(self.token.as_bytes())),
+                "nonce": self.nonce,
+            })
+        }
+    }
+
+    fn sign_write_proof(key: &SigningKey, payload: &Value) -> String {
+        use p256::ecdsa::signature::Signer as _;
+        let point = key.verifying_key().to_encoded_point(false);
+        let header = json!({
+            "typ": "dpop+jwt",
+            "alg": "ES256",
+            "jwk": {
+                "kty": "EC", "crv": "P-256",
+                "x": URL_SAFE_NO_PAD.encode(point.x().unwrap()),
+                "y": URL_SAFE_NO_PAD.encode(point.y().unwrap()),
+            }
+        });
+        let signing_input = format!(
+            "{}.{}",
+            URL_SAFE_NO_PAD.encode(serde_json::to_vec(&header).unwrap()),
+            URL_SAFE_NO_PAD.encode(serde_json::to_vec(payload).unwrap())
+        );
+        let signature: p256::ecdsa::Signature = key.sign(signing_input.as_bytes());
+        format!(
+            "{signing_input}.{}",
+            URL_SAFE_NO_PAD.encode(signature.to_bytes())
+        )
+    }
+
     async fn build_write_input_fixture() -> (
         tempfile::TempDir,
         Arc<crate::services::public_repo::PublicRepoStore>,
         Arc<WriteInputGate>,
         Router,
-        String,
+        WriteAccess,
     ) {
         build_write_input_fixture_for("did:web:pub.example.com", "https://h.example.com").await
     }
@@ -1880,7 +1937,7 @@ mod tests {
         Arc<crate::services::public_repo::PublicRepoStore>,
         Arc<WriteInputGate>,
         Router,
-        String,
+        WriteAccess,
     ) {
         let (dir, store, gate, app, token, _) =
             build_write_input_fixture_with_admission(did, issuer_url).await;
@@ -1895,7 +1952,7 @@ mod tests {
         Arc<crate::services::public_repo::PublicRepoStore>,
         Arc<WriteInputGate>,
         Router,
-        String,
+        WriteAccess,
         Arc<XrpcRepoStore>,
     ) {
         if hyprstream_rpc::auth::global_credential_revocation_store().is_none() {
@@ -1922,14 +1979,32 @@ mod tests {
         writable_state.public_repo_writer = Some(Arc::new(writer));
         let issuer = state.atproto_issuer_url();
         let now = chrono::Utc::now().timestamp();
+        let key = SigningKey::random(&mut OsRng);
+        let point = key.verifying_key().to_encoded_point(false);
+        let jkt = super::super::dpop::DpopKey::Es256 {
+            x: (*point.x().unwrap()).into(),
+            y: (*point.y().unwrap()).into(),
+        }
+        .jkt();
+        let nonce = state.issue_dpop_nonce().await;
+        state.mark_dpop_client_nonced(&jkt).await;
+        let htu = format!("{issuer}/xrpc/com.atproto.repo.createRecord");
         let claims = hyprstream_rpc::auth::Claims::new("xrpc-writer".to_owned(), now, now + 3600)
             .with_issuer(issuer.clone())
             .with_audience(Some(issuer))
             .with_tenant("xrpc-input-tests".to_owned())
             .with_client_id("xrpc-input-tests")
             .with_scope(Some("atproto".to_owned()))
+            .with_cnf_jkt_thumbprint(jkt)
             .with_jti();
         let token = hyprstream_rpc::auth::jwt::encode(&claims, &signing_key);
+        let token = WriteAccess {
+            token,
+            claims,
+            key,
+            htu,
+            nonce,
+        };
         let reads = state.xrpc_repos.clone();
         let app = build_production_app_from_state(state).await;
         (dir, store, gate, app, token, reads)
@@ -1948,16 +2023,187 @@ mod tests {
         })
     }
 
-    fn write_http_request(token: &str, input: &Value, headers: HeaderMap) -> HttpRequest<Body> {
+    fn write_http_request(
+        token: &WriteAccess,
+        input: &Value,
+        headers: HeaderMap,
+    ) -> HttpRequest<Body> {
         let mut request = HttpRequest::builder()
             .method("POST")
             .uri("/xrpc/com.atproto.repo.createRecord")
-            .header(header::AUTHORIZATION, format!("Bearer {token}"))
+            .header(header::AUTHORIZATION, format!("DPoP {}", token.token))
+            .header("DPoP", sign_write_proof(&token.key, &token.proof_payload()))
             .header(header::CONTENT_TYPE, "application/json")
             .body(Body::from(serde_json::to_vec(input).unwrap()))
             .unwrap();
         request.headers_mut().extend(headers);
         request
+    }
+
+    #[tokio::test]
+    async fn router_create_record_requires_bound_token_and_proof_before_native_calls() {
+        let (_dir, store, gate, app, access) = build_write_input_fixture().await;
+        let mut unbound = access.clone();
+        unbound.claims.cnf = None;
+        unbound.token = hyprstream_rpc::auth::jwt::encode(
+            &unbound.claims,
+            &ed25519_dalek::SigningKey::from_bytes(&[0x19; 32]),
+        );
+        for (token, scheme, include_proof, error) in [
+            (&unbound, "Bearer", false, errors::INVALID_REQUEST),
+            (&unbound, "DPoP", true, errors::INVALID_REQUEST),
+            (&access, "Bearer", false, "invalid_token"),
+            (&access, "Bearer", true, "invalid_token"),
+            (&access, "DPoP", false, "invalid_token"),
+        ] {
+            let mut request = write_http_request(token, &write_input(7), HeaderMap::new());
+            request.headers_mut().insert(
+                header::AUTHORIZATION,
+                format!("{scheme} {}", token.token).parse().unwrap(),
+            );
+            if !include_proof {
+                request.headers_mut().remove("DPoP");
+            }
+            let response = app.clone().oneshot(request).await.unwrap();
+            assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+            let body = body_json(response).await;
+            assert_eq!(body["error"], error);
+            if error == errors::INVALID_REQUEST {
+                assert_eq!(
+                    body["message"],
+                    "a DPoP-bound OAuth access token is required"
+                );
+            }
+            assert_eq!(gate.0.load(std::sync::atomic::Ordering::Relaxed), 0);
+            assert!(store.snapshot("did:web:pub.example.com").unwrap().is_none());
+        }
+    }
+
+    #[tokio::test]
+    async fn router_create_record_rejects_wrong_dpop_proofs_before_native_calls() {
+        let (_dir, store, gate, app, access) = build_write_input_fixture().await;
+        for case in [
+            "key",
+            "method",
+            "uri",
+            "ath",
+            "missing_ath",
+            "nonce",
+            "missing_nonce",
+        ] {
+            let mut payload = access.proof_payload();
+            let wrong_key = SigningKey::random(&mut OsRng);
+            let key = if case == "key" {
+                &wrong_key
+            } else {
+                &access.key
+            };
+            let error = match case {
+                "key" => "invalid_token",
+                "method" => {
+                    payload["htm"] = json!("GET");
+                    "invalid_dpop_proof"
+                }
+                "uri" => {
+                    payload["htu"] =
+                        json!("https://other.example/xrpc/com.atproto.repo.createRecord");
+                    "invalid_dpop_proof"
+                }
+                "ath" => {
+                    payload["ath"] = json!("wrong-token-hash");
+                    "invalid_dpop_proof"
+                }
+                "missing_ath" => {
+                    payload.as_object_mut().unwrap().remove("ath");
+                    "invalid_dpop_proof"
+                }
+                "nonce" => {
+                    payload["nonce"] = json!("invalid-server-nonce");
+                    "use_dpop_nonce"
+                }
+                "missing_nonce" => {
+                    payload.as_object_mut().unwrap().remove("nonce");
+                    "use_dpop_nonce"
+                }
+                _ => unreachable!(),
+            };
+            let mut headers = HeaderMap::new();
+            headers.insert("DPoP", sign_write_proof(key, &payload).parse().unwrap());
+            let response = app
+                .clone()
+                .oneshot(write_http_request(&access, &write_input(7), headers))
+                .await
+                .unwrap();
+            assert_eq!(response.status(), StatusCode::UNAUTHORIZED, "{case}");
+            assert_eq!(body_json(response).await["error"], error, "{case}");
+            assert_eq!(
+                gate.0.load(std::sync::atomic::Ordering::Relaxed),
+                0,
+                "{case}"
+            );
+            assert!(
+                store.snapshot("did:web:pub.example.com").unwrap().is_none(),
+                "{case}"
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn router_create_record_dpop_replay_rejected_but_fresh_retry_succeeds() {
+        let (_dir, store, gate, app, access) = build_write_input_fixture().await;
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            "DPoP",
+            sign_write_proof(&access.key, &access.proof_payload())
+                .parse()
+                .unwrap(),
+        );
+        headers.insert("Idempotency-Key", "dpop-retry".parse().unwrap());
+        let response = app
+            .clone()
+            .oneshot(write_http_request(
+                &access,
+                &write_input(7),
+                headers.clone(),
+            ))
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+        let created = body_json(response).await;
+        let head = store
+            .snapshot("did:web:pub.example.com")
+            .unwrap()
+            .unwrap()
+            .commit
+            .cid();
+        assert_eq!(gate.0.load(std::sync::atomic::Ordering::Relaxed), 1);
+
+        // Replay cannot reach the authorizer, even when the body/idempotency
+        // request changes. A fresh proof can retry the original operation.
+        for input in [write_input(7), write_input(8)] {
+            let response = app
+                .clone()
+                .oneshot(write_http_request(&access, &input, headers.clone()))
+                .await
+                .unwrap();
+            assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+            assert_eq!(body_json(response).await["error"], "invalid_dpop_proof");
+            assert_eq!(gate.0.load(std::sync::atomic::Ordering::Relaxed), 1);
+            let snapshot = store.snapshot("did:web:pub.example.com").unwrap().unwrap();
+            assert_eq!(snapshot.commit.cid(), head);
+            assert_eq!(snapshot.records.len(), 1);
+        }
+        headers.remove("DPoP");
+        let response = app
+            .oneshot(write_http_request(&access, &write_input(7), headers))
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+        assert_eq!(body_json(response).await, created);
+        assert_eq!(gate.0.load(std::sync::atomic::Ordering::Relaxed), 2);
+        let snapshot = store.snapshot("did:web:pub.example.com").unwrap().unwrap();
+        assert_eq!(snapshot.commit.cid(), head);
+        assert_eq!(snapshot.records.len(), 1);
     }
 
     fn read_request(uri: &str) -> HttpRequest<Body> {

--- a/crates/hyprstream/src/services/oauth/xrpc.rs
+++ b/crates/hyprstream/src/services/oauth/xrpc.rs
@@ -1153,26 +1153,38 @@ pub async fn create_record(
         },
         expected_prev,
     );
+    use crate::services::public_repo::PublicRepoWriteError;
     let result = match result {
         Ok(result) => result,
-        Err(error)
-            if error.to_string().contains("authorization")
-                || error.to_string().contains("denied") =>
-        {
-            return xrpc_error(StatusCode::FORBIDDEN, "AuthRequired", error.to_string())
-        }
-        Err(error)
-            if error.to_string().contains("CAS conflict")
-                || error.to_string().contains("already exists") =>
-        {
-            return xrpc_error(StatusCode::CONFLICT, "InvalidSwap", error.to_string())
-        }
         Err(error) => {
-            return xrpc_error(
-                StatusCode::BAD_REQUEST,
-                errors::INVALID_REQUEST,
-                error.to_string(),
-            )
+            let (status, code, message) = match error {
+                PublicRepoWriteError::InvalidRequest(_) => (
+                    StatusCode::BAD_REQUEST,
+                    errors::INVALID_REQUEST,
+                    "record or request parameters are invalid",
+                ),
+                PublicRepoWriteError::Authorization(_) => (
+                    StatusCode::FORBIDDEN,
+                    "AuthRequired",
+                    "public repository publication is not authorized",
+                ),
+                PublicRepoWriteError::RecordAlreadyExists => (
+                    StatusCode::CONFLICT,
+                    "RecordAlreadyExists",
+                    "record key already exists",
+                ),
+                PublicRepoWriteError::InvalidSwap => (
+                    StatusCode::CONFLICT,
+                    "InvalidSwap",
+                    "swapCommit does not match the repository head",
+                ),
+                PublicRepoWriteError::Internal(_) => (
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    "InternalServerError",
+                    "public repository operation failed",
+                ),
+            };
+            return xrpc_error(status, code, message);
         }
     };
     let mut response = json!({"uri": result.uri, "cid": result.cid.to_string()});
@@ -1748,11 +1760,17 @@ mod tests {
     }
 
     #[derive(Default)]
-    struct WriteInputGate(std::sync::atomic::AtomicUsize);
+    struct WriteInputGate(
+        std::sync::atomic::AtomicUsize,
+        parking_lot::Mutex<Option<String>>,
+    );
 
     impl crate::services::public_repo::PublicPublicationAuthorizer for WriteInputGate {
         fn authorize(&self, _: &str, _: &str, _: &str) -> anyhow::Result<()> {
             self.0.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+            if let Some(message) = self.1.lock().as_ref() {
+                anyhow::bail!(message.clone());
+            }
             Ok(())
         }
     }
@@ -1822,6 +1840,154 @@ mod tests {
             .unwrap();
         request.headers_mut().extend(headers);
         request
+    }
+
+    #[tokio::test]
+    async fn router_create_record_maps_input_and_conflicts_without_mutation() {
+        let (_dir, store, _gate, app, token) = build_write_input_fixture().await;
+        let mut invalid = write_input(7);
+        invalid["record"]["$type"] = json!("private.authorization.denied");
+        let response = app
+            .clone()
+            .oneshot(write_http_request(&token, &invalid, HeaderMap::new()))
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+        assert_eq!(
+            body_json(response).await,
+            json!({
+                "error": "InvalidRequest", "message": "record or request parameters are invalid"
+            })
+        );
+        assert!(store.snapshot("did:web:pub.example.com").unwrap().is_none());
+
+        let response = app
+            .clone()
+            .oneshot(write_http_request(
+                &token,
+                &write_input(7),
+                HeaderMap::new(),
+            ))
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+        let original = body_json(response).await;
+        let head = store
+            .snapshot("did:web:pub.example.com")
+            .unwrap()
+            .unwrap()
+            .commit
+            .cid_atproto()
+            .unwrap();
+        let mut headers = HeaderMap::new();
+        headers.insert("Idempotency-Key", "another-request".parse().unwrap());
+        let response = app
+            .clone()
+            .oneshot(write_http_request(&token, &write_input(7), headers))
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::CONFLICT);
+        assert_eq!(
+            body_json(response).await,
+            json!({
+                "error": "RecordAlreadyExists", "message": "record key already exists"
+            })
+        );
+        let mut stale = write_input(8);
+        stale["swapCommit"] = json!(hyprstream_pds::Cid::from_dag_cbor(b"stale").to_string());
+        let response = app
+            .clone()
+            .oneshot(write_http_request(&token, &stale, HeaderMap::new()))
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::CONFLICT);
+        assert_eq!(
+            body_json(response).await,
+            json!({
+                "error": "InvalidSwap", "message": "swapCommit does not match the repository head"
+            })
+        );
+        let snapshot = store.snapshot("did:web:pub.example.com").unwrap().unwrap();
+        assert_eq!(snapshot.commit.cid_atproto().unwrap(), head);
+        assert_eq!(snapshot.records.len(), 1);
+        let response = app
+            .oneshot(write_http_request(
+                &token,
+                &write_input(7),
+                HeaderMap::new(),
+            ))
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+        assert_eq!(body_json(response).await, original);
+    }
+
+    #[tokio::test]
+    async fn router_create_record_authorization_errors_ignore_source_text() {
+        let (_dir, store, gate, app, token) = build_write_input_fixture().await;
+        // Deliberately use words that formerly selected conflict or input status.
+        for detail in [
+            "private credential: CAS conflict",
+            "private credential: already exists",
+            "private credential",
+        ] {
+            *gate.1.lock() = Some(detail.to_owned());
+            let response = app
+                .clone()
+                .oneshot(write_http_request(
+                    &token,
+                    &write_input(7),
+                    HeaderMap::new(),
+                ))
+                .await
+                .unwrap();
+            assert_eq!(response.status(), StatusCode::FORBIDDEN);
+            assert_eq!(
+                body_json(response).await,
+                json!({
+                    "error": "AuthRequired", "message": "public repository publication is not authorized"
+                })
+            );
+            assert!(store.snapshot("did:web:pub.example.com").unwrap().is_none());
+        }
+        assert_eq!(gate.0.load(std::sync::atomic::Ordering::Relaxed), 3);
+    }
+
+    #[tokio::test]
+    async fn router_create_record_internal_errors_are_sanitized() {
+        let (_dir, store, gate, app, token) = build_write_input_fixture().await;
+        let private_key = "private-authorization-denied-CAS-conflict";
+        store
+            .insert_malformed_record_for_test(
+                "did:web:pub.example.com",
+                "app.bsky.feed.post",
+                private_key,
+            )
+            .unwrap();
+        let source = store
+            .snapshot("did:web:pub.example.com")
+            .unwrap_err()
+            .to_string();
+        assert!(
+            source.contains(private_key),
+            "fixture must exercise sensitive internal context"
+        );
+        let response = app
+            .oneshot(write_http_request(
+                &token,
+                &write_input(7),
+                HeaderMap::new(),
+            ))
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::INTERNAL_SERVER_ERROR);
+        assert_eq!(
+            body_json(response).await,
+            json!({
+                "error": "InternalServerError", "message": "public repository operation failed"
+            })
+        );
+        assert_eq!(gate.0.load(std::sync::atomic::Ordering::Relaxed), 1);
     }
 
     #[tokio::test]

--- a/crates/hyprstream/src/services/oauth/xrpc.rs
+++ b/crates/hyprstream/src/services/oauth/xrpc.rs
@@ -48,6 +48,7 @@ use rand::RngCore as _;
 use serde_json::{json, Value};
 use tokio::sync::{OwnedSemaphorePermit, RwLock, Semaphore};
 
+use hyprstream_pds::atproto_cbor::AtprotoRecordKey;
 use hyprstream_pds::car::{build_record_proof_car, car_block_bytes, car_header_bytes};
 use hyprstream_pds::commit::Commit;
 use hyprstream_pds::mst::{Node, NodeData};
@@ -1090,17 +1091,27 @@ pub async fn create_record(
             )
         }
     };
-    let rkey = match object
-        .get("rkey")
-        .and_then(Value::as_str)
-        .and_then(|value| Tid::parse(value).ok())
-    {
-        Some(rkey) => rkey,
-        None => {
+    let rkey = match (collection, object.get("rkey")) {
+        ("app.bsky.actor.profile", None) => AtprotoRecordKey::new("self").map(Some),
+        ("app.bsky.actor.profile", Some(Value::String(value))) if value == "self" => {
+            AtprotoRecordKey::new(value.clone()).map(Some)
+        }
+        ("app.bsky.actor.profile", _) => Err(anyhow::anyhow!("profile rkey must be self")),
+        (_, None) => Ok(None),
+        (_, Some(Value::String(value))) if Tid::parse(value).is_ok() => {
+            // Preserve an explicit key's bytes; parsing a TID is a syntax
+            // check, not permission to normalize the caller's record path.
+            AtprotoRecordKey::new(value.clone()).map(Some)
+        }
+        _ => Err(anyhow::anyhow!("a valid TID rkey is required when present")),
+    };
+    let rkey = match rkey {
+        Ok(rkey) => rkey,
+        Err(error) => {
             return xrpc_error(
                 StatusCode::BAD_REQUEST,
                 errors::INVALID_REQUEST,
-                "a valid TID rkey is required",
+                error.to_string(),
             )
         }
     };
@@ -1124,8 +1135,12 @@ pub async fn create_record(
             )
         }
     };
-    let request_id = request_id
-        .unwrap_or_else(|| format!("create-{}-{}", collection.replace('.', "_"), rkey.encode()));
+    let request_id = request_id.unwrap_or_else(|| match rkey.as_ref() {
+        Some(rkey) => format!("create-{}-{}", collection.replace('.', "_"), rkey.as_str()),
+        // Without a client idempotency key, distinct omitted-key requests
+        // create distinct records. Key allocation itself stays in the writer.
+        None => format!("create-{}", uuid::Uuid::new_v4()),
+    });
     let result = writer.create_record_with_expected_prev_text(
         crate::services::public_repo::PublicCreateRequest {
             request_id,
@@ -1929,6 +1944,144 @@ mod tests {
             2
         );
         assert_eq!(gate.0.load(std::sync::atomic::Ordering::Relaxed), 2);
+    }
+
+    #[tokio::test]
+    async fn router_create_record_profiles_use_self_for_explicit_and_omitted_keys() {
+        for omit_key in [false, true] {
+            let (_dir, store, gate, app, token) = build_write_input_fixture().await;
+            let mut input = json!({
+                "repo": "did:web:pub.example.com",
+                "collection": "app.bsky.actor.profile",
+                "record": {"$type": "app.bsky.actor.profile", "displayName": "Profile"},
+                "validate": false
+            });
+            for invalid in [
+                Value::Null,
+                json!(false),
+                json!(1),
+                json!(""),
+                json!("other"),
+                json!(Tid::from_raw(7).encode()),
+            ] {
+                let mut malformed = input.clone();
+                malformed["rkey"] = invalid;
+                let response = app
+                    .clone()
+                    .oneshot(write_http_request(&token, &malformed, HeaderMap::new()))
+                    .await
+                    .unwrap();
+                assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+                assert!(store.snapshot("did:web:pub.example.com").unwrap().is_none());
+                assert_eq!(gate.0.load(std::sync::atomic::Ordering::Relaxed), 0);
+            }
+            if !omit_key {
+                input["rkey"] = json!("self");
+            }
+            let response = app
+                .clone()
+                .oneshot(write_http_request(&token, &input, HeaderMap::new()))
+                .await
+                .unwrap();
+            assert_eq!(response.status(), StatusCode::OK);
+            let created = body_json(response).await;
+            assert_eq!(
+                created["uri"],
+                "at://did:web:pub.example.com/app.bsky.actor.profile/self"
+            );
+            let response = app
+                .oneshot(write_http_request(&token, &input, HeaderMap::new()))
+                .await
+                .unwrap();
+            assert_eq!(response.status(), StatusCode::OK);
+            assert_eq!(body_json(response).await, created);
+            let snapshot = store.snapshot("did:web:pub.example.com").unwrap().unwrap();
+            assert_eq!(snapshot.records.len(), 1);
+            assert!(snapshot.records.contains_key(&(
+                "app.bsky.actor.profile".into(),
+                AtprotoRecordKey::new("self").unwrap()
+            )));
+        }
+    }
+
+    #[tokio::test]
+    async fn router_create_record_generates_post_keys_and_recovers_idempotent_results() {
+        let (_dir, store, gate, app, token) = build_write_input_fixture().await;
+        let mut input = write_input(7);
+        input.as_object_mut().unwrap().remove("rkey");
+        for invalid in [
+            Value::Null,
+            json!(false),
+            json!(1),
+            json!(""),
+            json!("self"),
+            json!("bad/key"),
+        ] {
+            let mut malformed = input.clone();
+            malformed["rkey"] = invalid;
+            let response = app
+                .clone()
+                .oneshot(write_http_request(&token, &malformed, HeaderMap::new()))
+                .await
+                .unwrap();
+            assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+            assert!(store.snapshot("did:web:pub.example.com").unwrap().is_none());
+            assert_eq!(gate.0.load(std::sync::atomic::Ordering::Relaxed), 0);
+        }
+        let mut headers = HeaderMap::new();
+        headers.insert("Idempotency-Key", "generated-post".parse().unwrap());
+        let response = app
+            .clone()
+            .oneshot(write_http_request(&token, &input, headers.clone()))
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+        let created = body_json(response).await;
+        let generated_key = created["uri"].as_str().unwrap().rsplit('/').next().unwrap();
+        assert!(Tid::parse(generated_key).is_ok());
+        let mut uris = std::collections::BTreeSet::new();
+        uris.insert(created["uri"].as_str().unwrap().to_owned());
+        for _ in 0..2 {
+            let response = app
+                .clone()
+                .oneshot(write_http_request(&token, &input, HeaderMap::new()))
+                .await
+                .unwrap();
+            assert_eq!(response.status(), StatusCode::OK);
+            let created = body_json(response).await;
+            assert!(uris.insert(created["uri"].as_str().unwrap().to_owned()));
+        }
+        let latest = store
+            .snapshot("did:web:pub.example.com")
+            .unwrap()
+            .unwrap()
+            .commit
+            .cid_atproto()
+            .unwrap();
+        let response = app
+            .clone()
+            .oneshot(write_http_request(&token, &input, headers.clone()))
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+        assert_eq!(body_json(response).await, created);
+        let mut explicit_retry = input.clone();
+        explicit_retry["rkey"] = json!(generated_key);
+        let response = app
+            .clone()
+            .oneshot(write_http_request(&token, &explicit_retry, headers.clone()))
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+        input["record"]["text"] = json!("changed content");
+        let response = app
+            .oneshot(write_http_request(&token, &input, headers))
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+        let snapshot = store.snapshot("did:web:pub.example.com").unwrap().unwrap();
+        assert_eq!(snapshot.records.len(), 3);
+        assert_eq!(snapshot.commit.cid_atproto().unwrap(), latest);
     }
 
     // ── Finding 1: real capacity test through the mounted router ──────────────

--- a/crates/hyprstream/src/services/oauth/xrpc.rs
+++ b/crates/hyprstream/src/services/oauth/xrpc.rs
@@ -32,6 +32,7 @@
 //! - Write path (`repo.createRecord` etc.) — sequenced with #910.
 //! - `createSession`/`getSession` — sequenced with #1113/#948.
 
+mod durable_reads;
 mod record_validation;
 
 use std::collections::BTreeMap;
@@ -690,17 +691,44 @@ fn hex_val(b: u8) -> Option<u8> {
 // Core handler logic (testable without OAuthState)
 // ─────────────────────────────────────────────────────────────────────────────
 
-/// Resolve a handle to a DID via the store + issuer-derived self-handle.
-async fn resolve_handle_core(store: &XrpcRepoStore, issuer_url: &str, handle: &str) -> Response {
-    if let Some(snap) = store.by_handle_public(handle).await {
-        return axum::Json(json!({ "did": snap.did })).into_response();
+/// Trusted public registry/issuer resolution, shared by reads and owned writes.
+async fn resolve_handle_did(
+    store: &XrpcRepoStore,
+    issuer_url: &str,
+    handle: &str,
+) -> Option<String> {
+    let handle = handle.to_ascii_lowercase();
+    if !record_validation::valid_handle(&handle) {
+        return None;
+    }
+    if let Some(snap) = store.by_handle_public(&handle).await {
+        return Some(snap.did.clone());
     }
     if let Some(authority) = issuer_authority(issuer_url) {
         let self_handle = authority.split(':').next().unwrap_or(&authority);
         if handle == self_handle {
-            let did = format!("did:web:{authority}");
-            return axum::Json(json!({ "did": did })).into_response();
+            return Some(format!("did:web:{authority}"));
         }
+    }
+    None
+}
+
+async fn owned_public_writer(
+    state: &OAuthState,
+    repo: &str,
+) -> Option<Arc<crate::services::public_repo::PublicRepoWriter>> {
+    let writer = state.public_repo_writer.as_ref()?;
+    let did = if repo.starts_with("did:") {
+        repo.to_owned()
+    } else {
+        resolve_handle_did(&state.xrpc_repos, &state.issuer_url, repo).await?
+    };
+    (did == writer.did()).then(|| Arc::clone(writer))
+}
+
+async fn resolve_handle_core(store: &XrpcRepoStore, issuer_url: &str, handle: &str) -> Response {
+    if let Some(did) = resolve_handle_did(store, issuer_url, handle).await {
+        return axum::Json(json!({ "did": did })).into_response();
     }
     xrpc_error(
         StatusCode::BAD_REQUEST,
@@ -870,6 +898,9 @@ pub async fn describe_repo(
             );
         }
     };
+    if let Some(writer) = owned_public_writer(&state, key).await {
+        return durable_reads::describe_repo(&state, writer).await;
+    }
     describe_repo_core(&state.xrpc_repos, &state.issuer_url, key).await
 }
 
@@ -894,6 +925,9 @@ pub async fn get_record(State(state): State<Arc<OAuthState>>, RawQuery(raw): Raw
         }
     };
     let cid = params.get("cid").map(|c| c.trim());
+    if let Some(writer) = owned_public_writer(&state, repo).await {
+        return durable_reads::get_record(writer, collection, rkey, cid).await;
+    }
     get_record_core(&state.xrpc_repos, repo, collection, rkey, cid).await
 }
 
@@ -911,6 +945,13 @@ pub async fn get_repo(State(state): State<Arc<OAuthState>>, RawQuery(raw): RawQu
     };
     // Reject since by PRESENCE (not just non-empty) — ?since= and ?since=x both 400.
     let since_present = params.contains_key("since");
+    if let Some(writer) = state
+        .public_repo_writer
+        .as_ref()
+        .filter(|writer| writer.did() == did)
+    {
+        return durable_reads::get_repo(&state.xrpc_repos, Arc::clone(writer), since_present).await;
+    }
     get_repo_core(&state.xrpc_repos, did, since_present).await
 }
 
@@ -1059,7 +1100,12 @@ pub async fn create_record(
             )
         }
     };
-    if repo != writer.did() {
+    let repo = if repo.starts_with("did:") {
+        Some(repo.to_owned())
+    } else {
+        resolve_handle_did(&state.xrpc_repos, &state.issuer_url, repo).await
+    };
+    if repo.as_deref() != Some(writer.did()) {
         return xrpc_error(
             StatusCode::FORBIDDEN,
             "AuthRequired",
@@ -1155,18 +1201,26 @@ pub async fn create_record(
         // create distinct records. Key allocation itself stays in the writer.
         None => format!("create-{}", uuid::Uuid::new_v4()),
     });
-    let result = writer.create_record_with_expected_prev_text(
-        crate::services::public_repo::PublicCreateRequest {
-            request_id,
-            principal: user.user,
-            did: repo.to_owned(),
-            collection: collection.to_owned(),
-            rkey,
-            value: record,
-            expected_prev: None,
-        },
-        expected_prev,
-    );
+    let writer = Arc::clone(writer);
+    let expected_prev = expected_prev.map(str::to_owned);
+    let request = crate::services::public_repo::PublicCreateRequest {
+        request_id,
+        principal: user.user,
+        did: writer.did().to_owned(),
+        collection: collection.to_owned(),
+        rkey,
+        value: record,
+        expected_prev: None,
+    };
+    // Authorization remains inside the transaction before any store access.
+    // Native locks, RocksDB, signing and sync writes must not occupy Tokio workers.
+    let result = tokio::task::spawn_blocking(move || {
+        writer.create_record_with_expected_prev_text(request, expected_prev.as_deref())
+    })
+    .await
+    .unwrap_or_else(|error| {
+        Err(crate::services::public_repo::PublicRepoWriteError::Internal(error.into()))
+    });
     use crate::services::public_repo::PublicRepoWriteError;
     let result = match result {
         Ok(result) => result,
@@ -1854,6 +1908,256 @@ mod tests {
             .unwrap();
         request.headers_mut().extend(headers);
         request
+    }
+
+    fn read_request(uri: &str) -> HttpRequest<Body> {
+        HttpRequest::builder().uri(uri).body(Body::empty()).unwrap()
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn router_writes_release_tokio_worker_and_serialize_same_did() {
+        let (_dir, store, gate, app, token) = build_write_input_fixture().await;
+        let response = app
+            .clone()
+            .oneshot(write_http_request(
+                &token,
+                &write_input(7),
+                HeaderMap::new(),
+            ))
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+        let head = store
+            .snapshot("did:web:pub.example.com")
+            .unwrap()
+            .unwrap()
+            .commit
+            .cid_atproto()
+            .unwrap()
+            .to_string();
+        let (held_tx, held_rx) = std::sync::mpsc::channel();
+        let (release_tx, release_rx) = std::sync::mpsc::channel();
+        let locked_store = store.clone();
+        let owner = std::thread::spawn(move || {
+            locked_store
+                .with_account_lock_for_test("did:web:pub.example.com", || {
+                    held_tx.send(()).unwrap();
+                    let _ = release_rx.recv_timeout(std::time::Duration::from_secs(5));
+                })
+                .unwrap();
+        });
+        held_rx
+            .recv_timeout(std::time::Duration::from_secs(2))
+            .unwrap();
+        let started = std::time::Instant::now();
+        let mut writes = Vec::new();
+        for id in [8, 9] {
+            let mut input = write_input(id);
+            input["swapCommit"] = json!(head);
+            let request = write_http_request(&token, &input, HeaderMap::new());
+            let app = app.clone();
+            writes.push(tokio::spawn(
+                async move { app.oneshot(request).await.unwrap() },
+            ));
+        }
+        tokio::time::timeout(std::time::Duration::from_secs(2), async {
+            while gate.0.load(std::sync::atomic::Ordering::Relaxed) < 3 {
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .unwrap();
+        let response = app
+            .oneshot(read_request(
+                "/xrpc/com.atproto.identity.resolveHandle?handle=pub.example.com",
+            ))
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+        assert!(started.elapsed() < std::time::Duration::from_secs(2));
+        assert!(writes.iter().all(|write| !write.is_finished()));
+        release_tx.send(()).unwrap();
+        owner.join().unwrap();
+        let mut statuses = Vec::new();
+        for write in writes {
+            statuses.push(write.await.unwrap().status().as_u16());
+        }
+        statuses.sort();
+        assert_eq!(statuses, vec![200, 409]);
+        assert_eq!(
+            store
+                .snapshot("did:web:pub.example.com")
+                .unwrap()
+                .unwrap()
+                .records
+                .len(),
+            2
+        );
+    }
+
+    #[tokio::test]
+    async fn router_create_accepts_owned_handle_and_rejects_foreign_handles() {
+        let (_dir, store, gate, app, token) = build_write_input_fixture().await;
+        for repo in [
+            "priv.example.com",
+            "h.example.com",
+            "unknown.example.com",
+            "did:web:priv.example.com",
+        ] {
+            let mut input = write_input(7);
+            input["repo"] = json!(repo);
+            let response = app
+                .clone()
+                .oneshot(write_http_request(&token, &input, HeaderMap::new()))
+                .await
+                .unwrap();
+            assert_eq!(response.status(), StatusCode::FORBIDDEN, "{repo}");
+            assert!(store.snapshot("did:web:pub.example.com").unwrap().is_none());
+            assert_eq!(gate.0.load(std::sync::atomic::Ordering::Relaxed), 0);
+        }
+        let mut input = write_input(7);
+        input["repo"] = json!("PUB.EXAMPLE.COM");
+        let mut headers = HeaderMap::new();
+        headers.insert("Idempotency-Key", "owned-handle-retry".parse().unwrap());
+        let response = app
+            .clone()
+            .oneshot(write_http_request(&token, &input, headers.clone()))
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+        let created = body_json(response).await;
+        assert!(created["uri"]
+            .as_str()
+            .unwrap()
+            .starts_with("at://did:web:pub.example.com/"));
+        let retry = app
+            .oneshot(write_http_request(&token, &write_input(7), headers))
+            .await
+            .unwrap();
+        assert_eq!(retry.status(), StatusCode::OK);
+        assert_eq!(body_json(retry).await, created);
+        assert_eq!(gate.0.load(std::sync::atomic::Ordering::Relaxed), 2);
+        assert_eq!(
+            store
+                .snapshot("did:web:pub.example.com")
+                .unwrap()
+                .unwrap()
+                .records
+                .len(),
+            1
+        );
+    }
+
+    #[tokio::test]
+    async fn router_durable_creates_are_readable_without_stale_snapshot_fallback() {
+        let (_dir, store, _gate, app, token) = build_write_input_fixture().await;
+        let repo_uri = "/xrpc/com.atproto.sync.getRepo?did=did:web:pub.example.com";
+        // The fixture already contains a legacy model snapshot for this DID.
+        let missing = app.clone().oneshot(read_request(repo_uri)).await.unwrap();
+        assert_eq!(missing.status(), StatusCode::BAD_REQUEST);
+        assert_eq!(body_json(missing).await["error"], "RepoNotFound");
+        let mut input = write_input(7);
+        input["record"]["extension"] = json!({"bytes":{"$bytes":"AQI="},"link":{"$link":Cid::from_dag_cbor(b"extension").to_string()}});
+        let created = app
+            .clone()
+            .oneshot(write_http_request(&token, &input, HeaderMap::new()))
+            .await
+            .unwrap();
+        assert_eq!(created.status(), StatusCode::OK);
+        let created = body_json(created).await;
+        for repo in ["did:web:pub.example.com", "pub.example.com"] {
+            let uri = format!("/xrpc/com.atproto.repo.getRecord?repo={repo}&collection=app.bsky.feed.post&rkey={}", input["rkey"].as_str().unwrap());
+            let read = app.clone().oneshot(read_request(&uri)).await.unwrap();
+            assert_eq!(read.status(), StatusCode::OK);
+            let read = body_json(read).await;
+            assert_eq!(read["uri"], created["uri"]);
+            assert_eq!(read["cid"], created["cid"]);
+            assert_eq!(read["value"], input["record"]);
+        }
+        let profile = json!({"repo":"pub.example.com","collection":"app.bsky.actor.profile","rkey":"self","record":{"$type":"app.bsky.actor.profile","displayName":"Durable"}});
+        let response = app
+            .clone()
+            .oneshot(write_http_request(&token, &profile, HeaderMap::new()))
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+        let profile_read = app.clone().oneshot(read_request("/xrpc/com.atproto.repo.getRecord?repo=pub.example.com&collection=app.bsky.actor.profile&rkey=self")).await.unwrap();
+        assert_eq!(profile_read.status(), StatusCode::OK);
+        assert_eq!(body_json(profile_read).await["value"], profile["record"]);
+        let describe_uri = "/xrpc/com.atproto.repo.describeRepo?repo=pub.example.com";
+        let describe = app
+            .clone()
+            .oneshot(read_request(describe_uri))
+            .await
+            .unwrap();
+        assert_eq!(describe.status(), StatusCode::OK);
+        assert_eq!(
+            body_json(describe).await["collections"],
+            json!(["app.bsky.actor.profile", "app.bsky.feed.post"])
+        );
+        let exported = app.clone().oneshot(read_request(repo_uri)).await.unwrap();
+        assert_eq!(exported.status(), StatusCode::OK);
+        let bytes = axum::body::to_bytes(exported.into_body(), 1024 * 1024)
+            .await
+            .unwrap();
+        let (roots, blocks) = hyprstream_pds::car::parse_car_v1_atproto(&bytes).unwrap();
+        let snapshot = store.snapshot("did:web:pub.example.com").unwrap().unwrap();
+        assert_eq!(roots, vec![snapshot.commit.cid_atproto().unwrap()]);
+        for (cid, bytes) in &blocks {
+            assert_eq!(*cid, Cid::from_dag_cbor(bytes));
+        }
+        for record in snapshot.records.values() {
+            assert!(blocks
+                .iter()
+                .any(|(cid, bytes)| *cid == record.cid() && bytes == record.bytes()));
+        }
+        store
+            .insert_malformed_record_for_test(
+                "did:web:pub.example.com",
+                "app.bsky.feed.post",
+                "private-storage-context",
+            )
+            .unwrap();
+        for uri in [repo_uri, describe_uri, "/xrpc/com.atproto.repo.getRecord?repo=pub.example.com&collection=app.bsky.actor.profile&rkey=self"] {
+            let response = app.clone().oneshot(read_request(uri)).await.unwrap();
+            assert_eq!(response.status(), StatusCode::INTERNAL_SERVER_ERROR);
+            assert_eq!(body_json(response).await, json!({"error":"InternalServerError","message":"public repository read failed"}));
+        }
+    }
+
+    #[tokio::test]
+    async fn router_durable_export_holds_permit_until_body_drop() {
+        let (_dir, _store, _gate, app, token) = build_write_input_fixture().await;
+        let created = app
+            .clone()
+            .oneshot(write_http_request(
+                &token,
+                &write_input(7),
+                HeaderMap::new(),
+            ))
+            .await
+            .unwrap();
+        assert_eq!(created.status(), StatusCode::OK);
+        let uri = "/xrpc/com.atproto.sync.getRepo?did=did:web:pub.example.com";
+        let mut responses = Vec::new();
+        for _ in 0..GET_REPO_CONCURRENCY {
+            let response = app.clone().oneshot(read_request(uri)).await.unwrap();
+            assert_eq!(response.status(), StatusCode::OK);
+            responses.push(response);
+        }
+        let mut pending =
+            tokio::spawn(async move { app.oneshot(read_request(uri)).await.unwrap() });
+        assert!(
+            tokio::time::timeout(std::time::Duration::from_millis(50), &mut pending)
+                .await
+                .is_err()
+        );
+        drop(responses.pop());
+        let response = tokio::time::timeout(std::time::Duration::from_secs(2), pending)
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
     }
 
     #[tokio::test]

--- a/crates/hyprstream/src/services/oauth/xrpc.rs
+++ b/crates/hyprstream/src/services/oauth/xrpc.rs
@@ -60,7 +60,7 @@ use hyprstream_pds::repo_authority::accept_repo_authority;
 use hyprstream_pds::tid::Tid;
 use hyprstream_pds::Cid;
 
-use super::did_document::{build_did_document, issuer_authority, AtprotoIdentity};
+use super::did_document::{build_did_document, AtprotoIdentity};
 use super::state::OAuthState;
 use super::{
     auth::{self, AuthenticatedUser},
@@ -704,10 +704,9 @@ async fn resolve_handle_did(
     if let Some(snap) = store.by_handle_public(&handle).await {
         return Some(snap.did.clone());
     }
-    if let Some(authority) = issuer_authority(issuer_url) {
-        let self_handle = authority.split(':').next().unwrap_or(&authority);
-        if handle == self_handle {
-            return Some(format!("did:web:{authority}"));
+    if let Ok(origin) = url::Url::parse(issuer_url) {
+        if origin.host_str() == Some(handle.as_str()) {
+            return super::state::atproto_service_did_for_origin(issuer_url);
         }
     }
     None
@@ -1195,6 +1194,13 @@ pub async fn create_record(
             )
         }
     };
+    if crate::services::public_repo::reject_unverified_blobs(&record).is_err() {
+        return xrpc_error(
+            StatusCode::BAD_REQUEST,
+            errors::INVALID_REQUEST,
+            "blob storage verification is unavailable",
+        );
+    }
     let request_id = request_id.unwrap_or_else(|| match rkey.as_ref() {
         Some(rkey) => format!("create-{}-{}", collection.replace('.', "_"), rkey.as_str()),
         // Without a client idempotency key, distinct omitted-key requests
@@ -1850,6 +1856,19 @@ mod tests {
         Router,
         String,
     ) {
+        build_write_input_fixture_for("did:web:pub.example.com", "https://h.example.com").await
+    }
+
+    async fn build_write_input_fixture_for(
+        did: &str,
+        issuer_url: &str,
+    ) -> (
+        tempfile::TempDir,
+        Arc<crate::services::public_repo::PublicRepoStore>,
+        Arc<WriteInputGate>,
+        Router,
+        String,
+    ) {
         if hyprstream_rpc::auth::global_credential_revocation_store().is_none() {
             let _ = hyprstream_rpc::auth::set_global_credential_revocation_store(Arc::new(
                 hyprstream_rpc::auth::InMemoryCredentialRevocationStore::new(),
@@ -1861,7 +1880,7 @@ mod tests {
         let gate = Arc::new(WriteInputGate::default());
         let writer = crate::services::public_repo::PublicRepoWriter::new(
             store.clone(),
-            "did:web:pub.example.com",
+            did,
             SigningKey::random(&mut OsRng),
             gate.clone(),
         )
@@ -1869,6 +1888,7 @@ mod tests {
         let mut state = build_test_state(true).await;
         let signing_key = ed25519_dalek::SigningKey::from_bytes(&[0x19; 32]);
         let writable_state = Arc::get_mut(&mut state).unwrap();
+        writable_state.issuer_url = issuer_url.to_owned();
         writable_state.verifying_key_bytes = signing_key.verifying_key().to_bytes();
         writable_state.public_repo_writer = Some(Arc::new(writer));
         let issuer = state.atproto_issuer_url();
@@ -1912,6 +1932,202 @@ mod tests {
 
     fn read_request(uri: &str) -> HttpRequest<Body> {
         HttpRequest::builder().uri(uri).body(Body::empty()).unwrap()
+    }
+
+    #[tokio::test]
+    async fn router_rejects_unverified_blobs_in_every_validation_mode_and_read_path() {
+        let (_dir, store, gate, app, token) = build_write_input_fixture().await;
+        let blob = json!({"$type":"blob","ref":{"$link":Cid::from_raw(b"missing").to_string()},"mimeType":"image/png","size":7});
+        for mode in [None, Some(true), Some(false)] {
+            for extension in [
+                blob.clone(),
+                json!([{"nested":[blob.clone()]}]),
+                json!({"$type":"com.example.future","media":blob}),
+                json!({"cid":Cid::from_raw(b"missing").to_string(),"mimeType":"image/png"}),
+            ] {
+                let mut input = write_input(7);
+                input["record"]["extension"] = extension;
+                if let Some(mode) = mode {
+                    input["validate"] = json!(mode);
+                }
+                let response = app
+                    .clone()
+                    .oneshot(write_http_request(&token, &input, HeaderMap::new()))
+                    .await
+                    .unwrap();
+                assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+                assert_eq!(
+                    body_json(response).await,
+                    json!({"error":"InvalidRequest","message":"blob storage verification is unavailable"})
+                );
+                assert!(store.snapshot("did:web:pub.example.com").unwrap().is_none());
+                assert_eq!(gate.0.load(std::sync::atomic::Ordering::Relaxed), 0);
+            }
+        }
+        // Model an otherwise correctly signed repository from before blob enforcement.
+        store
+            .insert_unverified_blob_for_test("did:web:pub.example.com")
+            .unwrap();
+        assert!(store
+            .snapshot("did:web:pub.example.com")
+            .unwrap_err()
+            .to_string()
+            .contains("blob storage verification"));
+        for uri in [
+            "/xrpc/com.atproto.repo.getRecord?repo=pub.example.com&collection=app.bsky.feed.post&rkey=legacy",
+            "/xrpc/com.atproto.repo.describeRepo?repo=pub.example.com",
+            "/xrpc/com.atproto.sync.getRepo?did=did:web:pub.example.com",
+        ] {
+            let response = app.clone().oneshot(read_request(uri)).await.unwrap();
+            assert_eq!(response.status(), StatusCode::INTERNAL_SERVER_ERROR);
+            assert_eq!(body_json(response).await, json!({"error":"InternalServerError","message":"public repository read failed"}));
+        }
+    }
+
+    #[tokio::test]
+    async fn router_retry_rejects_substituted_swap_without_rechecking_latest_head() {
+        let (_dir, store, _gate, app, token) = build_write_input_fixture().await;
+        let first = app
+            .clone()
+            .oneshot(write_http_request(
+                &token,
+                &write_input(7),
+                HeaderMap::new(),
+            ))
+            .await
+            .unwrap();
+        assert_eq!(first.status(), StatusCode::OK);
+        let previous = store
+            .snapshot("did:web:pub.example.com")
+            .unwrap()
+            .unwrap()
+            .commit
+            .cid_atproto()
+            .unwrap()
+            .to_string();
+        let mut input = write_input(8);
+        input["swapCommit"] = json!(previous);
+        let second = app
+            .clone()
+            .oneshot(write_http_request(&token, &input, HeaderMap::new()))
+            .await
+            .unwrap();
+        assert_eq!(second.status(), StatusCode::OK);
+        let second = body_json(second).await;
+        let third = app
+            .clone()
+            .oneshot(write_http_request(
+                &token,
+                &write_input(9),
+                HeaderMap::new(),
+            ))
+            .await
+            .unwrap();
+        assert_eq!(third.status(), StatusCode::OK);
+        let head = store
+            .snapshot("did:web:pub.example.com")
+            .unwrap()
+            .unwrap()
+            .commit
+            .cid_atproto()
+            .unwrap();
+        let retry = app
+            .clone()
+            .oneshot(write_http_request(&token, &input, HeaderMap::new()))
+            .await
+            .unwrap();
+        assert_eq!(retry.status(), StatusCode::OK);
+        assert_eq!(body_json(retry).await, second);
+        for changed in [
+            Some(head.to_string()),
+            Some(Cid::from_dag_cbor(b"substituted").to_string()),
+            None,
+        ] {
+            let mut input = input.clone();
+            match changed {
+                Some(cid) => {
+                    input["swapCommit"] = json!(cid);
+                }
+                None => {
+                    input.as_object_mut().unwrap().remove("swapCommit");
+                }
+            }
+            let response = app
+                .clone()
+                .oneshot(write_http_request(&token, &input, HeaderMap::new()))
+                .await
+                .unwrap();
+            assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+            assert_eq!(
+                body_json(response).await,
+                json!({"error":"InvalidRequest","message":"record or request parameters are invalid"})
+            );
+            assert_eq!(
+                store
+                    .snapshot("did:web:pub.example.com")
+                    .unwrap()
+                    .unwrap()
+                    .commit
+                    .cid_atproto()
+                    .unwrap(),
+                head
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn router_issuer_port_handle_uses_canonical_did_without_registry_entry() {
+        let did = "did:web:pds.example.test%3A8443";
+        let (_dir, store, gate, app, token) =
+            build_write_input_fixture_for(did, "https://pds.example.test:8443").await;
+        let resolve = app
+            .clone()
+            .oneshot(read_request(
+                "/xrpc/com.atproto.identity.resolveHandle?handle=pds.example.test",
+            ))
+            .await
+            .unwrap();
+        assert_eq!(resolve.status(), StatusCode::OK);
+        assert_eq!(body_json(resolve).await, json!({"did":did}));
+        let mut input = write_input(7);
+        input["repo"] = json!("pds.example.test");
+        let created = app
+            .clone()
+            .oneshot(write_http_request(&token, &input, HeaderMap::new()))
+            .await
+            .unwrap();
+        assert_eq!(created.status(), StatusCode::OK);
+        let created = body_json(created).await;
+        input["repo"] = json!(did);
+        let retry = app
+            .clone()
+            .oneshot(write_http_request(&token, &input, HeaderMap::new()))
+            .await
+            .unwrap();
+        assert_eq!(retry.status(), StatusCode::OK);
+        assert_eq!(body_json(retry).await, created);
+        for repo in [
+            "pds.example.test".to_owned(),
+            urlencoding::encode(did).into_owned(),
+        ] {
+            let read = app.clone().oneshot(read_request(&format!("/xrpc/com.atproto.repo.getRecord?repo={repo}&collection=app.bsky.feed.post&rkey={}", input["rkey"].as_str().unwrap()))).await.unwrap();
+            assert_eq!(read.status(), StatusCode::OK);
+            assert_eq!(body_json(read).await["uri"], created["uri"]);
+            let describe = app
+                .clone()
+                .oneshot(read_request(&format!(
+                    "/xrpc/com.atproto.repo.describeRepo?repo={repo}"
+                )))
+                .await
+                .unwrap();
+            assert_eq!(describe.status(), StatusCode::OK);
+            let describe = body_json(describe).await;
+            assert_eq!(describe["did"], did);
+            assert_eq!(describe["handle"], "pds.example.test");
+            assert_eq!(describe["didDoc"]["id"], did);
+        }
+        assert_eq!(store.snapshot(did).unwrap().unwrap().records.len(), 1);
+        assert_eq!(gate.0.load(std::sync::atomic::Ordering::Relaxed), 2);
     }
 
     #[tokio::test(flavor = "current_thread")]
@@ -2510,6 +2726,13 @@ mod tests {
                 assert_eq!(gate.0.load(std::sync::atomic::Ordering::Relaxed), 0);
             }
             for mut input in [post, profile] {
+                record_validation::validate(
+                    input["collection"].as_str().unwrap(),
+                    &input["record"],
+                )
+                .unwrap();
+                input["record"].as_object_mut().unwrap().remove("embed");
+                input["record"].as_object_mut().unwrap().remove("avatar");
                 if let Some(mode) = mode {
                     input["validate"] = json!(mode);
                 }

--- a/crates/hyprstream/src/services/oauth/xrpc.rs
+++ b/crates/hyprstream/src/services/oauth/xrpc.rs
@@ -1552,6 +1552,27 @@ mod tests {
         assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
     }
 
+    #[tokio::test]
+    async fn router_create_record_is_absent_without_explicit_public_writer() {
+        // The production builder must not expose a write endpoint until a
+        // native-authorized PublicRepoWriter is explicitly installed.
+        let app = build_production_app(true).await;
+        let response = app
+            .oneshot(
+                HttpRequest::builder()
+                    .method("POST")
+                    .uri("/xrpc/com.atproto.repo.createRecord")
+                    .header(header::CONTENT_TYPE, "application/json")
+                    .body(Body::from(
+                        r#"{"repo":"did:web:pub.example.com","collection":"app.bsky.feed.post","rkey":"3jzfcijpj2z2a","record":{}}"#,
+                    ))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::NOT_FOUND);
+    }
+
     // ── Finding 1: real capacity test through the mounted router ──────────────
 
     #[tokio::test]

--- a/crates/hyprstream/src/services/oauth/xrpc.rs
+++ b/crates/hyprstream/src/services/oauth/xrpc.rs
@@ -925,7 +925,7 @@ pub async fn get_record(State(state): State<Arc<OAuthState>>, RawQuery(raw): Raw
     };
     let cid = params.get("cid").map(|c| c.trim());
     if let Some(writer) = owned_public_writer(&state, repo).await {
-        return durable_reads::get_record(writer, collection, rkey, cid).await;
+        return durable_reads::get_record(&state.xrpc_repos, writer, collection, rkey, cid).await;
     }
     get_record_core(&state.xrpc_repos, repo, collection, rkey, cid).await
 }
@@ -1932,6 +1932,115 @@ mod tests {
 
     fn read_request(uri: &str) -> HttpRequest<Body> {
         HttpRequest::builder().uri(uri).body(Body::empty()).unwrap()
+    }
+
+    #[tokio::test]
+    async fn router_durable_reads_enforce_aggregate_snapshot_budget() {
+        for (count, bytes) in [(257, 1), (18, 60_000)] {
+            let (_dir, store, _gate, app, _token) = build_write_input_fixture().await;
+            store
+                .insert_snapshot_budget_fixture_for_test("did:web:pub.example.com", count, bytes)
+                .unwrap();
+            for uri in [
+                "/xrpc/com.atproto.repo.getRecord?repo=pub.example.com&collection=app.bsky.feed.post&rkey=0000",
+                "/xrpc/com.atproto.repo.describeRepo?repo=pub.example.com",
+                "/xrpc/com.atproto.sync.getRepo?did=did:web:pub.example.com",
+            ] {
+                let response = app.clone().oneshot(read_request(uri)).await.unwrap();
+                assert_eq!(response.status(), StatusCode::INTERNAL_SERVER_ERROR);
+                assert_eq!(body_json(response).await, json!({"error":"InternalServerError","message":"public repository read failed"}));
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn router_all_durable_reads_share_export_admission() {
+        let (_dir, _store, _gate, app, token) = build_write_input_fixture().await;
+        let created = app
+            .clone()
+            .oneshot(write_http_request(
+                &token,
+                &write_input(7),
+                HeaderMap::new(),
+            ))
+            .await
+            .unwrap();
+        assert_eq!(created.status(), StatusCode::OK);
+        let mut held = Vec::new();
+        for _ in 0..GET_REPO_CONCURRENCY {
+            held.push(
+                app.clone()
+                    .oneshot(read_request(
+                        "/xrpc/com.atproto.sync.getRepo?did=did:web:pub.example.com",
+                    ))
+                    .await
+                    .unwrap(),
+            );
+        }
+        let mut pending = Vec::new();
+        for uri in [
+            format!("/xrpc/com.atproto.repo.getRecord?repo=pub.example.com&collection=app.bsky.feed.post&rkey={}", Tid::from_raw(7).encode()),
+            "/xrpc/com.atproto.repo.describeRepo?repo=pub.example.com".to_owned(),
+        ] {
+            let app = app.clone();
+            pending.push(tokio::spawn(async move { app.oneshot(read_request(&uri)).await.unwrap() }));
+        }
+        for request in &mut pending {
+            assert!(
+                tokio::time::timeout(std::time::Duration::from_millis(50), request)
+                    .await
+                    .is_err()
+            );
+        }
+        drop(held.pop());
+        for request in pending {
+            let response = tokio::time::timeout(std::time::Duration::from_secs(2), request)
+                .await
+                .unwrap()
+                .unwrap();
+            assert_eq!(response.status(), StatusCode::OK);
+        }
+    }
+
+    #[tokio::test]
+    async fn router_describes_nonissuer_writers_without_legacy_handle_metadata() {
+        for did in [
+            "did:plc:abcdefghijklmnopqrstuvwx",
+            "did:web:account.example.com",
+        ] {
+            let (_dir, _store, _gate, app, token) =
+                build_write_input_fixture_for(did, "https://pds.example.com").await;
+            let mut input = write_input(7);
+            input["repo"] = json!(did);
+            let created = app
+                .clone()
+                .oneshot(write_http_request(&token, &input, HeaderMap::new()))
+                .await
+                .unwrap();
+            assert_eq!(created.status(), StatusCode::OK);
+            let response = app
+                .clone()
+                .oneshot(read_request(&format!(
+                    "/xrpc/com.atproto.repo.describeRepo?repo={did}"
+                )))
+                .await
+                .unwrap();
+            assert_eq!(response.status(), StatusCode::OK);
+            let body = body_json(response).await;
+            assert_eq!(body["did"], did);
+            assert_eq!(body["didDoc"]["id"], did);
+            assert_eq!(body["handle"], "handle.invalid");
+            assert_eq!(body["handleIsCorrect"], false);
+            assert!(body["didDoc"].get("alsoKnownAs").is_none());
+            assert_eq!(body["collections"], json!(["app.bsky.feed.post"]));
+            // The unknown account handle must not claim the PDS issuer handle.
+            input["repo"] = json!("pds.example.com");
+            let foreign = app
+                .oneshot(write_http_request(&token, &input, HeaderMap::new()))
+                .await
+                .unwrap();
+            assert_eq!(foreign.status(), StatusCode::FORBIDDEN);
+        }
     }
 
     #[tokio::test]

--- a/crates/hyprstream/src/services/oauth/xrpc.rs
+++ b/crates/hyprstream/src/services/oauth/xrpc.rs
@@ -37,7 +37,7 @@ use std::sync::Arc;
 
 use axum::{
     extract::{Extension, RawQuery, State},
-    http::{header, StatusCode},
+    http::{header, HeaderMap, StatusCode},
     response::{IntoResponse, Response},
 };
 use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine as _};
@@ -95,6 +95,17 @@ pub fn xrpc_routes() -> axum::Router<Arc<OAuthState>> {
         .route("/xrpc/com.atproto.repo.describeRepo", get(describe_repo))
         .route("/xrpc/com.atproto.repo.getRecord", get(get_record))
         .route("/xrpc/com.atproto.sync.getRepo", get(get_repo))
+}
+
+/// Protected standard repository write routes. These are mounted only when a
+/// public writer is explicitly installed in OAuthState; the default remains
+/// read-only until account/session authorization is configured.
+pub fn xrpc_write_routes() -> axum::Router<Arc<OAuthState>> {
+    use axum::routing::post;
+    axum::Router::new().route(
+        "/xrpc/com.atproto.repo.createRecord",
+        post(create_record),
+    )
 }
 
 /// An in-memory snapshot of one repo's signed state — enough to answer the
@@ -901,6 +912,100 @@ pub async fn get_repo(State(state): State<Arc<OAuthState>>, RawQuery(raw): RawQu
     // Reject since by PRESENCE (not just non-empty) — ?since= and ?since=x both 400.
     let since_present = params.contains_key("since");
     get_repo_core(&state.xrpc_repos, did, since_present).await
+}
+
+/// `com.atproto.repo.createRecord` for the first native-authorized public
+/// posting slice. The route is deliberately opt-in: OAuthState must carry a
+/// PublicRepoWriter, and the normal bearer/DPoP middleware must have inserted
+/// AuthenticatedUser before this handler runs.
+pub async fn create_record(
+    State(state): State<Arc<OAuthState>>,
+    Extension(user): Extension<AuthenticatedUser>,
+    headers: HeaderMap,
+    body: Bytes,
+) -> Response {
+    const MAX_BODY_BYTES: usize = 1_048_576;
+    if body.len() > MAX_BODY_BYTES {
+        return xrpc_error(StatusCode::PAYLOAD_TOO_LARGE, errors::INVALID_REQUEST, "record body exceeds 1 MiB");
+    }
+    let Some(writer) = state.public_repo_writer.as_ref() else {
+        return xrpc_error(StatusCode::SERVICE_UNAVAILABLE, errors::INTERNAL_SERVER_ERROR, "public repository writer is not configured");
+    };
+    let Some(token) = user.token.as_deref() else {
+        return xrpc_error(StatusCode::UNAUTHORIZED, errors::INVALID_REQUEST, "verified OAuth access token is required");
+    };
+    let claims = match auth::validate_oauth_access_token(&state, token).await {
+        Ok(claims) => claims,
+        Err(_) => return xrpc_error(StatusCode::UNAUTHORIZED, errors::INVALID_REQUEST, "OAuth access token is invalid or expired"),
+    };
+    if !claims.has_scope("atproto") {
+        return xrpc_error(StatusCode::FORBIDDEN, "InsufficientScope", "the atproto scope is required");
+    }
+    if claims.sub != user.user || claims.tenant != user.verified_tenant {
+        return xrpc_error(StatusCode::UNAUTHORIZED, errors::INVALID_REQUEST, "OAuth identity binding is invalid");
+    }
+    let input: Value = match serde_json::from_slice(&body) {
+        Ok(value) => value,
+        Err(_) => return xrpc_error(StatusCode::BAD_REQUEST, errors::INVALID_REQUEST, "request body must be valid JSON"),
+    };
+    let object = match input.as_object() {
+        Some(object) => object,
+        None => return xrpc_error(StatusCode::BAD_REQUEST, errors::INVALID_REQUEST, "request body must be an object"),
+    };
+    let repo = match object.get("repo").and_then(Value::as_str) {
+        Some(repo) if !repo.is_empty() => repo,
+        _ => return xrpc_error(StatusCode::BAD_REQUEST, errors::INVALID_REQUEST, "repo is required"),
+    };
+    if repo != writer.did() {
+        return xrpc_error(StatusCode::FORBIDDEN, "AuthRequired", "the request repo is not owned by this writer");
+    }
+    let collection = match object.get("collection").and_then(Value::as_str) {
+        Some(collection) if matches!(collection, "app.bsky.feed.post" | "app.bsky.actor.profile") => collection,
+        Some(_) => return xrpc_error(StatusCode::BAD_REQUEST, errors::INVALID_REQUEST, "collection is outside the enabled posting slice"),
+        None => return xrpc_error(StatusCode::BAD_REQUEST, errors::INVALID_REQUEST, "collection is required"),
+    };
+    let rkey = match object.get("rkey").and_then(Value::as_str).and_then(|value| Tid::parse(value).ok()) {
+        Some(rkey) => rkey,
+        None => return xrpc_error(StatusCode::BAD_REQUEST, errors::INVALID_REQUEST, "a valid TID rkey is required"),
+    };
+    let record_value = match object.get("record") {
+        Some(record) => record,
+        None => return xrpc_error(StatusCode::BAD_REQUEST, errors::INVALID_REQUEST, "record is required"),
+    };
+    let record = match crate::services::public_repo::json_to_dag_cbor(record_value) {
+        Ok(record) => record,
+        Err(_) => return xrpc_error(StatusCode::BAD_REQUEST, errors::INVALID_REQUEST, "record contains unsupported data"),
+    };
+    let request_id = headers
+        .get("Idempotency-Key")
+        .and_then(|value| value.to_str().ok())
+        .filter(|value| !value.is_empty())
+        .map(ToOwned::to_owned)
+        .unwrap_or_else(|| format!("create-{}-{}", collection.replace('.', "_"), rkey.encode()));
+    let expected_prev = object.get("swapCommit").and_then(Value::as_str);
+    let result = writer.create_record_with_expected_prev_text(
+        crate::services::public_repo::PublicCreateRequest {
+            request_id,
+            principal: user.user,
+            did: repo.to_owned(),
+            collection: collection.to_owned(),
+            rkey,
+            value: record,
+            expected_prev: None,
+        },
+        expected_prev,
+    );
+    let result = match result {
+        Ok(result) => result,
+        Err(error) if error.to_string().contains("authorization") || error.to_string().contains("denied") => return xrpc_error(StatusCode::FORBIDDEN, "AuthRequired", error.to_string()),
+        Err(error) if error.to_string().contains("CAS conflict") || error.to_string().contains("already exists") => return xrpc_error(StatusCode::CONFLICT, "InvalidSwap", error.to_string()),
+        Err(error) => return xrpc_error(StatusCode::BAD_REQUEST, errors::INVALID_REQUEST, error.to_string()),
+    };
+    let mut response = json!({"uri": result.uri, "cid": result.cid.to_string()});
+    if object.get("returnRecord").and_then(Value::as_bool).unwrap_or(false) {
+        response["value"] = record_value.clone();
+    }
+    (StatusCode::OK, axum::Json(response)).into_response()
 }
 
 // ─────────────────────────────────────────────────────────────────────────────

--- a/crates/hyprstream/src/services/oauth/xrpc.rs
+++ b/crates/hyprstream/src/services/oauth/xrpc.rs
@@ -102,10 +102,7 @@ pub fn xrpc_routes() -> axum::Router<Arc<OAuthState>> {
 /// read-only until account/session authorization is configured.
 pub fn xrpc_write_routes() -> axum::Router<Arc<OAuthState>> {
     use axum::routing::post;
-    axum::Router::new().route(
-        "/xrpc/com.atproto.repo.createRecord",
-        post(create_record),
-    )
+    axum::Router::new().route("/xrpc/com.atproto.repo.createRecord", post(create_record))
 }
 
 /// An in-memory snapshot of one repo's signed state — enough to answer the
@@ -926,63 +923,209 @@ pub async fn create_record(
 ) -> Response {
     const MAX_BODY_BYTES: usize = 1_048_576;
     if body.len() > MAX_BODY_BYTES {
-        return xrpc_error(StatusCode::PAYLOAD_TOO_LARGE, errors::INVALID_REQUEST, "record body exceeds 1 MiB");
+        return xrpc_error(
+            StatusCode::PAYLOAD_TOO_LARGE,
+            errors::INVALID_REQUEST,
+            "record body exceeds 1 MiB",
+        );
     }
     let Some(writer) = state.public_repo_writer.as_ref() else {
-        return xrpc_error(StatusCode::SERVICE_UNAVAILABLE, errors::INTERNAL_SERVER_ERROR, "public repository writer is not configured");
+        return xrpc_error(
+            StatusCode::SERVICE_UNAVAILABLE,
+            errors::INTERNAL_SERVER_ERROR,
+            "public repository writer is not configured",
+        );
     };
     let Some(token) = user.token.as_deref() else {
-        return xrpc_error(StatusCode::UNAUTHORIZED, errors::INVALID_REQUEST, "verified OAuth access token is required");
+        return xrpc_error(
+            StatusCode::UNAUTHORIZED,
+            errors::INVALID_REQUEST,
+            "verified OAuth access token is required",
+        );
     };
     let claims = match auth::validate_oauth_access_token(&state, token).await {
         Ok(claims) => claims,
-        Err(_) => return xrpc_error(StatusCode::UNAUTHORIZED, errors::INVALID_REQUEST, "OAuth access token is invalid or expired"),
+        Err(_) => {
+            return xrpc_error(
+                StatusCode::UNAUTHORIZED,
+                errors::INVALID_REQUEST,
+                "OAuth access token is invalid or expired",
+            )
+        }
     };
     if !claims.has_scope("atproto") {
-        return xrpc_error(StatusCode::FORBIDDEN, "InsufficientScope", "the atproto scope is required");
+        return xrpc_error(
+            StatusCode::FORBIDDEN,
+            "InsufficientScope",
+            "the atproto scope is required",
+        );
     }
     if claims.sub != user.user || claims.tenant != user.verified_tenant {
-        return xrpc_error(StatusCode::UNAUTHORIZED, errors::INVALID_REQUEST, "OAuth identity binding is invalid");
+        return xrpc_error(
+            StatusCode::UNAUTHORIZED,
+            errors::INVALID_REQUEST,
+            "OAuth identity binding is invalid",
+        );
     }
     let input: Value = match serde_json::from_slice(&body) {
         Ok(value) => value,
-        Err(_) => return xrpc_error(StatusCode::BAD_REQUEST, errors::INVALID_REQUEST, "request body must be valid JSON"),
+        Err(_) => {
+            return xrpc_error(
+                StatusCode::BAD_REQUEST,
+                errors::INVALID_REQUEST,
+                "request body must be valid JSON",
+            )
+        }
     };
     let object = match input.as_object() {
         Some(object) => object,
-        None => return xrpc_error(StatusCode::BAD_REQUEST, errors::INVALID_REQUEST, "request body must be an object"),
+        None => {
+            return xrpc_error(
+                StatusCode::BAD_REQUEST,
+                errors::INVALID_REQUEST,
+                "request body must be an object",
+            )
+        }
+    };
+    let expected_prev = match object.get("swapCommit") {
+        None => None,
+        Some(Value::String(value)) if !value.is_empty() => Some(value.as_str()),
+        Some(_) => {
+            return xrpc_error(
+                StatusCode::BAD_REQUEST,
+                errors::INVALID_REQUEST,
+                "swapCommit must be a non-empty CID string when present",
+            )
+        }
+    };
+    match object.get("validate") {
+        None | Some(Value::Bool(false)) => {}
+        Some(Value::Bool(true)) => {
+            return xrpc_error(
+                StatusCode::BAD_REQUEST,
+                "UnsupportedValidation",
+                "Lexicon validation is not available; validate=true cannot be fulfilled",
+            )
+        }
+        Some(_) => {
+            return xrpc_error(
+                StatusCode::BAD_REQUEST,
+                errors::INVALID_REQUEST,
+                "validate must be a boolean when present",
+            )
+        }
+    }
+    let return_record = match object.get("returnRecord") {
+        None => false,
+        Some(Value::Bool(value)) => *value,
+        Some(_) => {
+            return xrpc_error(
+                StatusCode::BAD_REQUEST,
+                errors::INVALID_REQUEST,
+                "returnRecord must be a boolean when present",
+            )
+        }
+    };
+    let mut idempotency_keys = headers.get_all("Idempotency-Key").iter();
+    let request_id = match idempotency_keys.next() {
+        None => None,
+        Some(value) => {
+            let value = match value.to_str() {
+                Ok(value) if !value.is_empty() => value,
+                _ => {
+                    return xrpc_error(
+                        StatusCode::BAD_REQUEST,
+                        errors::INVALID_REQUEST,
+                        "Idempotency-Key must be a non-empty ASCII string",
+                    )
+                }
+            };
+            if idempotency_keys.next().is_some() {
+                return xrpc_error(
+                    StatusCode::BAD_REQUEST,
+                    errors::INVALID_REQUEST,
+                    "only one Idempotency-Key may be supplied",
+                );
+            }
+            // The native writer validates the publication request ID's length
+            // and alphabet before authorization or any repository access.
+            Some(value.to_owned())
+        }
     };
     let repo = match object.get("repo").and_then(Value::as_str) {
         Some(repo) if !repo.is_empty() => repo,
-        _ => return xrpc_error(StatusCode::BAD_REQUEST, errors::INVALID_REQUEST, "repo is required"),
+        _ => {
+            return xrpc_error(
+                StatusCode::BAD_REQUEST,
+                errors::INVALID_REQUEST,
+                "repo is required",
+            )
+        }
     };
     if repo != writer.did() {
-        return xrpc_error(StatusCode::FORBIDDEN, "AuthRequired", "the request repo is not owned by this writer");
+        return xrpc_error(
+            StatusCode::FORBIDDEN,
+            "AuthRequired",
+            "the request repo is not owned by this writer",
+        );
     }
     let collection = match object.get("collection").and_then(Value::as_str) {
-        Some(collection) if matches!(collection, "app.bsky.feed.post" | "app.bsky.actor.profile") => collection,
-        Some(_) => return xrpc_error(StatusCode::BAD_REQUEST, errors::INVALID_REQUEST, "collection is outside the enabled posting slice"),
-        None => return xrpc_error(StatusCode::BAD_REQUEST, errors::INVALID_REQUEST, "collection is required"),
+        Some(collection)
+            if matches!(collection, "app.bsky.feed.post" | "app.bsky.actor.profile") =>
+        {
+            collection
+        }
+        Some(_) => {
+            return xrpc_error(
+                StatusCode::BAD_REQUEST,
+                errors::INVALID_REQUEST,
+                "collection is outside the enabled posting slice",
+            )
+        }
+        None => {
+            return xrpc_error(
+                StatusCode::BAD_REQUEST,
+                errors::INVALID_REQUEST,
+                "collection is required",
+            )
+        }
     };
-    let rkey = match object.get("rkey").and_then(Value::as_str).and_then(|value| Tid::parse(value).ok()) {
+    let rkey = match object
+        .get("rkey")
+        .and_then(Value::as_str)
+        .and_then(|value| Tid::parse(value).ok())
+    {
         Some(rkey) => rkey,
-        None => return xrpc_error(StatusCode::BAD_REQUEST, errors::INVALID_REQUEST, "a valid TID rkey is required"),
+        None => {
+            return xrpc_error(
+                StatusCode::BAD_REQUEST,
+                errors::INVALID_REQUEST,
+                "a valid TID rkey is required",
+            )
+        }
     };
     let record_value = match object.get("record") {
         Some(record) => record,
-        None => return xrpc_error(StatusCode::BAD_REQUEST, errors::INVALID_REQUEST, "record is required"),
+        None => {
+            return xrpc_error(
+                StatusCode::BAD_REQUEST,
+                errors::INVALID_REQUEST,
+                "record is required",
+            )
+        }
     };
     let record = match crate::services::public_repo::json_to_dag_cbor(record_value) {
         Ok(record) => record,
-        Err(_) => return xrpc_error(StatusCode::BAD_REQUEST, errors::INVALID_REQUEST, "record contains unsupported data"),
+        Err(_) => {
+            return xrpc_error(
+                StatusCode::BAD_REQUEST,
+                errors::INVALID_REQUEST,
+                "record contains unsupported data",
+            )
+        }
     };
-    let request_id = headers
-        .get("Idempotency-Key")
-        .and_then(|value| value.to_str().ok())
-        .filter(|value| !value.is_empty())
-        .map(ToOwned::to_owned)
+    let request_id = request_id
         .unwrap_or_else(|| format!("create-{}-{}", collection.replace('.', "_"), rkey.encode()));
-    let expected_prev = object.get("swapCommit").and_then(Value::as_str);
     let result = writer.create_record_with_expected_prev_text(
         crate::services::public_repo::PublicCreateRequest {
             request_id,
@@ -997,12 +1140,28 @@ pub async fn create_record(
     );
     let result = match result {
         Ok(result) => result,
-        Err(error) if error.to_string().contains("authorization") || error.to_string().contains("denied") => return xrpc_error(StatusCode::FORBIDDEN, "AuthRequired", error.to_string()),
-        Err(error) if error.to_string().contains("CAS conflict") || error.to_string().contains("already exists") => return xrpc_error(StatusCode::CONFLICT, "InvalidSwap", error.to_string()),
-        Err(error) => return xrpc_error(StatusCode::BAD_REQUEST, errors::INVALID_REQUEST, error.to_string()),
+        Err(error)
+            if error.to_string().contains("authorization")
+                || error.to_string().contains("denied") =>
+        {
+            return xrpc_error(StatusCode::FORBIDDEN, "AuthRequired", error.to_string())
+        }
+        Err(error)
+            if error.to_string().contains("CAS conflict")
+                || error.to_string().contains("already exists") =>
+        {
+            return xrpc_error(StatusCode::CONFLICT, "InvalidSwap", error.to_string())
+        }
+        Err(error) => {
+            return xrpc_error(
+                StatusCode::BAD_REQUEST,
+                errors::INVALID_REQUEST,
+                error.to_string(),
+            )
+        }
     };
     let mut response = json!({"uri": result.uri, "cid": result.cid.to_string()});
-    if object.get("returnRecord").and_then(Value::as_bool).unwrap_or(false) {
+    if return_record {
         response["value"] = record_value.clone();
     }
     (StatusCode::OK, axum::Json(response)).into_response()
@@ -1571,6 +1730,205 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(response.status(), StatusCode::NOT_FOUND);
+    }
+
+    #[derive(Default)]
+    struct WriteInputGate(std::sync::atomic::AtomicUsize);
+
+    impl crate::services::public_repo::PublicPublicationAuthorizer for WriteInputGate {
+        fn authorize(&self, _: &str, _: &str, _: &str) -> anyhow::Result<()> {
+            self.0.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+            Ok(())
+        }
+    }
+
+    async fn build_write_input_fixture() -> (
+        tempfile::TempDir,
+        Arc<crate::services::public_repo::PublicRepoStore>,
+        Arc<WriteInputGate>,
+        Router,
+        String,
+    ) {
+        if hyprstream_rpc::auth::global_credential_revocation_store().is_none() {
+            let _ = hyprstream_rpc::auth::set_global_credential_revocation_store(Arc::new(
+                hyprstream_rpc::auth::InMemoryCredentialRevocationStore::new(),
+            ));
+        }
+        let dir = tempfile::tempdir().unwrap();
+        let store =
+            Arc::new(crate::services::public_repo::PublicRepoStore::open(dir.path()).unwrap());
+        let gate = Arc::new(WriteInputGate::default());
+        let writer = crate::services::public_repo::PublicRepoWriter::new(
+            store.clone(),
+            "did:web:pub.example.com",
+            SigningKey::random(&mut OsRng),
+            gate.clone(),
+        )
+        .unwrap();
+        let mut state = build_test_state(true).await;
+        let signing_key = ed25519_dalek::SigningKey::from_bytes(&[0x19; 32]);
+        let writable_state = Arc::get_mut(&mut state).unwrap();
+        writable_state.verifying_key_bytes = signing_key.verifying_key().to_bytes();
+        writable_state.public_repo_writer = Some(Arc::new(writer));
+        let issuer = state.atproto_issuer_url();
+        let now = chrono::Utc::now().timestamp();
+        let claims = hyprstream_rpc::auth::Claims::new("xrpc-writer".to_owned(), now, now + 3600)
+            .with_issuer(issuer.clone())
+            .with_audience(Some(issuer))
+            .with_tenant("xrpc-input-tests".to_owned())
+            .with_client_id("xrpc-input-tests")
+            .with_scope(Some("atproto".to_owned()))
+            .with_jti();
+        let token = hyprstream_rpc::auth::jwt::encode(&claims, &signing_key);
+        let app = build_production_app_from_state(state).await;
+        (dir, store, gate, app, token)
+    }
+
+    fn write_input(id: u64) -> Value {
+        json!({
+            "repo": "did:web:pub.example.com",
+            "collection": "app.bsky.feed.post",
+            "rkey": Tid::from_raw(id).encode(),
+            "record": {
+                "$type": "app.bsky.feed.post",
+                "text": "input validation",
+                "createdAt": "2026-09-10T00:00:00Z"
+            }
+        })
+    }
+
+    fn write_http_request(token: &str, input: &Value, headers: HeaderMap) -> HttpRequest<Body> {
+        let mut request = HttpRequest::builder()
+            .method("POST")
+            .uri("/xrpc/com.atproto.repo.createRecord")
+            .header(header::AUTHORIZATION, format!("Bearer {token}"))
+            .header(header::CONTENT_TYPE, "application/json")
+            .body(Body::from(serde_json::to_vec(input).unwrap()))
+            .unwrap();
+        request.headers_mut().extend(headers);
+        request
+    }
+
+    #[tokio::test]
+    async fn router_create_record_rejects_malformed_optional_fields_without_writes() {
+        let (_dir, store, gate, app, token) = build_write_input_fixture().await;
+        for field in ["swapCommit", "validate", "returnRecord"] {
+            let mut invalid = vec![Value::Null, json!(1), json!(""), json!([]), json!({})];
+            if field == "swapCommit" {
+                invalid.extend([json!(false), json!(true), json!("not-a-cid")]);
+            }
+            for value in invalid {
+                let mut input = write_input(7);
+                input[field] = value.clone();
+                let response = app
+                    .clone()
+                    .oneshot(write_http_request(&token, &input, HeaderMap::new()))
+                    .await
+                    .unwrap();
+                assert_eq!(
+                    response.status(),
+                    StatusCode::BAD_REQUEST,
+                    "{field}={value}"
+                );
+                assert_eq!(body_json(response).await["error"], errors::INVALID_REQUEST);
+                assert!(store.snapshot("did:web:pub.example.com").unwrap().is_none());
+                assert_eq!(gate.0.load(std::sync::atomic::Ordering::Relaxed), 0);
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn router_create_record_rejects_invalid_idempotency_headers_without_writes() {
+        use axum::http::HeaderValue;
+        let (_dir, store, gate, app, token) = build_write_input_fixture().await;
+        for value in [
+            HeaderValue::from_static(""),
+            HeaderValue::from_static(" "),
+            HeaderValue::from_static("bad/key"),
+            HeaderValue::from_static("first,second"),
+            HeaderValue::from_str(&"a".repeat(129)).unwrap(),
+            HeaderValue::from_bytes(&[0xff]).unwrap(),
+        ] {
+            let mut headers = HeaderMap::new();
+            headers.insert("Idempotency-Key", value);
+            let response = app
+                .clone()
+                .oneshot(write_http_request(&token, &write_input(7), headers))
+                .await
+                .unwrap();
+            assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+            assert_eq!(body_json(response).await["error"], errors::INVALID_REQUEST);
+            assert!(store.snapshot("did:web:pub.example.com").unwrap().is_none());
+            assert_eq!(gate.0.load(std::sync::atomic::Ordering::Relaxed), 0);
+        }
+        let mut headers = HeaderMap::new();
+        headers.append("Idempotency-Key", HeaderValue::from_static("first"));
+        headers.append("Idempotency-Key", HeaderValue::from_static("second"));
+        let response = app
+            .oneshot(write_http_request(&token, &write_input(7), headers))
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+        assert_eq!(body_json(response).await["error"], errors::INVALID_REQUEST);
+        assert!(store.snapshot("did:web:pub.example.com").unwrap().is_none());
+        assert_eq!(gate.0.load(std::sync::atomic::Ordering::Relaxed), 0);
+    }
+
+    #[tokio::test]
+    async fn router_create_record_requires_supported_validation_and_preserves_basic_mode() {
+        let (_dir, store, gate, app, token) = build_write_input_fixture().await;
+        let mut input = write_input(7);
+        input["validate"] = json!(true);
+        let response = app
+            .clone()
+            .oneshot(write_http_request(&token, &input, HeaderMap::new()))
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+        let error = body_json(response).await;
+        assert_eq!(error["error"], "UnsupportedValidation");
+        assert!(error["message"]
+            .as_str()
+            .unwrap()
+            .contains("Lexicon validation"));
+        assert!(store.snapshot("did:web:pub.example.com").unwrap().is_none());
+        assert_eq!(gate.0.load(std::sync::atomic::Ordering::Relaxed), 0);
+
+        // Valid authenticated requests prove the negative cases reached the
+        // enabled production write path, not an auth failure or a 404 stub.
+        for (id, explicit_validate) in [(7, true), (8, false)] {
+            let mut input = write_input(id);
+            if explicit_validate {
+                input["validate"] = json!(false);
+            }
+            input["returnRecord"] = json!(explicit_validate);
+            let mut headers = HeaderMap::new();
+            if explicit_validate {
+                headers.insert("Idempotency-Key", "valid-7.key_1".parse().unwrap());
+            }
+            let response = app
+                .clone()
+                .oneshot(write_http_request(&token, &input, headers))
+                .await
+                .unwrap();
+            assert_eq!(response.status(), StatusCode::OK);
+            let output = body_json(response).await;
+            if explicit_validate {
+                assert_eq!(output["value"], input["record"]);
+            } else {
+                assert!(output.get("value").is_none());
+            }
+        }
+        assert_eq!(
+            store
+                .snapshot("did:web:pub.example.com")
+                .unwrap()
+                .unwrap()
+                .records
+                .len(),
+            2
+        );
+        assert_eq!(gate.0.load(std::sync::atomic::Ordering::Relaxed), 2);
     }
 
     // ── Finding 1: real capacity test through the mounted router ──────────────

--- a/crates/hyprstream/src/services/oauth/xrpc.rs
+++ b/crates/hyprstream/src/services/oauth/xrpc.rs
@@ -2870,10 +2870,48 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn router_explicit_tids_preserve_odd_low_bits_in_all_validation_modes() {
+        for mode in [None, Some(true), Some(false)] {
+            let (_dir, store, gate, app, token) = build_write_input_fixture().await;
+            for rkey in ["3jzfcijpj2z2b", "2222222222223"] {
+                let mut input = write_input(7);
+                input["rkey"] = json!(rkey);
+                if let Some(mode) = mode {
+                    input["validate"] = json!(mode);
+                }
+                let response = app
+                    .clone()
+                    .oneshot(write_http_request(&token, &input, HeaderMap::new()))
+                    .await
+                    .unwrap();
+                assert_eq!(response.status(), StatusCode::OK);
+                let created = body_json(response).await;
+                assert!(created["uri"]
+                    .as_str()
+                    .unwrap()
+                    .ends_with(&format!("/{rkey}")));
+                let read = app.clone().oneshot(read_request(&format!("/xrpc/com.atproto.repo.getRecord?repo=pub.example.com&collection=app.bsky.feed.post&rkey={rkey}"))).await.unwrap();
+                assert_eq!(read.status(), StatusCode::OK);
+                assert_eq!(body_json(read).await["uri"], created["uri"]);
+            }
+            assert_eq!(
+                store
+                    .snapshot("did:web:pub.example.com")
+                    .unwrap()
+                    .unwrap()
+                    .records
+                    .len(),
+                2
+            );
+            assert_eq!(gate.0.load(std::sync::atomic::Ordering::Relaxed), 2);
+        }
+    }
+
+    #[tokio::test]
     async fn router_create_record_canonical_keys_and_unknown_collections() {
         let (_dir, store, gate, app, token) = build_write_input_fixture().await;
-        let noncanonical = "2222222222223";
-        assert_ne!(Tid::parse(noncanonical).unwrap().encode(), noncanonical);
+        let noncanonical = "kjzfcijpj2z2a";
+        assert!(Tid::parse(noncanonical).is_err());
         for mode in [None, Some(true), Some(false)] {
             let mut input = write_input(7);
             if let Some(mode) = mode {

--- a/crates/hyprstream/src/services/oauth/xrpc.rs
+++ b/crates/hyprstream/src/services/oauth/xrpc.rs
@@ -32,6 +32,8 @@
 //! - Write path (`repo.createRecord` etc.) — sequenced with #910.
 //! - `createSession`/`getSession` — sequenced with #1113/#948.
 
+mod record_validation;
+
 use std::collections::BTreeMap;
 use std::sync::Arc;
 
@@ -999,15 +1001,9 @@ pub async fn create_record(
             )
         }
     };
-    match object.get("validate") {
-        None | Some(Value::Bool(false)) => {}
-        Some(Value::Bool(true)) => {
-            return xrpc_error(
-                StatusCode::BAD_REQUEST,
-                "UnsupportedValidation",
-                "Lexicon validation is not available; validate=true cannot be fulfilled",
-            )
-        }
+    let validate = match object.get("validate") {
+        None => true, // Both collections in this posting slice have known schemas.
+        Some(Value::Bool(value)) => *value,
         Some(_) => {
             return xrpc_error(
                 StatusCode::BAD_REQUEST,
@@ -1015,7 +1011,7 @@ pub async fn create_record(
                 "validate must be a boolean when present",
             )
         }
-    }
+    };
     let return_record = match object.get("returnRecord") {
         None => false,
         Some(Value::Bool(value)) => *value,
@@ -1098,9 +1094,10 @@ pub async fn create_record(
         }
         ("app.bsky.actor.profile", _) => Err(anyhow::anyhow!("profile rkey must be self")),
         (_, None) => Ok(None),
-        (_, Some(Value::String(value))) if Tid::parse(value).is_ok() => {
-            // Preserve an explicit key's bytes; parsing a TID is a syntax
-            // check, not permission to normalize the caller's record path.
+        (_, Some(Value::String(value)))
+            if Tid::parse(value).is_ok_and(|tid| tid.encode() == *value) =>
+        {
+            // Reject alternate encodings instead of changing the record path.
             AtprotoRecordKey::new(value.clone()).map(Some)
         }
         _ => Err(anyhow::anyhow!("a valid TID rkey is required when present")),
@@ -1125,6 +1122,23 @@ pub async fn create_record(
             )
         }
     };
+    if validate {
+        if let Err(error) = record_validation::validate(collection, record_value) {
+            let (status, code, message) = match error {
+                record_validation::Error::Invalid => (
+                    StatusCode::BAD_REQUEST,
+                    errors::INVALID_REQUEST,
+                    "record does not match its known schema",
+                ),
+                record_validation::Error::SchemaUnavailable => (
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    errors::INTERNAL_SERVER_ERROR,
+                    "record schema validation is unavailable",
+                ),
+            };
+            return xrpc_error(status, code, message);
+        }
+    }
     let record = match crate::services::public_repo::json_to_dag_cbor(record_value) {
         Ok(record) => record,
         Err(_) => {
@@ -1847,6 +1861,7 @@ mod tests {
         let (_dir, store, _gate, app, token) = build_write_input_fixture().await;
         let mut invalid = write_input(7);
         invalid["record"]["$type"] = json!("private.authorization.denied");
+        invalid["validate"] = json!(false); // Exercise the writer's typed input failure.
         let response = app
             .clone()
             .oneshot(write_http_request(&token, &invalid, HeaderMap::new()))
@@ -2056,60 +2071,194 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn router_create_record_requires_supported_validation_and_preserves_basic_mode() {
-        let (_dir, store, gate, app, token) = build_write_input_fixture().await;
+    async fn router_create_record_false_skips_schema_but_not_structural_checks() {
+        let (_dir, store, _gate, app, token) = build_write_input_fixture().await;
         let mut input = write_input(7);
-        input["validate"] = json!(true);
+        input["validate"] = json!(false);
+        input["returnRecord"] = json!(true);
+        input["record"].as_object_mut().unwrap().remove("text");
+        input["record"].as_object_mut().unwrap().remove("createdAt");
         let response = app
             .clone()
             .oneshot(write_http_request(&token, &input, HeaderMap::new()))
             .await
             .unwrap();
-        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
-        let error = body_json(response).await;
-        assert_eq!(error["error"], "UnsupportedValidation");
-        assert!(error["message"]
-            .as_str()
+        assert_eq!(response.status(), StatusCode::OK);
+        assert_eq!(body_json(response).await["value"], input["record"]);
+        let head = store
+            .snapshot("did:web:pub.example.com")
             .unwrap()
-            .contains("Lexicon validation"));
-        assert!(store.snapshot("did:web:pub.example.com").unwrap().is_none());
-        assert_eq!(gate.0.load(std::sync::atomic::Ordering::Relaxed), 0);
+            .unwrap()
+            .commit
+            .cid_atproto()
+            .unwrap();
+        input["record"]["unsupported"] = json!(1.5);
+        let response = app
+            .oneshot(write_http_request(&token, &input, HeaderMap::new()))
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+        let snapshot = store.snapshot("did:web:pub.example.com").unwrap().unwrap();
+        assert_eq!(snapshot.records.len(), 1);
+        assert_eq!(snapshot.commit.cid_atproto().unwrap(), head);
+    }
 
-        // Valid authenticated requests prove the negative cases reached the
-        // enabled production write path, not an auth failure or a 404 stub.
-        for (id, explicit_validate) in [(7, true), (8, false)] {
-            let mut input = write_input(id);
-            if explicit_validate {
-                input["validate"] = json!(false);
+    #[tokio::test]
+    async fn router_create_record_known_schemas_validate_omitted_and_true() {
+        for mode in [None, Some(true)] {
+            let (_dir, store, gate, app, token) = build_write_input_fixture().await;
+            let blob = json!({"$type":"blob", "ref":{"$link":hyprstream_pds::Cid::from_raw(b"image").to_string()}, "mimeType":"image/png", "size":5});
+            let strong = json!({"uri":"at://did:plc:abc/app.bsky.feed.post/custom-key", "cid":hyprstream_pds::Cid::from_dag_cbor(b"record").to_string()});
+            let mut post = write_input(7);
+            post["record"]["text"] = json!("e\u{301}".repeat(300)); // 300 graphemes, 600 code points.
+            post["record"]["langs"] = json!(["en", "i-klingon", "qaa-Zzzz-419"]);
+            post["record"]["reply"] = json!({"root":strong.clone(), "parent":strong.clone()});
+            post["record"]["facets"] = json!([{"index":{"byteStart":0,"byteEnd":1}, "features":[
+                {"$type":"app.bsky.richtext.facet#mention", "did":"did:key:zExample"},
+                {"$type":"app.bsky.richtext.facet#link", "uri":"https://example.com/path"}
+            ]}]);
+            post["record"]["embed"] = json!({"$type":"app.bsky.embed.images","images":[{"image":blob.clone(),"alt":"image","aspectRatio":{"width":1,"height":1}}]});
+            let profile = json!({"repo":"did:web:pub.example.com", "collection":"app.bsky.actor.profile", "record":{
+                "$type":"app.bsky.actor.profile", "displayName":"Profile", "pronouns":"they/them", "website":"https://example.com", "avatar":blob, "pinnedPost":strong,
+                "createdAt":"1985-04-12T23:20:50.12345678912345Z"
+            }});
+            let mut invalid = Vec::new();
+            for field in ["text", "createdAt"] {
+                let mut missing = post.clone();
+                missing["record"].as_object_mut().unwrap().remove(field);
+                invalid.push(missing);
+                for bad in [Value::Null, json!(5), json!([])] {
+                    let mut bad_type = post.clone();
+                    bad_type["record"][field] = bad;
+                    invalid.push(bad_type);
+                }
             }
-            input["returnRecord"] = json!(explicit_validate);
-            let mut headers = HeaderMap::new();
-            if explicit_validate {
-                headers.insert("Idempotency-Key", "valid-7.key_1".parse().unwrap());
+            for (pointer, bad) in [
+                ("/record/text", json!("x".repeat(301))),
+                (
+                    "/record/text",
+                    json!(format!("x{}", "\u{301}".repeat(1600))),
+                ),
+                ("/record/createdAt", json!("2026-02-30T00:00:00Z")),
+                ("/record/createdAt", json!("2026-01-01t00:00:00z")),
+                ("/record/createdAt", json!("2026-01-01T00:00:00-00:00")),
+                ("/record/langs", json!(["en_US"])),
+                ("/record/langs", json!(["en", "en", "en", "en"])),
+                ("/record/reply/root/cid", json!("private-not-a-cid")),
+                (
+                    "/record/reply/root/uri",
+                    json!("at://invalid/app.bsky.feed.post/key"),
+                ),
+                ("/record/facets/0/index/byteStart", json!(-1)),
+                ("/record/facets/0/features/0/did", json!("did::private")),
+                (
+                    "/record/facets/0/features/1/uri",
+                    json!("https://example.com/invalid space"),
+                ),
+                ("/record/embed/images/0/image/mimeType", json!("text/plain")),
+                ("/record/embed/images/0/image/size", json!(2000001)),
+                ("/record/embed/images/0/aspectRatio/width", json!(0)),
+            ] {
+                let mut bad_input = post.clone();
+                *bad_input.pointer_mut(pointer).unwrap() = bad;
+                invalid.push(bad_input);
             }
-            let response = app
-                .clone()
-                .oneshot(write_http_request(&token, &input, headers))
-                .await
-                .unwrap();
-            assert_eq!(response.status(), StatusCode::OK);
-            let output = body_json(response).await;
-            if explicit_validate {
-                assert_eq!(output["value"], input["record"]);
-            } else {
-                assert!(output.get("value").is_none());
+            for (field, bad) in [
+                ("displayName", json!("x".repeat(65))),
+                ("description", json!("x".repeat(257))),
+                ("pronouns", json!("x".repeat(21))),
+                ("avatar", Value::Null),
+                ("website", json!("relative/path")),
+                ("displayName", json!(false)),
+                ("pinnedPost", json!({})),
+                (
+                    "labels",
+                    json!({"$type":"com.atproto.label.defs#selfLabels","values":[{}]}),
+                ),
+            ] {
+                let mut bad_input = profile.clone();
+                bad_input["record"][field] = bad;
+                invalid.push(bad_input);
+            }
+            for mut input in invalid {
+                if let Some(mode) = mode {
+                    input["validate"] = json!(mode);
+                }
+                let response = app
+                    .clone()
+                    .oneshot(write_http_request(&token, &input, HeaderMap::new()))
+                    .await
+                    .unwrap();
+                assert_eq!(response.status(), StatusCode::BAD_REQUEST, "{input}");
+                assert_eq!(
+                    body_json(response).await,
+                    json!({"error":"InvalidRequest","message":"record does not match its known schema"})
+                );
+                assert!(store.snapshot("did:web:pub.example.com").unwrap().is_none());
+                assert_eq!(gate.0.load(std::sync::atomic::Ordering::Relaxed), 0);
+            }
+            for mut input in [post, profile] {
+                if let Some(mode) = mode {
+                    input["validate"] = json!(mode);
+                }
+                let response = app
+                    .clone()
+                    .oneshot(write_http_request(&token, &input, HeaderMap::new()))
+                    .await
+                    .unwrap();
+                assert_eq!(
+                    response.status(),
+                    StatusCode::OK,
+                    "{}",
+                    body_json(response).await
+                );
+            }
+            assert_eq!(
+                store
+                    .snapshot("did:web:pub.example.com")
+                    .unwrap()
+                    .unwrap()
+                    .records
+                    .len(),
+                2
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn router_create_record_canonical_keys_and_unknown_collections() {
+        let (_dir, store, gate, app, token) = build_write_input_fixture().await;
+        let noncanonical = "2222222222223";
+        assert_ne!(Tid::parse(noncanonical).unwrap().encode(), noncanonical);
+        for mode in [None, Some(true), Some(false)] {
+            let mut input = write_input(7);
+            if let Some(mode) = mode {
+                input["validate"] = json!(mode);
+            }
+            let mut unknown = input.clone();
+            unknown["collection"] = json!("com.example.unknown");
+            unknown["record"]["$type"] = unknown["collection"].clone();
+            input["rkey"] = json!(noncanonical);
+            for invalid in [input, unknown] {
+                let response = app
+                    .clone()
+                    .oneshot(write_http_request(&token, &invalid, HeaderMap::new()))
+                    .await
+                    .unwrap();
+                assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+                assert_eq!(body_json(response).await["error"], errors::INVALID_REQUEST);
+                assert!(store.snapshot("did:web:pub.example.com").unwrap().is_none());
+                assert_eq!(gate.0.load(std::sync::atomic::Ordering::Relaxed), 0);
             }
         }
-        assert_eq!(
-            store
-                .snapshot("did:web:pub.example.com")
-                .unwrap()
-                .unwrap()
-                .records
-                .len(),
-            2
-        );
-        assert_eq!(gate.0.load(std::sync::atomic::Ordering::Relaxed), 2);
+        let mut input = write_input(7);
+        input["record"]["embed"] = json!({"$type":"com.example.futureEmbed","extension":true});
+        input["record"]["extension"] = json!({"value":true});
+        let response = app
+            .oneshot(write_http_request(&token, &input, HeaderMap::new()))
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::OK); // Open unions and extra properties stay extensible.
     }
 
     #[tokio::test]

--- a/crates/hyprstream/src/services/oauth/xrpc/durable_reads.rs
+++ b/crates/hyprstream/src/services/oauth/xrpc/durable_reads.rs
@@ -43,6 +43,7 @@ fn record_json(value: &DagCbor) -> anyhow::Result<Value> {
 }
 
 pub(super) async fn get_record(
+    store: &XrpcRepoStore,
     writer: Arc<PublicRepoWriter>,
     collection: &str,
     rkey: &str,
@@ -55,10 +56,15 @@ pub(super) async fn get_record(
             "collection and rkey are required",
         );
     }
+    let permit = match store.acquire_get_repo_owned().await {
+        Ok(permit) => permit,
+        Err(_) => return internal_error(),
+    };
     let collection = collection.to_owned();
     let rkey = rkey.to_owned();
     let cid = cid.map(str::to_owned);
     let result=tokio::task::spawn_blocking(move || -> anyhow::Result<Option<Option<Value>>> {
+        let _permit = permit;
         let Some((snapshot,_))=writer.public_snapshot()? else { return Ok(None); };
         let key=match AtprotoRecordKey::new(rkey) { Ok(key)=>key, Err(_)=>return Ok(Some(None)) };
         let Some(record)=snapshot.records.get(&(collection,key)) else { return Ok(Some(None)); };
@@ -77,6 +83,25 @@ pub(super) async fn get_record(
     }
 }
 
+const MAX_PUBLIC_CAR_BYTES: usize = 2 * 1024 * 1024;
+
+fn append_car_block(car: &mut Vec<u8>, cid: Cid, bytes: &[u8]) -> anyhow::Result<()> {
+    // Conservative framing bound, checked before section allocation/copy.
+    let extra = bytes
+        .len()
+        .checked_add(cid.as_bytes().len() + 10)
+        .ok_or_else(|| anyhow::anyhow!("public CAR length overflow"))?;
+    anyhow::ensure!(
+        car.len()
+            .checked_add(extra)
+            .is_some_and(|size| size <= MAX_PUBLIC_CAR_BYTES),
+        "public CAR exceeds byte budget"
+    );
+    car.try_reserve_exact(extra)?;
+    car.extend_from_slice(&hyprstream_pds::car::car_block_bytes(cid, bytes));
+    Ok(())
+}
+
 fn repo_car(snapshot: &PublicRepoSnapshot) -> anyhow::Result<Vec<u8>> {
     let keyed = snapshot
         .records
@@ -85,17 +110,19 @@ fn repo_car(snapshot: &PublicRepoSnapshot) -> anyhow::Result<Vec<u8>> {
         .collect();
     let (_, nodes) = Node::from_keyed_records(&keyed).to_node_data_with_blocks_atproto()?;
     let commit_cid = snapshot.commit.cid_atproto()?;
-    let mut blocks = vec![(commit_cid, snapshot.commit.to_atproto_dag_cbor()?)];
+    let mut car = hyprstream_pds::car::build_car_v1_atproto(&[commit_cid], &[])?;
+    append_car_block(
+        &mut car,
+        commit_cid,
+        &snapshot.commit.to_atproto_dag_cbor()?,
+    )?;
     for (cid, node) in nodes {
-        blocks.push((cid, node.encode_atproto()?));
+        append_car_block(&mut car, cid, &node.encode_atproto()?)?;
     }
-    blocks.extend(
-        snapshot
-            .records
-            .values()
-            .map(|record| (record.cid(), record.bytes().to_vec())),
-    );
-    hyprstream_pds::car::build_car_v1_atproto(&[commit_cid], &blocks)
+    for record in snapshot.records.values() {
+        append_car_block(&mut car, record.cid(), record.bytes())?;
+    }
+    Ok(car)
 }
 
 pub(super) async fn get_repo(
@@ -147,32 +174,58 @@ pub(super) async fn describe_repo(state: &OAuthState, writer: Arc<PublicRepoWrit
         .get_public(writer.did())
         .await
         .map(|snapshot| snapshot.handle.clone());
-    let handle = match handle {
-        Some(handle) => handle,
-        None => {
-            if state.atproto_service_did().as_deref() != Some(writer.did()) {
-                return missing_repo();
-            }
-            let Some(handle) = url::Url::parse(&state.issuer_url)
-                .ok()
-                .and_then(|url| url.host_str().map(str::to_owned))
-            else {
-                return missing_repo();
-            };
-            handle
-        }
+    // No trusted account handle exists for some PLC/non-issuer repositories.
+    // Use the protocol's invalid-handle sentinel without inventing a binding.
+    let handle = handle.or_else(|| {
+        (state.atproto_service_did().as_deref() == Some(writer.did()))
+            .then(|| {
+                url::Url::parse(&state.issuer_url)
+                    .ok()
+                    .and_then(|url| url.host_str().map(str::to_owned))
+            })
+            .flatten()
+    });
+    let handle_is_correct = handle.is_some();
+    let handle = handle.unwrap_or_else(|| "handle.invalid".to_owned());
+    let permit = match state.xrpc_repos.acquire_get_repo_owned().await {
+        Ok(permit) => permit,
+        Err(_) => return internal_error(),
     };
     let issuer = state.issuer_url.clone();
     let result=tokio::task::spawn_blocking(move || -> anyhow::Result<_> {
+        let _permit = permit;
         let Some((snapshot,key))=writer.public_snapshot()? else { return Ok(None); };
         let collections:std::collections::BTreeSet<_>=snapshot.records.keys().map(|(collection,_)|collection.as_str()).collect();
         let identity=AtprotoIdentity {p256_vk:&key,handle:&handle,drain:None,lead:None};
-        let did_doc=build_did_document(&snapshot.did,&issuer,&[],Some(&identity),&[],None,None);
-        Ok(Some(json!({"handle":handle,"did":snapshot.did,"didDoc":did_doc,"collections":collections,"handleIsCorrect":true})))
+        let mut did_doc=build_did_document(&snapshot.did,&issuer,&[],Some(&identity),&[],None,None);
+        if !handle_is_correct {
+            if let Some(document) = did_doc.as_object_mut() { document.remove("alsoKnownAs"); }
+        }
+        Ok(Some(json!({"handle":handle,"did":snapshot.did,"didDoc":did_doc,"collections":collections,"handleIsCorrect":handle_is_correct})))
     }).await;
     match result {
         Ok(Ok(Some(value))) => axum::Json(value).into_response(),
         Ok(Ok(None)) => missing_repo(),
         _ => internal_error(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn car_budget_rejects_before_appending_an_excess_section() {
+        let block = vec![0; 64 * 1024];
+        let cid = Cid::from_dag_cbor(&block);
+        let mut car = Vec::new();
+        loop {
+            let before = car.len();
+            if append_car_block(&mut car, cid, &block).is_err() {
+                assert_eq!(car.len(), before);
+                assert!(car.len() <= MAX_PUBLIC_CAR_BYTES);
+                break;
+            }
+        }
     }
 }

--- a/crates/hyprstream/src/services/oauth/xrpc/durable_reads.rs
+++ b/crates/hyprstream/src/services/oauth/xrpc/durable_reads.rs
@@ -1,0 +1,175 @@
+//! Public reads from the configured durable writer. Never populate or fall
+//! back to the independent hosted-model snapshot cache for this repository.
+use super::*;
+use crate::services::public_repo::{PublicRepoSnapshot, PublicRepoWriter};
+use hyprstream_pds::dag_cbor::DagCbor;
+
+fn internal_error() -> Response {
+    xrpc_error(
+        StatusCode::INTERNAL_SERVER_ERROR,
+        errors::INTERNAL_SERVER_ERROR,
+        "public repository read failed",
+    )
+}
+fn missing_repo() -> Response {
+    xrpc_error(
+        StatusCode::BAD_REQUEST,
+        errors::REPO_NOT_FOUND,
+        "public repository is not available",
+    )
+}
+
+fn record_json(value: &DagCbor) -> anyhow::Result<Value> {
+    Ok(match value {
+        DagCbor::Null => Value::Null,
+        DagCbor::Bool(v) => json!(v),
+        DagCbor::Unsigned(v) => json!(v),
+        DagCbor::Negative(v) => json!(i64::try_from(*v)?),
+        DagCbor::Text(v) => json!(v),
+        DagCbor::Bytes(v) => json!({"$bytes":base64::engine::general_purpose::STANDARD.encode(v)}),
+        DagCbor::Link(v) => json!({"$link":v.to_string()}),
+        DagCbor::List(v) => Value::Array(v.iter().map(record_json).collect::<anyhow::Result<_>>()?),
+        DagCbor::Map(entries) => {
+            let mut object = serde_json::Map::new();
+            for (key, value) in entries {
+                let DagCbor::Text(key) = key else {
+                    anyhow::bail!("invalid public map key");
+                };
+                object.insert(key.clone(), record_json(value)?);
+            }
+            Value::Object(object)
+        }
+    })
+}
+
+pub(super) async fn get_record(
+    writer: Arc<PublicRepoWriter>,
+    collection: &str,
+    rkey: &str,
+    cid: Option<&str>,
+) -> Response {
+    if collection.is_empty() || rkey.is_empty() {
+        return xrpc_error(
+            StatusCode::BAD_REQUEST,
+            errors::INVALID_REQUEST,
+            "collection and rkey are required",
+        );
+    }
+    let collection = collection.to_owned();
+    let rkey = rkey.to_owned();
+    let cid = cid.map(str::to_owned);
+    let result=tokio::task::spawn_blocking(move || -> anyhow::Result<Option<Option<Value>>> {
+        let Some((snapshot,_))=writer.public_snapshot()? else { return Ok(None); };
+        let key=match AtprotoRecordKey::new(rkey) { Ok(key)=>key, Err(_)=>return Ok(Some(None)) };
+        let Some(record)=snapshot.records.get(&(collection,key)) else { return Ok(Some(None)); };
+        if cid.is_some_and(|cid| cid != record.cid().to_string()) { return Ok(Some(None)); }
+        Ok(Some(Some(json!({"uri":record.uri(&snapshot.did),"cid":record.cid().to_string(),"value":record_json(record.value())?}))))
+    }).await;
+    match result {
+        Ok(Ok(Some(Some(value)))) => axum::Json(value).into_response(),
+        Ok(Ok(Some(None))) => xrpc_error(
+            StatusCode::BAD_REQUEST,
+            errors::RECORD_NOT_FOUND,
+            "public record not found",
+        ),
+        Ok(Ok(None)) => missing_repo(),
+        _ => internal_error(),
+    }
+}
+
+fn repo_car(snapshot: &PublicRepoSnapshot) -> anyhow::Result<Vec<u8>> {
+    let keyed = snapshot
+        .records
+        .iter()
+        .map(|((collection, key), record)| (format!("{collection}/{}", key.as_str()), record.cid()))
+        .collect();
+    let (_, nodes) = Node::from_keyed_records(&keyed).to_node_data_with_blocks_atproto()?;
+    let commit_cid = snapshot.commit.cid_atproto()?;
+    let mut blocks = vec![(commit_cid, snapshot.commit.to_atproto_dag_cbor()?)];
+    for (cid, node) in nodes {
+        blocks.push((cid, node.encode_atproto()?));
+    }
+    blocks.extend(
+        snapshot
+            .records
+            .values()
+            .map(|record| (record.cid(), record.bytes().to_vec())),
+    );
+    hyprstream_pds::car::build_car_v1_atproto(&[commit_cid], &blocks)
+}
+
+pub(super) async fn get_repo(
+    store: &XrpcRepoStore,
+    writer: Arc<PublicRepoWriter>,
+    since_present: bool,
+) -> Response {
+    if since_present {
+        return xrpc_error(
+            StatusCode::BAD_REQUEST,
+            errors::INVALID_REQUEST,
+            "since (revision delta) is not yet supported; omit for full export",
+        );
+    }
+    let permit = match store.acquire_get_repo_owned().await {
+        Ok(permit) => permit,
+        Err(_) => return internal_error(),
+    };
+    let result = tokio::task::spawn_blocking(move || -> anyhow::Result<_> {
+        let bytes = writer
+            .public_snapshot()?
+            .map(|(snapshot, _)| repo_car(&snapshot))
+            .transpose()?;
+        Ok((bytes, permit))
+    })
+    .await;
+    let (bytes, permit) = match result {
+        Ok(Ok((Some(bytes), permit))) => (bytes, permit),
+        Ok(Ok((None, _))) => return missing_repo(),
+        _ => return internal_error(),
+    };
+    // Hold the existing export permit through body EOF/drop, including slow
+    // clients. Snapshot validation and CAR encoding happen on the blocking pool.
+    let stream = stream::unfold((Some(Bytes::from(bytes)), permit), |mut state| async move {
+        let bytes = state.0.take()?;
+        Some((Ok::<_, std::io::Error>(bytes), state))
+    });
+    (
+        StatusCode::OK,
+        [(header::CONTENT_TYPE, "application/vnd.ipld.car")],
+        axum::body::Body::from_stream(stream),
+    )
+        .into_response()
+}
+
+pub(super) async fn describe_repo(state: &OAuthState, writer: Arc<PublicRepoWriter>) -> Response {
+    let handle = state
+        .xrpc_repos
+        .get_public(writer.did())
+        .await
+        .map(|snapshot| snapshot.handle.clone());
+    let handle = match handle {
+        Some(handle) => handle,
+        None => {
+            let Some(authority) = issuer_authority(&state.issuer_url) else {
+                return missing_repo();
+            };
+            if writer.did() != format!("did:web:{authority}") {
+                return missing_repo();
+            }
+            authority.split(':').next().unwrap_or(&authority).to_owned()
+        }
+    };
+    let issuer = state.issuer_url.clone();
+    let result=tokio::task::spawn_blocking(move || -> anyhow::Result<_> {
+        let Some((snapshot,key))=writer.public_snapshot()? else { return Ok(None); };
+        let collections:std::collections::BTreeSet<_>=snapshot.records.keys().map(|(collection,_)|collection.as_str()).collect();
+        let identity=AtprotoIdentity {p256_vk:&key,handle:&handle,drain:None,lead:None};
+        let did_doc=build_did_document(&snapshot.did,&issuer,&[],Some(&identity),&[],None,None);
+        Ok(Some(json!({"handle":handle,"did":snapshot.did,"didDoc":did_doc,"collections":collections,"handleIsCorrect":true})))
+    }).await;
+    match result {
+        Ok(Ok(Some(value))) => axum::Json(value).into_response(),
+        Ok(Ok(None)) => missing_repo(),
+        _ => internal_error(),
+    }
+}

--- a/crates/hyprstream/src/services/oauth/xrpc/durable_reads.rs
+++ b/crates/hyprstream/src/services/oauth/xrpc/durable_reads.rs
@@ -56,7 +56,7 @@ pub(super) async fn get_record(
             "collection and rkey are required",
         );
     }
-    let permit = match store.acquire_get_repo_owned().await {
+    let permit = match store.acquire_snapshot_work_owned().await {
         Ok(permit) => permit,
         Err(_) => return internal_error(),
     };
@@ -141,7 +141,12 @@ pub(super) async fn get_repo(
         Ok(permit) => permit,
         Err(_) => return internal_error(),
     };
+    let work_permit = match store.acquire_snapshot_work_owned().await {
+        Ok(permit) => permit,
+        Err(_) => return internal_error(),
+    };
     let result = tokio::task::spawn_blocking(move || -> anyhow::Result<_> {
+        let _work_permit = work_permit;
         let bytes = writer
             .public_snapshot()?
             .map(|(snapshot, _)| repo_car(&snapshot))
@@ -154,8 +159,8 @@ pub(super) async fn get_repo(
         Ok(Ok((None, _))) => return missing_repo(),
         _ => return internal_error(),
     };
-    // Hold the existing export permit through body EOF/drop, including slow
-    // clients. Snapshot validation and CAR encoding happen on the blocking pool.
+    // Only export admission survives through body EOF/drop. Snapshot-work
+    // admission ended with the blocking task, keeping point reads available.
     let stream = stream::unfold((Some(Bytes::from(bytes)), permit), |mut state| async move {
         let bytes = state.0.take()?;
         Some((Ok::<_, std::io::Error>(bytes), state))
@@ -187,7 +192,7 @@ pub(super) async fn describe_repo(state: &OAuthState, writer: Arc<PublicRepoWrit
     });
     let handle_is_correct = handle.is_some();
     let handle = handle.unwrap_or_else(|| "handle.invalid".to_owned());
-    let permit = match state.xrpc_repos.acquire_get_repo_owned().await {
+    let permit = match state.xrpc_repos.acquire_snapshot_work_owned().await {
         Ok(permit) => permit,
         Err(_) => return internal_error(),
     };

--- a/crates/hyprstream/src/services/oauth/xrpc/durable_reads.rs
+++ b/crates/hyprstream/src/services/oauth/xrpc/durable_reads.rs
@@ -150,13 +150,16 @@ pub(super) async fn describe_repo(state: &OAuthState, writer: Arc<PublicRepoWrit
     let handle = match handle {
         Some(handle) => handle,
         None => {
-            let Some(authority) = issuer_authority(&state.issuer_url) else {
-                return missing_repo();
-            };
-            if writer.did() != format!("did:web:{authority}") {
+            if state.atproto_service_did().as_deref() != Some(writer.did()) {
                 return missing_repo();
             }
-            authority.split(':').next().unwrap_or(&authority).to_owned()
+            let Some(handle) = url::Url::parse(&state.issuer_url)
+                .ok()
+                .and_then(|url| url.host_str().map(str::to_owned))
+            else {
+                return missing_repo();
+            };
+            handle
         }
     };
     let issuer = state.issuer_url.clone();

--- a/crates/hyprstream/src/services/oauth/xrpc/record_validation.rs
+++ b/crates/hyprstream/src/services/oauth/xrpc/record_validation.rs
@@ -293,7 +293,7 @@ fn valid_nsid(value: &str) -> bool {
         && name.bytes().all(|b| b.is_ascii_alphanumeric())
 }
 
-fn valid_handle(value: &str) -> bool {
+pub(super) fn valid_handle(value: &str) -> bool {
     valid_dns_labels(value)
         && value
             .rsplit('.')

--- a/crates/hyprstream/src/services/oauth/xrpc/record_validation.rs
+++ b/crates/hyprstream/src/services/oauth/xrpc/record_validation.rs
@@ -1,0 +1,372 @@
+//! Validation of the two enabled posting schemas and their pinned reference
+//! closure. No schema discovery, permissions, network fetches or data rewriting.
+use std::collections::BTreeMap;
+use std::sync::LazyLock;
+
+use chrono::Datelike as _;
+use serde_json::Value;
+use unicode_segmentation::UnicodeSegmentation as _;
+
+#[derive(Debug)]
+pub(super) enum Error {
+    Invalid,
+    SchemaUnavailable,
+}
+
+type Result<T> = std::result::Result<T, Error>;
+
+macro_rules! schema {
+    ($path:literal) => {
+        include_str!(concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/../../lexicons/upstream/atproto/",
+            $path,
+            ".json"
+        ))
+    };
+}
+
+static SCHEMAS: LazyLock<Result<BTreeMap<String, Value>>> = LazyLock::new(|| {
+    [
+        schema!("app/bsky/feed/post"),
+        schema!("app/bsky/actor/profile"),
+        schema!("app/bsky/embed/defs"),
+        schema!("app/bsky/embed/external"),
+        schema!("app/bsky/embed/gallery"),
+        schema!("app/bsky/embed/images"),
+        schema!("app/bsky/embed/record"),
+        schema!("app/bsky/embed/recordWithMedia"),
+        schema!("app/bsky/embed/video"),
+        schema!("app/bsky/richtext/facet"),
+        schema!("com/atproto/label/defs"),
+        schema!("com/atproto/repo/strongRef"),
+    ]
+    .into_iter()
+    .map(|text| {
+        let value: Value = serde_json::from_str(text).map_err(|_| Error::SchemaUnavailable)?;
+        let id = value
+            .get("id")
+            .and_then(Value::as_str)
+            .ok_or(Error::SchemaUnavailable)?
+            .to_owned();
+        Ok((id, value))
+    })
+    .collect()
+});
+
+pub(super) fn validate(collection: &str, value: &Value) -> Result<()> {
+    let schemas = SCHEMAS.as_ref().map_err(|_| Error::SchemaUnavailable)?;
+    validate_ref(schemas, collection, value, 0)
+}
+
+fn validate_ref(
+    schemas: &BTreeMap<String, Value>,
+    reference: &str,
+    value: &Value,
+    depth: usize,
+) -> Result<()> {
+    let (nsid, name) = reference.split_once('#').unwrap_or((reference, "main"));
+    let schema = schemas
+        .get(nsid)
+        .and_then(|s| s.get("defs"))
+        .and_then(|s| s.get(name))
+        .ok_or(Error::SchemaUnavailable)?;
+    if schema.get("type").and_then(Value::as_str) == Some("record") {
+        check(value.get("$type").and_then(Value::as_str) == Some(nsid))?;
+        validate_value(
+            schemas,
+            nsid,
+            schema.get("record").ok_or(Error::SchemaUnavailable)?,
+            value,
+            depth,
+        )
+    } else {
+        validate_value(schemas, nsid, schema, value, depth)
+    }
+}
+
+fn check(valid: bool) -> Result<()> {
+    if valid {
+        Ok(())
+    } else {
+        Err(Error::Invalid)
+    }
+}
+
+fn bounds(schema: &Value, minimum: &str, maximum: &str, size: usize) -> Result<()> {
+    check(
+        schema
+            .get(minimum)
+            .and_then(Value::as_u64)
+            .is_none_or(|n| size as u64 >= n)
+            && schema
+                .get(maximum)
+                .and_then(Value::as_u64)
+                .is_none_or(|n| size as u64 <= n),
+    )
+}
+
+fn resolve(nsid: &str, reference: &str) -> String {
+    if reference.starts_with('#') {
+        format!("{nsid}{reference}")
+    } else {
+        reference.to_owned()
+    }
+}
+
+fn validate_value(
+    schemas: &BTreeMap<String, Value>,
+    nsid: &str,
+    schema: &Value,
+    value: &Value,
+    depth: usize,
+) -> Result<()> {
+    check(depth <= 128)?;
+    check(schema.get("const").is_none_or(|expected| expected == value))?;
+    check(
+        schema
+            .get("enum")
+            .and_then(Value::as_array)
+            .is_none_or(|allowed| allowed.contains(value)),
+    )?;
+    match schema
+        .get("type")
+        .and_then(Value::as_str)
+        .ok_or(Error::SchemaUnavailable)?
+    {
+        "object" => {
+            let object = value.as_object().ok_or(Error::Invalid)?;
+            if let Some(required) = schema.get("required").and_then(Value::as_array) {
+                for key in required {
+                    check(object.contains_key(key.as_str().ok_or(Error::SchemaUnavailable)?))?;
+                }
+            }
+            for (key, field) in schema
+                .get("properties")
+                .and_then(Value::as_object)
+                .ok_or(Error::SchemaUnavailable)?
+            {
+                if let Some(value) = object.get(key) {
+                    let nullable = schema
+                        .get("nullable")
+                        .and_then(Value::as_array)
+                        .is_some_and(|fields| fields.contains(&Value::String(key.clone())));
+                    if !(nullable && value.is_null()) {
+                        validate_value(schemas, nsid, field, value, depth + 1)?;
+                    }
+                }
+            }
+            // Lexicon objects are extensible. Unrecognized properties still
+            // pass through the existing complete AT data-model/codec checks.
+            Ok(())
+        }
+        "array" => {
+            let items = value.as_array().ok_or(Error::Invalid)?;
+            bounds(schema, "minLength", "maxLength", items.len())?;
+            let item_schema = schema.get("items").ok_or(Error::SchemaUnavailable)?;
+            for item in items {
+                validate_value(schemas, nsid, item_schema, item, depth + 1)?;
+            }
+            Ok(())
+        }
+        "string" => {
+            let text = value.as_str().ok_or(Error::Invalid)?;
+            bounds(schema, "minLength", "maxLength", text.len())?;
+            bounds(
+                schema,
+                "minGraphemes",
+                "maxGraphemes",
+                text.graphemes(true).count(),
+            )?;
+            match schema.get("format").and_then(Value::as_str) {
+                Some(format) => check(valid_format(format, text)),
+                None => Ok(()),
+            }
+        }
+        "integer" => {
+            let n = value.as_i64().ok_or(Error::Invalid)?;
+            check(
+                schema
+                    .get("minimum")
+                    .and_then(Value::as_i64)
+                    .is_none_or(|min| n >= min)
+                    && schema
+                        .get("maximum")
+                        .and_then(Value::as_i64)
+                        .is_none_or(|max| n <= max),
+            )
+        }
+        "ref" => {
+            let reference = schema
+                .get("ref")
+                .and_then(Value::as_str)
+                .ok_or(Error::SchemaUnavailable)?;
+            validate_ref(schemas, &resolve(nsid, reference), value, depth + 1)
+        }
+        "union" => {
+            let discriminator = value
+                .get("$type")
+                .and_then(Value::as_str)
+                .ok_or(Error::Invalid)?;
+            let (id, fragment) = discriminator.split_once('#').unwrap_or((discriminator, ""));
+            check(
+                valid_nsid(id)
+                    && (fragment.is_empty()
+                        || (fragment != "main"
+                            && fragment
+                                .bytes()
+                                .all(|b| b.is_ascii_alphanumeric() || b == b'_'))),
+            )?;
+            let refs = schema
+                .get("refs")
+                .and_then(Value::as_array)
+                .ok_or(Error::SchemaUnavailable)?;
+            for reference in refs {
+                let reference = resolve(nsid, reference.as_str().ok_or(Error::SchemaUnavailable)?);
+                if reference == discriminator {
+                    return validate_ref(schemas, &reference, value, depth + 1);
+                }
+            }
+            // Open unions accept future variants, without claiming their schema
+            // is known. Closed unions cannot introduce new alternatives.
+            check(schema.get("closed").and_then(Value::as_bool) != Some(true))
+        }
+        "blob" => {
+            check(value.get("$type").and_then(Value::as_str) == Some("blob"))?;
+            let link = value.get("ref").ok_or(Error::Invalid)?;
+            let cid =
+                crate::services::public_repo::json_to_dag_cbor(link).map_err(|_| Error::Invalid)?;
+            check(
+                matches!(cid, hyprstream_pds::dag_cbor::DagCbor::Link(cid) if cid.as_bytes().get(1) == Some(&0x55)),
+            )?;
+            let size = value
+                .get("size")
+                .and_then(Value::as_u64)
+                .ok_or(Error::Invalid)?;
+            check(
+                size > 0
+                    && schema
+                        .get("maxSize")
+                        .and_then(Value::as_u64)
+                        .is_none_or(|max| size <= max),
+            )?;
+            let mime = value
+                .get("mimeType")
+                .and_then(Value::as_str)
+                .ok_or(Error::Invalid)?;
+            check(
+                !mime.is_empty()
+                    && schema
+                        .get("accept")
+                        .and_then(Value::as_array)
+                        .is_none_or(|types| {
+                            types.iter().any(|t| {
+                                t.as_str().is_some_and(|t| {
+                                    t == "*/*"
+                                        || t == mime
+                                        || t.strip_suffix("/*").is_some_and(|prefix| {
+                                            mime.strip_prefix(prefix).is_some_and(|rest| {
+                                                rest.starts_with('/') && rest.len() > 1
+                                            })
+                                        })
+                                })
+                            })
+                        }),
+            )
+        }
+        _ => Err(Error::SchemaUnavailable),
+    }
+}
+
+fn valid_nsid(value: &str) -> bool {
+    let Some((authority, name)) = value.rsplit_once('.') else {
+        return false;
+    };
+    value.len() <= 317
+        && valid_dns_labels(authority)
+        && authority
+            .as_bytes()
+            .first()
+            .is_some_and(u8::is_ascii_alphabetic)
+        && (1..=63).contains(&name.len())
+        && name.as_bytes().first().is_some_and(u8::is_ascii_alphabetic)
+        && name.bytes().all(|b| b.is_ascii_alphanumeric())
+}
+
+fn valid_handle(value: &str) -> bool {
+    valid_dns_labels(value)
+        && value
+            .rsplit('.')
+            .next()
+            .is_some_and(|tld| tld.as_bytes().first().is_some_and(u8::is_ascii_alphabetic))
+}
+
+fn valid_dns_labels(value: &str) -> bool {
+    value.len() <= 253
+        && value.contains('.')
+        && value.split('.').all(|part| {
+            (1..=63).contains(&part.len())
+                && !part.starts_with('-')
+                && !part.ends_with('-')
+                && part.bytes().all(|b| b.is_ascii_alphanumeric() || b == b'-')
+        })
+}
+
+fn valid_did(value: &str) -> bool {
+    let Some((method, id)) = value.strip_prefix("did:").and_then(|s| s.split_once(':')) else {
+        return false;
+    };
+    value.len() <= 2048
+        && !method.is_empty()
+        && method.bytes().all(|b| b.is_ascii_lowercase())
+        && !id.is_empty()
+        && !id.ends_with(':')
+        && id
+            .bytes()
+            .all(|b| b.is_ascii_alphanumeric() || b"._:%-".contains(&b))
+}
+
+fn valid_at_uri(value: &str) -> bool {
+    let Some(rest) = value.strip_prefix("at://") else {
+        return false;
+    };
+    let mut parts = rest.split('/');
+    let authority = parts.next().unwrap_or_default();
+    value.len() <= 8192
+        && (valid_did(authority) || valid_handle(authority))
+        && parts.next().is_none_or(valid_nsid)
+        && parts
+            .next()
+            .is_none_or(|key| hyprstream_pds::atproto_cbor::AtprotoRecordKey::new(key).is_ok())
+        && parts.next().is_none()
+}
+
+fn valid_format(format: &str, text: &str) -> bool {
+    match format {
+        "cid" => {
+            crate::services::public_repo::json_to_dag_cbor(&serde_json::json!({"$link": text}))
+                .is_ok()
+        }
+        "did" => valid_did(text),
+        "at-uri" => valid_at_uri(text),
+        "uri" => {
+            text.len() <= 8192 && (valid_at_uri(text) || uriparse::URI::try_from(text).is_ok())
+        }
+        "language" => language_tags::LanguageTag::parse(text).is_ok(),
+        "datetime" => {
+            static DATETIME: LazyLock<std::result::Result<regex::Regex, regex::Error>> =
+                LazyLock::new(|| {
+                    regex::Regex::new(
+                        r"^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}(\.[0-9]+)?(Z|[+-][0-9]{2}:[0-9]{2})$",
+                    )
+                });
+            !text.ends_with("-00:00")
+                && DATETIME
+                    .as_ref()
+                    .is_ok_and(|pattern| pattern.is_match(text))
+                && chrono::DateTime::parse_from_rfc3339(text)
+                    .is_ok_and(|dt| dt.with_timezone(&chrono::Utc).year() >= 0)
+        }
+        _ => false,
+    }
+}

--- a/crates/hyprstream/src/services/oauth/xrpc/record_validation.rs
+++ b/crates/hyprstream/src/services/oauth/xrpc/record_validation.rs
@@ -320,7 +320,7 @@ fn valid_did(value: &str) -> bool {
         && !method.is_empty()
         && method.bytes().all(|b| b.is_ascii_lowercase())
         && !id.is_empty()
-        && !id.ends_with(':')
+        && !id.ends_with([':', '%'])
         && id
             .bytes()
             .all(|b| b.is_ascii_alphanumeric() || b"._:%-".contains(&b))

--- a/crates/hyprstream/src/services/public_repo.rs
+++ b/crates/hyprstream/src/services/public_repo.rs
@@ -12,6 +12,10 @@ use std::path::Path;
 use std::sync::Arc;
 
 use anyhow::{anyhow, ensure, Context as _, Result};
+use base64::{
+    engine::general_purpose::{STANDARD, STANDARD_NO_PAD},
+    Engine as _,
+};
 use hyprstream_pds::atproto_cbor::{AtprotoRecord, AtprotoRecordKey};
 use hyprstream_pds::commit::{Commit, UnsignedCommit};
 use hyprstream_pds::dag_cbor::DagCbor;
@@ -541,7 +545,10 @@ impl PublicRepoWriter {
                     .snapshot(&self.did)?
                     .ok_or_else(|| anyhow!("public repo head is absent"))?;
                 let actual = snapshot.commit.cid_atproto()?;
-                ensure!(actual.to_string() == expected, "public repo head CAS conflict");
+                ensure!(
+                    actual.to_string() == expected,
+                    "public repo head CAS conflict"
+                );
                 Some(actual)
             }
             Some(_) => return Err(anyhow!("swapCommit must be a non-empty CID")),
@@ -550,9 +557,45 @@ impl PublicRepoWriter {
     }
 }
 
-/// Convert the JSON data model accepted by AT records into the bounded native
-/// value type used by the public codec. Floats, non-string object keys and
-/// integers outside signed 64-bit range are rejected before serialization.
+/// Decode a canonical AT JSON CID link without accepting other codecs,
+/// hashes, overlong varints, or noncanonical base32 spellings.
+fn parse_atproto_json_cid(text: &str) -> Result<Cid> {
+    // CIDv1, one-byte raw/DAG-CBOR codec, sha2-256, and 32 digest bytes.
+    // These 36 bytes occupy 58 base32 digits plus the multibase prefix.
+    ensure!(
+        text.len() == 59 && text.starts_with('b'),
+        "invalid AT CID text"
+    );
+    let mut raw = Vec::with_capacity(36);
+    let mut pending = 0u16;
+    let mut bits = 0u32;
+    for digit in text.bytes().skip(1) {
+        let digit = match digit {
+            b'a'..=b'z' => digit - b'a',
+            b'2'..=b'7' => digit - b'2' + 26,
+            _ => return Err(anyhow!("AT CID must use lowercase base32")),
+        };
+        pending = (pending << 5) | u16::from(digit);
+        bits += 5;
+        if bits >= 8 {
+            bits -= 8;
+            raw.push((pending >> bits) as u8);
+            pending &= (1 << bits) - 1;
+        }
+    }
+    ensure!(
+        pending == 0
+            && raw.len() == 36
+            && matches!(raw.as_slice(), [1, 0x55 | 0x71, 0x12, 0x20, ..]),
+        "AT CID requires canonical raw or DAG-CBOR SHA-256 bytes"
+    );
+    Cid::from_bytes(&raw)
+}
+
+/// Convert AT JSON into the value type used by the public codec. Reserved
+/// single-key `$link` and `$bytes` objects become links and byte strings,
+/// never ordinary maps. Invalid wrappers, floats and integers outside signed
+/// 64-bit range are rejected before serialization.
 pub fn json_to_dag_cbor(value: &serde_json::Value) -> Result<DagCbor> {
     Ok(match value {
         serde_json::Value::Null => DagCbor::Null,
@@ -575,6 +618,26 @@ pub fn json_to_dag_cbor(value: &serde_json::Value) -> Result<DagCbor> {
                 .map(json_to_dag_cbor)
                 .collect::<Result<Vec<_>>>()?,
         ),
+        serde_json::Value::Object(values) if values.contains_key("$link") => {
+            ensure!(values.len() == 1, "AT JSON link must contain only $link");
+            let text = values
+                .get("$link")
+                .and_then(serde_json::Value::as_str)
+                .ok_or_else(|| anyhow!("AT JSON $link must be a CID string"))?;
+            DagCbor::Link(parse_atproto_json_cid(text)?)
+        }
+        serde_json::Value::Object(values) if values.contains_key("$bytes") => {
+            ensure!(values.len() == 1, "AT JSON bytes must contain only $bytes");
+            let text = values
+                .get("$bytes")
+                .and_then(serde_json::Value::as_str)
+                .ok_or_else(|| anyhow!("AT JSON $bytes must be a base64 string"))?;
+            let bytes = STANDARD
+                .decode(text)
+                .or_else(|_| STANDARD_NO_PAD.decode(text))
+                .context("invalid AT JSON base64 bytes")?;
+            DagCbor::Bytes(bytes)
+        }
         serde_json::Value::Object(values) => DagCbor::Map(
             values
                 .iter()
@@ -1074,6 +1137,106 @@ mod tests {
             )
             .unwrap();
         assert!(store.snapshot(&writer.did).is_err());
+    }
+
+    #[test]
+    fn json_links_and_bytes_match_independent_public_record_fixture() {
+        // Independently encoded using Python hashlib/base64 and a minimal
+        // RFC 8949 encoder with public map ordering and tag-42 links.
+        let json = serde_json::json!({
+            "$type": "app.bsky.feed.post",
+            "text": "json",
+            "payload": {"$bytes": "AQI="},
+            "links": [{"$link": "bafyreifqwkmiw256ojf2zws6tzjeonw6bpd5vza4i22ccpcq4hjv2ts7cm"}],
+            "blob": {
+                "$type": "blob",
+                "ref": {"$link": "bafkreifbfby75yqq7odbski6v2qziwa4xustdzfsg5m5ejpwqbush5rsei"},
+                "mimeType": "image/png",
+                "size": 2
+            }
+        });
+        let value = json_to_dag_cbor(&json).expect("AT JSON");
+        let record = AtprotoRecord::new("app.bsky.feed.post", Tid::from_raw(7), value)
+            .expect("public record");
+        let fixture = hex::decode(concat!(
+            "a564626c6f62a463726566d82a58250001551220a12871fee210fb8619291eaea194581cbd2531e4b23759d225f6806923f63222",
+            "6473697a650265247479706564626c6f62686d696d655479706569696d6167652f706e676474657874646a736f6e",
+            "652474797065726170702e62736b792e666565642e706f7374656c696e6b7381d82a58250001711220b0b2988b6bbe724bacda5e9e524736de0bc7dae41c46b4213c50e1d35d4e5f13",
+            "677061796c6f6164420102"
+        )).expect("fixture");
+        assert_eq!(record.bytes(), fixture);
+        assert_eq!(
+            record.cid().to_string(),
+            "bafyreie3irn4tnywq3hxjm3knxuq7ovhni7cjqxa7weo7dncxsw6rj3s4m"
+        );
+        assert!(
+            AtprotoRecord::from_bytes("app.bsky.feed.post", Tid::from_raw(7), &fixture).is_ok()
+        );
+    }
+
+    #[test]
+    fn json_bytes_accept_standard_base64_with_optional_padding() {
+        for text in ["", "AQI", "AQI=", "+/8=", "+/8"] {
+            let value = json_to_dag_cbor(&serde_json::json!({"$bytes": text})).expect("bytes");
+            let expected = match text {
+                "" => vec![],
+                "AQI" | "AQI=" => vec![1, 2],
+                _ => vec![251, 255],
+            };
+            assert_eq!(value, DagCbor::Bytes(expected));
+        }
+    }
+
+    #[test]
+    fn json_rejects_malformed_reserved_wrappers_at_any_depth() {
+        let cid = Cid::from_raw(b"blob").to_string();
+        let malformed = [
+            serde_json::json!({"$link": false}),
+            serde_json::json!({"$link": "not-a-cid"}),
+            serde_json::json!({"$link": cid, "extra": 1}),
+            serde_json::json!({"$link": cid, "$bytes": "AQI="}),
+            serde_json::json!({"$bytes": 12}),
+            serde_json::json!({"$bytes": "AQI=", "extra": 1}),
+            serde_json::json!({"$bytes": "-_8="}),
+            serde_json::json!({"$bytes": "AQJ="}),
+            serde_json::json!({"$bytes": "AQI=="}),
+        ];
+        for value in malformed {
+            assert!(json_to_dag_cbor(&value).is_err(), "{value}");
+            assert!(json_to_dag_cbor(&serde_json::json!({"nested": [value]})).is_err());
+        }
+    }
+
+    #[test]
+    fn json_links_reject_noncanonical_and_unsupported_cids() {
+        let cid = Cid::from_raw(b"blob");
+        let text = cid.to_string();
+        assert_eq!(parse_atproto_json_cid(&text).expect("canonical"), cid);
+        assert!(parse_atproto_json_cid(&text.to_uppercase()).is_err());
+        assert!(parse_atproto_json_cid(&format!("{text}=")).is_err());
+        let mut noncanonical = text.into_bytes();
+        let last = noncanonical.last_mut().expect("last digit");
+        // The last base32 digit has two zero padding bits. Setting one leaves
+        // the decoded CID bytes unchanged but must not be accepted.
+        let alphabet = b"abcdefghijklmnopqrstuvwxyz234567";
+        let position = alphabet.iter().position(|c| c == last).expect("base32");
+        *last = alphabet[position + 1];
+        assert!(parse_atproto_json_cid(&String::from_utf8(noncanonical).unwrap()).is_err());
+        for (position, replacement) in [(1, 0x70), (2, 0x13), (3, 0x1f)] {
+            let mut raw = cid.as_bytes().to_vec();
+            raw[position] = replacement;
+            // Encode invalid bytes independently of the production parser.
+            let encoded = raw
+                .iter()
+                .flat_map(|byte| (0..8).rev().map(move |bit| (byte >> bit) & 1))
+                .collect::<Vec<_>>();
+            let mut text = String::from("b");
+            for chunk in encoded.chunks(5) {
+                let n = chunk.iter().fold(0u8, |n, bit| (n << 1) | bit) << (5 - chunk.len());
+                text.push(alphabet[n as usize] as char);
+            }
+            assert!(parse_atproto_json_cid(&text).is_err());
+        }
     }
 
     #[test]

--- a/crates/hyprstream/src/services/public_repo.rs
+++ b/crates/hyprstream/src/services/public_repo.rs
@@ -515,20 +515,26 @@ impl PublicRepoWriter {
                 .store
                 .snapshot(&self.did)?
                 .ok_or_else(|| anyhow!("publication intent exists without a repository"))?;
-            if !snapshot.records.get(&(request.collection.clone(), rkey))
-                .is_some_and(|stored| stored.bytes() == record.bytes()) {
-                return Err(anyhow!("publication intent does not match stored record").into());
+            if !snapshot
+                .records
+                .get(&(request.collection.clone(), rkey))
+                .is_some_and(|stored| stored.bytes() == record.bytes())
+            {
+                return Err(anyhow!("publication intent record does not match repository").into());
             }
             let commit_bytes = self
                 .store
                 .db
-                .get(commit_block_key(&self.did, &intent.commit_cid))?
+                .get(commit_block_key(&self.did, &intent.commit_cid))
+                .context("publication intent commit block read failed")?
                 .ok_or_else(|| anyhow!("publication intent commit block is missing"))?;
             let commit = Commit::from_atproto_dag_cbor(&commit_bytes)
                 .context("publication intent commit is invalid")?;
             let commit_cid = commit.cid_atproto()?;
             if commit.did != self.did || intent.commit_cid != commit_cid.to_string() {
-                return Err(anyhow!("publication intent commit does not match stored block").into());
+                return Err(
+                    anyhow!("publication intent commit does not match stored block").into(),
+                );
             }
             return Ok(PublicCommitResult {
                 uri: record.uri(&self.did),
@@ -1076,17 +1082,25 @@ mod tests {
                     ("text", DagCbor::Text("x".repeat(payload))),
                 ])
             };
-            let overhead = AtprotoRecord::new(&request.collection, request.rkey.as_ref().unwrap(), value(1024))
-                .unwrap()
-                .bytes()
-                .len()
+            let overhead = AtprotoRecord::new(
+                &request.collection,
+                request.rkey.as_ref().unwrap(),
+                value(1024),
+            )
+            .unwrap()
+            .bytes()
+            .len()
                 - 1024;
             request.value = value(size - overhead);
             assert_eq!(
-                AtprotoRecord::new(&request.collection, request.rkey.as_ref().unwrap(), request.value.clone())
-                    .unwrap()
-                    .bytes()
-                    .len(),
+                AtprotoRecord::new(
+                    &request.collection,
+                    request.rkey.as_ref().unwrap(),
+                    request.value.clone()
+                )
+                .unwrap()
+                .bytes()
+                .len(),
                 size
             );
             request
@@ -1183,7 +1197,7 @@ mod tests {
         let key = p256::ecdsa::SigningKey::random(&mut rand::rngs::OsRng);
         let mut profile = create_request(1, None);
         profile.collection = "app.bsky.actor.profile".into();
-        profile.rkey = AtprotoRecordKey::new("self").unwrap();
+        profile.rkey = Some(AtprotoRecordKey::new("self").unwrap());
         profile.value = DagCbor::str_map([
             ("$type", DagCbor::Text(profile.collection.clone())),
             ("displayName", DagCbor::Text("Profile".into())),
@@ -1196,7 +1210,7 @@ mod tests {
             format!("at://{}/app.bsky.actor.profile/self", profile.did)
         );
         let mut post = create_request(2, Some(first.commit_cid));
-        post.rkey = AtprotoRecordKey::new("custom-key:~").unwrap();
+        post.rkey = Some(AtprotoRecordKey::new("custom-key:~").unwrap());
         let second = writer.create_record(post.clone()).unwrap();
         assert_eq!(writer.create_record(profile.clone()).unwrap(), first);
         let mut duplicate = profile.clone();
@@ -1213,11 +1227,14 @@ mod tests {
         let store = Arc::new(PublicRepoStore::open(dir.path()).unwrap());
         let snapshot = store.snapshot(&profile.did).unwrap().unwrap();
         assert_eq!(snapshot.records.len(), 2);
-        let stored = &snapshot.records[&(profile.collection.clone(), profile.rkey.clone())];
+        let stored =
+            &snapshot.records[&(profile.collection.clone(), profile.rkey.clone().unwrap())];
         assert_eq!(stored.rkey().as_str(), "self");
         assert_eq!(stored.cid(), first.cid);
         assert_eq!(stored.value(), &profile.value);
-        assert!(snapshot.records.contains_key(&(post.collection, post.rkey)));
+        assert!(snapshot
+            .records
+            .contains_key(&(post.collection, post.rkey.unwrap())));
         snapshot.commit.verify_atproto(key.verifying_key()).unwrap();
         assert_eq!(snapshot.commit.cid_atproto().unwrap(), second.commit_cid);
         let writer = PublicRepoWriter::new(store.clone(), &profile.did, key, gate).unwrap();
@@ -1392,7 +1409,7 @@ mod tests {
             .unwrap()
             .unwrap();
         let missing = create_request(3, None);
-        intent.rkey = missing.rkey.as_str().to_owned();
+        intent.rkey = missing.rkey.as_ref().unwrap().as_str().to_owned();
         store
             .db
             .put(
@@ -1583,6 +1600,53 @@ mod tests {
         snapshot
             .commit
             .verify_atproto(&writer.active_verifying_key().unwrap())
+            .unwrap();
+    }
+
+    #[test]
+    fn generated_key_retry_survives_account_key_promotion_and_reopen() {
+        let (dir, store, gate, writer) = transaction_fixture();
+        let mut request = transaction_request(7);
+        request.rkey = None;
+        let first = writer
+            .create_record_with_expected_prev_text(request.clone(), None)
+            .unwrap();
+        let candidate = p256::ecdsa::SigningKey::random(&mut rand::rngs::OsRng);
+        let promoted = writer
+            .promote_signing_key(
+                "did:at9p:agent",
+                &writer.active_verifying_key().unwrap(),
+                candidate.clone(),
+            )
+            .unwrap()
+            .unwrap();
+        let mut later = transaction_request(8);
+        later.rkey = None;
+        writer
+            .create_record_with_expected_prev_text(later, Some(&promoted.to_string()))
+            .unwrap();
+        assert_eq!(
+            writer
+                .create_record_with_expected_prev_text(request.clone(), None)
+                .unwrap(),
+            first
+        );
+        drop(writer);
+        drop(store);
+        let store = Arc::new(PublicRepoStore::open(dir.path()).unwrap());
+        let writer =
+            PublicRepoWriter::new(store.clone(), &request.did, candidate.clone(), gate).unwrap();
+        assert_eq!(
+            writer
+                .create_record_with_expected_prev_text(request, None)
+                .unwrap(),
+            first
+        );
+        let snapshot = store.snapshot(writer.did()).unwrap().unwrap();
+        assert_eq!(snapshot.records.len(), 2);
+        snapshot
+            .commit
+            .verify_atproto(candidate.verifying_key())
             .unwrap();
     }
 

--- a/crates/hyprstream/src/services/public_repo.rs
+++ b/crates/hyprstream/src/services/public_repo.rs
@@ -297,6 +297,10 @@ impl std::fmt::Debug for PublicRepoWriter {
 }
 
 impl PublicRepoWriter {
+    pub fn did(&self) -> &str {
+        &self.did
+    }
+
     /// Bind a trusted account key to this store. All writer handles for the
     /// same DID share one active authority; a different key requires promotion.
     pub fn new(
@@ -519,6 +523,65 @@ impl PublicRepoWriter {
             commit_cid,
         })
     }
+
+    /// Variant used by JSON/XRPC adapters, which receive the standard base32
+    /// CID text form. The string is compared with the durable public head
+    /// before delegating to the typed transaction; no unvalidated CID parser
+    /// or native-format fallback is introduced.
+    pub fn create_record_with_expected_prev_text(
+        &self,
+        mut request: PublicCreateRequest,
+        expected_prev: Option<&str>,
+    ) -> Result<PublicCommitResult> {
+        request.expected_prev = match expected_prev {
+            None => None,
+            Some(expected) if !expected.is_empty() => {
+                let snapshot = self
+                    .store
+                    .snapshot(&self.did)?
+                    .ok_or_else(|| anyhow!("public repo head is absent"))?;
+                let actual = snapshot.commit.cid_atproto()?;
+                ensure!(actual.to_string() == expected, "public repo head CAS conflict");
+                Some(actual)
+            }
+            Some(_) => return Err(anyhow!("swapCommit must be a non-empty CID")),
+        };
+        self.create_record(request)
+    }
+}
+
+/// Convert the JSON data model accepted by AT records into the bounded native
+/// value type used by the public codec. Floats, non-string object keys and
+/// integers outside signed 64-bit range are rejected before serialization.
+pub fn json_to_dag_cbor(value: &serde_json::Value) -> Result<DagCbor> {
+    Ok(match value {
+        serde_json::Value::Null => DagCbor::Null,
+        serde_json::Value::Bool(value) => DagCbor::Bool(*value),
+        serde_json::Value::Number(number) => {
+            if let Some(value) = number.as_i64() {
+                if value >= 0 {
+                    DagCbor::Unsigned(value as u64)
+                } else {
+                    DagCbor::Negative(value as i128)
+                }
+            } else {
+                return Err(anyhow!("AT record numbers must be signed integers"));
+            }
+        }
+        serde_json::Value::String(value) => DagCbor::Text(value.clone()),
+        serde_json::Value::Array(values) => DagCbor::List(
+            values
+                .iter()
+                .map(json_to_dag_cbor)
+                .collect::<Result<Vec<_>>>()?,
+        ),
+        serde_json::Value::Object(values) => DagCbor::Map(
+            values
+                .iter()
+                .map(|(key, value)| Ok((DagCbor::Text(key.clone()), json_to_dag_cbor(value)?)))
+                .collect::<Result<Vec<_>>>()?,
+        ),
+    })
 }
 
 fn next_revision(previous: Option<Tid>) -> Tid {

--- a/crates/hyprstream/src/services/public_repo.rs
+++ b/crates/hyprstream/src/services/public_repo.rs
@@ -38,6 +38,36 @@ const MAX_PRINCIPAL: usize = 512;
 /// See https://atproto.com/specs/repository#security-considerations.
 pub const MAX_PUBLIC_RECORD_BYTES: usize = 64 * 1024;
 
+/// Blob storage is not wired to this public writer. Never accept caller-supplied
+/// blob claims as proof of account ownership, bytes, MIME type or size. Scan
+/// every object, including open unions/extensions and legacy blob objects.
+pub(crate) fn reject_unverified_blobs(value: &DagCbor) -> Result<()> {
+    match value {
+        DagCbor::Map(entries) => {
+            let field = |name: &str| {
+                entries.iter().find_map(|(key, value)| {
+                    matches!(key, DagCbor::Text(key) if key == name).then_some(value)
+                })
+            };
+            ensure!(
+                !matches!(field("$type"), Some(DagCbor::Text(kind)) if kind == "blob")
+                    && !(field("cid").is_some() && field("mimeType").is_some()),
+                "blob storage verification is unavailable"
+            );
+            for (_, value) in entries {
+                reject_unverified_blobs(value)?;
+            }
+        }
+        DagCbor::List(values) => {
+            for value in values {
+                reject_unverified_blobs(value)?;
+            }
+        }
+        _ => {}
+    }
+    Ok(())
+}
+
 fn record_prefix(did: &str) -> Vec<u8> {
     format!("{RECORD_PREFIX}{did}\0").into_bytes()
 }
@@ -153,6 +183,9 @@ struct PublicationIntent {
     generated_rkey: bool,
     cid: String,
     commit_cid: String,
+    /// Missing on older receipts: condition identity cannot safely be inferred.
+    #[serde(default)]
+    head_condition: Option<String>,
 }
 
 #[derive(Default)]
@@ -169,6 +202,14 @@ enum PublicHeadCondition {
 }
 
 impl PublicHeadCondition {
+    fn identity(&self) -> String {
+        match self {
+            Self::Unconditional => "unconditional".to_owned(),
+            Self::Exact(None) => "exact:genesis".to_owned(),
+            Self::Exact(Some(cid)) => format!("exact:{cid}"),
+        }
+    }
+
     fn matches(&self, actual: Option<Cid>) -> bool {
         match self {
             Self::Unconditional => true,
@@ -194,6 +235,48 @@ impl std::fmt::Debug for PublicRepoStore {
 }
 
 impl PublicRepoStore {
+    #[cfg(test)]
+    pub(crate) fn insert_unverified_blob_for_test(&self, did: &str) -> Result<()> {
+        let account = self
+            .accounts
+            .lock()
+            .get(did)
+            .cloned()
+            .ok_or_else(|| anyhow!("test writer account missing"))?;
+        let key = account.active_key.lock();
+        let record = AtprotoRecord::new(
+            "app.bsky.feed.post",
+            AtprotoRecordKey::new("legacy")?,
+            DagCbor::str_map([
+                ("$type", DagCbor::Text("app.bsky.feed.post".into())),
+                (
+                    "extension",
+                    DagCbor::str_map([
+                        ("$type", DagCbor::Text("blob".into())),
+                        ("ref", DagCbor::Link(Cid::from_raw(b"absent-content"))),
+                        ("mimeType", DagCbor::Text("image/png".into())),
+                        ("size", DagCbor::Unsigned(14)),
+                    ]),
+                ),
+            ]),
+        )?;
+        let keyed = BTreeMap::from([("app.bsky.feed.post/legacy".to_owned(), record.cid())]);
+        let (root, _) = Node::from_keyed_records(&keyed).to_node_data_with_blocks_atproto()?;
+        let commit = Commit::sign_atproto(
+            &UnsignedCommit::new(did.to_owned(), root.cid_atproto()?, Tid::from_raw(7), None),
+            key.as_ref()
+                .ok_or_else(|| anyhow!("test signing authority missing"))?,
+        )?;
+        let mut batch = rocksdb::WriteBatch::default();
+        batch.put(
+            record_key(did, record.collection(), record.rkey().as_str()),
+            record.bytes(),
+        );
+        batch.put(commit_key(did), commit.to_atproto_dag_cbor()?);
+        self.db.write(batch)?;
+        Ok(())
+    }
+
     #[cfg(test)]
     pub(crate) fn with_account_lock_for_test(&self, did: &str, held: impl FnOnce()) -> Result<()> {
         let account = self
@@ -257,6 +340,7 @@ impl PublicRepoStore {
                 AtprotoRecord::from_bytes(collection, &rkey, &bytes).with_context(|| {
                     format!("invalid public record {did}/{collection}/{}", rkey.as_str())
                 })?;
+            reject_unverified_blobs(record.value())?;
             records.insert((collection.to_owned(), rkey), record);
         }
         if records.is_empty() {
@@ -508,11 +592,17 @@ impl PublicRepoWriter {
             .authorize(&request.principal, &self.did, &request.collection)
             .map_err(PublicRepoWriteError::Authorization)?;
 
+        reject_unverified_blobs(&request.value).map_err(PublicRepoWriteError::InvalidRequest)?;
         let state = self.account.active_key.lock();
         let signing_key = state
             .as_ref()
             .ok_or_else(|| anyhow!("no active signing authority for repository"))?;
         if let Some(intent) = self.store.intent(&self.did, &request.request_id)? {
+            if intent.head_condition.as_deref() != Some(condition.identity().as_str()) {
+                return Err(PublicRepoWriteError::InvalidRequest(anyhow!(
+                    "publication request condition changed or is not bound"
+                )));
+            }
             if intent.generated_rkey != request.rkey.is_none() {
                 return Err(PublicRepoWriteError::InvalidRequest(anyhow!(
                     "publication request id was reused with a different key mode"
@@ -633,6 +723,7 @@ impl PublicRepoWriter {
             generated_rkey,
             cid: record.cid().to_string(),
             commit_cid: commit_cid.to_string(),
+            head_condition: Some(condition.identity()),
         };
         self.store
             .write_transaction(&self.did, &record, &commit, &intent)?;
@@ -1835,6 +1926,92 @@ mod tests {
     }
 
     #[test]
+    fn retries_bind_original_condition_under_race_and_legacy_receipts_fail_closed() {
+        let (_dir, store, _gate, writer) = transaction_fixture();
+        let first = writer
+            .create_record_with_expected_prev_text(transaction_request(7), None)
+            .unwrap();
+        let previous = first.commit_cid.to_string();
+        let barrier = std::sync::Barrier::new(2);
+        let outcomes = std::thread::scope(|scope| {
+            let workers: Vec<_> = [None, Some(previous.as_str())]
+                .into_iter()
+                .map(|condition| {
+                    let writer = &writer;
+                    let barrier = &barrier;
+                    scope.spawn(move || {
+                        barrier.wait();
+                        (
+                            condition,
+                            writer.create_record_with_expected_prev_text(
+                                transaction_request(8),
+                                condition,
+                            ),
+                        )
+                    })
+                })
+                .collect();
+            workers
+                .into_iter()
+                .map(|worker| worker.join().unwrap())
+                .collect::<Vec<_>>()
+        });
+        assert_eq!(
+            outcomes.iter().filter(|(_, result)| result.is_ok()).count(),
+            1
+        );
+        assert!(outcomes
+            .iter()
+            .any(|(_, result)| matches!(result, Err(PublicRepoWriteError::InvalidRequest(_)))));
+        let (condition, result) = outcomes.iter().find(|(_, result)| result.is_ok()).unwrap();
+        assert_eq!(
+            &writer
+                .create_record_with_expected_prev_text(transaction_request(8), *condition)
+                .unwrap(),
+            result.as_ref().unwrap()
+        );
+        assert_eq!(
+            store.snapshot(writer.did()).unwrap().unwrap().records.len(),
+            2
+        );
+        let mut legacy =
+            serde_json::to_value(store.intent(writer.did(), "req-8").unwrap().unwrap()).unwrap();
+        legacy.as_object_mut().unwrap().remove("head_condition");
+        store
+            .db
+            .put(
+                intent_key(writer.did(), "req-8"),
+                serde_json::to_vec(&legacy).unwrap(),
+            )
+            .unwrap();
+        assert!(matches!(
+            writer.create_record_with_expected_prev_text(transaction_request(8), *condition),
+            Err(PublicRepoWriteError::InvalidRequest(_))
+        ));
+    }
+
+    #[test]
+    fn native_publication_rejects_unverified_blob_extensions_without_mutation() {
+        let (_dir, store, _gate, writer) = transaction_fixture();
+        let mut request = transaction_request(7);
+        request.value = DagCbor::str_map([
+            ("$type", DagCbor::Text(request.collection.clone())),
+            (
+                "extension",
+                DagCbor::List(vec![DagCbor::str_map([(
+                    "$type",
+                    DagCbor::Text("blob".into()),
+                )])]),
+            ),
+        ]);
+        assert!(matches!(
+            writer.create_record(request),
+            Err(PublicRepoWriteError::InvalidRequest(_))
+        ));
+        assert!(store.snapshot(writer.did()).unwrap().is_none());
+    }
+
+    #[test]
     fn xrpc_retries_return_original_result_after_later_commit_and_reopen() {
         let (dir, store, gate, writer) = transaction_fixture();
         let first = writer
@@ -1878,6 +2055,12 @@ mod tests {
             second,
             "durable retry returns original commit, not the latest head"
         );
+        for changed in [None, Some(third.commit_cid.to_string().as_str())] {
+            assert!(matches!(
+                writer.create_record_with_expected_prev_text(transaction_request(8), changed),
+                Err(PublicRepoWriteError::InvalidRequest(_))
+            ));
+        }
         let mut changed = transaction_request(8);
         changed.value = DagCbor::str_map([
             ("$type", DagCbor::Text("app.bsky.feed.post".into())),

--- a/crates/hyprstream/src/services/public_repo.rs
+++ b/crates/hyprstream/src/services/public_repo.rs
@@ -194,6 +194,18 @@ impl std::fmt::Debug for PublicRepoStore {
 }
 
 impl PublicRepoStore {
+    #[cfg(test)]
+    pub(crate) fn insert_malformed_record_for_test(
+        &self,
+        did: &str,
+        collection: &str,
+        rkey: &str,
+    ) -> Result<()> {
+        self.db
+            .put(record_key(did, collection, rkey), b"invalid CBOR")?;
+        Ok(())
+    }
+
     pub fn open(path: &Path) -> Result<Self> {
         std::fs::create_dir_all(path)
             .with_context(|| format!("failed to create public repo store at {path:?}"))?;
@@ -301,6 +313,22 @@ impl PublicRepoStore {
             .context("public repo transaction failed")?;
         Ok(())
     }
+}
+
+/// Write failures are classified at their origin. HTTP callers must use these
+/// variants and fixed public messages; sources are for local diagnostics only.
+#[derive(Debug, thiserror::Error)]
+pub enum PublicRepoWriteError {
+    #[error("invalid publication request: {0}")]
+    InvalidRequest(#[source] anyhow::Error),
+    #[error("publication authorization failed: {0}")]
+    Authorization(#[source] anyhow::Error),
+    #[error("record key already exists")]
+    RecordAlreadyExists,
+    #[error("public repo head CAS conflict")]
+    InvalidSwap,
+    #[error("internal public repository failure: {0}")]
+    Internal(#[from] anyhow::Error),
 }
 
 /// Public repository writer with an explicit native authorization gate.
@@ -427,7 +455,10 @@ impl PublicRepoWriter {
         Ok(head)
     }
 
-    pub fn create_record(&self, request: PublicCreateRequest) -> Result<PublicCommitResult> {
+    pub fn create_record(
+        &self,
+        request: PublicCreateRequest,
+    ) -> Result<PublicCommitResult, PublicRepoWriteError> {
         let condition = PublicHeadCondition::Exact(request.expected_prev);
         self.create_record_with_condition(request, condition)
     }
@@ -436,50 +467,58 @@ impl PublicRepoWriter {
         &self,
         request: PublicCreateRequest,
         condition: PublicHeadCondition,
-    ) -> Result<PublicCommitResult> {
-        ensure!(
-            request.did == self.did,
-            "public request account does not match writer"
-        );
-        validate_request_id(&request.request_id)?;
-        validate_principal(&request.principal)?;
+    ) -> Result<PublicCommitResult, PublicRepoWriteError> {
+        if request.did != self.did {
+            return Err(PublicRepoWriteError::InvalidRequest(anyhow!(
+                "public request account does not match writer"
+            )));
+        }
+        validate_request_id(&request.request_id).map_err(PublicRepoWriteError::InvalidRequest)?;
+        validate_principal(&request.principal).map_err(PublicRepoWriteError::InvalidRequest)?;
         self.authorizer
-            .authorize(&request.principal, &self.did, &request.collection)?;
+            .authorize(&request.principal, &self.did, &request.collection)
+            .map_err(PublicRepoWriteError::Authorization)?;
 
         let state = self.account.active_key.lock();
         let signing_key = state
             .as_ref()
             .ok_or_else(|| anyhow!("no active signing authority for repository"))?;
         if let Some(intent) = self.store.intent(&self.did, &request.request_id)? {
-            ensure!(
-                intent.generated_rkey == request.rkey.is_none(),
-                "publication request id was reused with a different key mode"
-            );
+            if intent.generated_rkey != request.rkey.is_none() {
+                return Err(PublicRepoWriteError::InvalidRequest(anyhow!(
+                    "publication request id was reused with a different key mode"
+                )));
+            }
             let rkey = match request.rkey.as_ref() {
                 Some(rkey) => rkey.clone(),
                 None => AtprotoRecordKey::new(intent.rkey.clone())?,
             };
-            let record = AtprotoRecord::new(request.collection.clone(), &rkey, request.value)?;
-            ensure!(
-                intent.request_id == request.request_id
-                    && intent.principal == request.principal
-                    && intent.did == self.did
-                    && intent.collection == record.collection()
-                    && intent.rkey == record.rkey().as_str()
-                    && intent.cid == record.cid().to_string(),
-                "publication request id was reused with different content"
-            );
+            let record = AtprotoRecord::new(request.collection.clone(), &rkey, request.value)
+                .map_err(PublicRepoWriteError::InvalidRequest)?;
+            if record.bytes().len() > MAX_PUBLIC_RECORD_BYTES {
+                return Err(PublicRepoWriteError::InvalidRequest(anyhow!(
+                    "public record exceeds {MAX_PUBLIC_RECORD_BYTES}-byte canonical encoded limit"
+                )));
+            }
+            if !(intent.request_id == request.request_id
+                && intent.principal == request.principal
+                && intent.did == self.did
+                && intent.collection == record.collection()
+                && intent.rkey == record.rkey().as_str()
+                && intent.cid == record.cid().to_string())
+            {
+                return Err(PublicRepoWriteError::InvalidRequest(anyhow!(
+                    "publication request id was reused with different content"
+                )));
+            }
             let snapshot = self
                 .store
                 .snapshot(&self.did)?
                 .ok_or_else(|| anyhow!("publication intent exists without a repository"))?;
-            ensure!(
-                snapshot
-                    .records
-                    .get(&(request.collection.clone(), rkey))
-                    .is_some_and(|stored| stored.bytes() == record.bytes()),
-                "publication intent does not match stored record"
-            );
+            if !snapshot.records.get(&(request.collection.clone(), rkey))
+                .is_some_and(|stored| stored.bytes() == record.bytes()) {
+                return Err(anyhow!("publication intent does not match stored record").into());
+            }
             let commit_bytes = self
                 .store
                 .db
@@ -488,10 +527,9 @@ impl PublicRepoWriter {
             let commit = Commit::from_atproto_dag_cbor(&commit_bytes)
                 .context("publication intent commit is invalid")?;
             let commit_cid = commit.cid_atproto()?;
-            ensure!(
-                commit.did == self.did && intent.commit_cid == commit_cid.to_string(),
-                "publication intent commit does not match stored block"
-            );
+            if commit.did != self.did || intent.commit_cid != commit_cid.to_string() {
+                return Err(anyhow!("publication intent commit does not match stored block").into());
+            }
             return Ok(PublicCommitResult {
                 uri: record.uri(&self.did),
                 cid: record.cid(),
@@ -504,10 +542,9 @@ impl PublicRepoWriter {
             Some(snapshot) => {
                 let previous = snapshot.commit.cid_atproto()?;
                 let previous_rev = snapshot.commit.rev;
-                ensure!(
-                    condition.matches(Some(previous)),
-                    "public repo head CAS conflict"
-                );
+                if !condition.matches(Some(previous)) {
+                    return Err(PublicRepoWriteError::InvalidSwap);
+                }
                 let keyed = snapshot
                     .records
                     .into_iter()
@@ -518,7 +555,9 @@ impl PublicRepoWriter {
                 (keyed, Some(previous), Some(previous_rev))
             }
             None => {
-                ensure!(condition.matches(None), "public repo genesis CAS conflict");
+                if !condition.matches(None) {
+                    return Err(PublicRepoWriteError::InvalidSwap);
+                }
                 (BTreeMap::new(), None, None)
             }
         };
@@ -527,12 +566,17 @@ impl PublicRepoWriter {
             Some(rkey) => rkey,
             None => allocate_record_key(&request.collection, &keyed, previous_rev)?,
         };
-        let record = AtprotoRecord::new(request.collection.clone(), rkey, request.value)?;
+        let record = AtprotoRecord::new(request.collection.clone(), rkey, request.value)
+            .map_err(PublicRepoWriteError::InvalidRequest)?;
+        if record.bytes().len() > MAX_PUBLIC_RECORD_BYTES {
+            return Err(PublicRepoWriteError::InvalidRequest(anyhow!(
+                "public record exceeds {MAX_PUBLIC_RECORD_BYTES}-byte canonical encoded limit"
+            )));
+        }
         let record_key = format!("{}/{}", record.collection(), record.rkey().as_str());
-        ensure!(
-            !keyed.contains_key(&record_key),
-            "record key already exists"
-        );
+        if keyed.contains_key(&record_key) {
+            return Err(PublicRepoWriteError::RecordAlreadyExists);
+        }
         keyed.insert(record_key, record.cid());
 
         let tree = Node::from_keyed_records(&keyed);
@@ -573,11 +617,13 @@ impl PublicRepoWriter {
         &self,
         request: PublicCreateRequest,
         expected_prev: Option<&str>,
-    ) -> Result<PublicCommitResult> {
+    ) -> Result<PublicCommitResult, PublicRepoWriteError> {
         let condition = match expected_prev {
             None => PublicHeadCondition::Unconditional,
             Some(expected) => PublicHeadCondition::Exact(Some(
-                parse_atproto_json_cid(expected).context("invalid swapCommit CID")?,
+                parse_atproto_json_cid(expected)
+                    .context("invalid swapCommit CID")
+                    .map_err(PublicRepoWriteError::InvalidRequest)?,
             )),
         };
         self.create_record_with_condition(request, condition)
@@ -741,7 +787,7 @@ mod tests {
             principal: "did:at9p:agent".into(),
             did: "did:web:tormentnexus.social".into(),
             collection: "app.bsky.feed.post".into(),
-            rkey: Tid::from_raw(rkey).into(),
+            rkey: Some(Tid::from_raw(rkey).into()),
             value: post(),
             expected_prev,
         }
@@ -1030,14 +1076,14 @@ mod tests {
                     ("text", DagCbor::Text("x".repeat(payload))),
                 ])
             };
-            let overhead = AtprotoRecord::new(&request.collection, &request.rkey, value(1024))
+            let overhead = AtprotoRecord::new(&request.collection, request.rkey.as_ref().unwrap(), value(1024))
                 .unwrap()
                 .bytes()
                 .len()
                 - 1024;
             request.value = value(size - overhead);
             assert_eq!(
-                AtprotoRecord::new(&request.collection, &request.rkey, request.value.clone())
+                AtprotoRecord::new(&request.collection, request.rkey.as_ref().unwrap(), request.value.clone())
                     .unwrap()
                     .bytes()
                     .len(),
@@ -1209,7 +1255,7 @@ mod tests {
             principal: "did:at9p:agent".into(),
             did: "did:web:tormentnexus.social".into(),
             collection: "app.bsky.feed.post".into(),
-            rkey: Tid::from_raw(7).into(),
+            rkey: Some(Tid::from_raw(7).into()),
             value: post(),
             expected_prev: None,
         };
@@ -1222,7 +1268,7 @@ mod tests {
                 principal: "did:at9p:agent".into(),
                 did: "did:web:tormentnexus.social".into(),
                 collection: "app.bsky.feed.post".into(),
-                rkey: Tid::from_raw(8).into(),
+                rkey: Some(Tid::from_raw(8).into()),
                 value: post(),
                 expected_prev: Some(first.commit_cid),
             })
@@ -1430,7 +1476,7 @@ mod tests {
                 principal: "agent".into(),
                 did: "did:web:tormentnexus.social".into(),
                 collection: "app.bsky.feed.post".into(),
-                rkey: Tid::from_raw(1).into(),
+                rkey: Some(Tid::from_raw(1).into()),
                 value: post(),
                 expected_prev: None,
             })
@@ -1448,226 +1494,7 @@ mod tests {
         let key = p256::ecdsa::SigningKey::random(&mut rand::rngs::OsRng);
         assert!(PublicRepoWriter::new(store, "did:at9p:agent", key, gate).is_err());
     }
-    fn authorize(&self, principal: &str, account: &str, collection: &str) -> Result<()>;
-}
 
-/// A request to create one immutable public record under an owned repo.
-#[derive(Clone, Debug)]
-pub struct PublicCreateRequest {
-    pub request_id: String,
-    pub principal: String,
-    pub did: String,
-    pub collection: String,
-    /// Explicit general AT record key, or None to allocate a fresh TID under
-    /// the transaction lock. Retries recover a generated key from the intent.
-    pub rkey: Option<AtprotoRecordKey>,
-    pub value: DagCbor,
-    /// Required repo-head CAS value. None means this must create the genesis
-    /// record; retries use the request id and never silently fork a head.
-    pub expected_prev: Option<Cid>,
-}
-
-/// Durable result of a successful public repository transaction.
-#[derive(Clone, Debug, Eq, PartialEq)]
-pub struct PublicCommitResult {
-    pub uri: String,
-    pub cid: Cid,
-    pub commit_cid: Cid,
-}
-
-#[derive(Clone, Debug)]
-pub struct PublicRepoSnapshot {
-    pub did: String,
-    pub records: BTreeMap<(String, AtprotoRecordKey), AtprotoRecord>,
-    pub commit: Commit,
-}
-
-#[derive(Clone, Debug, Deserialize, Serialize)]
-struct PublicationIntent {
-    request_id: String,
-    principal: String,
-    did: String,
-    collection: String,
-    rkey: String,
-    /// Old intents always had an explicit key. Preserve their retry behavior.
-    #[serde(default)]
-    generated_rkey: bool,
-    cid: String,
-    commit_cid: String,
-}
-
-/// Native callers retain genesis-or-exact CAS; XRPC may omit its condition.
-enum PublicHeadCondition {
-    Unconditional,
-    Exact(Option<Cid>),
-}
-
-impl PublicHeadCondition {
-    fn matches(&self, actual: Option<Cid>) -> bool {
-        match self {
-            Self::Unconditional => true,
-            Self::Exact(expected) => *expected == actual,
-        }
-    }
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("PublicRepoStore").finish_non_exhaustive()
-    }
-    fn intent(&self, did: &str, request_id: &str) -> Result<Option<PublicationIntent>> {
-        let Some(bytes) = self.db.get(intent_key(did, request_id))? else {
-            return Ok(None);
-        };
-        Ok(Some(
-            serde_json::from_slice(&bytes).context("public publication intent is invalid")?,
-        ))
-    }
-    fn write_transaction(
-        &self,
-        did: &str,
-        record: &AtprotoRecord,
-        commit: &Commit,
-        intent: &PublicationIntent,
-    ) -> Result<()> {
-        let commit_bytes = commit.to_atproto_dag_cbor()?;
-        let intent_bytes = serde_json::to_vec(intent).context("encode publication intent")?;
-        let mut batch = rocksdb::WriteBatch::default();
-        batch.put(
-            record_key(did, record.collection(), record.rkey().as_str()),
-            record.bytes(),
-        );
-        batch.put(commit_key(did), commit_bytes);
-        batch.put(intent_key(did, &intent.request_id), intent_bytes);
-        let mut options = rocksdb::WriteOptions::default();
-        options.set_sync(true);
-        self.db
-            .write_opt(batch, &options)
-            .context("public repo transaction failed")?;
-        Ok(())
-    }
-    fn create_record_with_condition(
-        &self,
-        request: PublicCreateRequest,
-        condition: PublicHeadCondition,
-    ) -> Result<PublicCommitResult> {
-        ensure!(
-            request.did == self.did,
-            "public request account does not match writer"
-        );
-        validate_request_id(&request.request_id)?;
-        validate_principal(&request.principal)?;
-        self.authorizer
-            .authorize(&request.principal, &self.did, &request.collection)?;
-
-        let _guard = self.store.write_lock.lock();
-        if let Some(intent) = self.store.intent(&self.did, &request.request_id)? {
-            ensure!(
-                intent.generated_rkey == request.rkey.is_none(),
-                "publication request id was reused with a different key mode"
-            );
-            let rkey = match request.rkey.as_ref() {
-                Some(rkey) => rkey.clone(),
-                None => AtprotoRecordKey::new(intent.rkey.clone())?,
-            };
-            let record = AtprotoRecord::new(request.collection.clone(), &rkey, request.value)?;
-            ensure!(
-                intent.request_id == request.request_id
-                    && intent.principal == request.principal
-                    && intent.did == self.did
-                    && intent.collection == record.collection()
-                    && intent.rkey == record.rkey().as_str()
-                    && intent.cid == record.cid().to_string(),
-                "publication request id was reused with different content"
-            );
-            let snapshot = self
-                .store
-                .snapshot(&self.did)?
-                .ok_or_else(|| anyhow!("publication intent exists without a repository"))?;
-            ensure!(
-                snapshot
-                    .records
-                    .get(&(request.collection.clone(), rkey))
-                    .is_some_and(|stored| stored.cid() == record.cid()),
-                "publication intent does not match stored record"
-            );
-            // The intent was persisted atomically with this immutable record.
-            // Return its original result even after later writes advance the
-            // head; a retry is not a new conditional write.
-            let commit_cid = parse_atproto_json_cid(&intent.commit_cid)
-                .context("publication intent has invalid commit CID")?;
-            ensure!(
-                commit_cid.as_bytes().get(1) == Some(&0x71),
-                "publication intent commit must use DAG-CBOR"
-            );
-            return Ok(PublicCommitResult {
-                uri: record.uri(&self.did),
-                cid: record.cid(),
-                commit_cid,
-            });
-        }
-
-        let existing = self.store.snapshot(&self.did)?;
-        let (mut keyed, previous, previous_rev) = match existing {
-            Some(snapshot) => {
-                let previous = snapshot.commit.cid_atproto()?;
-                let previous_rev = snapshot.commit.rev;
-                ensure!(
-                    condition.matches(Some(previous)),
-                    "public repo head CAS conflict"
-                );
-                let keyed = snapshot
-                    .records
-                    .into_iter()
-                    .map(|((collection, rkey), record)| {
-                        (format!("{collection}/{}", rkey.as_str()), record.cid())
-                    })
-                    .collect();
-                (keyed, Some(previous), Some(previous_rev))
-            }
-            None => {
-                ensure!(condition.matches(None), "public repo genesis CAS conflict");
-                (BTreeMap::new(), None, None)
-            }
-        };
-        let generated_rkey = request.rkey.is_none();
-        let rkey = match request.rkey {
-            Some(rkey) => rkey,
-            None => allocate_record_key(&request.collection, &keyed, previous_rev)?,
-        };
-        let record = AtprotoRecord::new(request.collection.clone(), rkey, request.value)?;
-        let record_key = format!("{}/{}", record.collection(), record.rkey().as_str());
-        ensure!(
-            !keyed.contains_key(&record_key),
-            "record key already exists"
-        );
-        keyed.insert(record_key, record.cid());
-
-        let tree = Node::from_keyed_records(&keyed);
-        let (root_data, _) = tree.to_node_data_with_blocks_atproto()?;
-        let unsigned = UnsignedCommit::new(
-            self.did.clone(),
-            root_data.cid_atproto()?,
-            next_revision(previous_rev),
-            previous,
-        );
-        let commit = Commit::sign_atproto(&unsigned, &self.signing_key)?;
-        let commit_cid = commit.cid_atproto()?;
-        let intent = PublicationIntent {
-            request_id: request.request_id,
-            principal: request.principal,
-            did: self.did.clone(),
-            collection: record.collection().to_owned(),
-            rkey: record.rkey().as_str().to_owned(),
-            generated_rkey,
-            cid: record.cid().to_string(),
-            commit_cid: commit_cid.to_string(),
-        };
-        self.store
-            .write_transaction(&self.did, &record, &commit, &intent)?;
-        Ok(PublicCommitResult {
-            uri: record.uri(&self.did),
-            cid: record.cid(),
-            commit_cid,
-        })
-    }
     fn transaction_fixture() -> (
         tempfile::TempDir,
         Arc<PublicRepoStore>,
@@ -1689,6 +1516,7 @@ impl PublicHeadCondition {
         .expect("writer");
         (dir, store, gate, writer)
     }
+
     fn transaction_request(id: u64) -> PublicCreateRequest {
         PublicCreateRequest {
             request_id: format!("req-{id}"),
@@ -1700,6 +1528,7 @@ impl PublicHeadCondition {
             expected_prev: None,
         }
     }
+
     #[test]
     fn general_keys_survive_restart_and_legacy_intents_remain_retriable() {
         let (dir, store, gate, writer) = transaction_fixture();
@@ -1727,7 +1556,7 @@ impl PublicHeadCondition {
         general.value = DagCbor::str_map([("$type", DagCbor::Text(general.collection.clone()))]);
         general.expected_prev = Some(second.commit_cid);
         let third = writer.create_record(general.clone()).unwrap();
-        let signing_key = writer.signing_key.clone();
+        let signing_key = writer.account.active_key.lock().as_ref().unwrap().clone();
         drop(writer);
         drop(store);
         let store = Arc::new(PublicRepoStore::open(dir.path()).unwrap());
@@ -1753,9 +1582,10 @@ impl PublicHeadCondition {
         )));
         snapshot
             .commit
-            .verify_atproto(writer.signing_key.verifying_key())
+            .verify_atproto(&writer.active_verifying_key().unwrap())
             .unwrap();
     }
+
     #[test]
     fn generated_keys_recover_after_restart_and_bind_request_shape() {
         let (dir, store, gate, writer) = transaction_fixture();
@@ -1772,7 +1602,7 @@ impl PublicHeadCondition {
             .create_record_with_expected_prev_text(second_request, None)
             .unwrap();
         assert_ne!(first.uri, second.uri);
-        let signing_key = writer.signing_key.clone();
+        let signing_key = writer.account.active_key.lock().as_ref().unwrap().clone();
         drop(writer);
         drop(store);
         let store = Arc::new(PublicRepoStore::open(dir.path()).unwrap());
@@ -1831,6 +1661,7 @@ impl PublicHeadCondition {
             3
         );
     }
+
     #[test]
     fn generated_keys_are_unique_or_recovered_under_concurrent_requests() {
         for same_request in [false, true] {
@@ -1864,6 +1695,7 @@ impl PublicHeadCondition {
             );
         }
     }
+
     #[test]
     fn generated_key_skips_collisions_after_a_durable_future_revision() {
         let previous = Tid::from_raw(1 << 62);
@@ -1881,6 +1713,7 @@ impl PublicHeadCondition {
         let key = allocate_record_key(collection, &keyed, Some(previous)).unwrap();
         assert_eq!(key.as_str(), Tid::from_raw(previous.to_raw() + 3).encode());
     }
+
     #[test]
     fn xrpc_omitted_swap_allows_subsequent_creates_without_weakening_native_cas() {
         let (_dir, store, _gate, writer) = transaction_fixture();
@@ -1907,6 +1740,7 @@ impl PublicHeadCondition {
             3
         );
     }
+
     #[test]
     fn xrpc_retries_return_original_result_after_later_commit_and_reopen() {
         let (dir, store, gate, writer) = transaction_fixture();
@@ -1927,7 +1761,7 @@ impl PublicHeadCondition {
         let third = writer
             .create_record_with_expected_prev_text(transaction_request(9), None)
             .expect("head advances again");
-        let key = writer.signing_key.clone();
+        let key = writer.account.active_key.lock().as_ref().unwrap().clone();
         drop(writer);
         drop(store);
         let store = Arc::new(PublicRepoStore::open(dir.path()).expect("reopen"));
@@ -1976,6 +1810,7 @@ impl PublicHeadCondition {
         assert_eq!(snapshot.records.len(), 3);
         assert_eq!(snapshot.commit.cid_atproto().unwrap(), third.commit_cid);
     }
+
     #[test]
     fn xrpc_cas_and_unconditional_writes_share_one_atomic_head_selection() {
         for conditional in [true, false] {
@@ -2014,10 +1849,11 @@ impl PublicHeadCondition {
             assert_eq!(snapshot.records.len(), 1 + expected_successes);
             snapshot
                 .commit
-                .verify_atproto(writer.signing_key.verifying_key())
+                .verify_atproto(&writer.active_verifying_key().unwrap())
                 .unwrap();
         }
     }
+
     #[test]
     fn xrpc_swap_authorizes_before_reading_repository_state() {
         let (_dir, store, gate, writer) = transaction_fixture();
@@ -2039,6 +1875,7 @@ impl PublicHeadCondition {
         assert!(store.db.get(commit_key(writer.did())).unwrap().is_none());
         assert!(store.intent(writer.did(), "req-8").unwrap().is_none());
     }
+
     #[test]
     fn json_links_and_bytes_match_independent_public_record_fixture() {
         // Independently encoded using Python hashlib/base64 and a minimal
@@ -2073,6 +1910,7 @@ impl PublicHeadCondition {
             AtprotoRecord::from_bytes("app.bsky.feed.post", Tid::from_raw(7), &fixture).is_ok()
         );
     }
+
     #[test]
     fn json_bytes_accept_standard_base64_with_optional_padding() {
         for text in ["", "AQI", "AQI=", "+/8=", "+/8"] {
@@ -2085,6 +1923,7 @@ impl PublicHeadCondition {
             assert_eq!(value, DagCbor::Bytes(expected));
         }
     }
+
     #[test]
     fn json_rejects_malformed_reserved_wrappers_at_any_depth() {
         let cid = Cid::from_raw(b"blob").to_string();
@@ -2104,6 +1943,7 @@ impl PublicHeadCondition {
             assert!(json_to_dag_cbor(&serde_json::json!({"nested": [value]})).is_err());
         }
     }
+
     #[test]
     fn json_links_reject_noncanonical_and_unsupported_cids() {
         let cid = Cid::from_raw(b"blob");

--- a/crates/hyprstream/src/services/public_repo.rs
+++ b/crates/hyprstream/src/services/public_repo.rs
@@ -117,8 +117,9 @@ pub struct PublicCreateRequest {
     pub principal: String,
     pub did: String,
     pub collection: String,
-    /// A validated AT record key, including singleton keys such as `self`.
-    pub rkey: AtprotoRecordKey,
+    /// Explicit general AT record key, or None to allocate a fresh TID under
+    /// the transaction lock. Retries recover a generated key from the intent.
+    pub rkey: Option<AtprotoRecordKey>,
     pub value: DagCbor,
     /// Required repo-head CAS value. None means this must create the genesis
     /// record; retries use the request id and never silently fork a head.
@@ -147,6 +148,9 @@ struct PublicationIntent {
     did: String,
     collection: String,
     rkey: String,
+    /// Old intents always had an explicit key. Preserve their retry behavior.
+    #[serde(default)]
+    generated_rkey: bool,
     cid: String,
     commit_cid: String,
 }
@@ -446,12 +450,16 @@ impl PublicRepoWriter {
         let signing_key = state
             .as_ref()
             .ok_or_else(|| anyhow!("no active signing authority for repository"))?;
-        let record = AtprotoRecord::new(request.collection.clone(), &request.rkey, request.value)?;
-        ensure!(
-            record.bytes().len() <= MAX_PUBLIC_RECORD_BYTES,
-            "public record exceeds {MAX_PUBLIC_RECORD_BYTES}-byte canonical encoded limit"
-        );
         if let Some(intent) = self.store.intent(&self.did, &request.request_id)? {
+            ensure!(
+                intent.generated_rkey == request.rkey.is_none(),
+                "publication request id was reused with a different key mode"
+            );
+            let rkey = match request.rkey.as_ref() {
+                Some(rkey) => rkey.clone(),
+                None => AtprotoRecordKey::new(intent.rkey.clone())?,
+            };
+            let record = AtprotoRecord::new(request.collection.clone(), &rkey, request.value)?;
             ensure!(
                 intent.request_id == request.request_id
                     && intent.principal == request.principal
@@ -468,9 +476,9 @@ impl PublicRepoWriter {
             ensure!(
                 snapshot
                     .records
-                    .get(&(record.collection().to_owned(), request.rkey))
+                    .get(&(request.collection.clone(), rkey))
                     .is_some_and(|stored| stored.bytes() == record.bytes()),
-                "publication intent record does not match repository"
+                "publication intent does not match stored record"
             );
             let commit_bytes = self
                 .store
@@ -514,6 +522,12 @@ impl PublicRepoWriter {
                 (BTreeMap::new(), None, None)
             }
         };
+        let generated_rkey = request.rkey.is_none();
+        let rkey = match request.rkey {
+            Some(rkey) => rkey,
+            None => allocate_record_key(&request.collection, &keyed, previous_rev)?,
+        };
+        let record = AtprotoRecord::new(request.collection.clone(), rkey, request.value)?;
         let record_key = format!("{}/{}", record.collection(), record.rkey().as_str());
         ensure!(
             !keyed.contains_key(&record_key),
@@ -537,6 +551,7 @@ impl PublicRepoWriter {
             did: self.did.clone(),
             collection: record.collection().to_owned(),
             rkey: record.rkey().as_str().to_owned(),
+            generated_rkey,
             cid: record.cid().to_string(),
             commit_cid: commit_cid.to_string(),
         };
@@ -566,6 +581,29 @@ impl PublicRepoWriter {
             )),
         };
         self.create_record_with_condition(request, condition)
+    }
+}
+
+/// Allocate after authorization, retry lookup and head selection, while the
+/// writer lock is held. Advancing from the durable revision survives restarts
+/// and clock rollback; collision checks also cover explicitly supplied keys.
+fn allocate_record_key(
+    collection: &str,
+    keyed: &BTreeMap<String, Cid>,
+    previous_rev: Option<Tid>,
+) -> Result<AtprotoRecordKey> {
+    let mut candidate = next_revision(previous_rev);
+    loop {
+        let rkey = AtprotoRecordKey::from(candidate);
+        if !keyed.contains_key(&format!("{collection}/{}", rkey.as_str())) {
+            return Ok(rkey);
+        }
+        candidate = Tid::from_raw(
+            candidate
+                .to_raw()
+                .checked_add(1)
+                .ok_or_else(|| anyhow!("public record key space exhausted"))?,
+        );
     }
 }
 
@@ -1420,7 +1458,9 @@ pub struct PublicCreateRequest {
     pub principal: String,
     pub did: String,
     pub collection: String,
-    pub rkey: Tid,
+    /// Explicit general AT record key, or None to allocate a fresh TID under
+    /// the transaction lock. Retries recover a generated key from the intent.
+    pub rkey: Option<AtprotoRecordKey>,
     pub value: DagCbor,
     /// Required repo-head CAS value. None means this must create the genesis
     /// record; retries use the request id and never silently fork a head.
@@ -1438,7 +1478,7 @@ pub struct PublicCommitResult {
 #[derive(Clone, Debug)]
 pub struct PublicRepoSnapshot {
     pub did: String,
-    pub records: BTreeMap<(String, Tid), AtprotoRecord>,
+    pub records: BTreeMap<(String, AtprotoRecordKey), AtprotoRecord>,
     pub commit: Commit,
 }
 
@@ -1449,6 +1489,9 @@ struct PublicationIntent {
     did: String,
     collection: String,
     rkey: String,
+    /// Old intents always had an explicit key. Preserve their retry behavior.
+    #[serde(default)]
+    generated_rkey: bool,
     cid: String,
     commit_cid: String,
 }
@@ -1515,8 +1558,16 @@ impl PublicHeadCondition {
             .authorize(&request.principal, &self.did, &request.collection)?;
 
         let _guard = self.store.write_lock.lock();
-        let record = AtprotoRecord::new(request.collection.clone(), request.rkey, request.value)?;
         if let Some(intent) = self.store.intent(&self.did, &request.request_id)? {
+            ensure!(
+                intent.generated_rkey == request.rkey.is_none(),
+                "publication request id was reused with a different key mode"
+            );
+            let rkey = match request.rkey.as_ref() {
+                Some(rkey) => rkey.clone(),
+                None => AtprotoRecordKey::new(intent.rkey.clone())?,
+            };
+            let record = AtprotoRecord::new(request.collection.clone(), &rkey, request.value)?;
             ensure!(
                 intent.request_id == request.request_id
                     && intent.principal == request.principal
@@ -1533,7 +1584,7 @@ impl PublicHeadCondition {
             ensure!(
                 snapshot
                     .records
-                    .get(&(request.collection.clone(), request.rkey))
+                    .get(&(request.collection.clone(), rkey))
                     .is_some_and(|stored| stored.cid() == record.cid()),
                 "publication intent does not match stored record"
             );
@@ -1566,7 +1617,7 @@ impl PublicHeadCondition {
                     .records
                     .into_iter()
                     .map(|((collection, rkey), record)| {
-                        (format!("{collection}/{}", rkey.encode()), record.cid())
+                        (format!("{collection}/{}", rkey.as_str()), record.cid())
                     })
                     .collect();
                 (keyed, Some(previous), Some(previous_rev))
@@ -1576,6 +1627,12 @@ impl PublicHeadCondition {
                 (BTreeMap::new(), None, None)
             }
         };
+        let generated_rkey = request.rkey.is_none();
+        let rkey = match request.rkey {
+            Some(rkey) => rkey,
+            None => allocate_record_key(&request.collection, &keyed, previous_rev)?,
+        };
+        let record = AtprotoRecord::new(request.collection.clone(), rkey, request.value)?;
         let record_key = format!("{}/{}", record.collection(), record.rkey().as_str());
         ensure!(
             !keyed.contains_key(&record_key),
@@ -1599,6 +1656,7 @@ impl PublicHeadCondition {
             did: self.did.clone(),
             collection: record.collection().to_owned(),
             rkey: record.rkey().as_str().to_owned(),
+            generated_rkey,
             cid: record.cid().to_string(),
             commit_cid: commit_cid.to_string(),
         };
@@ -1637,10 +1695,191 @@ impl PublicHeadCondition {
             principal: "did:at9p:agent".into(),
             did: "did:web:tormentnexus.social".into(),
             collection: "app.bsky.feed.post".into(),
-            rkey: Tid::from_raw(id),
+            rkey: Some(Tid::from_raw(id).into()),
             value: post(),
             expected_prev: None,
         }
+    }
+    #[test]
+    fn general_keys_survive_restart_and_legacy_intents_remain_retriable() {
+        let (dir, store, gate, writer) = transaction_fixture();
+        let first = writer.create_record(transaction_request(7)).unwrap();
+        // Model an intent written before generated_rkey existed.
+        let mut legacy =
+            serde_json::to_value(store.intent(writer.did(), "req-7").unwrap().unwrap()).unwrap();
+        legacy.as_object_mut().unwrap().remove("generated_rkey");
+        store
+            .db
+            .put(
+                intent_key(writer.did(), "req-7"),
+                serde_json::to_vec(&legacy).unwrap(),
+            )
+            .unwrap();
+        let mut profile = transaction_request(8);
+        profile.collection = "app.bsky.actor.profile".into();
+        profile.rkey = Some(AtprotoRecordKey::new("self").unwrap());
+        profile.value = DagCbor::str_map([("$type", DagCbor::Text(profile.collection.clone()))]);
+        profile.expected_prev = Some(first.commit_cid);
+        let second = writer.create_record(profile.clone()).unwrap();
+        let mut general = transaction_request(9);
+        general.collection = "com.example.record".into();
+        general.rkey = Some(AtprotoRecordKey::new("literal:key~one").unwrap());
+        general.value = DagCbor::str_map([("$type", DagCbor::Text(general.collection.clone()))]);
+        general.expected_prev = Some(second.commit_cid);
+        let third = writer.create_record(general.clone()).unwrap();
+        let signing_key = writer.signing_key.clone();
+        drop(writer);
+        drop(store);
+        let store = Arc::new(PublicRepoStore::open(dir.path()).unwrap());
+        let writer = PublicRepoWriter::new(
+            store.clone(),
+            "did:web:tormentnexus.social",
+            signing_key,
+            gate,
+        )
+        .unwrap();
+        assert_eq!(writer.create_record(transaction_request(7)).unwrap(), first);
+        assert_eq!(writer.create_record(profile).unwrap(), second);
+        assert_eq!(writer.create_record(general).unwrap(), third);
+        let snapshot = store.snapshot(writer.did()).unwrap().unwrap();
+        assert_eq!(snapshot.records.len(), 3);
+        assert!(snapshot.records.contains_key(&(
+            "app.bsky.actor.profile".into(),
+            AtprotoRecordKey::new("self").unwrap()
+        )));
+        assert!(snapshot.records.contains_key(&(
+            "com.example.record".into(),
+            AtprotoRecordKey::new("literal:key~one").unwrap()
+        )));
+        snapshot
+            .commit
+            .verify_atproto(writer.signing_key.verifying_key())
+            .unwrap();
+    }
+    #[test]
+    fn generated_keys_recover_after_restart_and_bind_request_shape() {
+        let (dir, store, gate, writer) = transaction_fixture();
+        let mut request = transaction_request(7);
+        request.rkey = None;
+        let first = writer
+            .create_record_with_expected_prev_text(request.clone(), None)
+            .unwrap();
+        let first_key = first.uri.rsplit('/').next().unwrap();
+        assert!(Tid::parse(first_key).is_ok());
+        let mut second_request = transaction_request(8);
+        second_request.rkey = None;
+        let second = writer
+            .create_record_with_expected_prev_text(second_request, None)
+            .unwrap();
+        assert_ne!(first.uri, second.uri);
+        let signing_key = writer.signing_key.clone();
+        drop(writer);
+        drop(store);
+        let store = Arc::new(PublicRepoStore::open(dir.path()).unwrap());
+        let writer = PublicRepoWriter::new(
+            store.clone(),
+            "did:web:tormentnexus.social",
+            signing_key,
+            gate.clone(),
+        )
+        .unwrap();
+        assert_eq!(
+            writer
+                .create_record_with_expected_prev_text(request.clone(), None)
+                .unwrap(),
+            first
+        );
+        let mut explicit_retry = request.clone();
+        explicit_retry.rkey = Some(AtprotoRecordKey::new(first_key).unwrap());
+        assert!(writer
+            .create_record_with_expected_prev_text(explicit_retry, None)
+            .unwrap_err()
+            .to_string()
+            .contains("key mode"));
+        let mut changed = request.clone();
+        changed.value = DagCbor::str_map([
+            ("$type", DagCbor::Text(changed.collection.clone())),
+            ("text", DagCbor::Text("different".into())),
+        ]);
+        assert!(writer
+            .create_record_with_expected_prev_text(changed, None)
+            .is_err());
+        let mut other_principal = request.clone();
+        other_principal.principal = "did:at9p:other".into();
+        assert!(writer
+            .create_record_with_expected_prev_text(other_principal, None)
+            .is_err());
+        let explicit = transaction_request(9);
+        writer
+            .create_record_with_expected_prev_text(explicit.clone(), None)
+            .unwrap();
+        let mut omitted = explicit;
+        omitted.rkey = None;
+        assert!(writer
+            .create_record_with_expected_prev_text(omitted, None)
+            .unwrap_err()
+            .to_string()
+            .contains("key mode"));
+        gate.allow.store(false, Ordering::Release);
+        assert!(writer
+            .create_record_with_expected_prev_text(request, None)
+            .unwrap_err()
+            .to_string()
+            .contains("publication denied"));
+        assert_eq!(
+            store.snapshot(writer.did()).unwrap().unwrap().records.len(),
+            3
+        );
+    }
+    #[test]
+    fn generated_keys_are_unique_or_recovered_under_concurrent_requests() {
+        for same_request in [false, true] {
+            let (_dir, store, _gate, writer) = transaction_fixture();
+            let writer = Arc::new(writer);
+            let start = Arc::new(std::sync::Barrier::new(2));
+            let results = std::thread::scope(|scope| {
+                let mut workers = Vec::new();
+                for id in [7, if same_request { 7 } else { 8 }] {
+                    let writer = writer.clone();
+                    let start = start.clone();
+                    workers.push(scope.spawn(move || {
+                        let mut request = transaction_request(id);
+                        request.rkey = None;
+                        start.wait();
+                        writer
+                            .create_record_with_expected_prev_text(request, None)
+                            .unwrap()
+                    }));
+                }
+                workers
+                    .into_iter()
+                    .map(|worker| worker.join().unwrap())
+                    .collect::<Vec<_>>()
+            });
+            assert_eq!(results[0] == results[1], same_request);
+            let expected = if same_request { 1 } else { 2 };
+            assert_eq!(
+                store.snapshot(writer.did()).unwrap().unwrap().records.len(),
+                expected
+            );
+        }
+    }
+    #[test]
+    fn generated_key_skips_collisions_after_a_durable_future_revision() {
+        let previous = Tid::from_raw(1 << 62);
+        let collection = "app.bsky.feed.post";
+        let mut keyed = BTreeMap::new();
+        for offset in [1, 2] {
+            keyed.insert(
+                format!(
+                    "{collection}/{}",
+                    Tid::from_raw(previous.to_raw() + offset).encode()
+                ),
+                Cid::from_dag_cbor(b"occupied"),
+            );
+        }
+        let key = allocate_record_key(collection, &keyed, Some(previous)).unwrap();
+        assert_eq!(key.as_str(), Tid::from_raw(previous.to_raw() + 3).encode());
     }
     #[test]
     fn xrpc_omitted_swap_allows_subsequent_creates_without_weakening_native_cas() {

--- a/crates/hyprstream/src/services/public_repo.rs
+++ b/crates/hyprstream/src/services/public_repo.rs
@@ -195,6 +195,19 @@ impl std::fmt::Debug for PublicRepoStore {
 
 impl PublicRepoStore {
     #[cfg(test)]
+    pub(crate) fn with_account_lock_for_test(&self, did: &str, held: impl FnOnce()) -> Result<()> {
+        let account = self
+            .accounts
+            .lock()
+            .get(did)
+            .cloned()
+            .ok_or_else(|| anyhow!("test writer account missing"))?;
+        let _guard = account.active_key.lock();
+        held();
+        Ok(())
+    }
+
+    #[cfg(test)]
     pub(crate) fn insert_malformed_record_for_test(
         &self,
         did: &str,
@@ -350,6 +363,22 @@ impl std::fmt::Debug for PublicRepoWriter {
 impl PublicRepoWriter {
     pub fn did(&self) -> &str {
         &self.did
+    }
+
+    /// Blocking public read boundary. The account guard keeps the snapshot and
+    /// published verifying key consistent with concurrent writes/key promotion.
+    pub(crate) fn public_snapshot(
+        &self,
+    ) -> Result<Option<(PublicRepoSnapshot, p256::ecdsa::VerifyingKey)>> {
+        let state = self.account.active_key.lock();
+        let key = state
+            .as_ref()
+            .ok_or_else(|| anyhow!("public signing authority is unavailable"))?;
+        let Some(snapshot) = self.store.snapshot(&self.did)? else {
+            return Ok(None);
+        };
+        snapshot.commit.verify_atproto(key.verifying_key())?;
+        Ok(Some((snapshot, *key.verifying_key())))
     }
 
     /// Bind a trusted account key to this store. All writer handles for the

--- a/crates/hyprstream/src/services/public_repo.rs
+++ b/crates/hyprstream/src/services/public_repo.rs
@@ -38,6 +38,38 @@ const MAX_PRINCIPAL: usize = 512;
 /// See https://atproto.com/specs/repository#security-considerations.
 pub const MAX_PUBLIC_RECORD_BYTES: usize = 64 * 1024;
 
+/// MVP repository capacity: bounds raw records, decoded trees and MST work for
+/// every snapshot caller. Key bytes count too; tiny records also have a limit.
+pub const MAX_PUBLIC_SNAPSHOT_BYTES: usize = 1024 * 1024;
+pub const MAX_PUBLIC_SNAPSHOT_RECORDS: usize = 256;
+
+#[derive(Default)]
+struct SnapshotBudget {
+    bytes: usize,
+    records: usize,
+}
+
+impl SnapshotBudget {
+    fn charge(&mut self, key_bytes: usize, record_bytes: usize) -> Result<()> {
+        ensure!(
+            record_bytes <= MAX_PUBLIC_RECORD_BYTES,
+            "public snapshot record exceeds byte budget"
+        );
+        let bytes = self
+            .bytes
+            .checked_add(key_bytes)
+            .and_then(|bytes| bytes.checked_add(record_bytes));
+        ensure!(
+            self.records < MAX_PUBLIC_SNAPSHOT_RECORDS
+                && bytes.is_some_and(|bytes| bytes <= MAX_PUBLIC_SNAPSHOT_BYTES),
+            "public snapshot exceeds aggregate budget"
+        );
+        self.bytes = bytes.ok_or_else(|| anyhow!("public snapshot byte count overflow"))?;
+        self.records += 1;
+        Ok(())
+    }
+}
+
 /// Blob storage is not wired to this public writer. Never accept caller-supplied
 /// blob claims as proof of account ownership, bytes, MIME type or size. Scan
 /// every object, including open unions/extensions and legacy blob objects.
@@ -236,6 +268,36 @@ impl std::fmt::Debug for PublicRepoStore {
 
 impl PublicRepoStore {
     #[cfg(test)]
+    pub(crate) fn insert_snapshot_budget_fixture_for_test(
+        &self,
+        did: &str,
+        count: usize,
+        payload_bytes: usize,
+    ) -> Result<()> {
+        let value = DagCbor::str_map([
+            ("$type", DagCbor::Text("app.bsky.feed.post".into())),
+            ("text", DagCbor::Text("x".repeat(payload_bytes))),
+        ]);
+        let record = AtprotoRecord::new(
+            "app.bsky.feed.post",
+            AtprotoRecordKey::new("fixture")?,
+            value,
+        )?;
+        let mut batch = rocksdb::WriteBatch::default();
+        for index in 0..count {
+            let key = record_key(did, "app.bsky.feed.post", &format!("{index:04}"));
+            if index + 1 == count {
+                // Same size, invalid CBOR: capacity must fail BEFORE decoding it.
+                batch.put(key, vec![0xff; record.bytes().len()]);
+            } else {
+                batch.put(key, record.bytes());
+            }
+        }
+        self.db.write(batch)?;
+        Ok(())
+    }
+
+    #[cfg(test)]
     pub(crate) fn insert_unverified_blob_for_test(&self, did: &str) -> Result<()> {
         let account = self
             .accounts
@@ -322,14 +384,22 @@ impl PublicRepoStore {
         let snapshot = self.db.snapshot();
         let prefix = record_prefix(did);
         let mut records = BTreeMap::new();
-        for item in snapshot.iterator(rocksdb::IteratorMode::From(
-            &prefix,
-            rocksdb::Direction::Forward,
-        )) {
-            let (key, bytes) = item.context("public repo record scan failed")?;
+        let mut budget = SnapshotBudget::default();
+        // Borrow RocksDB's current key/value so oversized values are rejected
+        // before the iterator or decoder copies them into Rust-owned buffers.
+        let mut iterator = snapshot.raw_iterator();
+        iterator.seek(&prefix);
+        while iterator.valid() {
+            let key = iterator
+                .key()
+                .ok_or_else(|| anyhow!("public record key unavailable"))?;
             if !key.starts_with(&prefix) {
                 break;
             }
+            let bytes = iterator
+                .value()
+                .ok_or_else(|| anyhow!("public record bytes unavailable"))?;
+            budget.charge(key.len(), bytes.len())?;
             let suffix = std::str::from_utf8(&key[prefix.len()..])
                 .context("public repo record key is not UTF-8")?;
             let (collection, rkey) = suffix
@@ -337,19 +407,27 @@ impl PublicRepoStore {
                 .ok_or_else(|| anyhow!("public repo record key missing separator"))?;
             let rkey = AtprotoRecordKey::new(rkey)?;
             let record =
-                AtprotoRecord::from_bytes(collection, &rkey, &bytes).with_context(|| {
+                AtprotoRecord::from_bytes(collection, &rkey, bytes).with_context(|| {
                     format!("invalid public record {did}/{collection}/{}", rkey.as_str())
                 })?;
             reject_unverified_blobs(record.value())?;
             records.insert((collection.to_owned(), rkey), record);
+            iterator.next();
         }
+        iterator
+            .status()
+            .context("public repo record scan failed")?;
         if records.is_empty() {
             return Ok(None);
         }
         let bytes = snapshot
-            .get(commit_key(did))
+            .get_pinned(commit_key(did))
             .context("public repo commit read failed")?
             .ok_or_else(|| anyhow!("public repo has records but no signed commit"))?;
+        ensure!(
+            bytes.len() <= MAX_PUBLIC_RECORD_BYTES,
+            "public commit exceeds byte budget"
+        );
         let commit = Commit::from_atproto_dag_cbor(&bytes)
             .context("public repo signed commit is invalid")?;
         ensure!(commit.did == did, "public repo commit DID mismatch");
@@ -663,12 +741,19 @@ impl PublicRepoWriter {
         }
 
         let existing = self.store.snapshot(&self.did)?;
+        let mut budget = SnapshotBudget::default();
         let (mut keyed, previous, previous_rev) = match existing {
             Some(snapshot) => {
                 let previous = snapshot.commit.cid_atproto()?;
                 let previous_rev = snapshot.commit.rev;
                 if !condition.matches(Some(previous)) {
                     return Err(PublicRepoWriteError::InvalidSwap);
+                }
+                for ((collection, rkey), record) in &snapshot.records {
+                    budget.charge(
+                        record_key(&self.did, collection, rkey.as_str()).len(),
+                        record.bytes().len(),
+                    )?;
                 }
                 let keyed = snapshot
                     .records
@@ -702,6 +787,12 @@ impl PublicRepoWriter {
         if keyed.contains_key(&record_key) {
             return Err(PublicRepoWriteError::RecordAlreadyExists);
         }
+        budget
+            .charge(
+                self::record_key(&self.did, record.collection(), record.rkey().as_str()).len(),
+                record.bytes().len(),
+            )
+            .map_err(PublicRepoWriteError::InvalidRequest)?;
         keyed.insert(record_key, record.cid());
 
         let tree = Node::from_keyed_records(&keyed);
@@ -1923,6 +2014,69 @@ mod tests {
             store.snapshot(writer.did()).unwrap().unwrap().records.len(),
             3
         );
+    }
+
+    #[test]
+    fn publication_capacity_rejects_before_commit_and_keeps_existing_retries_valid() {
+        for payload_bytes in [0, 60_000] {
+            let (_dir, store, _gate, writer) = transaction_fixture();
+            let mut last = None;
+            for id in 1..=MAX_PUBLIC_SNAPSHOT_RECORDS + 1 {
+                let mut request = transaction_request(id as u64);
+                request.value = DagCbor::str_map([
+                    ("$type", DagCbor::Text(request.collection.clone())),
+                    ("text", DagCbor::Text("x".repeat(payload_bytes))),
+                ]);
+                let result = writer.create_record_with_expected_prev_text(request.clone(), None);
+                if let Ok(result) = result {
+                    last = Some((request, result));
+                } else {
+                    assert!(matches!(
+                        result,
+                        Err(PublicRepoWriteError::InvalidRequest(_))
+                    ));
+                    let (request, original) = last.as_ref().unwrap();
+                    let snapshot = store.snapshot(writer.did()).unwrap().unwrap();
+                    assert_eq!(snapshot.records.len(), id - 1);
+                    assert_eq!(snapshot.commit.cid_atproto().unwrap(), original.commit_cid);
+                    assert_eq!(
+                        writer
+                            .create_record_with_expected_prev_text(request.clone(), None)
+                            .unwrap(),
+                        *original
+                    );
+                    if payload_bytes == 0 {
+                        assert_eq!(snapshot.records.len(), MAX_PUBLIC_SNAPSHOT_RECORDS);
+                    } else {
+                        assert!(snapshot.records.len() < MAX_PUBLIC_SNAPSHOT_RECORDS);
+                    }
+                    break;
+                }
+                assert!(id <= MAX_PUBLIC_SNAPSHOT_RECORDS);
+            }
+        }
+    }
+
+    #[test]
+    fn snapshot_budget_fails_before_decoding_over_limit_records() {
+        for (count, bytes) in [
+            (MAX_PUBLIC_SNAPSHOT_RECORDS + 1, 1),
+            (18, 60_000),
+            (1, MAX_PUBLIC_RECORD_BYTES + 1),
+        ] {
+            let (_dir, store, _gate, writer) = transaction_fixture();
+            store
+                .insert_snapshot_budget_fixture_for_test(writer.did(), count, bytes)
+                .unwrap();
+            // Last record is intentionally invalid; budget wins before decode.
+            let error = store.snapshot(writer.did()).unwrap_err().to_string();
+            assert!(error.contains("budget"), "{error}");
+            assert!(writer
+                .public_snapshot()
+                .unwrap_err()
+                .to_string()
+                .contains("budget"));
+        }
     }
 
     #[test]

--- a/crates/hyprstream/src/services/public_repo.rs
+++ b/crates/hyprstream/src/services/public_repo.rs
@@ -158,6 +158,21 @@ struct AccountSigningState {
     active_key: Mutex<Option<p256::ecdsa::SigningKey>>,
 }
 
+/// Native callers retain genesis-or-exact CAS; XRPC may omit its condition.
+enum PublicHeadCondition {
+    Unconditional,
+    Exact(Option<Cid>),
+}
+
+impl PublicHeadCondition {
+    fn matches(&self, actual: Option<Cid>) -> bool {
+        match self {
+            Self::Unconditional => true,
+            Self::Exact(expected) => *expected == actual,
+        }
+    }
+}
+
 /// Durable public repository storage. It uses a distinct RocksDB directory
 /// and key namespace so native signed artifacts are never re-encoded as public
 /// bytes.
@@ -409,6 +424,15 @@ impl PublicRepoWriter {
     }
 
     pub fn create_record(&self, request: PublicCreateRequest) -> Result<PublicCommitResult> {
+        let condition = PublicHeadCondition::Exact(request.expected_prev);
+        self.create_record_with_condition(request, condition)
+    }
+
+    fn create_record_with_condition(
+        &self,
+        request: PublicCreateRequest,
+        condition: PublicHeadCondition,
+    ) -> Result<PublicCommitResult> {
         ensure!(
             request.did == self.did,
             "public request account does not match writer"
@@ -473,7 +497,7 @@ impl PublicRepoWriter {
                 let previous = snapshot.commit.cid_atproto()?;
                 let previous_rev = snapshot.commit.rev;
                 ensure!(
-                    request.expected_prev == Some(previous),
+                    condition.matches(Some(previous)),
                     "public repo head CAS conflict"
                 );
                 let keyed = snapshot
@@ -486,10 +510,7 @@ impl PublicRepoWriter {
                 (keyed, Some(previous), Some(previous_rev))
             }
             None => {
-                ensure!(
-                    request.expected_prev.is_none(),
-                    "public repo genesis CAS conflict"
-                );
+                ensure!(condition.matches(None), "public repo genesis CAS conflict");
                 (BTreeMap::new(), None, None)
             }
         };
@@ -528,32 +549,23 @@ impl PublicRepoWriter {
         })
     }
 
-    /// Variant used by JSON/XRPC adapters, which receive the standard base32
-    /// CID text form. The string is compared with the durable public head
-    /// before delegating to the typed transaction; no unvalidated CID parser
-    /// or native-format fallback is introduced.
+    /// XRPC creation with an optional base32 CID head condition. Unlike the
+    /// native typed API, omission permits a new write on any current head.
+    /// Authorization, retry lookup, head comparison and the write all use the
+    /// shared transaction path; no repository state is read by this adapter.
+    /// This argument supersedes `request.expected_prev`.
     pub fn create_record_with_expected_prev_text(
         &self,
-        mut request: PublicCreateRequest,
+        request: PublicCreateRequest,
         expected_prev: Option<&str>,
     ) -> Result<PublicCommitResult> {
-        request.expected_prev = match expected_prev {
-            None => None,
-            Some(expected) if !expected.is_empty() => {
-                let snapshot = self
-                    .store
-                    .snapshot(&self.did)?
-                    .ok_or_else(|| anyhow!("public repo head is absent"))?;
-                let actual = snapshot.commit.cid_atproto()?;
-                ensure!(
-                    actual.to_string() == expected,
-                    "public repo head CAS conflict"
-                );
-                Some(actual)
-            }
-            Some(_) => return Err(anyhow!("swapCommit must be a non-empty CID")),
+        let condition = match expected_prev {
+            None => PublicHeadCondition::Unconditional,
+            Some(expected) => PublicHeadCondition::Exact(Some(
+                parse_atproto_json_cid(expected).context("invalid swapCommit CID")?,
+            )),
         };
-        self.create_record(request)
+        self.create_record_with_condition(request, condition)
     }
 }
 
@@ -1140,106 +1152,6 @@ mod tests {
     }
 
     #[test]
-    fn json_links_and_bytes_match_independent_public_record_fixture() {
-        // Independently encoded using Python hashlib/base64 and a minimal
-        // RFC 8949 encoder with public map ordering and tag-42 links.
-        let json = serde_json::json!({
-            "$type": "app.bsky.feed.post",
-            "text": "json",
-            "payload": {"$bytes": "AQI="},
-            "links": [{"$link": "bafyreifqwkmiw256ojf2zws6tzjeonw6bpd5vza4i22ccpcq4hjv2ts7cm"}],
-            "blob": {
-                "$type": "blob",
-                "ref": {"$link": "bafkreifbfby75yqq7odbski6v2qziwa4xustdzfsg5m5ejpwqbush5rsei"},
-                "mimeType": "image/png",
-                "size": 2
-            }
-        });
-        let value = json_to_dag_cbor(&json).expect("AT JSON");
-        let record = AtprotoRecord::new("app.bsky.feed.post", Tid::from_raw(7), value)
-            .expect("public record");
-        let fixture = hex::decode(concat!(
-            "a564626c6f62a463726566d82a58250001551220a12871fee210fb8619291eaea194581cbd2531e4b23759d225f6806923f63222",
-            "6473697a650265247479706564626c6f62686d696d655479706569696d6167652f706e676474657874646a736f6e",
-            "652474797065726170702e62736b792e666565642e706f7374656c696e6b7381d82a58250001711220b0b2988b6bbe724bacda5e9e524736de0bc7dae41c46b4213c50e1d35d4e5f13",
-            "677061796c6f6164420102"
-        )).expect("fixture");
-        assert_eq!(record.bytes(), fixture);
-        assert_eq!(
-            record.cid().to_string(),
-            "bafyreie3irn4tnywq3hxjm3knxuq7ovhni7cjqxa7weo7dncxsw6rj3s4m"
-        );
-        assert!(
-            AtprotoRecord::from_bytes("app.bsky.feed.post", Tid::from_raw(7), &fixture).is_ok()
-        );
-    }
-
-    #[test]
-    fn json_bytes_accept_standard_base64_with_optional_padding() {
-        for text in ["", "AQI", "AQI=", "+/8=", "+/8"] {
-            let value = json_to_dag_cbor(&serde_json::json!({"$bytes": text})).expect("bytes");
-            let expected = match text {
-                "" => vec![],
-                "AQI" | "AQI=" => vec![1, 2],
-                _ => vec![251, 255],
-            };
-            assert_eq!(value, DagCbor::Bytes(expected));
-        }
-    }
-
-    #[test]
-    fn json_rejects_malformed_reserved_wrappers_at_any_depth() {
-        let cid = Cid::from_raw(b"blob").to_string();
-        let malformed = [
-            serde_json::json!({"$link": false}),
-            serde_json::json!({"$link": "not-a-cid"}),
-            serde_json::json!({"$link": cid, "extra": 1}),
-            serde_json::json!({"$link": cid, "$bytes": "AQI="}),
-            serde_json::json!({"$bytes": 12}),
-            serde_json::json!({"$bytes": "AQI=", "extra": 1}),
-            serde_json::json!({"$bytes": "-_8="}),
-            serde_json::json!({"$bytes": "AQJ="}),
-            serde_json::json!({"$bytes": "AQI=="}),
-        ];
-        for value in malformed {
-            assert!(json_to_dag_cbor(&value).is_err(), "{value}");
-            assert!(json_to_dag_cbor(&serde_json::json!({"nested": [value]})).is_err());
-        }
-    }
-
-    #[test]
-    fn json_links_reject_noncanonical_and_unsupported_cids() {
-        let cid = Cid::from_raw(b"blob");
-        let text = cid.to_string();
-        assert_eq!(parse_atproto_json_cid(&text).expect("canonical"), cid);
-        assert!(parse_atproto_json_cid(&text.to_uppercase()).is_err());
-        assert!(parse_atproto_json_cid(&format!("{text}=")).is_err());
-        let mut noncanonical = text.into_bytes();
-        let last = noncanonical.last_mut().expect("last digit");
-        // The last base32 digit has two zero padding bits. Setting one leaves
-        // the decoded CID bytes unchanged but must not be accepted.
-        let alphabet = b"abcdefghijklmnopqrstuvwxyz234567";
-        let position = alphabet.iter().position(|c| c == last).expect("base32");
-        *last = alphabet[position + 1];
-        assert!(parse_atproto_json_cid(&String::from_utf8(noncanonical).unwrap()).is_err());
-        for (position, replacement) in [(1, 0x70), (2, 0x13), (3, 0x1f)] {
-            let mut raw = cid.as_bytes().to_vec();
-            raw[position] = replacement;
-            // Encode invalid bytes independently of the production parser.
-            let encoded = raw
-                .iter()
-                .flat_map(|byte| (0..8).rev().map(move |bit| (byte >> bit) & 1))
-                .collect::<Vec<_>>();
-            let mut text = String::from("b");
-            for chunk in encoded.chunks(5) {
-                let n = chunk.iter().fold(0u8, |n, bit| (n << 1) | bit) << (5 - chunk.len());
-                text.push(alphabet[n as usize] as char);
-            }
-            assert!(parse_atproto_json_cid(&text).is_err());
-        }
-    }
-
-    #[test]
     fn authorized_create_is_atomic_durable_and_idempotent() {
         let dir = tempfile::tempdir().expect("tempdir");
         let store = Arc::new(PublicRepoStore::open(dir.path()).expect("store"));
@@ -1497,5 +1409,491 @@ mod tests {
         });
         let key = p256::ecdsa::SigningKey::random(&mut rand::rngs::OsRng);
         assert!(PublicRepoWriter::new(store, "did:at9p:agent", key, gate).is_err());
+    }
+    fn authorize(&self, principal: &str, account: &str, collection: &str) -> Result<()>;
+}
+
+/// A request to create one immutable public record under an owned repo.
+#[derive(Clone, Debug)]
+pub struct PublicCreateRequest {
+    pub request_id: String,
+    pub principal: String,
+    pub did: String,
+    pub collection: String,
+    pub rkey: Tid,
+    pub value: DagCbor,
+    /// Required repo-head CAS value. None means this must create the genesis
+    /// record; retries use the request id and never silently fork a head.
+    pub expected_prev: Option<Cid>,
+}
+
+/// Durable result of a successful public repository transaction.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct PublicCommitResult {
+    pub uri: String,
+    pub cid: Cid,
+    pub commit_cid: Cid,
+}
+
+#[derive(Clone, Debug)]
+pub struct PublicRepoSnapshot {
+    pub did: String,
+    pub records: BTreeMap<(String, Tid), AtprotoRecord>,
+    pub commit: Commit,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize)]
+struct PublicationIntent {
+    request_id: String,
+    principal: String,
+    did: String,
+    collection: String,
+    rkey: String,
+    cid: String,
+    commit_cid: String,
+}
+
+/// Native callers retain genesis-or-exact CAS; XRPC may omit its condition.
+enum PublicHeadCondition {
+    Unconditional,
+    Exact(Option<Cid>),
+}
+
+impl PublicHeadCondition {
+    fn matches(&self, actual: Option<Cid>) -> bool {
+        match self {
+            Self::Unconditional => true,
+            Self::Exact(expected) => *expected == actual,
+        }
+    }
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("PublicRepoStore").finish_non_exhaustive()
+    }
+    fn intent(&self, did: &str, request_id: &str) -> Result<Option<PublicationIntent>> {
+        let Some(bytes) = self.db.get(intent_key(did, request_id))? else {
+            return Ok(None);
+        };
+        Ok(Some(
+            serde_json::from_slice(&bytes).context("public publication intent is invalid")?,
+        ))
+    }
+    fn write_transaction(
+        &self,
+        did: &str,
+        record: &AtprotoRecord,
+        commit: &Commit,
+        intent: &PublicationIntent,
+    ) -> Result<()> {
+        let commit_bytes = commit.to_atproto_dag_cbor()?;
+        let intent_bytes = serde_json::to_vec(intent).context("encode publication intent")?;
+        let mut batch = rocksdb::WriteBatch::default();
+        batch.put(
+            record_key(did, record.collection(), record.rkey().as_str()),
+            record.bytes(),
+        );
+        batch.put(commit_key(did), commit_bytes);
+        batch.put(intent_key(did, &intent.request_id), intent_bytes);
+        let mut options = rocksdb::WriteOptions::default();
+        options.set_sync(true);
+        self.db
+            .write_opt(batch, &options)
+            .context("public repo transaction failed")?;
+        Ok(())
+    }
+    fn create_record_with_condition(
+        &self,
+        request: PublicCreateRequest,
+        condition: PublicHeadCondition,
+    ) -> Result<PublicCommitResult> {
+        ensure!(
+            request.did == self.did,
+            "public request account does not match writer"
+        );
+        validate_request_id(&request.request_id)?;
+        validate_principal(&request.principal)?;
+        self.authorizer
+            .authorize(&request.principal, &self.did, &request.collection)?;
+
+        let _guard = self.store.write_lock.lock();
+        let record = AtprotoRecord::new(request.collection.clone(), request.rkey, request.value)?;
+        if let Some(intent) = self.store.intent(&self.did, &request.request_id)? {
+            ensure!(
+                intent.request_id == request.request_id
+                    && intent.principal == request.principal
+                    && intent.did == self.did
+                    && intent.collection == record.collection()
+                    && intent.rkey == record.rkey().as_str()
+                    && intent.cid == record.cid().to_string(),
+                "publication request id was reused with different content"
+            );
+            let snapshot = self
+                .store
+                .snapshot(&self.did)?
+                .ok_or_else(|| anyhow!("publication intent exists without a repository"))?;
+            ensure!(
+                snapshot
+                    .records
+                    .get(&(request.collection.clone(), request.rkey))
+                    .is_some_and(|stored| stored.cid() == record.cid()),
+                "publication intent does not match stored record"
+            );
+            // The intent was persisted atomically with this immutable record.
+            // Return its original result even after later writes advance the
+            // head; a retry is not a new conditional write.
+            let commit_cid = parse_atproto_json_cid(&intent.commit_cid)
+                .context("publication intent has invalid commit CID")?;
+            ensure!(
+                commit_cid.as_bytes().get(1) == Some(&0x71),
+                "publication intent commit must use DAG-CBOR"
+            );
+            return Ok(PublicCommitResult {
+                uri: record.uri(&self.did),
+                cid: record.cid(),
+                commit_cid,
+            });
+        }
+
+        let existing = self.store.snapshot(&self.did)?;
+        let (mut keyed, previous, previous_rev) = match existing {
+            Some(snapshot) => {
+                let previous = snapshot.commit.cid_atproto()?;
+                let previous_rev = snapshot.commit.rev;
+                ensure!(
+                    condition.matches(Some(previous)),
+                    "public repo head CAS conflict"
+                );
+                let keyed = snapshot
+                    .records
+                    .into_iter()
+                    .map(|((collection, rkey), record)| {
+                        (format!("{collection}/{}", rkey.encode()), record.cid())
+                    })
+                    .collect();
+                (keyed, Some(previous), Some(previous_rev))
+            }
+            None => {
+                ensure!(condition.matches(None), "public repo genesis CAS conflict");
+                (BTreeMap::new(), None, None)
+            }
+        };
+        let record_key = format!("{}/{}", record.collection(), record.rkey().as_str());
+        ensure!(
+            !keyed.contains_key(&record_key),
+            "record key already exists"
+        );
+        keyed.insert(record_key, record.cid());
+
+        let tree = Node::from_keyed_records(&keyed);
+        let (root_data, _) = tree.to_node_data_with_blocks_atproto()?;
+        let unsigned = UnsignedCommit::new(
+            self.did.clone(),
+            root_data.cid_atproto()?,
+            next_revision(previous_rev),
+            previous,
+        );
+        let commit = Commit::sign_atproto(&unsigned, &self.signing_key)?;
+        let commit_cid = commit.cid_atproto()?;
+        let intent = PublicationIntent {
+            request_id: request.request_id,
+            principal: request.principal,
+            did: self.did.clone(),
+            collection: record.collection().to_owned(),
+            rkey: record.rkey().as_str().to_owned(),
+            cid: record.cid().to_string(),
+            commit_cid: commit_cid.to_string(),
+        };
+        self.store
+            .write_transaction(&self.did, &record, &commit, &intent)?;
+        Ok(PublicCommitResult {
+            uri: record.uri(&self.did),
+            cid: record.cid(),
+            commit_cid,
+        })
+    }
+    fn transaction_fixture() -> (
+        tempfile::TempDir,
+        Arc<PublicRepoStore>,
+        Arc<Gate>,
+        PublicRepoWriter,
+    ) {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let store = Arc::new(PublicRepoStore::open(dir.path()).expect("store"));
+        let gate = Arc::new(Gate {
+            allow: AtomicBool::new(true),
+        });
+        let key = p256::ecdsa::SigningKey::random(&mut rand::rngs::OsRng);
+        let writer = PublicRepoWriter::new(
+            store.clone(),
+            "did:web:tormentnexus.social",
+            key,
+            gate.clone(),
+        )
+        .expect("writer");
+        (dir, store, gate, writer)
+    }
+    fn transaction_request(id: u64) -> PublicCreateRequest {
+        PublicCreateRequest {
+            request_id: format!("req-{id}"),
+            principal: "did:at9p:agent".into(),
+            did: "did:web:tormentnexus.social".into(),
+            collection: "app.bsky.feed.post".into(),
+            rkey: Tid::from_raw(id),
+            value: post(),
+            expected_prev: None,
+        }
+    }
+    #[test]
+    fn xrpc_omitted_swap_allows_subsequent_creates_without_weakening_native_cas() {
+        let (_dir, store, _gate, writer) = transaction_fixture();
+        let first = writer
+            .create_record_with_expected_prev_text(transaction_request(7), None)
+            .expect("genesis");
+        let native_none = writer
+            .create_record(transaction_request(8))
+            .expect_err("native genesis only");
+        assert!(native_none.to_string().contains("CAS conflict"));
+        let second = writer
+            .create_record_with_expected_prev_text(transaction_request(8), None)
+            .expect("unconditional second write");
+        let mut third = transaction_request(9);
+        third.expected_prev = Some(first.commit_cid);
+        assert!(
+            writer.create_record(third.clone()).is_err(),
+            "native stale CAS"
+        );
+        third.expected_prev = Some(second.commit_cid);
+        writer.create_record(third).expect("native exact CAS");
+        assert_eq!(
+            store.snapshot(writer.did()).unwrap().unwrap().records.len(),
+            3
+        );
+    }
+    #[test]
+    fn xrpc_retries_return_original_result_after_later_commit_and_reopen() {
+        let (dir, store, gate, writer) = transaction_fixture();
+        let first = writer
+            .create_record_with_expected_prev_text(transaction_request(7), None)
+            .expect("genesis");
+        let previous = first.commit_cid.to_string();
+        let second = writer
+            .create_record_with_expected_prev_text(transaction_request(8), Some(&previous))
+            .expect("conditional second write");
+        assert_eq!(
+            writer
+                .create_record_with_expected_prev_text(transaction_request(8), Some(&previous))
+                .unwrap(),
+            second,
+            "immediate retry must not compare against its own new head"
+        );
+        let third = writer
+            .create_record_with_expected_prev_text(transaction_request(9), None)
+            .expect("head advances again");
+        let key = writer.signing_key.clone();
+        drop(writer);
+        drop(store);
+        let store = Arc::new(PublicRepoStore::open(dir.path()).expect("reopen"));
+        let writer = PublicRepoWriter::new(
+            store.clone(),
+            "did:web:tormentnexus.social",
+            key,
+            gate.clone(),
+        )
+        .unwrap();
+        assert_eq!(
+            writer
+                .create_record_with_expected_prev_text(transaction_request(7), None)
+                .unwrap(),
+            first
+        );
+        assert_eq!(
+            writer
+                .create_record_with_expected_prev_text(transaction_request(8), Some(&previous))
+                .unwrap(),
+            second,
+            "durable retry returns original commit, not the latest head"
+        );
+        let mut changed = transaction_request(8);
+        changed.value = DagCbor::str_map([
+            ("$type", DagCbor::Text("app.bsky.feed.post".into())),
+            ("text", DagCbor::Text("changed".into())),
+        ]);
+        assert!(writer
+            .create_record_with_expected_prev_text(changed, Some(&previous))
+            .is_err());
+        let mut different_principal = transaction_request(8);
+        different_principal.principal = "did:at9p:other".into();
+        assert!(writer
+            .create_record_with_expected_prev_text(different_principal, Some(&previous))
+            .is_err());
+        gate.allow.store(false, Ordering::Release);
+        let denied = writer
+            .create_record_with_expected_prev_text(transaction_request(8), Some(&previous))
+            .unwrap_err();
+        assert!(
+            denied.to_string().contains("publication denied"),
+            "retries reauthorize"
+        );
+        let snapshot = store.snapshot(writer.did()).unwrap().unwrap();
+        assert_eq!(snapshot.records.len(), 3);
+        assert_eq!(snapshot.commit.cid_atproto().unwrap(), third.commit_cid);
+    }
+    #[test]
+    fn xrpc_cas_and_unconditional_writes_share_one_atomic_head_selection() {
+        for conditional in [true, false] {
+            let (_dir, store, _gate, writer) = transaction_fixture();
+            let first = writer.create_record(transaction_request(7)).unwrap();
+            let writer = Arc::new(writer);
+            let start = Arc::new(std::sync::Barrier::new(2));
+            let results = std::thread::scope(|scope| {
+                let mut workers = Vec::new();
+                for id in [8, 9] {
+                    let writer = writer.clone();
+                    let start = start.clone();
+                    let expected = conditional.then(|| first.commit_cid.to_string());
+                    workers.push(scope.spawn(move || {
+                        start.wait();
+                        writer.create_record_with_expected_prev_text(
+                            transaction_request(id),
+                            expected.as_deref(),
+                        )
+                    }));
+                }
+                workers
+                    .into_iter()
+                    .map(|worker| worker.join().expect("writer thread"))
+                    .collect::<Vec<_>>()
+            });
+            let expected_successes = if conditional { 1 } else { 2 };
+            assert_eq!(
+                results.iter().filter(|result| result.is_ok()).count(),
+                expected_successes
+            );
+            for error in results.iter().filter_map(|result| result.as_ref().err()) {
+                assert!(error.to_string().contains("CAS conflict"));
+            }
+            let snapshot = store.snapshot(writer.did()).unwrap().unwrap();
+            assert_eq!(snapshot.records.len(), 1 + expected_successes);
+            snapshot
+                .commit
+                .verify_atproto(writer.signing_key.verifying_key())
+                .unwrap();
+        }
+    }
+    #[test]
+    fn xrpc_swap_authorizes_before_reading_repository_state() {
+        let (_dir, store, gate, writer) = transaction_fixture();
+        // A read would fail decoding this record before reaching the gate in
+        // the old text adapter. A denied request must not inspect it at all.
+        let key = record_key(
+            writer.did(),
+            "app.bsky.feed.post",
+            Tid::from_raw(7).encode().as_str(),
+        );
+        store.db.put(&key, b"malformed record").unwrap();
+        gate.allow.store(false, Ordering::Release);
+        let expected = Cid::from_dag_cbor(b"any head").to_string();
+        let error = writer
+            .create_record_with_expected_prev_text(transaction_request(8), Some(&expected))
+            .unwrap_err();
+        assert!(error.to_string().contains("publication denied"));
+        assert_eq!(store.db.get(key).unwrap().unwrap(), b"malformed record");
+        assert!(store.db.get(commit_key(writer.did())).unwrap().is_none());
+        assert!(store.intent(writer.did(), "req-8").unwrap().is_none());
+    }
+    #[test]
+    fn json_links_and_bytes_match_independent_public_record_fixture() {
+        // Independently encoded using Python hashlib/base64 and a minimal
+        // RFC 8949 encoder with public map ordering and tag-42 links.
+        let json = serde_json::json!({
+            "$type": "app.bsky.feed.post",
+            "text": "json",
+            "payload": {"$bytes": "AQI="},
+            "links": [{"$link": "bafyreifqwkmiw256ojf2zws6tzjeonw6bpd5vza4i22ccpcq4hjv2ts7cm"}],
+            "blob": {
+                "$type": "blob",
+                "ref": {"$link": "bafkreifbfby75yqq7odbski6v2qziwa4xustdzfsg5m5ejpwqbush5rsei"},
+                "mimeType": "image/png",
+                "size": 2
+            }
+        });
+        let value = json_to_dag_cbor(&json).expect("AT JSON");
+        let record = AtprotoRecord::new("app.bsky.feed.post", Tid::from_raw(7), value)
+            .expect("public record");
+        let fixture = hex::decode(concat!(
+            "a564626c6f62a463726566d82a58250001551220a12871fee210fb8619291eaea194581cbd2531e4b23759d225f6806923f63222",
+            "6473697a650265247479706564626c6f62686d696d655479706569696d6167652f706e676474657874646a736f6e",
+            "652474797065726170702e62736b792e666565642e706f7374656c696e6b7381d82a58250001711220b0b2988b6bbe724bacda5e9e524736de0bc7dae41c46b4213c50e1d35d4e5f13",
+            "677061796c6f6164420102"
+        )).expect("fixture");
+        assert_eq!(record.bytes(), fixture);
+        assert_eq!(
+            record.cid().to_string(),
+            "bafyreie3irn4tnywq3hxjm3knxuq7ovhni7cjqxa7weo7dncxsw6rj3s4m"
+        );
+        assert!(
+            AtprotoRecord::from_bytes("app.bsky.feed.post", Tid::from_raw(7), &fixture).is_ok()
+        );
+    }
+    #[test]
+    fn json_bytes_accept_standard_base64_with_optional_padding() {
+        for text in ["", "AQI", "AQI=", "+/8=", "+/8"] {
+            let value = json_to_dag_cbor(&serde_json::json!({"$bytes": text})).expect("bytes");
+            let expected = match text {
+                "" => vec![],
+                "AQI" | "AQI=" => vec![1, 2],
+                _ => vec![251, 255],
+            };
+            assert_eq!(value, DagCbor::Bytes(expected));
+        }
+    }
+    #[test]
+    fn json_rejects_malformed_reserved_wrappers_at_any_depth() {
+        let cid = Cid::from_raw(b"blob").to_string();
+        let malformed = [
+            serde_json::json!({"$link": false}),
+            serde_json::json!({"$link": "not-a-cid"}),
+            serde_json::json!({"$link": cid, "extra": 1}),
+            serde_json::json!({"$link": cid, "$bytes": "AQI="}),
+            serde_json::json!({"$bytes": 12}),
+            serde_json::json!({"$bytes": "AQI=", "extra": 1}),
+            serde_json::json!({"$bytes": "-_8="}),
+            serde_json::json!({"$bytes": "AQJ="}),
+            serde_json::json!({"$bytes": "AQI=="}),
+        ];
+        for value in malformed {
+            assert!(json_to_dag_cbor(&value).is_err(), "{value}");
+            assert!(json_to_dag_cbor(&serde_json::json!({"nested": [value]})).is_err());
+        }
+    }
+    #[test]
+    fn json_links_reject_noncanonical_and_unsupported_cids() {
+        let cid = Cid::from_raw(b"blob");
+        let text = cid.to_string();
+        assert_eq!(parse_atproto_json_cid(&text).expect("canonical"), cid);
+        assert!(parse_atproto_json_cid(&text.to_uppercase()).is_err());
+        assert!(parse_atproto_json_cid(&format!("{text}=")).is_err());
+        let mut noncanonical = text.into_bytes();
+        let last = noncanonical.last_mut().expect("last digit");
+        // The last base32 digit has two zero padding bits. Setting one leaves
+        // the decoded CID bytes unchanged but must not be accepted.
+        let alphabet = b"abcdefghijklmnopqrstuvwxyz234567";
+        let position = alphabet.iter().position(|c| c == last).expect("base32");
+        *last = alphabet[position + 1];
+        assert!(parse_atproto_json_cid(&String::from_utf8(noncanonical).unwrap()).is_err());
+        for (position, replacement) in [(1, 0x70), (2, 0x13), (3, 0x1f)] {
+            let mut raw = cid.as_bytes().to_vec();
+            raw[position] = replacement;
+            // Encode invalid bytes independently of the production parser.
+            let encoded = raw
+                .iter()
+                .flat_map(|byte| (0..8).rev().map(move |bit| (byte >> bit) & 1))
+                .collect::<Vec<_>>();
+            let mut text = String::from("b");
+            for chunk in encoded.chunks(5) {
+                let n = chunk.iter().fold(0u8, |n, bit| (n << 1) | bit) << (5 - chunk.len());
+                text.push(alphabet[n as usize] as char);
+            }
+            assert!(parse_atproto_json_cid(&text).is_err());
+        }
     }
 }

--- a/scripts/loopback-baseline.txt
+++ b/scripts/loopback-baseline.txt
@@ -13,6 +13,7 @@
 2	crates/hyprstream-metrics/src/storage/cached.rs
 1	crates/hyprstream-p2p/src/bin/gittorrentd.rs
 1	crates/hyprstream-p2p/src/service.rs
+3	crates/hyprstream-pds/src/repo_authority.rs
 1	crates/hyprstream-rpc/src/auth/key_source.rs
 3	crates/hyprstream-rpc/src/did_web.rs
 2	crates/hyprstream-service/src/service/spawner/service.rs


### PR DESCRIPTION
## Summary

This PR adds the first protected standard AT Protocol write endpoint for the Hyprstream bridge: `com.atproto.repo.createRecord`.

The route is deliberately opt-in. It is mounted only when an explicitly configured `PublicRepoWriter` is installed in `OAuthState`; the default production path remains unchanged until the native identity, account, and runtime prerequisites are wired.

## Behavior

- Reuses the existing bearer/DPoP protected-router middleware.
- Revalidates the access token and requires the `atproto` scope plus the native user binding.
- Binds `repo` to the configured writer DID, so a caller cannot publish for another repository.
- Bounds the JSON request body to 1 MiB.
- Supports `swapCommit` against the durable public head and deterministic or `Idempotency-Key` request IDs.
- Uses the public DAG-CBOR/MST/commit transaction path and the writer's explicit native publication authorizer.
- Covers the initial `app.bsky.feed.post` and `app.bsky.actor.profile` collection slice; unsupported collections are rejected until their validation and schema contracts are implemented.
- Returns the created `uri` and `cid`, with the submitted value when `returnRecord` is requested.

No native key material is reused, crypto checks are weakened, or firehose/account/session behavior is implied by this route.

## Validation

- `cargo test -p hyprstream services::oauth::xrpc --lib` — 40 passed.
- `cargo clippy -p hyprstream --lib -- -D warnings` — passed.
- The commit pre-commit release Clippy hook completed successfully.

## Follow-up gates

Account/session creation and validation, full Lexicon and unknown-collection semantics, update/delete/blob endpoints, firehose publication, native runtime/image/IaC deployment, cross-host probes, browser validation, and the #1506 human-originator decision remain separate acceptance gates.
