### PR TITLE
fix: install Discovery proof in native bootstrap

### DIFF
--- a/crates/hyprstream/src/services/factories.rs
+++ b/crates/hyprstream/src/services/factories.rs
@@ -257,7 +257,11 @@ pub fn with_checkpointed_native_announcements(
     let store = crate::services::discovery::PdsRecordStore::open_readonly(&pds_store_dir(&ctx)?)?
         .with_at9p_deployment_verifier(acceptance_identity);
     let states = store.accepted_at9p_states()?;
-    let iroh_required = ctx.iroh_required();
+    // The native-profile flag is installed during authenticated deployment
+    // bootstrap, before `ServiceContext` owns its shared QUIC config.  Read
+    // that process-wide decision here so split Discovery receives its
+    // checkpointed proof before its Event client initializer runs.
+    let iroh_required = hyprstream_discovery::native_network_required();
     for service_name in service_names
         .iter()
         .filter(|name| checkpoint_announces_service(iroh_required, name))
@@ -3154,6 +3158,10 @@ mod tests {
         assert!(
             body.contains("checkpoint_announces_service(iroh_required, name)"),
             "the checkpoint loop must route services through the compatibility decision"
+        );
+        assert!(
+            body.contains("hyprstream_discovery::native_network_required()"),
+            "required native bootstrap must gate Discovery proof installation before QUIC setup"
         );
     }
 


### PR DESCRIPTION
## Problem

In required native networking mode, a split Discovery process exits before publishing its Iroh endpoint because its Event client initializer requires a checkpointed MoQ admission proof. `with_checkpointed_native_announcements` checked `ServiceContext::iroh_required()` before shared QUIC configuration was installed, so Discovery was incorrectly exempted from proof installation.

## Fix

Use the authenticated process bootstrap's process-wide `native_network_required()` flag when selecting checkpoint announcements. This preserves the compatibility exemption while ensuring required native Discovery receives its proof before Event initialization.

## Validation

- BuildQ focused factory regression test
- BuildQ `cargo check -p hyprstream`
- BuildQ release pre-commit Clippy with cached CUDA 13.0 libtorch
