### PR TITLE
fix: bound required Policy initial Iroh publication wait on main

### DIFF
--- a/crates/hyprstream-rpc/src/transport/lazy_iroh.rs
+++ b/crates/hyprstream-rpc/src/transport/lazy_iroh.rs
@@ -40,6 +40,19 @@ use crate::transport::iroh_substrate::{ALPN_HYPRSTREAM_RPC, OwnedIrohClientEndpo
 use crate::transport::iroh_transport::{IrohPendingStream, IrohPublishStub, IrohTransport};
 use crate::transport_traits::Transport;
 
+/// Availability failures before a request is dispatched. This deliberately
+/// excludes malformed addresses, missing client setup, peer authentication,
+/// ALPN rejection, and all errors after connection establishment.
+#[derive(Debug, thiserror::Error)]
+pub enum IrohPeerUnavailable {
+    #[error("iroh connect timed out")]
+    ConnectTimeout,
+    #[error("iroh peer is in reconnect backoff")]
+    ReconnectBackoff,
+    #[error("iroh peer address discovery is not available yet")]
+    AddressDiscovery(#[source] iroh::endpoint::ConnectError),
+}
+
 /// Default per-request deadline when the caller passes `None`.
 const DEFAULT_TIMEOUT: Duration = Duration::from_secs(30);
 
@@ -104,6 +117,9 @@ pub struct LazyIrohTransport {
     relay_url: Option<String>,
     /// Cached session + reconnect backoff (#156).
     state: Mutex<LazyState<IrohTransport>>,
+    /// Accessed only while holding `state`: a later backoff must not turn a
+    /// prior authentication/configuration rejection into availability.
+    availability_backoff: std::sync::atomic::AtomicBool,
     /// Test-only dial endpoint override.
     ///
     /// Production always dials from the process-global install-once endpoint
@@ -132,6 +148,7 @@ impl LazyIrohTransport {
             direct_addrs,
             relay_url,
             state: Mutex::new(LazyState::default()),
+            availability_backoff: std::sync::atomic::AtomicBool::new(false),
             #[cfg(test)]
             endpoint_override: None,
         }
@@ -152,6 +169,7 @@ impl LazyIrohTransport {
             direct_addrs,
             relay_url,
             state: Mutex::new(LazyState::default()),
+            availability_backoff: std::sync::atomic::AtomicBool::new(false),
             endpoint_override: Some(endpoint),
         }
     }
@@ -191,9 +209,11 @@ impl LazyIrohTransport {
             return Ok(transport.clone());
         }
         if let Some(remaining) = guard.backoff.cooldown_remaining() {
-            return Err(anyhow!(
-                "iroh peer is in reconnect backoff — retry in {remaining:.1?}"
-            ));
+            return if self.availability_backoff.load(std::sync::atomic::Ordering::Relaxed) {
+                Err(IrohPeerUnavailable::ReconnectBackoff.into())
+            } else {
+                Err(anyhow!("iroh peer is in reconnect backoff — retry in {remaining:.1?}"))
+            };
         }
         let endpoint = self.dial_endpoint().ok_or_else(|| {
             anyhow!(
@@ -210,14 +230,28 @@ impl LazyIrohTransport {
         {
             Err(_) => {
                 guard.backoff.record_failure();
-                Err(anyhow!("iroh connect timed out after {CONNECT_TIMEOUT:?}"))
+                self.availability_backoff.store(true, std::sync::atomic::Ordering::Relaxed);
+                Err(IrohPeerUnavailable::ConnectTimeout.into())
             }
             Ok(Err(e)) => {
                 guard.backoff.record_failure();
-                Err(anyhow!("iroh connect: {e}"))
+                let unavailable = matches!(
+                    &e,
+                    iroh::endpoint::ConnectError::Connect {
+                        source: iroh::endpoint::ConnectWithOptsError::NoAddress { .. },
+                        ..
+                    }
+                );
+                self.availability_backoff.store(unavailable, std::sync::atomic::Ordering::Relaxed);
+                if unavailable {
+                    Err(IrohPeerUnavailable::AddressDiscovery(e).into())
+                } else {
+                    Err(anyhow::Error::new(e).context("iroh connect"))
+                }
             }
             Ok(Ok(conn)) => {
                 guard.backoff.record_success();
+                self.availability_backoff.store(false, std::sync::atomic::Ordering::Relaxed);
                 let transport = IrohTransport::new(conn);
                 guard.cached = Some(transport.clone());
                 Ok(transport)
@@ -231,6 +265,7 @@ impl LazyIrohTransport {
         let mut guard = self.state.lock().await;
         guard.cached = None;
         guard.backoff.record_failure();
+        self.availability_backoff.store(false, std::sync::atomic::Ordering::Relaxed);
     }
 }
 
@@ -286,6 +321,26 @@ mod tests {
         let mut k = [0u8; 32];
         rand::thread_rng().fill_bytes(&mut k);
         k
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn lazy_iroh_absent_peer_is_typed_availability_before_dispatch() {
+        let client = IrohSubstrate::new_test(
+            fresh_key(), NoopHandler::new("client moq"), NoopHandler::new("client rpc"),
+        ).await.unwrap();
+        let peer = ed25519_dalek::SigningKey::from_bytes(&fresh_key()).verifying_key().to_bytes();
+        // Minimal test carrier has neither a relay nor address lookup. No
+        // server exists, so these bytes can never have reached a handler.
+        let transport = LazyIrohTransport::new_with_endpoint(peer, vec![], None, client.endpoint().clone());
+        let error = transport.send(b"not-dispatched".to_vec(), Some(100)).await.unwrap_err();
+        assert!(crate::transport_traits::is_pre_dispatch_transport_error(&error));
+        assert!(error.chain().any(|cause| cause.downcast_ref::<IrohPeerUnavailable>().is_some()));
+        assert!(transport.state.lock().await.cached.is_none());
+        // Backoff preserves its explicit availability provenance.
+        let error = transport.send(b"still-not-dispatched".to_vec(), Some(100)).await.unwrap_err();
+        assert!(error.chain().any(|cause| matches!(cause.downcast_ref::<IrohPeerUnavailable>(), Some(IrohPeerUnavailable::ReconnectBackoff))));
+        drop(transport);
+        client.shutdown().await.unwrap();
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
@@ -361,8 +416,13 @@ mod tests {
         let res = tokio::time::timeout(Duration::from_secs(8), t.send(b"x".to_vec(), Some(3_000)))
             .await
             .expect("send must complete (with an error) — wrong identity should reject, not hang");
-        assert!(res.is_err(), "dialing a server's address under a wrong EndpointId must fail");
+        let error = res.expect_err("dialing a server's address under a wrong EndpointId must fail");
+        assert!(!error.chain().any(|cause| cause.downcast_ref::<IrohPeerUnavailable>().is_some()),
+            "a peer-identity handshake rejection must not become retryable availability");
         assert!(t.state.lock().await.cached.is_none(), "a failed handshake caches nothing");
+        let backoff_error = t.send(b"x".to_vec(), Some(3_000)).await.expect_err("rejection backoff");
+        assert!(!backoff_error.chain().any(|cause| cause.downcast_ref::<IrohPeerUnavailable>().is_some()),
+            "backoff must retain the prior permanent failure classification");
 
         // As above, release the transport's endpoint clone before cleanly
         // draining every substrate owned by this test.

--- a/crates/hyprstream/src/bin/main.rs
+++ b/crates/hyprstream/src/bin/main.rs
@@ -2341,6 +2341,46 @@ where
     result
 }
 
+/// Policy must serve authority probes while Discovery starts, but is not READY
+/// until Discovery accepts its announcement. Only typed pre-dispatch Iroh
+/// unavailability can keep that initial publication pending.
+const POLICY_INITIAL_PUBLICATION_BUDGET: std::time::Duration = std::time::Duration::from_secs(120);
+const POLICY_INITIAL_PUBLICATION_RETRY: std::time::Duration = std::time::Duration::from_millis(500);
+
+async fn wait_for_policy_initial_publication<F, Fut>(
+    cancellation: &tokio_util::sync::CancellationToken,
+    budget: std::time::Duration,
+    mut attempt: F,
+) -> anyhow::Result<()>
+where
+    F: FnMut() -> Fut,
+    Fut: std::future::Future<Output = anyhow::Result<()>>,
+{
+    let deadline = tokio::time::Instant::now() + budget;
+    loop {
+        let result = tokio::select! {
+            biased;
+            _ = cancellation.cancelled() => anyhow::bail!("Policy initial publication cancelled"),
+            _ = tokio::time::sleep_until(deadline) => anyhow::bail!("Policy initial publication deadline exceeded"),
+            result = async { attempt().await } => result,
+        };
+        match result {
+            Ok(()) => return Ok(()),
+            Err(error) if hyprstream_rpc::transport_traits::is_pre_dispatch_transport_error(&error)
+                && error.chain().any(|cause| cause.downcast_ref::<hyprstream_rpc::transport::lazy_iroh::IrohPeerUnavailable>().is_some()) => {
+                tracing::info!(%error, "Policy awaiting Discovery initial publication");
+            }
+            Err(error) => return Err(error),
+        }
+        tokio::select! {
+            biased;
+            _ = cancellation.cancelled() => anyhow::bail!("Policy initial publication cancelled"),
+            _ = tokio::time::sleep_until(deadline) => anyhow::bail!("Policy initial publication deadline exceeded"),
+            _ = tokio::time::sleep(POLICY_INITIAL_PUBLICATION_RETRY) => {}
+        }
+    }
+}
+
 /// Spawn the native-announcement refresh loop on its own current-thread Tokio
 /// runtime and return a channel for the first announcement result.
 ///
@@ -2741,7 +2781,6 @@ fn main() -> Result<()> {
         init_registry(mode, runtime_dir);
     }
     // ========== END ENDPOINT REGISTRY INITIALIZATION ==========
-
     // ── Wizard / first-run early dispatch ───────────────────────────────────
     // The wizard is a bootstrap command: it creates credentials that the
     // registry client init (below) depends on. Handle both `wizard` and the
@@ -3557,6 +3596,52 @@ fn main() -> Result<()> {
                                                                 return;
                                                             }
                                                         };
+                                                        if service_name == "policy"
+                                                            && hyprstream_discovery::native_network_required()
+                                                            && matches!(request.reach, hyprstream_service::NativeAnnouncementReach::Iroh { .. })
+                                                        {
+                                                            let cancellation = request.cancellation.clone();
+                                                            let initial = wait_for_policy_initial_publication(
+                                                                &cancellation,
+                                                                POLICY_INITIAL_PUBLICATION_BUDGET,
+                                                                || {
+                                                                    // Re-read signed current state and the exact service
+                                                                    // key's credential on every attempt, before any dial.
+                                                                    let announcement = hyprstream_core::services::factories::current_native_announcement(&mut request);
+                                                                    let client = &client;
+                                                                    async move {
+                                                                        let announcement = announcement?;
+                                                                        let jwt_expiry = announcement.service_jwt.as_deref()
+                                                                            .and_then(hyprstream_core::auth::identity_store::decode_jwt_exp_raw)
+                                                                            .and_then(|seconds| seconds.checked_mul(1_000))
+                                                                            .context("Policy initial announcement requires a bounded service JWT")?;
+                                                                        let expiry = announcement.expires_at_unix_ms.min(jwt_expiry);
+                                                                        let remaining = expiry.saturating_sub(chrono::Utc::now().timestamp_millis());
+                                                                        anyhow::ensure!(remaining > 0, "Policy initial announcement authority expired");
+                                                                        let duration = std::time::Duration::from_millis(u64::try_from(remaining)?);
+                                                                        tokio::time::timeout(duration, client.announce(&announcement)).await
+                                                                            .context("Policy initial announcement authority expired during publication")??;
+                                                                        anyhow::ensure!(chrono::Utc::now().timestamp_millis() < expiry,
+                                                                            "Policy initial announcement authority expired before readiness");
+                                                                        Ok(())
+                                                                    }
+                                                                },
+                                                            ).await;
+                                                            // Report only success or terminal failure, never a
+                                                            // transient availability error. The spawner's existing
+                                                            // bind/publication READY and cancellation gates remain.
+                                                            if let Some(tx) = announce_tx.as_ref() {
+                                                                if let Some(tx) = tx.lock().take() {
+                                                                    let _ = tx.send(initial.as_ref().map(|_| ()).map_err(ToString::to_string));
+                                                                }
+                                                            }
+                                                            if initial.is_err() { return; }
+                                                            tokio::select! {
+                                                                biased;
+                                                                _ = cancellation.cancelled() => return,
+                                                                _ = tokio::time::sleep(std::time::Duration::from_secs(25)) => {}
+                                                            }
+                                                        }
                                                         let _completion = refresh_native_announcement(
                                                             &service_name,
                                                             &socket_kind,
@@ -4415,6 +4500,95 @@ mod resolver_startup_controls {
             vec!["hyprstream", "pds", "inspect-services", "--service", "model", "--valid-for-seconds", "86400"],
             vec!["hyprstream", "pds", "inspect-services", "--service", "model", "--roster-export", "out.json"],
         ] { assert!(super::build_cli().try_get_matches_from(args).is_err()); }
+    }
+
+    fn unavailable_policy_publication() -> anyhow::Error {
+        hyprstream_rpc::transport_traits::PreDispatchTransportError::new(
+            hyprstream_rpc::transport::lazy_iroh::IrohPeerUnavailable::ConnectTimeout.into(),
+        ).into()
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn policy_initial_publication_retries_only_typed_availability_and_reprojects() {
+        let cancellation = tokio_util::sync::CancellationToken::new();
+        let mut projections = 0;
+        let start = tokio::time::Instant::now();
+        super::wait_for_policy_initial_publication(&cancellation, std::time::Duration::from_secs(120), || {
+            projections += 1;
+            let generation = projections;
+            async move {
+                if generation < 3 { Err(unavailable_policy_publication()) } else { Ok(()) }
+            }
+        }).await.expect("late Discovery should allow Policy to publish");
+        assert_eq!(projections, 3, "every retry must request fresh authority material");
+        assert_eq!(start.elapsed(), std::time::Duration::from_secs(1));
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn policy_initial_publication_permanent_error_after_availability_is_terminal() {
+        let cancellation = tokio_util::sync::CancellationToken::new();
+        // These are intentionally untyped security/projection errors. Even
+        // availability-looking text must never select the retry path.
+        for terminal in ["expired current authority", "revoked service JWT", "iroh connect timed out"] {
+            let mut attempts = 0;
+            let error = super::wait_for_policy_initial_publication(&cancellation, std::time::Duration::from_secs(120), || {
+                attempts += 1;
+                let first = attempts == 1;
+                async move {
+                    if first { Err(unavailable_policy_publication()) } else { anyhow::bail!(terminal) }
+                }
+            }).await.expect_err("security failures must be terminal");
+            assert_eq!(error.to_string(), terminal);
+            assert_eq!(attempts, 2);
+        }
+        let mut attempts = 0;
+        let error = super::wait_for_policy_initial_publication(&cancellation, std::time::Duration::from_secs(120), || {
+            attempts += 1;
+            async {
+                Err(hyprstream_rpc::transport_traits::PreDispatchTransportError::new(
+                    anyhow::anyhow!("missing Iroh client endpoint"),
+                ).into())
+            }
+        }).await.expect_err("pre-dispatch alone is not an availability proof");
+        assert_eq!(attempts, 1);
+        assert!(error.to_string().contains("missing Iroh client endpoint"));
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn policy_initial_publication_deadline_bounds_retries_and_inflight_call() {
+        let cancellation = tokio_util::sync::CancellationToken::new();
+        let start = tokio::time::Instant::now();
+        let error = super::wait_for_policy_initial_publication(&cancellation, std::time::Duration::from_secs(2), || async {
+            Err(unavailable_policy_publication())
+        }).await.expect_err("absent Discovery cannot keep startup pending forever");
+        assert!(error.to_string().contains("deadline exceeded"));
+        assert_eq!(start.elapsed(), std::time::Duration::from_secs(2));
+        let start = tokio::time::Instant::now();
+        let error = super::wait_for_policy_initial_publication(&cancellation, std::time::Duration::from_secs(2), std::future::pending).await
+            .expect_err("deadline also interrupts a stalled RPC");
+        assert!(error.to_string().contains("deadline exceeded"));
+        assert_eq!(start.elapsed(), std::time::Duration::from_secs(2));
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn policy_initial_publication_cancellation_precedes_success() {
+        let cancellation = tokio_util::sync::CancellationToken::new();
+        cancellation.cancel();
+        let mut called = false;
+        super::wait_for_policy_initial_publication(&cancellation, std::time::Duration::from_secs(120), || {
+            called = true;
+            async { Ok(()) }
+        }).await.expect_err("cancelled startup cannot publish or become ready");
+        assert!(!called);
+        let cancellation = tokio_util::sync::CancellationToken::new();
+        let cancel = cancellation.clone();
+        let cancel_task = tokio::spawn(async move {
+            tokio::time::sleep(std::time::Duration::from_secs(1)).await;
+            cancel.cancel();
+        });
+        super::wait_for_policy_initial_publication(&cancellation, std::time::Duration::from_secs(120), std::future::pending).await
+            .expect_err("shutdown interrupts an in-flight publication");
+        cancel_task.await.expect("canceller");
     }
 
     #[test]

--- a/docs/service-identity-bootstrap.md
+++ b/docs/service-identity-bootstrap.md
@@ -60,6 +60,32 @@ processes retain their own credentials; Policy loads its provisioned service
 JWT without an RPC to itself. Required Policy clients and the policy CLI resolve
 over Iroh. The required service loop does not bind a local RPC socket.
 
+In a split required-profile deployment, start Policy and Discovery concurrently
+once offline provisioning and key generation finish. Policy must not be ordered
+`After=Discovery` (nor Discovery after Policy readiness): Discovery probes the
+canonical Policy revocation/session stores before its factory can bind. Policy's
+Iroh handler binds before its announcement wait, so it can answer authenticated
+probes while Discovery starts. No authority store is bypassed or replaced.
+
+Only required Iroh Policy startup retries initial announcement availability
+failures. The wait has a 120-second monotonic deadline and 500ms retry delay;
+each connect retains the transport's existing 10-second timeout. Every retry
+reprojects current signed state and the current service credential, and each
+publication is additionally bounded by that credential and identity's expiry.
+Only typed pre-dispatch address-discovery, connect-timeout and backoff failures
+retry. Authentication/authorization rejection and invalid local authority are
+terminal. A deadline, cancellation or failure never signals READY. Successful
+initial publication is followed by the existing 25-second refresh cadence.
+Set these bootstrap units' `TimeoutStartSec` above the application wait plus
+startup allowance (180 seconds is the intended staging contract). This requires
+a concurrent launch contract in deployment units, not a readiness-order cycle.
+
+The pinned bootstrap MAC table does not yet declare the Policy revocation/session
+probe leaves or Discovery announcement. The reviewed generated inventory and
+its production MAC consumer must provide these declarations before a complete
+isolated-process IdentityAware startup can succeed. Publication retry does not
+supply policy labels, widen activation or replace the #1506 human decision.
+
 Compatibility clients permit validated QUIC or Iroh reach; browser provisioning
 retains its explicit WebTransport profile. Systemd notification sockets carry
 lifecycle signals only. Event/Streams MoQL networking and deployment unit wiring


### PR DESCRIPTION
Integrate the bounded required Policy initial Iroh publication wait onto current main after the roster and CBOR merges.

This carries the reviewed Policy wait behavior from PR1582 onto current main without rebasing its shared stacked branch. It retries only typed pre-dispatch Iroh availability, re-reads signed authority on each attempt, bounds expiry/cancellation, and preserves no-UDS readiness semantics. Permanent authentication/configuration failures remain terminal.

Validation on exact head `50341800c`: 
- BuildQ `cargo test -p hyprstream --bin hyprstream resolver_startup_controls`: 20 passed (including isolated child regressions)
- BuildQ `cargo test -p hyprstream-rpc --lib lazy_iroh`: 4 passed
- pre-commit release Clippy passed with canonical cached CUDA130 libtorch
