### PR TITLE
test(oauth): warm hosted DID index in authority fixture

### DIFF
--- a/crates/hyprstream/src/auth/key_rotation.rs
+++ b/crates/hyprstream/src/auth/key_rotation.rs
@@ -2701,6 +2701,16 @@ mod tests {
                     },
                 )
                 .await?;
+                let hosted_store = hosted_account_store("multiprocess-oauth", "example.test")?;
+                // The production account store warms its signed hosted-DID
+                // index during startup.  This isolated multi-process fixture
+                // constructs the store directly, so warm the same index before
+                // the OAuth child accepts its first authorization-code exchange.
+                hosted_store
+                    .refresh_hosted_did_index(&hyprstream_rpc::Subject::new(
+                        hyprstream_pds_service::OAUTH_ACCOUNT_RESOLVER_SUBJECT,
+                    ))
+                    .await?;
                 let state = Arc::new(
                     crate::services::oauth::state::OAuthState::new(
                         &config,
@@ -2712,10 +2722,7 @@ mod tests {
                     .with_hosted_account_zone(crate::account::AccountZone::new(
                         "example.test",
                     )?)
-                    .with_hosted_account_store(hosted_account_store(
-                        "multiprocess-oauth",
-                        "example.test",
-                    )?),
+                    .with_hosted_account_store(hosted_store),
                 );
                 let verifier = "multiprocess-pkce-verifier";
                 let challenge = URL_SAFE_NO_PAD.encode(Sha256::digest(verifier.as_bytes()));


### PR DESCRIPTION
The PR1605 merge-boundary suite exposed a test fixture regression after hosted-DID resolution became indexed: the multi-process OAuth fixture created its synthetic account store directly but did not warm the signed hosted-DID index before the first authorization-code exchange. That caused `account has no hosted DID tenant binding` and blocked the required post-merge validation.

This correction warms the index with the OAuth resolver subject before serving the fixture. It does not change production authorization, tenant derivation, or cryptographic behavior.

Validation:
- BuildQ focused nextest: `composite_authority_production_paths_reject_semantic_rollback` 1/1 (`e4a0b0fc-35a8-4dbf-b8e2-a4af6e67f02e`)
- BuildQ scoped Hyprstream Clippy: PASS
- Normal release Clippy pre-commit hook: PASS with configured cached libtorch
- `git diff --check`: PASS
