### PR TITLE
fix(iroh): restore N0 reachability without weakening owned ALPN admission

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8139,8 +8139,7 @@ dependencies = [
 [[package]]
 name = "iroh"
 version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fca9b4b462c343ff88fc0af4096c186f939b602a0bc08723536ef2c31c93971"
+source = "git+https://github.com/ewindisch/iroh.git?rev=df6302e0561fadcbf91199ad15d564224a3e7d93#df6302e0561fadcbf91199ad15d564224a3e7d93"
 dependencies = [
  "backon",
  "blake3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -164,7 +164,8 @@ http = "1"
 # Note: web-transport-iroh 0.6.x requires iroh ^1 (0.5.x pinned =1.0.0-rc.0 exactly);
 # co-bump these together. Staying on the RC held noq/noq-proto at 1.0.0-rc.0, which
 # predates the n0-computer/noq#690 GSO-batch alignment fix (#1456).
-iroh = { version = "^1", default-features = false, features = ["tls-ring"] }
+iroh = { git = "https://github.com/ewindisch/iroh.git", rev = "df6302e0561fadcbf91199ad15d564224a3e7d93", default-features = false, features = ["tls-ring"] }
+
 moq-net = "0.1"
 web-transport-iroh = { version = "0.6.0", default-features = false, features = ["ring"] }
 web-transport-quinn = { version = "0.11.9", default-features = false, features = ["ring"] }
@@ -283,6 +284,9 @@ criterion = "0.5.1"
 # web_sys::WebTransport-backed Session can drive the moq subscriber. Upstreamed as
 # moq-dev/moq#2085 (merged 2026-07-04, commit 07f558fea819c9b4c9a68617383146449f5edc87).
 [patch.crates-io]
+# Hyprstream's owned carrier stays on the exact iroh commit below; this also
+# overrides web-transport-iroh's registry edge so both crates share one type.
+iroh = { git = "https://github.com/ewindisch/iroh.git", rev = "df6302e0561fadcbf91199ad15d564224a3e7d93" }
 # Pinned to the upstream merge commit rather than a crates-io release: #2085 landed
 # on moq-dev/moq main but hasn't shipped in a moq-net release yet. Pinning to a rev
 # (not a branch) keeps the build reproducible even if main advances further. Drop

--- a/crates/hyprstream-rpc/Cargo.toml
+++ b/crates/hyprstream-rpc/Cargo.toml
@@ -128,6 +128,7 @@ moq-net = { workspace = true }
 web-transport-iroh = { workspace = true }
 web-transport-quinn = { workspace = true }
 web-transport-trait = { workspace = true }
+noq = { version = "^1", default-features = false, features = ["rustls-aws-lc-rs"] }
 yamux = { workspace = true }  # UDS transport: stream-multiplexer for Session-over-UnixStream
 url = { workspace = true }
 # HTTPS did:web DID-document fetch (#279). Native-only; mirrors the JWKS
@@ -179,7 +180,6 @@ tracing-subscriber = { workspace = true }
 # (the #1425 r2 P2 browser fetch test) does not try to compile a native UDP/mio
 # stack for the browser target).
 [target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
-noq = { version = "^1", default-features = false, features = ["rustls-aws-lc-rs"] }
 # Quinn hides the negotiated NamedGroup behind this upstream diagnostic feature.
 # Enabling it only for tests lets live zmtp assertions use handshake_data without
 # packet parsing or changing production wire behavior.

--- a/crates/hyprstream-rpc/src/transport/iroh_substrate.rs
+++ b/crates/hyprstream-rpc/src/transport/iroh_substrate.rs
@@ -141,10 +141,10 @@ impl IrohSubstrate {
     /// Build the substrate from raw 32-byte Ed25519 secret key material.
     ///
     /// Uses iroh's `presets::N0` for discovery (n0 DNS + pkarr) and relay
-    /// fallback. The endpoint offers PQ-hybrid TLS first, with classical
-    /// X25519 needed for the public N0 HTTPS relay/pkarr services. The
-    /// [`HybridCarrierHook`] rejects classical negotiation on HyprStream's
-    /// owned ALPNs before any handler receives the connection.
+    /// fallback. The native carrier remains strict PQ-hybrid; the patched iroh
+    /// builder routes only external CA-validated HTTPS through its compatible
+    /// provider, so public N0 infrastructure can be reached without weakening
+    /// the owned carrier policy.
     ///
     /// **pkarr here is liveness-only** — see the module-level "D3" note. The
     /// published record carries reach hints (relay + direct addrs) for this
@@ -167,9 +167,10 @@ impl IrohSubstrate {
         let endpoint = Endpoint::builder(presets::N0)
             .address_lookup(iroh::address_lookup::PkarrResolver::n0_dns())
             .secret_key(SecretKey::from_bytes(&secret_key_bytes))
-            // Public N0 relay/pkarr HTTPS currently requires classical
-            // X25519. The carrier hook above keeps HyprStream ALPNs hybrid-only.
-            .crypto_provider(crate::transport::pq_provider::pq_crypto_provider())
+            .crypto_provider(
+                crate::transport::pq_provider::internal_mesh_crypto_provider(),
+            )
+            .ca_crypto_provider(crate::transport::pq_provider::pq_crypto_provider())
             .hooks(HybridCarrierHook)
             .bind()
             .await

--- a/crates/hyprstream-rpc/src/transport/iroh_substrate.rs
+++ b/crates/hyprstream-rpc/src/transport/iroh_substrate.rs
@@ -61,7 +61,7 @@
 //! self-hosted `iroh-dns-server` configured through the owned endpoint builder.
 
 use anyhow::Result;
-use iroh::endpoint::{Connection, presets};
+use iroh::endpoint::{AfterHandshakeOutcome, Connection, EndpointHooks, presets};
 use iroh::protocol::{AcceptError, DynProtocolHandler, ProtocolHandler, Router};
 use iroh::{Endpoint, EndpointAddr, EndpointId, SecretKey};
 
@@ -70,6 +70,43 @@ pub const ALPN_MOQ_LITE: &[u8] = b"moql";
 
 /// ALPN for the raw Cap'n Proto bidi RPC plane.
 pub const ALPN_HYPRSTREAM_RPC: &[u8] = b"hyprstream-rpc/1";
+
+/// Keep the owned HyprStream ALPNs on a PQ-hybrid carrier while allowing the
+/// endpoint's outer HTTPS clients (N0 relay and pkarr) to interoperate with
+/// classical-only public infrastructure. The provider therefore offers
+/// X25519 as a fallback, but a completed HyprStream carrier handshake that
+/// negotiated it is rejected before the protocol router sees the connection.
+#[derive(Debug, Clone, Copy, Default)]
+struct HybridCarrierHook;
+
+impl EndpointHooks for HybridCarrierHook {
+    async fn after_handshake(&self, conn: &Connection) -> AfterHandshakeOutcome {
+        if !matches!(conn.alpn(), ALPN_MOQ_LITE | ALPN_HYPRSTREAM_RPC) {
+            return AfterHandshakeOutcome::Accept;
+        }
+
+        let Some(data) = conn.handshake_data() else {
+            return AfterHandshakeOutcome::Reject {
+                error_code: 403u32.into(),
+                reason: b"missing iroh handshake data".to_vec(),
+            };
+        };
+        let Ok(data) = data.downcast::<noq::crypto::rustls::HandshakeData>() else {
+            return AfterHandshakeOutcome::Reject {
+                error_code: 403u32.into(),
+                reason: b"unsupported iroh handshake data".to_vec(),
+            };
+        };
+        if data.negotiated_key_exchange_group == Some(rustls::NamedGroup::X25519MLKEM768) {
+            AfterHandshakeOutcome::Accept
+        } else {
+            AfterHandshakeOutcome::Reject {
+                error_code: 403u32.into(),
+                reason: b"hyprstream carrier requires PQ-hybrid TLS".to_vec(),
+            }
+        }
+    }
+}
 
 /// Two-plane iroh substrate: one shared QUIC endpoint, two ALPN-dispatched
 /// protocol handlers.
@@ -82,7 +119,7 @@ pub struct IrohSubstrate {
 }
 
 /// Capability proving an outbound iroh endpoint was constructed by
-/// [`IrohSubstrate::new`] with the owned hybrid-only crypto provider.
+/// [`IrohSubstrate::new`] with the owned PQ-hybrid carrier policy.
 ///
 /// The inner endpoint is intentionally private: an already-bound iroh endpoint
 /// does not expose its effective provider, so arbitrary endpoints cannot be
@@ -103,10 +140,10 @@ impl IrohSubstrate {
     /// Build the substrate from raw 32-byte Ed25519 secret key material.
     ///
     /// Uses iroh's `presets::N0` for discovery (n0 DNS + pkarr) and relay
-    /// fallback. Alternate discovery configuration must be added through an
-    /// owned builder that also installs this same hybrid-only provider; a
-    /// prebuilt endpoint cannot safely be accepted because iroh exposes no
-    /// effective-provider introspection after bind.
+    /// fallback. The endpoint offers PQ-hybrid TLS first, with classical
+    /// X25519 needed for the public N0 HTTPS relay/pkarr services. The
+    /// [`HybridCarrierHook`] rejects classical negotiation on HyprStream's
+    /// owned ALPNs before any handler receives the connection.
     ///
     /// **pkarr here is liveness-only** — see the module-level "D3" note. The
     /// published record carries reach hints (relay + direct addrs) for this
@@ -122,16 +159,26 @@ impl IrohSubstrate {
         M: Into<Box<dyn DynProtocolHandler>>,
         R: Into<Box<dyn DynProtocolHandler>>,
     {
+        // N0 1.0.x configures native resolution through DNS TXT only, while
+        // its publisher writes relay-only reach to the HTTPS pkarr service.
+        // Install the matching HTTPS resolver as well so node-id-only native
+        // announcements can resolve the same reach that N0 publishes.
         let endpoint = Endpoint::builder(presets::N0)
+            .address_lookup(iroh::address_lookup::PkarrResolver::n0_dns())
             .secret_key(SecretKey::from_bytes(&secret_key_bytes))
-            // Owned mesh policy: require X25519MLKEM768 with no classical
-            // fallback. RFC 7250 raw-public-key identity is orthogonal to kx.
-            .crypto_provider(crate::transport::pq_provider::internal_mesh_crypto_provider())
+            // Public N0 relay/pkarr HTTPS currently requires classical
+            // X25519. The carrier hook above keeps HyprStream ALPNs hybrid-only.
+            .crypto_provider(crate::transport::pq_provider::pq_crypto_provider())
+            .hooks(HybridCarrierHook)
             .bind()
             .await
             .map_err(|e| anyhow::anyhow!("iroh endpoint bind: {e}"))?;
 
-        Ok(Self::from_owned_endpoint(endpoint, moq_handler, rpc_handler))
+        Ok(Self::from_owned_endpoint(
+            endpoint,
+            moq_handler,
+            rpc_handler,
+        ))
     }
 
     /// Build a hermetic direct-only substrate for unit tests.
@@ -159,16 +206,16 @@ impl IrohSubstrate {
             .await
             .map_err(|e| anyhow::anyhow!("test iroh endpoint bind: {e}"))?;
 
-        Ok(Self::from_owned_endpoint(endpoint, moq_handler, rpc_handler))
+        Ok(Self::from_owned_endpoint(
+            endpoint,
+            moq_handler,
+            rpc_handler,
+        ))
     }
 
     /// Attach the owned ALPNs to an endpoint constructed immediately above.
     /// Kept private because `Endpoint` does not reveal its effective provider.
-    fn from_owned_endpoint<M, R>(
-        endpoint: Endpoint,
-        moq_handler: M,
-        rpc_handler: R,
-    ) -> Self
+    fn from_owned_endpoint<M, R>(endpoint: Endpoint, moq_handler: M, rpc_handler: R) -> Self
     where
         M: Into<Box<dyn DynProtocolHandler>>,
         R: Into<Box<dyn DynProtocolHandler>>,
@@ -402,11 +449,14 @@ mod tests {
             )
             .await
             .expect("classical-only iroh mutation handshake must terminate");
-            assert!(
-                result.is_err(),
-                "internal iroh outbound endpoint reached owned ALPN {:?}",
-                String::from_utf8_lossy(alpn)
-            );
+            match result {
+                Err(_) => {}
+                Ok(conn) => {
+                    tokio::time::timeout(std::time::Duration::from_secs(5), conn.closed())
+                        .await
+                        .expect("classical-only carrier must be closed by the hybrid hook");
+                }
+            }
         }
 
         classical_client.close().await;

--- a/crates/hyprstream-rpc/src/transport/iroh_substrate.rs
+++ b/crates/hyprstream-rpc/src/transport/iroh_substrate.rs
@@ -61,9 +61,10 @@
 //! self-hosted `iroh-dns-server` configured through the owned endpoint builder.
 
 use anyhow::Result;
-use iroh::endpoint::{AfterHandshakeOutcome, Connection, EndpointHooks, presets};
+use iroh::endpoint::{Accepting, AfterHandshakeOutcome, Connection, EndpointHooks, presets};
 use iroh::protocol::{AcceptError, DynProtocolHandler, ProtocolHandler, Router};
 use iroh::{Endpoint, EndpointAddr, EndpointId, SecretKey};
+use std::{future::Future, pin::Pin};
 
 /// ALPN for moq-net (moq-lite). Must equal `moq_net::version::ALPN_LITE`.
 pub const ALPN_MOQ_LITE: &[u8] = b"moql";
@@ -215,14 +216,28 @@ impl IrohSubstrate {
 
     /// Attach the owned ALPNs to an endpoint constructed immediately above.
     /// Kept private because `Endpoint` does not reveal its effective provider.
+    ///
+    /// The wrapper completes the full TLS handshake before delegating to a
+    /// protocol handler. Iroh otherwise permits a handler's `on_accepting`
+    /// hook to consume 0-RTT data before `EndpointHooks` runs; owned ALPNs must
+    /// not expose that early-data path while carrier admission is enforced
+    /// after the handshake.
     fn from_owned_endpoint<M, R>(endpoint: Endpoint, moq_handler: M, rpc_handler: R) -> Self
     where
         M: Into<Box<dyn DynProtocolHandler>>,
         R: Into<Box<dyn DynProtocolHandler>>,
     {
         let router = Router::builder(endpoint.clone())
-            .accept(ALPN_MOQ_LITE, moq_handler.into())
-            .accept(ALPN_HYPRSTREAM_RPC, rpc_handler.into())
+            .accept(
+                ALPN_MOQ_LITE,
+                Box::new(FullHandshakeHandler::new(moq_handler.into()))
+                    as Box<dyn DynProtocolHandler>,
+            )
+            .accept(
+                ALPN_HYPRSTREAM_RPC,
+                Box::new(FullHandshakeHandler::new(rpc_handler.into()))
+                    as Box<dyn DynProtocolHandler>,
+            )
             .spawn();
         Self { endpoint, router }
     }
@@ -265,6 +280,40 @@ impl IrohSubstrate {
             .await
             .map_err(|e| anyhow::anyhow!("router shutdown: {e}"))?;
         Ok(())
+    }
+}
+
+/// Restrict owned ALPN handlers to the full-handshake `accept(Connection)`
+/// path. This prevents a custom handler from consuming 0-RTT before the
+/// post-handshake carrier policy has run.
+#[derive(Debug)]
+struct FullHandshakeHandler {
+    inner: Box<dyn DynProtocolHandler>,
+}
+
+impl FullHandshakeHandler {
+    fn new(inner: Box<dyn DynProtocolHandler>) -> Self {
+        Self { inner }
+    }
+}
+
+impl DynProtocolHandler for FullHandshakeHandler {
+    fn on_accepting(
+        &self,
+        accepting: Accepting,
+    ) -> Pin<Box<dyn Future<Output = Result<Connection, AcceptError>> + Send + '_>> {
+        Box::pin(async move { accepting.await.map_err(AcceptError::from_err) })
+    }
+
+    fn accept(
+        &self,
+        connection: Connection,
+    ) -> Pin<Box<dyn Future<Output = Result<(), AcceptError>> + Send + '_>> {
+        self.inner.accept(connection)
+    }
+
+    fn shutdown(&self) -> Pin<Box<dyn Future<Output = ()> + Send + '_>> {
+        self.inner.shutdown()
     }
 }
 
@@ -345,12 +394,31 @@ mod tests {
     use iroh::TransportAddr;
     use noq::crypto::rustls::HandshakeData;
     use rand::RngCore;
-    use std::sync::Arc;
+    use std::sync::{
+        Arc,
+        atomic::{AtomicBool, Ordering},
+    };
 
     fn fresh_key() -> [u8; 32] {
         let mut k = [0u8; 32];
         rand::thread_rng().fill_bytes(&mut k);
         k
+    }
+
+    #[derive(Debug, Clone)]
+    struct EarlyDataProbe(Arc<AtomicBool>);
+
+    impl ProtocolHandler for EarlyDataProbe {
+        async fn on_accepting(&self, _accepting: Accepting) -> Result<Connection, AcceptError> {
+            self.0.store(true, Ordering::SeqCst);
+            Err(AcceptError::from_err(std::io::Error::other(
+                "early-data hook must not be delegated",
+            )))
+        }
+
+        async fn accept(&self, _connection: Connection) -> Result<(), AcceptError> {
+            Ok(())
+        }
     }
 
     /// Build an `EndpointAddr` for a server directly from its bound sockets +
@@ -425,6 +493,31 @@ mod tests {
 
         // Sanity: server id is stable.
         assert_eq!(server.endpoint_id(), server_id);
+
+        client.shutdown().await?;
+        server.shutdown().await?;
+        Ok(())
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn owned_handlers_complete_handshake_before_delegation() -> Result<()> {
+        let called = Arc::new(AtomicBool::new(false));
+        let server = IrohSubstrate::new_test(
+            fresh_key(),
+            EarlyDataProbe(called.clone()),
+            NoopHandler::new("rpc"),
+        )
+        .await?;
+        let client = IrohSubstrate::new_test(
+            fresh_key(),
+            NoopHandler::new("moq"),
+            NoopHandler::new("rpc"),
+        )
+        .await?;
+
+        let conn = client.connect(direct_addr(&server), ALPN_MOQ_LITE).await?;
+        assert_hybrid_handshake(&conn, ALPN_MOQ_LITE);
+        assert!(!called.load(Ordering::SeqCst));
 
         client.shutdown().await?;
         server.shutdown().await?;

--- a/crates/hyprstream-rpc/src/transport/lazy_iroh.rs
+++ b/crates/hyprstream-rpc/src/transport/lazy_iroh.rs
@@ -79,7 +79,10 @@ static IROH_CLIENT_ENDPOINT: OnceLock<iroh::Endpoint> = OnceLock::new();
 /// response-signing key, or authorization authority. The capability can only
 /// be obtained from
 /// [`crate::transport::iroh_substrate::IrohSubstrate::owned_client_endpoint`],
-/// which proves the endpoint was bound with the exact hybrid-only provider.
+/// which proves the endpoint was bound with the provider configured for N0
+/// interoperability. Owned Hyprstream ALPNs still require the hybrid group at
+/// the completed-carrier admission hook, while public relay/pkarr HTTPS needs
+/// the provider's X25519 fallback.
 ///
 /// Arbitrary already-bound endpoints are rejected by the type system:
 ///

--- a/crates/hyprstream-rpc/src/transport/pq_provider.rs
+++ b/crates/hyprstream-rpc/src/transport/pq_provider.rs
@@ -1,14 +1,14 @@
 //! Post-quantum hybrid TLS crypto-provider policies (#557 / S6 of epic #550).
 //!
-//! The owned internal mesh (zmtp and both iroh ALPNs) is hybrid-only: it has no
-//! classical key-exchange fallback. The process-wide provider used by the
-//! external WebTransport/HTTP perimeter deliberately retains X25519 fallback
-//! for browser and third-party interoperability. Application-layer HyKEM is the
-//! primary, transport-independent confidentiality guarantee on every path.
+//! The owned iroh endpoint uses a provider that offers hybrid X25519MLKEM768
+//! plus classical X25519 because iroh reuses it for public N0 relay and pkarr
+//! HTTPS. The owned Hyprstream ALPNs remain hybrid-only at the completed
+//! carrier-admission hook, and application-layer HyKEM remains the primary,
+//! transport-independent confidentiality guarantee on every path.
 
 use std::sync::Arc;
 
-use rustls::crypto::{aws_lc_rs, CryptoProvider};
+use rustls::crypto::{CryptoProvider, aws_lc_rs};
 
 const INTERNAL_MESH_GROUPS: &[rustls::NamedGroup] = &[rustls::NamedGroup::X25519MLKEM768];
 const EXTERNAL_INTEROP_GROUPS: &[rustls::NamedGroup] = &[


### PR DESCRIPTION
## Problem
Staging Discovery publishes a node-only Iroh endpoint, but Policy cannot resolve it. Iroh 1.0.2 reuses the endpoint crypto provider for public N0 pkarr and relay HTTPS; the strict hybrid-only provider therefore cannot interoperate with the public classical X25519 service.

## Change

- install the native N0 `PkarrResolver` so node-only native announcements can resolve published reach
- keep the native Iroh carrier on `internal_mesh_crypto_provider()` (hybrid-only)
- use the new `Builder::ca_crypto_provider()` API for external CA-validated N0 HTTPS, with the compatibility provider only at that outer boundary
- carry the dependency patch at exact iroh commit `df6302e0561fadcbf91199ad15d564224a3e7d93` in the temporary `ewindisch/iroh` fork; upstream proposal is [n0-computer/iroh#4528](https://github.com/n0-computer/iroh/pull/4528)
- retain `HybridCarrierHook` and full-handshake handler wrappers so owned `moql` and `hyprstream-rpc/1` connections cannot reach handlers or 0-RTT before carrier admission
- update provider-boundary documentation

Application-level HyKEM and existing identity/admission checks remain authoritative.

The provider split preserves the literal hybrid-only owned carrier requirement while allowing public N0 lookup/relay HTTPS to negotiate the classical group those services currently require.

## Validation

- BuildQ `cargo check -p hyprstream-rpc`
- BuildQ substrate tests: 3 passed
- BuildQ `cargo clippy -p hyprstream-rpc --lib -- -D warnings`
- release pre-commit Clippy gate passed with the pinned libtorch path
- exact head `a9b1b075a` uses one Iroh source for Hyprstream and `web-transport-iroh` via `[patch.crates-io]`
- independent exact-head review pending

The hosted Loopback-literal burn-down check is currently failing on unrelated `crates/hyprstream-pds/src/repo_authority.rs` baseline drift; this PR does not touch that file. No image publish or staging apply is triggered until hosted checks are terminal green, exact-head review passes, and the unrelated required check is dispositioned.
