### PR TITLE
feat(pds): add credential-free hosted account HTTP face

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7004,6 +7004,7 @@ dependencies = [
  "web-transport-iroh",
  "web-transport-quinn",
  "webpki-roots 0.26.11",
+ "x509-parser",
  "xdg",
  "zeroize",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7349,6 +7349,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "async-trait",
+ "axum 0.7.9",
  "ed25519-dalek 2.2.0",
  "hyprstream-crypto",
  "hyprstream-pds",
@@ -7361,6 +7362,7 @@ dependencies = [
  "serde_json",
  "thiserror 1.0.69",
  "tokio",
+ "tower 0.5.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -141,6 +141,7 @@ tonic = { version = "0.12.3", features = ["transport", "codegen", "prost", "tls"
 # any classical-only path. prefer-post-quantum orders the PQ group first.
 rustls = { version = "0.23.1", features = ["ring", "aws_lc_rs", "prefer-post-quantum"] }
 rustls-pemfile = "2.1.0"
+x509-parser = "0.16"
 rustls-acme = { version = "0.11", features = ["tokio"] }
 axum = { version = "0.7", features = ["macros", "tokio"] }
 axum-server = { version = "0.7", features = ["tls-rustls"] }

--- a/crates/hyprstream-pds-service/Cargo.toml
+++ b/crates/hyprstream-pds-service/Cargo.toml
@@ -8,6 +8,7 @@ description = "Tenant-scoped PDS account record service over the Hyprstream 9P m
 
 [dependencies]
 anyhow = { workspace = true }
+axum = { workspace = true }
 async-trait = { workspace = true }
 hyprstream-pds = { path = "../hyprstream-pds" }
 hyprstream-rpc = { path = "../hyprstream-rpc" }
@@ -23,6 +24,7 @@ ed25519-dalek = { workspace = true }
 hyprstream-crypto = { path = "../hyprstream-crypto" }
 hyprstream-rpc = { path = "../hyprstream-rpc", features = ["test-classical-policy"] }
 rand = { workspace = true }
+"tower" = { version = "0.5", features = ["util"] }
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
 
 [lints]

--- a/crates/hyprstream-pds-service/Cargo.toml
+++ b/crates/hyprstream-pds-service/Cargo.toml
@@ -18,6 +18,7 @@ p256 = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 thiserror = { workspace = true }
+tokio = { workspace = true, features = ["sync"] }
 
 [dev-dependencies]
 ed25519-dalek = { workspace = true }
@@ -25,7 +26,6 @@ hyprstream-crypto = { path = "../hyprstream-crypto" }
 hyprstream-rpc = { path = "../hyprstream-rpc", features = ["test-classical-policy"] }
 rand = { workspace = true }
 "tower" = { version = "0.5", features = ["util"] }
-tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
 
 [lints]
 workspace = true

--- a/crates/hyprstream-pds-service/src/account_http.rs
+++ b/crates/hyprstream-pds-service/src/account_http.rs
@@ -195,10 +195,7 @@ pub struct MountedHostedAccountHttpDirectory {
     store: Arc<AccountRecordStore>,
     authority: hyprstream_rpc::Subject,
     zone: String,
-    tenant_cache: Arc<tokio::sync::Mutex<BTreeMap<String, Option<String>>>>,
 }
-
-const MAX_TENANT_CACHE_ENTRIES: usize = 1024;
 
 impl MountedHostedAccountHttpDirectory {
     pub fn new(
@@ -210,12 +207,15 @@ impl MountedHostedAccountHttpDirectory {
             authority.name() == Some(OAUTH_ACCOUNT_RESOLVER_SUBJECT),
             "hosted HTTP directory requires the fixed OAuth resolver subject"
         );
-        Ok(Self {
+        let directory = Self {
             store,
             authority,
             zone: canonical_zone(&zone.into())?,
-            tenant_cache: Arc::new(tokio::sync::Mutex::new(BTreeMap::new())),
-        })
+        };
+        directory
+            .store
+            .schedule_hosted_did_index_refresh(directory.authority.clone());
+        Ok(directory)
     }
 }
 
@@ -224,26 +224,13 @@ impl HostedAccountHttpDirectory for MountedHostedAccountHttpDirectory {
     async fn lookup(&self, label: &str) -> Result<Option<Arc<HostedAccountHttpArtifacts>>> {
         AccountLabel::parse(label).map_err(|error| anyhow::anyhow!(error))?;
         let did = format!("did:web:{label}.{}", self.zone);
-        // Tenant resolution is an index miss only once per label. Hold the
-        // cache lock across the miss so concurrent requests cannot all repeat
-        // the tenant scan; cache both hits and misses to keep attacker-chosen
-        // nonexistent labels from repeatedly walking every tenant.
-        let tenant = {
-            let mut cache = self.tenant_cache.lock().await;
-            if let Some(tenant) = cache.get(label).cloned() {
-                tenant
-            } else {
-                let tenant = self
-                    .store
-                    .resolve_tenant_for_hosted_did(&self.authority, &did)
-                    .await?;
-                if cache.len() >= MAX_TENANT_CACHE_ENTRIES {
-                    cache.pop_first();
-                }
-                cache.insert(label.to_owned(), tenant.clone());
-                tenant
-            }
-        };
+        // The store keeps a refreshed immutable label/DID index, so each
+        // request performs one bounded map lookup. Index refresh is serialized
+        // independently and never holds the request lookup lock.
+        let tenant = self
+            .store
+            .resolve_tenant_for_hosted_did(&self.authority, &did)
+            .await?;
         let Some(tenant) = tenant else {
             return Ok(None);
         };
@@ -752,6 +739,11 @@ mod tests {
     #[tokio::test]
     async fn mounted_directory_reads_only_authorized_sealed_files() {
         let (directory, document, log) = mounted_directory();
+        directory
+            .store
+            .refresh_hosted_did_index(&directory.authority)
+            .await
+            .unwrap();
         let app = router(DEFAULT_ACCOUNT_ZONE, directory).unwrap();
         let did_response = app
             .clone()
@@ -802,12 +794,22 @@ mod tests {
             altered_document.replace("https://pds.example.com", "https://other.example.com");
         let document_directory =
             mounted_directory_with_files(Some(altered_document.into_bytes()), Some(log.clone())).0;
+        document_directory
+            .store
+            .refresh_hosted_did_index(&document_directory.authority)
+            .await
+            .unwrap();
         assert!(document_directory.lookup("alice").await.is_err());
 
         let mut altered_log = log;
         let last = altered_log.len() - 1;
         altered_log[last] ^= 1;
         let log_directory = mounted_directory_with_files(None, Some(altered_log)).0;
+        log_directory
+            .store
+            .refresh_hosted_did_index(&log_directory.authority)
+            .await
+            .unwrap();
         assert!(log_directory.lookup("alice").await.is_err());
     }
 

--- a/crates/hyprstream-pds-service/src/account_http.rs
+++ b/crates/hyprstream-pds-service/src/account_http.rs
@@ -203,6 +203,26 @@ impl MountedHostedAccountHttpDirectory {
         authority: hyprstream_rpc::Subject,
         zone: impl Into<String>,
     ) -> Result<Self> {
+        Self::new_inner(store, authority, zone, true)
+    }
+
+    /// Construct a directory without scheduling a refresh on the caller's
+    /// runtime. Production OAuth uses this after performing the bounded warm-up
+    /// on its owned runtime, avoiding detached blocking work during shutdown.
+    pub fn new_without_refresh(
+        store: Arc<AccountRecordStore>,
+        authority: hyprstream_rpc::Subject,
+        zone: impl Into<String>,
+    ) -> Result<Self> {
+        Self::new_inner(store, authority, zone, false)
+    }
+
+    fn new_inner(
+        store: Arc<AccountRecordStore>,
+        authority: hyprstream_rpc::Subject,
+        zone: impl Into<String>,
+        schedule_refresh: bool,
+    ) -> Result<Self> {
         ensure!(
             authority.name() == Some(OAUTH_ACCOUNT_RESOLVER_SUBJECT),
             "hosted HTTP directory requires the fixed OAuth resolver subject"
@@ -212,9 +232,11 @@ impl MountedHostedAccountHttpDirectory {
             authority,
             zone: canonical_zone(&zone.into())?,
         };
-        directory
-            .store
-            .schedule_hosted_did_index_refresh(directory.authority.clone());
+        if schedule_refresh {
+            directory
+                .store
+                .schedule_hosted_did_index_refresh(directory.authority.clone());
+        }
         Ok(directory)
     }
 }

--- a/crates/hyprstream-pds-service/src/account_http.rs
+++ b/crates/hyprstream-pds-service/src/account_http.rs
@@ -56,9 +56,22 @@ impl HostedAccountHttpArtifacts {
         ensure!(
             !host.is_empty()
                 && !host.contains([':', '/'])
+                && host.split('.').count() >= 2
                 && host.split('.').next() == Some(label.as_str()),
             "hosted account HTTP artifact DID does not match its label"
         );
+        for component in host.split('.') {
+            ensure!(
+                !component.is_empty()
+                    && component.len() <= 63
+                    && component.bytes().all(|byte| {
+                        byte.is_ascii_lowercase() || byte.is_ascii_digit() || byte == b'-'
+                    })
+                    && !component.starts_with('-')
+                    && !component.ends_with('-'),
+                "hosted account HTTP artifact DID contains an invalid DNS label"
+            );
+        }
         let did_document: Arc<[u8]> = did_document.into().into();
         let atproto_did: Arc<[u8]> = atproto_did.into().into();
         let did_log: Arc<[u8]> = did_log.into().into();
@@ -238,8 +251,10 @@ async fn serve_artifact(
     let Some(label) = host_label(host, &state.zone) else {
         return StatusCode::NOT_FOUND.into_response();
     };
-    let Ok(Some(artifact)) = state.directory.lookup(&label).await else {
-        return StatusCode::NOT_FOUND.into_response();
+    let artifact = match state.directory.lookup(&label).await {
+        Ok(Some(artifact)) => artifact,
+        Ok(None) => return StatusCode::NOT_FOUND.into_response(),
+        Err(_) => return StatusCode::SERVICE_UNAVAILABLE.into_response(),
     };
     if artifact.did() != format!("did:web:{label}.{}", state.zone) {
         return StatusCode::NOT_FOUND.into_response();

--- a/crates/hyprstream-pds-service/src/account_http.rs
+++ b/crates/hyprstream-pds-service/src/account_http.rs
@@ -398,7 +398,34 @@ mod tests {
 
     use super::*;
     use axum::{body::to_bytes, http::Request};
+    use ed25519_dalek::SigningKey;
+    use hyprstream_crypto::pq::{ml_dsa_generate_keypair, ml_dsa_vk_bytes};
+    use hyprstream_pds::did_op::{
+        sign_genesis, GenesisRepoHead, GenesisRotationKeys, HostKeyEnrollment, HybridRotationKey,
+        RecoveryKeyEnrollment, UserRotationKey,
+    };
+    use hyprstream_pds::{AllocatedAccountName, HostedAccountMint};
+    use hyprstream_rpc::auth::mac::{MacDecision, SecurityContext};
+    use hyprstream_rpc::Subject;
+    use hyprstream_vfs::{SyntheticMount, SyntheticNode};
+    use rand::rngs::OsRng;
     use tower::ServiceExt;
+
+    use crate::{PDS_ACCOUNTS_DIRECTORY, PDS_ACCOUNT_RECORD_FILE};
+
+    struct PermitReads;
+
+    impl crate::AccountRecordReadAuthorizer for PermitReads {
+        fn check_read(
+            &self,
+            _subject: &Subject,
+            _verified_tenant: Option<&str>,
+            _security_context: Option<&SecurityContext>,
+            _object_id: &str,
+        ) -> MacDecision {
+            MacDecision::Permit
+        }
+    }
 
     fn directory() -> Arc<StaticHostedAccountHttpDirectory> {
         Arc::new(
@@ -412,6 +439,66 @@ mod tests {
             .unwrap()])
             .unwrap(),
         )
+    }
+
+    fn mounted_directory() -> (Arc<MountedHostedAccountHttpDirectory>, Vec<u8>, Vec<u8>) {
+        let ed = SigningKey::generate(&mut OsRng);
+        let (pq, pq_vk) = ml_dsa_generate_keypair();
+        let hybrid =
+            HybridRotationKey::new(ed.verifying_key().to_bytes(), ml_dsa_vk_bytes(&pq_vk)).unwrap();
+        let rotations = GenesisRotationKeys::new(
+            UserRotationKey::new(hybrid),
+            RecoveryKeyEnrollment::Declined,
+            HostKeyEnrollment::Absent,
+        )
+        .unwrap();
+        let name =
+            AllocatedAccountName::new("alice", "did:web:alice.tormentnexus.social".to_owned())
+                .unwrap();
+        let mint = HostedAccountMint::begin(name, rotations).unwrap();
+        let document = mint.seal_did_document("https://pds.example.com").unwrap();
+        let pending = mint
+            .prepare_genesis(document, GenesisRepoHead::EmptyRepo)
+            .unwrap();
+        let signature = sign_genesis(pending.unsigned_genesis(), &ed, &pq).unwrap();
+        let account = pending.seal(signature).unwrap();
+        let document_bytes = account.did_document().as_bytes().to_vec();
+        let log_bytes = account.genesis_bytes().to_vec();
+        let root = SyntheticNode::dir().with_child(
+            "tenant",
+            SyntheticNode::dir().with_child(
+                PDS_ACCOUNTS_DIRECTORY,
+                SyntheticNode::dir().with_child(
+                    "alice",
+                    SyntheticNode::dir()
+                        .with_child(
+                            PDS_ACCOUNT_RECORD_FILE,
+                            SyntheticNode::file(account.record_bytes().to_vec()),
+                        )
+                        .with_child(
+                            PDS_ACCOUNT_DID_DOCUMENT_FILE,
+                            SyntheticNode::file(document_bytes.clone()),
+                        )
+                        .with_child(
+                            PDS_ACCOUNT_DID_LOG_FILE,
+                            SyntheticNode::file(log_bytes.clone()),
+                        ),
+                ),
+            ),
+        );
+        let store = Arc::new(crate::AccountRecordStore::new(
+            Arc::new(SyntheticMount::new(root)),
+            Arc::new(PermitReads),
+        ));
+        let directory = Arc::new(
+            MountedHostedAccountHttpDirectory::new(
+                store,
+                Subject::new(crate::OAUTH_ACCOUNT_RESOLVER_SUBJECT),
+                DEFAULT_ACCOUNT_ZONE,
+            )
+            .unwrap(),
+        );
+        (directory, document_bytes, log_bytes)
     }
 
     #[tokio::test]
@@ -525,6 +612,49 @@ mod tests {
                 .unwrap();
             assert_eq!(response.status(), StatusCode::BAD_REQUEST);
         }
+    }
+
+    #[tokio::test]
+    async fn mounted_directory_reads_only_authorized_sealed_files() {
+        let (directory, document, log) = mounted_directory();
+        let app = router(DEFAULT_ACCOUNT_ZONE, directory).unwrap();
+        let did_response = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .uri("/.well-known/did.json")
+                    .header(header::HOST, "alice.tormentnexus.social")
+                    .body(axum::body::Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(did_response.status(), StatusCode::OK);
+        assert_eq!(
+            to_bytes(did_response.into_body(), 16 * 1024)
+                .await
+                .unwrap()
+                .as_ref(),
+            document
+        );
+        let log_response = app
+            .oneshot(
+                Request::builder()
+                    .uri("/.well-known/did-log.json")
+                    .header(header::HOST, "alice.tormentnexus.social")
+                    .body(axum::body::Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(log_response.status(), StatusCode::OK);
+        assert_eq!(
+            to_bytes(log_response.into_body(), 64 * 1024)
+                .await
+                .unwrap()
+                .as_ref(),
+            log
+        );
     }
 
     #[test]

--- a/crates/hyprstream-pds-service/src/account_http.rs
+++ b/crates/hyprstream-pds-service/src/account_http.rs
@@ -326,17 +326,24 @@ async fn serve_artifact(
         }
         // HTTP/1.1 supplies Host, while HTTP/2 carries the origin in the
         // :authority pseudo-header, which `http` exposes as the URI authority.
-        // Prefer an explicitly supplied Host; only an absent Host may fall back
-        // to :authority. This keeps malformed Host values fail-closed.
-        let host = match headers.get(header::HOST) {
-            Some(value) => match value.to_str() {
-                Ok(host) => host,
-                Err(_) => return StatusCode::BAD_REQUEST.into_response(),
-            },
-            None => match request.uri().authority() {
-                Some(authority) => authority.as_str(),
-                None => return StatusCode::BAD_REQUEST.into_response(),
-            },
+        // When both are present, they must be byte-identical: accepting a
+        // mismatched Host would let a proxy route one public account while the
+        // request authority names another. Only an absent URI authority may
+        // use Host as its target.
+        let uri_authority = request.uri().authority().map(Authority::as_str);
+        let host_header = headers
+            .get(header::HOST)
+            .map(|value| value.to_str().unwrap_or_default());
+        if headers.contains_key(header::HOST) && host_header == Some("") {
+            return StatusCode::BAD_REQUEST.into_response();
+        }
+        let host = match (uri_authority, host_header) {
+            (Some(authority), Some(host)) if authority != host => {
+                return StatusCode::BAD_REQUEST.into_response();
+            }
+            (Some(authority), _) => authority,
+            (None, Some(host)) => host,
+            (None, None) => return StatusCode::BAD_REQUEST.into_response(),
         };
         if host.is_empty() {
             return StatusCode::BAD_REQUEST.into_response();
@@ -558,6 +565,22 @@ mod tests {
             to_bytes(response.into_body(), 1024).await.unwrap().as_ref(),
             b"sealed-did-document"
         );
+    }
+
+    #[tokio::test]
+    async fn mismatched_http2_authority_and_host_fail_closed() {
+        let app = router("tormentnexus.social", directory()).unwrap();
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .uri("https://bob.tormentnexus.social/.well-known/did.json")
+                    .header(header::HOST, "alice.tormentnexus.social")
+                    .body(axum::body::Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
     }
 
     #[tokio::test]

--- a/crates/hyprstream-pds-service/src/account_http.rs
+++ b/crates/hyprstream-pds-service/src/account_http.rs
@@ -1,0 +1,455 @@
+//! Credential-free HTTP face for hosted-account identity artifacts (#1165).
+//!
+//! The router in this module is intentionally a complete, small Axum router
+//! with no session, cookie, bearer, or authorization middleware. It serves
+//! immutable bytes loaded from sealed publication artifacts on a separately
+//! bound listener. The listener and TLS termination are deployment concerns;
+//! this module owns the routing and credential-free security contract.
+
+use std::{collections::BTreeMap, sync::Arc};
+
+use anyhow::{ensure, Result};
+use async_trait::async_trait;
+use axum::{
+    extract::State,
+    http::{header, uri::Authority, HeaderMap, HeaderValue, StatusCode},
+    response::{IntoResponse, Response},
+    routing::get,
+    Router,
+};
+use hyprstream_pds::{AccountLabel, SealedHostedAccount};
+
+/// Canonical hosted account zone used by the default deployment.
+pub const DEFAULT_ACCOUNT_ZONE: &str = "tormentnexus.social";
+
+/// A byte-stable set of artifacts for one hosted account.
+///
+/// Values are copied into this object once, at publication/index-load time.
+/// Request handlers only clone the `Arc`-backed bytes; they never regenerate
+/// or reserialize a DID document or operation log.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct HostedAccountHttpArtifacts {
+    label: String,
+    did: String,
+    did_document: Arc<[u8]>,
+    atproto_did: Arc<[u8]>,
+    did_log: Arc<[u8]>,
+}
+
+impl HostedAccountHttpArtifacts {
+    /// Construct an artifact bundle after the publisher has validated the
+    /// sealed bytes. The constructor checks identity binding and rejects empty
+    /// artifacts; it does not parse or rewrite any bytes.
+    pub fn new(
+        label: impl Into<String>,
+        did: impl Into<String>,
+        did_document: impl Into<Vec<u8>>,
+        atproto_did: impl Into<Vec<u8>>,
+        did_log: impl Into<Vec<u8>>,
+    ) -> Result<Self> {
+        let label = label.into();
+        AccountLabel::parse(&label).map_err(|error| anyhow::anyhow!(error))?;
+        let did = did.into();
+        let host = did
+            .strip_prefix("did:web:")
+            .ok_or_else(|| anyhow::anyhow!("hosted account HTTP artifact DID is not did:web"))?;
+        ensure!(
+            !host.is_empty()
+                && !host.contains([':', '/'])
+                && host.split('.').next() == Some(label.as_str()),
+            "hosted account HTTP artifact DID does not match its label"
+        );
+        let did_document: Arc<[u8]> = did_document.into().into();
+        let atproto_did: Arc<[u8]> = atproto_did.into().into();
+        let did_log: Arc<[u8]> = did_log.into().into();
+        ensure!(!did_document.is_empty(), "sealed DID document is empty");
+        ensure!(
+            !atproto_did.is_empty(),
+            "sealed atproto DID artifact is empty"
+        );
+        ensure!(!did_log.is_empty(), "sealed DID operation log is empty");
+        ensure!(
+            atproto_did.as_ref() == did.as_bytes(),
+            "atproto DID artifact does not match its sealed DID"
+        );
+        Ok(Self {
+            label,
+            did,
+            did_document,
+            atproto_did,
+            did_log,
+        })
+    }
+
+    /// Build the HTTP bundle from a sealed account publication.
+    ///
+    /// `SealedHostedAccount` has already bound the DID document and operation
+    /// log into the signed genesis. This method only copies those exact bytes
+    /// and creates the plaintext atproto-did artifact once.
+    pub fn from_sealed(account: &SealedHostedAccount) -> Result<Self> {
+        let label = account.record().name().label().to_owned();
+        let did = account.record().name().did().to_owned();
+        let document = account.did_document().as_bytes();
+        let parsed = hyprstream_pds::SealedHostedDidDocument::from_canonical_json(document)?;
+        ensure!(
+            parsed.did() == did,
+            "sealed DID document does not match account record"
+        );
+        Self::new(
+            label,
+            did.clone(),
+            document.to_vec(),
+            did.into_bytes(),
+            account.genesis_bytes().to_vec(),
+        )
+    }
+
+    #[must_use]
+    pub fn label(&self) -> &str {
+        &self.label
+    }
+
+    #[must_use]
+    pub fn did(&self) -> &str {
+        &self.did
+    }
+
+    #[must_use]
+    pub fn did_document(&self) -> &[u8] {
+        &self.did_document
+    }
+
+    #[must_use]
+    pub fn atproto_did(&self) -> &[u8] {
+        &self.atproto_did
+    }
+
+    #[must_use]
+    pub fn did_log(&self) -> &[u8] {
+        &self.did_log
+    }
+}
+
+/// Read-only account artifact index used by the credential-free router.
+#[async_trait]
+pub trait HostedAccountHttpDirectory: Send + Sync {
+    /// Return the immutable artifact bundle for one canonical host label.
+    async fn lookup(&self, label: &str) -> Result<Option<Arc<HostedAccountHttpArtifacts>>>;
+}
+
+/// Immutable in-memory index suitable for a startup-loaded sealed artifact
+/// snapshot and for deterministic tests.
+#[derive(Clone, Default)]
+pub struct StaticHostedAccountHttpDirectory {
+    entries: Arc<BTreeMap<String, Arc<HostedAccountHttpArtifacts>>>,
+}
+
+impl StaticHostedAccountHttpDirectory {
+    pub fn new(artifacts: impl IntoIterator<Item = HostedAccountHttpArtifacts>) -> Result<Self> {
+        let mut entries = BTreeMap::new();
+        for artifact in artifacts {
+            let label = artifact.label().to_owned();
+            ensure!(
+                entries.insert(label.clone(), Arc::new(artifact)).is_none(),
+                "duplicate hosted account HTTP label {label:?}"
+            );
+        }
+        Ok(Self {
+            entries: Arc::new(entries),
+        })
+    }
+}
+
+#[async_trait]
+impl HostedAccountHttpDirectory for StaticHostedAccountHttpDirectory {
+    async fn lookup(&self, label: &str) -> Result<Option<Arc<HostedAccountHttpArtifacts>>> {
+        Ok(self.entries.get(label).cloned())
+    }
+}
+
+#[derive(Clone)]
+struct AccountHttpState {
+    zone: String,
+    directory: Arc<dyn HostedAccountHttpDirectory>,
+}
+
+/// Build the separate credential-free account-artifact router.
+///
+/// The returned router has only three GET routes and no layers. Bind it to a
+/// distinct listener from authenticated OAuth/XRPC routes. The caller remains
+/// responsible for binding the wildcard certificate and for refusing to mount
+/// this router into an authenticated listener.
+pub fn router(
+    zone: impl Into<String>,
+    directory: Arc<dyn HostedAccountHttpDirectory>,
+) -> Result<Router> {
+    let zone = canonical_zone(&zone.into())?;
+    let state = AccountHttpState { zone, directory };
+    Ok(Router::new()
+        .route("/.well-known/did.json", get(serve_did_document))
+        .route("/.well-known/atproto-did", get(serve_atproto_did))
+        .route("/.well-known/did-log.json", get(serve_did_log))
+        .with_state(Arc::new(state)))
+}
+
+async fn serve_did_document(
+    State(state): State<Arc<AccountHttpState>>,
+    headers: HeaderMap,
+) -> Response {
+    serve_artifact(&state, &headers, ArtifactKind::DidDocument).await
+}
+
+async fn serve_atproto_did(
+    State(state): State<Arc<AccountHttpState>>,
+    headers: HeaderMap,
+) -> Response {
+    serve_artifact(&state, &headers, ArtifactKind::AtprotoDid).await
+}
+
+async fn serve_did_log(State(state): State<Arc<AccountHttpState>>, headers: HeaderMap) -> Response {
+    serve_artifact(&state, &headers, ArtifactKind::DidLog).await
+}
+
+#[derive(Clone, Copy)]
+enum ArtifactKind {
+    DidDocument,
+    AtprotoDid,
+    DidLog,
+}
+
+async fn serve_artifact(
+    state: &AccountHttpState,
+    headers: &HeaderMap,
+    kind: ArtifactKind,
+) -> Response {
+    // A credential-bearing request must never reach an artifact lookup. This
+    // explicit rejection is the testable security boundary for the separate
+    // origin; there is no cookie/session/bearer middleware to accidentally
+    // inherit from the authenticated service.
+    if headers.contains_key(header::AUTHORIZATION) || headers.contains_key(header::COOKIE) {
+        return (StatusCode::BAD_REQUEST, "credentials are not accepted").into_response();
+    }
+    let Some(host) = headers
+        .get(header::HOST)
+        .and_then(|value| value.to_str().ok())
+    else {
+        return StatusCode::BAD_REQUEST.into_response();
+    };
+    let Some(label) = host_label(host, &state.zone) else {
+        return StatusCode::NOT_FOUND.into_response();
+    };
+    let Ok(Some(artifact)) = state.directory.lookup(&label).await else {
+        return StatusCode::NOT_FOUND.into_response();
+    };
+    if artifact.did() != format!("did:web:{label}.{}", state.zone) {
+        return StatusCode::NOT_FOUND.into_response();
+    }
+    let (body, content_type): (&[u8], &'static str) = match kind {
+        ArtifactKind::DidDocument => (artifact.did_document(), "application/did+json"),
+        ArtifactKind::AtprotoDid => (artifact.atproto_did(), "text/plain; charset=utf-8"),
+        // The current sealed operation-log artifact is a signed CBOR genesis
+        // envelope even though the stable URL retains its historical .json
+        // suffix. Never transcode it at the HTTP boundary.
+        ArtifactKind::DidLog => (artifact.did_log(), "application/cbor"),
+    };
+    let mut response = body.to_vec().into_response();
+    response
+        .headers_mut()
+        .insert(header::CONTENT_TYPE, HeaderValue::from_static(content_type));
+    response.headers_mut().insert(
+        header::CACHE_CONTROL,
+        HeaderValue::from_static("public, max-age=300, immutable"),
+    );
+    response
+}
+
+fn canonical_zone(zone: &str) -> Result<String> {
+    ensure!(
+        !zone.is_empty() && zone.is_ascii(),
+        "account zone must be ASCII"
+    );
+    let zone = zone.trim_end_matches('.');
+    let labels: Vec<&str> = zone.split('.').collect();
+    ensure!(labels.len() >= 2, "account zone must contain two labels");
+    for label in labels {
+        ensure!(
+            !label.is_empty()
+                && label.len() <= 63
+                && label
+                    .bytes()
+                    .all(|byte| byte.is_ascii_lowercase() || byte.is_ascii_digit() || byte == b'-')
+                && !label.starts_with('-')
+                && !label.ends_with('-'),
+            "account zone contains an invalid DNS label"
+        );
+    }
+    Ok(zone.to_owned())
+}
+
+fn host_label(host: &str, zone: &str) -> Option<String> {
+    let authority: Authority = host.parse().ok()?;
+    let hostname = authority.host().trim_end_matches('.');
+    let suffix = format!(".{zone}");
+    let label = hostname.strip_suffix(&suffix)?;
+    if label.contains('.') {
+        return None;
+    }
+    AccountLabel::parse(label).ok().map(|_| label.to_owned())
+}
+
+#[cfg(test)]
+mod tests {
+    #![allow(clippy::expect_used, clippy::unwrap_used)]
+
+    use super::*;
+    use axum::{body::to_bytes, http::Request};
+    use tower::ServiceExt;
+
+    fn directory() -> Arc<StaticHostedAccountHttpDirectory> {
+        Arc::new(
+            StaticHostedAccountHttpDirectory::new([HostedAccountHttpArtifacts::new(
+                "alice",
+                "did:web:alice.tormentnexus.social",
+                b"sealed-did-document".to_vec(),
+                b"did:web:alice.tormentnexus.social".to_vec(),
+                b"sealed-did-log".to_vec(),
+            )
+            .unwrap()])
+            .unwrap(),
+        )
+    }
+
+    #[tokio::test]
+    async fn serves_exact_sealed_bytes_by_host_label() {
+        let app = router("tormentnexus.social", directory()).unwrap();
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .uri("/.well-known/did.json")
+                    .header(header::HOST, "alice.tormentnexus.social")
+                    .body(axum::body::Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+        assert_eq!(
+            response.headers()[header::CONTENT_TYPE],
+            "application/did+json"
+        );
+        assert_eq!(
+            to_bytes(response.into_body(), 1024).await.unwrap().as_ref(),
+            b"sealed-did-document"
+        );
+    }
+
+    #[tokio::test]
+    async fn serves_atproto_did_and_did_log_without_transcoding() {
+        let app = router("tormentnexus.social", directory()).unwrap();
+        for (path, expected, content_type) in [
+            (
+                "/.well-known/atproto-did",
+                &b"did:web:alice.tormentnexus.social"[..],
+                "text/plain; charset=utf-8",
+            ),
+            (
+                "/.well-known/did-log.json",
+                &b"sealed-did-log"[..],
+                "application/cbor",
+            ),
+        ] {
+            let response = app
+                .clone()
+                .oneshot(
+                    Request::builder()
+                        .uri(path)
+                        .header(header::HOST, "alice.tormentnexus.social:443")
+                        .body(axum::body::Body::empty())
+                        .unwrap(),
+                )
+                .await
+                .unwrap();
+            assert_eq!(response.status(), StatusCode::OK);
+            assert_eq!(response.headers()[header::CONTENT_TYPE], content_type);
+            assert_eq!(
+                to_bytes(response.into_body(), 1024).await.unwrap(),
+                expected
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn unknown_or_malformed_hosts_are_not_synthesized() {
+        let app = router("tormentnexus.social", directory()).unwrap();
+        for host in [
+            "bob.tormentnexus.social",
+            "alice.other.example",
+            "nested.alice.tormentnexus.social",
+            "-alice.tormentnexus.social",
+        ] {
+            let response = app
+                .clone()
+                .oneshot(
+                    Request::builder()
+                        .uri("/.well-known/did.json")
+                        .header(header::HOST, host)
+                        .body(axum::body::Body::empty())
+                        .unwrap(),
+                )
+                .await
+                .unwrap();
+            assert_eq!(response.status(), StatusCode::NOT_FOUND, "host={host}");
+        }
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .uri("/.well-known/did.json")
+                    .body(axum::body::Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    }
+
+    #[tokio::test]
+    async fn credentials_are_rejected_before_lookup() {
+        let app = router("tormentnexus.social", directory()).unwrap();
+        for name in [header::AUTHORIZATION, header::COOKIE] {
+            let response = app
+                .clone()
+                .oneshot(
+                    Request::builder()
+                        .uri("/.well-known/did.json")
+                        .header(header::HOST, "alice.tormentnexus.social")
+                        .header(name, "present")
+                        .body(axum::body::Body::empty())
+                        .unwrap(),
+                )
+                .await
+                .unwrap();
+            assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+        }
+    }
+
+    #[test]
+    fn duplicate_labels_are_rejected() {
+        let first = HostedAccountHttpArtifacts::new(
+            "alice",
+            "did:web:alice.tormentnexus.social",
+            vec![1],
+            b"did:web:alice.tormentnexus.social".to_vec(),
+            vec![2],
+        )
+        .unwrap();
+        let second = HostedAccountHttpArtifacts::new(
+            "alice",
+            "did:web:alice.tormentnexus.social",
+            vec![3],
+            b"did:web:alice.tormentnexus.social".to_vec(),
+            vec![4],
+        )
+        .unwrap();
+        assert!(StaticHostedAccountHttpDirectory::new([first, second]).is_err());
+    }
+}

--- a/crates/hyprstream-pds-service/src/account_http.rs
+++ b/crates/hyprstream-pds-service/src/account_http.rs
@@ -427,7 +427,9 @@ mod tests {
         sign_genesis, GenesisRepoHead, GenesisRotationKeys, HostKeyEnrollment, HybridRotationKey,
         RecoveryKeyEnrollment, UserRotationKey,
     };
-    use hyprstream_pds::{AllocatedAccountName, HostedAccountMint};
+    use hyprstream_pds::{
+        AllocatedAccountName, HostedAccountMint, DID_DOCUMENT_FILE, GENESIS_DID_OP_FILE,
+    };
     use hyprstream_rpc::auth::mac::{MacDecision, SecurityContext};
     use hyprstream_rpc::Subject;
     use hyprstream_vfs::{SyntheticMount, SyntheticNode};
@@ -499,13 +501,10 @@ mod tests {
                             SyntheticNode::file(account.record_bytes().to_vec()),
                         )
                         .with_child(
-                            PDS_ACCOUNT_DID_DOCUMENT_FILE,
+                            DID_DOCUMENT_FILE,
                             SyntheticNode::file(document_bytes.clone()),
                         )
-                        .with_child(
-                            PDS_ACCOUNT_DID_LOG_FILE,
-                            SyntheticNode::file(log_bytes.clone()),
-                        ),
+                        .with_child(GENESIS_DID_OP_FILE, SyntheticNode::file(log_bytes.clone())),
                 ),
             ),
         );

--- a/crates/hyprstream-pds-service/src/account_http.rs
+++ b/crates/hyprstream-pds-service/src/account_http.rs
@@ -11,7 +11,7 @@ use std::{collections::BTreeMap, sync::Arc};
 use anyhow::{ensure, Result};
 use async_trait::async_trait;
 use axum::{
-    extract::State,
+    extract::{Request, State},
     http::{header, uri::Authority, HeaderMap, HeaderValue, StatusCode},
     response::{IntoResponse, Response},
     routing::get,
@@ -287,20 +287,20 @@ pub fn router(
 
 async fn serve_did_document(
     State(state): State<Arc<AccountHttpState>>,
-    headers: HeaderMap,
+    request: Request,
 ) -> Response {
-    serve_artifact(&state, &headers, ArtifactKind::DidDocument).await
+    serve_artifact(&state, request, ArtifactKind::DidDocument).await
 }
 
 async fn serve_atproto_did(
     State(state): State<Arc<AccountHttpState>>,
-    headers: HeaderMap,
+    request: Request,
 ) -> Response {
-    serve_artifact(&state, &headers, ArtifactKind::AtprotoDid).await
+    serve_artifact(&state, request, ArtifactKind::AtprotoDid).await
 }
 
-async fn serve_did_log(State(state): State<Arc<AccountHttpState>>, headers: HeaderMap) -> Response {
-    serve_artifact(&state, &headers, ArtifactKind::DidLog).await
+async fn serve_did_log(State(state): State<Arc<AccountHttpState>>, request: Request) -> Response {
+    serve_artifact(&state, request, ArtifactKind::DidLog).await
 }
 
 #[derive(Clone, Copy)]
@@ -312,25 +312,41 @@ enum ArtifactKind {
 
 async fn serve_artifact(
     state: &AccountHttpState,
-    headers: &HeaderMap,
+    request: Request,
     kind: ArtifactKind,
 ) -> Response {
     // A credential-bearing request must never reach an artifact lookup. This
     // explicit rejection is the testable security boundary for the separate
     // origin; there is no cookie/session/bearer middleware to accidentally
     // inherit from the authenticated service.
-    if headers.contains_key(header::AUTHORIZATION) || headers.contains_key(header::COOKIE) {
-        return (StatusCode::BAD_REQUEST, "credentials are not accepted").into_response();
-    }
-    let Some(host) = headers
-        .get(header::HOST)
-        .and_then(|value| value.to_str().ok())
-    else {
-        return StatusCode::BAD_REQUEST.into_response();
+    let label = {
+        let headers: &HeaderMap = request.headers();
+        if headers.contains_key(header::AUTHORIZATION) || headers.contains_key(header::COOKIE) {
+            return (StatusCode::BAD_REQUEST, "credentials are not accepted").into_response();
+        }
+        // HTTP/1.1 supplies Host, while HTTP/2 carries the origin in the
+        // :authority pseudo-header, which `http` exposes as the URI authority.
+        // Prefer an explicitly supplied Host; only an absent Host may fall back
+        // to :authority. This keeps malformed Host values fail-closed.
+        let host = match headers.get(header::HOST) {
+            Some(value) => match value.to_str() {
+                Ok(host) => host,
+                Err(_) => return StatusCode::BAD_REQUEST.into_response(),
+            },
+            None => match request.uri().authority() {
+                Some(authority) => authority.as_str(),
+                None => return StatusCode::BAD_REQUEST.into_response(),
+            },
+        };
+        if host.is_empty() {
+            return StatusCode::BAD_REQUEST.into_response();
+        }
+        let Some(label) = host_label(host, &state.zone) else {
+            return StatusCode::NOT_FOUND.into_response();
+        };
+        label
     };
-    let Some(label) = host_label(host, &state.zone) else {
-        return StatusCode::NOT_FOUND.into_response();
-    };
+    drop(request);
     let artifact = match state.directory.lookup(&label).await {
         Ok(Some(artifact)) => artifact,
         Ok(None) => return StatusCode::NOT_FOUND.into_response(),
@@ -523,6 +539,44 @@ mod tests {
             to_bytes(response.into_body(), 1024).await.unwrap().as_ref(),
             b"sealed-did-document"
         );
+    }
+
+    #[tokio::test]
+    async fn authority_only_requests_use_http2_uri_authority() {
+        let app = router("tormentnexus.social", directory()).unwrap();
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .uri("https://alice.tormentnexus.social/.well-known/did.json")
+                    .body(axum::body::Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+        assert_eq!(
+            to_bytes(response.into_body(), 1024).await.unwrap().as_ref(),
+            b"sealed-did-document"
+        );
+    }
+
+    #[tokio::test]
+    async fn authority_only_requests_still_reject_credentials() {
+        let app = router("tormentnexus.social", directory()).unwrap();
+        for name in [header::AUTHORIZATION, header::COOKIE] {
+            let response = app
+                .clone()
+                .oneshot(
+                    Request::builder()
+                        .uri("https://alice.tormentnexus.social/.well-known/did.json")
+                        .header(name, "present")
+                        .body(axum::body::Body::empty())
+                        .unwrap(),
+                )
+                .await
+                .unwrap();
+            assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+        }
     }
 
     #[tokio::test]

--- a/crates/hyprstream-pds-service/src/account_http.rs
+++ b/crates/hyprstream-pds-service/src/account_http.rs
@@ -17,7 +17,12 @@ use axum::{
     routing::get,
     Router,
 };
-use hyprstream_pds::{AccountLabel, SealedHostedAccount};
+use hyprstream_pds::{AccountLabel, SealedHostedAccount, SealedHostedDidDocument};
+
+use crate::{
+    AccountRecordStore, OAUTH_ACCOUNT_RESOLVER_SUBJECT, PDS_ACCOUNT_DID_DOCUMENT_FILE,
+    PDS_ACCOUNT_DID_LOG_FILE,
+};
 
 /// Canonical hosted account zone used by the default deployment.
 pub const DEFAULT_ACCOUNT_ZONE: &str = "tormentnexus.social";
@@ -177,6 +182,81 @@ impl StaticHostedAccountHttpDirectory {
 impl HostedAccountHttpDirectory for StaticHostedAccountHttpDirectory {
     async fn lookup(&self, label: &str) -> Result<Option<Arc<HostedAccountHttpArtifacts>>> {
         Ok(self.entries.get(label).cloned())
+    }
+}
+
+/// Live adapter that loads the immutable artifact bundle from the authorized
+/// PDS mount. The OAuth service identity is fixed at construction; callers
+/// cannot substitute a tenant or subject through an HTTP request.
+#[derive(Clone)]
+pub struct MountedHostedAccountHttpDirectory {
+    store: Arc<AccountRecordStore>,
+    authority: hyprstream_rpc::Subject,
+    zone: String,
+}
+
+impl MountedHostedAccountHttpDirectory {
+    pub fn new(
+        store: Arc<AccountRecordStore>,
+        authority: hyprstream_rpc::Subject,
+        zone: impl Into<String>,
+    ) -> Result<Self> {
+        ensure!(
+            authority.name() == Some(OAUTH_ACCOUNT_RESOLVER_SUBJECT),
+            "hosted HTTP directory requires the fixed OAuth resolver subject"
+        );
+        Ok(Self {
+            store,
+            authority,
+            zone: canonical_zone(&zone.into())?,
+        })
+    }
+}
+
+#[async_trait]
+impl HostedAccountHttpDirectory for MountedHostedAccountHttpDirectory {
+    async fn lookup(&self, label: &str) -> Result<Option<Arc<HostedAccountHttpArtifacts>>> {
+        AccountLabel::parse(label).map_err(|error| anyhow::anyhow!(error))?;
+        let did = format!("did:web:{label}.{}", self.zone);
+        let Some(tenant) = self
+            .store
+            .resolve_tenant_for_hosted_did(&self.authority, &did)
+            .await?
+        else {
+            return Ok(None);
+        };
+        let document = self
+            .store
+            .read_hosted_http_artifact(
+                &self.authority,
+                &tenant,
+                label,
+                PDS_ACCOUNT_DID_DOCUMENT_FILE,
+                16 * 1024,
+            )
+            .await?;
+        let parsed = SealedHostedDidDocument::from_canonical_json(&document)?;
+        ensure!(
+            parsed.did() == did,
+            "served DID document does not match host"
+        );
+        let log = self
+            .store
+            .read_hosted_http_artifact(
+                &self.authority,
+                &tenant,
+                label,
+                PDS_ACCOUNT_DID_LOG_FILE,
+                64 * 1024,
+            )
+            .await?;
+        Ok(Some(Arc::new(HostedAccountHttpArtifacts::new(
+            label,
+            did.clone(),
+            document,
+            did.into_bytes(),
+            log,
+        )?)))
     }
 }
 

--- a/crates/hyprstream-pds-service/src/account_http.rs
+++ b/crates/hyprstream-pds-service/src/account_http.rs
@@ -383,17 +383,17 @@ async fn serve_artifact(
             (None, None) => return StatusCode::BAD_REQUEST.into_response(),
         };
         if host.is_empty() {
-            return StatusCode::BAD_REQUEST.into_response();
+            return negative_response(StatusCode::BAD_REQUEST);
         }
         let Some(label) = host_label(host, &state.zone) else {
-            return StatusCode::NOT_FOUND.into_response();
+            return negative_response(StatusCode::NOT_FOUND);
         };
         label
     };
     drop(request);
     let artifact = match state.directory.lookup(&label).await {
         Ok(Some(artifact)) => artifact,
-        Ok(None) => return StatusCode::NOT_FOUND.into_response(),
+        Ok(None) => return negative_response(StatusCode::NOT_FOUND),
         Err(_) => return StatusCode::SERVICE_UNAVAILABLE.into_response(),
     };
     if artifact.did() != format!("did:web:{label}.{}", state.zone) {
@@ -414,6 +414,15 @@ async fn serve_artifact(
     response.headers_mut().insert(
         header::CACHE_CONTROL,
         HeaderValue::from_static("public, max-age=300, immutable"),
+    );
+    response
+}
+
+fn negative_response(status: StatusCode) -> Response {
+    let mut response = status.into_response();
+    response.headers_mut().insert(
+        header::CACHE_CONTROL,
+        HeaderValue::from_static("no-store"),
     );
     response
 }
@@ -452,7 +461,7 @@ fn host_label(host: &str, zone: &str) -> Option<String> {
             return None;
         }
     }
-    let hostname = authority.host().trim_end_matches('.');
+    let hostname = authority.host().trim_end_matches('.').to_ascii_lowercase();
     let suffix = format!(".{zone}");
     let label = hostname.strip_suffix(&suffix)?;
     if label.contains('.') {
@@ -688,6 +697,39 @@ mod tests {
                 .unwrap();
             assert_eq!(response.status(), StatusCode::BAD_REQUEST);
         }
+    }
+
+    #[tokio::test]
+    async fn hostname_matching_is_case_insensitive() {
+        let app = router("tormentnexus.social", directory()).unwrap();
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .uri("/.well-known/did.json")
+                    .header(header::HOST, "ALICE.TORMENTNEXUS.SOCIAL")
+                    .body(axum::body::Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+    }
+
+    #[tokio::test]
+    async fn unallocated_label_404_is_not_cached() {
+        let app = router("tormentnexus.social", directory()).unwrap();
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .uri("/.well-known/did.json")
+                    .header(header::HOST, "bob.tormentnexus.social")
+                    .body(axum::body::Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::NOT_FOUND);
+        assert_eq!(response.headers()[header::CACHE_CONTROL], "no-store");
     }
 
     #[tokio::test]

--- a/crates/hyprstream-pds-service/src/account_http.rs
+++ b/crates/hyprstream-pds-service/src/account_http.rs
@@ -8,20 +8,22 @@
 
 use std::{collections::BTreeMap, sync::Arc};
 
-use anyhow::{ensure, Result};
+use anyhow::{Result, ensure};
 use async_trait::async_trait;
 use axum::{
+    Router,
     extract::{Request, State},
-    http::{header, uri::Authority, HeaderMap, HeaderValue, StatusCode},
+    http::{HeaderMap, HeaderValue, StatusCode, header, uri::Authority},
     response::{IntoResponse, Response},
     routing::get,
-    Router,
 };
-use hyprstream_pds::{AccountLabel, SealedHostedAccount, SealedHostedDidDocument};
+use hyprstream_pds::{
+    AccountLabel, AccountRecord, GenesisDidOp, SealedHostedAccount, SealedHostedDidDocument,
+};
 
 use crate::{
     AccountRecordStore, OAUTH_ACCOUNT_RESOLVER_SUBJECT, PDS_ACCOUNT_DID_DOCUMENT_FILE,
-    PDS_ACCOUNT_DID_LOG_FILE,
+    PDS_ACCOUNT_DID_LOG_FILE, PDS_ACCOUNT_RECORD_FILE,
 };
 
 /// Canonical hosted account zone used by the default deployment.
@@ -193,7 +195,10 @@ pub struct MountedHostedAccountHttpDirectory {
     store: Arc<AccountRecordStore>,
     authority: hyprstream_rpc::Subject,
     zone: String,
+    tenant_cache: Arc<tokio::sync::Mutex<BTreeMap<String, Option<String>>>>,
 }
+
+const MAX_TENANT_CACHE_ENTRIES: usize = 1024;
 
 impl MountedHostedAccountHttpDirectory {
     pub fn new(
@@ -209,6 +214,7 @@ impl MountedHostedAccountHttpDirectory {
             store,
             authority,
             zone: canonical_zone(&zone.into())?,
+            tenant_cache: Arc::new(tokio::sync::Mutex::new(BTreeMap::new())),
         })
     }
 }
@@ -218,13 +224,44 @@ impl HostedAccountHttpDirectory for MountedHostedAccountHttpDirectory {
     async fn lookup(&self, label: &str) -> Result<Option<Arc<HostedAccountHttpArtifacts>>> {
         AccountLabel::parse(label).map_err(|error| anyhow::anyhow!(error))?;
         let did = format!("did:web:{label}.{}", self.zone);
-        let Some(tenant) = self
-            .store
-            .resolve_tenant_for_hosted_did(&self.authority, &did)
-            .await?
-        else {
+        // Tenant resolution is an index miss only once per label. Hold the
+        // cache lock across the miss so concurrent requests cannot all repeat
+        // the tenant scan; cache both hits and misses to keep attacker-chosen
+        // nonexistent labels from repeatedly walking every tenant.
+        let tenant = {
+            let mut cache = self.tenant_cache.lock().await;
+            if let Some(tenant) = cache.get(label).cloned() {
+                tenant
+            } else {
+                let tenant = self
+                    .store
+                    .resolve_tenant_for_hosted_did(&self.authority, &did)
+                    .await?;
+                if cache.len() >= MAX_TENANT_CACHE_ENTRIES {
+                    cache.pop_first();
+                }
+                cache.insert(label.to_owned(), tenant.clone());
+                tenant
+            }
+        };
+        let Some(tenant) = tenant else {
             return Ok(None);
         };
+        let record_bytes = self
+            .store
+            .read_hosted_http_artifact(
+                &self.authority,
+                &tenant,
+                label,
+                PDS_ACCOUNT_RECORD_FILE,
+                16 * 1024,
+            )
+            .await?;
+        let record = AccountRecord::from_dag_cbor(&record_bytes)?;
+        ensure!(
+            record.name().label() == label && record.name().did() == did,
+            "hosted account record does not match host"
+        );
         let document = self
             .store
             .read_hosted_http_artifact(
@@ -237,8 +274,8 @@ impl HostedAccountHttpDirectory for MountedHostedAccountHttpDirectory {
             .await?;
         let parsed = SealedHostedDidDocument::from_canonical_json(&document)?;
         ensure!(
-            parsed.did() == did,
-            "served DID document does not match host"
+            parsed.did() == did && parsed.cid() == record.doc_cid(),
+            "served DID document does not match host or account record"
         );
         let log = self
             .store
@@ -250,6 +287,11 @@ impl HostedAccountHttpDirectory for MountedHostedAccountHttpDirectory {
                 64 * 1024,
             )
             .await?;
+        let genesis = GenesisDidOp::from_dag_cbor(&log)?;
+        ensure!(
+            genesis.cid()? == record.genesis_op(),
+            "served genesis operation does not match account record"
+        );
         Ok(Some(Arc::new(HostedAccountHttpArtifacts::new(
             label,
             did.clone(),
@@ -405,7 +447,16 @@ fn canonical_zone(zone: &str) -> Result<String> {
 }
 
 fn host_label(host: &str, zone: &str) -> Option<String> {
+    if host.contains('@') {
+        return None;
+    }
     let authority: Authority = host.parse().ok()?;
+    if host.contains(':') {
+        let port = authority.port()?;
+        if !port.as_str().bytes().all(|byte| byte.is_ascii_digit()) {
+            return None;
+        }
+    }
     let hostname = authority.host().trim_end_matches('.');
     let suffix = format!(".{zone}");
     let label = hostname.strip_suffix(&suffix)?;
@@ -424,19 +475,19 @@ mod tests {
     use ed25519_dalek::SigningKey;
     use hyprstream_crypto::pq::{ml_dsa_generate_keypair, ml_dsa_vk_bytes};
     use hyprstream_pds::did_op::{
-        sign_genesis, GenesisRepoHead, GenesisRotationKeys, HostKeyEnrollment, HybridRotationKey,
-        RecoveryKeyEnrollment, UserRotationKey,
+        GenesisRepoHead, GenesisRotationKeys, HostKeyEnrollment, HybridRotationKey,
+        RecoveryKeyEnrollment, UserRotationKey, sign_genesis,
     };
     use hyprstream_pds::{
-        AllocatedAccountName, HostedAccountMint, DID_DOCUMENT_FILE, GENESIS_DID_OP_FILE,
+        AllocatedAccountName, DID_DOCUMENT_FILE, GENESIS_DID_OP_FILE, HostedAccountMint,
     };
-    use hyprstream_rpc::auth::mac::{MacDecision, SecurityContext};
     use hyprstream_rpc::Subject;
+    use hyprstream_rpc::auth::mac::{MacDecision, SecurityContext};
     use hyprstream_vfs::{SyntheticMount, SyntheticNode};
     use rand::rngs::OsRng;
     use tower::ServiceExt;
 
-    use crate::{PDS_ACCOUNTS_DIRECTORY, PDS_ACCOUNT_RECORD_FILE};
+    use crate::{PDS_ACCOUNT_RECORD_FILE, PDS_ACCOUNTS_DIRECTORY};
 
     struct PermitReads;
 
@@ -467,6 +518,13 @@ mod tests {
     }
 
     fn mounted_directory() -> (Arc<MountedHostedAccountHttpDirectory>, Vec<u8>, Vec<u8>) {
+        mounted_directory_with_files(None, None)
+    }
+
+    fn mounted_directory_with_files(
+        document_override: Option<Vec<u8>>,
+        log_override: Option<Vec<u8>>,
+    ) -> (Arc<MountedHostedAccountHttpDirectory>, Vec<u8>, Vec<u8>) {
         let ed = SigningKey::generate(&mut OsRng);
         let (pq, pq_vk) = ml_dsa_generate_keypair();
         let hybrid =
@@ -489,6 +547,8 @@ mod tests {
         let account = pending.seal(signature).unwrap();
         let document_bytes = account.did_document().as_bytes().to_vec();
         let log_bytes = account.genesis_bytes().to_vec();
+        let document_file = document_override.unwrap_or_else(|| document_bytes.clone());
+        let log_file = log_override.unwrap_or_else(|| log_bytes.clone());
         let root = SyntheticNode::dir().with_child(
             "tenant",
             SyntheticNode::dir().with_child(
@@ -500,11 +560,8 @@ mod tests {
                             PDS_ACCOUNT_RECORD_FILE,
                             SyntheticNode::file(account.record_bytes().to_vec()),
                         )
-                        .with_child(
-                            DID_DOCUMENT_FILE,
-                            SyntheticNode::file(document_bytes.clone()),
-                        )
-                        .with_child(GENESIS_DID_OP_FILE, SyntheticNode::file(log_bytes.clone())),
+                        .with_child(DID_DOCUMENT_FILE, SyntheticNode::file(document_file))
+                        .with_child(GENESIS_DID_OP_FILE, SyntheticNode::file(log_file)),
                 ),
             ),
         );
@@ -644,6 +701,8 @@ mod tests {
             "alice.other.example",
             "nested.alice.tormentnexus.social",
             "-alice.tormentnexus.social",
+            "attacker@alice.tormentnexus.social",
+            "alice.tormentnexus.social:bad",
         ] {
             let response = app
                 .clone()
@@ -731,6 +790,25 @@ mod tests {
                 .as_ref(),
             log
         );
+    }
+
+    #[tokio::test]
+    async fn mounted_directory_rejects_artifacts_rebound_from_account_record() {
+        let (_directory, document, log) = mounted_directory();
+
+        let mut altered_document = String::from_utf8(document).unwrap();
+        assert!(altered_document.contains("https://pds.example.com"));
+        altered_document =
+            altered_document.replace("https://pds.example.com", "https://other.example.com");
+        let document_directory =
+            mounted_directory_with_files(Some(altered_document.into_bytes()), Some(log.clone())).0;
+        assert!(document_directory.lookup("alice").await.is_err());
+
+        let mut altered_log = log;
+        let last = altered_log.len() - 1;
+        altered_log[last] ^= 1;
+        let log_directory = mounted_directory_with_files(None, Some(altered_log)).0;
+        assert!(log_directory.lookup("alice").await.is_err());
     }
 
     #[test]

--- a/crates/hyprstream-pds-service/src/account_http.rs
+++ b/crates/hyprstream-pds-service/src/account_http.rs
@@ -493,8 +493,12 @@ fn equivalent_authorities(left: &str, right: &str, zone: &str) -> bool {
     let Ok(right_authority) = right.parse::<Authority>() else {
         return false;
     };
-    left_authority.port().map(|port| port.as_str().to_owned())
-        == right_authority.port().map(|port| port.as_str().to_owned())
+    let effective_port = |authority: &Authority| {
+        authority
+            .port()
+            .map_or(Some(443), |port| port.as_str().parse::<u16>().ok())
+    };
+    effective_port(&left_authority) == effective_port(&right_authority)
 }
 
 #[cfg(test)]
@@ -721,6 +725,20 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(response.status(), StatusCode::OK);
+    }
+
+    #[test]
+    fn equivalent_authorities_accept_implicit_https_port() {
+        assert!(equivalent_authorities(
+            "alice.tormentnexus.social",
+            "alice.tormentnexus.social:443",
+            "tormentnexus.social",
+        ));
+        assert!(!equivalent_authorities(
+            "alice.tormentnexus.social",
+            "alice.tormentnexus.social:8443",
+            "tormentnexus.social",
+        ));
     }
 
     #[tokio::test]

--- a/crates/hyprstream-pds-service/src/account_http.rs
+++ b/crates/hyprstream-pds-service/src/account_http.rs
@@ -264,6 +264,11 @@ impl HostedAccountHttpDirectory for MountedHostedAccountHttpDirectory {
             parsed.did() == did && parsed.cid() == record.doc_cid(),
             "served DID document does not match host or account record"
         );
+        ensure!(
+            parsed.atproto_verifying_key()?.to_encoded_point(true)
+                == record.atproto_verifying_key()?.to_encoded_point(true),
+            "served DID document #atproto key does not match account record"
+        );
         let log = self
             .store
             .read_hosted_http_artifact(
@@ -963,6 +968,45 @@ mod tests {
             .await
             .unwrap();
         assert!(log_directory.lookup("alice").await.is_err());
+    }
+
+    #[tokio::test]
+    async fn mounted_directory_rejects_document_key_rebound_from_account_record() {
+        let (_original, document, log, record) = mounted_directory();
+        let replacement = p256::ecdsa::SigningKey::random(&mut OsRng)
+            .verifying_key()
+            .to_encoded_point(true)
+            .as_bytes()
+            .to_vec();
+        let mut record_value = DagCbor::decode(&record).unwrap();
+        let fields = match &mut record_value {
+            DagCbor::Map(fields) => fields,
+            other => panic!("account record must be a map, got {other:?}"),
+        };
+        let mut replaced = false;
+        for (key, value) in fields {
+            if matches!(key, DagCbor::Text(name) if name == "atproto_key") {
+                *value = DagCbor::Bytes(replacement.clone());
+                replaced = true;
+            }
+        }
+        assert!(replaced, "account record must contain atproto_key");
+        let rebound = mounted_directory_with_files(
+            Some(record_value.encode()),
+            Some(document),
+            Some(log),
+        )
+        .0;
+        rebound
+            .store
+            .refresh_hosted_did_index(&rebound.authority)
+            .await
+            .unwrap();
+        let error = rebound
+            .lookup("alice")
+            .await
+            .expect_err("document key rebound must be rejected");
+        assert!(error.to_string().contains("#atproto key"));
     }
 
     #[tokio::test]

--- a/crates/hyprstream-pds-service/src/account_http.rs
+++ b/crates/hyprstream-pds-service/src/account_http.rs
@@ -314,6 +314,13 @@ impl HostedAccountHttpDirectory for MountedHostedAccountHttpDirectory {
             genesis.unsigned().doc_cid() == record.doc_cid(),
             "served genesis operation does not match account document"
         );
+        // This immutable layout contains only the sealed genesis envelope,
+        // not a validated update chain. Match the sealed-bundle and hosted
+        // connect-time validators instead of presenting genesis as current.
+        ensure!(
+            record.current_op() == record.genesis_op(),
+            "immutable hosted account record current operation is not genesis"
+        );
         Ok(Some(Arc::new(HostedAccountHttpArtifacts::new(
             label,
             did.clone(),
@@ -1047,6 +1054,48 @@ mod tests {
             .await
             .expect_err("document key rebound must be rejected");
         assert!(error.to_string().contains("#atproto key"));
+    }
+
+    #[tokio::test]
+    async fn mounted_directory_rejects_non_genesis_current_operation_on_every_route() {
+        let (original, document, log, record) = mounted_directory();
+        original.store.refresh_hosted_did_index(&original.authority).await.unwrap();
+        assert!(original.lookup("alice").await.unwrap().is_some());
+
+        // Change only current_op: host, document, key, and sealed genesis
+        // remain valid and mutually consistent, so no other guard can mask
+        // the unsupported current-operation pointer.
+        let mut record_value = DagCbor::decode(&record).unwrap();
+        let fields = match &mut record_value {
+            DagCbor::Map(fields) => fields,
+            other => panic!("account record must be a map, got {other:?}"),
+        };
+        let mut replaced = false;
+        for (key, value) in fields {
+            if matches!(key, DagCbor::Text(name) if name == "current_op") {
+                *value = DagCbor::Link(Cid::from_dag_cbor(b"unvalidated-current-operation"));
+                replaced = true;
+            }
+        }
+        assert!(replaced, "account record must contain current_op");
+        let invalid = mounted_directory_with_files(
+            Some(record_value.encode()), Some(document), Some(log),
+        ).0;
+        invalid.store.refresh_hosted_did_index(&invalid.authority).await.unwrap();
+        let error = invalid.lookup("alice").await.expect_err("current op must be sealed genesis");
+        assert!(error.to_string().contains("current operation is not genesis"));
+        let app = router(DEFAULT_ACCOUNT_ZONE, invalid).unwrap();
+        for path in ["/.well-known/did.json", "/.well-known/atproto-did", "/.well-known/did-log.json"] {
+            let response = app.clone().oneshot(
+                Request::builder()
+                    .uri(path)
+                    .header(header::HOST, "alice.tormentnexus.social")
+                    .body(axum::body::Body::empty())
+                    .unwrap(),
+            ).await.unwrap();
+            assert_eq!(response.status(), StatusCode::SERVICE_UNAVAILABLE);
+            assert!(to_bytes(response.into_body(), 1024).await.unwrap().is_empty());
+        }
     }
 
     #[tokio::test]

--- a/crates/hyprstream-pds-service/src/account_http.rs
+++ b/crates/hyprstream-pds-service/src/account_http.rs
@@ -375,7 +375,9 @@ async fn serve_artifact(
             return StatusCode::BAD_REQUEST.into_response();
         }
         let host = match (uri_authority, host_header) {
-            (Some(authority), Some(host)) if authority != host => {
+            (Some(authority), Some(host))
+                if !equivalent_authorities(authority, host, &state.zone) =>
+            {
                 return StatusCode::BAD_REQUEST.into_response();
             }
             (Some(authority), _) => authority,
@@ -468,6 +470,26 @@ fn host_label(host: &str, zone: &str) -> Option<String> {
         return None;
     }
     AccountLabel::parse(label).ok().map(|_| label.to_owned())
+}
+
+fn equivalent_authorities(left: &str, right: &str, zone: &str) -> bool {
+    let Some(left_label) = host_label(left, zone) else {
+        return false;
+    };
+    let Some(right_label) = host_label(right, zone) else {
+        return false;
+    };
+    if left_label != right_label {
+        return false;
+    }
+    let Ok(left_authority) = left.parse::<Authority>() else {
+        return false;
+    };
+    let Ok(right_authority) = right.parse::<Authority>() else {
+        return false;
+    };
+    left_authority.port().map(|port| port.as_str().to_owned())
+        == right_authority.port().map(|port| port.as_str().to_owned())
 }
 
 #[cfg(test)]
@@ -681,6 +703,22 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn equivalent_http2_authority_and_host_ignore_dns_case() {
+        let app = router("tormentnexus.social", directory()).unwrap();
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .uri("https://alice.tormentnexus.social/.well-known/did.json")
+                    .header(header::HOST, "ALICE.TORMENTNEXUS.SOCIAL")
+                    .body(axum::body::Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+    }
+
+    #[tokio::test]
     async fn authority_only_requests_still_reject_credentials() {
         let app = router("tormentnexus.social", directory()).unwrap();
         for name in [header::AUTHORIZATION, header::COOKIE] {
@@ -869,6 +907,29 @@ mod tests {
                 .as_ref(),
             log
         );
+    }
+
+    #[tokio::test]
+    async fn mounted_directory_unallocated_404_is_not_cached() {
+        let (directory, _document, _log, _record) = mounted_directory();
+        directory
+            .store
+            .refresh_hosted_did_index(&directory.authority)
+            .await
+            .unwrap();
+        let response = router(DEFAULT_ACCOUNT_ZONE, directory)
+            .unwrap()
+            .oneshot(
+                Request::builder()
+                    .uri("/.well-known/did.json")
+                    .header(header::HOST, "bob.tormentnexus.social")
+                    .body(axum::body::Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::NOT_FOUND);
+        assert_eq!(response.headers()[header::CACHE_CONTROL], "no-store");
     }
 
     #[tokio::test]

--- a/crates/hyprstream-pds-service/src/account_http.rs
+++ b/crates/hyprstream-pds-service/src/account_http.rs
@@ -279,6 +279,14 @@ impl HostedAccountHttpDirectory for MountedHostedAccountHttpDirectory {
             genesis.cid()? == record.genesis_op(),
             "served genesis operation does not match account record"
         );
+        ensure!(
+            genesis.unsigned().did() == did,
+            "served genesis operation does not match hosted DID"
+        );
+        ensure!(
+            genesis.unsigned().doc_cid() == record.doc_cid(),
+            "served genesis operation does not match account document"
+        );
         Ok(Some(Arc::new(HostedAccountHttpArtifacts::new(
             label,
             did.clone(),
@@ -466,8 +474,9 @@ mod tests {
         RecoveryKeyEnrollment, UserRotationKey, sign_genesis,
     };
     use hyprstream_pds::{
-        AllocatedAccountName, DID_DOCUMENT_FILE, GENESIS_DID_OP_FILE, HostedAccountMint,
+        AllocatedAccountName, Cid, DID_DOCUMENT_FILE, GENESIS_DID_OP_FILE, HostedAccountMint,
     };
+    use hyprstream_pds::dag_cbor::DagCbor;
     use hyprstream_rpc::Subject;
     use hyprstream_rpc::auth::mac::{MacDecision, SecurityContext};
     use hyprstream_vfs::{SyntheticMount, SyntheticNode};
@@ -504,14 +513,25 @@ mod tests {
         )
     }
 
-    fn mounted_directory() -> (Arc<MountedHostedAccountHttpDirectory>, Vec<u8>, Vec<u8>) {
-        mounted_directory_with_files(None, None)
+    fn mounted_directory() -> (
+        Arc<MountedHostedAccountHttpDirectory>,
+        Vec<u8>,
+        Vec<u8>,
+        Vec<u8>,
+    ) {
+        mounted_directory_with_files(None, None, None)
     }
 
     fn mounted_directory_with_files(
+        record_override: Option<Vec<u8>>,
         document_override: Option<Vec<u8>>,
         log_override: Option<Vec<u8>>,
-    ) -> (Arc<MountedHostedAccountHttpDirectory>, Vec<u8>, Vec<u8>) {
+    ) -> (
+        Arc<MountedHostedAccountHttpDirectory>,
+        Vec<u8>,
+        Vec<u8>,
+        Vec<u8>,
+    ) {
         let ed = SigningKey::generate(&mut OsRng);
         let (pq, pq_vk) = ml_dsa_generate_keypair();
         let hybrid =
@@ -532,8 +552,10 @@ mod tests {
             .unwrap();
         let signature = sign_genesis(pending.unsigned_genesis(), &ed, &pq).unwrap();
         let account = pending.seal(signature).unwrap();
+        let record_bytes = account.record_bytes().to_vec();
         let document_bytes = account.did_document().as_bytes().to_vec();
         let log_bytes = account.genesis_bytes().to_vec();
+        let record_file = record_override.unwrap_or_else(|| record_bytes.clone());
         let document_file = document_override.unwrap_or_else(|| document_bytes.clone());
         let log_file = log_override.unwrap_or_else(|| log_bytes.clone());
         let root = SyntheticNode::dir().with_child(
@@ -545,7 +567,7 @@ mod tests {
                     SyntheticNode::dir()
                         .with_child(
                             PDS_ACCOUNT_RECORD_FILE,
-                            SyntheticNode::file(account.record_bytes().to_vec()),
+                            SyntheticNode::file(record_file),
                         )
                         .with_child(DID_DOCUMENT_FILE, SyntheticNode::file(document_file))
                         .with_child(GENESIS_DID_OP_FILE, SyntheticNode::file(log_file)),
@@ -564,7 +586,30 @@ mod tests {
             )
             .unwrap(),
         );
-        (directory, document_bytes, log_bytes)
+        (directory, document_bytes, log_bytes, record_bytes)
+    }
+
+    fn alternate_genesis_same_did() -> Vec<u8> {
+        let ed = SigningKey::generate(&mut OsRng);
+        let (pq, pq_vk) = ml_dsa_generate_keypair();
+        let hybrid =
+            HybridRotationKey::new(ed.verifying_key().to_bytes(), ml_dsa_vk_bytes(&pq_vk)).unwrap();
+        let rotations = GenesisRotationKeys::new(
+            UserRotationKey::new(hybrid),
+            RecoveryKeyEnrollment::Declined,
+            HostKeyEnrollment::Absent,
+        )
+        .unwrap();
+        let name =
+            AllocatedAccountName::new("alice", "did:web:alice.tormentnexus.social".to_owned())
+                .unwrap();
+        let mint = HostedAccountMint::begin(name, rotations).unwrap();
+        let document = mint.seal_did_document("https://alternate.example.com").unwrap();
+        let pending = mint
+            .prepare_genesis(document, GenesisRepoHead::EmptyRepo)
+            .unwrap();
+        let signature = sign_genesis(pending.unsigned_genesis(), &ed, &pq).unwrap();
+        pending.seal(signature).unwrap().genesis_bytes().to_vec()
     }
 
     #[tokio::test]
@@ -738,7 +783,7 @@ mod tests {
 
     #[tokio::test]
     async fn mounted_directory_reads_only_authorized_sealed_files() {
-        let (directory, document, log) = mounted_directory();
+        let (directory, document, log, _record) = mounted_directory();
         directory
             .store
             .refresh_hosted_did_index(&directory.authority)
@@ -786,14 +831,18 @@ mod tests {
 
     #[tokio::test]
     async fn mounted_directory_rejects_artifacts_rebound_from_account_record() {
-        let (_directory, document, log) = mounted_directory();
+        let (_directory, document, log, _record) = mounted_directory();
 
         let mut altered_document = String::from_utf8(document).unwrap();
         assert!(altered_document.contains("https://pds.example.com"));
         altered_document =
             altered_document.replace("https://pds.example.com", "https://other.example.com");
-        let document_directory =
-            mounted_directory_with_files(Some(altered_document.into_bytes()), Some(log.clone())).0;
+        let document_directory = mounted_directory_with_files(
+            None,
+            Some(altered_document.into_bytes()),
+            Some(log.clone()),
+        )
+        .0;
         document_directory
             .store
             .refresh_hosted_did_index(&document_directory.authority)
@@ -804,13 +853,50 @@ mod tests {
         let mut altered_log = log;
         let last = altered_log.len() - 1;
         altered_log[last] ^= 1;
-        let log_directory = mounted_directory_with_files(None, Some(altered_log)).0;
+        let log_directory = mounted_directory_with_files(None, None, Some(altered_log)).0;
         log_directory
             .store
             .refresh_hosted_did_index(&log_directory.authority)
             .await
             .unwrap();
         assert!(log_directory.lookup("alice").await.is_err());
+    }
+
+    #[tokio::test]
+    async fn mounted_directory_rejects_genesis_rebound_from_document() {
+        let (_original, document, _log, record) = mounted_directory();
+        let alternate_log = alternate_genesis_same_did();
+        let alternate_cid = Cid::from_dag_cbor(&alternate_log);
+        let mut record_value = DagCbor::decode(&record).unwrap();
+        let fields = match &mut record_value {
+            DagCbor::Map(fields) => fields,
+            other => panic!("account record must be a map, got {other:?}"),
+        };
+        let mut replaced = false;
+        for (key, value) in fields {
+            if matches!(key, DagCbor::Text(name) if name == "genesis_op") {
+                *value = DagCbor::Link(alternate_cid);
+                replaced = true;
+            }
+        }
+        assert!(replaced, "account record must contain genesis_op");
+        let rebound_record = record_value.encode();
+        let rebound = mounted_directory_with_files(
+            Some(rebound_record),
+            Some(document),
+            Some(alternate_log),
+        )
+        .0;
+        rebound
+            .store
+            .refresh_hosted_did_index(&rebound.authority)
+            .await
+            .unwrap();
+        let error = rebound
+            .lookup("alice")
+            .await
+            .expect_err("genesis for another document must be rejected");
+        assert!(error.to_string().contains("account document"));
     }
 
     #[test]

--- a/crates/hyprstream-pds-service/src/hosted_account_mint.rs
+++ b/crates/hyprstream-pds-service/src/hosted_account_mint.rs
@@ -567,6 +567,10 @@ mod tests {
         );
         let store =
             AccountRecordStore::new(Arc::new(SyntheticMount::new(root)), Arc::new(PermitReads));
+        store
+            .refresh_hosted_did_index(&Subject::new(crate::OAUTH_ACCOUNT_RESOLVER_SUBJECT))
+            .await
+            .unwrap();
 
         assert_eq!(
             store

--- a/crates/hyprstream-pds-service/src/lib.rs
+++ b/crates/hyprstream-pds-service/src/lib.rs
@@ -136,6 +136,7 @@ pub struct AccountRecordStore {
     hosted_did_index: Arc<tokio::sync::RwLock<Option<HostedDidIndex>>>,
     hosted_did_index_refresh: Arc<tokio::sync::Mutex<()>>,
     hosted_did_index_refreshing: Arc<AtomicBool>,
+    hosted_did_index_refreshed: Arc<tokio::sync::Notify>,
     hosted_did_index_last_attempt: Arc<parking_lot::Mutex<Option<Instant>>>,
 }
 
@@ -147,6 +148,7 @@ struct HostedDidIndex {
 const HOSTED_DID_INDEX_TTL: Duration = Duration::from_secs(5);
 const HOSTED_DID_MAX_STALE: Duration = Duration::from_secs(30);
 const HOSTED_DID_REFRESH_RETRY_COOLDOWN: Duration = Duration::from_secs(1);
+const HOSTED_DID_REFRESH_WAIT: Duration = Duration::from_secs(1);
 const HOSTED_DID_NEGATIVE_TTL: Duration = HOSTED_DID_INDEX_TTL;
 
 impl AccountRecordStore {
@@ -163,6 +165,7 @@ impl AccountRecordStore {
             hosted_did_index: Arc::new(tokio::sync::RwLock::new(None)),
             hosted_did_index_refresh: Arc::new(tokio::sync::Mutex::new(())),
             hosted_did_index_refreshing: Arc::new(AtomicBool::new(false)),
+            hosted_did_index_refreshed: Arc::new(tokio::sync::Notify::new()),
             hosted_did_index_last_attempt: Arc::new(parking_lot::Mutex::new(None)),
         }
     }
@@ -215,7 +218,22 @@ impl AccountRecordStore {
             return Ok(None);
         };
 
-        let index = self.hosted_did_index.read().await;
+        let mut index = self.hosted_did_index.read().await;
+        if index.as_ref().is_some_and(|snapshot| {
+            snapshot.built_at.elapsed() >= HOSTED_DID_INDEX_TTL + HOSTED_DID_MAX_STALE
+        }) {
+            // The first request after an idle period may wait for the shared
+            // isolated refresher, but must never scan tenants itself or serve
+            // an expired binding. Subscribe before releasing the read lock so
+            // a concurrent refresh cannot publish unnoticed.
+            let refreshed = self.hosted_did_index_refreshed.notified();
+            tokio::pin!(refreshed);
+            refreshed.as_mut().enable();
+            drop(index);
+            self.schedule_hosted_did_index_refresh(authority.clone());
+            let _ = tokio::time::timeout(HOSTED_DID_REFRESH_WAIT, refreshed).await;
+            index = self.hosted_did_index.read().await;
+        }
         let Some(snapshot) = index.as_ref() else {
             // A request must never become the tenant enumerator. Startup
             // refresh runs independently; callers retry after the index is
@@ -246,7 +264,7 @@ impl AccountRecordStore {
         }
     }
 
-    /// Start a bounded refresh without making the caller perform tenant
+    /// Start a single-flight refresh without making the caller perform tenant
     /// enumeration. A stale snapshot remains available for O(1) lookups while
     /// one background task refreshes it; the refresh lock prevents duplicate
     /// scans. Before the first snapshot, lookups return
@@ -283,6 +301,7 @@ impl AccountRecordStore {
                     store
                         .hosted_did_index_refreshing
                         .store(false, Ordering::Release);
+                    store.hosted_did_index_refreshed.notify_waiters();
                     return;
                 }
             };
@@ -293,11 +312,13 @@ impl AccountRecordStore {
             store
                 .hosted_did_index_refreshing
                 .store(false, Ordering::Release);
+            store.hosted_did_index_refreshed.notify_waiters();
             })
             .is_err()
         {
             self.hosted_did_index_refreshing
                 .store(false, Ordering::Release);
+            self.hosted_did_index_refreshed.notify_waiters();
         }
     }
 
@@ -1091,8 +1112,18 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn hosted_did_positive_binding_has_a_hard_stale_deadline() {
+    async fn hosted_did_idle_lookup_waits_for_fresh_binding() {
         let store = store();
+        seed_expired_hosted_did_binding(&store).await;
+        let tenant = store
+            .resolve_tenant_for_hosted_did(&oauth_authority(), "did:web:alice.acme.example")
+            .await
+            .expect("first lookup after idle must recover within its refresh budget");
+        assert_eq!(tenant.as_deref(), Some("acme"));
+        assert!(store.hosted_did_index_ready().await);
+    }
+
+    async fn seed_expired_hosted_did_binding(store: &AccountRecordStore) {
         store
             .hosted_did_index
             .write()
@@ -1100,15 +1131,106 @@ mod tests {
             .replace(HostedDidIndex {
                 entries: BTreeMap::from([(
                     ("alice".to_owned(), "did:web:alice.acme.example".to_owned()),
-                    Some("acme".to_owned()),
+                    Some("obsolete-tenant".to_owned()),
                 )]),
                 built_at: Instant::now() - HOSTED_DID_INDEX_TTL - HOSTED_DID_MAX_STALE,
             });
+    }
+
+    #[tokio::test]
+    async fn hosted_did_positive_binding_has_a_hard_stale_deadline() {
+        let root = SyntheticNode::dir().with_child(
+            "acme",
+            tenant_node("alice", b"corrupt account record".to_vec()),
+        );
+        let store =
+            AccountRecordStore::new(Arc::new(SyntheticMount::new(root)), permit_account_reads());
+        seed_expired_hosted_did_binding(&store).await;
         let error = store
             .resolve_tenant_for_hosted_did(&oauth_authority(), "did:web:alice.acme.example")
             .await
             .unwrap_err();
         assert!(matches!(error, AccountReadError::HostedDidIndexNotReady));
+        assert!(!store.hosted_did_index_ready().await);
+        assert!(!store.hosted_did_index_refreshing.load(Ordering::Acquire));
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn hosted_did_idle_wait_is_bounded_coalesced_and_off_request_executor() {
+        struct BlockRootRead {
+            release: parking_lot::Mutex<std::sync::mpsc::Receiver<()>>,
+            scans: std::sync::atomic::AtomicUsize,
+            request_thread: std::thread::ThreadId,
+        }
+        impl AccountRecordReadAuthorizer for BlockRootRead {
+            fn check_read(
+                &self,
+                _subject: &Subject,
+                _verified_tenant: Option<&str>,
+                _security_context: Option<&SecurityContext>,
+                object_id: &str,
+            ) -> MacDecision {
+                if object_id == PDS_NAMESPACE {
+                    assert_ne!(std::thread::current().id(), self.request_thread);
+                    self.scans.fetch_add(1, Ordering::AcqRel);
+                    self.release
+                        .lock()
+                        .recv_timeout(Duration::from_secs(5))
+                        .unwrap();
+                }
+                MacDecision::Permit
+            }
+        }
+        let (release, blocked) = std::sync::mpsc::channel();
+        let authorizer = Arc::new(BlockRootRead {
+            release: parking_lot::Mutex::new(blocked),
+            scans: std::sync::atomic::AtomicUsize::new(0),
+            request_thread: std::thread::current().id(),
+        });
+        let mut store = store();
+        store.read_authorizer = authorizer.clone();
+        seed_expired_hosted_did_binding(&store).await;
+        let authority = oauth_authority();
+        let started = Instant::now();
+        let (first, second, heartbeat) = tokio::join!(
+            store.resolve_tenant_for_hosted_did(&authority, "did:web:alice.acme.example"),
+            store.resolve_tenant_for_hosted_did(&authority, "did:web:alice.acme.example"),
+            async {
+                tokio::time::sleep(Duration::from_millis(10)).await;
+                started.elapsed()
+            },
+        );
+        let elapsed = started.elapsed();
+        // Another timed-out caller must share the existing worker as well.
+        let third = store
+            .resolve_tenant_for_hosted_did(&authority, "did:web:alice.acme.example")
+            .await;
+        let refreshed = store.hosted_did_index_refreshed.notified();
+        tokio::pin!(refreshed);
+        refreshed.as_mut().enable();
+        release.send(()).unwrap();
+        tokio::time::timeout(Duration::from_secs(2), refreshed)
+            .await
+            .expect("released refresh must finish");
+
+        for result in [first, second, third] {
+            assert!(matches!(
+                result,
+                Err(AccountReadError::HostedDidIndexNotReady)
+            ));
+        }
+        assert!(elapsed >= HOSTED_DID_REFRESH_WAIT);
+        assert!(elapsed < HOSTED_DID_REFRESH_WAIT + Duration::from_millis(500));
+        assert!(heartbeat < Duration::from_millis(500));
+        assert_eq!(authorizer.scans.load(Ordering::Acquire), 1);
+        assert_eq!(
+            store
+                .resolve_tenant_for_hosted_did(&authority, "did:web:alice.acme.example")
+                .await
+                .unwrap()
+                .as_deref(),
+            Some("acme")
+        );
     }
 
     #[tokio::test]

--- a/crates/hyprstream-pds-service/src/lib.rs
+++ b/crates/hyprstream-pds-service/src/lib.rs
@@ -252,9 +252,6 @@ impl AccountRecordStore {
     /// scans. Before the first snapshot, lookups return
     /// [`AccountReadError::HostedDidIndexNotReady`] while this task warms it.
     pub fn schedule_hosted_did_index_refresh(&self, authority: Subject) {
-        let Ok(handle) = tokio::runtime::Handle::try_current() else {
-            return;
-        };
         if self
             .hosted_did_index_refreshing
             .compare_exchange(false, true, Ordering::AcqRel, Ordering::Acquire)
@@ -274,7 +271,9 @@ impl AccountRecordStore {
             *last_attempt = Some(Instant::now());
         }
         let store = self.clone();
-        handle.spawn_blocking(move || {
+        let _ = std::thread::Builder::new()
+            .name("hyprstream-pds-index-refresh".to_owned())
+            .spawn(move || {
             let runtime = match tokio::runtime::Builder::new_current_thread()
                 .enable_all()
                 .build()
@@ -294,7 +293,7 @@ impl AccountRecordStore {
             store
                 .hosted_did_index_refreshing
                 .store(false, Ordering::Release);
-        });
+            });
     }
 
     pub async fn refresh_hosted_did_index(

--- a/crates/hyprstream-pds-service/src/lib.rs
+++ b/crates/hyprstream-pds-service/src/lib.rs
@@ -13,10 +13,14 @@
 pub mod account_http;
 pub mod federation_intake;
 
-use std::sync::Arc;
+use std::{
+    collections::BTreeMap,
+    sync::Arc,
+    time::{Duration, Instant},
+};
 
 use hyprstream_pds::{
-    AccountRecord, ATPROTO_SIGNING_KEY_FILE, DID_DOCUMENT_FILE, GENESIS_DID_OP_FILE,
+    ATPROTO_SIGNING_KEY_FILE, AccountLabel, AccountRecord, DID_DOCUMENT_FILE, GENESIS_DID_OP_FILE,
 };
 use hyprstream_rpc::auth::mac::{MacDecision, MacDenyReason, SecurityContext};
 use hyprstream_rpc::{EnvelopeContext, Subject};
@@ -66,6 +70,8 @@ pub enum AccountReadError {
     InvalidHostedAccountDid(String),
     #[error("hosted account DID {0:?} is bound to more than one tenant")]
     AmbiguousHostedAccountDid(String),
+    #[error("hosted account DID index is still warming")]
+    HostedDidIndexNotReady,
     #[error("PDS account record exceeds the {limit}-byte read limit")]
     RecordTooLarge { limit: usize },
     #[error("PDS account record for {requested:?} contains label {stored:?}")]
@@ -124,7 +130,17 @@ pub struct AccountRecordStore {
     pds_mount: Arc<dyn Mount>,
     read_authorizer: Arc<dyn AccountRecordReadAuthorizer>,
     max_record_bytes: usize,
+    hosted_did_index: Arc<tokio::sync::RwLock<Option<HostedDidIndex>>>,
+    hosted_did_index_refresh: Arc<tokio::sync::Mutex<()>>,
 }
+
+struct HostedDidIndex {
+    entries: BTreeMap<(String, String), Option<String>>,
+    built_at: Instant,
+}
+
+const HOSTED_DID_INDEX_TTL: Duration = Duration::from_secs(5);
+const HOSTED_DID_NEGATIVE_TTL: Duration = Duration::from_secs(1);
 
 impl AccountRecordStore {
     /// Construct a store over the mount bound at `/pds` and a mandatory MAC
@@ -137,6 +153,8 @@ impl AccountRecordStore {
             pds_mount,
             read_authorizer,
             max_record_bytes: DEFAULT_MAX_RECORD_BYTES,
+            hosted_did_index: Arc::new(tokio::sync::RwLock::new(None)),
+            hosted_did_index_refresh: Arc::new(tokio::sync::Mutex::new(())),
         }
     }
 
@@ -188,6 +206,71 @@ impl AccountRecordStore {
             return Ok(None);
         };
 
+        let index = self.hosted_did_index.read().await;
+        let Some(snapshot) = index.as_ref() else {
+            // A request must never become the tenant enumerator. Startup
+            // refresh runs independently; callers retry after the index is
+            // ready instead of amplifying a full mount scan per miss.
+            self.schedule_hosted_did_index_refresh(authority.clone());
+            return Err(AccountReadError::HostedDidIndexNotReady);
+        };
+        let age = snapshot.built_at.elapsed();
+        if age >= HOSTED_DID_INDEX_TTL {
+            self.schedule_hosted_did_index_refresh(authority.clone());
+        }
+        let key = (label.to_owned(), did.to_owned());
+        match snapshot.entries.get(&key) {
+            Some(Some(tenant)) => Ok(Some(tenant.clone())),
+            Some(None) => Err(AccountReadError::AmbiguousHostedAccountDid(did.to_owned())),
+            None if age < HOSTED_DID_NEGATIVE_TTL => Ok(None),
+            None => {
+                // Negative entries expire independently of the positive
+                // snapshot, so a newly published account is not hidden
+                // forever while refresh remains asynchronous.
+                self.schedule_hosted_did_index_refresh(authority.clone());
+                Err(AccountReadError::HostedDidIndexNotReady)
+            }
+        }
+    }
+
+    /// Start a bounded refresh without making the caller perform tenant
+    /// enumeration. A stale snapshot remains available for O(1) lookups while
+    /// one background task refreshes it; the refresh lock prevents duplicate
+    /// scans. Before the first snapshot, lookups return
+    /// [`AccountReadError::HostedDidIndexNotReady`] while this task warms it.
+    pub fn schedule_hosted_did_index_refresh(&self, authority: Subject) {
+        let Ok(handle) = tokio::runtime::Handle::try_current() else {
+            return;
+        };
+        let store = self.clone();
+        handle.spawn(async move {
+            let _ = store.refresh_hosted_did_index(&authority).await;
+        });
+    }
+
+    async fn refresh_hosted_did_index(&self, authority: &Subject) -> Result<(), AccountReadError> {
+        let _refresh = self.hosted_did_index_refresh.lock().await;
+        let stale = self
+            .hosted_did_index
+            .read()
+            .await
+            .as_ref()
+            .map(|snapshot| snapshot.built_at.elapsed() >= HOSTED_DID_INDEX_TTL)
+            .unwrap_or(true);
+        if stale {
+            let entries = self.build_hosted_did_index(authority).await?;
+            self.hosted_did_index.write().await.replace(HostedDidIndex {
+                entries,
+                built_at: Instant::now(),
+            });
+        }
+        Ok(())
+    }
+
+    async fn build_hosted_did_index(
+        &self,
+        authority: &Subject,
+    ) -> Result<BTreeMap<(String, String), Option<String>>, AccountReadError> {
         let tenants = read_directory(
             self.pds_mount.as_ref(),
             self.read_authorizer.as_ref(),
@@ -197,23 +280,17 @@ impl AccountRecordStore {
             None,
         )
         .await?;
-        let mut resolved = None;
+        let mut index = BTreeMap::new();
         for entry in tenants.into_iter().filter(|entry| entry.is_dir) {
             validate_tenant_component(&entry.name)?;
-            let components = [
-                entry.name.as_str(),
-                PDS_ACCOUNTS_DIRECTORY,
-                label,
-                PDS_ACCOUNT_RECORD_FILE,
-            ];
-            let bytes = match read_file(
+            let accounts_components = [entry.name.as_str(), PDS_ACCOUNTS_DIRECTORY];
+            let accounts = match read_directory(
                 self.pds_mount.as_ref(),
                 self.read_authorizer.as_ref(),
-                &components,
+                &accounts_components,
                 authority,
                 Some(entry.name.as_str()),
                 None,
-                self.max_record_bytes,
             )
             .await
             {
@@ -221,23 +298,51 @@ impl AccountRecordStore {
                 Err(AccountReadError::Mount(MountError::NotFound(_))) => continue,
                 Err(error) => return Err(error),
             };
-            let record =
-                AccountRecord::from_dag_cbor(&bytes).map_err(AccountReadError::InvalidRecord)?;
-            if record.name().label() != label {
-                return Err(AccountReadError::RecordLabelMismatch {
-                    requested: label.to_owned(),
-                    stored: record.name().label().to_owned(),
-                });
+            for account in accounts.into_iter().filter(|account| account.is_dir) {
+                let label = account.name;
+                AccountLabel::parse(&label)
+                    .map_err(|_| AccountReadError::InvalidAccountLabel(label.clone()))?;
+                let components = [
+                    entry.name.as_str(),
+                    PDS_ACCOUNTS_DIRECTORY,
+                    label.as_str(),
+                    PDS_ACCOUNT_RECORD_FILE,
+                ];
+                let bytes = match read_file(
+                    self.pds_mount.as_ref(),
+                    self.read_authorizer.as_ref(),
+                    &components,
+                    authority,
+                    Some(entry.name.as_str()),
+                    None,
+                    self.max_record_bytes,
+                )
+                .await
+                {
+                    Ok(bytes) => bytes,
+                    Err(AccountReadError::Mount(MountError::NotFound(_))) => continue,
+                    Err(error) => return Err(error),
+                };
+                let record = AccountRecord::from_dag_cbor(&bytes)
+                    .map_err(AccountReadError::InvalidRecord)?;
+                if record.name().label() != label {
+                    return Err(AccountReadError::RecordLabelMismatch {
+                        requested: label,
+                        stored: record.name().label().to_owned(),
+                    });
+                }
+                let key = (label, record.name().did().to_owned());
+                match index.entry(key) {
+                    std::collections::btree_map::Entry::Vacant(slot) => {
+                        slot.insert(Some(entry.name.clone()));
+                    }
+                    std::collections::btree_map::Entry::Occupied(mut slot) => {
+                        slot.insert(None);
+                    }
+                }
             }
-            if record.name().did() != did {
-                continue;
-            }
-            if resolved.is_some() {
-                return Err(AccountReadError::AmbiguousHostedAccountDid(did.to_owned()));
-            }
-            resolved = Some(entry.name);
         }
-        Ok(resolved)
+        Ok(index)
     }
 
     /// Sign bytes with the account-specific `#atproto` key for one hosted DID.
@@ -256,7 +361,17 @@ impl AccountRecordStore {
     ) -> Result<Option<Vec<u8>>, AccountReadError> {
         use p256::ecdsa::signature::Signer as _;
 
-        let Some(tenant) = self.resolve_tenant_for_hosted_did(authority, did).await? else {
+        let resolved = match self.resolve_tenant_for_hosted_did(authority, did).await {
+            Err(AccountReadError::HostedDidIndexNotReady) => {
+                // Internal signing is already an authorized operation; warm
+                // its index explicitly, while the public HTTP lookup remains
+                // strictly non-blocking.
+                self.refresh_hosted_did_index(authority).await?;
+                self.resolve_tenant_for_hosted_did(authority, did).await
+            }
+            result => result,
+        }?;
+        let Some(tenant) = resolved else {
             return Ok(None);
         };
         let Some(label) = hosted_account_label(did)? else {
@@ -587,8 +702,8 @@ mod tests {
     use ed25519_dalek::SigningKey;
     use hyprstream_crypto::pq::{ml_dsa_generate_keypair, ml_dsa_vk_bytes};
     use hyprstream_pds::did_op::{
-        sign_genesis, GenesisRepoHead, GenesisRotationKeys, HostKeyEnrollment, HybridRotationKey,
-        RecoveryKeyEnrollment, UserRotationKey,
+        GenesisRepoHead, GenesisRotationKeys, HostKeyEnrollment, HybridRotationKey,
+        RecoveryKeyEnrollment, UserRotationKey, sign_genesis,
     };
     use hyprstream_pds::{AllocatedAccountName, HostedAccountMint};
     use hyprstream_rpc::Subject;
@@ -709,6 +824,10 @@ mod tests {
     #[tokio::test]
     async fn oauth_authority_resolves_tenant_from_matching_account_record() {
         let store = store();
+        store
+            .refresh_hosted_did_index(&oauth_authority())
+            .await
+            .unwrap();
 
         assert_eq!(
             store
@@ -759,15 +878,48 @@ mod tests {
         let root = SyntheticNode::dir()
             .with_child("acme", tenant_node("alice", duplicated.clone()))
             .with_child("beta", tenant_node("alice", duplicated));
-        let ambiguous =
-            AccountRecordStore::new(Arc::new(SyntheticMount::new(root)), permit_account_reads())
-                .resolve_tenant_for_hosted_did(&oauth_authority(), "did:web:alice.acme.example")
-                .await
-                .unwrap_err();
+        let ambiguous_store =
+            AccountRecordStore::new(Arc::new(SyntheticMount::new(root)), permit_account_reads());
+        ambiguous_store
+            .refresh_hosted_did_index(&oauth_authority())
+            .await
+            .unwrap();
+        let ambiguous = ambiguous_store
+            .resolve_tenant_for_hosted_did(&oauth_authority(), "did:web:alice.acme.example")
+            .await
+            .unwrap_err();
         assert!(matches!(
             ambiguous,
             AccountReadError::AmbiguousHostedAccountDid(_)
         ));
+    }
+
+    #[tokio::test]
+    async fn cold_hosted_did_lookup_never_enumerates_on_request_path() {
+        let store = store();
+        let error = store
+            .resolve_tenant_for_hosted_did(&oauth_authority(), "did:web:alice.acme.example")
+            .await
+            .unwrap_err();
+        assert!(matches!(error, AccountReadError::HostedDidIndexNotReady));
+    }
+
+    #[tokio::test]
+    async fn hosted_did_negative_lookup_expires() {
+        let store = store();
+        store
+            .hosted_did_index
+            .write()
+            .await
+            .replace(HostedDidIndex {
+                entries: BTreeMap::new(),
+                built_at: Instant::now() - HOSTED_DID_NEGATIVE_TTL - Duration::from_millis(1),
+            });
+        let error = store
+            .resolve_tenant_for_hosted_did(&oauth_authority(), "did:web:new.acme.example")
+            .await
+            .unwrap_err();
+        assert!(matches!(error, AccountReadError::HostedDidIndexNotReady));
     }
 
     #[tokio::test]

--- a/crates/hyprstream-pds-service/src/lib.rs
+++ b/crates/hyprstream-pds-service/src/lib.rs
@@ -301,6 +301,14 @@ impl AccountRecordStore {
         }
     }
 
+    /// Check an already-published snapshot without starting filesystem work.
+    /// In-process consumers must warm their injected store before startup.
+    pub async fn hosted_did_index_ready(&self) -> bool {
+        self.hosted_did_index.read().await.as_ref().is_some_and(|snapshot| {
+            snapshot.built_at.elapsed() < HOSTED_DID_INDEX_TTL + HOSTED_DID_MAX_STALE
+        })
+    }
+
     pub async fn refresh_hosted_did_index(
         &self,
         authority: &Subject,

--- a/crates/hyprstream-pds-service/src/lib.rs
+++ b/crates/hyprstream-pds-service/src/lib.rs
@@ -352,8 +352,14 @@ impl AccountRecordStore {
             };
             for account in accounts.into_iter().filter(|account| account.is_dir) {
                 let label = account.name;
-                AccountLabel::parse(&label)
-                    .map_err(|_| AccountReadError::InvalidAccountLabel(label.clone()))?;
+                // A failed mint can leave its private staging directory in
+                // the published `accounts` directory.  Staging names (and
+                // any other non-canonical directory entries) are not account
+                // labels and must never abort the whole index refresh; only
+                // canonical labels below are authoritative account records.
+                if AccountLabel::parse(&label).is_err() {
+                    continue;
+                }
                 let components = [
                     entry.name.as_str(),
                     PDS_ACCOUNTS_DIRECTORY,
@@ -930,6 +936,38 @@ mod tests {
                 .await
                 .unwrap(),
             None,
+        );
+    }
+
+    #[tokio::test]
+    async fn hosted_did_index_ignores_mint_staging_directories() {
+        let record = account_bytes("alice", "acme.example");
+        let accounts = SyntheticNode::dir()
+            .with_child("alice", SyntheticNode::dir().with_child(
+                PDS_ACCOUNT_RECORD_FILE,
+                SyntheticNode::file(record),
+            ))
+            .with_child(".alice.mint-123-0", SyntheticNode::dir());
+        let root = SyntheticNode::dir().with_child(
+            "acme",
+            SyntheticNode::dir().with_child(PDS_ACCOUNTS_DIRECTORY, accounts),
+        );
+        let store = AccountRecordStore::new(
+            Arc::new(SyntheticMount::new(root)),
+            permit_account_reads(),
+        );
+
+        store
+            .refresh_hosted_did_index(&oauth_authority())
+            .await
+            .expect("staging residue must not abort index refresh");
+        assert_eq!(
+            store
+                .resolve_tenant_for_hosted_did(&oauth_authority(), "did:web:alice.acme.example")
+                .await
+                .unwrap()
+                .as_deref(),
+            Some("acme")
         );
     }
 

--- a/crates/hyprstream-pds-service/src/lib.rs
+++ b/crates/hyprstream-pds-service/src/lib.rs
@@ -1115,6 +1115,10 @@ mod tests {
         );
         let store =
             AccountRecordStore::new(Arc::new(SyntheticMount::new(root)), permit_account_reads());
+        store
+            .refresh_hosted_did_index(&oauth_authority())
+            .await
+            .expect("startup warm-up must complete before signing");
         let input = b"header.payload";
         let signature = store
             .sign_for_hosted_did(&oauth_authority(), did, input)
@@ -1138,7 +1142,12 @@ mod tests {
         let missing = AccountRecordStore::new(
             Arc::new(SyntheticMount::new(missing_root)),
             permit_account_reads(),
-        )
+        );
+        missing
+            .refresh_hosted_did_index(&oauth_authority())
+            .await
+            .expect("startup warm-up must complete before signing");
+        let missing = missing
         .sign_for_hosted_did(&oauth_authority(), did, input)
         .await
         .unwrap_err();
@@ -1153,7 +1162,12 @@ mod tests {
         let mismatch = AccountRecordStore::new(
             Arc::new(SyntheticMount::new(mismatch_root)),
             permit_account_reads(),
-        )
+        );
+        mismatch
+            .refresh_hosted_did_index(&oauth_authority())
+            .await
+            .expect("startup warm-up must complete before signing");
+        let mismatch = mismatch
         .sign_for_hosted_did(&oauth_authority(), did, input)
         .await
         .unwrap_err();

--- a/crates/hyprstream-pds-service/src/lib.rs
+++ b/crates/hyprstream-pds-service/src/lib.rs
@@ -15,7 +15,9 @@ pub mod federation_intake;
 
 use std::sync::Arc;
 
-use hyprstream_pds::{AccountRecord, ATPROTO_SIGNING_KEY_FILE};
+use hyprstream_pds::{
+    AccountRecord, ATPROTO_SIGNING_KEY_FILE, DID_DOCUMENT_FILE, GENESIS_DID_OP_FILE,
+};
 use hyprstream_rpc::auth::mac::{MacDecision, MacDenyReason, SecurityContext};
 use hyprstream_rpc::{EnvelopeContext, Subject};
 use hyprstream_vfs::{Mount, MountError, OREAD};
@@ -29,9 +31,9 @@ pub const PDS_ACCOUNTS_DIRECTORY: &str = "accounts";
 /// Public account-record publication marker.
 pub const PDS_ACCOUNT_RECORD_FILE: &str = "account-record.cbor";
 /// Sealed account DID-document bytes published beside the account record.
-pub const PDS_ACCOUNT_DID_DOCUMENT_FILE: &str = "did.json";
+pub const PDS_ACCOUNT_DID_DOCUMENT_FILE: &str = DID_DOCUMENT_FILE;
 /// Sealed account operation-log bytes published beside the account record.
-pub const PDS_ACCOUNT_DID_LOG_FILE: &str = "did-log.json";
+pub const PDS_ACCOUNT_DID_LOG_FILE: &str = GENESIS_DID_OP_FILE;
 
 pub mod hosted_account_mint;
 

--- a/crates/hyprstream-pds-service/src/lib.rs
+++ b/crates/hyprstream-pds-service/src/lib.rs
@@ -352,14 +352,11 @@ impl AccountRecordStore {
             };
             for account in accounts.into_iter().filter(|account| account.is_dir) {
                 let label = account.name;
-                // A failed mint can leave its private staging directory in
-                // the published `accounts` directory.  Staging names (and
-                // any other non-canonical directory entries) are not account
-                // labels and must never abort the whole index refresh; only
-                // canonical labels below are authoritative account records.
-                if AccountLabel::parse(&label).is_err() {
+                if hyprstream_pds::is_hosted_account_staging_directory(&label) {
                     continue;
                 }
+                AccountLabel::parse(&label)
+                    .map_err(|_| AccountReadError::InvalidAccountLabel(label.clone()))?;
                 let components = [
                     entry.name.as_str(),
                     PDS_ACCOUNTS_DIRECTORY,
@@ -943,19 +940,18 @@ mod tests {
     async fn hosted_did_index_ignores_mint_staging_directories() {
         let record = account_bytes("alice", "acme.example");
         let accounts = SyntheticNode::dir()
-            .with_child("alice", SyntheticNode::dir().with_child(
-                PDS_ACCOUNT_RECORD_FILE,
-                SyntheticNode::file(record),
-            ))
+            .with_child(
+                "alice",
+                SyntheticNode::dir()
+                    .with_child(PDS_ACCOUNT_RECORD_FILE, SyntheticNode::file(record)),
+            )
             .with_child(".alice.mint-123-0", SyntheticNode::dir());
         let root = SyntheticNode::dir().with_child(
             "acme",
             SyntheticNode::dir().with_child(PDS_ACCOUNTS_DIRECTORY, accounts),
         );
-        let store = AccountRecordStore::new(
-            Arc::new(SyntheticMount::new(root)),
-            permit_account_reads(),
-        );
+        let store =
+            AccountRecordStore::new(Arc::new(SyntheticMount::new(root)), permit_account_reads());
 
         store
             .refresh_hosted_did_index(&oauth_authority())
@@ -963,12 +959,36 @@ mod tests {
             .expect("staging residue must not abort index refresh");
         assert_eq!(
             store
-                .resolve_tenant_for_hosted_did(&oauth_authority(), "did:web:alice.acme.example")
+                .resolve_tenant_for_hosted_did(&oauth_authority(), "did:web:alice.acme.example",)
                 .await
                 .unwrap()
                 .as_deref(),
             Some("acme")
         );
+    }
+
+    #[tokio::test]
+    async fn hosted_did_index_rejects_malformed_permanent_account_labels() {
+        for label in [".alice.mint-*", ".garbage", "Alice", "alice_"] {
+            let accounts = SyntheticNode::dir().with_child(label, SyntheticNode::dir());
+            let root = SyntheticNode::dir().with_child(
+                "acme",
+                SyntheticNode::dir().with_child(PDS_ACCOUNTS_DIRECTORY, accounts),
+            );
+            let store = AccountRecordStore::new(
+                Arc::new(SyntheticMount::new(root)),
+                permit_account_reads(),
+            );
+
+            let error = store
+                .refresh_hosted_did_index(&oauth_authority())
+                .await
+                .expect_err("malformed permanent labels must fail closed");
+            assert!(
+                matches!(error, AccountReadError::InvalidAccountLabel(ref actual) if actual == label),
+                "unexpected error for {label:?}: {error:?}"
+            );
+        }
     }
 
     #[tokio::test]

--- a/crates/hyprstream-pds-service/src/lib.rs
+++ b/crates/hyprstream-pds-service/src/lib.rs
@@ -15,12 +15,15 @@ pub mod federation_intake;
 
 use std::{
     collections::BTreeMap,
-    sync::Arc,
+    sync::{
+        atomic::{AtomicBool, Ordering},
+        Arc,
+    },
     time::{Duration, Instant},
 };
 
 use hyprstream_pds::{
-    ATPROTO_SIGNING_KEY_FILE, AccountLabel, AccountRecord, DID_DOCUMENT_FILE, GENESIS_DID_OP_FILE,
+    AccountLabel, AccountRecord, ATPROTO_SIGNING_KEY_FILE, DID_DOCUMENT_FILE, GENESIS_DID_OP_FILE,
 };
 use hyprstream_rpc::auth::mac::{MacDecision, MacDenyReason, SecurityContext};
 use hyprstream_rpc::{EnvelopeContext, Subject};
@@ -132,6 +135,8 @@ pub struct AccountRecordStore {
     max_record_bytes: usize,
     hosted_did_index: Arc<tokio::sync::RwLock<Option<HostedDidIndex>>>,
     hosted_did_index_refresh: Arc<tokio::sync::Mutex<()>>,
+    hosted_did_index_refreshing: Arc<AtomicBool>,
+    hosted_did_index_last_attempt: Arc<parking_lot::Mutex<Option<Instant>>>,
 }
 
 struct HostedDidIndex {
@@ -140,7 +145,9 @@ struct HostedDidIndex {
 }
 
 const HOSTED_DID_INDEX_TTL: Duration = Duration::from_secs(5);
-const HOSTED_DID_NEGATIVE_TTL: Duration = Duration::from_secs(1);
+const HOSTED_DID_MAX_STALE: Duration = Duration::from_secs(30);
+const HOSTED_DID_REFRESH_RETRY_COOLDOWN: Duration = Duration::from_secs(1);
+const HOSTED_DID_NEGATIVE_TTL: Duration = HOSTED_DID_INDEX_TTL;
 
 impl AccountRecordStore {
     /// Construct a store over the mount bound at `/pds` and a mandatory MAC
@@ -155,6 +162,8 @@ impl AccountRecordStore {
             max_record_bytes: DEFAULT_MAX_RECORD_BYTES,
             hosted_did_index: Arc::new(tokio::sync::RwLock::new(None)),
             hosted_did_index_refresh: Arc::new(tokio::sync::Mutex::new(())),
+            hosted_did_index_refreshing: Arc::new(AtomicBool::new(false)),
+            hosted_did_index_last_attempt: Arc::new(parking_lot::Mutex::new(None)),
         }
     }
 
@@ -218,17 +227,21 @@ impl AccountRecordStore {
         if age >= HOSTED_DID_INDEX_TTL {
             self.schedule_hosted_did_index_refresh(authority.clone());
         }
+        if age >= HOSTED_DID_INDEX_TTL + HOSTED_DID_MAX_STALE {
+            return Err(AccountReadError::HostedDidIndexNotReady);
+        }
         let key = (label.to_owned(), did.to_owned());
         match snapshot.entries.get(&key) {
             Some(Some(tenant)) => Ok(Some(tenant.clone())),
             Some(None) => Err(AccountReadError::AmbiguousHostedAccountDid(did.to_owned())),
             None if age < HOSTED_DID_NEGATIVE_TTL => Ok(None),
             None => {
-                // Negative entries expire independently of the positive
-                // snapshot, so a newly published account is not hidden
-                // forever while refresh remains asynchronous.
+                // A negative entry is eligible for refresh at the normal
+                // snapshot interval, but remains a stable 404 while refresh
+                // runs. This avoids turning ordinary missing-account traffic
+                // into repeated transient OAuth/HTTP failures.
                 self.schedule_hosted_did_index_refresh(authority.clone());
-                Err(AccountReadError::HostedDidIndexNotReady)
+                Ok(None)
             }
         }
     }
@@ -242,13 +255,37 @@ impl AccountRecordStore {
         let Ok(handle) = tokio::runtime::Handle::try_current() else {
             return;
         };
+        if self
+            .hosted_did_index_refreshing
+            .compare_exchange(false, true, Ordering::AcqRel, Ordering::Acquire)
+            .is_err()
+        {
+            return;
+        }
+        {
+            let mut last_attempt = self.hosted_did_index_last_attempt.lock();
+            if last_attempt
+                .is_some_and(|attempt| attempt.elapsed() < HOSTED_DID_REFRESH_RETRY_COOLDOWN)
+            {
+                self.hosted_did_index_refreshing
+                    .store(false, Ordering::Release);
+                return;
+            }
+            *last_attempt = Some(Instant::now());
+        }
         let store = self.clone();
         handle.spawn(async move {
             let _ = store.refresh_hosted_did_index(&authority).await;
+            store
+                .hosted_did_index_refreshing
+                .store(false, Ordering::Release);
         });
     }
 
-    async fn refresh_hosted_did_index(&self, authority: &Subject) -> Result<(), AccountReadError> {
+    pub async fn refresh_hosted_did_index(
+        &self,
+        authority: &Subject,
+    ) -> Result<(), AccountReadError> {
         let _refresh = self.hosted_did_index_refresh.lock().await;
         let stale = self
             .hosted_did_index
@@ -702,8 +739,8 @@ mod tests {
     use ed25519_dalek::SigningKey;
     use hyprstream_crypto::pq::{ml_dsa_generate_keypair, ml_dsa_vk_bytes};
     use hyprstream_pds::did_op::{
-        GenesisRepoHead, GenesisRotationKeys, HostKeyEnrollment, HybridRotationKey,
-        RecoveryKeyEnrollment, UserRotationKey, sign_genesis,
+        sign_genesis, GenesisRepoHead, GenesisRotationKeys, HostKeyEnrollment, HybridRotationKey,
+        RecoveryKeyEnrollment, UserRotationKey,
     };
     use hyprstream_pds::{AllocatedAccountName, HostedAccountMint};
     use hyprstream_rpc::Subject;
@@ -915,8 +952,28 @@ mod tests {
                 entries: BTreeMap::new(),
                 built_at: Instant::now() - HOSTED_DID_NEGATIVE_TTL - Duration::from_millis(1),
             });
-        let error = store
+        let result = store
             .resolve_tenant_for_hosted_did(&oauth_authority(), "did:web:new.acme.example")
+            .await;
+        assert_eq!(result.unwrap(), None);
+    }
+
+    #[tokio::test]
+    async fn hosted_did_positive_binding_has_a_hard_stale_deadline() {
+        let store = store();
+        store
+            .hosted_did_index
+            .write()
+            .await
+            .replace(HostedDidIndex {
+                entries: BTreeMap::from([(
+                    ("alice".to_owned(), "did:web:alice.acme.example".to_owned()),
+                    Some("acme".to_owned()),
+                )]),
+                built_at: Instant::now() - HOSTED_DID_INDEX_TTL - HOSTED_DID_MAX_STALE,
+            });
+        let error = store
+            .resolve_tenant_for_hosted_did(&oauth_authority(), "did:web:alice.acme.example")
             .await
             .unwrap_err();
         assert!(matches!(error, AccountReadError::HostedDidIndexNotReady));

--- a/crates/hyprstream-pds-service/src/lib.rs
+++ b/crates/hyprstream-pds-service/src/lib.rs
@@ -28,6 +28,10 @@ pub const PDS_NAMESPACE: &str = "/pds";
 pub const PDS_ACCOUNTS_DIRECTORY: &str = "accounts";
 /// Public account-record publication marker.
 pub const PDS_ACCOUNT_RECORD_FILE: &str = "account-record.cbor";
+/// Sealed account DID-document bytes published beside the account record.
+pub const PDS_ACCOUNT_DID_DOCUMENT_FILE: &str = "did.json";
+/// Sealed account operation-log bytes published beside the account record.
+pub const PDS_ACCOUNT_DID_LOG_FILE: &str = "did-log.json";
 
 pub mod hosted_account_mint;
 
@@ -336,6 +340,31 @@ impl AccountRecordStore {
     fn with_max_record_bytes(mut self, max_record_bytes: usize) -> Self {
         self.max_record_bytes = max_record_bytes;
         self
+    }
+
+    /// Read one immutable public identity artifact after the hosted DID has
+    /// already resolved to its authority-owned tenant.
+    pub(crate) async fn read_hosted_http_artifact(
+        &self,
+        authority: &Subject,
+        tenant: &str,
+        label: &str,
+        file: &str,
+        limit: usize,
+    ) -> Result<Vec<u8>, AccountReadError> {
+        validate_tenant_component(tenant)?;
+        validate_account_label(label)?;
+        let components = [tenant, PDS_ACCOUNTS_DIRECTORY, label, file];
+        read_file(
+            self.pds_mount.as_ref(),
+            self.read_authorizer.as_ref(),
+            &components,
+            authority,
+            Some(tenant),
+            None,
+            limit,
+        )
+        .await
     }
 }
 

--- a/crates/hyprstream-pds-service/src/lib.rs
+++ b/crates/hyprstream-pds-service/src/lib.rs
@@ -274,8 +274,23 @@ impl AccountRecordStore {
             *last_attempt = Some(Instant::now());
         }
         let store = self.clone();
-        handle.spawn(async move {
-            let _ = store.refresh_hosted_did_index(&authority).await;
+        handle.spawn_blocking(move || {
+            let runtime = match tokio::runtime::Builder::new_current_thread()
+                .enable_all()
+                .build()
+            {
+                Ok(runtime) => runtime,
+                Err(_) => {
+                    store
+                        .hosted_did_index_refreshing
+                        .store(false, Ordering::Release);
+                    return;
+                }
+            };
+            let refresh_store = store.clone();
+            runtime.block_on(async {
+                let _ = refresh_store.refresh_hosted_did_index(&authority).await;
+            });
             store
                 .hosted_did_index_refreshing
                 .store(false, Ordering::Release);
@@ -761,6 +776,24 @@ mod tests {
         }
     }
 
+    struct SlowPermitAccountReads;
+
+    impl AccountRecordReadAuthorizer for SlowPermitAccountReads {
+        fn check_read(
+            &self,
+            _subject: &Subject,
+            _verified_tenant: Option<&str>,
+            _security_context: Option<&SecurityContext>,
+            _object_id: &str,
+        ) -> MacDecision {
+            // This models the synchronous filesystem/audit work performed by
+            // the production authorizer and mount. A current-thread OAuth
+            // runtime must remain able to make progress while it runs.
+            std::thread::sleep(Duration::from_millis(200));
+            MacDecision::Permit
+        }
+    }
+
     fn permit_account_reads() -> Arc<dyn AccountRecordReadAuthorizer> {
         Arc::new(PermitAccountReads)
     }
@@ -939,6 +972,26 @@ mod tests {
             .await
             .unwrap_err();
         assert!(matches!(error, AccountReadError::HostedDidIndexNotReady));
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn scheduled_hosted_did_refresh_does_not_block_current_thread_runtime() {
+        let root = SyntheticNode::dir().with_child(
+            "acme",
+            tenant_node("alice", account_bytes("alice", "acme.example")),
+        );
+        let store = AccountRecordStore::new(
+            Arc::new(SyntheticMount::new(root)),
+            Arc::new(SlowPermitAccountReads),
+        );
+
+        store.schedule_hosted_did_index_refresh(oauth_authority());
+        tokio::time::timeout(
+            Duration::from_millis(100),
+            tokio::time::sleep(Duration::from_millis(10)),
+        )
+        .await
+        .expect("index refresh must not block the HTTP runtime");
     }
 
     #[tokio::test]

--- a/crates/hyprstream-pds-service/src/lib.rs
+++ b/crates/hyprstream-pds-service/src/lib.rs
@@ -416,16 +416,11 @@ impl AccountRecordStore {
     ) -> Result<Option<Vec<u8>>, AccountReadError> {
         use p256::ecdsa::signature::Signer as _;
 
-        let resolved = match self.resolve_tenant_for_hosted_did(authority, did).await {
-            Err(AccountReadError::HostedDidIndexNotReady) => {
-                // Internal signing is already an authorized operation; warm
-                // its index explicitly, while the public HTTP lookup remains
-                // strictly non-blocking.
-                self.refresh_hosted_did_index(authority).await?;
-                self.resolve_tenant_for_hosted_did(authority, did).await
-            }
-            result => result,
-        }?;
+        // Signing runs on authenticated request paths; never turn a cold or
+        // hard-stale lookup into a synchronous tenant enumeration. Startup
+        // warms the index before OAuth readiness, while this resolver remains
+        // fail-closed until a snapshot is available.
+        let resolved = self.resolve_tenant_for_hosted_did(authority, did).await?;
         let Some(tenant) = resolved else {
             return Ok(None);
         };
@@ -1027,6 +1022,20 @@ mod tests {
         let store = store();
         let error = store
             .resolve_tenant_for_hosted_did(&oauth_authority(), "did:web:alice.acme.example")
+            .await
+            .unwrap_err();
+        assert!(matches!(error, AccountReadError::HostedDidIndexNotReady));
+    }
+
+    #[tokio::test]
+    async fn cold_hosted_did_signing_never_refreshes_on_request_path() {
+        let store = store();
+        let error = store
+            .sign_for_hosted_did(
+                &oauth_authority(),
+                "did:web:alice.acme.example",
+                b"header.payload",
+            )
             .await
             .unwrap_err();
         assert!(matches!(error, AccountReadError::HostedDidIndexNotReady));

--- a/crates/hyprstream-pds-service/src/lib.rs
+++ b/crates/hyprstream-pds-service/src/lib.rs
@@ -10,6 +10,7 @@
 //! `verified_tenant`. The tenant is never inferred from the subject, accepted
 //! from a request payload, or supplied as a free-form method argument.
 
+pub mod account_http;
 pub mod federation_intake;
 
 use std::sync::Arc;

--- a/crates/hyprstream-pds-service/src/lib.rs
+++ b/crates/hyprstream-pds-service/src/lib.rs
@@ -271,7 +271,7 @@ impl AccountRecordStore {
             *last_attempt = Some(Instant::now());
         }
         let store = self.clone();
-        let _ = std::thread::Builder::new()
+        if std::thread::Builder::new()
             .name("hyprstream-pds-index-refresh".to_owned())
             .spawn(move || {
             let runtime = match tokio::runtime::Builder::new_current_thread()
@@ -293,7 +293,12 @@ impl AccountRecordStore {
             store
                 .hosted_did_index_refreshing
                 .store(false, Ordering::Release);
-            });
+            })
+            .is_err()
+        {
+            self.hosted_did_index_refreshing
+                .store(false, Ordering::Release);
+        }
     }
 
     pub async fn refresh_hosted_did_index(

--- a/crates/hyprstream-pds/src/hosted_account.rs
+++ b/crates/hyprstream-pds/src/hosted_account.rs
@@ -45,8 +45,8 @@ use hyprstream_rpc::identity::UNAUTHENTICATED_DID_SENTINEL;
 pub const ACCOUNT_RECORD_VERSION: u16 = 1;
 const COMPRESSED_P256_PUBLIC_KEY_LEN: usize = 33;
 const ACCOUNT_RECORD_FILE: &str = "account-record.cbor";
-const GENESIS_DID_OP_FILE: &str = "genesis.didop.cbor";
-const DID_DOCUMENT_FILE: &str = "did-document.json";
+pub const GENESIS_DID_OP_FILE: &str = "genesis.didop.cbor";
+pub const DID_DOCUMENT_FILE: &str = "did-document.json";
 /// Secret account-specific P-256 key paired with the public `#atproto`
 /// verification method in the immutable account record and DID document.
 ///

--- a/crates/hyprstream-pds/src/hosted_account.rs
+++ b/crates/hyprstream-pds/src/hosted_account.rs
@@ -47,6 +47,37 @@ const COMPRESSED_P256_PUBLIC_KEY_LEN: usize = 33;
 const ACCOUNT_RECORD_FILE: &str = "account-record.cbor";
 pub const GENESIS_DID_OP_FILE: &str = "genesis.didop.cbor";
 pub const DID_DOCUMENT_FILE: &str = "did-document.json";
+const ACCOUNT_STAGING_MARKER: &str = ".mint-";
+
+/// Return whether `name` is an unpublished account-mint staging directory.
+///
+/// The writer uses this exact private name shape while assembling a complete
+/// account bundle: `.{label}.mint-{random_u128}-{attempt}`. A crash can leave
+/// one of these directories behind, so readers may ignore only names that
+/// match the complete documented shape and contain a valid permanent label.
+pub fn is_hosted_account_staging_directory(name: &str) -> bool {
+    let Some(name) = name.strip_prefix('.') else {
+        return false;
+    };
+    let Some((label, suffix)) = name.split_once(ACCOUNT_STAGING_MARKER) else {
+        return false;
+    };
+    if AccountLabel::parse(label).is_err() {
+        return false;
+    }
+    let Some((random_text, attempt_text)) = suffix.rsplit_once('-') else {
+        return false;
+    };
+    let Ok(random) = random_text.parse::<u128>() else {
+        return false;
+    };
+    let Ok(attempt) = attempt_text.parse::<u32>() else {
+        return false;
+    };
+    // Keep this in lockstep with new_staging_directory's bounded retry loop.
+    random.to_string() == random_text && attempt.to_string() == attempt_text && attempt < 128
+}
+
 /// Secret account-specific P-256 key paired with the public `#atproto`
 /// verification method in the immutable account record and DID document.
 ///

--- a/crates/hyprstream-pds/src/lib.rs
+++ b/crates/hyprstream-pds/src/lib.rs
@@ -91,7 +91,7 @@ pub use did_op::{
 pub use hosted_account::{
     AccountRecord, AllocatedAccountName, DirectoryHostedAccountStore, HostedAccountMint,
     PendingHostedAccountMint, SealedHostedAccount, ACCOUNT_RECORD_VERSION,
-    ATPROTO_SIGNING_KEY_FILE,
+    ATPROTO_SIGNING_KEY_FILE, DID_DOCUMENT_FILE, GENESIS_DID_OP_FILE,
 };
 pub use hosted_did_document::{
     SealedHostedDidDocument, DID_DOCUMENT_MEDIA_TYPE, DID_DOCUMENT_PATH, DID_OPERATION_LOG_PATH,

--- a/crates/hyprstream-pds/src/lib.rs
+++ b/crates/hyprstream-pds/src/lib.rs
@@ -90,7 +90,8 @@ pub use did_op::{
 };
 pub use hosted_account::{
     AccountRecord, AllocatedAccountName, DirectoryHostedAccountStore, HostedAccountMint,
-    PendingHostedAccountMint, SealedHostedAccount, ACCOUNT_RECORD_VERSION,
+    PendingHostedAccountMint, SealedHostedAccount, is_hosted_account_staging_directory,
+    ACCOUNT_RECORD_VERSION,
     ATPROTO_SIGNING_KEY_FILE, DID_DOCUMENT_FILE, GENESIS_DID_OP_FILE,
 };
 pub use hosted_did_document::{

--- a/crates/hyprstream-service/src/service/factory.rs
+++ b/crates/hyprstream-service/src/service/factory.rs
@@ -505,6 +505,9 @@ pub struct ServiceContext {
     /// Identity provider for purpose-keyed signing
     identity_provider: Arc<hyprstream_rpc::node_identity::NodeIdentityProvider>,
 
+    /// Launcher-proven single service hosted by this process; never derived from transport.
+    dedicated_process_service: Option<String>,
+
     /// Whether running in IPC mode (vs inproc)
     ipc: bool,
 
@@ -616,6 +619,7 @@ impl ServiceContext {
             signing_key,
             verifying_key,
             identity_provider,
+            dedicated_process_service: None,
             ipc,
             models_dir,
             quic_shared: None,
@@ -632,6 +636,17 @@ impl ServiceContext {
             ca_ml_dsa_verifying_key: None,
             secrets_dir: None,
         }
+    }
+
+    /// The launcher may set this only after enforcing one service per process.
+    /// It authorizes that service to terminate the process on an unjoinable worker.
+    pub fn with_dedicated_process_service(mut self, service: String) -> Self {
+        self.dedicated_process_service = Some(service);
+        self
+    }
+
+    pub fn is_dedicated_process_for(&self, service: &str) -> bool {
+        self.dedicated_process_service.as_deref() == Some(service)
     }
 
     /// Carry the explicitly resolved credentials directory into factories.
@@ -1865,5 +1880,21 @@ mod tests {
             .status()
             .expect("authority mutation subprocess");
         assert!(status.success(), "authority mutation subprocess failed");
+    }
+}
+
+#[cfg(test)]
+mod dedicated_process_tests {
+    use super::*;
+
+    #[test]
+    fn process_containment_is_explicit_and_service_specific() {
+        let key = SigningKey::from_bytes(&[9; 32]);
+        // IPC transport alone must never authorize killing the process.
+        let context = ServiceContext::new(key.clone(), key.verifying_key(), true, "models".into());
+        assert!(!context.is_dedicated_process_for("oauth"));
+        let context = context.with_dedicated_process_service("oauth".to_owned());
+        assert!(context.is_dedicated_process_for("oauth"));
+        assert!(!context.is_dedicated_process_for("model"));
     }
 }

--- a/crates/hyprstream/Cargo.toml
+++ b/crates/hyprstream/Cargo.toml
@@ -106,6 +106,7 @@ prost.workspace = true
 rcgen.workspace = true  # Self-signed TLS cert generation for QUIC
 rustls.workspace = true  # TLS runtime (ring crypto provider for axum-server)
 rustls-pemfile.workspace = true  # PEM file parsing for TLS certs
+x509-parser.workspace = true
 rustls-acme.workspace = true  # ACME (Let's Encrypt / step-ca) automatic cert provisioning
 web-transport-quinn.workspace = true
 zeroize.workspace = true  # Zeroing private key material on drop

--- a/crates/hyprstream/src/account/config.rs
+++ b/crates/hyprstream/src/account/config.rs
@@ -30,6 +30,7 @@
 //! ```
 
 use std::net::{Ipv4Addr, Ipv6Addr};
+use std::path::PathBuf;
 
 use serde::{Deserialize, Serialize};
 
@@ -71,6 +72,37 @@ pub struct AccountZoneConfig {
     /// IPv6 target for the wildcard AAAA record (`*.<apex>`).
     #[serde(default)]
     pub wildcard_ipv6: Option<Ipv6Addr>,
+
+    /// Optional credential-free HTTPS listener for the public hosted-account
+    /// DID artifacts. The listener is disabled unless this section is present;
+    /// enabling it requires an explicit account-zone certificate and key.
+    #[serde(default)]
+    pub http: Option<AccountHttpConfig>,
+}
+
+/// Deployment configuration for the separate public hosted-account listener.
+///
+/// This deliberately has no default port or certificate. A deployment must
+/// opt in with all listener material present so an account host can never
+/// silently bind the OAuth listener or fall back to a self-signed certificate.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AccountHttpConfig {
+    /// Bind address for the public account-artifact listener.
+    #[serde(default = "default_http_host")]
+    pub host: String,
+
+    /// Bind port for the public account-artifact listener.
+    pub port: u16,
+
+    /// PEM certificate chain covering `*.zone`.
+    pub tls_cert: PathBuf,
+
+    /// PEM private key corresponding to `tls_cert`.
+    pub tls_key: PathBuf,
+}
+
+fn default_http_host() -> String {
+    "0.0.0.0".to_owned()
 }
 
 impl AccountZoneConfig {
@@ -120,6 +152,7 @@ mod tests {
         assert!(!cfg.is_configured());
         assert!(matches!(cfg.resolve_zone(), Err(AccountZoneError::Unset)));
         assert!(!cfg.dns01_ready());
+        assert!(cfg.http.is_none());
     }
 
     #[test]
@@ -177,5 +210,21 @@ wildcard_ipv4 = "203.0.113.10"
         let cfg: AccountZoneConfig = toml::from_str(toml).unwrap();
         assert_eq!(cfg.zone.as_deref(), Some("acct.example.com"));
         assert_eq!(cfg.wildcard_ipv4, Some("203.0.113.10".parse().unwrap()));
+        assert!(cfg.http.is_none());
+    }
+
+    #[test]
+    fn http_listener_requires_explicit_material() {
+        let toml = r#"
+zone = "acct.example.com"
+[http]
+port = 443
+tls_cert = "/run/secrets/account/fullchain.pem"
+tls_key = "/run/secrets/account/key.pem"
+"#;
+        let cfg: AccountZoneConfig = toml::from_str(toml).unwrap();
+        let http = cfg.http.unwrap();
+        assert_eq!(http.host, "0.0.0.0");
+        assert_eq!(http.port, 443);
     }
 }

--- a/crates/hyprstream/src/account/mod.rs
+++ b/crates/hyprstream/src/account/mod.rs
@@ -32,7 +32,7 @@ pub mod renewal;
 pub mod tls;
 pub mod zone;
 
-pub use config::AccountZoneConfig;
+pub use config::{AccountHttpConfig, AccountZoneConfig};
 pub use dns::{DnsError, DnsProvider, UnconfiguredDnsProvider};
 pub use renewal::{CertHealth, CertHealthMonitor, CertRenewer, AlarmThresholds};
 pub use tls::{CertHandle, IssuedCert, IssuanceError, NullWildcardCertIssuer, WildcardCertIssuer};

--- a/crates/hyprstream/src/bin/main.rs
+++ b/crates/hyprstream/src/bin/main.rs
@@ -1557,12 +1557,9 @@ fn resolve_moq_relay_reach(
         .ok_or_else(|| anyhow::anyhow!("relay URI is not a network-routable transport"))
 }
 
-/// Select the process identity before constructing any resolver/client. Transport
-/// flags do not decide whose identity a required-native split service uses.
-fn native_service_process_name(matches: &clap::ArgMatches, config: &HyprConfig) -> Result<Option<String>> {
-    if !config.quic.iroh_required() {
-        return Ok(None);
-    }
+/// Resolve the services hosted by this foreground process independently of
+/// transport profile. Background start commands do not host their children.
+fn foreground_service_process_names(matches: &clap::ArgMatches, config: &HyprConfig) -> Result<Option<Vec<String>>> {
     let Some(("service", service_matches)) = matches.subcommand() else {
         return Ok(None);
     };
@@ -1578,6 +1575,29 @@ fn native_service_process_name(matches: &clap::ArgMatches, config: &HyprConfig) 
         config.services.startup.clone()
     } else {
         services.unwrap_or_else(|| name.into_iter().collect())
+    };
+    Ok(Some(names))
+}
+
+/// Process termination is safe only when this process hosts one known service.
+fn dedicated_service_process_name(matches: &clap::ArgMatches, config: &HyprConfig) -> Result<Option<String>> {
+    let Some(names) = foreground_service_process_names(matches, config)? else {
+        return Ok(None);
+    };
+    match names.as_slice() {
+        [service] if get_factory(service).is_some() => Ok(Some(service.clone())),
+        _ => Ok(None),
+    }
+}
+
+/// Select the process identity before constructing any resolver/client. Transport
+/// flags do not decide whose identity a required-native split service uses.
+fn native_service_process_name(matches: &clap::ArgMatches, config: &HyprConfig) -> Result<Option<String>> {
+    if !config.quic.iroh_required() {
+        return Ok(None);
+    }
+    let Some(names) = foreground_service_process_names(matches, config)? else {
+        return Ok(None);
     };
     anyhow::ensure!(names.len() == 1,
         "network-iroh-required requires exactly one service per foreground process; launch each provisioned service separately");
@@ -2963,6 +2983,7 @@ fn main() -> Result<()> {
     }
 
     let native_service_name = native_service_process_name(&matches, &config)?;
+    let dedicated_service_name = dedicated_service_process_name(&matches, &config)?;
 
     // Start registry service ONCE at CLI level
     let _registry_runtime = tokio::runtime::Builder::new_multi_thread()
@@ -3166,9 +3187,9 @@ fn main() -> Result<()> {
                                     )?,
                                 );
 
-                                // native_service_process_name already enforces one service
-                                // per foreground process; IPC flags are not containment proof.
-                                if let Some(service) = &native_service_name {
+                                // Containment follows the actual single-service launch,
+                                // independently of native/compatibility transport selection.
+                                if let Some(service) = &dedicated_service_name {
                                     ctx = ctx.with_dedicated_process_service(service.clone());
                                 }
 
@@ -4315,6 +4336,54 @@ mod resolver_startup_controls {
             std::fs::write(&key_path, [seed; 31])?;
             assert!(runtime.block_on(super::load_process_signing_key(&config, selected.as_deref())).is_err());
             assert_eq!(std::fs::read(&key_path)?, vec![seed; 31], "malformed key must not be repaired during startup");
+        }
+        Ok(())
+    }
+
+    #[test]
+    fn dedicated_service_containment_is_independent_of_network_profile() -> anyhow::Result<()> {
+        use hyprstream_core::config::NativeNetworkProfile;
+        let mut config = super::HyprConfig::default();
+        config.account.http = Some(hyprstream_core::account::AccountHttpConfig {
+            host: "::1".to_owned(),
+            port: 8443,
+            tls_cert: "unused.pem".into(),
+            tls_key: "unused.key".into(),
+        });
+        for profile in [NativeNetworkProfile::Compatibility, NativeNetworkProfile::NetworkIrohRequired] {
+            config.quic.native_network_profile = profile;
+            for argv in [
+                vec!["hyprstream", "service", "start", "oauth", "--foreground"],
+                vec!["hyprstream", "service", "start", "--foreground", "--services", "oauth"],
+                vec!["hyprstream", "service", "start", "--standalone"],
+            ] {
+                config.services.startup = vec!["oauth".into()];
+                let matches = super::build_cli().try_get_matches_from(argv)?;
+                let service = super::dedicated_service_process_name(&matches, &config)?
+                    .expect("a single OAuth foreground service has process containment");
+                assert_eq!(service, "oauth");
+                let key = super::SigningKey::from_bytes(&[9; 32]);
+                let context = super::ServiceContext::new(
+                    key.clone(), key.verifying_key(), false, "/unused".into(),
+                ).with_dedicated_process_service(service);
+                assert!(context.is_dedicated_process_for("oauth"));
+                assert!(!context.is_dedicated_process_for("registry"));
+                assert_eq!(
+                    super::native_service_process_name(&matches, &config)?.is_some(),
+                    config.quic.iroh_required(),
+                    "containment must not change compatibility signing-key selection",
+                );
+            }
+            config.services.startup = vec!["oauth".into(), "registry".into()];
+            for argv in [
+                vec!["hyprstream", "service", "start", "oauth"],
+                vec!["hyprstream", "service", "start", "--standalone"],
+                vec!["hyprstream", "service", "start", "--foreground", "--services", "oauth,registry"],
+                vec!["hyprstream", "service", "status"],
+            ] {
+                let matches = super::build_cli().try_get_matches_from(argv)?;
+                assert_eq!(super::dedicated_service_process_name(&matches, &config)?, None);
+            }
         }
         Ok(())
     }

--- a/crates/hyprstream/src/bin/main.rs
+++ b/crates/hyprstream/src/bin/main.rs
@@ -3166,6 +3166,12 @@ fn main() -> Result<()> {
                                     )?,
                                 );
 
+                                // native_service_process_name already enforces one service
+                                // per foreground process; IPC flags are not containment proof.
+                                if let Some(service) = &native_service_name {
+                                    ctx = ctx.with_dedicated_process_service(service.clone());
+                                }
+
                                 // Wire QUIC shared config from --quic-bind or [quic] config
                                 let mut quic_cfg = if let Some(ref bind_addr) = quic_bind {
                                     let mut qc = hyprstream_core::config::QuicConfig::default();

--- a/crates/hyprstream/src/mac/pds_pep.rs
+++ b/crates/hyprstream/src/mac/pds_pep.rs
@@ -13,7 +13,7 @@ use async_trait::async_trait;
 use hyprstream_pds::ATPROTO_SIGNING_KEY_FILE;
 use hyprstream_pds_service::{
     AccountRecordReadAuthorizer, OAUTH_ACCOUNT_RESOLVER_SUBJECT, PDS_ACCOUNTS_DIRECTORY,
-    PDS_ACCOUNT_RECORD_FILE,
+    PDS_ACCOUNT_DID_DOCUMENT_FILE, PDS_ACCOUNT_DID_LOG_FILE, PDS_ACCOUNT_RECORD_FILE,
 };
 use hyprstream_rpc::auth::mac::{
     Assurance, CompartmentSet, Level, MacDecision, MacDenyReason, ObjectLabelResolver, ObjectRef,
@@ -67,7 +67,13 @@ impl ObjectLabelResolver for PdsAccountObjectLabelResolver {
                 if valid_tenant_component(tenant)
                     && *accounts == PDS_ACCOUNTS_DIRECTORY
                     && valid_account_component(account)
-                    && matches!(*file, PDS_ACCOUNT_RECORD_FILE | ATPROTO_SIGNING_KEY_FILE) =>
+                    && matches!(
+                        *file,
+                        PDS_ACCOUNT_RECORD_FILE
+                            | ATPROTO_SIGNING_KEY_FILE
+                            | PDS_ACCOUNT_DID_DOCUMENT_FILE
+                            | PDS_ACCOUNT_DID_LOG_FILE
+                    ) =>
             {
                 Some(pds_account_label())
             }
@@ -1006,6 +1012,26 @@ mod tests {
                 PDS_ACCOUNTS_DIRECTORY,
                 "alice",
                 PDS_ACCOUNT_RECORD_FILE,
+            ])),
+            Some(pds_account_label())
+        );
+        assert_eq!(
+            resolver.resolve(ObjectRef::Path(&[
+                "pds",
+                "acme",
+                PDS_ACCOUNTS_DIRECTORY,
+                "alice",
+                PDS_ACCOUNT_DID_DOCUMENT_FILE,
+            ])),
+            Some(pds_account_label())
+        );
+        assert_eq!(
+            resolver.resolve(ObjectRef::Path(&[
+                "pds",
+                "acme",
+                PDS_ACCOUNTS_DIRECTORY,
+                "alice",
+                PDS_ACCOUNT_DID_LOG_FILE,
             ])),
             Some(pds_account_label())
         );

--- a/crates/hyprstream/src/mac/pds_pep.rs
+++ b/crates/hyprstream/src/mac/pds_pep.rs
@@ -63,6 +63,19 @@ impl ObjectLabelResolver for PdsAccountObjectLabelResolver {
         };
         match components {
             ["pds"] => Some(pds_account_label()),
+            ["pds", tenant] if valid_tenant_component(tenant) => Some(pds_account_label()),
+            ["pds", tenant, accounts]
+                if valid_tenant_component(tenant) && *accounts == PDS_ACCOUNTS_DIRECTORY =>
+            {
+                Some(pds_account_label())
+            }
+            ["pds", tenant, accounts, account]
+                if valid_tenant_component(tenant)
+                    && *accounts == PDS_ACCOUNTS_DIRECTORY
+                    && valid_account_component(account) =>
+            {
+                Some(pds_account_label())
+            }
             ["pds", tenant, accounts, account, file]
                 if valid_tenant_component(tenant)
                     && *accounts == PDS_ACCOUNTS_DIRECTORY
@@ -624,10 +637,12 @@ pub fn production_pds_account_record_store(
     mount: Arc<PdsDirectoryMount>,
     sink: Arc<dyn AuditSink>,
 ) -> Arc<hyprstream_pds_service::AccountRecordStore> {
-    Arc::new(hyprstream_pds_service::AccountRecordStore::new(
+    let store = Arc::new(hyprstream_pds_service::AccountRecordStore::new(
         mount,
         production_pds_account_read_authorizer(sink),
-    ))
+    ));
+    store.schedule_hosted_did_index_refresh(Subject::new(OAUTH_ACCOUNT_RESOLVER_SUBJECT));
+    store
 }
 
 #[cfg(test)]
@@ -1003,6 +1018,23 @@ mod tests {
         let resolver = PdsAccountObjectLabelResolver;
         assert_eq!(
             resolver.resolve(ObjectRef::Path(&["pds"])),
+            Some(pds_account_label())
+        );
+        assert_eq!(
+            resolver.resolve(ObjectRef::Path(&["pds", "acme"])),
+            Some(pds_account_label())
+        );
+        assert_eq!(
+            resolver.resolve(ObjectRef::Path(&["pds", "acme", PDS_ACCOUNTS_DIRECTORY,])),
+            Some(pds_account_label())
+        );
+        assert_eq!(
+            resolver.resolve(ObjectRef::Path(&[
+                "pds",
+                "acme",
+                PDS_ACCOUNTS_DIRECTORY,
+                "alice",
+            ])),
             Some(pds_account_label())
         );
         assert_eq!(

--- a/crates/hyprstream/src/mac/pds_pep.rs
+++ b/crates/hyprstream/src/mac/pds_pep.rs
@@ -900,12 +900,8 @@ mod tests {
             sink.clone(),
         ));
         let store = AccountRecordStore::new(mount.clone(), authorizer);
-
         let error = store
-            .resolve_tenant_for_hosted_did(
-                &Subject::new(OAUTH_ACCOUNT_RESOLVER_SUBJECT),
-                "did:web:alice.example.test",
-            )
+            .refresh_hosted_did_index(&Subject::new(OAUTH_ACCOUNT_RESOLVER_SUBJECT))
             .await
             .unwrap_err();
         assert!(matches!(

--- a/crates/hyprstream/src/mac/pds_pep.rs
+++ b/crates/hyprstream/src/mac/pds_pep.rs
@@ -637,12 +637,10 @@ pub fn production_pds_account_record_store(
     mount: Arc<PdsDirectoryMount>,
     sink: Arc<dyn AuditSink>,
 ) -> Arc<hyprstream_pds_service::AccountRecordStore> {
-    let store = Arc::new(hyprstream_pds_service::AccountRecordStore::new(
+    Arc::new(hyprstream_pds_service::AccountRecordStore::new(
         mount,
         production_pds_account_read_authorizer(sink),
-    ));
-    store.schedule_hosted_did_index_refresh(Subject::new(OAUTH_ACCOUNT_RESOLVER_SUBJECT));
-    store
+    ))
 }
 
 #[cfg(test)]

--- a/crates/hyprstream/src/services/factories.rs
+++ b/crates/hyprstream/src/services/factories.rs
@@ -2065,13 +2065,14 @@ fn create_oauth_service(ctx: &ServiceContext) -> anyhow::Result<Box<dyn Spawnabl
     // Register this service's verifying key with PolicyService
     register_service_key(ctx, "oauth", &sk)?;
 
+    let pds_root = ctx.deployment_data_dir()?.join("pds");
     let identity_registration_api =
         crate::services::oauth::identity_registration::production_identity_registration_api(
             &config.oauth,
             &config.account,
             &config.quic,
             sk.clone(),
-            ctx.deployment_data_dir()?.join("pds"),
+            pds_root.clone(),
         )
         .context("compose production identity registration API")?;
 
@@ -2090,7 +2091,8 @@ fn create_oauth_service(ctx: &ServiceContext) -> anyhow::Result<Box<dyn Spawnabl
         ctx.jwt_verifying_key(),
     )
     .with_quic_config(config.quic.clone())
-    .with_identity_registration_api(identity_registration_api);
+    .with_identity_registration_api(identity_registration_api)
+    .with_pds_root(pds_root);
 
     Ok(Box::new(oauth_service))
 }

--- a/crates/hyprstream/src/services/factories.rs
+++ b/crates/hyprstream/src/services/factories.rs
@@ -2092,7 +2092,8 @@ fn create_oauth_service(ctx: &ServiceContext) -> anyhow::Result<Box<dyn Spawnabl
     )
     .with_quic_config(config.quic.clone())
     .with_identity_registration_api(identity_registration_api)
-    .with_pds_root(pds_root);
+    .with_pds_root(pds_root)
+    .with_dedicated_process(ctx.is_dedicated_process_for("oauth"));
 
     Ok(Box::new(oauth_service))
 }

--- a/crates/hyprstream/src/services/oauth/account_tls.rs
+++ b/crates/hyprstream/src/services/oauth/account_tls.rs
@@ -1,0 +1,142 @@
+//! Account-zone certificate rotation stays inside the owned account worker.
+
+use crate::account::{AccountHttpConfig, AccountZone};
+use crate::server::tls::{serve_bound, BoundHttpListener};
+use hyprstream_rpc::error::RpcError;
+use std::{sync::Arc, time::Duration};
+use tokio::sync::Notify;
+
+pub(super) async fn serve_with_reload(
+    bound: BoundHttpListener,
+    app: axum::Router,
+    shutdown: Arc<Notify>,
+    config: AccountHttpConfig,
+    zone: AccountZone,
+    reload_interval: Duration,
+) -> Result<(), RpcError> {
+    let live_tls = match &bound {
+        BoundHttpListener::Https(_, tls) => tls.clone(),
+        BoundHttpListener::Http(_) => {
+            return Err(RpcError::SpawnFailed(
+                "account listener requires TLS".to_owned(),
+            ));
+        }
+    };
+    let reload = async {
+        let mut tick = tokio::time::interval(reload_interval);
+        tick.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+        // Startup already validated the first pair. Subsequent reads also
+        // catch atomic file/symlink replacement without a filesystem watcher.
+        tick.tick().await;
+        loop {
+            tick.tick().await;
+            match super::resolve_account_http_tls(&config, &zone).await {
+                Ok(candidate) => live_tls.reload_from_config(candidate.get_inner()),
+                Err(error) => tracing::warn!(
+                    "account TLS rotation rejected; retaining previous certificate and retrying: {error:#}"
+                ),
+            }
+        }
+    };
+    // No spawned watcher can outlive this serve future. A slow reload does not
+    // stop polling the listener/shutdown; the enclosing ContainedWorker owns
+    // the runtime and preserves the existing bounded process-exit guarantee.
+    tokio::select! {
+        result = serve_bound(bound, app, shutdown, "AccountHttpService") => result,
+        () = reload => unreachable!("account certificate reload loop is permanent"),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #![allow(clippy::expect_used, clippy::unwrap_used)]
+
+    use super::*;
+
+    #[tokio::test]
+    async fn account_tls_rotation_updates_live_https_and_preserves_shutdown() -> anyhow::Result<()>
+    {
+        hyprstream_rpc::transport::install_pq_crypto_provider()?;
+        let directory = tempfile::tempdir()?;
+        let zone = AccountZone::new("acct.example.com")?;
+        let first = rcgen::generate_simple_self_signed(vec![zone.wildcard_domain().to_owned()])?;
+        let second = rcgen::generate_simple_self_signed(vec![zone.wildcard_domain().to_owned()])?;
+        let wrong_zone =
+            rcgen::generate_simple_self_signed(vec!["*.other.example.com".to_owned()])?;
+        let config = AccountHttpConfig {
+            host: "127.0.0.1".to_owned(),
+            port: 8443,
+            tls_cert: directory.path().join("cert.pem"),
+            tls_key: directory.path().join("key.pem"),
+        };
+        std::fs::write(&config.tls_cert, first.cert.pem())?;
+        std::fs::write(&config.tls_key, first.key_pair.serialize_pem())?;
+        let tls = super::super::resolve_account_http_tls(&config, &zone).await?;
+        let bound = crate::server::tls::bind_listener(
+            "127.0.0.1:0".parse()?,
+            Some(tls),
+            "AccountRotationTest",
+        )?;
+        let address = match &bound {
+            BoundHttpListener::Https(listener, _) => listener.local_addr()?,
+            _ => unreachable!(),
+        };
+        let shutdown = Arc::new(Notify::new());
+        let server = tokio::spawn(serve_with_reload(
+            bound,
+            axum::Router::new().route("/", axum::routing::get(|| async { "account-ok" })),
+            shutdown.clone(),
+            config.clone(),
+            zone,
+            Duration::from_millis(20),
+        ));
+        let client = reqwest::Client::builder()
+            .use_rustls_tls()
+            .no_proxy()
+            .tls_info(true)
+            .pool_max_idle_per_host(0)
+            .add_root_certificate(reqwest::Certificate::from_der(first.cert.der())?)
+            .add_root_certificate(reqwest::Certificate::from_der(second.cert.der())?)
+            .resolve("alice.acct.example.com", address)
+            .timeout(Duration::from_secs(2))
+            .build()?;
+        let url = format!("https://alice.acct.example.com:{}/", address.port());
+        let peer = || async {
+            let response = client.get(&url).send().await?.error_for_status()?;
+            let certificate = response
+                .extensions()
+                .get::<reqwest::tls::TlsInfo>()
+                .and_then(|info| info.peer_certificate())
+                .expect("live TLS handshake must report the peer certificate")
+                .to_vec();
+            assert_eq!(response.text().await?, "account-ok");
+            Ok::<_, anyhow::Error>(certificate)
+        };
+        assert_eq!(peer().await?, first.cert.der().as_ref());
+
+        // Reject a valid keypair for the wrong account zone, then an incomplete
+        // cert/key rotation. Both must leave the trusted live pair untouched.
+        std::fs::write(&config.tls_cert, wrong_zone.cert.pem())?;
+        std::fs::write(&config.tls_key, wrong_zone.key_pair.serialize_pem())?;
+        tokio::time::sleep(Duration::from_millis(80)).await;
+        assert_eq!(peer().await?, first.cert.der().as_ref());
+        std::fs::write(&config.tls_cert, second.cert.pem())?;
+        tokio::time::sleep(Duration::from_millis(80)).await;
+        assert_eq!(peer().await?, first.cert.der().as_ref());
+
+        std::fs::write(&config.tls_key, second.key_pair.serialize_pem())?;
+        tokio::time::timeout(Duration::from_secs(2), async {
+            loop {
+                if peer().await? == second.cert.der().as_ref() {
+                    return Ok::<_, anyhow::Error>(());
+                }
+                tokio::time::sleep(Duration::from_millis(10)).await;
+            }
+        })
+        .await??;
+        shutdown.notify_one();
+        tokio::time::timeout(Duration::from_secs(2), server).await???;
+        drop(std::net::TcpListener::bind(address)?);
+        Ok(())
+    }
+}

--- a/crates/hyprstream/src/services/oauth/account_worker.rs
+++ b/crates/hyprstream/src/services/oauth/account_worker.rs
@@ -1,0 +1,211 @@
+//! Blocking account I/O is contained by a dedicated OAuth process.
+//!
+//! A Rust thread cannot be safely killed while inside filesystem/audit I/O.
+//! Keep its actual handle and join completion; an overdue or abandoned worker
+//! terminates the dedicated process instead of detaching a live listener. The
+//! OAuth entrypoint checks launcher-provided containment before creating one.
+
+use std::{thread::JoinHandle, time::Duration};
+
+use hyprstream_rpc::error::RpcError;
+use tokio::sync::oneshot;
+
+pub(super) const WORKER_FAILURE_EXIT: i32 = 70;
+
+fn terminate(name: &str) -> ! {
+    tracing::error!(
+        worker = name,
+        "account worker did not stop; terminating dedicated OAuth process"
+    );
+    std::process::exit(WORKER_FAILURE_EXIT);
+}
+
+pub(super) struct ContainedWorker<T> {
+    name: &'static str,
+    thread: Option<JoinHandle<()>>,
+    completion: oneshot::Receiver<T>,
+}
+
+impl<T: Send + 'static> ContainedWorker<T> {
+    pub(super) fn spawn(
+        name: &'static str,
+        work: impl FnOnce() -> T + Send + 'static,
+    ) -> Result<Self, RpcError> {
+        let (tx, completion) = oneshot::channel();
+        let thread = std::thread::Builder::new()
+            .name(name.to_owned())
+            .spawn(move || {
+                let result = work();
+                let _ = tx.send(result);
+            })
+            .map_err(|error| RpcError::SpawnFailed(format!("{name} thread spawn: {error}")))?;
+        Ok(Self {
+            name,
+            thread: Some(thread),
+            completion,
+        })
+    }
+
+    pub(super) fn is_joined(&self) -> bool {
+        self.thread.is_none()
+    }
+
+    pub(super) async fn result(&mut self) -> Result<T, RpcError> {
+        let result = (&mut self.completion).await;
+        // The sender runs after work (including runtime destruction) returns.
+        // Its only remaining operation is returning from the thread closure.
+        if let Some(thread) = self.thread.take() {
+            thread
+                .join()
+                .map_err(|_| RpcError::SpawnFailed(format!("{} thread panicked", self.name,)))?;
+        }
+        result.map_err(|_| {
+            RpcError::SpawnFailed(format!("{} thread exited without a result", self.name,))
+        })
+    }
+
+    pub(super) async fn finish(&mut self, timeout: Duration) -> Result<T, RpcError> {
+        match tokio::time::timeout(timeout, self.result()).await {
+            Ok(result) => result,
+            Err(_) => terminate(self.name),
+        }
+    }
+}
+
+impl<T> Drop for ContainedWorker<T> {
+    fn drop(&mut self) {
+        if let Some(thread) = self.thread.take() {
+            if !thread.is_finished() {
+                // Covers cancellation/unwind before common teardown as well.
+                terminate(self.name);
+            }
+            let _ = thread.join();
+        }
+    }
+}
+
+#[cfg(test)]
+pub(super) mod tests {
+    #![allow(clippy::unwrap_used, clippy::expect_used)]
+
+    use super::*;
+    use std::{net::TcpListener, process::Command, time::Instant};
+
+    pub(crate) fn is_child(test: &str) -> bool {
+        std::env::var("HYPRSTREAM_CONTAINED_WORKER_TEST").as_deref() == Ok(test)
+    }
+
+    pub(crate) fn expect_contained_exit(test: &str, env: &[(&str, String)]) {
+        let mut command = Command::new(std::env::current_exe().unwrap());
+        command
+            .args(["--exact", test, "--nocapture"])
+            .env("HYPRSTREAM_CONTAINED_WORKER_TEST", test);
+        for (key, value) in env {
+            command.env(key, value);
+        }
+        let mut child = command.spawn().unwrap();
+        let deadline = Instant::now() + Duration::from_secs(5);
+        loop {
+            if let Some(status) = child.try_wait().unwrap() {
+                assert_eq!(status.code(), Some(WORKER_FAILURE_EXIT));
+                break;
+            }
+            if Instant::now() >= deadline {
+                let _ = child.kill();
+                let _ = child.wait();
+                panic!("contained worker process failed to exit within deadline");
+            }
+            std::thread::sleep(Duration::from_millis(10));
+        }
+    }
+
+    #[tokio::test]
+    async fn completed_worker_is_joined() {
+        let mut worker = ContainedWorker::spawn("test-completes", || 42).unwrap();
+        assert_eq!(worker.finish(Duration::from_secs(1)).await.unwrap(), 42);
+        assert!(worker.is_joined());
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn early_shutdown_joins_real_listener_and_releases_port() {
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        listener.set_nonblocking(true).unwrap();
+        let addr = listener.local_addr().unwrap();
+        let shutdown = std::sync::Arc::new(tokio::sync::Notify::new());
+        // Signal before the worker registers: the permit must survive.
+        shutdown.notify_one();
+        let mut worker = ContainedWorker::spawn("test-listener-stop", move || {
+            let runtime = tokio::runtime::Builder::new_current_thread()
+                .enable_all()
+                .build()
+                .unwrap();
+            runtime.block_on(async move {
+                let bound = crate::server::tls::BoundHttpListener::Http(
+                    tokio::net::TcpListener::from_std(listener).unwrap(),
+                );
+                crate::server::tls::serve_bound(
+                    bound,
+                    axum::Router::new(),
+                    shutdown,
+                    "AccountHttpTest",
+                )
+                .await
+            })
+        })
+        .unwrap();
+        worker
+            .finish(Duration::from_secs(2))
+            .await
+            .unwrap()
+            .unwrap();
+        assert!(worker.is_joined());
+        TcpListener::bind(addr).expect("joined listener must release its socket");
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn listener_timeout_terminates_process_and_releases_port() {
+        const TEST: &str = "services::oauth::account_worker::tests::listener_timeout_terminates_process_and_releases_port";
+        if !is_child(TEST) {
+            let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+            let addr = listener.local_addr().unwrap();
+            drop(listener);
+            expect_contained_exit(
+                TEST,
+                &[("HYPRSTREAM_CONTAINED_WORKER_ADDR", addr.to_string())],
+            );
+            TcpListener::bind(addr).expect("terminated worker must release its listening socket");
+            return;
+        }
+        let addr = std::env::var("HYPRSTREAM_CONTAINED_WORKER_ADDR").unwrap();
+        let (ready_tx, ready_rx) = std::sync::mpsc::channel();
+        let mut worker = ContainedWorker::spawn("test-stuck-listener", move || {
+            let _listener = TcpListener::bind(addr).unwrap();
+            ready_tx.send(()).unwrap();
+            loop {
+                std::thread::park();
+            }
+        })
+        .unwrap();
+        ready_rx.recv_timeout(Duration::from_secs(1)).unwrap();
+        let _ = worker.finish(Duration::from_millis(20)).await;
+        panic!("a live timed-out listener must not be detached");
+    }
+
+    #[test]
+    fn cancellation_cannot_detach_live_worker() {
+        const TEST: &str =
+            "services::oauth::account_worker::tests::cancellation_cannot_detach_live_worker";
+        if !is_child(TEST) {
+            expect_contained_exit(TEST, &[]);
+            return;
+        }
+        let worker = ContainedWorker::spawn("test-cancelled-worker", || {
+            loop {
+                std::thread::park();
+            }
+        })
+        .unwrap();
+        drop(worker);
+        panic!("dropping a live worker must terminate its process");
+    }
+}

--- a/crates/hyprstream/src/services/oauth/browser_session.rs
+++ b/crates/hyprstream/src/services/oauth/browser_session.rs
@@ -291,7 +291,7 @@ mod tests {
         _storage: tempfile::TempDir,
     }
 
-    fn fixture(local: bool) -> SessionFixture {
+    async fn fixture(local: bool) -> SessionFixture {
         let storage = tempfile::TempDir::new().unwrap();
         let signing_key = ed25519_dalek::SigningKey::from_bytes(&[0x71; 32]);
         let remote_key = ed25519_dalek::SigningKey::from_bytes(&[0x72; 32]).verifying_key();
@@ -402,6 +402,15 @@ mod tests {
                 Arc::new(RejectIdentityResolver),
             )
             .unwrap();
+
+        if let Some(store) = hosted_store.as_ref() {
+            store
+                .refresh_hosted_did_index(&hyprstream_rpc::Subject::new(
+                    hyprstream_pds_service::OAUTH_ACCOUNT_RESOLVER_SUBJECT,
+                ))
+                .await
+                .unwrap();
+        }
 
         let mut state = OAuthState::new(
             &oauth,
@@ -539,7 +548,7 @@ mod tests {
 
     #[tokio::test]
     async fn local_atproto_exchange_cookie_whoami_and_register_end_to_end() {
-        let fixture = fixture(true);
+        let fixture = fixture(true).await;
         let exchange = exchange_request(&fixture, "local-service", "local-dpop").await;
         assert_eq!(exchange.status(), StatusCode::OK);
         let session_cookie = cookie(&exchange);
@@ -582,7 +591,7 @@ mod tests {
 
     #[tokio::test]
     async fn federated_exchange_whoami_has_no_local_authority() {
-        let fixture = fixture(false);
+        let fixture = fixture(false).await;
         let exchange = exchange_request(&fixture, "foreign-service", "foreign-dpop").await;
         assert_eq!(exchange.status(), StatusCode::OK);
         let session_cookie = cookie(&exchange);
@@ -606,7 +615,7 @@ mod tests {
 
     #[tokio::test]
     async fn unauthenticated_whoami_is_public_floor() {
-        let fixture = fixture(false);
+        let fixture = fixture(false).await;
         let generic_id = fixture
             .state
             .sessions
@@ -642,7 +651,7 @@ mod tests {
 
     #[tokio::test]
     async fn exchange_requires_dpop_and_consumes_service_assertion_once() {
-        let fixture = fixture(false);
+        let fixture = fixture(false).await;
         let app = super::super::create_app(Arc::clone(&fixture.state), &fixture.cors);
         let missing_dpop = app
             .clone()

--- a/crates/hyprstream/src/services/oauth/mod.rs
+++ b/crates/hyprstream/src/services/oauth/mod.rs
@@ -643,6 +643,16 @@ impl OAuthService {
     }
 }
 
+fn account_http_socket_addr(config: &crate::account::AccountHttpConfig) -> Result<SocketAddr> {
+    // Preserve bracketed IPv6 configurations while accepting bare IP literals.
+    let host = config.host.strip_prefix('[')
+        .and_then(|host| host.strip_suffix(']'))
+        .unwrap_or(&config.host);
+    let ip = host.parse::<std::net::IpAddr>()
+        .map_err(|error| anyhow::anyhow!("invalid account HTTP bind IP: {error}"))?;
+    Ok(SocketAddr::new(ip, config.port))
+}
+
 /// Resolve explicitly provisioned TLS material for the public account
 /// listener. Account hosts must never fall back to the node/self-signed
 /// certificate, so enabling the listener requires both PEM paths and a valid
@@ -749,7 +759,7 @@ impl Spawnable for OAuthService {
         let contains_account_workers = self.account_config.http.is_some();
         if contains_account_workers && !self.dedicated_process {
             return Err(hyprstream_rpc::error::RpcError::SpawnFailed(
-                "hosted account workers require a dedicated native OAuth process".to_owned(),
+                "hosted account workers require a dedicated foreground OAuth process".to_owned(),
             ));
         }
         // Timed-out synchronous I/O cannot be cancelled safely. This service
@@ -1281,11 +1291,11 @@ impl Spawnable for OAuthService {
                                 "compose account HTTP router: {error}"
                             ))
                         })?;
-                let account_addr: SocketAddr = format!("{}:{}", http_config.host, http_config.port)
-                    .parse()
+                let account_addr = account_http_socket_addr(http_config)
                     .map_err(|error| {
                         hyprstream_rpc::error::RpcError::SpawnFailed(format!(
-                            "invalid account HTTP address: {error}"
+                            "invalid account HTTP bind host '{}': {error}",
+                            http_config.host
                         ))
                     })?;
                 let account_tls = resolve_account_http_tls(http_config, &zone)
@@ -1741,6 +1751,30 @@ mod tests {
     }
 
     #[test]
+    fn account_http_socket_address_preserves_ipv4_and_ipv6_literals() {
+        let mut config = crate::account::AccountHttpConfig {
+            host: String::new(),
+            port: 8443,
+            tls_cert: "unused.pem".into(),
+            tls_key: "unused.key".into(),
+        };
+        for (host, expected) in [
+            ("127.0.0.1", "127.0.0.1:8443"),
+            ("0.0.0.0", "0.0.0.0:8443"),
+            ("::1", "[::1]:8443"),
+            ("::", "[::]:8443"),
+            ("[::1]", "[::1]:8443"),
+        ] {
+            config.host = host.to_owned();
+            assert_eq!(account_http_socket_addr(&config).unwrap().to_string(), expected);
+        }
+        for invalid in ["localhost", "[::1", "::1]", "127.0.0.1:8443"] {
+            config.host = invalid.to_owned();
+            assert!(account_http_socket_addr(&config).is_err());
+        }
+    }
+
+    #[test]
     fn account_worker_requires_launcher_process_containment() {
         let sk = ed25519_dalek::SigningKey::from_bytes(&[3; 32]);
         let account = crate::account::AccountZoneConfig {
@@ -1761,7 +1795,7 @@ mod tests {
         let result = Box::new(service).run(Arc::new(Notify::new()), None);
         assert!(matches!(result,
             Err(hyprstream_rpc::error::RpcError::SpawnFailed(message))
-                if message.contains("dedicated native OAuth process")
+                if message.contains("dedicated foreground OAuth process")
         ));
     }
 

--- a/crates/hyprstream/src/services/oauth/mod.rs
+++ b/crates/hyprstream/src/services/oauth/mod.rs
@@ -856,15 +856,29 @@ impl Spawnable for OAuthService {
                 let authority = hyprstream_rpc::Subject::new(
                     hyprstream_pds_service::OAUTH_ACCOUNT_RESOLVER_SUBJECT,
                 );
+                let refresh_store = Arc::clone(store);
                 tokio::time::timeout(
                     std::time::Duration::from_secs(30),
-                    store.refresh_hosted_did_index(&authority),
+                    tokio::task::spawn_blocking(move || {
+                        let runtime = tokio::runtime::Builder::new_current_thread()
+                            .enable_all()
+                            .build()
+                            .map_err(|error| format!("warm-up runtime: {error}"))?;
+                        runtime
+                            .block_on(refresh_store.refresh_hosted_did_index(&authority))
+                            .map_err(|error| format!("index refresh: {error}"))
+                    }),
                 )
                 .await
                 .map_err(|_| {
                     hyprstream_rpc::error::RpcError::SpawnFailed(
                         "hosted account index warm-up timed out".to_owned(),
                     )
+                })?
+                .map_err(|error| {
+                    hyprstream_rpc::error::RpcError::SpawnFailed(format!(
+                        "hosted account index warm-up task failed: {error}"
+                    ))
                 })?
                 .map_err(|error| {
                     hyprstream_rpc::error::RpcError::SpawnFailed(format!(
@@ -1214,7 +1228,7 @@ mod tests {
     fn oauth_warms_hosted_did_index_before_readiness() {
         let source = include_str!("mod.rs");
         let warmup = source
-            .find("store.refresh_hosted_did_index(&authority)")
+            .find("refresh_store.refresh_hosted_did_index(&authority)")
             .expect("OAuth startup must warm the hosted-DID index");
         let ready = source
             .find("if let Some(tx) = on_ready")

--- a/crates/hyprstream/src/services/oauth/mod.rs
+++ b/crates/hyprstream/src/services/oauth/mod.rs
@@ -68,7 +68,7 @@ pub mod userinfo;
 pub mod wit_bootstrap;
 pub mod xrpc;
 
-use std::sync::Arc;
+use std::{net::SocketAddr, path::PathBuf, sync::Arc};
 
 use anyhow::Result;
 use axum::{
@@ -593,6 +593,10 @@ pub struct OAuthService {
     hosted_account_store: Option<Arc<hyprstream_pds_service::AccountRecordStore>>,
     /// Authenticated hosted-account registration and federation-intake face.
     identity_registration_api: Option<Arc<identity_registration::IdentityRegistrationApi>>,
+    /// Authoritative publication root for the hosted-account tree. Set by the
+    /// production factory so OAuth and the public account listener share one
+    /// descriptor-bound store.
+    pds_root: Option<PathBuf>,
 }
 
 impl OAuthService {
@@ -620,6 +624,7 @@ impl OAuthService {
             jwt_verifying_key: jwt_verifying_key.to_bytes(),
             hosted_account_store: None,
             identity_registration_api: None,
+            pds_root: None,
         }
     }
 
@@ -646,6 +651,42 @@ impl OAuthService {
         self.identity_registration_api = Some(api);
         self
     }
+
+    /// Attach the authoritative published-account root used by production
+    /// OAuth/account HTTP composition.
+    pub fn with_pds_root(mut self, root: PathBuf) -> Self {
+        self.pds_root = Some(root);
+        self
+    }
+}
+
+/// Resolve explicitly provisioned TLS material for the public account
+/// listener. Account hosts must never fall back to the node/self-signed
+/// certificate, so enabling the listener requires both PEM paths and a valid
+/// rustls keypair.
+async fn resolve_account_http_tls(
+    config: &crate::account::AccountHttpConfig,
+    zone: &crate::account::AccountZone,
+) -> anyhow::Result<axum_server::tls_rustls::RustlsConfig> {
+    anyhow::ensure!(config.port != 0, "account HTTP listener port must be non-zero");
+    anyhow::ensure!(
+        config.tls_cert.is_file(),
+        "account TLS certificate is unavailable: {}",
+        config.tls_cert.display()
+    );
+    anyhow::ensure!(
+        config.tls_key.is_file(),
+        "account TLS private key is unavailable: {}",
+        config.tls_key.display()
+    );
+    axum_server::tls_rustls::RustlsConfig::from_pem_file(&config.tls_cert, &config.tls_key)
+        .await
+        .map_err(|error| {
+            anyhow::anyhow!(
+                "failed to load account-zone TLS for {}: {error}",
+                zone.wildcard_domain()
+            )
+        })
 }
 
 #[cfg(test)]
@@ -878,6 +919,37 @@ impl Spawnable for OAuthService {
                 }
             };
 
+            // The public account face and OAuth's hosted-DID resolver must
+            // share one descriptor-bound store over the authoritative
+            // publication root. Enabling the listener therefore fails closed
+            // when the root or mandatory audit sink is unavailable.
+            let hosted_account_store = if let Some(store) = &self.hosted_account_store {
+                Some(Arc::clone(store))
+            } else if self.account_config.http.is_some() {
+                let root = self.pds_root.clone().ok_or_else(|| {
+                    hyprstream_rpc::error::RpcError::SpawnFailed(
+                        "account HTTP listener enabled without a PDS publication root".to_owned(),
+                    )
+                })?;
+                let sink = audit_sink.clone().ok_or_else(|| {
+                    hyprstream_rpc::error::RpcError::SpawnFailed(
+                        "account HTTP listener requires a usable MAC audit sink".to_owned(),
+                    )
+                })?;
+                let mount = crate::mac::PdsDirectoryMount::open(&root).map_err(|error| {
+                    hyprstream_rpc::error::RpcError::SpawnFailed(format!(
+                        "open published PDS account root {}: {error}",
+                        root.display()
+                    ))
+                })?;
+                Some(crate::mac::production_pds_account_record_store(
+                    Arc::new(mount),
+                    sink,
+                ))
+            } else {
+                None
+            };
+
             let (ca_jwt_key, signing_key_store) = match crate::auth::identity_store::load_ca_signing_key(&credentials_dir) {
                 Ok(root_key) => {
                     let key = hyprstream_rpc::node_identity::derive_purpose_key(&root_key, "hyprstream-jwt-v1");
@@ -971,7 +1043,7 @@ impl Spawnable for OAuthService {
                 discovery_client.clone(),
                 jwt_verifying_key,
             );
-            if let Some(store) = &self.hosted_account_store {
+            if let Some(store) = &hosted_account_store {
                 oauth_state = oauth_state.with_hosted_account_store(Arc::clone(store));
             }
             if let Some(api) = &self.identity_registration_api {
@@ -1011,7 +1083,7 @@ impl Spawnable for OAuthService {
             // tenant enumeration; a bounded startup failure keeps OAuth
             // fail-closed instead of serving valid hosted users intermittently
             // while the first snapshot is still absent.
-            if let Some(store) = &self.hosted_account_store {
+            if let Some(store) = &hosted_account_store {
                 let authority = hyprstream_rpc::Subject::new(
                     hyprstream_pds_service::OAUTH_ACCOUNT_RESOLVER_SUBJECT,
                 );
@@ -1154,6 +1226,65 @@ impl Spawnable for OAuthService {
             // here, while the supervised launcher still owns the launch.
             let bound = crate::server::tls::bind_listener(addr, rustls_config, "OAuthService")?;
 
+            // Optional public hosted-account face. It has its own listener,
+            // certificate, and shutdown signal; it is never mounted into the
+            // authenticated OAuth router.
+            let account_endpoint = if let Some(http_config) = self.account_config.http.as_ref() {
+                let zone = self.account_config.resolve_zone().map_err(|error| {
+                    hyprstream_rpc::error::RpcError::SpawnFailed(format!(
+                        "account HTTP listener requires a valid account zone: {error}"
+                    ))
+                })?;
+                let store = hosted_account_store.clone().ok_or_else(|| {
+                    hyprstream_rpc::error::RpcError::SpawnFailed(
+                        "account HTTP listener has no hosted-account store".to_owned(),
+                    )
+                })?;
+                let directory = Arc::new(
+                    hyprstream_pds_service::account_http::MountedHostedAccountHttpDirectory::new(
+                        store,
+                        hyprstream_rpc::Subject::new(
+                            hyprstream_pds_service::OAUTH_ACCOUNT_RESOLVER_SUBJECT,
+                        ),
+                        zone.apex(),
+                    )
+                    .map_err(|error| {
+                        hyprstream_rpc::error::RpcError::SpawnFailed(format!(
+                            "compose account HTTP directory: {error}"
+                        ))
+                    })?,
+                );
+                let account_app =
+                    hyprstream_pds_service::account_http::router(zone.apex(), directory)
+                        .map_err(|error| {
+                            hyprstream_rpc::error::RpcError::SpawnFailed(format!(
+                                "compose account HTTP router: {error}"
+                            ))
+                        })?;
+                let account_addr: SocketAddr = format!("{}:{}", http_config.host, http_config.port)
+                    .parse()
+                    .map_err(|error| {
+                        hyprstream_rpc::error::RpcError::SpawnFailed(format!(
+                            "invalid account HTTP address: {error}"
+                        ))
+                    })?;
+                let account_tls = resolve_account_http_tls(http_config, &zone)
+                    .await
+                    .map_err(|error| {
+                        hyprstream_rpc::error::RpcError::SpawnFailed(format!(
+                            "account HTTP TLS: {error:#}"
+                        ))
+                    })?;
+                let account_bound = crate::server::tls::bind_listener(
+                    account_addr,
+                    Some(account_tls),
+                    "AccountHttpService",
+                )?;
+                Some((account_bound, account_app))
+            } else {
+                None
+            };
+
             let iroh_required = self
                 .quic_config
                 .as_ref()
@@ -1218,6 +1349,11 @@ impl Spawnable for OAuthService {
             // (join handle, whether the select branch already consumed it).
             let mut rpc_owner: Option<(tokio::task::JoinHandle<anyhow::Result<()>>, bool)> =
                 None;
+            let account_shutdown = Arc::new(Notify::new());
+            let mut account_owner: Option<(
+                tokio::task::JoinHandle<Result<(), hyprstream_rpc::error::RpcError>>,
+                bool,
+            )> = None;
             let bridge_init: Result<Arc<LocalServiceBridge>, hyprstream_rpc::error::RpcError> =
                 async {
                     let (bridge, bridge_ready_rx) =
@@ -1340,6 +1476,20 @@ impl Spawnable for OAuthService {
                         )
                         .await
                     });
+                    let mut account_loop = match account_endpoint {
+                        Some((account_bound, account_app)) => tokio::task::spawn_local(
+                            crate::server::tls::serve_bound(
+                                account_bound,
+                                account_app,
+                                Arc::clone(&account_shutdown),
+                                "AccountHttpService",
+                            ),
+                        ),
+                        None => tokio::task::spawn_local(async {
+                            std::future::pending::<Result<(), hyprstream_rpc::error::RpcError>>().await
+                        }),
+                    };
+                    let mut account_consumed = false;
                     let mut rpc_consumed = false;
                     let outcome = tokio::select! {
                         http = crate::server::tls::serve_bound(
@@ -1348,6 +1498,20 @@ impl Spawnable for OAuthService {
                             shutdown.clone(),
                             "OAuthService",
                         ) => http.map_err(|e| anyhow::anyhow!("OAuthService HTTP serve error: {e}")),
+                        account = &mut account_loop => {
+                            account_consumed = true;
+                            match account {
+                                Ok(Ok(())) => Err(anyhow::anyhow!(
+                                    "AccountHttpService stopped unexpectedly"
+                                )),
+                                Ok(Err(e)) => Err(anyhow::anyhow!(
+                                    "AccountHttpService error: {e}"
+                                )),
+                                Err(join) => Err(anyhow::anyhow!(
+                                    "AccountHttpService task join error: {join}"
+                                )),
+                            }
+                        },
                         rpc = &mut rpc_loop => {
                             // This select branch consumed the completed
                             // JoinHandle — the teardown below must not poll it
@@ -1375,6 +1539,7 @@ impl Spawnable for OAuthService {
                         }
                     };
                     rpc_owner = Some((rpc_loop, rpc_consumed));
+                    account_owner = Some((account_loop, account_consumed));
                     outcome
                 }.await
             };
@@ -1384,6 +1549,31 @@ impl Spawnable for OAuthService {
             // readiness failure, HTTP or RPC error, or clean shutdown. The
             // primary error is preserved; cleanup failures are logged as
             // context, never masked. ──
+            account_shutdown.notify_waiters();
+            if let Some((mut account_loop, account_consumed)) = account_owner.take() {
+                if !account_consumed {
+                    match tokio::time::timeout(
+                        std::time::Duration::from_secs(45),
+                        &mut account_loop,
+                    )
+                    .await
+                    {
+                        Ok(Ok(Ok(()))) => {}
+                        Ok(Ok(Err(error))) => {
+                            tracing::warn!("account HTTP task error during shutdown: {error}");
+                        }
+                        Ok(Err(join)) => {
+                            tracing::warn!("account HTTP task join error during shutdown: {join}");
+                        }
+                        Err(_) => {
+                            account_loop.abort();
+                            tracing::warn!(
+                                "account HTTP task did not stop within the shutdown budget; aborted"
+                            );
+                        }
+                    }
+                }
+            }
             serve_shutdown.notify_one();
             if let Some(bridge) = &bridge_owner {
                 bridge.begin_shutdown(

--- a/crates/hyprstream/src/services/oauth/mod.rs
+++ b/crates/hyprstream/src/services/oauth/mod.rs
@@ -856,29 +856,15 @@ impl Spawnable for OAuthService {
                 let authority = hyprstream_rpc::Subject::new(
                     hyprstream_pds_service::OAUTH_ACCOUNT_RESOLVER_SUBJECT,
                 );
-                let refresh_store = Arc::clone(store);
                 tokio::time::timeout(
                     std::time::Duration::from_secs(30),
-                    tokio::task::spawn_blocking(move || {
-                        let runtime = tokio::runtime::Builder::new_current_thread()
-                            .enable_all()
-                            .build()
-                            .map_err(|error| format!("warm-up runtime: {error}"))?;
-                        runtime
-                            .block_on(refresh_store.refresh_hosted_did_index(&authority))
-                            .map_err(|error| format!("index refresh: {error}"))
-                    }),
+                    store.refresh_hosted_did_index(&authority),
                 )
                 .await
                 .map_err(|_| {
                     hyprstream_rpc::error::RpcError::SpawnFailed(
                         "hosted account index warm-up timed out".to_owned(),
                     )
-                })?
-                .map_err(|error| {
-                    hyprstream_rpc::error::RpcError::SpawnFailed(format!(
-                        "hosted account index warm-up task failed: {error}"
-                    ))
                 })?
                 .map_err(|error| {
                     hyprstream_rpc::error::RpcError::SpawnFailed(format!(
@@ -1228,7 +1214,7 @@ mod tests {
     fn oauth_warms_hosted_did_index_before_readiness() {
         let source = include_str!("mod.rs");
         let warmup = source
-            .find("refresh_store.refresh_hosted_did_index(&authority)")
+            .find("store.refresh_hosted_did_index(&authority)")
             .expect("OAuth startup must warm the hosted-DID index");
         let ready = source
             .find("if let Some(tx) = on_ready")
@@ -1239,6 +1225,10 @@ mod tests {
             warmup_block.contains("tokio::time::timeout")
                 && warmup_block.contains("Duration::from_secs(30)"),
             "hosted-DID warm-up must have a bounded timeout"
+        );
+        assert!(
+            !warmup_block.contains("spawn_blocking"),
+            "hosted-DID warm-up timeout must not leave an uncancellable blocking task"
         );
     }
 

--- a/crates/hyprstream/src/services/oauth/mod.rs
+++ b/crates/hyprstream/src/services/oauth/mod.rs
@@ -1503,32 +1503,22 @@ impl Spawnable for OAuthService {
                     let mut account_loop = match account_endpoint {
                         Some((account_bound, account_app)) => {
                             let account_shutdown_task = Arc::clone(&account_shutdown);
-                            tokio::task::spawn_local(
-                            async move {
-                                tokio::task::spawn_blocking(move || {
-                                    let runtime = tokio::runtime::Builder::new_current_thread()
-                                        .enable_all()
-                                        .build()
-                                        .map_err(|error| {
-                                            hyprstream_rpc::error::RpcError::SpawnFailed(
-                                                format!("account HTTP runtime: {error}"),
-                                            )
-                                        })?;
-                                    runtime.block_on(crate::server::tls::serve_bound(
-                                        account_bound,
-                                        account_app,
-                                        account_shutdown_task,
-                                        "AccountHttpService",
-                                    ))
-                                })
-                                .await
-                                .map_err(|join| {
-                                    hyprstream_rpc::error::RpcError::SpawnFailed(format!(
-                                        "account HTTP worker join error: {join}"
-                                    ))
-                                })?
-                            },
-                            )
+                            tokio::task::spawn_blocking(move || {
+                                let runtime = tokio::runtime::Builder::new_current_thread()
+                                    .enable_all()
+                                    .build()
+                                    .map_err(|error| {
+                                        hyprstream_rpc::error::RpcError::SpawnFailed(
+                                            format!("account HTTP runtime: {error}"),
+                                        )
+                                    })?;
+                                runtime.block_on(crate::server::tls::serve_bound(
+                                    account_bound,
+                                    account_app,
+                                    account_shutdown_task,
+                                    "AccountHttpService",
+                                ))
+                            })
                         }
                         None => tokio::task::spawn_local(async {
                             std::future::pending::<Result<(), hyprstream_rpc::error::RpcError>>().await
@@ -1594,7 +1584,10 @@ impl Spawnable for OAuthService {
             // readiness failure, HTTP or RPC error, or clean shutdown. The
             // primary error is preserved; cleanup failures are logged as
             // context, never masked. ──
-            account_shutdown.notify_waiters();
+            // There is exactly one account listener. `notify_one` preserves a
+            // permit when teardown races worker startup; `notify_waiters` can
+            // lose the signal before the isolated runtime begins awaiting.
+            account_shutdown.notify_one();
             if let Some((mut account_loop, account_consumed, account_enabled)) = account_owner.take() {
                 if !account_enabled {
                     account_loop.abort();

--- a/crates/hyprstream/src/services/oauth/mod.rs
+++ b/crates/hyprstream/src/services/oauth/mod.rs
@@ -423,6 +423,54 @@ async fn build_oauth_iroh_substrate(
     .await
 }
 
+async fn warm_hosted_did_index(
+    store: Arc<hyprstream_pds_service::AccountRecordStore>,
+    authority: hyprstream_rpc::Subject,
+    timeout: std::time::Duration,
+) -> Result<(), hyprstream_rpc::error::RpcError> {
+    // The descriptor-backed PDS mount performs synchronous file and audit I/O
+    // inside its async trait methods. Run the warm-up on an owned OS thread so
+    // the timeout can return without leaving a Tokio blocking-pool task that
+    // runtime shutdown must await.
+    let (warmup_tx, warmup_rx) = tokio::sync::oneshot::channel();
+    std::thread::Builder::new()
+        .name("hyprstream-oauth-index-warmup".to_owned())
+        .spawn(move || {
+            let result = (|| {
+                let runtime = tokio::runtime::Builder::new_current_thread()
+                    .enable_all()
+                    .build()
+                    .map_err(|error| format!("warm-up runtime: {error}"))?;
+                runtime
+                    .block_on(store.refresh_hosted_did_index(&authority))
+                    .map_err(|error| format!("index refresh: {error}"))
+            })();
+            let _ = warmup_tx.send(result);
+        })
+        .map_err(|error| {
+            hyprstream_rpc::error::RpcError::SpawnFailed(format!(
+                "hosted account index warm-up thread failed: {error}"
+            ))
+        })?;
+    tokio::time::timeout(timeout, warmup_rx)
+        .await
+        .map_err(|_| {
+            hyprstream_rpc::error::RpcError::SpawnFailed(
+                "hosted account index warm-up timed out".to_owned(),
+            )
+        })?
+        .map_err(|error| {
+            hyprstream_rpc::error::RpcError::SpawnFailed(format!(
+                "hosted account index warm-up thread exited: {error}"
+            ))
+        })?
+        .map_err(|error| {
+            hyprstream_rpc::error::RpcError::SpawnFailed(format!(
+                "hosted account index warm-up failed: {error}"
+            ))
+        })
+}
+
 pub struct OAuthService {
     config: OAuthConfig,
     /// Global TLS configuration (passed from factory, avoids re-loading config)
@@ -856,21 +904,12 @@ impl Spawnable for OAuthService {
                 let authority = hyprstream_rpc::Subject::new(
                     hyprstream_pds_service::OAUTH_ACCOUNT_RESOLVER_SUBJECT,
                 );
-                tokio::time::timeout(
+                warm_hosted_did_index(
+                    Arc::clone(store),
+                    authority,
                     std::time::Duration::from_secs(30),
-                    store.refresh_hosted_did_index(&authority),
                 )
-                .await
-                .map_err(|_| {
-                    hyprstream_rpc::error::RpcError::SpawnFailed(
-                        "hosted account index warm-up timed out".to_owned(),
-                    )
-                })?
-                .map_err(|error| {
-                    hyprstream_rpc::error::RpcError::SpawnFailed(format!(
-                        "hosted account index warm-up failed: {error}"
-                    ))
-                })?;
+                .await?;
             }
             // Populate legacy JWKS nbf/exp from signing-key file mtime (used when store absent).
             let key_nbf = crate::auth::identity_store::node_signing_key_mtime(&credentials_dir);
@@ -1229,6 +1268,48 @@ mod tests {
         assert!(
             !warmup_block.contains("spawn_blocking"),
             "hosted-DID warm-up timeout must not leave an uncancellable blocking task"
+        );
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn hosted_did_warmup_timeout_does_not_wait_for_blocking_scan() {
+        struct SlowReads;
+        impl hyprstream_pds_service::AccountRecordReadAuthorizer for SlowReads {
+            fn check_read(
+                &self,
+                _subject: &hyprstream_rpc::Subject,
+                _verified_tenant: Option<&str>,
+                _security_context: Option<&hyprstream_rpc::auth::mac::SecurityContext>,
+                _object_id: &str,
+            ) -> hyprstream_rpc::auth::mac::MacDecision {
+                std::thread::sleep(std::time::Duration::from_millis(200));
+                hyprstream_rpc::auth::mac::MacDecision::Permit
+            }
+        }
+
+        let store = Arc::new(hyprstream_pds_service::AccountRecordStore::new(
+            Arc::new(hyprstream_vfs::SyntheticMount::new(
+                hyprstream_vfs::SyntheticNode::dir(),
+            )),
+            Arc::new(SlowReads),
+        ));
+        let started = std::time::Instant::now();
+        let result = warm_hosted_did_index(
+            store,
+            hyprstream_rpc::Subject::new(
+                hyprstream_pds_service::OAUTH_ACCOUNT_RESOLVER_SUBJECT,
+            ),
+            std::time::Duration::from_millis(20),
+        )
+        .await;
+        assert!(matches!(
+            result,
+            Err(hyprstream_rpc::error::RpcError::SpawnFailed(message))
+                if message.contains("timed out")
+        ));
+        assert!(
+            started.elapsed() < std::time::Duration::from_millis(150),
+            "timeout must return without joining the blocking scan"
         );
     }
 

--- a/crates/hyprstream/src/services/oauth/mod.rs
+++ b/crates/hyprstream/src/services/oauth/mod.rs
@@ -1503,21 +1503,39 @@ impl Spawnable for OAuthService {
                     let mut account_loop = match account_endpoint {
                         Some((account_bound, account_app)) => {
                             let account_shutdown_task = Arc::clone(&account_shutdown);
-                            tokio::task::spawn_blocking(move || {
-                                let runtime = tokio::runtime::Builder::new_current_thread()
-                                    .enable_all()
-                                    .build()
-                                    .map_err(|error| {
-                                        hyprstream_rpc::error::RpcError::SpawnFailed(
-                                            format!("account HTTP runtime: {error}"),
-                                        )
-                                    })?;
-                                runtime.block_on(crate::server::tls::serve_bound(
-                                    account_bound,
-                                    account_app,
-                                    account_shutdown_task,
-                                    "AccountHttpService",
-                                ))
+                            let (account_tx, account_rx) = tokio::sync::oneshot::channel();
+                            std::thread::Builder::new()
+                                .name("hyprstream-account-http".to_owned())
+                                .spawn(move || {
+                                    let result = (|| {
+                                        let runtime = tokio::runtime::Builder::new_current_thread()
+                                            .enable_all()
+                                            .build()
+                                            .map_err(|error| {
+                                                hyprstream_rpc::error::RpcError::SpawnFailed(
+                                                    format!("account HTTP runtime: {error}"),
+                                                )
+                                            })?;
+                                        runtime.block_on(crate::server::tls::serve_bound(
+                                            account_bound,
+                                            account_app,
+                                            account_shutdown_task,
+                                            "AccountHttpService",
+                                        ))
+                                    })();
+                                    let _ = account_tx.send(result);
+                                })
+                                .map_err(|error| {
+                                    hyprstream_rpc::error::RpcError::SpawnFailed(format!(
+                                        "account HTTP thread spawn failed: {error}"
+                                    ))
+                                })?;
+                            tokio::task::spawn_local(async move {
+                                account_rx.await.map_err(|_| {
+                                    hyprstream_rpc::error::RpcError::SpawnFailed(
+                                        "account HTTP thread exited without a result".to_owned(),
+                                    )
+                                })?
                             })
                         }
                         None => tokio::task::spawn_local(async {

--- a/crates/hyprstream/src/services/oauth/mod.rs
+++ b/crates/hyprstream/src/services/oauth/mod.rs
@@ -1742,6 +1742,11 @@ mod tests {
             Arc::new(SyntheticMount::new(pds_root)),
             Arc::new(PermitFixtureAccountReads),
         ));
+        hosted_account_store
+            .refresh_hosted_did_index(&hyprstream_rpc::Subject::new(
+                hyprstream_pds_service::OAUTH_ACCOUNT_RESOLVER_SUBJECT,
+            ))
+            .await?;
         let mut oauth_state = OAuthState::new(
             &config,
             policy_client,

--- a/crates/hyprstream/src/services/oauth/mod.rs
+++ b/crates/hyprstream/src/services/oauth/mod.rs
@@ -26,6 +26,8 @@
 //!   /oauth/device/verify                     → user verification page
 //! ```
 
+mod account_worker;
+
 pub mod auth;
 pub mod authorize;
 pub mod browser_session;
@@ -431,47 +433,20 @@ async fn warm_hosted_did_index(
     authority: hyprstream_rpc::Subject,
     timeout: std::time::Duration,
 ) -> Result<(), hyprstream_rpc::error::RpcError> {
-    // The descriptor-backed PDS mount performs synchronous file and audit I/O
-    // inside its async trait methods. Run the warm-up on an owned OS thread so
-    // the timeout can return without leaving a Tokio blocking-pool task that
-    // runtime shutdown must await.
-    let (warmup_tx, warmup_rx) = tokio::sync::oneshot::channel();
-    std::thread::Builder::new()
-        .name("hyprstream-oauth-index-warmup".to_owned())
-        .spawn(move || {
-            let result = (|| {
-                let runtime = tokio::runtime::Builder::new_current_thread()
-                    .enable_all()
-                    .build()
-                    .map_err(|error| format!("warm-up runtime: {error}"))?;
-                runtime
-                    .block_on(store.refresh_hosted_did_index(&authority))
-                    .map_err(|error| format!("index refresh: {error}"))
-            })();
-            let _ = warmup_tx.send(result);
-        })
-        .map_err(|error| {
-            hyprstream_rpc::error::RpcError::SpawnFailed(format!(
-                "hosted account index warm-up thread failed: {error}"
-            ))
-        })?;
-    tokio::time::timeout(timeout, warmup_rx)
-        .await
-        .map_err(|_| {
-            hyprstream_rpc::error::RpcError::SpawnFailed(
-                "hosted account index warm-up timed out".to_owned(),
-            )
-        })?
-        .map_err(|error| {
-            hyprstream_rpc::error::RpcError::SpawnFailed(format!(
-                "hosted account index warm-up thread exited: {error}"
-            ))
-        })?
-        .map_err(|error| {
-            hyprstream_rpc::error::RpcError::SpawnFailed(format!(
-                "hosted account index warm-up failed: {error}"
-            ))
-        })
+    let mut worker = account_worker::ContainedWorker::spawn("hyprstream-oauth-index-warmup", move || {
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .map_err(|error| format!("warm-up runtime: {error}"))?;
+        runtime
+            .block_on(store.refresh_hosted_did_index(&authority))
+            .map_err(|error| format!("index refresh: {error}"))
+    })?;
+    worker.finish(timeout).await?.map_err(|error| {
+        hyprstream_rpc::error::RpcError::SpawnFailed(format!(
+            "hosted account index warm-up failed: {error}"
+        ))
+    })
 }
 
 /// Profile-aware bind of OAuth's inbound reach-only substrate, using the
@@ -597,6 +572,7 @@ pub struct OAuthService {
     /// production factory so OAuth and the public account listener share one
     /// descriptor-bound store.
     pds_root: Option<PathBuf>,
+    dedicated_process: bool,
 }
 
 impl OAuthService {
@@ -625,6 +601,7 @@ impl OAuthService {
             hosted_account_store: None,
             identity_registration_api: None,
             pds_root: None,
+            dedicated_process: false,
         }
     }
 
@@ -649,6 +626,12 @@ impl OAuthService {
         api: Arc<identity_registration::IdentityRegistrationApi>,
     ) -> Self {
         self.identity_registration_api = Some(api);
+        self
+    }
+
+    /// Set only from the launcher's explicit single-service process context.
+    pub(crate) fn with_dedicated_process(mut self, dedicated: bool) -> Self {
+        self.dedicated_process = dedicated;
         self
     }
 
@@ -763,6 +746,15 @@ impl Spawnable for OAuthService {
         shutdown: Arc<Notify>,
         on_ready: Option<tokio::sync::oneshot::Sender<()>>,
     ) -> Result<(), hyprstream_rpc::error::RpcError> {
+        let contains_account_workers = self.account_config.http.is_some();
+        if contains_account_workers && !self.dedicated_process {
+            return Err(hyprstream_rpc::error::RpcError::SpawnFailed(
+                "hosted account workers require a dedicated native OAuth process".to_owned(),
+            ));
+        }
+        // Timed-out synchronous I/O cannot be cancelled safely. This service
+        // owns the whole process when account workers are enabled; terminal
+        // startup/shutdown therefore ends that process and all its workers.
         // Use single-threaded runtime + LocalSet because HTTP handlers make ZMQ RPC
         // calls (e.g., policy_client.issue_token()), and ZMQ clients use spawn_local.
         let rt = tokio::runtime::Builder::new_current_thread()
@@ -771,7 +763,7 @@ impl Spawnable for OAuthService {
             .map_err(|e| hyprstream_rpc::error::RpcError::SpawnFailed(format!("runtime: {e}")))?;
 
         let local = tokio::task::LocalSet::new();
-        local.block_on(&rt, async move {
+        let result = local.block_on(&rt, async move {
             let addr_str = format!("{}:{}", self.config.host, self.config.port);
             let addr: std::net::SocketAddr = addr_str.parse().map_err(|e| {
                 hyprstream_rpc::error::RpcError::SpawnFailed(format!("Invalid address: {e}"))
@@ -1109,12 +1101,18 @@ impl Spawnable for OAuthService {
                 let authority = hyprstream_rpc::Subject::new(
                     hyprstream_pds_service::OAUTH_ACCOUNT_RESOLVER_SUBJECT,
                 );
-                warm_hosted_did_index(
-                    Arc::clone(store),
-                    authority,
-                    std::time::Duration::from_secs(30),
-                )
-                .await?;
+                if contains_account_workers {
+                    warm_hosted_did_index(
+                        Arc::clone(store),
+                        authority,
+                        std::time::Duration::from_secs(30),
+                    )
+                    .await?;
+                } else if !store.hosted_did_index_ready().await {
+                    return Err(hyprstream_rpc::error::RpcError::SpawnFailed(
+                        "in-process hosted-account store must be warmed before injection".to_owned(),
+                    ));
+                }
             }
             // Populate legacy JWKS nbf/exp from signing-key file mtime (used when store absent).
             let key_nbf = crate::auth::identity_store::node_signing_key_mtime(&credentials_dir);
@@ -1372,11 +1370,9 @@ impl Spawnable for OAuthService {
             let mut rpc_owner: Option<(tokio::task::JoinHandle<anyhow::Result<()>>, bool)> =
                 None;
             let account_shutdown = Arc::new(Notify::new());
-            let mut account_owner: Option<(
-                tokio::task::JoinHandle<Result<(), hyprstream_rpc::error::RpcError>>,
-                bool,
-                bool,
-            )> = None;
+            let mut account_owner: Option<account_worker::ContainedWorker<
+                Result<(), hyprstream_rpc::error::RpcError>,
+            >> = None;
             let bridge_init: Result<Arc<LocalServiceBridge>, hyprstream_rpc::error::RpcError> =
                 async {
                     let (bridge, bridge_ready_rx) =
@@ -1440,7 +1436,7 @@ impl Spawnable for OAuthService {
             // the prebound listener concurrently with the RPC loop. Whichever
             // side finishes first decides the primary outcome; the actual
             // serve result propagates (no log-and-swallow).
-            let primary: anyhow::Result<()> = match bridge_init {
+            let mut primary: anyhow::Result<()> = match bridge_init {
                 Err(e) => Err(anyhow::anyhow!("OAuthService startup failed: {e}")),
                 Ok(bridge) => async {
                     if iroh_enabled {
@@ -1484,6 +1480,28 @@ impl Spawnable for OAuthService {
                             }
                         }
                     }
+                    // Finish all fallible account-worker creation before the RPC
+                    // task can signal readiness. Keep the actual thread owner.
+                    if let Some((account_bound, account_app)) = account_endpoint {
+                        let account_shutdown_task = Arc::clone(&account_shutdown);
+                        let runtime = tokio::runtime::Builder::new_current_thread()
+                            .enable_all()
+                            .build()
+                            .map_err(|error| hyprstream_rpc::error::RpcError::SpawnFailed(
+                                format!("account HTTP runtime: {error}"),
+                            ))?;
+                        account_owner = Some(account_worker::ContainedWorker::spawn(
+                            "hyprstream-account-http",
+                            move || {
+                                runtime.block_on(crate::server::tls::serve_bound(
+                                    account_bound,
+                                    account_app,
+                                    account_shutdown_task,
+                                    "AccountHttpService",
+                                ))
+                            },
+                        )?);
+                    }
                     let control_transport = self.control_transport.clone();
                     let rpc_signing_key = self.signing_key.clone();
                     let processor: Arc<
@@ -1499,50 +1517,6 @@ impl Spawnable for OAuthService {
                         )
                         .await
                     });
-                    let account_enabled = account_endpoint.is_some();
-                    let mut account_loop = match account_endpoint {
-                        Some((account_bound, account_app)) => {
-                            let account_shutdown_task = Arc::clone(&account_shutdown);
-                            let (account_tx, account_rx) = tokio::sync::oneshot::channel();
-                            std::thread::Builder::new()
-                                .name("hyprstream-account-http".to_owned())
-                                .spawn(move || {
-                                    let result = (|| {
-                                        let runtime = tokio::runtime::Builder::new_current_thread()
-                                            .enable_all()
-                                            .build()
-                                            .map_err(|error| {
-                                                hyprstream_rpc::error::RpcError::SpawnFailed(
-                                                    format!("account HTTP runtime: {error}"),
-                                                )
-                                            })?;
-                                        runtime.block_on(crate::server::tls::serve_bound(
-                                            account_bound,
-                                            account_app,
-                                            account_shutdown_task,
-                                            "AccountHttpService",
-                                        ))
-                                    })();
-                                    let _ = account_tx.send(result);
-                                })
-                                .map_err(|error| {
-                                    hyprstream_rpc::error::RpcError::SpawnFailed(format!(
-                                        "account HTTP thread spawn failed: {error}"
-                                    ))
-                                })?;
-                            tokio::task::spawn_local(async move {
-                                account_rx.await.map_err(|_| {
-                                    hyprstream_rpc::error::RpcError::SpawnFailed(
-                                        "account HTTP thread exited without a result".to_owned(),
-                                    )
-                                })?
-                            })
-                        }
-                        None => tokio::task::spawn_local(async {
-                            std::future::pending::<Result<(), hyprstream_rpc::error::RpcError>>().await
-                        }),
-                    };
-                    let mut account_consumed = false;
                     let mut rpc_consumed = false;
                     let outcome = tokio::select! {
                         http = crate::server::tls::serve_bound(
@@ -1551,8 +1525,12 @@ impl Spawnable for OAuthService {
                             shutdown.clone(),
                             "OAuthService",
                         ) => http.map_err(|e| anyhow::anyhow!("OAuthService HTTP serve error: {e}")),
-                        account = &mut account_loop => {
-                            account_consumed = true;
+                        account = async {
+                            match account_owner.as_mut() {
+                                Some(worker) => worker.result().await,
+                                None => std::future::pending().await,
+                            }
+                        } => {
                             match account {
                                 Ok(Ok(())) => Err(anyhow::anyhow!(
                                     "AccountHttpService stopped unexpectedly"
@@ -1592,7 +1570,6 @@ impl Spawnable for OAuthService {
                         }
                     };
                     rpc_owner = Some((rpc_loop, rpc_consumed));
-                    account_owner = Some((account_loop, account_consumed, account_enabled));
                     outcome
                 }.await
             };
@@ -1606,34 +1583,18 @@ impl Spawnable for OAuthService {
             // permit when teardown races worker startup; `notify_waiters` can
             // lose the signal before the isolated runtime begins awaiting.
             account_shutdown.notify_one();
-            if let Some((mut account_loop, account_consumed, account_enabled)) = account_owner.take() {
-                if !account_enabled {
-                    account_loop.abort();
-                    let _ = account_loop.await;
-                } else if !account_consumed {
-                    match tokio::time::timeout(
-                        std::time::Duration::from_secs(45),
-                        &mut account_loop,
-                    )
-                    .await
-                    {
-                        Ok(Ok(Ok(()))) => {}
-                        Ok(Ok(Err(error))) => {
-                            tracing::warn!("account HTTP task error during shutdown: {error}");
-                        }
-                        Ok(Err(join)) => {
-                            tracing::warn!("account HTTP task join error during shutdown: {join}");
-                        }
-                        Err(_) => {
-                            account_loop.abort();
-                            tracing::warn!(
-                                "account HTTP task did not stop within the shutdown budget; aborted"
-                            );
+            serve_shutdown.notify_one();
+            if let Some(mut worker) = account_owner.take() {
+                if !worker.is_joined() {
+                    let completion = worker.finish(std::time::Duration::from_secs(45)).await;
+                    if let Err(error) = completion.and_then(|result| result) {
+                        tracing::warn!(%error, "account HTTP worker failed during shutdown");
+                        if primary.is_ok() {
+                            primary = Err(anyhow::anyhow!(error));
                         }
                     }
                 }
             }
-            serve_shutdown.notify_one();
             if let Some(bridge) = &bridge_owner {
                 bridge.begin_shutdown(
                     tokio::time::Instant::now() + std::time::Duration::from_secs(5),
@@ -1679,7 +1640,14 @@ impl Spawnable for OAuthService {
                 hyprstream_rpc::error::RpcError::SpawnFailed(format!("{e:#}"))
             })?;
             Ok(())
-        })
+        });
+        if contains_account_workers {
+            if let Err(error) = &result {
+                tracing::error!(%error, "dedicated OAuth process failed");
+            }
+            std::process::exit(if result.is_ok() { 0 } else { account_worker::WORKER_FAILURE_EXIT });
+        }
+        result
     }
 }
 
@@ -1773,6 +1741,31 @@ mod tests {
     }
 
     #[test]
+    fn account_worker_requires_launcher_process_containment() {
+        let sk = ed25519_dalek::SigningKey::from_bytes(&[3; 32]);
+        let account = crate::account::AccountZoneConfig {
+            http: Some(crate::account::AccountHttpConfig {
+                host: "127.0.0.1".to_owned(),
+                port: 443,
+                tls_cert: PathBuf::from("unused.pem"),
+                tls_key: PathBuf::from("unused.key"),
+            }),
+            ..Default::default()
+        };
+        let transport = TransportConfig::inproc("test-containment-unused");
+        let service = OAuthService::new(
+            Default::default(), Default::default(), account, sk.clone(),
+            transport.clone(), transport.clone(), transport,
+            sk.verifying_key(), sk.verifying_key(),
+        );
+        let result = Box::new(service).run(Arc::new(Notify::new()), None);
+        assert!(matches!(result,
+            Err(hyprstream_rpc::error::RpcError::SpawnFailed(message))
+                if message.contains("dedicated native OAuth process")
+        ));
+    }
+
+    #[test]
     fn oauth_warms_hosted_did_index_before_readiness() {
         let source = include_str!("mod.rs");
         let production = source
@@ -1812,6 +1805,11 @@ mod tests {
 
     #[tokio::test(flavor = "current_thread")]
     async fn hosted_did_warmup_timeout_does_not_wait_for_blocking_scan() {
+        const TEST: &str = "services::oauth::tests::hosted_did_warmup_timeout_does_not_wait_for_blocking_scan";
+        if !account_worker::tests::is_child(TEST) {
+            account_worker::tests::expect_contained_exit(TEST, &[]);
+            return;
+        }
         struct SlowReads;
         impl hyprstream_pds_service::AccountRecordReadAuthorizer for SlowReads {
             fn check_read(
@@ -1832,8 +1830,7 @@ mod tests {
             )),
             Arc::new(SlowReads),
         ));
-        let started = std::time::Instant::now();
-        let result = warm_hosted_did_index(
+        let _ = warm_hosted_did_index(
             store,
             hyprstream_rpc::Subject::new(
                 hyprstream_pds_service::OAUTH_ACCOUNT_RESOLVER_SUBJECT,
@@ -1841,15 +1838,7 @@ mod tests {
             std::time::Duration::from_millis(20),
         )
         .await;
-        assert!(matches!(
-            result,
-            Err(hyprstream_rpc::error::RpcError::SpawnFailed(message))
-                if message.contains("timed out")
-        ));
-        assert!(
-            started.elapsed() < std::time::Duration::from_millis(150),
-            "timeout must return without joining the blocking scan"
-        );
+        panic!("timed-out warm-up must terminate its dedicated process");
     }
 
     fn encode_form(fields: &[(&str, &str)]) -> String {

--- a/crates/hyprstream/src/services/oauth/mod.rs
+++ b/crates/hyprstream/src/services/oauth/mod.rs
@@ -679,6 +679,28 @@ async fn resolve_account_http_tls(
         "account TLS private key is unavailable: {}",
         config.tls_key.display()
     );
+    let cert_pem = std::fs::read(&config.tls_cert)?;
+    let cert_der = rustls_pemfile::certs(&mut &cert_pem[..])
+        .next()
+        .ok_or_else(|| anyhow::anyhow!("account TLS certificate contains no certificate"))??;
+    let (_, certificate) = x509_parser::parse_x509_certificate(cert_der.as_ref())
+        .map_err(|error| anyhow::anyhow!("invalid account TLS certificate: {error}"))?;
+    let wildcard = zone.wildcard_domain();
+    let covers_zone = certificate.extensions().iter().any(|extension| {
+        matches!(
+            extension.parsed_extension(),
+            x509_parser::extensions::ParsedExtension::SubjectAlternativeName(names)
+                if names.general_names.iter().any(|name| matches!(
+                    name,
+                    x509_parser::extensions::GeneralName::DNSName(dns)
+                        if dns.eq_ignore_ascii_case(wildcard)
+                ))
+        )
+    });
+    anyhow::ensure!(
+        covers_zone,
+        "account TLS certificate does not cover account zone wildcard {wildcard}"
+    );
     axum_server::tls_rustls::RustlsConfig::from_pem_file(&config.tls_cert, &config.tls_key)
         .await
         .map_err(|error| {
@@ -1241,7 +1263,7 @@ impl Spawnable for OAuthService {
                     )
                 })?;
                 let directory = Arc::new(
-                    hyprstream_pds_service::account_http::MountedHostedAccountHttpDirectory::new(
+                    hyprstream_pds_service::account_http::MountedHostedAccountHttpDirectory::new_without_refresh(
                         store,
                         hyprstream_rpc::Subject::new(
                             hyprstream_pds_service::OAUTH_ACCOUNT_RESOLVER_SUBJECT,
@@ -1352,6 +1374,7 @@ impl Spawnable for OAuthService {
             let account_shutdown = Arc::new(Notify::new());
             let mut account_owner: Option<(
                 tokio::task::JoinHandle<Result<(), hyprstream_rpc::error::RpcError>>,
+                bool,
                 bool,
             )> = None;
             let bridge_init: Result<Arc<LocalServiceBridge>, hyprstream_rpc::error::RpcError> =
@@ -1476,15 +1499,37 @@ impl Spawnable for OAuthService {
                         )
                         .await
                     });
+                    let account_enabled = account_endpoint.is_some();
                     let mut account_loop = match account_endpoint {
-                        Some((account_bound, account_app)) => tokio::task::spawn_local(
-                            crate::server::tls::serve_bound(
-                                account_bound,
-                                account_app,
-                                Arc::clone(&account_shutdown),
-                                "AccountHttpService",
-                            ),
-                        ),
+                        Some((account_bound, account_app)) => {
+                            let account_shutdown_task = Arc::clone(&account_shutdown);
+                            tokio::task::spawn_local(
+                            async move {
+                                tokio::task::spawn_blocking(move || {
+                                    let runtime = tokio::runtime::Builder::new_current_thread()
+                                        .enable_all()
+                                        .build()
+                                        .map_err(|error| {
+                                            hyprstream_rpc::error::RpcError::SpawnFailed(
+                                                format!("account HTTP runtime: {error}"),
+                                            )
+                                        })?;
+                                    runtime.block_on(crate::server::tls::serve_bound(
+                                        account_bound,
+                                        account_app,
+                                        account_shutdown_task,
+                                        "AccountHttpService",
+                                    ))
+                                })
+                                .await
+                                .map_err(|join| {
+                                    hyprstream_rpc::error::RpcError::SpawnFailed(format!(
+                                        "account HTTP worker join error: {join}"
+                                    ))
+                                })?
+                            },
+                            )
+                        }
                         None => tokio::task::spawn_local(async {
                             std::future::pending::<Result<(), hyprstream_rpc::error::RpcError>>().await
                         }),
@@ -1539,7 +1584,7 @@ impl Spawnable for OAuthService {
                         }
                     };
                     rpc_owner = Some((rpc_loop, rpc_consumed));
-                    account_owner = Some((account_loop, account_consumed));
+                    account_owner = Some((account_loop, account_consumed, account_enabled));
                     outcome
                 }.await
             };
@@ -1550,8 +1595,11 @@ impl Spawnable for OAuthService {
             // primary error is preserved; cleanup failures are logged as
             // context, never masked. ──
             account_shutdown.notify_waiters();
-            if let Some((mut account_loop, account_consumed)) = account_owner.take() {
-                if !account_consumed {
+            if let Some((mut account_loop, account_consumed, account_enabled)) = account_owner.take() {
+                if !account_enabled {
+                    account_loop.abort();
+                    let _ = account_loop.await;
+                } else if !account_consumed {
                     match tokio::time::timeout(
                         std::time::Duration::from_secs(45),
                         &mut account_loop,

--- a/crates/hyprstream/src/services/oauth/mod.rs
+++ b/crates/hyprstream/src/services/oauth/mod.rs
@@ -27,6 +27,7 @@
 //! ```
 
 mod account_worker;
+mod account_tls;
 
 pub mod auth;
 pub mod authorize;
@@ -672,7 +673,8 @@ async fn resolve_account_http_tls(
         "account TLS private key is unavailable: {}",
         config.tls_key.display()
     );
-    let cert_pem = std::fs::read(&config.tls_cert)?;
+    let cert_pem = tokio::fs::read(&config.tls_cert).await?;
+    let key_pem = tokio::fs::read(&config.tls_key).await?;
     let cert_der = rustls_pemfile::certs(&mut &cert_pem[..])
         .next()
         .ok_or_else(|| anyhow::anyhow!("account TLS certificate contains no certificate"))??;
@@ -694,7 +696,9 @@ async fn resolve_account_http_tls(
         covers_zone,
         "account TLS certificate does not cover account zone wildcard {wildcard}"
     );
-    axum_server::tls_rustls::RustlsConfig::from_pem_file(&config.tls_cert, &config.tls_key)
+    // Validate and install the same bytes, including during rotation. Reopening
+    // the paths here could install a different certificate than the SAN check.
+    axum_server::tls_rustls::RustlsConfig::from_pem(cert_pem, key_pem)
         .await
         .map_err(|error| {
             anyhow::anyhow!(
@@ -1310,7 +1314,7 @@ impl Spawnable for OAuthService {
                     Some(account_tls),
                     "AccountHttpService",
                 )?;
-                Some((account_bound, account_app))
+                Some((account_bound, account_app, http_config.clone(), zone))
             } else {
                 None
             };
@@ -1492,7 +1496,7 @@ impl Spawnable for OAuthService {
                     }
                     // Finish all fallible account-worker creation before the RPC
                     // task can signal readiness. Keep the actual thread owner.
-                    if let Some((account_bound, account_app)) = account_endpoint {
+                    if let Some((account_bound, account_app, account_config, account_zone)) = account_endpoint {
                         let account_shutdown_task = Arc::clone(&account_shutdown);
                         let runtime = tokio::runtime::Builder::new_current_thread()
                             .enable_all()
@@ -1503,11 +1507,13 @@ impl Spawnable for OAuthService {
                         account_owner = Some(account_worker::ContainedWorker::spawn(
                             "hyprstream-account-http",
                             move || {
-                                runtime.block_on(crate::server::tls::serve_bound(
+                                runtime.block_on(account_tls::serve_with_reload(
                                     account_bound,
                                     account_app,
                                     account_shutdown_task,
-                                    "AccountHttpService",
+                                    account_config,
+                                    account_zone,
+                                    std::time::Duration::from_secs(30),
                                 ))
                             },
                         )?);

--- a/crates/hyprstream/src/services/oauth/mod.rs
+++ b/crates/hyprstream/src/services/oauth/mod.rs
@@ -846,6 +846,32 @@ impl Spawnable for OAuthService {
             if let Some(sink) = audit_sink {
                 oauth_state = oauth_state.with_audit_sink(sink);
             }
+
+            // Warm the authority-owned hosted-DID index before exposing OAuth
+            // readiness. Request paths remain O(1) lookups and never perform
+            // tenant enumeration; a bounded startup failure keeps OAuth
+            // fail-closed instead of serving valid hosted users intermittently
+            // while the first snapshot is still absent.
+            if let Some(store) = &self.hosted_account_store {
+                let authority = hyprstream_rpc::Subject::new(
+                    hyprstream_pds_service::OAUTH_ACCOUNT_RESOLVER_SUBJECT,
+                );
+                tokio::time::timeout(
+                    std::time::Duration::from_secs(30),
+                    store.refresh_hosted_did_index(&authority),
+                )
+                .await
+                .map_err(|_| {
+                    hyprstream_rpc::error::RpcError::SpawnFailed(
+                        "hosted account index warm-up timed out".to_owned(),
+                    )
+                })?
+                .map_err(|error| {
+                    hyprstream_rpc::error::RpcError::SpawnFailed(format!(
+                        "hosted account index warm-up failed: {error}"
+                    ))
+                })?;
+            }
             // Populate legacy JWKS nbf/exp from signing-key file mtime (used when store absent).
             let key_nbf = crate::auth::identity_store::node_signing_key_mtime(&credentials_dir);
             oauth_state = oauth_state.with_jwt_key_timestamps(key_nbf, key_nbf + 14 * 86400);
@@ -1181,6 +1207,24 @@ mod tests {
         assert!(
             !run.contains("DiscoveryClient::for_local_bootstrap("),
             "OAuth must not use the process-local Discovery registry"
+        );
+    }
+
+    #[test]
+    fn oauth_warms_hosted_did_index_before_readiness() {
+        let source = include_str!("mod.rs");
+        let warmup = source
+            .find("store.refresh_hosted_did_index(&authority)")
+            .expect("OAuth startup must warm the hosted-DID index");
+        let ready = source
+            .find("if let Some(tx) = on_ready")
+            .expect("OAuth readiness signal must remain explicit");
+        assert!(warmup < ready, "OAuth must not signal readiness before index warm-up");
+        let warmup_block = &source[warmup.saturating_sub(512)..ready];
+        assert!(
+            warmup_block.contains("tokio::time::timeout")
+                && warmup_block.contains("Duration::from_secs(30)"),
+            "hosted-DID warm-up must have a bounded timeout"
         );
     }
 

--- a/crates/hyprstream/src/services/oauth/mod.rs
+++ b/crates/hyprstream/src/services/oauth/mod.rs
@@ -1526,21 +1526,37 @@ mod tests {
     #[test]
     fn oauth_warms_hosted_did_index_before_readiness() {
         let source = include_str!("mod.rs");
-        let warmup = source
-            .find("store.refresh_hosted_did_index(&authority)")
+        let production = source
+            .get(..source
+                .find("\n#[cfg(test)]\n#[allow(clippy::unwrap_used")
+                .expect("test module must remain explicit"))
+            .expect("production source must precede tests");
+        let run_start = production
+            .find("impl Spawnable for OAuthService")
+            .expect("OAuthService must implement Spawnable");
+        let run = &production[run_start..];
+        let warmup = run
+            .find("warm_hosted_did_index(")
             .expect("OAuth startup must warm the hosted-DID index");
-        let ready = source
-            .find("if let Some(tx) = on_ready")
-            .expect("OAuth readiness signal must remain explicit");
+        let ready = run
+            .find("serve_bridged(")
+            .expect("OAuth readiness boundary must remain explicit");
         assert!(warmup < ready, "OAuth must not signal readiness before index warm-up");
-        let warmup_block = &source[warmup.saturating_sub(512)..ready];
+        let warmup_block = &run[warmup..ready];
         assert!(
-            warmup_block.contains("tokio::time::timeout")
+            warmup_block.contains("warm_hosted_did_index(")
                 && warmup_block.contains("Duration::from_secs(30)"),
             "hosted-DID warm-up must have a bounded timeout"
         );
+        let helper_start = production
+            .find("async fn warm_hosted_did_index(")
+            .expect("warm-up helper must remain explicit");
+        let helper_end = production
+            .find("/// Profile-aware bind of OAuth's inbound reach-only substrate")
+            .expect("warm-up helper must be bounded by the next helper");
+        let helper = &production[helper_start..helper_end];
         assert!(
-            !warmup_block.contains("spawn_blocking"),
+            !helper.contains("spawn_blocking"),
             "hosted-DID warm-up timeout must not leave an uncancellable blocking task"
         );
     }


### PR DESCRIPTION
## Problem
Hosted-account DID identity artifacts need a dedicated credential-free HTTP origin. Mounting these routes on the authenticated OAuth listener risks inheriting cookies, bearer handling, or session middleware.

## Change
- add a separate Axum router with only the three hosted-account well-known GET routes
- route by canonical wildcard host label and return 404 for unknown/mismatched accounts
- reject `Authorization` and `Cookie` before directory lookup
- serve immutable sealed DID, atproto-DID, and operation-log bytes without per-request regeneration
- add an immutable startup index seam and focused security/byte-stability tests

This PR is stacked on the account-label foundation (#1160 / PR1608). It does not bind a listener, alter TLS, or enable deployment.

## Validation
- BuildQ `cargo test -p hyprstream-pds-service` (23 passed)
- BuildQ `cargo test -p hyprstream-pds` (258 unit, 9 integration, doc test passed)
- BuildQ `cargo clippy -p hyprstream-pds-service --lib --tests -- -D warnings`
- `git diff --check`

The repository-wide pre-commit hook remains environment-blocked by the inherited absent `/home/birdetta/Downloads/libtorch`; the focused BuildQ gates above pass with the warmed cache.
